### PR TITLE
Added links to DatePicker component in DatePicker API page under Demos

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -398,5 +398,5 @@
   },
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx",
-  "demos": "<ul><li><a href=\"/x/react-data-grid#commercial-version\">DataGridPro</a></li></ul>"
+  "demos": "<ul><li><a href=\"/components/data-grid#commercial-version\">DataGridPro</a></li></ul>"
 }

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -348,5 +348,5 @@
   },
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx",
-  "demos": "<ul><li><a href=\"/x/react-data-grid/#mit-version\">DataGrid</a></li></ul>"
+  "demos": "<ul><li><a href=\"/components/data-grid#mit-version\">DataGrid</a></li></ul>"
 }

--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -104,5 +104,5 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDatePicker" },
   "filename": "/packages/x-date-pickers/src/DatePicker/DatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul></ul>"
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">DataPicker</a></li></ul>"
 }


### PR DESCRIPTION
The Demos section in DatePicker's [API Documentation](https://mui.com/x/api/date-pickers/date-picker/) is empty. Updated the list item with a link to the [DatePicker component](https://mui.com/x/react-date-pickers/date-picker/)

Before:
![image](https://user-images.githubusercontent.com/54573655/164700502-b62d66c0-9dce-41c7-a5b5-ffd5dc87eafe.png)

After:
![image](https://user-images.githubusercontent.com/54573655/164700628-0cee4bf6-5c09-4ac1-bdde-41cd0b51cdf0.png)
