### PR TITLE
[DataGrid] Use true content height to dispatch `rowsScrollEnd`

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/infiniteLoader/useGridInfiniteLoader.ts
+++ b/packages/grid/_modules_/grid/hooks/features/infiniteLoader/useGridInfiniteLoader.ts
@@ -11,6 +11,9 @@ import { GridRowScrollEndParams } from '../../../models/params/gridRowScrollEndP
 import { visibleGridColumnsSelector } from '../columns/gridColumnsSelector';
 import { GridComponentProps } from '../../../GridComponentProps';
 import { GridScrollParams } from '../../../models/params/gridScrollParams';
+import { visibleSortedGridRowsAsArraySelector } from '../filter/gridFilterSelector';
+import { gridPaginationSelector } from '../pagination/gridPaginationSelector';
+import { gridDensityRowHeightSelector } from '../density/densitySelector';
 
 /**
  * Only available in DataGridPro
@@ -22,10 +25,32 @@ import { GridScrollParams } from '../../../models/params/gridScrollParams';
  */
 export const useGridInfiniteLoader = (
   apiRef: GridApiRef,
-  props: Pick<GridComponentProps, 'onRowsScrollEnd' | 'scrollEndThreshold'>,
+  props: Pick<
+    GridComponentProps,
+    'onRowsScrollEnd' | 'scrollEndThreshold' | 'pagination' | 'paginationMode'
+  >,
 ): void => {
   const containerSizes = useGridSelector(apiRef, gridContainerSizesSelector);
   const visibleColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
+  const visibleSortedRowsAsArray = useGridSelector(apiRef, visibleSortedGridRowsAsArraySelector);
+  const paginationState = useGridSelector(apiRef, gridPaginationSelector);
+  const rowHeight = useGridSelector(apiRef, gridDensityRowHeightSelector);
+
+  const rowsInCurrentPage = React.useMemo(() => {
+    if (props.pagination && props.paginationMode === 'client') {
+      const start = paginationState.pageSize * paginationState.page;
+      return visibleSortedRowsAsArray.slice(start, start + paginationState.pageSize);
+    }
+    return visibleSortedRowsAsArray;
+  }, [
+    paginationState.page,
+    paginationState.pageSize,
+    props.pagination,
+    props.paginationMode,
+    visibleSortedRowsAsArray,
+  ]);
+
+  const contentHeight = Math.max(rowsInCurrentPage.length * rowHeight, 1);
 
   const isInScrollBottomArea = React.useRef<boolean>(false);
 
@@ -35,15 +60,14 @@ export const useGridInfiniteLoader = (
         return;
       }
 
-      const scrollPositionBottom =
-        scrollPosition.top + containerSizes.windowSizes.height + props.scrollEndThreshold;
+      const scrollPositionBottom = scrollPosition.top + containerSizes.windowSizes.height;
 
-      if (scrollPositionBottom < containerSizes.dataContainerSizes.height) {
+      if (scrollPositionBottom < contentHeight - props.scrollEndThreshold) {
         isInScrollBottomArea.current = false;
       }
 
       if (
-        scrollPositionBottom >= containerSizes.dataContainerSizes.height &&
+        scrollPositionBottom >= contentHeight - props.scrollEndThreshold &&
         !isInScrollBottomArea.current
       ) {
         const rowScrollEndParam: GridRowScrollEndParams = {
@@ -55,7 +79,7 @@ export const useGridInfiniteLoader = (
         isInScrollBottomArea.current = true;
       }
     },
-    [apiRef, props.scrollEndThreshold, visibleColumns, containerSizes],
+    [containerSizes, contentHeight, props.scrollEndThreshold, visibleColumns, apiRef],
   );
 
   const handleGridScroll = React.useCallback(

--- a/packages/grid/x-grid/src/tests/events.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/events.DataGridPro.test.tsx
@@ -270,51 +270,42 @@ describe('<DataGridPro /> - Events Params', () => {
   });
 
   it('call onRowsScrollEnd when viewport scroll reaches the bottom', () => {
+    const baseRows = [
+      { id: 0, brand: 'Nike' },
+      { id: 1, brand: 'Adidas' },
+      { id: 2, brand: 'Puma' },
+      { id: 3, brand: 'Under Armor' },
+      { id: 4, brand: 'Jordan' },
+      { id: 5, brand: 'Reebok' },
+    ];
     const handleRowsScrollEnd = spy();
-    const data = {
-      rows: [
-        {
-          id: 0,
-          brand: 'Nike',
-        },
-        {
-          id: 1,
-          brand: 'Adidas',
-        },
-        {
-          id: 2,
-          brand: 'Puma',
-        },
-        {
-          id: 3,
-          brand: 'Under Armor',
-        },
-        {
-          id: 4,
-          brand: 'Jordan',
-        },
-        {
-          id: 5,
-          brand: 'Reebok',
-        },
-      ],
-      columns: [{ field: 'brand', width: 100 }],
+    const TestCase = ({ rows }) => {
+      return (
+        <div style={{ width: 300, height: 300 }}>
+          <DataGridPro
+            columns={[{ field: 'brand', width: 100 }]}
+            rows={rows}
+            onRowsScrollEnd={handleRowsScrollEnd}
+          />
+        </div>
+      );
     };
-
-    const { container } = render(
-      <div style={{ width: 300, height: 300 }}>
-        <DataGridPro
-          columns={data.columns}
-          rows={data.rows}
-          onRowsScrollEnd={handleRowsScrollEnd}
-        />
-      </div>,
-    );
+    const { container, setProps } = render(<TestCase rows={baseRows} />);
     const virtualScroller = container.querySelector('.MuiDataGrid-virtualScroller');
     // arbitrary number to make sure that the bottom of the grid window is reached.
     virtualScroller.scrollTop = 12345;
     virtualScroller.dispatchEvent(new Event('scroll'));
     expect(handleRowsScrollEnd.callCount).to.equal(1);
+    setProps({
+      rows: baseRows.concat(
+        { id: 6, brand: 'Gucci' },
+        { id: 7, brand: "Levi's" },
+        { id: 8, brand: 'Ray-Ban' },
+      ),
+    });
+    virtualScroller.scrollTop = 12345;
+    virtualScroller.dispatchEvent(new Event('scroll'));
+    expect(handleRowsScrollEnd.callCount).to.equal(2);
   });
 
   it('should publish GridEvents.unmount when unmounting the Grid', () => {


### PR DESCRIPTION
Preview: https://deploy-preview-2938--material-ui-x.netlify.app/components/data-grid/rows/#infinite-loading

On https://next--material-ui-x.netlify.app/components/data-grid/rows/#infinite-loading:

<img width="500" src="https://user-images.githubusercontent.com/42154031/138359855-aef88e54-4a34-4389-bcba-3d956a61472d.gif" alt="yQvTmjIk7t" style="max-width: 100%;">

The infinite loading stops at 40 rows. This happens because it was using `containerSizes.dataContainerSizes.height` which is not the same height used by the virtualization.