### PR TITLE
[docs] Fix typo in Data Grid/Editing/Client-side validation

### DIFF
--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -87,7 +87,7 @@ If the `error` attribute is true, the value will never be committed.
 const columns: GridColDef[] = [
   {
     field: 'firstName',
-    preProcessEditCellProps: (params: GridEditCellPropsChangeParams) => {
+    preProcessEditCellProps: (params: GridPreProcessEditCellProps) => {
       const hasError = params.props.value.length < 3;
       return { ...params.props, error: hasError };
     },


### PR DESCRIPTION
In the documentation for [Data Grid/Editing/Client-side validation](https://mui.com/components/data-grid/editing/#client-side-validation), `params` is incorrectly typed. This PR makes the example consistent with the `preProcessEditCellProps` property of [GridColDef](https://mui.com/api/data-grid/grid-col-def/#properties).