### PR TITLE
[DataGrid] Add missing classes on `gridClasses` and `gridPanelClasses`

### DIFF
--- a/docs/pages/api-docs/data-grid/data-grid-pro.json
+++ b/docs/pages/api-docs/data-grid/data-grid-pro.json
@@ -292,6 +292,7 @@
   "name": "DataGridPro",
   "styles": {
     "classes": [
+      "actionsCell",
       "autoHeight",
       "booleanCell",
       "cell--editable",
@@ -384,7 +385,9 @@
       "toolbarFilterList",
       "withBorder",
       "treeDataGroupingCell",
-      "treeDataGroupingCellToggle"
+      "treeDataGroupingCellToggle",
+      "groupingCriteriaCell",
+      "groupingCriteriaCellToggle"
     ],
     "globalClasses": {},
     "name": "MuiDataGrid"

--- a/docs/pages/api-docs/data-grid/data-grid.json
+++ b/docs/pages/api-docs/data-grid/data-grid.json
@@ -242,6 +242,7 @@
   "name": "DataGrid",
   "styles": {
     "classes": [
+      "actionsCell",
       "autoHeight",
       "booleanCell",
       "cell--editable",
@@ -334,7 +335,9 @@
       "toolbarFilterList",
       "withBorder",
       "treeDataGroupingCell",
-      "treeDataGroupingCellToggle"
+      "treeDataGroupingCellToggle",
+      "groupingCriteriaCell",
+      "groupingCriteriaCellToggle"
     ],
     "globalClasses": {},
     "name": "MuiDataGrid"

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -292,6 +292,7 @@
   "name": "DataGridPro",
   "styles": {
     "classes": [
+      "actionsCell",
       "autoHeight",
       "booleanCell",
       "cell--editable",
@@ -384,7 +385,9 @@
       "toolbarFilterList",
       "withBorder",
       "treeDataGroupingCell",
-      "treeDataGroupingCellToggle"
+      "treeDataGroupingCellToggle",
+      "groupingCriteriaCell",
+      "groupingCriteriaCellToggle"
     ],
     "globalClasses": {},
     "name": "MuiDataGrid"

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -242,6 +242,7 @@
   "name": "DataGrid",
   "styles": {
     "classes": [
+      "actionsCell",
       "autoHeight",
       "booleanCell",
       "cell--editable",
@@ -334,7 +335,9 @@
       "toolbarFilterList",
       "withBorder",
       "treeDataGroupingCell",
-      "treeDataGroupingCellToggle"
+      "treeDataGroupingCellToggle",
+      "groupingCriteriaCell",
+      "groupingCriteriaCellToggle"
     ],
     "globalClasses": {},
     "name": "MuiDataGrid"

--- a/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
@@ -129,6 +129,9 @@
     "treeData": "If <code>true</code>, the rows will be gathered in a tree structure according to the <code>getTreeDataPath</code> prop."
   },
   "classDescriptions": {
+    "actionsCell": {
+      "description": "Styles applied to the root element of the cell with type=\"actions\""
+    },
     "autoHeight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -502,11 +505,17 @@
     },
     "treeDataGroupingCell": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the root of the grouping column of the tree data"
+      "nodeName": "the root of the grouping cell of the tree data"
     },
     "treeDataGroupingCellToggle": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the toggle of the grouping column of the tree data"
+      "nodeName": "the toggle of the grouping cell of the tree data"
+    },
+    "groupingCriteriaCell": {
+      "description": "Styles applied to the root element of the grouping criteria cell"
+    },
+    "groupingCriteriaCellToggle": {
+      "description": "Styles applied to the toggle of the grouping criteria cell"
     }
   },
   "slotDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
@@ -129,6 +129,9 @@
     "treeData": "If <code>true</code>, the rows will be gathered in a tree structure according to the <code>getTreeDataPath</code> prop."
   },
   "classDescriptions": {
+    "actionsCell": {
+      "description": "Styles applied to the root element of the cell with type=\"actions\""
+    },
     "autoHeight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -502,11 +505,17 @@
     },
     "treeDataGroupingCell": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the root of the grouping column of the tree data"
+      "nodeName": "the root of the grouping cell of the tree data"
     },
     "treeDataGroupingCellToggle": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the toggle of the grouping column of the tree data"
+      "nodeName": "the toggle of the grouping cell of the tree data"
+    },
+    "groupingCriteriaCell": {
+      "description": "Styles applied to the root element of the grouping criteria cell"
+    },
+    "groupingCriteriaCellToggle": {
+      "description": "Styles applied to the toggle of the grouping criteria cell"
     }
   },
   "slotDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -129,6 +129,9 @@
     "treeData": "If <code>true</code>, the rows will be gathered in a tree structure according to the <code>getTreeDataPath</code> prop."
   },
   "classDescriptions": {
+    "actionsCell": {
+      "description": "Styles applied to the root element of the cell with type=\"actions\""
+    },
     "autoHeight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -502,11 +505,17 @@
     },
     "treeDataGroupingCell": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the root of the grouping column of the tree data"
+      "nodeName": "the root of the grouping cell of the tree data"
     },
     "treeDataGroupingCellToggle": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the toggle of the grouping column of the tree data"
+      "nodeName": "the toggle of the grouping cell of the tree data"
+    },
+    "groupingCriteriaCell": {
+      "description": "Styles applied to the root element of the grouping criteria cell"
+    },
+    "groupingCriteriaCellToggle": {
+      "description": "Styles applied to the toggle of the grouping criteria cell"
     }
   },
   "slotDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pt.json
