### PR TITLE
[docs] The new deploy docs target of v4

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "rimraf ./node_modules/.cache/babel-loader && next dev --port 3001",
-    "deploy": "git push upstream master:release",
+    "deploy": "git push upstream master:docs-v4",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "typescript": "tsc -p tsconfig.json",


### PR DESCRIPTION
The main repository is configured to serve the `docs-v4` branch on https://v4.mui.com/, not `release` since https://github.com/mui-org/material-ui/pull/28896.
