### PR TITLE
[TimePicker] Fix bug when time picker clear value

### DIFF
--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -250,6 +250,34 @@ describe('<DesktopTimePicker />', () => {
     );
   });
 
+  it('should keep the date when time value is cleaned', function test() {
+    const handleChange = spy();
+
+    render(
+      <DesktopTimePicker
+        ampm
+        onChange={handleChange}
+        open
+        renderInput={(params) => <TextField {...params} />}
+        value={adapterToUse.date('2019-01-01T04:20:00.000')}
+      />,
+    );
+
+    // reset the time value
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '' } });
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleChange.lastCall.args[0]).to.equal(null);
+
+    // call `onChange` with a valid time
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '07:00 pm' },
+    });
+    expect(handleChange.callCount).to.equal(2);
+    expect(handleChange.lastCall.args[0]).toEqualDateTime(
+      adapterToUse.date('2019-01-01T19:00:00.000'),
+    );
+  });
+
   context('input validation', () => {
     const shouldDisableTime: TimePickerProps['shouldDisableTime'] = (value) => value === 10;
 

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -19,7 +19,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   areValuesEqual: (utils: MuiPickersAdapter<unknown>, a: unknown, b: unknown) =>
     utils.isEqual(a, b),
   valueReducer: (utils, prevValue, newValue) => {
-    if (prevValue == null) {
+    if (prevValue == null || newValue == null) {
       return newValue;
     }
 

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -16,7 +16,7 @@ const valueManager: PickerStateValueManager<unknown, unknown> = {
   areValuesEqual: (utils: MuiPickersAdapter<unknown>, a: unknown, b: unknown) =>
     utils.isEqual(a, b),
   valueReducer: (utils, prevValue, newValue) => {
-    if (prevValue == null) {
+    if (prevValue == null || newValue == null) {
       return newValue;
     }
 

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -15,7 +15,7 @@ export interface PickerStateValueManager<TInputValue, TDateValue> {
   valueReducer?: (
     utils: MuiPickersAdapter<TDateValue>,
     prevValue: TDateValue | null,
-    value: TDateValue,
+    value: TDateValue | null,
   ) => TDateValue;
 }
 


### PR DESCRIPTION
Fix #4578

The bug has been introduced in #4398 
When the new value is `null` it can not be merged with the previous date.

I always forget one of the three types of values the components deal with: `Date` | `null` | invalid-date