### PR TITLE
[DataGrid] Fix `api` prop leaking to DOM

### DIFF
--- a/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { useForkRef } from '@mui/material/utils';
 import { GridEvents } from '../../models/events';
-import { GridCellParams } from '../../models/params/gridCellParams';
+import { GridRenderCellParams } from '../../models/params/gridCellParams';
 import { isNavigationKey, isSpaceKey } from '../../utils/keyboardUtils';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
@@ -27,7 +27,7 @@ interface TouchRippleActions {
   stop: (event: any, callback?: () => void) => void;
 }
 
-const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellParams>(
+const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRenderCellParams>(
   function GridCellCheckboxRenderer(props, ref) {
     const {
       field,
@@ -42,6 +42,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellPa
       hasFocus,
       tabIndex,
       getValue,
+      api,
       ...other
     } = props;
     const apiRef = useGridApiContext();
@@ -118,6 +119,11 @@ GridCellCheckboxForwardRef.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * GridApi that let you manipulate the grid.
+   * @deprecated Use the `apiRef` returned by `useGridApiContext` or `useGridApiRef` (only available in `@mui/x-data-grid-pro`)
+   */
+  api: PropTypes.any.isRequired,
   /**
    * The mode of the cell.
    */


### PR DESCRIPTION
Fixes

<img width="600" src="https://user-images.githubusercontent.com/42154031/162084606-7cc591f5-aa81-4b56-9b57-25545c487490.png" alt="image" style="max-width: 100%;">

_Screenshot taken from https://mui.com/components/data-grid/demo/_