### PR TITLE
[core] Add CLI to decode license key

### DIFF
--- a/packages/x-license-pro/bin/license-decode-script.js
+++ b/packages/x-license-pro/bin/license-decode-script.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+/* eslint-disable */
+require = require('esm')(module);
+
+require('../build/node/cli/license-cli').licenseDecodeCli();

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -14,7 +14,8 @@
     "access": "public"
   },
   "bin": {
-    "licensegen": "./bin/license-gen-script.js"
+    "licensegen": "./bin/license-gen-script.js",
+    "licensedecode": "./bin/license-decode-script.js"
   },
   "scripts": {
     "typescript": "tsc -p tsconfig.json",

--- a/packages/x-license-pro/src/cli/license-cli.ts
+++ b/packages/x-license-pro/src/cli/license-cli.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import * as yargs from 'yargs';
 import { generateLicence } from '../generateLicense/generateLicense';
-import {base64Decode} from "../encoding/base64";
+import { base64Decode } from '../encoding/base64';
 
 const oneDayInMs = 1000 * 60 * 60 * 24;
 
@@ -11,37 +11,36 @@ interface LicenseGenArgv {
 }
 
 interface LicenseDecodeArgv {
-    key: string;
+  key: string;
 }
 
 export function licenseDecodeCli() {
-    yargs
-        .command({
-            command: '$0',
-            describe: 'Decode a license key',
-            builder: (command) => {
-                return command
-                    .option('key', {
-                        default: '',
-                        alias: 'k',
-                        describe: 'License key.',
-                        type: 'string',
-                    })
-            },
-            handler: (argv: yargs.ArgumentsCamelCase<LicenseDecodeArgv>) => {
-                if (!argv.key) {
-                    throw new Error('MUI: You forgot to pass a license key. $ > licensegen -k xxx');
-                }
+  yargs
+    .command({
+      command: '$0',
+      describe: 'Decode a license key',
+      builder: (command) => {
+        return command.option('key', {
+          default: '',
+          alias: 'k',
+          describe: 'License key.',
+          type: 'string',
+        });
+      },
+      handler: (argv: yargs.ArgumentsCamelCase<LicenseDecodeArgv>) => {
+        if (!argv.key) {
+          throw new Error('MUI: You forgot to pass a license key. $ > licensegen -k xxx');
+        }
 
-                console.log(`Decoding license key "${argv.key}"`);
-                const license = base64Decode(argv.key.substr(32));
-                console.log(`Decoded license: \n${license}`);
-            },
-        })
-        .help()
-        .strict(true)
-        .version(false)
-        .parse();
+        console.log(`Decoding license key "${argv.key}"`);
+        const license = base64Decode(argv.key.substr(32));
+        console.log(`Decoded license: \n${license}`);
+      },
+    })
+    .help()
+    .strict(true)
+    .version(false)
+    .parse();
 }
 
 export function licenseGenCli() {

--- a/packages/x-license-pro/src/cli/license-cli.ts
+++ b/packages/x-license-pro/src/cli/license-cli.ts
@@ -1,19 +1,54 @@
 /* eslint-disable no-console */
 import * as yargs from 'yargs';
 import { generateLicence } from '../generateLicense/generateLicense';
+import {base64Decode} from "../encoding/base64";
 
 const oneDayInMs = 1000 * 60 * 60 * 24;
 
-interface HandlerArgv {
+interface LicenseGenArgv {
   order: string;
   expiry: string;
+}
+
+interface LicenseDecodeArgv {
+    key: string;
+}
+
+export function licenseDecodeCli() {
+    yargs
+        .command({
+            command: '$0',
+            describe: 'Decode a license key',
+            builder: (command) => {
+                return command
+                    .option('key', {
+                        default: '',
+                        alias: 'k',
+                        describe: 'License key.',
+                        type: 'string',
+                    })
+            },
+            handler: (argv: yargs.ArgumentsCamelCase<LicenseDecodeArgv>) => {
+                if (!argv.key) {
+                    throw new Error('MUI: You forgot to pass a license key. $ > licensegen -k xxx');
+                }
+
+                console.log(`Decoding license key "${argv.key}"`);
+                const license = base64Decode(argv.key.substr(32));
+                console.log(`Decoded license: \n${license}`);
+            },
+        })
+        .help()
+        .strict(true)
+        .version(false)
+        .parse();
 }
 
 export function licenseGenCli() {
   yargs
     .command({
       command: '$0',
-      describe: 'Generates Component.propTypes from TypeScript declarations',
+      describe: 'Generates a license key',
       builder: (command) => {
         return command
           .option('order', {
@@ -28,7 +63,7 @@ export function licenseGenCli() {
             type: 'string',
           });
       },
-      handler: (argv: yargs.ArgumentsCamelCase<HandlerArgv>) => {
+      handler: (argv: yargs.ArgumentsCamelCase<LicenseGenArgv>) => {
         if (!argv.order) {
           throw new Error('MUI: You forgot to pass an order number. $ > licensegen -o order_123.');
         }


### PR DESCRIPTION
@mbrookes, with this you would be able to do:

```shell
npm i -g @mui/x-license-pro
npx licensedecode -k xxx
```

I took the same naming strategy as `licensegen` but in a 2nd version I would like to correctly namespace the commands and do:

```shell
npx mui-license gen -o xxx
npx mui-license decode -k xxx
```
