### PR TITLE
[DataGrid] Fix overlay blocking scrollbar when `rows` is empty

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/dimensions/gridDimensionsApi.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/dimensions/gridDimensionsApi.ts
@@ -9,12 +9,10 @@ export interface GridDimensions {
    * The viewport size not including scrollbars.
    */
   viewportInnerSize: ElementSize;
-
   /**
    * Indicates if a scroll is currently needed to go from the beginning of the first column to the end of the last column.
    */
   hasScrollX: boolean;
-
   /**
    * Indicates if a scroll is currently needed to go from the beginning of the first row to the end of the last row.
    */
@@ -26,17 +24,20 @@ export interface GridDimensionsApi {
    * Triggers a resize of the component and recalculation of width and height.
    */
   resize: () => void;
-
   /**
    * Returns the dimensions of the grid
    * @returns {GridDimensions | null} The dimension information of the grid. If `null`, the grid is not ready yet.
    */
   getRootDimensions: () => GridDimensions | null;
-
   /**
    * Returns the amount of rows that are currently visible in the viewport
    * @returns {number} The amount of rows visible in the viewport
    * @ignore - do not document.
    */
   unstable_getViewportPageSize: () => number;
+  /**
+   * Forces a recalculation of all dimensions.
+   * @ignore - do not document.
+   */
+  unstable_updateGridDimensionsRef: () => void;
 }

--- a/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -183,6 +183,7 @@ export function useGridDimensions(
     resize,
     getRootDimensions,
     unstable_getViewportPageSize: getViewportPageSize,
+    unstable_updateGridDimensionsRef: updateGridDimensionsRef,
   };
 
   useGridApiMethod(apiRef, dimensionsApi, 'GridDimensionsApi');

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -865,6 +865,27 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       expect(virtualScroller!.scrollWidth - virtualScroller!.clientWidth).not.to.equal(0);
     });
 
+    it('should not place the overlay on top of the horizontal scrollbar when rows=[]', () => {
+      const headerHeight = 40;
+      const height = 300;
+      const border = 1;
+      render(
+        <div style={{ width: 100 + 2 * border, height: height + 2 * border }}>
+          <DataGrid
+            rows={[]}
+            columns={[{ field: 'brand' }, { field: 'price' }]}
+            headerHeight={headerHeight}
+            hideFooter
+          />
+        </div>,
+      );
+      const virtualScroller = document.querySelector<HTMLElement>('.MuiDataGrid-virtualScroller');
+      const scrollBarSize = virtualScroller!.offsetHeight - virtualScroller!.clientHeight;
+      const overlayWrapper = screen.getByText('No rows').parentElement;
+      const expectedHeight = height - headerHeight - scrollBarSize;
+      expect(overlayWrapper).toHaveComputedStyle({ height: `${expectedHeight}px` });
+    });
+
     // See https://github.com/mui/mui-x/issues/3795#issuecomment-1028001939
     it('should expand content height when there are no rows', () => {
       render(


### PR DESCRIPTION
Fixes 2nd bug from https://github.com/mui/mui-x/issues/4275#issuecomment-1079451619

CodeSandbox: https://codesandbox.io/s/flamboyant-framework-zcmw34?file=/src/App.js

If the `rows` prop is not empty, `updateGridDimensionsRef` is called at least 3 times. The 2 first calls come from the following effect and the `visibleRowSet` event.

https://github.com/mui/mui-x/blob/e66404d4b15c5bfc524cfb6ab1b39e013cd91167/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts#L247

Additionally, there's a third call after rows hydration. This ensures that in one of these calls `apiRef.current.rootElementRef` will be defined and the scrollbar can be calculated from it.

If `rows=[]` this scenario doesn't repeat. In the rows hydration, `rowsMeta.currentPageTotalHeight` is always `0`, so we don't have the third call when the dependencies change. We rely purely on the effect above. When `updateGridDimensionsRef` is called, `apiRef.current.rootElementRef` is still `null` because we wrap the component that sets this prop into a `<NoSsr />`. The ref will only be set after the effect inside `NoSsr` has run. This falls into the condition below. The result is the overlay going over the scrollbar.

https://github.com/mui/mui-x/blob/e66404d4b15c5bfc524cfb6ab1b39e013cd91167/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts#L84-L85

This PR fixes this bug by only running the effect above after the component has mounted. I replaced `NoSsr` with our own implementation.

⚠ We need to be cautious when doing `React.useEffect(() => {}, [])` if inside the effect we also use any ref. It will be `null` when the effect runs. One place that does that is:

https://github.com/mui/mui-x/blob/e66404d4b15c5bfc524cfb6ab1b39e013cd91167/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts#L265-L272

I think we should move the `mountedState` to `apiRef.isMounted` and use it as a dependency, but that's for another PR. I'll open an issue if I find more locations that do this.

