### PR TITLE
[DataGrid] Allow to translate `checkboxSelection` labels

### DIFF
--- a/packages/grid/_modules_/grid/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -25,7 +25,21 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 
 const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellParams>(
   function GridCellCheckboxRenderer(props, ref) {
-    const { field, id, value, tabIndex, hasFocus } = props;
+    const {
+      field,
+      id,
+      value: isChecked,
+      formattedValue,
+      row,
+      rowNode,
+      colDef,
+      isEditable,
+      cellMode,
+      hasFocus,
+      tabIndex,
+      getValue,
+      ...other
+    } = props;
     const apiRef = useGridApiContext();
     const rootProps = useGridRootProps();
     const ownerState = { classes: rootProps.classes };
@@ -68,18 +82,23 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellPa
     const isSelectable =
       !rootProps.isRowSelectable || rootProps.isRowSelectable(apiRef.current.getRowParams(id));
 
+    const label = apiRef.current.getLocaleText(
+      isChecked ? 'checkboxSelectionUnselectRow' : 'checkboxSelectionSelectRow',
+    );
+
     return (
       <rootProps.components.BaseCheckbox
         ref={handleRef}
         tabIndex={tabIndex}
-        checked={!!value}
+        checked={isChecked}
         onChange={handleChange}
         className={classes.root}
         color="primary"
-        inputProps={{ 'aria-label': 'Select Row checkbox' }}
+        inputProps={{ 'aria-label': label }}
         onKeyDown={handleKeyDown}
         disabled={!isSelectable}
         {...rootProps.componentsProps?.baseCheckbox}
+        {...other}
       />
     );
   },

--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -29,6 +29,7 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 
 const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderParams>(
   function GridHeaderCheckbox(props, ref) {
+    const { field, colDef, ...other } = props;
     const [, forceUpdate] = React.useState(false);
     const apiRef = useGridApiContext();
     const rootProps = useGridRootProps();
@@ -128,6 +129,10 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
       return apiRef.current.subscribeEvent(GridEvents.selectionChange, handleSelectionChange);
     }, [apiRef, handleSelectionChange]);
 
+    const label = apiRef.current.getLocaleText(
+      isChecked ? 'checkboxSelectionUnselectAllRows' : 'checkboxSelectionSelectAllRows',
+    );
+
     return (
       <rootProps.components.BaseCheckbox
         ref={ref}
@@ -136,10 +141,11 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
         onChange={handleChange}
         className={classes.root}
         color="primary"
-        inputProps={{ 'aria-label': 'Select All Rows checkbox' }}
+        inputProps={{ 'aria-label': label }}
         tabIndex={tabIndex}
         onKeyDown={handleKeyDown}
         {...rootProps.componentsProps?.baseCheckbox}
+        {...other}
       />
     );
   },

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -98,6 +98,10 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Checkbox selection',
+  checkboxSelectionSelectAllRows: 'Select all rows',
+  checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  checkboxSelectionSelectRow: 'Select row',
+  checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/arSD.ts
+++ b/packages/grid/_modules_/grid/locales/arSD.ts
@@ -98,6 +98,10 @@ const arSDGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'تحديد',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'صحيح',

--- a/packages/grid/_modules_/grid/locales/bgBG.ts
+++ b/packages/grid/_modules_/grid/locales/bgBG.ts
@@ -97,6 +97,10 @@ const bgBGGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   // checkboxSelectionHeaderName: 'Checkbox selection',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   // booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/csCZ.ts
+++ b/packages/grid/_modules_/grid/locales/csCZ.ts
@@ -132,6 +132,10 @@ const csCZGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Výběr řádku',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'ano',

--- a/packages/grid/_modules_/grid/locales/daDK.ts
+++ b/packages/grid/_modules_/grid/locales/daDK.ts
@@ -100,6 +100,10 @@ const daDKGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Afkrydsningsvalg',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   // booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/deDE.ts
+++ b/packages/grid/_modules_/grid/locales/deDE.ts
@@ -100,6 +100,10 @@ const deDEGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Checkbox Auswahl',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'Ja',

