### PR TITLE
[DataGrid] Don't use `field` to match columns in the columns panel when `headerName` is available

### DIFF
--- a/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
@@ -93,18 +93,16 @@ export function GridColumnsPanel() {
     setSearchValue(event.target.value);
   }, []);
 
-  const currentColumns = React.useMemo(
-    () =>
-      !searchValue
-        ? columns
-        : columns.filter(
-            (column) =>
-              column.field.toLowerCase().indexOf(searchValue.toLowerCase()) > -1 ||
-              (column.headerName &&
-                column.headerName.toLowerCase().indexOf(searchValue.toLowerCase()) > -1),
-          ),
-    [columns, searchValue],
-  );
+  const currentColumns = React.useMemo(() => {
+    if (!searchValue) {
+      return columns;
+    }
+    const searchValueToCheck = searchValue.toLowerCase();
+    return columns.filter(
+      (column) =>
+        (column.headerName || column.field).toLowerCase().indexOf(searchValueToCheck) > -1,
+    );
+  }, [columns, searchValue]);
 
   React.useEffect(() => {
     searchInputRef.current!.focus();


### PR DESCRIPTION
Fixes #3927