### PR TITLE
[pickers] Do not apply the current time when no date provided in `DayPicker`

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { userEvent, screen } from '@mui/monorepo/test/utils';
+import { DayPicker } from './DayPicker';
+import { adapterToUse, createPickerRenderer } from '../../../../test/utils/pickers-utils';
+
+describe('<DayPicker />', () => {
+  const { render } = createPickerRenderer({ clock: 'fake' });
+
+  it('should set time to be midnight when selecting a date without a previous date', () => {
+    const onChange = spy();
+
+    render(
+      <DayPicker
+        date={null}
+        focusedDay={null}
+        onFocusedDayChange={() => {}}
+        onMonthSwitchingAnimationEnd={() => {}}
+        isDateDisabled={() => false}
+        isMonthSwitchingAnimating={false}
+        slideDirection="right"
+        reduceAnimations={false}
+        currentMonth={adapterToUse.date('2018-01-01T00:00:00.000')}
+        onChange={onChange}
+      />,
+    );
+
+    userEvent.mousePress(screen.getByLabelText('Jan 2, 2018'));
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.lastCall.args[0]).toEqualDateTime(adapterToUse.date('2018-01-02T00:00:00.000'));
+  });
+
+  it('should keep the time of the currently provided date', () => {
+    const onChange = spy();
+
+    render(
+      <DayPicker
+        date={adapterToUse.date('2018-01-03T11:11:11.111')}
+        focusedDay={null}
+        onFocusedDayChange={() => {}}
+        onMonthSwitchingAnimationEnd={() => {}}
+        isDateDisabled={() => false}
+        isMonthSwitchingAnimating={false}
+        slideDirection="right"
+        reduceAnimations={false}
+        currentMonth={adapterToUse.date('2018-01-01T00:00:00.000')}
+        onChange={onChange}
+      />,
+    );
+
+    userEvent.mousePress(screen.getByLabelText('Jan 2, 2018'));
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.lastCall.args[0]).toEqualDateTime(adapterToUse.date('2018-01-02T11:11:11.000'));
+  });
+});

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -141,13 +141,13 @@ export function DayPicker<TDate>(props: PickersCalendarProps<TDate>) {
       }
 
       // TODO possibly buggy line figure out and add tests
-      let finalDate: TDate
+      let finalDate: TDate;
       if (date && !Array.isArray(date)) {
         // If we are selecting a single date (not a range) and there is a date already selected
         // Then we want to keep the time from this date
-        finalDate = utils.mergeDateAndTime(day, date)
+        finalDate = utils.mergeDateAndTime(day, date);
       } else {
-        finalDate = day
+        finalDate = day;
       }
 
       onChange(finalDate, isFinish);

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -139,12 +139,20 @@ export function DayPicker<TDate>(props: PickersCalendarProps<TDate>) {
       if (readOnly) {
         return;
       }
+
       // TODO possibly buggy line figure out and add tests
-      const finalDate = Array.isArray(date) ? day : utils.mergeDateAndTime(day, date || now);
+      let finalDate: TDate
+      if (date && !Array.isArray(date)) {
+        // If we are selecting a single date (not a range) and there is a date already selected
+        // Then we want to keep the time from this date
+        finalDate = utils.mergeDateAndTime(day, date)
+      } else {
+        finalDate = day
+      }
 
       onChange(finalDate, isFinish);
     },
-    [date, now, onChange, readOnly, utils],
+    [date, onChange, readOnly, utils],
   );
 
   const currentMonthNumber = utils.getMonth(currentMonth);

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.test.tsx
@@ -15,7 +15,7 @@ describe('<DatePicker />', () => {
           inputRef={inputRef}
           value={null}
           onChange={() => {}}
-          renderInput={(params) => <TextField id="test-focusing-picker" {...params} />}
+          renderInput={(params) => <TextField {...params} />}
         />,
       );
 


### PR DESCRIPTION
Fixes #4449 

- [x] If we use the `DatePicker` or `DateTimePicker`, when clicking on a date for the 1st time, it should set the time to `00:00:00`not the current time

- [x] Add tests
