### PR TITLE
[docs] Fix some links to date picker docs

### DIFF
--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -26,4 +26,4 @@ This component has three peer dependencies that you will need to install as well
 
 ## Documentation
 
-[The documentation](https://mui.com/components/x/react-date-pickers/date-picker/)
+[The documentation](https://mui.com/x/react-date-pickers/date-picker/)

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui-x/issues"
   },
-  "homepage": "https://mui.com/components/x/react-date-pickers/date-picker/",
+  "homepage": "https://mui.com/x/react-date-pickers/date-picker/",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -93,7 +93,7 @@ type DateRangePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Range Picker](https://mui.com/components/x/react-date-pickers/date-range-picker/)
+ * - [Date Range Picker](https://mui.com/x/react-date-pickers/date-range-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -375,7 +375,7 @@ const propsAreEqual = (
  *
  * Demos:
  *
- * - [Date Range Picker](https://mui.com/components/x/react-date-pickers/date-range-picker/)
+ * - [Date Range Picker](https://mui.com/x/react-date-pickers/date-range-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -98,7 +98,7 @@ type DesktopDateRangePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Range Picker](https://mui.com/components/x/react-date-pickers/date-range-picker/)
+ * - [Date Range Picker](https://mui.com/x/react-date-pickers/date-range-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -98,7 +98,7 @@ type MobileDateRangePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Range Picker](https://mui.com/components/x/react-date-pickers/date-range-picker/)
+ * - [Date Range Picker](https://mui.com/x/react-date-pickers/date-range-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -95,7 +95,7 @@ type StaticDateRangePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Range Picker](https://mui.com/components/x/react-date-pickers/date-range-picker/)
+ * - [Date Range Picker](https://mui.com/x/react-date-pickers/date-range-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -26,4 +26,4 @@ This component has three peer dependencies that you will need to install as well
 
 ## Documentation
 
-[The documentation](https://mui.com/components/x/react-date-pickers/date-picker/)
+[The documentation](https://mui.com/x/react-date-pickers/date-picker/)

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui-x/issues"
   },
-  "homepage": "https://mui.com/components/x/react-date-pickers/date-picker/",
+  "homepage": "https://mui.com/x/react-date-pickers/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/mui-org/material-ui-x/issues"
   },
-  "homepage": "https://mui.com/x/react-date-pickers/",
+  "homepage": "https://mui.com/x/react-date-pickers/date-picker/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -152,7 +152,7 @@ type CalendarPickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/x-date-pickers/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -87,7 +87,7 @@ const monthMap = [
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -24,7 +24,7 @@ type DatePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  * - [Pickers](https://mui.com/x/react-date-pickers/)
  *
  * API:

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -24,7 +24,7 @@ type DateTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Time Picker](https://mui.com/components/x/react-date-pickers/date-time-picker/)
+ * - [Date Time Picker](https://mui.com/x/react-date-pickers/date-time-picker/)
  * - [Pickers](https://mui.com/x/react-date-pickers/)
  *
  * API:

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -32,7 +32,7 @@ type DesktopDatePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -35,7 +35,7 @@ type DesktopDateTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Time Picker](https://mui.com/components/x/react-date-pickers/date-time-picker/)
+ * - [Date Time Picker](https://mui.com/x/react-date-pickers/date-time-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -32,7 +32,7 @@ type DesktopTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Time Picker](https://mui.com/components/x/react-date-pickers/time-picker/)
+ * - [Time Picker](https://mui.com/x/react-date-pickers/time-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -29,7 +29,7 @@ type MobileDatePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -32,7 +32,7 @@ type MobileDateTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Time Picker](https://mui.com/components/x/react-date-pickers/date-time-picker/)
+ * - [Date Time Picker](https://mui.com/x/react-date-pickers/date-time-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -29,7 +29,7 @@ type MobileTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Time Picker](https://mui.com/components/x/react-date-pickers/time-picker/)
+ * - [Time Picker](https://mui.com/x/react-date-pickers/time-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -436,7 +436,7 @@ PickersDayRaw.propTypes = {
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -35,7 +35,7 @@ type StaticDatePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Picker](https://mui.com/components/x/react-date-pickers/date-picker/)
+ * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -38,7 +38,7 @@ type StaticDateTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Date Time Picker](https://mui.com/components/x/react-date-pickers/date-time-picker/)
+ * - [Date Time Picker](https://mui.com/x/react-date-pickers/date-time-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
@@ -35,7 +35,7 @@ type StaticTimePickerComponent = (<TDate>(
  *
  * Demos:
  *
- * - [Time Picker](https://mui.com/components/x/react-date-pickers/time-picker/)
+ * - [Time Picker](https://mui.com/x/react-date-pickers/time-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
@@ -25,7 +25,7 @@ type TimePickerComponent = (<TDate>(
  * Demos:
  *
  * - [Pickers](https://mui.com/x/react-date-pickers/)
- * - [Time Picker](https://mui.com/components/x/react-date-pickers/time-picker/)
+ * - [Time Picker](https://mui.com/x/react-date-pickers/time-picker/)
  *
  * API:
  *


### PR DESCRIPTION
The /components/ folder looked wrong, this seems to be a safe change. 

---

Two thoughts:

1. The data grid entry point has a flat folder structure: https://master--material-ui-x.netlify.app/x/react-data-grid/ but the date picker doesn't: https://master--material-ui-x.netlify.app/x/react-date-pickers/getting-started/. The former seems more efficient from an SEO perspective. What if we added an overview page too for the date picker?
2. Where should the npm `@mui/x-date-picker` package "homepage" link to? `/x/react-date-pickers/` or the specific component. I kind of like the former for suggesting it's a broad package, date picker, time picker, etc.