### PR TITLE
[DataGrid] Fix column headers misaligned when render context changes

### DIFF
--- a/docs/src/pages/components/data-grid/virtualization/ColumnVirtualizationGrid.js
+++ b/docs/src/pages/components/data-grid/virtualization/ColumnVirtualizationGrid.js
@@ -39,7 +39,7 @@ export default function ColumnVirtualizationGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid {...data} columnBuffer={2} />
+      <DataGrid {...data} columnBuffer={2} columnThreshold={2} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/virtualization/ColumnVirtualizationGrid.tsx
+++ b/docs/src/pages/components/data-grid/virtualization/ColumnVirtualizationGrid.tsx
@@ -49,7 +49,7 @@ export default function ColumnVirtualizationGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid {...data} columnBuffer={2} />
+      <DataGrid {...data} columnBuffer={2} columnThreshold={2} />
     </div>
   );
 }

--- a/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaders.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaders.tsx
@@ -116,7 +116,7 @@ export const GridColumnsHeader = React.forwardRef<HTMLDivElement, any>(function 
       );
 
       const offset =
-        firstColumnToRender > 0 ? left % columnsMeta.positions[firstColumnToRender] : left;
+        firstColumnToRender > 0 ? left - columnsMeta.positions[firstColumnToRender] : left;
       wrapperRef!.current!.style.transform = `translate3d(${-offset}px, 0px, 0px)`;
     },
     [columnsMeta.positions, rootProps.columnBuffer],

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -116,6 +116,28 @@ async function main() {
       });
     });
 
+    it('should position the headers matching the columns', async function test() {
+      const route = `${baseUrl}/docs-components-data-grid-virtualization/ColumnVirtualizationGrid`;
+      const screenshotPath = path.resolve(
+        screenshotDir,
+        `${route.replace(baseUrl, '.')}ScrollLeft400px.png`,
+      );
+      await fse.ensureDir(path.dirname(screenshotPath));
+
+      const testcaseIndex = routes.indexOf(route);
+      await page.$eval(`#tests li:nth-of-type(${testcaseIndex + 1}) a`, (link) => {
+        link.click();
+      });
+
+      await page.mouse.move(200, 200);
+      await page.mouse.wheel(400, 0);
+
+      const testcase = await page.waitForSelector(
+        '[data-testid="testcase"]:not([aria-busy="true"])',
+      );
+      await testcase.screenshot({ path: screenshotPath, type: 'png' });
+    });
+
     it('should take a screenshot of the print preview', async function test() {
       this.timeout(10000);
 


### PR DESCRIPTION
Preview: https://deploy-preview-2937--material-ui-x.netlify.app/components/data-grid/demo/

Steps to reproduce:

- Open https://next--material-ui-x.netlify.app/components/data-grid/demo/#data-grid-demo
- Run `document.querySelector('.MuiDataGrid-virtualScroller').scrollLeft = 400`
- The headers are misaligned

<img width="500" src="https://user-images.githubusercontent.com/42154031/138297756-90cc2fd7-2629-43d5-9ffa-9e95c6b379ae.png" alt="image" style="max-width: 100%;">