### PR TITLE
[docs] Fix JSX closing tag in `getActions` example

### DIFF
--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -278,8 +278,8 @@ However, some types require additional properties to be set to make them work co
     field: 'actions',
     type: 'actions',
     getActions: (params: GridRowParams) => [
-      <GridActionsCellItem icon={...} onClick={...} label="Delete"/>,
-      <GridActionsCellItem icon={...} onClick={...} label="Print" showInMenu/>,
+      <GridActionsCellItem icon={...} onClick={...} label="Delete" />,
+      <GridActionsCellItem icon={...} onClick={...} label="Print" showInMenu />,
     ]
   }
   ```


### PR DESCRIPTION
Fixes #2838.

Fixes two incorrectly closed `<GridActionsCellItem />` components in the column action type documentation.

---

This is a tiny PR, but hopefully a foot in the door to me contributing more in the future :)