### PR TITLE
[DataGrid] Fix last column border inconsistency

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -182,7 +182,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
           column={column}
           colIndex={columnIndex}
           isResizing={resizeCol === column.field}
-          isLastColumn={columnIndex === columns.length - 1}
+          isLastColumn={columnIndex === visibleColumns.length - 1}
           extendRowFullWidth={!rootProps.disableExtendRowFullWidth}
           hasFocus={hasFocus}
           tabIndex={tabIndex}


### PR DESCRIPTION
Fix #4200 

## Why headers and row behave differently

The inconsistency between header and rows comes from the computation of the last column, which should be modified as follow
```diff
-isLastColumn={columnIndex === columns.length - 1}
+isLastColumn={columnIndex === visibleColumns.length - 1}
```

It appears in the issue example because one of the columns was hidden

## Proposed solution

In #2444 the consistency has been added, and the chosen solution was to remove borders for the last column. I propose to do the opposite for two reasons:

- It seems that at that time if the last column was flex, it displayed a double border. One for the grid container, and one for the cell border. This problem does not occur now
- In the Pro version, we need handlers to resize columns. If `showColumnRightBorder=true` this handlers became invisible, and so we need a border to know exactly where doe the last column ends 

