### PR TITLE
[docs] Use regex instead of specific url in e2e-website-tests

### DIFF
--- a/test/e2e-website/data-grid-current.spec.ts
+++ b/test/e2e-website/data-grid-current.spec.ts
@@ -94,7 +94,7 @@ test.describe('DataGrid docs', () => {
 
       const anchor = await page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")');
 
-      await expect(anchor.first()).toHaveAttribute('href', /^components\/data-grid\//);
+      await expect(anchor.first()).toHaveAttribute('href', /^\/components\/data-grid\//);
     });
 
     test('should have correct link when searching API', async ({ page }) => {

--- a/test/e2e-website/data-grid-current.spec.ts
+++ b/test/e2e-website/data-grid-current.spec.ts
@@ -94,10 +94,7 @@ test.describe('DataGrid docs', () => {
 
       const anchor = await page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")');
 
-      await expect(anchor.first()).toHaveAttribute(
-        'href',
-        `/components/data-grid/components/#main-content`,
-      );
+      await expect(anchor.first()).toHaveAttribute('href', /^components\/data-grid\//);
     });
 
     test('should have correct link when searching API', async ({ page }) => {


### PR DESCRIPTION
Somehow, the search result changes on the old search (it previously showed the `Components` as the first item). This PR reduces the fragility of the test by using regex instead of a specific url.

<img width="1214" alt="Screen Shot 2565-03-08 at 17 43 12" src="https://user-images.githubusercontent.com/18292247/157222598-f86767ae-1782-4180-8eb6-26ac0e487dc5.png">