### PR TITLE
[test] Fix flaky e2e:website tests in CI

### DIFF
--- a/test/e2e-website/data-grid-current.spec.ts
+++ b/test/e2e-website/data-grid-current.spec.ts
@@ -15,7 +15,7 @@ test.describe('DataGrid docs', () => {
 
     const anchors = page.locator('[aria-label="Page table of contents"] ul a');
 
-    const firstAnchor = await anchors.first();
+    const firstAnchor = anchors.first();
     const textContent = await firstAnchor.textContent();
 
     await expect(firstAnchor).toHaveAttribute(
@@ -28,9 +28,9 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for API section', async ({ page }) => {
       await page.goto(`/components/data-grid/`);
 
-      const anchors = await page.locator('div > h2#heading-api ~ ul a');
+      const anchors = page.locator('div > h2#heading-api ~ ul a');
 
-      const firstAnchor = await anchors.first();
+      const firstAnchor = anchors.first();
       const textContent = await firstAnchor.textContent();
 
       await expect(firstAnchor).toHaveAttribute(
@@ -42,7 +42,8 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto(`/components/data-grid/`);
 
-      const anchor = await page.locator('nav[aria-label="documentation"] ul a:text-is("Overview")');
+      const anchor = page.locator('nav[aria-label="documentation"] ul a:text-is("Overview")');
+      await anchor.waitFor();
 
       await expect(anchor).toHaveAttribute('href', `/components/data-grid/`);
     });
@@ -52,7 +53,8 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto(`/api/data-grid/data-grid/`);
 
-      const anchor = await page.locator('nav[aria-label="documentation"] ul a:text-is("DataGrid")');
+      const anchor = page.locator('nav[aria-label="documentation"] ul a:text-is("DataGrid")');
+      await anchor.waitFor();
 
       await expect(anchor).toHaveAttribute('app-drawer-active', '');
       await expect(anchor).toHaveAttribute('href', `/api/data-grid/data-grid/`);
@@ -61,7 +63,7 @@ test.describe('DataGrid docs', () => {
     test('all the links in the main content should have correct prefix', async ({ page }) => {
       await page.goto(`/api/data-grid/data-grid/`);
 
-      const anchors = await page.locator('div#main-content a');
+      const anchors = page.locator('div#main-content a');
 
       const handles = await anchors.elementHandles();
 
@@ -92,9 +94,10 @@ test.describe('DataGrid docs', () => {
 
       await page.type('input#docsearch-input', 'datagrid', { delay: 50 });
 
-      const anchor = await page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")');
+      const anchor = page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")').first();
+      await anchor.waitFor();
 
-      await expect(anchor.first()).toHaveAttribute('href', /^\/components\/data-grid\//);
+      await expect(anchor).toHaveAttribute('href', /^\/components\/data-grid\//);
     });
 
     test('should have correct link when searching API', async ({ page }) => {
@@ -104,12 +107,10 @@ test.describe('DataGrid docs', () => {
 
       await page.type('input#docsearch-input', 'datagrid api', { delay: 50 });
 
-      const anchor = await page.locator('.DocSearch-Hits a:has-text("DataGrid API")');
+      const anchor = page.locator('.DocSearch-Hits a:has-text("DataGrid API")').first();
+      await anchor.waitFor();
 
-      await expect(anchor.first()).toHaveAttribute(
-        'href',
-        `/api/data-grid/data-grid/#main-content`,
-      );
+      await expect(anchor).toHaveAttribute('href', `/api/data-grid/data-grid/#main-content`);
     });
 
     test('should have correct link when searching pro API', async ({ page }) => {
@@ -119,12 +120,10 @@ test.describe('DataGrid docs', () => {
 
       await page.type('input#docsearch-input', 'datagridpro api', { delay: 50 });
 
-      const anchor = await page.locator('.DocSearch-Hits a:has-text("DataGridPro API")');
+      const anchor = page.locator('.DocSearch-Hits a:has-text("DataGridPro API")').first();
+      await anchor.waitFor();
 
-      await expect(anchor.first()).toHaveAttribute(
-        'href',
-        `/api/data-grid/data-grid-pro/#main-content`,
-      );
+      await expect(anchor).toHaveAttribute('href', `/api/data-grid/data-grid-pro/#main-content`);
     });
   });
 });

--- a/test/e2e-website/data-grid-new.spec.ts
+++ b/test/e2e-website/data-grid-new.spec.ts
@@ -15,7 +15,7 @@ test.describe('DataGrid docs', () => {
 
     const anchors = page.locator('[aria-label="Page table of contents"] ul a');
 
-    const firstAnchor = await anchors.first();
+    const firstAnchor = anchors.first();
     const textContent = await firstAnchor.textContent();
 
     await expect(firstAnchor).toHaveAttribute(
@@ -28,9 +28,9 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for API section', async ({ page }) => {
       await page.goto(`/x/react-data-grid/`);
 
-      const anchors = await page.locator('div > h2#heading-api ~ ul a');
+      const anchors = page.locator('div > h2#heading-api ~ ul a');
 
-      const firstAnchor = await anchors.first();
+      const firstAnchor = anchors.first();
       const textContent = await firstAnchor.textContent();
 
       await expect(firstAnchor).toHaveAttribute(
@@ -42,7 +42,8 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto(`/x/react-data-grid/`);
 
-      const anchor = await page.locator('nav[aria-label="documentation"] ul a:text-is("Overview")');
+      const anchor = page.locator('nav[aria-label="documentation"] ul a:text-is("Overview")');
+      await anchor.waitFor();
 
       await expect(anchor).toHaveAttribute('href', `/x/react-data-grid/`);
     });
@@ -52,7 +53,8 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto(`/x/api/data-grid/data-grid/`);
 
-      const anchor = await page.locator('nav[aria-label="documentation"] ul a:text-is("DataGrid")');
+      const anchor = page.locator('nav[aria-label="documentation"] ul a:text-is("DataGrid")');
+      await anchor.waitFor();
 
       await expect(anchor).toHaveAttribute('app-drawer-active', '');
       await expect(anchor).toHaveAttribute('href', `/x/api/data-grid/data-grid/`);
@@ -61,7 +63,7 @@ test.describe('DataGrid docs', () => {
     test('all the links in the main content should have correct prefix', async ({ page }) => {
       await page.goto(`/x/api/data-grid/`);
 
-      const anchors = await page.locator('div#main-content a');
+      const anchors = page.locator('div#main-content a');
 
       const handles = await anchors.elementHandles();
 
@@ -98,9 +100,10 @@ test.describe('DataGrid docs', () => {
 
   //     await page.type('input#docsearch-input', 'datagrid', { delay: 50 });
 
-  //     const anchor = await page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")');
+  //     const anchor = page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")').first();
+  //     await anchor.waitFor();
 
-  //     await expect(anchor.first()).toHaveAttribute(
+  //     await expect(anchor).toHaveAttribute(
   //       'href',
   //       `/x/react-data-grid/components/#main-content`,
   //     );
@@ -113,9 +116,10 @@ test.describe('DataGrid docs', () => {
 
   //     await page.type('input#docsearch-input', 'datagrid api', { delay: 50 });
 
-  //     const anchor = await page.locator('.DocSearch-Hits a:has-text("DataGrid API")');
+  //     const anchor = page.locator('.DocSearch-Hits a:has-text("DataGrid API")').first();
+  //     await anchor.waitFor();
 
-  //     await expect(anchor.first()).toHaveAttribute(
+  //     await expect(anchor).toHaveAttribute(
   //       'href',
   //       `/x/api/data-grid/data-grid/#main-content`,
   //     );
@@ -128,9 +132,10 @@ test.describe('DataGrid docs', () => {
 
   //     await page.type('input#docsearch-input', 'datagridpro api', { delay: 50 });
 
-  //     const anchor = await page.locator('.DocSearch-Hits a:has-text("DataGridPro API")');
+  //     const anchor = page.locator('.DocSearch-Hits a:has-text("DataGridPro API")').first();
+  //     await anchor.waitFor();
 
-  //     await expect(anchor.first()).toHaveAttribute(
+  //     await expect(anchor).toHaveAttribute(
   //       'href',
   //       `/x/api/data-grid/data-grid-pro/#main-content`,
   //     );


### PR DESCRIPTION
`test:e2e:website` often fails like this:
https://app.circleci.com/pipelines/github/mui/mui-x/14660/workflows/2b6cb444-5705-4f72-b310-4fa2fd901b91/jobs/85906/parallel-runs/0/steps/0-111

This PR uses [`locator.waitFor()`](https://playwright.dev/docs/api/class-locator#locator-wait-for) API to wait for elements.
I've also removed unnecessary `await`s in places where return value is not a promise.

Not sure if it helps, since I have no way to consistently reproduce the issue, let's give it a try.