### PR TITLE
[internal] Register event async if not registered

### DIFF
--- a/packages/grid/_modules_/grid/hooks/utils/useGridApiEventHandler.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useGridApiEventHandler.ts
@@ -40,10 +40,25 @@ export function useGridApiEventHandler<Params, Event extends MuiEvent>(
   }
 
   React.useEffect(() => {
+    if (!subscription.current && handlerRef.current) {
+      const enhancedHandler: GridListener<Params, Event> = (params, event, details) => {
+        if (!event.defaultMuiPrevented) {
+          handlerRef.current?.(params, event, details);
+        }
+      };
+
+      subscription.current = apiRef.current.subscribeEvent<Params, Event>(
+        eventName,
+        enhancedHandler,
+        options,
+      );
+    }
+
     return () => {
       subscription.current?.();
+      subscription.current = null;
     };
-  }, []);
+  }, [apiRef, eventName, options]);
 }
 
 const optionsSubscriberOptions: GridSubscribeEventOptions = { isFirst: true };


### PR DESCRIPTION
When [Fast Refresh](https://nextjs.org/docs/basic-features/fast-refresh) kicks in, it first calls the clean up function of `useEffect`, then runs the effect again. The problem is that events are subscribed synchronously now, outside the effect, so they are unregistered (by the clean up) and never registered again after the cleaning. With the new virtualization, this caused the headers to not move once a refresh occur, since the listener for the `rowsScroll` event is lost. This PR fixes this bug by also registering the event in the effect, only if it's not already registered.

_I don't have an idea how to unit-test it. It only happens when Fast Refresh is on_

To reproduce the bug, do the following steps:

- On HEAD, run `yarn docs:dev` 
- Go to http://localhost:3001/components/data-grid/#commercial-version
- Change something to trigger Fast Refresh (e.g. add an import)

https://user-images.githubusercontent.com/42154031/138000489-5a8967cd-7f11-44c9-b2a9-5b409b1cfc64.mp4

