### PR TITLE
[docs] Fix links to prevent duplicate search result

### DIFF
--- a/docs/data/data-grid/columns/columns.md
+++ b/docs/data/data-grid/columns/columns.md
@@ -217,7 +217,7 @@ const columns: GridColDef[] = [
 
 The `renderCell` render function allows customizing the rendered in "view mode" only.
 For the "edit mode", set the `renderEditCell` function to customize the edit component.
-Check the [editing page](/components/data-grid/editing) for more details about editing.
+Check the [editing page](/components/data-grid/editing/) for more details about editing.
 
 #### Expand cell renderer
 
@@ -542,7 +542,7 @@ Those selectors consider all the defined columns, including hidden ones.
 
 {{"demo": "ColumnsSelectorsNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
-More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state#access-the-state).
+More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state/#access-the-state).
 
 ## API
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -144,7 +144,7 @@ The demo lets you edit the ratings by double-clicking the cell.
 
 ### Edit using external button [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
 
-You can override the default [start editing](#start-editing) triggers using the [`event.defaultMuiPrevented`](/components/data-grid/events#disabling-the-default-behavior) on the synthetic React events.
+You can override the default [start editing](#start-editing) triggers using the [`event.defaultMuiPrevented`](/components/data-grid/events/#disabling-the-default-behavior) on the synthetic React events.
 
 {{"demo": "StartEditButtonGrid.js", "bg": "inline", "disableAd": true}}
 

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -328,7 +328,7 @@ However, it can be implemented as in the demo below.
 
 {{"demo": "FilterSelectorsNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
-More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state#access-the-state)
+More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state/#access-the-state)
 
 ## API
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -54,7 +54,7 @@ import { DataGridPro } from '@mui/x-data-grid-pro';
 - [Filtering](/components/data-grid/filtering/) and [multi-filtering](/components/data-grid/filtering/#multi-filtering) <span class="plan-pro"></span>
 - [Pagination](/components/data-grid/pagination/)
 - [Row & Cell editing](/components/data-grid/editing/)
-- [Sorting](/components/data-grid/sorting) and [multi-sorting](/components/data-grid/sorting/#multi-sorting) <span class="plan-pro"></span>
+- [Sorting](/components/data-grid/sorting/) and [multi-sorting](/components/data-grid/sorting/#multi-sorting) <span class="plan-pro"></span>
 - [Selection](/components/data-grid/selection/)
 - [Column virtualization](/components/data-grid/virtualization/#column-virtualization) and [rows virtualization](/components/data-grid/virtualization/#row-virtualization) <span class="plan-pro"></span>
 - [Row grouping](/components/data-grid/group-pivot/#row-grouping) <span class="plan-premium"></span>

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -132,7 +132,7 @@ You can customize the rendering of the pagination in the footer following [the c
 
 {{"demo": "PaginationSelectorsNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
-More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state#access-the-state)
+More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state/#access-the-state)
 
 ## API
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -146,7 +146,7 @@ Sorting can be run server-side by setting the `sortingMode` prop to `server`, an
 
 {{"demo": "SortingSelectorsNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
-More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state#access-the-state)
+More information about the selectors and how to use them on the [dedicated page](/components/data-grid/state/#access-the-state)
 
 ## API
 


### PR DESCRIPTION
Open https://mui.com/x/react-data-grid/ and try searching for "edit".

<img width="936" alt="Screen Shot 2565-03-09 at 09 48 42" src="https://user-images.githubusercontent.com/18292247/157363066-43c92f6d-d280-4254-9369-87624597dc02.png">

The result from Algolia indicates that the duplicated result does not have `/`.

<img width="1096" alt="Screen Shot 2565-03-09 at 09 50 36" src="https://user-images.githubusercontent.com/18292247/157363341-ab5553e5-dba8-4e7b-9254-7e803d2a0d00.png">

