### PR TITLE
[license] Improve license message

### DIFF
--- a/packages/license/src/licenseErrorMessageUtils.ts
+++ b/packages/license/src/licenseErrorMessageUtils.ts
@@ -1,45 +1,45 @@
-export function showInvalidLicenseError() {
+function showError(message) {
   console.error(
-    '*************************************************************************\n' +
-      '************************* Material-UI X License *************************\n' +
-      '**************************** Invalid License ****************************\n' +
-      '*                                                                       *\n' +
-      '* Your license for Material-UI X is not valid, please contact           *\n' +
-      '* license@material-ui.com to get a valid license.                       *\n' +
-      '*                                                                       *\n' +
-      '*************************************************************************\n' +
-      '*************************************************************************\n',
+    [
+      '************************************************************',
+      '*************************************************************',
+      ,
+      '',
+      ...message,
+      '',
+      '*************************************************************',
+      '*************************************************************',
+    ].join('\n'),
   );
+}
+
+export function showInvalidLicenseError() {
+  showError([
+    'Material-UI X: Invalid license.',
+    '',
+    'Your license for Material-UI X is not valid, please contact',
+    'license@material-ui.com to get a valid license.',
+  ]);
 }
 
 export function showNotFoundLicenseError() {
-  console.error(
-    '*************************************************************************\n' +
-      '************************* Material-UI X License *************************\n' +
-      '************************* License Key Not Found *************************\n' +
-      '*                                                                       *\n' +
-      '* All Material-UI X features are unlocked. \n' +
-      '* This is an evaluation only version, it is not licensed for            *\n' +
-      '* development projects intended for production                          *\n' +
-      '*                                                                       *\n' +
-      '* If you want to hide the watermark, please email                       *\n' +
-      '* license@material-ui.com  for a trial license.                         *\n' +
-      '*                                                                       *\n' +
-      '*************************************************************************\n' +
-      '*************************************************************************',
-  );
+  showError([
+    'Material-UI X: License key not found.',
+    '',
+    'All Material-UI X features are unlocked.',
+    'This is an evaluation only version, it is not licensed for',
+    'development projects intended for production.',
+    '',
+    'If you want a license to use the features, please email',
+    'license@material-ui.com  for a trial license.',
+  ]);
 }
 
 export function showExpiredLicenseError() {
-  console.error(
-    '*************************************************************************\n' +
-      '************************* Material-UI X License *************************\n' +
-      '************************** License Key Expired **************************\n' +
-      '*                                                                       *\n' +
-      '* Please contact license@material-ui.com to renew your subscription     *\n' +
-      '* and get the latest version of Material-UI X                           *\n' +
-      '*                                                                       *\n' +
-      '*************************************************************************\n' +
-      '*************************************************************************',
-  );
+  showError([
+    'Material-UI X: License key expired.',
+    '',
+    'Please contact license@material-ui.com to renew your subscription',
+    'and get the latest version of Material-UI X.',
+  ]);
 }


### PR DESCRIPTION
Continuation on https://github.com/mui-org/material-ui-x/pull/17#discussion_r438292870.

**Before**

<img width="499" alt="Capture d’écran 2020-06-13 à 14 53 11" src="https://user-images.githubusercontent.com/3165635/84405656-bd11d600-ac08-11ea-996d-ba6c9a8e96bc.png">

**After**

<img width="568" alt="Capture d’écran 2020-06-13 à 14 53 11" src="https://user-images.githubusercontent.com/3165635/84569287-a5139100-ad85-11ea-9863-47e17722f267.png">

---

I have a 13" screen. 1280 pixels available. The size analytics from the traffic on Material-UI:

<img width="1011" alt="Capture d’écran 2020-06-15 à 11 43 42" src="https://user-images.githubusercontent.com/3165635/84642979-83d5b080-aefd-11ea-908e-ee44c2a5cdb3.png">

Regarding the leading `*` does it mean we need to calculate the right number of spaces when we want to iterate on the content?