### PR TITLE
[core] Remove dead code

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -13,7 +13,6 @@ import { gridRowsMetaSelector } from '../rows/gridRowsMetaSelector';
 import { GridScrollParams } from '../../../models/params/gridScrollParams';
 import { GridScrollApi } from '../../../models/api/gridScrollApi';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
-import { useGridNativeEventListener } from '../../utils/useGridNativeEventListener';
 
 // Logic copied from https://www.w3.org/TR/wai-aria-practices/examples/listbox/js/listbox.js
 // Similar to https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
@@ -140,16 +139,4 @@ export const useGridScroll = (
     getScrollPosition,
   };
   useGridApiMethod(apiRef, scrollApi, 'GridScrollApi');
-
-  const preventScroll = React.useCallback((event: any) => {
-    event.target.scrollLeft = 0;
-    event.target.scrollTop = 0;
-  }, []);
-
-  useGridNativeEventListener(
-    apiRef,
-    () => apiRef.current?.renderingZoneRef?.current?.parentElement,
-    'scroll',
-    preventScroll,
-  );
 };


### PR DESCRIPTION
I have found this by looking into #4280 in more detail. This code path is never reached, it seemed to have been here for when we implemented the virtualization without using a native scroll container, so we had to reset the scrollLeft and scrollRight. This is no longer the case.