### PR TITLE
[DatePicker] Fix previous input value issues

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -72,6 +72,7 @@ export const usePickerState = <TInput, TDateValue>(
   }
 
   const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
+  const [wrapper, setWrapper] = React.useState<WrapperVariant>(null);
 
   // Mobile keyboard view is a special case.
   // When it's open picker should work like closed, cause we are just showing text field
@@ -97,7 +98,11 @@ export const usePickerState = <TInput, TDateValue>(
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
       onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(initialDate, true),
+      onDismiss: () =>
+        acceptDate(
+          wrapper === 'mobile' || !disableCloseOnSelect ? initialDate : draftState.draft,
+          true,
+        ),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });
@@ -112,6 +117,7 @@ export const usePickerState = <TInput, TDateValue>(
       draftState.draft,
       valueManager.emptyValue,
       initialDate,
+      wrapper,
     ],
   );
 
@@ -125,6 +131,7 @@ export const usePickerState = <TInput, TDateValue>(
         wrapperVariant: WrapperVariant,
         selectionState: PickerSelectionState = 'partial',
       ) => {
+        setWrapper(wrapperVariant);
         dispatch({ type: 'update', payload: newDate });
         if (selectionState === 'partial') {
           acceptDate(newDate, false);

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -97,7 +97,7 @@ export const usePickerState = <TInput, TDateValue>(
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
       onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(initialDate, true),
+      onDismiss: () => acceptDate(disableCloseOnSelect ? draftState.draft : initialDate, true),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -83,7 +83,7 @@ export const usePickerState = <TInput, TDateValue>(
 
       if (needClosePicker) {
         setIsOpen(false);
-        setInitialDate(acceptedDate);
+
         if (onAccept) {
           onAccept(acceptedDate);
         }
@@ -146,9 +146,12 @@ export const usePickerState = <TInput, TDateValue>(
       onChange,
       open: isOpen,
       rawValue: value,
-      openPicker: () => setIsOpen(true),
+      openPicker: () => {
+        setInitialDate(parsedDateValue);
+        setIsOpen(true);
+      },
     }),
-    [onChange, isOpen, value, setIsOpen],
+    [onChange, isOpen, value, parsedDateValue, setIsOpen],
   );
 
   const pickerState = { pickerProps, inputProps, wrapperProps };

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -97,7 +97,7 @@ export const usePickerState = <TInput, TDateValue>(
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
       onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(disableCloseOnSelect ? draftState.draft : initialDate, true),
+      onDismiss: () => acceptDate(initialDate, true),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });


### PR DESCRIPTION
Re-open https://github.com/mui/material-ui/pull/31929 here

fixes mui/mui-x#4478, fixes mui/mui-x#4469

not sure whether mui/material-ui#4358 is really a bug. I think people need a way to cancel their selections on the desktop.

mui/mui-x#4478 and mui/mui-x#4469 are caused by calling `setInitialDate` whenever we close the picker. This design could not handle the input change after closing. Instead, we should call `setInitialDate` just before the picker opens.