### PR TITLE
[DataGrid] Fix white blank when scrolling

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -235,17 +235,25 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
       ? prevRenderContext.current
       : computeRenderContext();
 
-    const rowsScrolledSincePreviousRender = Math.abs(
+    const topRowsScrolledSincePreviousRender = Math.abs(
       nextRenderContext.firstRowIndex - prevRenderContext.current.firstRowIndex,
     );
+    const bottomRowsScrolledSincePreviousRender = Math.abs(
+      nextRenderContext.lastRowIndex - prevRenderContext.current.lastRowIndex,
+    );
 
-    const columnsScrolledSincePreviousRender = Math.abs(
+    const topColumnsScrolledSincePreviousRender = Math.abs(
       nextRenderContext.firstColumnIndex - prevRenderContext.current.firstColumnIndex,
+    );
+    const bottomColumnsScrolledSincePreviousRender = Math.abs(
+      nextRenderContext.lastColumnIndex - prevRenderContext.current.lastColumnIndex,
     );
 
     const shouldSetState =
-      rowsScrolledSincePreviousRender >= rootProps.rowThreshold ||
-      columnsScrolledSincePreviousRender >= rootProps.columnThreshold ||
+      topRowsScrolledSincePreviousRender >= rootProps.rowThreshold ||
+      bottomRowsScrolledSincePreviousRender >= rootProps.rowThreshold ||
+      topColumnsScrolledSincePreviousRender >= rootProps.columnThreshold ||
+      bottomColumnsScrolledSincePreviousRender >= rootProps.columnThreshold ||
       prevTotalWidth.current !== columnsTotalWidth;
 
     // TODO v6: rename event to a wider name, it's not only fired for row scrolling


### PR DESCRIPTION
Fix #3436 

The problem is the following: To know when the rendered context must be updated, it relies on the top-left cell. If the index of the cell has changed by more than `rowThreshold` or `columnThreshold`, the `renderContext` is updated, which will rerender visible rows/cells and their buffer
This would work if columns/rows have the same size, which is not the case. Here is an example of scrolling on the right.

In purple you have the initial render context and in blue the buffer. From top to bottom we scrolled enough, such that 
- the visible left cell changed from 3 to 4 (a gap of 1)
- the visible right cell changed from 5 to 8 (a gap of 3)

To be sure that visible columns are always rendered, we need to increase verify on the left and the right (same thing for the top/bottom)

![image](https://user-images.githubusercontent.com/45398769/157856770-74ca971b-62d5-4cfc-8228-872d4c1a013f.png)