--- a/packages/grid/_modules_/grid/locales/elGR.ts
+++ b/packages/grid/_modules_/grid/locales/elGR.ts
@@ -99,6 +99,10 @@ const elGRGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   // checkboxSelectionHeaderName: 'Checkbox selection',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   // booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/esES.ts
+++ b/packages/grid/_modules_/grid/locales/esES.ts
@@ -100,6 +100,10 @@ const esESGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   // checkboxSelectionHeaderName: 'Checkbox selection',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   // booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/faIR.ts
+++ b/packages/grid/_modules_/grid/locales/faIR.ts
@@ -100,6 +100,10 @@ const faIRGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'انتخاب چک‌باکس',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'صحیح',

--- a/packages/grid/_modules_/grid/locales/fiFI.ts
+++ b/packages/grid/_modules_/grid/locales/fiFI.ts
@@ -100,6 +100,10 @@ const fiFIGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Valintaruutu',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'tosi',

--- a/packages/grid/_modules_/grid/locales/frFR.ts
+++ b/packages/grid/_modules_/grid/locales/frFR.ts
@@ -100,6 +100,10 @@ const frFRGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Sélection',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'vrai',

--- a/packages/grid/_modules_/grid/locales/heIL.ts
+++ b/packages/grid/_modules_/grid/locales/heIL.ts
@@ -98,6 +98,10 @@ const heILGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'בחירה',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'כן',

--- a/packages/grid/_modules_/grid/locales/itIT.ts
+++ b/packages/grid/_modules_/grid/locales/itIT.ts
@@ -100,6 +100,10 @@ const itITGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Seleziona',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'vero',

--- a/packages/grid/_modules_/grid/locales/jaJP.ts
+++ b/packages/grid/_modules_/grid/locales/jaJP.ts
@@ -95,6 +95,10 @@ const jaJPGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'チェックボックス',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: '真',

--- a/packages/grid/_modules_/grid/locales/koKR.ts
+++ b/packages/grid/_modules_/grid/locales/koKR.ts
@@ -95,6 +95,10 @@ const koKRGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: '선택',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: '참',

--- a/packages/grid/_modules_/grid/locales/nlNL.ts
+++ b/packages/grid/_modules_/grid/locales/nlNL.ts
@@ -100,6 +100,10 @@ const nlNLGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Checkbox selectie',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'waar',

--- a/packages/grid/_modules_/grid/locales/plPL.ts
+++ b/packages/grid/_modules_/grid/locales/plPL.ts
@@ -95,6 +95,10 @@ const plPLGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   // checkboxSelectionHeaderName: 'Checkbox selection',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   // booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/ptBR.ts
+++ b/packages/grid/_modules_/grid/locales/ptBR.ts
@@ -100,6 +100,10 @@ const ptBRGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Seleção',
+  checkboxSelectionSelectAllRows: 'Selecionar todas linhas',
+  checkboxSelectionUnselectAllRows: 'Deselecionar todas linhas',
+  checkboxSelectionSelectRow: 'Selecionar linha',
+  checkboxSelectionUnselectRow: 'Deselecionar linha',
 
   // Boolean cell text
   booleanCellTrueLabel: 'sim',

--- a/packages/grid/_modules_/grid/locales/ruRU.ts
+++ b/packages/grid/_modules_/grid/locales/ruRU.ts
@@ -128,6 +128,10 @@ const ruRUGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Выбор флажка',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'истина',

--- a/packages/grid/_modules_/grid/locales/skSK.ts
+++ b/packages/grid/_modules_/grid/locales/skSK.ts
@@ -132,6 +132,10 @@ const skSKGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Výber riadku',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'áno',

--- a/packages/grid/_modules_/grid/locales/trTR.ts
+++ b/packages/grid/_modules_/grid/locales/trTR.ts
@@ -95,6 +95,10 @@ const trTRGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Seçim',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   // booleanCellTrueLabel: 'true',

