### PR TITLE
[core] Add hook `useGridPagination` to call `onGridPage` and `onGridPageSize`

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/pagination/useGridPagination.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/useGridPagination.ts
@@ -1,0 +1,25 @@
+import { useGridPageSize } from './useGridPageSize';
+import { GridApiRef } from '../../../models/api/gridApiRef';
+import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
+import { useGridPage } from './useGridPage';
+
+/**
+ * @requires useGridFilter (state)
+ * @requires useGridDimensions (event) - can be after
+ */
+export const useGridPagination = (
+  apiRef: GridApiRef,
+  props: Pick<
+    DataGridProcessedProps,
+    | 'page'
+    | 'pageSize'
+    | 'onPageChange'
+    | 'onPageSizeChange'
+    | 'autoPageSize'
+    | 'rowCount'
+    | 'initialState'
+  >,
+) => {
+  useGridPageSize(apiRef, props);
+  useGridPage(apiRef, props);
+};

--- a/packages/grid/x-data-grid-pro/src/useDataGridProComponent.tsx
+++ b/packages/grid/x-data-grid-pro/src/useDataGridProComponent.tsx
@@ -16,8 +16,7 @@ import { useGridFocus } from '../../_modules_/grid/hooks/features/focus/useGridF
 import { useGridInfiniteLoader } from '../../_modules_/grid/hooks/features/infiniteLoader/useGridInfiniteLoader';
 import { useGridKeyboard } from '../../_modules_/grid/hooks/features/keyboard/useGridKeyboard';
 import { useGridKeyboardNavigation } from '../../_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation';
-import { useGridPageSize } from '../../_modules_/grid/hooks/features/pagination/useGridPageSize';
-import { useGridPage } from '../../_modules_/grid/hooks/features/pagination/useGridPage';
+import { useGridPagination } from '../../_modules_/grid/hooks/features/pagination/useGridPagination';
 import { useGridPreferencesPanel } from '../../_modules_/grid/hooks/features/preferencesPanel/useGridPreferencesPanel';
 import { useGridEditing } from '../../_modules_/grid/hooks/features/editRows/useGridEditing';
 import { useGridRows } from '../../_modules_/grid/hooks/features/rows/useGridRows';
@@ -57,8 +56,7 @@ export const useDataGridProComponent = (
   useGridDensity(apiRef, props);
   useGridColumnReorder(apiRef, props);
   useGridColumnResize(apiRef, props);
-  useGridPageSize(apiRef, props);
-  useGridPage(apiRef, props);
+  useGridPagination(apiRef, props);
   useGridRowsMeta(apiRef, props);
   useGridScroll(apiRef, props);
   useGridInfiniteLoader(apiRef, props);

--- a/packages/grid/x-data-grid/src/useDataGridComponent.tsx
+++ b/packages/grid/x-data-grid/src/useDataGridComponent.tsx
@@ -12,8 +12,7 @@ import { useGridFilter } from '../../_modules_/grid/hooks/features/filter/useGri
 import { useGridFocus } from '../../_modules_/grid/hooks/features/focus/useGridFocus';
 import { useGridKeyboard } from '../../_modules_/grid/hooks/features/keyboard/useGridKeyboard';
 import { useGridKeyboardNavigation } from '../../_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation';
-import { useGridPageSize } from '../../_modules_/grid/hooks/features/pagination/useGridPageSize';
-import { useGridPage } from '../../_modules_/grid/hooks/features/pagination/useGridPage';
+import { useGridPagination } from '../../_modules_/grid/hooks/features/pagination/useGridPagination';
 import { useGridPreferencesPanel } from '../../_modules_/grid/hooks/features/preferencesPanel/useGridPreferencesPanel';
 import { useGridEditing } from '../../_modules_/grid/hooks/features/editRows/useGridEditing';
 import { useGridRows } from '../../_modules_/grid/hooks/features/rows/useGridRows';
@@ -38,8 +37,7 @@ export const useDataGridComponent = (props: DataGridProcessedProps) => {
   useGridSorting(apiRef, props);
   useGridPreferencesPanel(apiRef, props);
   useGridFilter(apiRef, props);
-  useGridPageSize(apiRef, props);
-  useGridPage(apiRef, props);
+  useGridPagination(apiRef, props);
   useGridRowsMeta(apiRef, props);
   useGridScroll(apiRef, props);
   useGridColumnMenu(apiRef);


### PR DESCRIPTION
That way the split between `useGridPage` and `useGridPageSize` only occurs inside `hooks/features/pagination`
And outside of this folder we have 1 substate = 1 feature hook