### PR TITLE
[DataGrid] Override componentsProps typing

### DIFF
--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarFilterButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarFilterButton.tsx
@@ -36,9 +36,7 @@ export interface GridToolbarFilterButtonProps
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps?: ('componentsProps' extends keyof TooltipProps
-    ? Pick<TooltipProps, 'componentsProps'>
-    : {}) & { button?: ButtonProps };
+  componentsProps?: { button?: ButtonProps };
 }
 
 const GridToolbarFilterButton = React.forwardRef<HTMLButtonElement, GridToolbarFilterButtonProps>(


### PR DESCRIPTION
Resolve #2804 : In `@mui/material` v5.0.3 `componentsProps` is defined in `TooltipProps`. This conflicts with the `GridToolbarFilterButtonProps` which extends `TooltipProps`.

Because `componentsProps` are completely different between `GridToolbarFilterButtonProps` and `TooltipProps`, I propose to omit it from the extension, and redefine `componentsProps` in the interface