### PR TITLE
[core] Fix Lerna package change detection

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,8 +35,8 @@ The following steps must be proposed as a pull request.
 - [ ] Checkout the last version of the working branch
 - [ ] Make sure you have the latest dependencies installed: `yarn`.
 - [ ] Build the packages: `yarn release:build`.
-- [ ] Release the versions on NPM: `yarn release:publish` (you need your 2FA device).
-- [ ] Create a new tag named with the release you just did `git tag v4.0.0-alpha.30 && git push upstream --tag`
+- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
+- [ ] Create a new tag named with the release you just did `git tag -a v4.0.0-alpha.30 -m "Version 4.0.0-alpha.30" && git push upstream --tag`
 
 ### Publish the documentation
 


### PR DESCRIPTION
See https://github.com/mui/mui-x/pull/3831#discussion_r827443134 for why. A TL:DR of the problem:

1. `git checkout v5.6.1`
2. `yarn lerna changed`
3. LOL WUT?

```
$ yarn lerna changed
yarn run v1.22.17
$ /Users/oliviertassinari/mui-x/node_modules/.bin/lerna changed
lerna notice cli v4.0.0
lerna info Looking for changed packages since v4.0.0-alpha.25
@mui/x-license-pro
@mui/x-data-grid-generator
@mui/x-data-grid-pro
@mui/x-data-grid
lerna success found 4 packages ready to
```


I have discovered this problem trying to make my point on that `@mui/x-license-pro` should almost never be published in the current state of things. We need to use an annotated tag. It's done correctly in https://github.com/mui/material-ui. Sebastian fixed this problem in the core a while ago.