### PR TITLE
[docs] reorganize export docs to prepare excel export doc

### DIFF
--- a/docs/data/data-grid/export/RemovePrintExport.js
+++ b/docs/data/data-grid/export/RemovePrintExport.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { DataGrid, GridToolbarContainer, GridToolbarExport } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+function CustomToolbar() {
+  return (
+    <GridToolbarContainer>
+      <GridToolbarExport printOptions={{ disableToolbarButton: true }} />
+    </GridToolbarContainer>
+  );
+}
+export default function RemovePrintExport() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 4,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 300, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        components={{
+          Toolbar: CustomToolbar,
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/export/RemovePrintExport.tsx
+++ b/docs/data/data-grid/export/RemovePrintExport.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { DataGrid, GridToolbarContainer, GridToolbarExport } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+function CustomToolbar() {
+  return (
+    <GridToolbarContainer>
+      <GridToolbarExport printOptions={{ disableToolbarButton: true }} />
+    </GridToolbarContainer>
+  );
+}
+export default function RemovePrintExport() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 4,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 300, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        components={{
+          Toolbar: CustomToolbar,
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/export/RemovePrintExport.tsx.preview
+++ b/docs/data/data-grid/export/RemovePrintExport.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  {...data}
+  loading={loading}
+  components={{
+    Toolbar: CustomToolbar,
+  }}
+/>

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -92,14 +92,11 @@ There are a few ways to include or hide other columns. The exported columns are 
 
 ## Exported rows
 
-> ⚠️ This section only applies for the CSV and the Excel export.
+> ⚠️ This section only applies to the CSV and the Excel export.
 > The print export always prints rows in their current state.
-> 
-> By default, the grid exports the selected rows if an.
-> If not, it exports all rows (filtered and sorted rows, if any rules are active), including the collapsed ones.
-> It does concern, the CSV and the excel export.
-> By default, if some rows are selected, the `DataGrid` exports only those.
-> If there's no selection, it exports all rows (filtered and sorted rows, if any rules are active), including the collapsed ones.
+
+By default, the grid exports the selected rows if there are any.
+If not, it exports all rows (filtered and sorted rows, according to active rules), including the collapsed ones.
 
 Alternatively, you can set the `getRowsToExport` function and export any rows you want, as in the following example.
 The grid exports a few [selectors](/components/data-grid/state/#access-the-state) that can help you get the rows for the most common use-cases:

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -6,46 +6,79 @@ title: Data Grid - Export
 
 <p class="description">Easily export the rows in various file formats such as CSV, Excel, or PDF.</p>
 
-## CSV export
+## Enabling export
 
-The easiest way to enable the CSV export is to pass the `GridToolbar` component in the `Toolbar` [component slot](/components/data-grid/components/#toolbar).
+### Default Toolbar
+
+To enable the export menu, pass the `GridToolbar` component in the `Toolbar` [component slot](/components/data-grid/components/#toolbar).
 
 {{"demo": "ExportDefaultToolbar.js", "bg": "inline"}}
 
-### Custom toolbar
+### Custom Toolbar
 
-To enable the CSV export in a custom toolbar, use the `GridToolbarExport` component.
+The export menu is provided in a stand-alone component named `GridToolbarExport`. You can use it in a custom toolbar component as follow.
 
-{{"demo": "ExportCustomToolbar.js", "bg": "inline"}}
+```jsx
+function CustomToolbar() {
+  return (
+    <GridToolbarContainer>
+      <GridToolbarExport />
+    </GridToolbarContainer>
+  );
+}
+```
 
-### Custom exported content
+{{"demo": "ExportCustomToolbar.js", "bg": "inline", "defaultCodeOpen": false}}
 
-The csv export can be customized by passing a [`csvOptions`](/api/data-grid/grid-csv-export-options/) object either to the `GridToolbar` or to the `GridToolbarExport` as a prop.
+## Export options
 
-The following sections describes some customizations available on this interface.
+By default, the export menu displays all the available export formats, according to your license, which are
+
+- [Print](#print-export)
+- [CSV](#csv-export)
+- [Excel](#excel-export) [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/) (🚧 Not delivered yet)
+- [Clipboard](#clipboard) [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/) (🚧 Not delivered yet)
+
+You can customize their respective behavior by passing an options object either to the `GridToolbar` or to the `GridToolbarExport` as a prop.
 
 ```tsx
 <DataGrid componentsProps={{ toolbar: { csvOptions } }} />
-
 // same as
-
 <GridToolbarExport csvOptions={csvOptions} />
 ```
 
-#### Exported columns
+Each export option has its own API page:
 
-By default, the CSV will only contain the visible columns of the grid.
-There are a few ways to include or hide other columns:
+- [`csvOptions`](/api/data-grid/grid-csv-export-options/)
+- [`printOptions`](/api/data-grid/grid-print-export-options/)
 
-1. Set the exact columns to be exported in [`csvOptions`](/api/data-grid/grid-csv-export-options/).
+## Disabled format
+
+You can remove an export format from the toolbar by setting its option property `disableToolbarButton` to `true`.
+In the following example, the print export is disabled.
 
 ```jsx
 <DataGrid
-  componentsProps={{ toolbar: { csvOptions: { fields: ['id', 'name'] } } }}
+  componentsProps={{ toolbar: { printOptions: { disableToolbarButton: true } } }}
 />
 ```
 
-2. Set `allColumns` in [`csvOptions`](/api/data-grid/grid-csv-export-options/) to `true` to include hidden columns, instead of only the visible ones.
+{{"demo": "RemovePrintExport.js", "bg": "inline", "defaultCodeOpen": false}}
+
+## Exported columns
+
+By default, the export will only contain the visible columns of the grid.
+There are a few ways to include or hide other columns. The exported columns are chosen in the following order:
+
+1. Set the exact columns to be exported in the export option
+
+```jsx
+<DataGrid
+  componentsProps={{ toolbar: { csvOptions: { fields: ['name', 'brand'] } } }}
+/>
+```
+
+2. Set `allColumns` in export option to `true` to also include hidden columns.
 
 ```jsx
 <DataGrid componentsProps={{ toolbar: { csvOptions: { allColumns: true } } }} />
@@ -54,32 +87,35 @@ There are a few ways to include or hide other columns:
 3. Set the `disableExport` attribute to `true` in each `GridColDef`.
 
 ```jsx
-<DataGrid columns={[{ field: 'id', disableExport: true }, { field: 'brand' }]} />
+<DataGrid columns={[{ field: 'name', disableExport: true }, { field: 'brand' }]} />
 ```
 
-#### Exported rows
+## Exported rows
 
-By default, if some rows are selected, the `DataGrid` exports only those.
-If there's no selection, it exports all rows (filtered and sorted rows, if any rules are active), including the collapsed ones.
+> ⚠️ This section does not concern the print export, which prints rows in their current state.
+> It does concern, the CSV and the excel export.
+> By default, if some rows are selected, the `DataGrid` exports only those.
+> If there's no selection, it exports all rows (filtered and sorted rows, if any rules are active), including the collapsed ones.
 
 Alternatively, you can set the `getRowsToExport` function and export any rows you want, as in the following example.
-The grid exports a few selectors that can help you get the rows for the most common use-cases:
+The grid exports a few [selectors](/components/data-grid/state/#access-the-state) that can help you get the rows for the most common use-cases:
 
 | Selector                                       | Behavior                                                                                                                                                                                                                   |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `gridRowIdsSelector`                           | The rows in their original order.                                                                                                                                                                                          |
 | `gridSortedRowIdsSelector`                     | The rows after applying the sorting rules.                                                                                                                                                                                 |
-| `gridFilteredSortedRowIdsSelector`             | The rows after applying the sorting rules and the filtering rules.                                                                                                                                                         |
-| `gridVisibleSortedRowIdsSelector`              | The rows after applying the sorting rules, the filtering rules and without the collapsed rows.                                                                                                                             |
+| `gridFilteredSortedRowIdsSelector`             | The rows after applying the sorting rules, and the filtering rules.                                                                                                                                                        |
+| `gridVisibleSortedRowIdsSelector`              | The rows after applying the sorting rules, the filtering rules, and without the collapsed rows.                                                                                                                            |
 | `gridPaginatedVisibleSortedGridRowIdsSelector` | The rows after applying the sorting rules, the filtering rules, without the collapsed rows and only for the current page (**Note**: If the pagination is disabled, it will still take the value of `page` and `pageSize`). |
 
 {{"demo": "CsvGetRowsToExport.js", "bg": "inline", "defaultCodeOpen": false}}
-
 When using [Row grouping](/components/data-grid/group-pivot/#row-grouping), it can be useful to remove the groups from the CSV export
 
 {{"demo": "CsvGetRowsToExportRowGrouping.js", "bg": "inline", "defaultCodeOpen": false}}
 
-#### Exported cells
+## CSV export
+
+### Exported cells
 
 When the value of a field is an object or a `renderCell` is provided, the CSV export might not display the value correctly.
 You can provide a [`valueFormatter`](/components/data-grid/columns/#value-formatter) with a string representation to be used.
@@ -96,125 +132,67 @@ You can provide a [`valueFormatter`](/components/data-grid/columns/#value-format
 />
 ```
 
-### Remove the export button
+### File encoding
 
-You can remove the CSV export option from the toolbar by setting `disableToolbarButton` option to `true`.
+You can use `csvOptions` to specify the format of the export, such as the `delimiter` character used to separate fields, the `fileName`, or `utf8WithBom` to prefix the exported file with UTF-8 Byte Order Mark (BOM).
+For more details on these options, please visit the [`csvOptions` api page](/api/data-grid/grid-csv-export-options/).
 
 ```jsx
-<DataGrid
-  componentsProps={{ toolbar: { csvOptions: { disableToolbarButton: true } } }}
+<GridToolbarExport
+  csvOptions={{
+    fileName: 'customerDataBase',
+    delimiter: ';',
+    utf8WithBom: true,
+  }}
 />
 ```
-
-### apiRef [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
-
-> ⚠️ Only use this API as the last option. Give preference to the props to control the grid.
-
-{{"demo": "CsvExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## Print export
 
-The DataGrid provides the ability to optimize the layout of the grid for print mode. It can also be used to export to PDF.
+### Customize grid display
 
-The easiest way to enable the Print export is to pass the `GridToolbar` component in the `Toolbar` [component slot](/components/data-grid/components/#toolbar).
-
-{{"demo": "ExportDefaultToolbar.js", "bg": "inline"}}
-
-### Custom toolbar
-
-To enable the Print export in a custom toolbar, use the `GridToolbarExport` component.
-
-{{"demo": "ExportCustomToolbar.js", "bg": "inline"}}
-
-### Custom exported content
-
-The print export can be customized by passing a [`printOptions`](/api/data-grid/grid-print-export-options/) object either to the `GridToolbar` or to the `GridToolbarExport` as a prop.
-
-The following sections describes some customizations available on this interface.
-
-```tsx
-<DataGrid componentsProps={{ toolbar: { printOptions }}} />
-
-// same as
-
-<GridToolbarExport printOptions={printOptions} />
-```
-
-#### Exported columns
-
-By default, the Print will only contain the visible columns of the grid.
-There are a few ways to include or hide other columns:
-
-1. Set the exact columns to be exported in [`printOptions`](/api/data-grid/grid-print-export-options/).
+By default, the print export display all the DataGrid. It is possible to remove the footer and the toolbar by setting respectively `hideFooter` and `hideToolbar` to `true`.
 
 ```jsx
-<DataGrid
-  componentsProps={{ toolbar: { printOptions: { fields: ['id', 'name'] } } }}
+<GridToolbarExport
+  printOptions={{
+    hideFooter: true,
+    hideToolbar: true,
+  }}
 />
 ```
 
-2. Set `allColumns` in [`printOptions`](/api/data-grid/grid-print-export-options/) to `true` to include hidden columns, instead of only the visible ones.
-
-```jsx
-<DataGrid componentsProps={{ toolbar: { printOptions: { allColumns: true } } }} />
-```
-
-3. Set the `disableExport` attribute to true in each `GridColDef`.
-
-```jsx
-<DataGrid columns={[{ field: 'id', disableExport: true }, { field: 'brand' }]} />
-```
-
-#### Exported cells
-
-When the value of a field is an object or a `renderCell` is provided, the Print export might not display the value correctly.
-You can provide a [`valueFormatter`](/components/data-grid/columns/#value-formatter) with a string representation to be used.
-
-```jsx
-<DataGrid
-  columns={[
-    {
-      field: 'progress',
-      valueFormatter: ({ value }) => `${value * 100}%`,
-      renderCell: ({ value }) => <ProgressBar value={value} />,
-    },
-  ]}
-/>
-```
-
-### Remove the export button
-
-You can remove the Print export option from the toolbar by setting `disableToolbarButton` option to `true`.
-
-```jsx
-<DataGrid
-  componentsProps={{ toolbar: { printOptions: { disableToolbarButton: true } } }}
-/>
-```
-
-### apiRef [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
-
-> ⚠️ Only use this API as the last option. Give preference to the props to control the grid.
-
-{{"demo": "PrintExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
+For more option to customize the print export, please visit the [`printOptions` api page](/api/data-grid/grid-print-export-options/).
 
 ## 🚧 Excel export [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/)
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
-> 👍 Upvote [issue #198](https://github.com/mui/mui-x/issues/198) if you want to see it land faster.
-
-You will be able to export the displayed data to Excel with an API call, or using the grid UI.
+> 👍 Upvote [issue #198](https://github.com/mui-org/material-ui-x/issues/198) if you want to see it land faster.
+> You will be able to export the displayed data to Excel with an API call, or using the grid UI.
 
 ## 🚧 Clipboard [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/)
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
-> 👍 Upvote [issue #199](https://github.com/mui/mui-x/issues/199) if you want to see it land faster.
+> 👍 Upvote [issue #199](https://github.com/mui-org/material-ui-x/issues/199) if you want to see it land faster.
+> You will be able to copy and paste items to and from the grid using the system clipboard.
 
-You will be able to copy and paste items to and from the grid using the system clipboard.
+## apiRef [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
+
+> ⚠️ Only use this API as the last option. Give preference to the props to control the grid.
+
+### CSV
+
+{{"demo": "CsvExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
+
+### Print
+
+{{"demo": "PrintExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## API
 
+- [csvOptions](/api/data-grid/grid-csv-export-options/)
+- [printOptions](/api/data-grid/grid-print-export-options/)
 - [DataGrid](/api/data-grid/data-grid/)
 - [DataGridPro](/api/data-grid/data-grid-pro/)

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -68,9 +68,9 @@ In the following example, the print export is disabled.
 ## Exported columns
 
 By default, the export will only contain the visible columns of the grid.
-There are a few ways to include or hide other columns. The exported columns are chosen in the following order:
+There are a few ways to include or hide other columns.
 
-1. Set the exact columns to be exported in the export option
+- Set the exact columns to be exported in the export option
 
 ```jsx
 <DataGrid
@@ -78,13 +78,13 @@ There are a few ways to include or hide other columns. The exported columns are 
 />
 ```
 
-2. Set `allColumns` in export option to `true` to also include hidden columns.
+- Set `allColumns` in export option to `true` to also include hidden columns.
 
 ```jsx
 <DataGrid componentsProps={{ toolbar: { csvOptions: { allColumns: true } } }} />
 ```
 
-3. Set the `disableExport` attribute to `true` in each `GridColDef`.
+- Set the `disableExport` attribute to `true` in each `GridColDef`.
 
 ```jsx
 <DataGrid columns={[{ field: 'name', disableExport: true }, { field: 'brand' }]} />

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -92,7 +92,11 @@ There are a few ways to include or hide other columns. The exported columns are 
 
 ## Exported rows
 
-> ⚠️ This section does not concern the print export, which prints rows in their current state.
+> ⚠️ This section only applies for the CSV and the Excel export.
+> The print export always prints rows in their current state.
+> 
+> By default, the grid exports the selected rows if an.
+> If not, it exports all rows (filtered and sorted rows, if any rules are active), including the collapsed ones.
 > It does concern, the CSV and the excel export.
 > By default, if some rows are selected, the `DataGrid` exports only those.
 > If there's no selection, it exports all rows (filtered and sorted rows, if any rules are active), including the collapsed ones.


### PR DESCRIPTION
Fix #3756

[preview](https://deploy-preview-3822--material-ui-x.netlify.app/components/data-grid/export/)

I propose the following structure, starting from common properties to export format-specific ones

### The common properties to all export format
- Enabling export
  - Default Toolbar
  - Custom Toolbar
- Customize export selector
  - Remove an export option
- Exported columns
### The common properties to csv and excel
- Exported rows
### CSV specific
- CSV export
  - Exported cells
  - File encoding
### Print specific
- Print export
  - Customize grid display
- apiRef
  - CSV
  - Print
- Excel export
- Clipboard
- API