### PR TITLE
[DataGrid] Fix focus after stopping row edit mode with pagination enabled

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
@@ -7,7 +7,6 @@ import {
   DataGridPro,
   GridRenderEditCellParams,
   GridPreProcessEditCellProps,
-  GridCellProps,
 } from '@mui/x-data-grid-pro';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, fireEvent } from '@mui/monorepo/test/utils';
@@ -25,13 +24,23 @@ describe('<DataGridPro /> - Row Editing', () => {
 
   const defaultData = getData(4, 4);
 
-  const renderEditCell1 = spy((() => <input />) as (
-    props: GridRenderEditCellParams,
-  ) => React.ReactNode);
+  const CustomEditComponent = ({ hasFocus }: GridRenderEditCellParams) => {
+    const ref = React.useRef<HTMLInputElement>(null);
+    React.useLayoutEffect(() => {
+      if (hasFocus) {
+        ref.current!.focus();
+      }
+    }, [hasFocus]);
+    return <input ref={ref} />;
+  };
 
-  const renderEditCell2 = spy((() => <input />) as (
-    props: GridRenderEditCellParams,
-  ) => React.ReactNode);
+  const renderEditCell1 = spy((props: GridRenderEditCellParams) => (
+    <CustomEditComponent {...props} />
+  ));
+
+  const renderEditCell2 = spy((props: GridRenderEditCellParams) => (
+    <CustomEditComponent {...props} />
+  ));
 
   let column1Props: any = {};
   let column2Props: any = {};
@@ -303,16 +312,6 @@ describe('<DataGridPro /> - Row Editing', () => {
     });
 
     describe('stopRowEditMode', () => {
-      const CustomEditComponent = ({ hasFocus }: GridCellProps) => {
-        const ref = React.useRef<HTMLInputElement>(null);
-        React.useLayoutEffect(() => {
-          if (hasFocus) {
-            ref.current!.focus();
-          }
-        }, [hasFocus]);
-        return <input ref={ref} />;
-      };
-
       it('should reject when the cell is not in edit mode', async () => {
         render(<TestCase />);
         expect(() => apiRef.current.stopRowEditMode({ id: 0 })).to.throw(
@@ -467,7 +466,6 @@ describe('<DataGridPro /> - Row Editing', () => {
       });
 
       it('should move focus to the cell below when cellToFocusAfter=below', () => {
-        column1Props.renderEditCell = (props: GridCellProps) => <CustomEditComponent {...props} />;
         render(<TestCase />);
         apiRef.current.startRowEditMode({ id: 0, fieldToFocus: 'currencyPair' });
         expect(getCell(0, 1).querySelector('input')).toHaveFocus();
@@ -476,7 +474,6 @@ describe('<DataGridPro /> - Row Editing', () => {
       });
 
       it('should move focus to the cell below when cellToFocusAfter=right', () => {
-        column1Props.renderEditCell = (props: GridCellProps) => <CustomEditComponent {...props} />;
         render(<TestCase />);
         apiRef.current.startRowEditMode({ id: 0, fieldToFocus: 'currencyPair' });
         expect(getCell(0, 1).querySelector('input')).toHaveFocus();
@@ -485,7 +482,6 @@ describe('<DataGridPro /> - Row Editing', () => {
       });
 
       it('should move focus to the cell below when cellToFocusAfter=left', () => {
-        column2Props.renderEditCell = (props: GridCellProps) => <CustomEditComponent {...props} />;
         render(<TestCase />);
         apiRef.current.startRowEditMode({ id: 0, fieldToFocus: 'price1M' });
         expect(getCell(0, 2).querySelector('input')).toHaveFocus();
@@ -753,7 +749,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
         expect(listener.callCount).to.equal(0);
-        fireEvent.keyDown(cell, { key: 'Escape' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Escape' });
         expect(listener.lastCall.args[0].reason).to.equal('escapeKeyDown');
       });
 
@@ -764,7 +760,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
-        fireEvent.keyDown(cell, { key: 'Escape' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Escape' });
         expect(spiedStopRowEditMode.callCount).to.equal(1);
         expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
           id: 0,
@@ -785,18 +781,18 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
         expect(listener.callCount).to.equal(0);
-        fireEvent.keyDown(cell, { key: 'Enter' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Enter' });
         expect(listener.lastCall.args[0].reason).to.equal('enterKeyDown');
       });
 
-      it('should call stopRowEditMode with ignoreModifications=false and cellToFocusAfter', () => {
+      it('should call stopRowEditMode with ignoreModifications=false and cellToFocusAfter=below', () => {
         render(<TestCase />);
         const spiedStopRowEditMode = spy(apiRef.current, 'stopRowEditMode');
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
-        fireEvent.keyDown(cell, { key: 'Enter' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Enter' });
         expect(spiedStopRowEditMode.callCount).to.equal(1);
         expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
           id: 0,
@@ -816,7 +812,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
         apiRef.current.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' });
-        fireEvent.keyDown(cell, { key: 'Enter' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Enter' });
         expect(spiedStopRowEditMode.callCount).to.equal(1);
         expect(spiedStopRowEditMode.lastCall.args[0].ignoreModifications).to.equal(true);
       });
@@ -832,7 +828,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
         expect(listener.callCount).to.equal(0);
-        fireEvent.keyDown(cell, { key: 'Tab' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab' });
         expect(listener.lastCall.args[0].reason).to.equal('tabKeyDown');
       });
 
@@ -845,7 +841,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
         expect(listener.callCount).to.equal(0);
-        fireEvent.keyDown(cell, { key: 'Tab', shiftKey: true });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab', shiftKey: true });
         expect(listener.lastCall.args[0].reason).to.equal('shiftTabKeyDown');
       });
 
@@ -856,7 +852,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
-        fireEvent.keyDown(cell, { key: 'Tab' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab' });
         expect(spiedStopRowEditMode.callCount).to.equal(1);
         expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
           id: 0,
@@ -873,7 +869,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
-        fireEvent.keyDown(cell, { key: 'Tab', shiftKey: true });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab', shiftKey: true });
         expect(spiedStopRowEditMode.callCount).to.equal(1);
         expect(spiedStopRowEditMode.lastCall.args[0]).to.deep.equal({
           id: 0,
@@ -893,9 +889,43 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.click(cell);
         fireEvent.doubleClick(cell);
         apiRef.current.setEditCellValue({ id: 0, field: 'price1M', value: 'USD GBP' });
-        fireEvent.keyDown(cell, { key: 'Tab' });
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab' });
         expect(spiedStopRowEditMode.callCount).to.equal(1);
         expect(spiedStopRowEditMode.lastCall.args[0].ignoreModifications).to.equal(true);
+      });
+
+      it('should keep focus on the first column when editing the first column of the first row of the 2nd page', () => {
+        render(
+          <TestCase
+            rowsPerPageOptions={[2]}
+            pageSize={2}
+            page={1}
+            columnVisibilityModel={{ id: false }}
+            pagination
+          />,
+        );
+        const cell = getCell(2, 0);
+        fireEvent.doubleClick(cell);
+        expect(cell.querySelector('input')).toHaveFocus();
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab', shiftKey: true });
+        expect(getCell(2, 0)).toHaveFocus();
+      });
+
+      it('should keep focus on the last column when editing the last column of the last row of the 2nd page', () => {
+        render(
+          <TestCase
+            rowsPerPageOptions={[2]}
+            pageSize={2}
+            page={1}
+            columnVisibilityModel={{ price2M: false, price3M: false }}
+            pagination
+          />,
+        );
+        const cell = getCell(3, 2);
+        fireEvent.doubleClick(cell);
+        expect(cell.querySelector('input')).toHaveFocus();
+        fireEvent.keyDown(cell.querySelector('input'), { key: 'Tab' });
+        expect(getCell(3, 2)).toHaveFocus();
       });
     });
   });

--- a/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -102,27 +102,31 @@ export const useGridFocus = (
         rowIndexToFocus += 1;
       }
 
-      if (columnIndexToFocus >= visibleColumns.length) {
-        // Go to next row if we are at the last column
-        rowIndexToFocus += 1;
-        columnIndexToFocus = 0;
-      } else if (columnIndexToFocus < 0) {
-        // Go to previous row if we are at the first column
-        rowIndexToFocus -= 1;
-        columnIndexToFocus = visibleColumns.length - 1;
-      }
-
       const currentPage = getVisibleRows(apiRef, {
         pagination: props.pagination,
         paginationMode: props.paginationMode,
       });
 
-      rowIndexToFocus = clamp(
-        rowIndexToFocus,
-        currentPage.range!.firstRowIndex,
-        currentPage.range!.lastRowIndex,
-      );
+      if (columnIndexToFocus >= visibleColumns.length) {
+        // Go to next row if we are after the last column
+        rowIndexToFocus += 1;
 
+        if (rowIndexToFocus < currentPage.rows.length) {
+          // Go to first column of the next row if there's one more row
+          columnIndexToFocus = 0;
+        }
+      } else if (columnIndexToFocus < 0) {
+        // Go to previous row if we are before the first column
+        rowIndexToFocus -= 1;
+
+        if (rowIndexToFocus >= 0) {
+          // Go to last column of the previous if there's one more row
+          columnIndexToFocus = visibleColumns.length - 1;
+        }
+      }
+
+      rowIndexToFocus = clamp(rowIndexToFocus, 0, currentPage.rows.length - 1);
+      columnIndexToFocus = clamp(columnIndexToFocus, 0, visibleColumns.length - 1);
       const rowToFocus = currentPage.rows[rowIndexToFocus];
       const columnToFocus = visibleColumns[columnIndexToFocus];
       apiRef.current.setCellFocus(rowToFocus.id, columnToFocus.field);


### PR DESCRIPTION
In #4252 I forgot to `clamp` the indexes. This was raised in https://github.com/mui/mui-x/pull/4252#issuecomment-1084673222

I also took the opportunity to improve which cell receives focus when editing the first column of the first row or the last column of the last column. Previously, focus would jump to the last cell or the first cell when these conditions are met. Now we keep focus on the current cell.

### Steps to reproduce

1. Open https://codesandbox.io/s/basicroweditinggrid-material-demo-forked-zdftxh?file=/demo.tsx
2. Double-click on the "Last login" cell of the last row
3. Press <kbd>Tab</kbd>
4. 💥

CodeSandbox with the fix: https://codesandbox.io/s/basicroweditinggrid-material-demo-forked-soxqwq?file=/demo.tsx