### PR TITLE
[test] Add regression test for `showCellRightBorder`

### DIFF
--- a/packages/grid/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -52,7 +52,7 @@ describe('<DataGrid /> - Cells', () => {
     });
   });
 
-  describe('showCellRightBorder', () => {
+  describe('prop: showCellRightBorder', () => {
     function expectRightBorder(element: HTMLElement) {
       expect(element).to.have.class(gridClasses.withBorder);
 

--- a/packages/storybook/src/stories/grid-data.stories.tsx
+++ b/packages/storybook/src/stories/grid-data.stories.tsx
@@ -39,6 +39,9 @@ export const LoadingRowsAutoHeight = () => (
 export const VerticalScroll = () => <GridDataSet nbRows={200} nbCols={2} />;
 export const HorizontalScroll = () => <GridDataSet nbRows={15} nbCols={20} />;
 export const BothScroll = () => <GridDataSet nbRows={200} nbCols={50} />;
+export const AutoHeightWithRightBordersSnap = () => (
+  <GridDataSet nbRows={5} nbCols={5} autoHeight showCellRightBorder showColumnRightBorder />
+);
 export const BothScrollNoExtendAndBorders = () => (
   <GridDataSet nbRows={200} nbCols={50} disableExtendRowFullWidth showCellRightBorder />
 );


### PR DESCRIPTION
Follow up on https://github.com/mui/mui-x/pull/4140#pullrequestreview-908790622

I've added new story, since the issue is not reproducible in `BothScrollNoExtendAndBorders `