### PR TITLE
[pickers] Add react-dom to pickers peer deps to satisfy react-transition-group

### DIFF
--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -60,7 +60,8 @@
     "dayjs": "^1.10.7",
     "luxon": "^1.28.0 || ^2.0.0",
     "moment": "^2.29.1",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependenciesMeta": {
     "date-fns": {

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -61,7 +61,8 @@
     "dayjs": "^1.10.7",
     "luxon": "^1.28.0 || ^2.0.0",
     "moment": "^2.29.1",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependenciesMeta": {
     "date-fns": {


### PR DESCRIPTION
```
$ yarn explain peer-requirements pe404c
➤ YN0000: @mui/x-date-pickers@npm:5.0.0-alpha.0 [b95f3] doesn't provide react-dom, breaking the following requirements:

➤ YN0000: react-transition-group@npm:4.4.2 [419ef] → >=16.6.0 ✘
```