### PR TITLE
[core] Merge `page` and `pageSize` state initializer into a single `pagination` state initializer

### DIFF
--- a/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProComponent.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProComponent.tsx
@@ -15,8 +15,7 @@ import {
   useGridKeyboard,
   useGridKeyboardNavigation,
   useGridPagination,
-  pageStateInitializer,
-  pageSizeStateInitializer,
+  paginationStateInitializer,
   useGridPreferencesPanel,
   useGridEditing,
   useGridRows,
@@ -75,8 +74,7 @@ export const useDataGridProComponent = (
    * Register all state initializers here.
    */
   useGridInitializeState(filterStateInitializer, apiRef, props);
-  useGridInitializeState(pageSizeStateInitializer, apiRef, props);
-  useGridInitializeState(pageStateInitializer, apiRef, props);
+  useGridInitializeState(paginationStateInitializer, apiRef, props);
   useGridInitializeState(sortingStateInitializer, apiRef, props);
   useGridInitializeState(columnPinningStateInitializer, apiRef, props);
   useGridInitializeState(rowGroupingStateInitializer, apiRef, props);

--- a/packages/grid/x-data-grid/src/DataGrid/useDataGridComponent.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/useDataGridComponent.tsx
@@ -14,9 +14,10 @@ import { useGridFilter, filterStateInitializer } from '../hooks/features/filter/
 import { useGridFocus } from '../hooks/features/focus/useGridFocus';
 import { useGridKeyboard } from '../hooks/features/keyboard/useGridKeyboard';
 import { useGridKeyboardNavigation } from '../hooks/features/keyboard/useGridKeyboardNavigation';
-import { useGridPagination } from '../hooks/features/pagination/useGridPagination';
-import { pageStateInitializer } from '../hooks/features/pagination/useGridPage';
-import { pageSizeStateInitializer } from '../hooks/features/pagination/useGridPageSize';
+import {
+  useGridPagination,
+  paginationStateInitializer,
+} from '../hooks/features/pagination/useGridPagination';
 import { useGridPreferencesPanel } from '../hooks/features/preferencesPanel/useGridPreferencesPanel';
 import { useGridEditing } from '../hooks/features/editRows/useGridEditing';
 import { useGridRows, rowsStateInitializer } from '../hooks/features/rows/useGridRows';
@@ -42,8 +43,7 @@ export const useDataGridComponent = (props: DataGridProcessedProps) => {
    * Register all state initializers here.
    */
   useGridInitializeState(filterStateInitializer, apiRef, props);
-  useGridInitializeState(pageSizeStateInitializer, apiRef, props);
-  useGridInitializeState(pageStateInitializer, apiRef, props);
+  useGridInitializeState(paginationStateInitializer, apiRef, props);
   useGridInitializeState(rowsStateInitializer, apiRef, props);
   useGridInitializeState(sortingStateInitializer, apiRef, props);
   useGridInitializeState(columnsStateInitializer, apiRef, props);

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPage.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPage.ts
@@ -14,7 +14,6 @@ import { gridVisibleTopLevelRowCountSelector } from '../filter';
 import { gridPageSelector } from './gridPaginationSelector';
 import { GridPreProcessor, useGridRegisterPreProcessor } from '../../core/preProcessing';
 import { buildWarning } from '../../../utils/warning';
-import { GridStateInitializer } from '../../utils/useGridInitializeState';
 
 export const getPageCount = (rowCount: number, pageSize: number): number => {
   if (pageSize > 0 && rowCount > 0) {

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPage.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPage.ts
@@ -16,7 +16,7 @@ import { GridPreProcessor, useGridRegisterPreProcessor } from '../../core/prePro
 import { buildWarning } from '../../../utils/warning';
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
 
-const getPageCount = (rowCount: number, pageSize: number): number => {
+export const getPageCount = (rowCount: number, pageSize: number): number => {
   if (pageSize > 0 && rowCount > 0) {
     return Math.ceil(rowCount / pageSize);
   }
@@ -52,17 +52,6 @@ const noRowCountInServerMode = buildWarning(
   ],
   'error',
 );
-export const pageStateInitializer: GridStateInitializer<
-  Pick<DataGridProcessedProps, 'initialState' | 'rowCount' | 'page'>
-> = (state, props) => ({
-  ...state,
-  pagination: {
-    ...state.pagination!,
-    page: props.page ?? props.initialState?.pagination?.page ?? 0,
-    pageCount: getPageCount(props.rowCount ?? 0, state.pagination!.pageSize!),
-    rowCount: props.rowCount ?? 0,
-  },
-});
 
 /**
  * @requires useGridPageSize (event)

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPageSize.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPageSize.ts
@@ -13,29 +13,8 @@ import {
 import { gridPageSizeSelector } from './gridPaginationSelector';
 import { gridDensityRowHeightSelector } from '../density';
 import { GridPreProcessor, useGridRegisterPreProcessor } from '../../core/preProcessing';
-import { GridStateInitializer } from '../../utils/useGridInitializeState';
 
-const defaultPageSize = (autoPageSize: boolean) => (autoPageSize ? 0 : 100);
-
-export const pageSizeStateInitializer: GridStateInitializer<
-  Pick<DataGridProcessedProps, 'pageSize' | 'initialState' | 'autoPageSize'>
-> = (state, props) => {
-  let pageSize: number;
-  if (props.pageSize != null) {
-    pageSize = props.pageSize;
-  } else if (props.initialState?.pagination?.pageSize != null) {
-    pageSize = props.initialState.pagination.pageSize;
-  } else {
-    pageSize = defaultPageSize(props.autoPageSize);
-  }
-
-  return {
-    ...state,
-    pagination: {
-      pageSize,
-    },
-  };
-};
+export const defaultPageSize = (autoPageSize: boolean) => (autoPageSize ? 0 : 100);
 
 const mergeStateWithPageSize =
   (pageSize: number) =>

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPagination.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPagination.ts
@@ -1,8 +1,32 @@
 import * as React from 'react';
-import { useGridPageSize } from './useGridPageSize';
+import { useGridPageSize, defaultPageSize } from './useGridPageSize';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
-import { useGridPage } from './useGridPage';
+import { useGridPage, getPageCount } from './useGridPage';
+import { GridStateInitializer } from '../../utils/useGridInitializeState';
+
+export const paginationStateInitializer: GridStateInitializer<
+  Pick<DataGridProcessedProps, 'page' | 'pageSize' | 'rowCount' | 'initialState' | 'autoPageSize'>
+> = (state, props) => {
+  let pageSize: number;
+  if (props.pageSize != null) {
+    pageSize = props.pageSize;
+  } else if (props.initialState?.pagination?.pageSize != null) {
+    pageSize = props.initialState.pagination.pageSize;
+  } else {
+    pageSize = defaultPageSize(props.autoPageSize);
+  }
+
+  return {
+    ...state,
+    pagination: {
+      pageSize,
+      page: props.page ?? props.initialState?.pagination?.page ?? 0,
+      pageCount: getPageCount(props.rowCount ?? 0, pageSize),
+      rowCount: props.rowCount ?? 0,
+    },
+  };
+};
 
 /**
  * @requires useGridFilter (state)

--- a/packages/grid/x-data-grid/src/internals/index.ts
+++ b/packages/grid/x-data-grid/src/internals/index.ts
@@ -33,9 +33,10 @@ export type {
 export { useGridFocus } from '../hooks/features/focus/useGridFocus';
 export { useGridKeyboard } from '../hooks/features/keyboard/useGridKeyboard';
 export { useGridKeyboardNavigation } from '../hooks/features/keyboard/useGridKeyboardNavigation';
-export { useGridPagination } from '../hooks/features/pagination/useGridPagination';
-export { pageStateInitializer } from '../hooks/features/pagination/useGridPage';
-export { pageSizeStateInitializer } from '../hooks/features/pagination/useGridPageSize';
+export {
+  useGridPagination,
+  paginationStateInitializer,
+} from '../hooks/features/pagination/useGridPagination';
 export { useGridPreferencesPanel } from '../hooks/features/preferencesPanel/useGridPreferencesPanel';
 export { useGridEditing } from '../hooks/features/editRows/useGridEditing';
 export { useGridRows, rowsStateInitializer } from '../hooks/features/rows/useGridRows';


### PR DESCRIPTION
That way the split between `useGridPage` and `useGridPageSize` remains an implementation details of the `hooks/features/pagination` folder.