### PR TITLE
[core] Fix Argos flakyness for pickers tests

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -37,19 +37,23 @@ function MockTime(props) {
     // Use a "real timestamp" so that we see a useful date instead of "00:00"
     // eslint-disable-next-line react-hooks/rules-of-hooks -- not a React hook
     clock = useFakeTimers({
-      now: new Date('Mon Aug 18 14:11:54 2014 -0500'),
-      toFake: ['Date'],
+      now: new Date('Mon Aug 18 14:11:54 2014 -0500').getTime(),
+      // We need to let time advance to use `useDemoData`, but on the pickers test it makes the tests flaky
+      shouldAdvanceTime: props.isDataGridTest,
     });
-
     setReady(true);
 
     return () => {
       clock.restore();
     };
-  }, []);
+  }, [props.isDataGridTest]);
 
   return ready ? props.children : null;
 }
+
+MockTime.prototype = {
+  isDataGridTest: PropTypes.bool,
+};
 
 function LoadFont(props) {
   const { children, ...other } = props;
@@ -58,6 +62,7 @@ function LoadFont(props) {
   // In the end children passive effects should've been flushed.
   // React doesn't have any such guarantee outside of `act()` so we're approximating it.
   const [ready, setReady] = React.useState(false);
+
   // In react-router v6, with multiple routes sharing the same element,
   // this effect will only run once if no dependency is passed.
   React.useEffect(() => {
@@ -127,9 +132,9 @@ function TestViewer(props) {
           },
         }}
       />
-      <MockTime>
+      <MockTime isDataGridTest={isDataGridTest}>
         <LoadFont isDataGridTest={isDataGridTest}>{children}</LoadFont>
-      </MockTime>
+      </MockTime>{' '}
     </React.Fragment>
   );
 }

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -134,7 +134,7 @@ function TestViewer(props) {
       />
       <MockTime isDataGridTest={isDataGridTest}>
         <LoadFont isDataGridTest={isDataGridTest}>{children}</LoadFont>
-      </MockTime>{' '}
+      </MockTime>
     </React.Fragment>
   );
 }

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -37,8 +37,8 @@ function MockTime(props) {
     // Use a "real timestamp" so that we see a useful date instead of "00:00"
     // eslint-disable-next-line react-hooks/rules-of-hooks -- not a React hook
     clock = useFakeTimers({
-      now: new Date('Mon Aug 18 14:11:54 2014 -0500').getTime(),
-      shouldAdvanceTime: true,
+      now: new Date('Mon Aug 18 14:11:54 2014 -0500'),
+      toFake: ['Date'],
     });
 
     setReady(true);


### PR DESCRIPTION
On tests that displays the seconds, letting the time tick means that depending on the execution speed, the date visible can vary by one second.

- [x] Do not advance the time during regression testing for the date pickers

It would be nice to avoid advancing it for the data grid as well, but that would require changing our approach.
The core is only mocking `Date` so all the other async processes are handled out of the box. But in our case it breaks other stuff.