### PR TITLE
[DataGrid] Don't select the row when clicking on an item in the `actions` column type

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridActionsCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridActionsCell.tsx
@@ -26,7 +26,10 @@ const GridActionsCell = (props: GridActionsCellProps) => {
     throw new Error('MUI: Missing the `getActions` property in the `GridColDef`.');
   }
 
-  const showMenu = () => setOpen(true);
+  const showMenu = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    setOpen(true);
+  };
 
   const hideMenu = () => setOpen(false);
 

--- a/packages/grid/_modules_/grid/components/cell/GridActionsCellItem.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridActionsCellItem.tsx
@@ -13,18 +13,26 @@ export type GridActionsCellItemProps = {
 );
 
 const GridActionsCellItem = (props: GridActionsCellItemProps) => {
-  const { label, icon, showInMenu, ...other } = props;
+  const { label, icon, showInMenu, onClick, ...other } = props;
+
+  const handleClick = (event: any) => {
+    event.stopPropagation();
+
+    if (onClick) {
+      onClick(event);
+    }
+  };
 
   if (!showInMenu) {
     return (
-      <IconButton size="small" aria-label={label} {...(other as any)}>
+      <IconButton size="small" aria-label={label} {...(other as any)} onClick={handleClick}>
         {React.cloneElement(icon!, { fontSize: 'small' })}
       </IconButton>
     );
   }
 
   return (
-    <MenuItem {...(other as any)}>
+    <MenuItem {...(other as any)} onClick={onClick}>
       {icon && <ListItemIcon>{icon}</ListItemIcon>}
       {label}
     </MenuItem>


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui-x/issues/891#issuecomment-926429837

Before: https://codesandbox.io/s/columntypesgrid-material-demo-forked-6codp?file=/demo.tsx

After: https://codesandbox.io/s/columntypesgrid-material-demo-forked-nrrs5?file=/demo.tsx

Click on any item from the last column and check the console.