### PR TITLE
[core] Use international locale format

### DIFF
--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -207,7 +207,7 @@ async function generateReport(
     if (info.locations.length === 0) {
       return;
     }
-    lines.push(`### ${countryToFlag(code.slice(2))} ${code}`);
+    lines.push(`### ${countryToFlag(code.slice(2))} ${code.slice(0, 2)}-${code.slice(2)}`);
     info.locations.forEach((location) => {
       const permalink = `${SOURCE_CODE_REPO}/blob/${lastCommitRef}/${info.path}#L${location}`;
       lines.push(permalink);


### PR DESCRIPTION
The intent is to update

<img width="388" alt="Screenshot 2022-02-10 at 23 21 20" src="https://user-images.githubusercontent.com/3165635/153506562-94e2bbdd-52e3-4dfd-b82c-f13c0687b1b1.png">

https://github.com/mui/mui-x/issues/3211

to show `### ar-SD` instead of `### arSD`. I'm trying to solve the root cause of https://github.com/mui/mui-x/pull/3831#pullrequestreview-872229983.