### PR TITLE
[DataGrid] Memoize Popper modifiers passed to panel

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
@@ -297,6 +297,40 @@ describe('<DataGridPro /> - Filter', () => {
     expect(apiRef.current.getVisibleRowModels().get(1)).to.deep.equal({ id: 1, brand: 'Adidas' });
   });
 
+  it('should not scroll the page when a filter is removed from the panel', function test() {
+    if (isJSDOM) {
+      this.skip(); // Needs layout
+    }
+    render(
+      <div>
+        {/* To simulate a page that needs to be scrolled to reach the grid. */}
+        <div style={{ height: '100vh', width: '100vh' }} />
+        <TestCase
+          initialState={{
+            preferencePanel: {
+              open: true,
+              openedPanelValue: GridPreferencePanelsValue.filters,
+            },
+            filter: {
+              filterModel: {
+                linkOperator: GridLinkOperator.Or,
+                items: [
+                  { id: 1, columnField: 'brand', value: 'a', operatorValue: 'contains' },
+                  { id: 2, columnField: 'brand', value: 'm', operatorValue: 'contains' },
+                ],
+              },
+            },
+          }}
+        />
+      </div>,
+    );
+    screen.getByRole('grid').scrollIntoView();
+    const initialScrollPosition = window.scrollY;
+    expect(initialScrollPosition).not.to.equal(0);
+    fireEvent.click(screen.getAllByRole('button', { name: /delete/i })[1]);
+    expect(window.scrollY).to.equal(initialScrollPosition);
+  });
+
   describe('Server', () => {
     it('should refresh the filter panel when adding filters', () => {
       function loadServerRows(commodityFilterValue) {

--- a/packages/grid/x-data-grid/src/internals/components/panel/GridPanel.tsx
+++ b/packages/grid/x-data-grid/src/internals/components/panel/GridPanel.tsx
@@ -67,6 +67,24 @@ const GridPanel = React.forwardRef<HTMLDivElement, GridPanelProps>((props, ref) 
     [apiRef],
   );
 
+  const modifiers = React.useMemo(
+    () => [
+      {
+        name: 'flip',
+        enabled: false,
+      },
+      {
+        name: 'isPlaced',
+        enabled: true,
+        phase: 'main' as const,
+        fn: () => {
+          setIsPlaced(true);
+        },
+      },
+    ],
+    [],
+  );
+
   const anchorEl = apiRef.current.columnHeadersContainerElementRef?.current;
 
   if (!anchorEl) {
@@ -79,20 +97,7 @@ const GridPanel = React.forwardRef<HTMLDivElement, GridPanelProps>((props, ref) 
       placement="bottom-start"
       className={clsx(className, classes.panel)}
       anchorEl={anchorEl}
-      modifiers={[
-        {
-          name: 'flip',
-          enabled: false,
-        },
-        {
-          name: 'isPlaced',
-          enabled: true,
-          phase: 'main',
-          fn: () => {
-            setIsPlaced(true);
-          },
-        },
-      ]}
+      modifiers={modifiers}
       {...other}
     >
       <ClickAwayListener onClickAway={handleClickAway}>


### PR DESCRIPTION
Fixes #3809

The reason for this bug is very simple. Without memoizing the modifiers array, its reference changes in every render. Since it's [listed](https://github.com/mui/material-ui/blob/4214d4d1b03586dd0fd5e6733e1ede6bad010787/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js#L155) as dependency in the effect that creates the Popper instance, in `PopperUnstyled`, it's recreated and repositioned every time that a rerender occurs, like when deleting a filter.