### PR TITLE
[docs] Document Print export `X-Frame-Options` limitation

### DIFF
--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -185,6 +185,10 @@ The demo below shows how to add a JSON export.
 
 {{"demo": "CustomExport.js", "bg": "inline", "defaultCodeOpen": false}}
 
+> ⚠️ Due to the fact that the Print export relies on the usage of an `iframe` to prepare and only alow for the data grid to be printed and not the entire page there is a limitation around the usage of `X-Frame-Options`.
+>
+> In order for the Print export to work as expected set `X-Frame-Options: SAMEORIGIN`
+
 ## 🚧 Excel export [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/)
 
 > ⚠️ This feature isn't implemented yet. It's coming.

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -185,7 +185,7 @@ The demo below shows how to add a JSON export.
 
 {{"demo": "CustomExport.js", "bg": "inline", "defaultCodeOpen": false}}
 
-> ⚠️ Due to the fact that the Print export relies on the usage of an `iframe` to prepare and only print the data grid and not the entire page, there is a limitation around the usage of `X-Frame-Options`.
+> ⚠️ Due to the fact that the Print export relies on the usage of an `iframe`, there is a limitation around the usage of `X-Frame-Options`.
 >
 > In order for the Print export to work as expected set `X-Frame-Options: SAMEORIGIN`.
 

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -185,9 +185,9 @@ The demo below shows how to add a JSON export.
 
 {{"demo": "CustomExport.js", "bg": "inline", "defaultCodeOpen": false}}
 
-> ⚠️ Due to the fact that the Print export relies on the usage of an `iframe` to prepare and only alow for the data grid to be printed and not the entire page there is a limitation around the usage of `X-Frame-Options`.
+> ⚠️ Due to the fact that the Print export relies on the usage of an `iframe` to prepare and only print the data grid and not the entire page, there is a limitation around the usage of `X-Frame-Options`.
 >
-> In order for the Print export to work as expected set `X-Frame-Options: SAMEORIGIN`
+> In order for the Print export to work as expected set `X-Frame-Options: SAMEORIGIN`.
 
 ## 🚧 Excel export [<span class="plan-premium"></span>](https://mui.com/store/items/material-ui-pro/)
 


### PR DESCRIPTION
Follow up from https://github.com/mui/material-ui/pull/31807

Preview: https://deploy-preview-4222--material-ui-x.netlify.app/components/data-grid/export/#print-export