### PR TITLE
[docs] Explain how to manage focus with `renderCell`

### DIFF
--- a/docs/data/data-grid/columns/RenderCellGrid.js
+++ b/docs/data/data-grid/columns/RenderCellGrid.js
@@ -15,6 +15,14 @@ const columns = [
           color="primary"
           size="small"
           style={{ marginLeft: 16 }}
+          // Remove button from tab sequence when cell does not have focus
+          tabIndex={params.hasFocus ? 0 : -1}
+          onKeyDown={(event) => {
+            if (event.key === ' ') {
+              // Prevent key navigation when focus is on button
+              event.stopPropagation();
+            }
+          }}
         >
           Open
         </Button>

--- a/docs/data/data-grid/columns/RenderCellGrid.tsx
+++ b/docs/data/data-grid/columns/RenderCellGrid.tsx
@@ -15,6 +15,14 @@ const columns: GridColDef[] = [
           color="primary"
           size="small"
           style={{ marginLeft: 16 }}
+          // Remove button from tab sequence when cell does not have focus
+          tabIndex={params.hasFocus ? 0 : -1}
+          onKeyDown={(event) => {
+            if (event.key === ' ') {
+              // Prevent key navigation when focus is on button
+              event.stopPropagation();
+            }
+          }}
         >
           Open
         </Button>

--- a/docs/data/data-grid/columns/columns.md
+++ b/docs/data/data-grid/columns/columns.md
@@ -196,6 +196,7 @@ const columns: GridColDef[] = [
           color="primary"
           size="small"
           style={{ marginLeft: 16 }}
+          tabIndex={params.hasFocus ? 0 : -1}
         >
           Open
         </Button>
@@ -205,13 +206,17 @@ const columns: GridColDef[] = [
 ];
 ```
 
-{{"demo": "RenderCellGrid.js", "bg": "inline"}}
+{{"demo": "RenderCellGrid.js", "bg": "inline", "defaultCodeOpen": false }}
 
-**Note**: It is recommended to also set a `valueFormatter` providing a representation for the value to be used when [exporting](/components/data-grid/export/#exported-cells) the data.
-
-> ⚠️ When using `renderCell` with object cell values
-> remember to handle [sorting](/components/data-grid/sorting/#custom-comparator).
-> Otherwise, sorting won't work.
+> ⚠️ Using `renderCell`, requires paying attention to the following points.
+>
+> - If the value returned `valueGetter` does not correspond to the column `type`, you should:
+>
+>   - handle [sorting](/components/data-grid/sorting/#custom-comparator) by providing `sortComparator` to the column.
+>   - set a `valueFormatter` providing a representation for the value to be used when [exporting](/components/data-grid/export/#exported-cells) the data.
+>
+> - According to [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices-1.1/#grid), only one of the focusable elements contained by the grid should be included in the page tab sequence.
+>   To render focusable elements, use `params.hasFocus` to remove them from the tab sequence when the cell does not have the focus.
 
 #### Render edit cell
 


### PR DESCRIPTION
Part of #4219 

The goal of this PR is to explain in the doc how to remove focusable elements from the tab sequence if the cell does not have the focus