### PR TITLE
[docs] The `page` prop is zero-based

### DIFF
--- a/docs/pages/api-docs/data-grid/data-grid-pro.md
+++ b/docs/pages/api-docs/data-grid/data-grid-pro.md
@@ -108,7 +108,7 @@ The name <code>MuiDataGrid</code> can be used when providing [default props](/cu
 | <span class="prop-name">onSelectionModelChange</span> | <span class="prop-type">(model: GridSelectionModel) => void</span> |   | Callback fired when the selection state of one or multiple rows changes. |
 | <span class="prop-name">onSortModelChange</span> | <span class="prop-type">(model: GridSortModel) => void</span> |   | Callback fired when the sort model changes before a column is sorted. |
 | <span class="prop-name">onViewportRowsChange</span> | <span class="prop-type">(params: GridViewportRowsChangeParams) => void</span> |   | Callback fired when the rows in the viewport change. |
-| <span class="prop-name">page</span> | <span class="prop-type">number</span> | 1   |  Set the current page. |
+| <span class="prop-name">page</span> | <span class="prop-type">number</span> | 0   |  The zero-based index of the current page. |
 | <span class="prop-name">pageSize</span> | <span class="prop-type">number</span> | 100 | Set the number of rows in one page. |
 | <span class="prop-name">pagination</span> | <span class="prop-type">boolean</span> | false | If `true`, pagination is enabled. |
 | <span class="prop-name">paginationMode</span> | <span class="prop-type">GridFeatureMode</span> | 'client' | Pagination can be processed on the server or client-side. Set it to 'client' if you would like to handle the pagination on the client-side. Set it to 'server' if you would like to handle the pagination on the server-side. |

--- a/docs/pages/api-docs/data-grid/data-grid.md
+++ b/docs/pages/api-docs/data-grid/data-grid.md
@@ -98,7 +98,7 @@ The name <code>MuiDataGrid</code> can be used when providing [default props](/cu
 | <span class="prop-name">onRowLeave</span> | <span class="prop-type">(params: GridRowParams, event: MuiEvent<React.MouseEvent>, details: GridCallbackDetails) => void</span> |   | Callback fired when a mouse leave event comes from a row container element. |
 | <span class="prop-name">onSelectionModelChange</span> | <span class="prop-type">(model: GridSelectionModel) => void</span> |   | Callback fired when the selection state of one or multiple rows changes. |
 | <span class="prop-name">onSortModelChange</span> | <span class="prop-type">(model: GridSortModel) => void</span> |   | Callback fired when the sort model changes before a column is sorted. |
-| <span class="prop-name">page</span> | <span class="prop-type">number</span> | 1   |  Set the current page. |
+| <span class="prop-name">page</span> | <span class="prop-type">number</span> | 0   |  The zero-based index of the current page. |
 | <span class="prop-name">pageSize</span> | <span class="prop-type">number</span> | 100 | Set the number of rows in one page. |
 | <span class="prop-name">paginationMode</span> | <span class="prop-type">GridFeatureMode</span> | 'client' | Pagination can be processed on the server or client-side. Set it to 'client' if you would like to handle the pagination on the client-side. Set it to 'server' if you would like to handle the pagination on the server-side. |
 | <span class="prop-name">rowCount</span> | <span class="prop-type">number</span> |   |  Set the total number of rows, if it is different than the length of the value `rows` prop. |

--- a/packages/grid/_modules_/grid/GridComponentProps.ts
+++ b/packages/grid/_modules_/grid/GridComponentProps.ts
@@ -485,10 +485,9 @@ interface GridComponentOtherProps {
     event: MuiEvent<{}>,
     details: GridCallbackDetails,
   ) => void;
-
   /**
-   * Set the current page.
-   * @default 1
+   * The zero-based index of the current page.
+   * @default 0
    */
   page?: number;
   /**

--- a/packages/grid/data-grid/src/DataGrid.tsx
+++ b/packages/grid/data-grid/src/DataGrid.tsx
@@ -542,8 +542,8 @@ DataGridRaw.propTypes = {
    */
   onStateChange: PropTypes.func,
   /**
-   * Set the current page.
-   * @default 1
+   * The zero-based index of the current page.
+   * @default 0
    */
   page: PropTypes.number,
   /**

--- a/packages/grid/x-grid/src/DataGridPro.tsx
+++ b/packages/grid/x-grid/src/DataGridPro.tsx
@@ -615,8 +615,8 @@ DataGridProRaw.propTypes = {
    */
   onViewportRowsChange: PropTypes.func,
   /**
-   * Set the current page.
-   * @default 1
+   * The zero-based index of the current page.
+   * @default 0
    */
   page: PropTypes.number,
   /**


### PR DESCRIPTION
Noticed while reviewing #2787 

Proof:

https://github.com/mui-org/material-ui-x/blob/168cd3eb15d93dbfa79a0644a1df2f536c0ee4ca/packages/grid/_modules_/grid/hooks/features/pagination/useGridPage.ts#L28