### PR TITLE
[docs] Update the feature table in the Getting Started page of the data grid

### DIFF
--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -158,7 +158,7 @@ All the features of the community version are available in the enterprise one.
 The enterprise components come in two plans: Pro and Premium.
 
 | Features                                                                               | Community | Pro <span class="plan-pro"></span> | Premium <span class="plan-premium"></span> |
-|:---------------------------------------------------------------------------------------| :-------: | :--------------------------------: | :----------------------------------------: |
+| :------------------------------------------------------------------------------------- | :-------: | :--------------------------------: | :----------------------------------------: |
 | **Column**                                                                             |           |                                    |
 | [Column groups](/x/react-data-grid/columns/#column-groups)                             |    🚧     |                 🚧                 |                     🚧                     |
 | [Column spanning](/x/react-data-grid/columns/#column-spanning)                         |    ✅     |                 ✅                 |                     ✅                     |

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -167,7 +167,7 @@ The enterprise components come in two plans: Pro and Premium.
 | [Column pinning](/x/react-data-grid/columns/#column-pinning)                           |    ❌     |                 ✅                 |                     ✅                     |
 | **Row**                                                                                |           |                                    |                                            |
 | [Row height](/x/react-data-grid/rows/#row-height)                                      |    ✅     |                 ✅                 |                     ✅                     |
-| [Row spanning](/x/react-data-grid/rows/#row-spanning)                                  |    🚧     |                 🚧                 |                     🚧                     |
+| [Row spanning](/x/react-data-grid/rows/#row-spanning)                                  |    ✅     |                 🚧                 |                     🚧                     |
 | [Row reordering](/x/react-data-grid/rows/#row-reorder)                                 |    ❌     |                 ✅                 |                     ✅                     |
 | [Row pinning](/x/react-data-grid/rows/#row-pinning)                                    |    ❌     |                 🚧                 |                     🚧                     |
 | **Selection**                                                                          |           |                                    |                                            |
@@ -200,7 +200,7 @@ The enterprise components come in two plans: Pro and Premium.
 | **Group & Pivot**                                                                      |           |                                    |                                            |
 | [Tree data](/x/react-data-grid/tree-data)                                              |    ❌     |                 ✅                 |                     ✅                     |
 | [Master detail](/x/react-data-grid/master-detail)                                      |    ❌     |                 ✅                 |                     ✅                     |
-| [Grouping](/x/react-data-grid/row-grouping)                                            |    ❌     |                 ❌                 |                     🚧                     |
+| [Grouping](/x/react-data-grid/row-grouping)                                            |    ❌     |                 ❌                 |                     ✅                     |
 | [Aggregation](/x/react-data-grid/aggregation)                                          |    ❌     |                 ❌                 |                     🚧                     |
 | [Pivoting](/x/react-data-grid/pivoting)                                                |    ❌     |                 ❌                 |                     🚧                     |
 | **Misc**                                                                               |           |                                    |                                            |

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -167,7 +167,7 @@ The enterprise components come in two plans: Pro and Premium.
 | [Column pinning](/x/react-data-grid/columns/#column-pinning)                           |    ❌     |                 ✅                 |                     ✅                     |
 | **Row**                                                                                |           |                                    |                                            |
 | [Row height](/x/react-data-grid/rows/#row-height)                                      |    ✅     |                 ✅                 |                     ✅                     |
-| [Row spanning](/x/react-data-grid/rows/#row-spanning)                                  |    ✅     |                 🚧                 |                     🚧                     |
+| [Row spanning](/x/react-data-grid/rows/#row-spanning)                                  |    🚧     |                 🚧                 |                     🚧                     |
 | [Row reordering](/x/react-data-grid/rows/#row-reorder)                                 |    ❌     |                 ✅                 |                     ✅                     |
 | [Row pinning](/x/react-data-grid/rows/#row-pinning)                                    |    ❌     |                 🚧                 |                     🚧                     |
 | **Selection**                                                                          |           |                                    |                                            |

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -158,7 +158,7 @@ All the features of the community version are available in the enterprise one.
 The enterprise components come in two plans: Pro and Premium.
 
 | Features                                                                               | Community | Pro <span class="plan-pro"></span> | Premium <span class="plan-premium"></span> |
-| :------------------------------------------------------------------------------------- | :-------: | :--------------------------------: | :----------------------------------------: |
+|:---------------------------------------------------------------------------------------| :-------: | :--------------------------------: | :----------------------------------------: |
 | **Column**                                                                             |           |                                    |
 | [Column groups](/x/react-data-grid/columns/#column-groups)                             |    🚧     |                 🚧                 |                     🚧                     |
 | [Column spanning](/x/react-data-grid/columns/#column-spanning)                         |    ✅     |                 ✅                 |                     ✅                     |
@@ -200,7 +200,7 @@ The enterprise components come in two plans: Pro and Premium.
 | **Group & Pivot**                                                                      |           |                                    |                                            |
 | [Tree data](/x/react-data-grid/tree-data)                                              |    ❌     |                 ✅                 |                     ✅                     |
 | [Master detail](/x/react-data-grid/master-detail)                                      |    ❌     |                 ✅                 |                     ✅                     |
-| [Grouping](/x/react-data-grid/row-grouping)                                            |    ❌     |                 ❌                 |                     ✅                     |
+| [Row Grouping](/x/react-data-grid/row-grouping)                                        |    ❌     |                 ❌                 |                     ✅                     |
 | [Aggregation](/x/react-data-grid/aggregation)                                          |    ❌     |                 ❌                 |                     🚧                     |
 | [Pivoting](/x/react-data-grid/pivoting)                                                |    ❌     |                 ❌                 |                     🚧                     |
 | **Misc**                                                                               |           |                                    |                                            |


### PR DESCRIPTION
I forgot to update it when releasing the feature

- [x] Mark the row grouping as released
- [x] Rename "Grouping" => "Row Grouping" to be consistent with the doc page