### PR TITLE
[DataGrid] Prevent focus while Popper is not fully positioned

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
@@ -331,6 +331,41 @@ describe('<DataGridPro /> - Filter', () => {
     expect(window.scrollY).to.equal(initialScrollPosition);
   });
 
+  it('should not scroll the page when opening the filter panel and the operator=isAnyOf', function test() {
+    if (isJSDOM) {
+      this.skip(); // Needs layout
+    }
+
+    render(
+      <div>
+        {/* To simulate a page that needs to be scrolled to reach the grid. */}
+        <div style={{ height: '100vh', width: '100vh' }} />
+        <TestCase
+          initialState={{
+            preferencePanel: {
+              open: true,
+              openedPanelValue: GridPreferencePanelsValue.filters,
+            },
+            filter: {
+              filterModel: {
+                linkOperator: GridLinkOperator.Or,
+                items: [{ id: 1, columnField: 'brand', operatorValue: 'isAnyOf' }],
+              },
+            },
+          }}
+        />
+      </div>,
+    );
+
+    screen.getByRole('grid').scrollIntoView();
+    const initialScrollPosition = window.scrollY;
+    expect(initialScrollPosition).not.to.equal(0);
+    apiRef.current.hidePreferences();
+    clock.tick(100);
+    apiRef.current.showPreferences(GridPreferencePanelsValue.filters);
+    expect(window.scrollY).to.equal(initialScrollPosition);
+  });
+
   describe('Server', () => {
     it('should refresh the filter panel when adding filters', () => {
       function loadServerRows(commodityFilterValue) {

--- a/packages/grid/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPanel.tsx
@@ -80,6 +80,9 @@ const GridPanel = React.forwardRef<HTMLDivElement, GridPanelProps>((props, ref) 
         fn: () => {
           setIsPlaced(true);
         },
+        effect: () => () => {
+          setIsPlaced(false);
+        },
       },
     ],
     [],


### PR DESCRIPTION
Fixes #4011 

Preview: https://deploy-preview-4067--material-ui-x.netlify.app/components/data-grid/

We weren't resetting `isPlaced` when the panel is closed. Not doing that was making it to be opened, during the second time, as if it was already positioned. When it opens, we try to focus the input element, but since it's not correctly positioned yet it focus while the panel is still at the top-left corner of the page = unwanted scroll. For some reason, this only happens with the `isAnyOf` operator. A hypothesis is that, because the Autocomplete is a heavy component, it takes more time for React to process it than a TextField, delaying the Popper modifier that is responsible for positioning the panel. With the TextField, React only calls the effect below when the panel is already positioned = no scroll.

https://github.com/mui/mui-x/blob/1a367816440a87400636a571408aadaac694f65b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx#L115-L117