### PR TITLE
[DataGrid] Do not restore the focus to the trigger element of the `GridPanel` when unmounting it

### DIFF
--- a/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
@@ -43,7 +43,7 @@ export function GridPanelWrapper(
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <TrapFocus open disableEnforceFocus isEnabled={isEnabled}>
+    <TrapFocus open disableEnforceFocus disableRestoreFocus isEnabled={isEnabled}>
       <GridPanelWrapperRoot tabIndex={-1} className={clsx(className, classes.root)} {...other} />
     </TrapFocus>
   );


### PR DESCRIPTION
FIx #3830

Preview: https://codesandbox.io/s/datagridpro-v5-quick-start-forked-l3y8h

As the panel does not block the scroll, it is unsafe to restore the previous focus when unmounting it since it can be totally outside the viewport.