### PR TITLE
[DataGrid] Don't close column menu when updating rows

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
@@ -65,8 +65,7 @@ describe('<DataGridPro /> - Column Headers', () => {
       clock.runToLast();
       expect(screen.queryByRole('menu')).not.to.equal(null);
       const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
-      virtualScroller.scrollTop = 50;
-      virtualScroller.dispatchEvent(new Event('scroll'));
+      fireEvent.wheel(virtualScroller);
       clock.runToLast();
       expect(screen.queryByRole('menu')).to.equal(null);
     });

--- a/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, fireEvent, screen } from '@mui/monorepo/test/utils';
 import { expect } from 'chai';
-import { gridClasses, DataGridPro } from '@mui/x-data-grid-pro';
+import { gridClasses, DataGridPro, DataGridProProps } from '@mui/x-data-grid-pro';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -55,7 +55,7 @@ describe('<DataGridPro /> - Column Headers', () => {
   describe('GridColumnHeaderMenu', () => {
     it('should close the menu when the window is scrolled', () => {
       render(
-        <div style={{ width: 300, height: 500 }}>
+        <div style={{ width: 300, height: 200 }}>
           <DataGridPro {...baselineProps} columns={[{ field: 'brand' }]} />
         </div>,
       );
@@ -65,9 +65,29 @@ describe('<DataGridPro /> - Column Headers', () => {
       clock.runToLast();
       expect(screen.queryByRole('menu')).not.to.equal(null);
       const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
-      fireEvent.scroll(virtualScroller);
+      virtualScroller.scrollTop = 50;
+      virtualScroller.dispatchEvent(new Event('scroll'));
       clock.runToLast();
       expect(screen.queryByRole('menu')).to.equal(null);
+    });
+
+    it('should not close the menu when updating the rows prop', () => {
+      const Test = (props: Partial<DataGridProProps>) => {
+        return (
+          <div style={{ width: 300, height: 500 }}>
+            <DataGridPro {...baselineProps} columns={[{ field: 'brand' }]} {...props} />
+          </div>
+        );
+      };
+      const { setProps } = render(<Test />);
+      const columnCell = getColumnHeaderCell(0);
+      const menuIconButton = columnCell.querySelector('button[aria-label="Menu"]');
+      fireEvent.click(menuIconButton);
+      clock.runToLast();
+      expect(screen.queryByRole('menu')).not.to.equal(null);
+      setProps({ rows: [...baselineProps.rows] });
+      clock.runToLast();
+      expect(screen.queryByRole('menu')).not.to.equal(null);
     });
 
     it('should not modify column order when menu is clicked', () => {

--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -102,7 +102,7 @@ const GridMenu = (props: GridMenuProps) => {
       {...rootProps.componentsProps?.basePopper}
     >
       {({ TransitionProps, placement }) => (
-        <ClickAwayListener onClickAway={onClickAway}>
+        <ClickAwayListener onClickAway={onClickAway} mouseEvent="onMouseDown">
           <Grow
             {...TransitionProps}
             style={{ transformOrigin: transformOrigin[placement as keyof typeof transformOrigin] }}

--- a/packages/grid/x-data-grid/src/hooks/features/columnMenu/useGridColumnMenu.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columnMenu/useGridColumnMenu.ts
@@ -3,7 +3,7 @@ import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridEvents } from '../../../models/events';
 import { useGridLogger, useGridApiMethod, useGridApiEventHandler } from '../../utils';
 import { gridColumnMenuSelector } from './columnMenuSelector';
-import { GridColumnMenuApi, GridEventListener } from '../../../models';
+import { GridColumnMenuApi } from '../../../models';
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
 
 export const columnMenuStateInitializer: GridStateInitializer = (state) => ({
@@ -87,12 +87,11 @@ export const useGridColumnMenu = (apiRef: React.MutableRefObject<GridApiCommunit
   /**
    * EVENTS
    */
-  const handleVirtualScrollerWheel = React.useCallback<
-    GridEventListener<GridEvents.virtualScrollerWheel>
-  >(() => {
-    apiRef.current.hideColumnMenu();
-  }, [apiRef]);
-
   useGridApiEventHandler(apiRef, GridEvents.columnResizeStart, hideColumnMenu);
-  useGridApiEventHandler(apiRef, GridEvents.virtualScrollerWheel, handleVirtualScrollerWheel);
+  useGridApiEventHandler(apiRef, GridEvents.virtualScrollerWheel, apiRef.current.hideColumnMenu);
+  useGridApiEventHandler(
+    apiRef,
+    GridEvents.virtualScrollerTouchMove,
+    apiRef.current.hideColumnMenu,
+  );
 };

--- a/packages/grid/x-data-grid/src/hooks/features/columnMenu/useGridColumnMenu.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columnMenu/useGridColumnMenu.ts
@@ -17,7 +17,6 @@ export const columnMenuStateInitializer: GridStateInitializer = (state) => ({
  */
 export const useGridColumnMenu = (apiRef: React.MutableRefObject<GridApiCommunity>): void => {
   const logger = useGridLogger(apiRef, 'useGridColumnMenu');
-  const scrollTop = React.useRef(apiRef.current.getScrollPosition().top);
 
   /**
    * API METHODS
@@ -30,7 +29,6 @@ export const useGridColumnMenu = (apiRef: React.MutableRefObject<GridApiCommunit
         }
 
         logger.debug('Opening Column Menu');
-        scrollTop.current = apiRef.current.getScrollPosition().top;
 
         return {
           ...state,
@@ -53,6 +51,7 @@ export const useGridColumnMenu = (apiRef: React.MutableRefObject<GridApiCommunit
       }
 
       logger.debug('Hiding Column Menu');
+
       return {
         ...state,
         columnMenu: { ...state.columnMenu, open: false, field: undefined },
@@ -88,15 +87,12 @@ export const useGridColumnMenu = (apiRef: React.MutableRefObject<GridApiCommunit
   /**
    * EVENTS
    */
-  const handleRowsScroll = React.useCallback<GridEventListener<GridEvents.rowsScroll>>(
-    (params) => {
-      if (params.top !== scrollTop.current) {
-        apiRef.current.hideColumnMenu();
-      }
-    },
-    [apiRef],
-  );
+  const handleVirtualScrollerWheel = React.useCallback<
+    GridEventListener<GridEvents.virtualScrollerWheel>
+  >(() => {
+    apiRef.current.hideColumnMenu();
+  }, [apiRef]);
 
   useGridApiEventHandler(apiRef, GridEvents.columnResizeStart, hideColumnMenu);
-  useGridApiEventHandler(apiRef, GridEvents.rowsScroll, handleRowsScroll);
+  useGridApiEventHandler(apiRef, GridEvents.virtualScrollerWheel, handleVirtualScrollerWheel);
 };

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -290,6 +290,10 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     }
   };
 
+  const handleWheel = (event: React.WheelEvent) => {
+    apiRef.current.publishEvent(GridEvents.virtualScrollerWheel, {}, event);
+  };
+
   const getRows = (
     params: {
       renderContext: GridRenderContext | null;
@@ -449,6 +453,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     getRootProps: ({ style = {}, ...other } = {}) => ({
       ref: handleRef,
       onScroll: handleScroll,
+      onWheel: handleWheel,
       style: { ...style, ...rootStyle },
       ...other,
     }),

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -294,6 +294,10 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     apiRef.current.publishEvent(GridEvents.virtualScrollerWheel, {}, event);
   };
 
+  const handleTouchMove = (event: React.TouchEvent) => {
+    apiRef.current.publishEvent(GridEvents.virtualScrollerTouchMove, {}, event);
+  };
+
   const getRows = (
     params: {
       renderContext: GridRenderContext | null;
@@ -454,6 +458,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
       ref: handleRef,
       onScroll: handleScroll,
       onWheel: handleWheel,
+      onTouchMove: handleTouchMove,
       style: { ...style, ...rootStyle },
       ...other,
     }),

--- a/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
@@ -210,6 +210,7 @@ export interface GridEventLookup
   rowsScroll: { params: GridScrollParams; event: React.UIEvent | MuiBaseEvent };
   virtualScrollerContentSizeChange: {};
   virtualScrollerWheel: { params: {}; event: React.WheelEvent };
+  virtualScrollerTouchMove: { params: {}; event: React.TouchEvent };
 
   // Selection
   headerSelectionCheckboxChange: { params: GridHeaderSelectionCheckboxParams };

--- a/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
@@ -209,6 +209,7 @@ export interface GridEventLookup
   // Scroll
   rowsScroll: { params: GridScrollParams; event: React.UIEvent | MuiBaseEvent };
   virtualScrollerContentSizeChange: {};
+  virtualScrollerWheel: { params: {}; event: React.WheelEvent };
 
   // Selection
   headerSelectionCheckboxChange: { params: GridHeaderSelectionCheckboxParams };

--- a/packages/grid/x-data-grid/src/models/events/gridEvents.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEvents.ts
@@ -319,9 +319,16 @@ enum GridEvents {
   virtualScrollerContentSizeChange = 'virtualScrollerContentSizeChange',
   /**
    * Fired when the content is scrolled by the mouse wheel.
+   * It's attached to the "mousewheel" event.
    * @ignore - do not document.
    */
   virtualScrollerWheel = 'virtualScrollerWheel',
+  /**
+   * Fired when the content is moved using a touch device.
+   * It's attached to the "touchmove" event.
+   * @ignore - do not document.
+   */
+  virtualScrollerTouchMove = 'virtualScrollerTouchMove',
   /**
    * Fired when the preferences panel is closed.
    */

--- a/packages/grid/x-data-grid/src/models/events/gridEvents.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEvents.ts
@@ -318,6 +318,11 @@ enum GridEvents {
    */
   virtualScrollerContentSizeChange = 'virtualScrollerContentSizeChange',
   /**
+   * Fired when the content is scrolled by the mouse wheel.
+   * @ignore - do not document.
+   */
+  virtualScrollerWheel = 'virtualScrollerWheel',
+  /**
    * Fired when the preferences panel is closed.
    */
   preferencePanelClose = 'preferencePanelClose',

--- a/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -249,11 +249,15 @@ describe('<DataGrid /> - Rows', () => {
       );
       expect(screen.queryAllByRole('menu')).to.have.length(2);
 
-      fireEvent.click(screen.getAllByRole('menuitem', { name: 'more' })[0]);
+      const more1 = screen.getAllByRole('menuitem', { name: 'more' })[0];
+      fireEvent.mouseDown(more1);
+      fireEvent.click(more1);
       clock.runToLast();
       expect(screen.queryAllByRole('menu')).to.have.length(2 + 1);
 
-      fireEvent.click(screen.getAllByRole('menuitem', { name: 'more' })[1]);
+      const more2 = screen.getAllByRole('menuitem', { name: 'more' })[1];
+      fireEvent.mouseDown(more2);
+      fireEvent.click(more2);
       clock.runToLast();
       expect(screen.queryAllByRole('menu')).to.have.length(2 + 1);
     });


### PR DESCRIPTION
Fixes #4139 

Preview: https://deploy-preview-4498--material-ui-x.netlify.app/x/react-data-grid/

CodeSandbox: https://codesandbox.io/s/fullfeatureddemo-material-demo-forked-98j7cp?file=/demo.tsx

I implemented the solution from https://github.com/mui/mui-x/issues/4139#issuecomment-1092047815. I chose this one because it also unlocks the possibility to have filters inside the column menu. Previously, we couldn't because the column menu closes when filtering: https://github.com/mui/mui-x/issues/3571#issuecomment-1009524740