@@ -98,6 +98,9 @@
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
   },
   "classDescriptions": {
+    "actionsCell": {
+      "description": "Styles applied to the root element of the cell with type=\"actions\""
+    },
     "autoHeight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -471,11 +474,17 @@
     },
     "treeDataGroupingCell": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the root of the grouping column of the tree data"
+      "nodeName": "the root of the grouping cell of the tree data"
     },
     "treeDataGroupingCellToggle": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the toggle of the grouping column of the tree data"
+      "nodeName": "the toggle of the grouping cell of the tree data"
+    },
+    "groupingCriteriaCell": {
+      "description": "Styles applied to the root element of the grouping criteria cell"
+    },
+    "groupingCriteriaCellToggle": {
+      "description": "Styles applied to the toggle of the grouping criteria cell"
     }
   },
   "slotDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-zh.json
@@ -98,6 +98,9 @@
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
   },
   "classDescriptions": {
+    "actionsCell": {
+      "description": "Styles applied to the root element of the cell with type=\"actions\""
+    },
     "autoHeight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -471,11 +474,17 @@
     },
     "treeDataGroupingCell": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the root of the grouping column of the tree data"
+      "nodeName": "the root of the grouping cell of the tree data"
     },
     "treeDataGroupingCellToggle": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the toggle of the grouping column of the tree data"
+      "nodeName": "the toggle of the grouping cell of the tree data"
+    },
+    "groupingCriteriaCell": {
+      "description": "Styles applied to the root element of the grouping criteria cell"
+    },
+    "groupingCriteriaCellToggle": {
+      "description": "Styles applied to the toggle of the grouping criteria cell"
     }
   },
   "slotDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -98,6 +98,9 @@
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
   },
   "classDescriptions": {
+    "actionsCell": {
+      "description": "Styles applied to the root element of the cell with type=\"actions\""
+    },
     "autoHeight": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -471,11 +474,17 @@
     },
     "treeDataGroupingCell": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the root of the grouping column of the tree data"
+      "nodeName": "the root of the grouping cell of the tree data"
     },
     "treeDataGroupingCellToggle": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the toggle of the grouping column of the tree data"
+      "nodeName": "the toggle of the grouping cell of the tree data"
+    },
+    "groupingCriteriaCell": {
+      "description": "Styles applied to the root element of the grouping criteria cell"
+    },
+    "groupingCriteriaCellToggle": {
+      "description": "Styles applied to the toggle of the grouping criteria cell"
     }
   },
   "slotDescriptions": {

--- a/packages/grid/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPanel.tsx
@@ -12,7 +12,7 @@ import { isEscapeKey } from '../../utils/keyboardUtils';
 
 export interface GridPanelClasses {
   /** Styles applied to the root element. */
-  root: string;
+  panel: string;
   /** Styles applied to the paper element. */
   paper: string;
 }
@@ -27,7 +27,10 @@ export interface GridPanelProps
   open: boolean;
 }
 
-export const gridPanelClasses = generateUtilityClasses('MuiDataGrid', ['panel', 'paper']);
+export const gridPanelClasses = generateUtilityClasses<keyof GridPanelClasses>('MuiDataGrid', [
+  'panel',
+  'paper',
+]);
 
 const GridPanelRoot = styled(Popper, {
   name: 'MuiDataGrid',

--- a/packages/grid/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/grid/x-data-grid/src/constants/gridClasses.ts
@@ -2,6 +2,10 @@ import { generateUtilityClasses, generateUtilityClass } from '@mui/material';
 
 export interface GridClasses {
   /**
+   * Styles applied to the root element of the cell with type="actions"
+   */
+  actionsCell: string;
+  /**
    * Styles applied to the root element if `autoHeight={true}`.
    */
   autoHeight: string;
@@ -367,13 +371,21 @@ export interface GridClasses {
    */
   withBorder: string;
   /**
-   * Styles applied to the root of the grouping column of the tree data.
+   * Styles applied to the root of the grouping cell of the tree data.
    */
   treeDataGroupingCell: string;
   /**
-   * Styles applied to the toggle of the grouping column of the tree data.
+   * Styles applied to the toggle of the grouping cell of the tree data.
    */
   treeDataGroupingCellToggle: string;
+  /**
+   * Styles applied to the root element of the grouping criteria cell
+   */
+  groupingCriteriaCell: string;
+  /**
+   * Styles applied to the toggle of the grouping criteria cell
+   */
+  groupingCriteriaCellToggle: string;
 }
 
 export type GridClassKey = keyof GridClasses;
@@ -382,7 +394,7 @@ export function getDataGridUtilityClass(slot: string): string {
   return generateUtilityClass('MuiDataGrid', slot);
 }
 
-export const gridClasses = generateUtilityClasses('MuiDataGrid', [
+export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'actionsCell',
   'autoHeight',
   'booleanCell',


### PR DESCRIPTION
- [x] Add missing classes on `gridClasses` that were listed in the array given to `generateUtilityClasses` but not on the `GridClasses` interface
- [x] Rename `GridPanelClasses['root']` into `GridPanelClasses['panel']` (the typing was wrong, I kept the actual classes used in the code to avoid breaking change)
- [x] Add a generic to `generateUtilityClasses` for both `gridClasses` and `gridPanelClasses` to have TS complains when the interface and the array are not equivalents