### PR TITLE
[DataGridPro] Avoid imports from `@mui/base`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,7 +111,7 @@ module.exports = {
     },
     {
       files: ['packages/grid/**/*{.ts,.tsx,.js}'],
-      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
+      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx', '**.test.tx', '**.test.tsx'],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,7 +111,14 @@ module.exports = {
     },
     {
       files: ['packages/grid/**/*{.ts,.tsx,.js}'],
-      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx', '**.test.tx', '**.test.tsx'],
+      excludedFiles: [
+        'packages/grid/x-data-grid-generator/**',
+        '*.d.ts',
+        '*.spec.ts',
+        '*.spec.tsx',
+        '**.test.tx',
+        '**.test.tsx',
+      ],
       rules: {
         'no-restricted-imports': [
           'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,5 +109,28 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['packages/grid/**/*{.ts,.tsx,.js}'],
+      excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: '@mui/base',
+                message: 'Use @mui/material instead',
+              },
+            ],
+            patterns: [
+              {
+                group: ['@mui/base/*'],
+                message: 'Use @mui/material instead',
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/docs/data/data-grid/group-pivot/TreeDataLazyLoading.js
+++ b/docs/data/data-grid/group-pivot/TreeDataLazyLoading.js
@@ -8,7 +8,7 @@ import {
   useGridApiRef,
   useGridRootProps,
 } from '@mui/x-data-grid-pro';
-import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { unstable_composeClasses as composeClasses } from '@mui/material';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 

--- a/docs/data/data-grid/group-pivot/TreeDataLazyLoading.tsx
+++ b/docs/data/data-grid/group-pivot/TreeDataLazyLoading.tsx
@@ -14,7 +14,7 @@ import {
   useGridApiRef,
   useGridRootProps,
 } from '@mui/x-data-grid-pro';
-import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { unstable_composeClasses as composeClasses } from '@mui/material';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 

--- a/packages/grid/_modules_/grid/components/cell/GridGroupingCriteriaCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridGroupingCriteriaCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { unstable_composeClasses as composeClasses } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';

--- a/packages/grid/x-data-grid-generator/src/renderer/renderEditProgress.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderEditProgress.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { GridRenderEditCellParams } from '@mui/x-data-grid';
 import Slider, { SliderProps, sliderClasses } from '@mui/material/Slider';
-import { ValueLabelProps } from '@mui/base/SliderUnstyled';
 import Tooltip from '@mui/material/Tooltip';
 import { debounce } from '@mui/material/utils';
 import { alpha, styled } from '@mui/material/styles';
@@ -43,7 +42,11 @@ const StyledSlider = styled(Slider)(({ theme }) => ({
   },
 }));
 
-const ValueLabelComponent = (props: ValueLabelProps) => {
+const ValueLabelComponent = (props: {
+  open: boolean;
+  value: number;
+  children: React.ReactElement;
+}) => {
   const { children, open, value } = props;
 
   return (

--- a/packages/grid/x-data-grid-generator/src/renderer/renderEditProgress.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderEditProgress.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { GridRenderEditCellParams } from '@mui/x-data-grid';
 import Slider, { SliderProps, sliderClasses } from '@mui/material/Slider';
+import { ValueLabelProps } from '@mui/base/SliderUnstyled';
 import Tooltip from '@mui/material/Tooltip';
 import { debounce } from '@mui/material/utils';
 import { alpha, styled } from '@mui/material/styles';
@@ -42,11 +43,7 @@ const StyledSlider = styled(Slider)(({ theme }) => ({
   },
 }));
 
-const ValueLabelComponent = (props: {
-  open: boolean;
-  value: number;
-  children: React.ReactElement;
-}) => {
+const ValueLabelComponent = (props: ValueLabelProps) => {
   const { children, open, value } = props;
 
   return (


### PR DESCRIPTION
Fixes #3899 and #3883

`@mui/base` is transitive dependency not declared in `package.json`.
Yarn PnP requires packages to [only import what they list in dependencies](https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies)

TODO:
- [x] add eslint rule to avoid `@mui/base` imports in the future