### PR TITLE
[DataGrid] Fix scrollbar grabbing issue in Safari

### DIFF
--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
@@ -24,6 +24,8 @@ const VirtualScrollerRoot = styled('div', {
   overridesResolver: (props, styles) => styles.virtualScroller,
 })({
   overflow: 'auto',
+  // See https://github.com/mui/mui-x/issues/4360
+  position: 'relative',
   '@media print': {
     overflow: 'hidden',
   },

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerContent.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerContent.tsx
@@ -22,9 +22,7 @@ const VirtualScrollerContentRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'VirtualScrollerContent',
   overridesResolver: (props, styles) => styles.virtualScrollerContent,
-})({
-  position: 'relative',
-});
+})({});
 
 const GridVirtualScrollerContent = React.forwardRef<
   HTMLDivElement,

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
@@ -26,6 +26,8 @@ const VirtualScrollerRenderZoneRoot = styled('div', {
   position: 'absolute',
   display: 'flex', // Prevents margin collapsing when using `getRowSpacing`
   flexDirection: 'column',
+  // See https://github.com/mui/mui-x/issues/4360
+  zIndex: -1,
 });
 
 const GridVirtualScrollerRenderZone = React.forwardRef<

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
@@ -26,8 +26,6 @@ const VirtualScrollerRenderZoneRoot = styled('div', {
   position: 'absolute',
   display: 'flex', // Prevents margin collapsing when using `getRowSpacing`
   flexDirection: 'column',
-  // See https://github.com/mui/mui-x/issues/4360
-  zIndex: -1,
 });
 
 const GridVirtualScrollerRenderZone = React.forwardRef<


### PR DESCRIPTION
Preview: https://deploy-preview-4405--material-ui-x.netlify.app/components/data-grid/#commercial-version

Closes #4360 

Before: 

https://user-images.githubusercontent.com/13808724/162418465-d58fa4df-e9a1-4156-9561-f4bbb9f9e885.mov

After:

https://user-images.githubusercontent.com/13808724/162440323-2e888f2d-d7ca-4df2-88fd-da1151f4f7a2.mov