--- a/packages/grid/_modules_/grid/locales/ukUA.ts
+++ b/packages/grid/_modules_/grid/locales/ukUA.ts
@@ -129,6 +129,10 @@ const ukUAGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Вибір прапорця',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'так',

--- a/packages/grid/_modules_/grid/locales/viVN.ts
+++ b/packages/grid/_modules_/grid/locales/viVN.ts
@@ -98,6 +98,10 @@ const viVNGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Tích vào ô trống',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: 'Có',

--- a/packages/grid/_modules_/grid/locales/zhCN.ts
+++ b/packages/grid/_modules_/grid/locales/zhCN.ts
@@ -96,6 +96,10 @@ const zhCNGrid: Partial<GridLocaleText> = {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: '多选框',
+  // checkboxSelectionSelectAllRows: 'Select all rows',
+  // checkboxSelectionUnselectAllRows: 'Unselect all rows',
+  // checkboxSelectionSelectRow: 'Select row',
+  // checkboxSelectionUnselectRow: 'Unselect row',
 
   // Boolean cell text
   booleanCellTrueLabel: '真',

--- a/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
@@ -95,6 +95,10 @@ export interface GridLocaleText {
 
   // Checkbox selection text
   checkboxSelectionHeaderName: string;
+  checkboxSelectionSelectAllRows: string;
+  checkboxSelectionUnselectAllRows: string;
+  checkboxSelectionSelectRow: string;
+  checkboxSelectionUnselectRow: string;
 
   // Boolean cell text
   booleanCellTrueLabel: string;

--- a/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
@@ -55,7 +55,7 @@ describe('<DataGridPro /> - Selection', () => {
         />,
       );
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
       expect(apiRef.current.getSelectedRows()).to.have.length(4);
@@ -75,7 +75,7 @@ describe('<DataGridPro /> - Selection', () => {
       expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
       expect(apiRef.current.getSelectedRows()).to.have.length(0);
@@ -94,7 +94,7 @@ describe('<DataGridPro /> - Selection', () => {
       );
 
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
       expect(apiRef.current.getSelectedRows()).to.have.length(rowLength);
@@ -113,7 +113,7 @@ describe('<DataGridPro /> - Selection', () => {
       );
 
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
 
       fireEvent.click(getCell(0, 0).querySelector('input'));
@@ -148,7 +148,7 @@ describe('<DataGridPro /> - Selection', () => {
       expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
       expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2, 3]);
@@ -171,7 +171,7 @@ describe('<DataGridPro /> - Selection', () => {
       fireEvent.click(getCell(2, 0).querySelector('input'));
       expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2]);
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
       expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
@@ -193,7 +193,7 @@ describe('<DataGridPro /> - Selection', () => {
       fireEvent.click(getCell(1, 0));
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       const selectAllCheckbox = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       expect(selectAllCheckbox).to.have.attr('data-indeterminate', 'false');
     });
@@ -375,7 +375,7 @@ describe('<DataGridPro /> - Selection', () => {
   it('should select only filtered rows after filter is applied', () => {
     render(<TestDataGridSelection checkboxSelection />);
     const selectAll = screen.getByRole('checkbox', {
-      name: /select all rows checkbox/i,
+      name: /select all rows/i,
     });
     apiRef.current.setFilterModel({
       items: [

--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -232,7 +232,7 @@ describe('<DataGrid /> - Selection', () => {
     it('should check the checkbox when there is no rows', () => {
       render(<TestDataGridSelection rows={[]} checkboxSelection />);
       const selectAll = screen.getByRole('checkbox', {
-        name: /select all rows checkbox/i,
+        name: /select all rows/i,
       });
       expect(selectAll).to.have.property('checked', false);
     });
@@ -306,6 +306,24 @@ describe('<DataGrid /> - Selection', () => {
       setProps({ checkboxSelection: false });
       expect(getSelectedRowIds()).to.deep.equal([2]);
       expect(screen.getByText('1 row selected')).not.to.equal(null);
+    });
+
+    it('should set the correct aria-label on the column header checkbox', () => {
+      render(<TestDataGridSelection checkboxSelection />);
+      expect(screen.queryByRole('checkbox', { name: 'Unselect all rows' })).to.equal(null);
+      expect(screen.queryByRole('checkbox', { name: 'Select all rows' })).not.to.equal(null);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select all rows' }));
+      expect(screen.queryByRole('checkbox', { name: 'Select all rows' })).to.equal(null);
+      expect(screen.queryByRole('checkbox', { name: 'Unselect all rows' })).not.to.equal(null);
+    });
+
+    it('should set the correct aria-label on the cell checkbox', () => {
+      render(<TestDataGridSelection checkboxSelection rows={[{ id: 0, name: 'React' }]} />);
+      expect(screen.queryByRole('checkbox', { name: 'Unselect row' })).to.equal(null);
+      expect(screen.queryByRole('checkbox', { name: 'Select row' })).not.to.equal(null);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select row' }));
+      expect(screen.queryByRole('checkbox', { name: 'Select row' })).to.equal(null);
+      expect(screen.queryByRole('checkbox', { name: 'Unselect row' })).not.to.equal(null);
     });
   });
 
@@ -382,7 +400,7 @@ describe('<DataGrid /> - Selection', () => {
       }
       const data = getData(20, 1);
       render(<TestDataGridSelection {...data} rowHeight={50} checkboxSelection hideFooter />);
-      const checkboxes = screen.queryAllByRole('checkbox', { name: /select row checkbox/i });
+      const checkboxes = screen.queryAllByRole('checkbox', { name: /select row/i });
       checkboxes[0].focus();
       fireEvent.keyDown(checkboxes[0], { key: 'ArrowDown' });
       fireEvent.keyDown(checkboxes[1], { key: 'ArrowDown' });
@@ -395,14 +413,13 @@ describe('<DataGrid /> - Selection', () => {
 
     it('should set tabindex=0 on the checkbox when the it receives focus', () => {
       render(<TestDataGridSelection checkboxSelection />);
-      const checkbox = screen.getAllByRole('checkbox', { name: /select row checkbox/i })[0];
+      const checkbox = screen.getAllByRole('checkbox', { name: /select row/i })[0];
       const checkboxCell = getCell(0, 0);
       const secondCell = getCell(0, 1);
       expect(checkbox).to.have.attribute('tabindex', '-1');
       expect(checkboxCell).to.have.attribute('tabindex', '-1');
       expect(secondCell).to.have.attribute('tabindex', '-1');
 
-      secondCell.focus();
       fireEvent.mouseUp(secondCell);
       fireEvent.click(secondCell);
       expect(secondCell).to.have.attribute('tabindex', '0');

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -99,7 +99,7 @@ async function testSelect100kRows(page) {
   await page.goto(baseUrl);
 
   const t0 = await page.evaluate(() => performance.now());
-  await page.click('[aria-label="Select All Rows checkbox"]');
+  await page.click('[aria-label="Select all rows"]');
   const t1 = await page.evaluate(() => performance.now());
   return t1 - t0;
 }
@@ -108,9 +108,9 @@ async function testDeselect100kRows(page) {
   const baseUrl = `http://localhost:${PORT}/performance/DataGrid/SelectRows100000`;
   await page.goto(baseUrl);
 
-  await page.click('[aria-label="Select All Rows checkbox"]');
+  await page.click('[aria-label="Select all rows"]');
   const t0 = await page.evaluate(() => performance.now());
-  await page.click('[aria-label="Select All Rows checkbox"]');
+  await page.click('[aria-label="Unselect all rows"]');
   const t1 = await page.evaluate(() => performance.now());
   return t1 - t0;
 }


### PR DESCRIPTION
Closes #1457 

See https://github.com/mui-org/material-ui-x/issues/1457#issuecomment-826102508

CodeSandbox without having to wrap `Tooltip` in a div: https://codesandbox.io/s/material-demo-forked-xpydy?file=/demo.tsx