### PR TITLE
[docs] Include `date-fns` dependency when opening demos in CodeSandbox

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -60,6 +60,7 @@ ponyfillGlobal.muiDocConfig = {
 
     if (newDeps['@mui/x-date-pickers']) {
       newDeps['@mui/material'] = versions['@mui/material'];
+      newDeps['date-fns'] = versions['date-fns'];
     }
 
     if (newDeps['@mui/x-date-pickers-pro']) {
@@ -75,6 +76,7 @@ ponyfillGlobal.muiDocConfig = {
       '@mui/x-data-grid-pro': getMuiPackageVersion('x-data-grid-pro', muiCommitRef),
       '@mui/x-data-grid-generator': getMuiPackageVersion('x-data-grid-generator', muiCommitRef),
       '@mui/x-data-grid': getMuiPackageVersion('x-data-grid', muiCommitRef),
+      'date-fns': 'latest',
     };
     return output;
   },


### PR DESCRIPTION
`@date-io/date-fns` has a peer dependency on `date-fns`.

Preview: https://deploy-preview-4508--material-ui-x.netlify.app/x/react-date-pickers/date-picker/

### Steps to reproduce

1. Go to https://mui.com/x/react-date-pickers/date-picker/#basic-usage
2. Click to open the demo in CodeSandbox
3. Fails with "Could not find dependency: 'date-fns' relative..."
