### PR TITLE
[core] Make is clearer this is only for questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/4.premium-support.yml
+++ b/.github/ISSUE_TEMPLATE/4.premium-support.yml
@@ -1,7 +1,7 @@
-name: 'Pro plan: question ❔'
-description: I'm a Pro plan user, I can't find a solution to my problem with MUI X.
+name: 'Premium plan: question ❔'
+description: I'm a Premium plan user, I can't find a solution to my problem with MUI X.
 title: "[question] "
-labels: ['status: needs triage', 'pro plan', 'support: commercial']
+labels: ['status: needs triage', 'Premium plan', 'support: commercial']
 body:
   - type: markdown
     attributes:
@@ -13,7 +13,7 @@ body:
     id: contact
     attributes:
       label: Order ID 💳
-      description: The order ID of the purchased Pro plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
+      description: The order ID of the purchased Premium plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
       placeholder: 'ex. #11111'
     validations:
       required: true


### PR DESCRIPTION
After reading https://groups.google.com/a/mui.com/g/custom-work/c/5RRqH0YkZ6o/m/aWBVaxkrBAAJ?utm_medium=email&utm_source=footer, I recalled the point that @cherniavskii did during our last retrospective that this issue template is only meant for cases where the problem is not a bug nor a feature request. But the current description is not very clear.

To be clear, this PR is modifying https://github.com/mui/mui-x/issues/new/choose