### PR TITLE
[DataGrid] Allows to use keyboard navigation even with no rows

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -52,7 +52,8 @@ export const useGridScroll = (
     (params: Partial<GridCellIndexCoordinates>) => {
       const totalRowCount = gridRowCountSelector(apiRef);
       const visibleColumns = gridVisibleColumnDefinitionsSelector(apiRef);
-      if (totalRowCount === 0 || visibleColumns.length === 0) {
+      const scrollToHeader = params.rowIndex == null;
+      if ((!scrollToHeader && totalRowCount === 0) || visibleColumns.length === 0) {
         return false;
       }
 

--- a/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -319,6 +319,25 @@ describe('<DataGrid /> - Keyboard', () => {
       expect(virtualScroller.scrollLeft).not.to.equal(0);
     });
 
+    it('should scroll horizontally when navigating between column headers with arrows even if rows are empty', function test() {
+      if (isJSDOM) {
+        // Need layouting for column virtualization
+        this.skip();
+      }
+      render(
+        <div style={{ width: 60, height: 300 }}>
+          <DataGrid autoHeight={isJSDOM} {...getData(10, 10)} rows={[]} />
+        </div>,
+      );
+      getColumnHeaderCell(0).focus();
+      const virtualScroller = document.querySelector(
+        '.MuiDataGrid-virtualScroller',
+      )! as HTMLElement;
+      expect(virtualScroller.scrollLeft).to.equal(0);
+      fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
+      expect(virtualScroller.scrollLeft).not.to.equal(0);
+    });
+
     it('should move to the first row when pressing "ArrowDown" on a column header on the 1st page', () => {
       render(<NavigationTestCaseNoScrollX />);
       getColumnHeaderCell(1).focus();


### PR DESCRIPTION
Fix the following bug: https://github.com/mui/mui-x/pull/4280#discussion_r835798116

- Go in codesandbox.io/s/datagridprodemo-material-demo-forked-8e4l8w
- Click on a column header
- Press <kbd>Arrow Right</kbd> to navigate to the last column
- You are not able to do it because there is no row in the grid

