### PR TITLE
[docs] Fix typo on row grouping section

### DIFF
--- a/docs/data/data-grid/group-pivot/group-pivot.md
+++ b/docs/data/data-grid/group-pivot/group-pivot.md
@@ -166,7 +166,7 @@ If you are rendering leaves with the `leafField` property of `groupColDef`, the 
 
 In both cases, you can force the sorting and filtering to be applied on another grouping criteria with the `mainGroupingCriteria` property of `groupColDef`
 
-> ⚠️ This feature is not yet compatible with `sortingMode = "server` and `filteringMode = "server"`
+> ⚠️ This feature is not yet compatible with `sortingMode = "server"` and `filteringMode = "server"`
 
 {{"demo": "RowGroupingSortingSingleGroupingColDef.js", "bg": "inline", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
I fixed a typo in the documentation. I found it while exploring the experiemental features of mui-x.