### PR TITLE
[docs] New page for the pickers migration from the lab

### DIFF
--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -24,11 +24,9 @@ If you are using one of these components, you will have to take a Pro license in
 
 **Note**: If you already have a license for `@mui/x-data-grid-pro`, you can use the same one for `@mui/x-date-pickers-pro` with no additional fee!
 
-## How to migrate ?
+## Migration steps
 
-### Installation
-
-#### Pro Plan
+### 1. Install MUI X packages
 
 ```sh
 // with npm
@@ -61,9 +59,15 @@ npm install @mui/x-date-pickers
 yarn add @mui/x-data-grid
 ```
 
-#### Migrate your imports
+### 2. Run the code mod
 
-To migrate, update the package name and change from a default export to a named export:
+We have prepared a codemod to help you migrate your codebase
+
+```sh
+npx @mui/codemod v5.0.0/date-pickers-moved-to-x <path>
+```
+
+Which will transform the imports like this:
 
 ```ts
 // before
@@ -76,10 +80,4 @@ import DatePicker from '@mui/x-date-pickers/DatePicker';
 import DateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
 import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`
 import { DateRangePicker } from '@mui/x-date-pickers-pro';
-```
-
-We have prepared a codemod to help you migrate your codebase from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`:
-
-```sh
-npx @mui/codemod v5.0.0/date-pickers-moved-to-x <path>
 ```

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -1,0 +1,85 @@
+---
+title: MUI X - Migration from the lab
+---
+
+# MUI X - Migration from the lab
+
+<p class="description">MUI Date and time pickers are now available on X!</p>
+
+## Introduction
+
+This is a reference for migrating your site's pickers from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`.
+This migration should be easy
+
+We explored the reasons of this migration in a [blog post](https://mui.com/blog/lab-date-pickers-to-mui-x/)
+
+## License
+
+Most of our components remains MIT and are accessible for free in `@mui/x-date-pickers`.
+
+The components `DateRangePicker`, `DateRangePickerDay`, `DesktopDateRangePicker`, `MobileDateRangePicker` and `StaticDateRangePicker`
+were marked as "intended for MUI X Pro" in our documentation and are now part of MUI X Pro.
+
+If you are using one of these components, you will have to take a Pro license in order to migrate to `@mui/x-date-pickers-pro` (see the [Pricing](https://mui.com/pricing/) page for more information).
+
+**Note**: If you already have a license for `@mui/x-data-grid-pro`, you can use the same one for `@mui/x-date-pickers-pro` with no additional fee!
+
+## How to migrate ?
+
+### Installation
+
+#### Pro Plan
+
+```sh
+// with npm
+npm install @mui/x-date-pickers-pro @mui/x-license-pro
+
+// with yarn
+yarn add @mui/x-date-pickers-pro @mui/x-license-pro
+```
+
+When you purchase a commercial license, you'll receive a license key by email.
+You must set the license key before rendering the first component.
+
+```jsx
+import { LicenseInfo } from '@mui/x-license-pro';
+
+LicenseInfo.setLicenseKey(
+  'x0jTPl0USVkVZV0SsMjM1kDNyADM5cjM2ETPZJVSQhVRsIDN0YTM6IVREJ1T0b9586ef25c9853decfa7709eee27a1e',
+);
+```
+
+More information [here](/x/advanced-components/#license-key-installation)
+
+#### Community Plan
+
+```sh
+// with npm
+npm install @mui/x-date-pickers
+
+// with yarn
+yarn add @mui/x-data-grid
+```
+
+#### Migrate your imports
+
+To migrate, update the package name and change from a default export to a named export:
+
+```ts
+// before
+import DatePicker from '@mui/lab/DatePicker';
+import DateRangePicker from '@mui/lab/DateRangePicker';
+import { DatePicker, DateRangePicker } from '@mui/lab';
+
+// after
+import DatePicker from '@mui/x-date-pickers/DatePicker';
+import DateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
+import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`
+import { DateRangePicker } from '@mui/x-date-pickers-pro';
+```
+
+We have prepared a codemod to help you migrate your codebase from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`:
+
+```sh
+npx @mui/codemod v5.0.0/date-pickers-moved-to-x <path>
+```

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -81,3 +81,4 @@ Which will transform the imports like this:
 - import { DatePicker, DateRangePicker } from '@mui/lab';
 + import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`
 + import { DateRangePicker } from '@mui/x-date-pickers-pro';
+```

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -28,6 +28,8 @@ If you are using one of these components, you will have to take a Pro license in
 
 ### 1. Install MUI X packages
 
+**Note:** `@mui/x-date-pickers-pro` re-exports everything from `@mui/x-date-pickers`. You don't have to install both when using the Pro Plan.
+
 #### Community Plan
 
 ```sh
@@ -47,8 +49,6 @@ npm install @mui/x-date-pickers-pro @mui/x-license-pro
 // with yarn
 yarn add @mui/x-date-pickers-pro @mui/x-license-pro
 ```
-
-**Note:** `@mui/x-date-pickers-pro` re-exports everything from `@mui/x-date-pickers`. You don't have to install both.
 
 When you purchase a commercial license, you'll receive a license key by email.
 You must set the license key before rendering the first component.

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -35,7 +35,7 @@ If you are using one of these components, you will have to take a Pro license in
 npm install @mui/x-date-pickers
 
 // with yarn
-yarn add @mui/x-data-grid
+yarn add @mui/x-date-pickers
 ```
 
 #### Pro Plan

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -28,6 +28,18 @@ If you are using one of these components, you will have to take a Pro license in
 
 ### 1. Install MUI X packages
 
+#### Community Plan
+
+```sh
+// with npm
+npm install @mui/x-date-pickers
+
+// with yarn
+yarn add @mui/x-data-grid
+```
+
+#### Pro Plan
+
 ```sh
 // with npm
 npm install @mui/x-date-pickers-pro @mui/x-license-pro
@@ -48,16 +60,6 @@ LicenseInfo.setLicenseKey(
 ```
 
 More information [here](/x/advanced-components/#license-key-installation)
-
-#### Community Plan
-
-```sh
-// with npm
-npm install @mui/x-date-pickers
-
-// with yarn
-yarn add @mui/x-data-grid
-```
 
 ### 2. Run the code mod
 

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -4,7 +4,7 @@ title: MUI X - Migration from the lab
 
 # MUI X - Migration from the lab
 
-<p class="description">MUI Date and time pickers are now available on X!</p>
+<p class="description">MUI date and time pickers are now available on X!</p>
 
 ## Introduction
 

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -9,7 +9,7 @@ title: MUI X - Migration from the lab
 ## Introduction
 
 This is a reference for migrating your site's pickers from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`.
-This migration should be easy
+This migration only concerns packages and should do not affect the behavior of the components in your app.
 
 We explored the reasons of this migration in a [blog post](https://mui.com/blog/lab-date-pickers-to-mui-x/)
 
@@ -17,7 +17,7 @@ We explored the reasons of this migration in a [blog post](https://mui.com/blog/
 
 Most of our components remains MIT and are accessible for free in `@mui/x-date-pickers`.
 
-The components `DateRangePicker`, `DateRangePickerDay`, `DesktopDateRangePicker`, `MobileDateRangePicker` and `StaticDateRangePicker`
+The range-picker components: `DateRangePicker`, `DateRangePickerDay`, `DesktopDateRangePicker`, `MobileDateRangePicker` and `StaticDateRangePicker`
 were marked as "intended for MUI X Pro" in our documentation and are now part of MUI X Pro.
 
 If you are using one of these components, you will have to take a Pro license in order to migrate to `@mui/x-date-pickers-pro` (see the [Pricing](https://mui.com/pricing/) page for more information).
@@ -48,6 +48,8 @@ npm install @mui/x-date-pickers-pro @mui/x-license-pro
 yarn add @mui/x-date-pickers-pro @mui/x-license-pro
 ```
 
+**Note:** `@mui/x-date-pickers-pro` re-exports everything from `@mui/x-date-pickers`. You don't have to install both.
+
 When you purchase a commercial license, you'll receive a license key by email.
 You must set the license key before rendering the first component.
 
@@ -73,10 +75,10 @@ Which will transform the imports like this:
 
 ```diff
 - import DatePicker from '@mui/lab/DatePicker';
-+ import DatePicker from '@mui/x-date-pickers/DatePicker';
++ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 - import DateRangePicker from '@mui/lab/DateRangePicker';
-+ import DateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
++ import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 
 - import { DatePicker, DateRangePicker } from '@mui/lab';
 + import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -71,15 +71,13 @@ npx @mui/codemod v5.0.0/date-pickers-moved-to-x <path>
 
 Which will transform the imports like this:
 
-```ts
-// before
-import DatePicker from '@mui/lab/DatePicker';
-import DateRangePicker from '@mui/lab/DateRangePicker';
-import { DatePicker, DateRangePicker } from '@mui/lab';
+```diff
+- import DatePicker from '@mui/lab/DatePicker';
++ import DatePicker from '@mui/x-date-pickers/DatePicker';
 
-// after
-import DatePicker from '@mui/x-date-pickers/DatePicker';
-import DateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
-import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`
-import { DateRangePicker } from '@mui/x-date-pickers-pro';
-```
+- import DateRangePicker from '@mui/lab/DateRangePicker';
++ import DateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
+
+- import { DatePicker, DateRangePicker } from '@mui/lab';
++ import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`
++ import { DateRangePicker } from '@mui/x-date-pickers-pro';

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -8,7 +8,7 @@ const pages = [
       { pathname: '/x/react-data-grid', title: 'Overview' },
       { pathname: '/x/react-data-grid/demo' },
       { pathname: '/x/react-data-grid/getting-started' },
-      { pathname: '/x/react-data-grid/migration-v4', title: 'Migration From v4' },
+      { pathname: '/x/react-data-grid/migration-v4', title: 'Migration from v4' },
       { pathname: '/x/react-data-grid/layout' },
       { pathname: '/x/react-data-grid/columns' },
       { pathname: '/x/react-data-grid/rows' },
@@ -62,6 +62,7 @@ const pages = [
     icon: 'TableViewIcon',
     children: [
       { pathname: '/x/react-date-pickers/getting-started' },
+      { pathname: '/x/react-date-pickers/migration-lab', title: 'Migration from the lab' },
       { pathname: '/x/react-date-pickers/date-picker' },
       {
         pathname: '/x/react-date-pickers/date-range-picker',

--- a/docs/pages/x/react-date-pickers/migration-lab.js
+++ b/docs/pages/x/react-date-pickers/migration-lab.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import {
+  demos,
+  docs,
+  demoComponents,
+} from 'docsx/data/date-pickers/migration-lab/migration-lab.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
+}


### PR DESCRIPTION
@siriwatknp rightfully pointed out that we were missing a dedicated migration page.

[Doc preview](https://deploy-preview-4327--material-ui-x.netlify.app/x/react-date-pickers/migration-lab/)