### PR TITLE
v5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## v.5.10.0
+
+_Apr 22, 2022_
+
+We'd like to offer a big thanks to the 3 contributors who made this release possible. Here are some highlights ✨:
+
+TODO INSERT HIGHLIGHTS
+
+### `@mui/x-data-grid@v5.10.0` / `@mui/x-data-grid-pro@v5.10.0`
+
+- [DataGrid] Don't close column menu when updating rows (#4498) @m4theushw
+- TODO: Row pinning
+
+### `@mui/x-date-pickers@5.0.0-alpha.2` / `@mui/x-date-pickers-pro@5.0.0-alpha.2`
+
+- [pickers] Pass `PaperProps` to `DesktopWrapper` component (#4584) @alexfauquette
+- [TimePicker] Fix bug when time picker clear value (#4582) @alexfauquette
+
+### Docs
+
+- [docs] Clarify where to install the license (#4452) @oliviertassinari
+- [docs] Fix CodeSandbox links for demo with pickers (#4570) @alexfauquette
+- [docs] Include date-fns dependency when opening demos in CodeSandbox (#4508) @m4theushw
+- [docs] Split the 'Group & Pivot' page (#4441) @flaviendelangle
+
+### Core
+
+- [test] Fix test to not depend on screen resolution (#4587) @m4theushw
+
 ## v5.9.0
 
 _Apr 14, 2022_

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benchmark",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "private": true,
   "scripts": {
     "browser": "webpack --config browser/webpack.config.js && node browser/scripts/benchmark.js"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "private": true,
   "author": "MUI Team",
   "license": "MIT",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.9.0",
+  "version": "5.10.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.9.0",
+  "version": "5.10.0",
   "private": true,
   "scripts": {
     "start": "yarn docs:dev",

--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-material-ui",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "private": true,
   "description": "Custom eslint rules for MUI X.",
   "main": "src/index.js",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@mui/base": "^5.0.0-alpha.77",
-    "@mui/x-data-grid-pro": "5.9.0",
+    "@mui/x-data-grid-pro": "5.10.0",
     "chance": "^1.1.8",
     "clsx": "^1.1.1",
     "lru-cache": "^7.8.1"

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "The commercial edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@mui/utils": "^5.6.1",
-    "@mui/x-data-grid": "5.9.0",
-    "@mui/x-license-pro": "5.9.0",
+    "@mui/x-data-grid": "5.10.0",
+    "@mui/x-license-pro": "5.10.0",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.0.4",
     "prop-types": "^15.8.1",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Storybook components",
   "author": "MUI Team",
   "private": true,
@@ -18,10 +18,10 @@
   "dependencies": {
     "@mui/icons-material": "^5.6.2",
     "@mui/material": "^5.6.2",
-    "@mui/x-data-grid": "5.9.0",
-    "@mui/x-data-grid-generator": "5.9.0",
-    "@mui/x-data-grid-pro": "5.9.0",
-    "@mui/x-license-pro": "5.9.0",
+    "@mui/x-data-grid": "5.10.0",
+    "@mui/x-data-grid-generator": "5.10.0",
+    "@mui/x-data-grid-pro": "5.10.0",
+    "@mui/x-license-pro": "5.10.0",
     "@storybook/builder-webpack5": "^6.4.21",
     "@storybook/manager-webpack5": "^6.4.21",
     "react": "^17.0.2",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -46,8 +46,8 @@
     "@date-io/luxon": "^2.11.1",
     "@date-io/moment": "^2.11.0",
     "@mui/utils": "^5.6.1",
-    "@mui/x-date-pickers": "5.0.0-alpha.1",
-    "@mui/x-license-pro": "5.9.0",
+    "@mui/x-date-pickers": "5.0.0-alpha.2",
+    "@mui/x-license-pro": "5.10.0",
     "clsx": "^1.1.1",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.4.2",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license-pro",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,7 +27,7 @@ The following steps must be proposed as a pull request.
 - [ ] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
 - [ ] Update the root `package.json`'s version
 - [ ] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
-- [ ] Fix manually the package version in `x-date-picker/package.json` and `x-date-picker-pro/package.json`.
+- [ ] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
 - [ ] Open PR with changes and wait for review and green CI.
 - [ ] Merge PR once CI is green, and it has been approved.
 


### PR DESCRIPTION

- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [x] Update the root `package.json`'s version
- [x] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
- [x] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
- [ ] Open PR with changes and wait for review and green CI.
- [ ] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Create a new tag named with the release you just did `git tag -a v4.0.0-alpha.30 -m "Version 4.0.0-alpha.30" && git push upstream --tag`

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

```sh
git push upstream master:docs-v5 -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v5` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)

### Announce

- [ ] Follow the instructions in https://mui-org.notion.site/Releases-7490ef9581b4447ebdbf86b13164272d.