### PR TITLE
[DataGridPro] Disable export for detail panel column

### DIFF
--- a/packages/grid/x-data-grid-pro/src/internals/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
+++ b/packages/grid/x-data-grid-pro/src/internals/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
@@ -17,6 +17,7 @@ export const GRID_DETAIL_PANEL_TOGGLE_COL_DEF: GridColDef<GridApiPro> = {
   resizable: false,
   disableColumnMenu: true,
   disableReorder: true,
+  disableExport: true,
   align: 'left',
   width: 40,
   valueGetter: (params) => {


### PR DESCRIPTION
Currently, export a table with detailed panels exports a column with name: 
`__detail_panel_toggle__`and only values: ` true` or `false` indicating the state.

These are not usefull values and should be disabled by default