### PR TITLE
[DataGrid] Do not unselect row when shift + click on the last selected row of a range

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
@@ -109,7 +109,7 @@ export const useGridSelection = (
         const startIndex = visibleRowIds.findIndex((rowId) => rowId === startId);
         const endIndex = visibleRowIds.findIndex((rowId) => rowId === endId);
         if (startIndex === endIndex) {
-            return
+          return;
         }
         if (startIndex > endIndex) {
           endId = visibleRowIds[endIndex + 1];

--- a/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
@@ -108,6 +108,9 @@ export const useGridSelection = (
         const visibleRowIds = gridVisibleSortedRowIdsSelector(apiRef);
         const startIndex = visibleRowIds.findIndex((rowId) => rowId === startId);
         const endIndex = visibleRowIds.findIndex((rowId) => rowId === endId);
+        if (startIndex === endIndex) {
+            return
+        }
         if (startIndex > endIndex) {
           endId = visibleRowIds[endIndex + 1];
         } else {

--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -285,7 +285,7 @@ describe('<DataGrid /> - Selection', () => {
       expect(getSelectedRowIds()).to.deep.equal([0, 1, 2]);
       fireEvent.click(getCell(2, 0).querySelector('input'), { shiftKey: true });
       expect(getSelectedRowIds()).to.deep.equal([0, 1, 2]);
-    })
+    });
 
     it('should keep only one selected row when turning off checkboxSelection', () => {
       const { setProps } = render(<TestDataGridSelection checkboxSelection />);

--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -277,6 +277,16 @@ describe('<DataGrid /> - Selection', () => {
       expect(getSelectedRowIds()).to.deep.equal([0, 1]);
     });
 
+    it('should not change the selection with shift pressed when clicking on the last row of the selection', () => {
+      render(<TestDataGridSelection checkboxSelection />);
+      fireEvent.click(getCell(0, 0).querySelector('input'));
+      expect(getSelectedRowIds()).to.deep.equal([0]);
+      fireEvent.click(getCell(2, 0).querySelector('input'), { shiftKey: true });
+      expect(getSelectedRowIds()).to.deep.equal([0, 1, 2]);
+      fireEvent.click(getCell(2, 0).querySelector('input'), { shiftKey: true });
+      expect(getSelectedRowIds()).to.deep.equal([0, 1, 2]);
+    })
+
     it('should keep only one selected row when turning off checkboxSelection', () => {
       const { setProps } = render(<TestDataGridSelection checkboxSelection />);
       fireEvent.click(getCell(0, 0).querySelector('input'));


### PR DESCRIPTION
Fixes #4156