### PR TITLE
[docs] Use Grammarly to fix some typo

### DIFF
--- a/docs/data/data-grid/columns/columns.md
+++ b/docs/data/data-grid/columns/columns.md
@@ -125,7 +125,7 @@ The value generated is used for filtering, sorting, rendering, etc. unless overr
 ### Value setter
 
 The value setter is to be used when editing rows and it is the counterpart of the value getter.
-It allows customizing how the entered value is stored in the row.
+This enables you to customize how the entered value is stored in the row.
 A common use case for it is when the data is a nested structure.
 Refer to the [cell editing](/components/data-grid/editing/#saving-nested-structures) documentation to see an example using it.
 
@@ -157,7 +157,7 @@ In the following demo, a formatter is used to display the tax rate's decimal val
 {{"demo": "ValueFormatterGrid.js", "bg": "inline"}}
 
 The value generated is only used for rendering purposes.
-Filtering and sorting will not rely on the formatted value.
+Filtering and sorting do not rely on the formatted value.
 Use the [`valueParser`](/components/data-grid/columns/#value-parser) to support filtering.
 
 ### Value parser
@@ -441,7 +441,7 @@ In addition, column reordering emits the following events that can be imported:
 
 ## Column pinning [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
 
-Pinned (or frozen, locked, or sticky) columns are columns that are visible all the time while the user scrolls the grid horizontally.
+Pinned (or frozen, locked, or sticky) columns are columns that are visible at all time while the user scrolls the grid horizontally.
 They can be pinned either to the left or right side and cannot be reordered.
 
 To pin a column, there are a few ways:
@@ -475,7 +475,7 @@ The following demos illustrates how this approach works:
 
 ### Controlling the pinned columns
 
-While the `initialState` prop only works for setting pinned columns during the initialization, the `pinnedColumns` prop allows modifying at any time which columns to pin.
+While the `initialState` prop only works for setting pinned columns during the initialization, the `pinnedColumns` prop allows you to modify which columns are pinned at any time.
 The value passed to it follows the same shape from the previous approach.
 Use it together with `onPinnedColumnsChange` to know when a column is pinned or unpinned.
 
@@ -524,7 +524,7 @@ Grouping columns allows you to have multiple levels of columns in your header an
 > 👍 Upvote [issue #192](https://github.com/mui/mui-x/issues/192) if you want to see it land faster.
 
 Each cell takes up the width of one column.
-Column spanning allows modifying this default behavior.
+You can modify this default behavior with column spanning.
 It allows cells to span multiple columns.
 This is very close to the "column spanning" in an HTML `<table>`.
 

--- a/docs/data/data-grid/columns/columns.md
+++ b/docs/data/data-grid/columns/columns.md
@@ -60,12 +60,12 @@ To change the minimum width of a column, use the `minWidth` property available i
 
 ### Fluid width
 
-Column fluidity or responsiveness can be by achieved by setting the `flex` property in `GridColDef`.
+Column fluidity or responsiveness can be achieved by setting the `flex` property in `GridColDef`.
 
 The `flex` property accepts a value between 0 and ∞.
 It works by dividing the remaining space in the grid among all flex columns in proportion to their `flex` value.
 
-For example, consider a grid with a total width of 500px that has three columns: the first with `width: 200`; the second with `flex: 1`; and third with `flex: 0.5`.
+For example, consider a grid with a total width of 500px that has three columns: the first with `width: 200`; the second with `flex: 1`; and the third with `flex: 0.5`.
 The first column will be 200px wide, leaving 300px remaining. The column with `flex: 1` is twice the size of `flex: 0.5`, which means that final sizes will be: 200px, 200px, 100px.
 
 To set a minimum and maximum width for a `flex` column set the `minWidth` and the `maxWidth` property in `GridColDef`.
@@ -125,7 +125,7 @@ The value generated is used for filtering, sorting, rendering, etc. unless overr
 ### Value setter
 
 The value setter is to be used when editing rows and it is the counterpart of the value getter.
-It allows to customize how the entered value is stored in the row.
+It allows customizing how the entered value is stored in the row.
 A common use case for it is when the data is a nested structure.
 Refer to the [cell editing](/components/data-grid/editing/#saving-nested-structures) documentation to see an example using it.
 
@@ -157,7 +157,7 @@ In the following demo, a formatter is used to display the tax rate's decimal val
 {{"demo": "ValueFormatterGrid.js", "bg": "inline"}}
 
 The value generated is only used for rendering purposes.
-Filtering and sorting will not relay on the formatted value.
+Filtering and sorting will not rely on the formatted value.
 Use the [`valueParser`](/components/data-grid/columns/#value-parser) to support filtering.
 
 ### Value parser
@@ -172,7 +172,7 @@ In the following demo, the tax rate is displayed as a percentage (e.g. 20%) but 
 
 ### Render cell
 
-By default, the grid render the value as a string in the cell.
+By default, the grid renders the value as a string in the cell.
 It resolves the rendered output in the following order:
 
 1. `renderCell() => ReactElement`
@@ -261,7 +261,7 @@ You can check the [styling cells](/components/data-grid/style/#styling-cells) se
 
 ## Column types
 
-To facilitate configuration of the columns, some column types are predefined.
+To facilitate the configuration of the columns, some column types are predefined.
 By default, columns are assumed to hold strings, so the default column string type will be applied. As a result, column sorting will use the string comparator, and the column content will be aligned to the left side of the cell.
 
 The following are the native column types:
@@ -372,7 +372,7 @@ You can use the `onColumnVisibilityModelChange` prop to listen to the changes to
 
 > ⚠️The grid does not handle switching between controlled and uncontrolled modes.
 >
-> This edge case will be supported in v6 after the removal of legacy `hide` field.
+> This edge case will be supported in v6 after the removal of the legacy `hide` field.
 
 {{"demo": "VisibleColumnsModelControlled.js", "bg": "inline"}}
 
@@ -441,7 +441,7 @@ In addition, column reordering emits the following events that can be imported:
 
 ## Column pinning [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
 
-Pinned (or frozen, locked, or sticky) columns are columns that are visible at all of the time while the user scrolls the grid horizontally.
+Pinned (or frozen, locked, or sticky) columns are columns that are visible all the time while the user scrolls the grid horizontally.
 They can be pinned either to the left or right side and cannot be reordered.
 
 To pin a column, there are a few ways:
@@ -475,7 +475,7 @@ The following demos illustrates how this approach works:
 
 ### Controlling the pinned columns
 
-While the `initialState` prop only works for setting pinned columns during the initialization, the `pinnedColumns` prop allows to change at anytime which columns to pin.
+While the `initialState` prop only works for setting pinned columns during the initialization, the `pinnedColumns` prop allows modifying at any time which columns to pin.
 The value passed to it follows the same shape from the previous approach.
 Use it together with `onPinnedColumnsChange` to know when a column is pinned or unpinned.
 
@@ -524,7 +524,7 @@ Grouping columns allows you to have multiple levels of columns in your header an
 > 👍 Upvote [issue #192](https://github.com/mui/mui-x/issues/192) if you want to see it land faster.
 
 Each cell takes up the width of one column.
-Column spanning allows to change this default behavior.
+Column spanning allows modifying this default behavior.
 It allows cells to span multiple columns.
 This is very close to the "column spanning" in an HTML `<table>`.
 

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -11,8 +11,8 @@ The filters can be modified through the grid interface in several ways:
 - By opening the column menu and clicking the _Filter_ menu item.
 - By clicking the _Filters_ button in the grid toolbar (if enabled).
 
-Each column types has its own filter operators.
-The demo below let you explore all the operators for each built-in column type.
+Each column type has its own filter operators.
+The demo below lets you explore all the operators for each built-in column type.
 
 _See [the dedicated section](#customize-the-operators) to learn how to create your own custom filter operator._
 
@@ -267,7 +267,7 @@ The demo below shows how to anchor the filter panel to the toolbar button instea
 
 Filtering can be run server-side by setting the `filterMode` prop to `server`, and implementing the `onFilterModelChange` handler.
 
-Below is a very simple demo on how you could achieve server-side filtering.
+Below is a very simple demo about how you could achieve server-side filtering.
 
 {{"demo": "ServerFilterGrid.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -267,7 +267,7 @@ The demo below shows how to anchor the filter panel to the toolbar button instea
 
 Filtering can be run server-side by setting the `filterMode` prop to `server`, and implementing the `onFilterModelChange` handler.
 
-Below is a very simple demo about how you could achieve server-side filtering.
+The example below demonstrates how to achieve server-side filtering.
 
 {{"demo": "ServerFilterGrid.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/getting-started/migration-v4.md
+++ b/docs/data/data-grid/getting-started/migration-v4.md
@@ -259,7 +259,7 @@ To use the v5 version of MUI X, you first need to update to the new package name
   | `filterGridColumnLookupSelector`  | `gridFilterActiveItemsLookupSelector` |
   | `densitySelector`                 | `gridDensitySelector`                 |
 
-- Some selectors have been removed / reworked
+- Some selectors have been removed/reworked
 
   1. `sortedGridRowsSelector` was removed. You can use `gridSortedRowEntriesSelector` instead.
 
@@ -368,7 +368,7 @@ To use the v5 version of MUI X, you first need to update to the new package name
   +   */
   +  value: GridCellValue;
   +  /**
-  +   * GridApi that let you manipulate the grid.
+  +   * GridApi that lets you manipulate the grid.
   +   */
   +  api: any;
   +}
@@ -436,8 +436,8 @@ To use the v5 version of MUI X, you first need to update to the new package name
 
 ### Removals from the public API
 
-We removed some API methods / selectors from what we consider public by adding the `unstable_` prefix on them.
-You can continue to use these methods if you desire, but they may be subject to breaking changes in the future without prior notice..
+We removed some API methods/selectors from what we consider public by adding the `unstable_` prefix on them.
+You can continue to use these methods if you desire, but they may be subject to breaking changes in the future without prior notice.
 
 1. `apiRef.current.applyFilters` was renamed `apiRef.current.unstable_applyFilters`
 2. `gridContainerSizesSelector` was renamed `unstable_gridContainerSizesSelector`

--- a/docs/data/data-grid/group-pivot/group-pivot.md
+++ b/docs/data/data-grid/group-pivot/group-pivot.md
@@ -9,7 +9,7 @@ title: Data Grid - Group & Pivot
 ## Row grouping [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/)
 
 For when you need to group rows based on repeated column values, and/or custom functions.
-On the following example, we're grouping all movies based on their production `company`
+In the following example, we're grouping all movies based on their production `company`
 
 {{"demo": "RowGroupingBasicExample.js", "bg": "inline", "defaultCodeOpen": false}}
 
@@ -58,7 +58,7 @@ If you have multiple grouped columns, this column name will be set to "Group".
 
 {{"demo": "RowGroupingSingleGroupingCol.js", "bg": "inline", "defaultCodeOpen": false}}
 
-#### Multiple grouping column
+#### Multiple grouping columns
 
 To display a column for each grouping criterion, set the `rowGroupingColumnMode` prop to `multiple`.
 
@@ -67,7 +67,7 @@ To display a column for each grouping criterion, set the `rowGroupingColumnMode`
 #### Custom grouping column
 
 To customize the rendering of the grouping column, use the `groupingColDef` prop.
-You can override the **headerName** or any property of the `GridColDef` interface, except the `field`, the `type` and the properties related to inline edition.
+You can override the **headerName** or any property of the `GridColDef` interface, except the `field`, the `type`, and the properties related to inline edition.
 
 {{"demo": "RowGroupingCustomGroupingColDefObject.js", "bg": "inline", "defaultCodeOpen": false}}
 
@@ -111,7 +111,7 @@ In the example below, the `director` column can not be grouped. And in all examp
 
 ### Using `groupingValueGetter` for complex grouping value
 
-The grouping value has to be either a `string`, a `number`, `null` or `undefined`.
+The grouping value has to be either a `string`, a `number`, `null`, or `undefined`.
 If your cell value is more complex, pass a `groupingValueGetter` property to the column definition to convert it into a valid value.
 
 ```ts
@@ -126,7 +126,7 @@ const columns: GridColumns = [
 
 {{"demo": "RowGroupingGroupingValueGetter.js", "bg": "inline", "defaultCodeOpen": false}}
 
-**Note**: If your column also have a `valueGetter` property, the value passed to the `groupingValueGetter` method will still be the row value from the `row[field]`.
+**Note**: If your column also has a `valueGetter` property, the value passed to the `groupingValueGetter` method will still be the row value from the `row[field]`.
 
 ### Rows with missing groups
 
@@ -136,13 +136,13 @@ If the grouping key of a grouping criteria is `null` or `undefined` for a row, t
 
 ### Group expansion
 
-By default, all groups are initially displayed collapsed. You can change this behaviour by setting the `defaultGroupingExpansionDepth` prop to expand all the groups up to a given depth when loading the data.
+By default, all groups are initially displayed collapsed. You can change this behavior by setting the `defaultGroupingExpansionDepth` prop to expand all the groups up to a given depth when loading the data.
 If you want to expand the whole tree, set `defaultGroupingExpansionDepth = -1`
 
 {{"demo": "RowGroupingDefaultExpansionDepth.js", "bg": "inline", "defaultCodeOpen": false}}
 
 If you want to expand groups by default according to a more complex logic, use the `isGroupExpandedByDefault` prop which is a callback receiving the node as an argument.
-When defined, this callback will always have the priority over the `defaultGroupingExpansionDepth` prop.
+When defined, this callback will always have priority over the `defaultGroupingExpansionDepth` prop.
 
 ```tsx
 isGroupExpandedByDefault={
@@ -160,7 +160,7 @@ Use the `setRowChildrenExpansion` method on `apiRef` to programmatically set the
 
 #### Single grouping column
 
-When using `rowGroupingColumnMode = "single"`, the default behavior is to apply the `sortComparator` and `filterOperators` of the top level grouping criteria.
+When using `rowGroupingColumnMode = "single"`, the default behavior is to apply the `sortComparator` and `filterOperators` of the top-level grouping criteria.
 
 If you are rendering leaves with the `leafField` property of `groupColDef`, the sorting and filtering will be applied on the leaves based on the `sortComparator` and `filterOperators` of their original column.
 
@@ -170,7 +170,7 @@ In both cases, you can force the sorting and filtering to be applied on another 
 
 {{"demo": "RowGroupingSortingSingleGroupingColDef.js", "bg": "inline", "defaultCodeOpen": false}}
 
-#### Multiple grouping column
+#### Multiple grouping columns
 
 When using `rowGroupingColumnMode = "multiple"`, the default behavior is to apply the `sortComparator` and `filterOperators` of the grouping criteria of each grouping column.
 
@@ -185,7 +185,7 @@ In the example below:
 
 {{"demo": "RowGroupingSortingMultipleGroupingColDef.js", "bg": "inline", "defaultCodeOpen": false}}
 
-> ⚠️ If you are dynamically switching the `leafField` or `mainGroupingCriteria`, the sorting and filtering models will not automatically be cleaned-up and the sorting / filtering will not be re-applied.
+> ⚠️ If you are dynamically switching the `leafField` or `mainGroupingCriteria`, the sorting and filtering models will not automatically be cleaned-up and the sorting/filtering will not be re-applied.
 
 ### Full example
 
@@ -280,7 +280,7 @@ If some entries are missing to build the full tree, the `DataGridPro` will autom
 
 A node is included if one of the following criteria is met:
 
-- at least one of its descendant is passing the filters
+- at least one of its descendants is passing the filters
 - it is passing the filters
 
 By default, the filtering is applied to every depth of the tree.
@@ -291,7 +291,7 @@ You can limit the filtering to the top-level rows with the `disableChildrenFilte
 ### Sorting
 
 By default, the sorting is applied to every depth of the tree.
-You can limit the sorting to the top level rows with the `disableChildrenSorting` prop.
+You can limit the sorting to the top-level rows with the `disableChildrenSorting` prop.
 
 {{"demo": "TreeDataDisableChildrenSorting.js", "bg": "inline", "defaultCodeOpen": false}}
 
@@ -312,7 +312,7 @@ You can limit the sorting to the top level rows with the `disableChildrenSorting
 >
 > 👍 Upvote [issue #3377](https://github.com/mui/mui-x/issues/3377) if you want to see it land faster.
 
-Alternatively, you can achieve a similar behavior by implementing this feature outside the component as shown bellow.
+Alternatively, you can achieve a similar behavior by implementing this feature outside the component as shown below.
 This implementation does not support every feature of the grid but can be a good starting point for large datasets.
 
 The idea is to add a property `descendantCount` on the row and to use it instead of the internal grid state.
@@ -402,7 +402,7 @@ If this is not sufficient, the entire toggle component can be overridden.
 To fully customize it, add another column with `field: GRID_DETAIL_PANEL_TOGGLE_FIELD` to your set of columns.
 The grid will detect that there is already a toggle column defined and it will not add another toggle in the default position.
 The new toggle component can be provided via [`renderCell`](/components/data-grid/columns/#render-cell) in the same as any other column.
-By only setting the `field`, is up to you to configure the remaning options (e.g. disable the column menu, filtering, sorting).
+By only setting the `field`, is up to you to configure the remaining options (e.g. disable the column menu, filtering, sorting).
 To already start with a few suggested options configured, spread `GRID_DETAIL_PANEL_TOGGLE_COL_DEF` when defining the column.
 
 ```tsx

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -93,7 +93,7 @@ If your dataset is too big, and you only want to fetch the current page, you can
 
 - Set the prop `paginationMode` to `server`
 - Provide a `rowCount` prop to let the grid know how many pages there are
-- Add a `onPageChange` callback to load the rows when the page changes
+- Add an `onPageChange` callback to load the rows when the page changes
 
 {{"demo": "ServerPaginationGrid.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -92,8 +92,8 @@ If your dataset is too big, and you only want to fetch the current page, you can
 ### Basic implementation
 
 - Set the prop `paginationMode` to `server`
-- Provide a `rowCount` prop to let the grid know how many pages there is
-- Add a `onPageChange` callback ot load the rows when the page changes
+- Provide a `rowCount` prop to let the grid know how many pages there are
+- Add a `onPageChange` callback to load the rows when the page changes
 
 {{"demo": "ServerPaginationGrid.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/selection/selection.md
+++ b/docs/data/data-grid/selection/selection.md
@@ -26,7 +26,7 @@ Row selection can be performed with a simple mouse click, or using the [keyboard
 
 ### Single row selection
 
-Single row selection is enable by default with the `DataGrid` component.
+Single row selection is enabled by default with the `DataGrid` component.
 To unselect a row, hold the <kbd class="key">CTRL</kbd> key and click on it.
 
 {{"demo": "SingleRowSelectionGrid.js", "bg": "inline"}}


### PR DESCRIPTION
I tried a Grammarly extension to help catch English errors in the doc. @samuelsycamore could you check that I'm not introducing  new ones 