### PR TITLE
[core] Check if `process` is available

### DIFF
--- a/packages/grid/x-data-grid-generator/src/services/random-generator.ts
+++ b/packages/grid/x-data-grid-generator/src/services/random-generator.ts
@@ -15,7 +15,7 @@ import { GridDataGeneratorContext } from './gridColDefGenerator';
 const chanceId = globalChance();
 let chance: Chance.Chance;
 
-if (process.env.DISABLE_CHANCE_RANDOM) {
+if (typeof process !== 'undefined' && process.env.DISABLE_CHANCE_RANDOM) {
   chance = globalChance(() => 0.5);
 } else {
   chance = chanceId;

--- a/packages/grid/x-data-grid-generator/src/services/random-generator.ts
+++ b/packages/grid/x-data-grid-generator/src/services/random-generator.ts
@@ -15,7 +15,9 @@ import { GridDataGeneratorContext } from './gridColDefGenerator';
 const chanceId = globalChance();
 let chance: Chance.Chance;
 
-if (typeof process !== 'undefined' && process.env.DISABLE_CHANCE_RANDOM) {
+declare const DISABLE_CHANCE_RANDOM: any;
+
+if (typeof DISABLE_CHANCE_RANDOM !== 'undefined' && DISABLE_CHANCE_RANDOM) {
   chance = globalChance(() => 0.5);
 } else {
   chance = chanceId;

--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -22,9 +22,7 @@ module.exports = {
       template: path.resolve(__dirname, './template.html'),
     }),
     new webpack.DefinePlugin({
-      'process.env': {
-        DISABLE_CHANCE_RANDOM: JSON.stringify(true),
-      },
+      DISABLE_CHANCE_RANDOM: JSON.stringify(true),
     }),
   ],
   module: {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/4144#issuecomment-1066853139

Vite doesn't make available environment variables other than `process.env.NODE_ENV`.