### PR TITLE
[docs] Avoid crash in demos using row grouping and custom formatted cells

### DIFF
--- a/packages/grid/x-data-grid-generator/src/columns/commodities.columns.tsx
+++ b/packages/grid/x-data-grid-generator/src/columns/commodities.columns.tsx
@@ -244,7 +244,7 @@ export const getCommodityColumns = (editable = false): GridColDefGenerator<any>[
 
       return value;
     },
-    valueFormatter: ({ value }) => (value as typeof COUNTRY_ISO_OPTIONS_SORTED[number]).label,
+    valueFormatter: ({ value }) => (value as typeof COUNTRY_ISO_OPTIONS_SORTED[number])?.label,
     groupingValueGetter: (params) => params.value.code,
     sortComparator: (v1, v2, param1, param2) =>
       gridStringOrNumberComparator(

--- a/packages/grid/x-data-grid-generator/src/columns/employees.columns.tsx
+++ b/packages/grid/x-data-grid-generator/src/columns/employees.columns.tsx
@@ -103,7 +103,7 @@ export const getEmployeeColumns = (): GridColDefGenerator<any>[] => [
     headerName: 'Country',
     type: 'singleSelect',
     valueOptions: COUNTRY_ISO_OPTIONS_SORTED,
-    valueFormatter: ({ value }) => (value as typeof COUNTRY_ISO_OPTIONS_SORTED[number]).label,
+    valueFormatter: ({ value }) => (value as typeof COUNTRY_ISO_OPTIONS_SORTED[number])?.label,
     generateData: randomCountry,
     renderCell: renderCountry,
     renderEditCell: renderEditCountry,


### PR DESCRIPTION
1. Open https://master--material-ui-x.netlify.app/components/data-grid/group-pivot/#full-example
2. Scroll all the way to the right
3. 💥

I noticed while reviewing #4030 

A better solution would be to not render the cells in auto-generated rows, but we have the problem where we need to call `getCellParams` to pass to `cellClassName` which calls the value formatter.