### PR TITLE
[pickers] Add overrides to `PickersArrowSwitcher`

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
+import { generateUtilityClasses } from '@mui/material';
 import { useTheme, styled } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';
 import { ArrowLeft, ArrowRight } from './icons';
@@ -50,19 +52,33 @@ interface ArrowSwitcherProps
   onRightClick: () => void;
 }
 
-const PickersArrowSwitcherRoot = styled('div')<{
+const classes = generateUtilityClasses('MuiPickersArrowSwitcher', ['root', 'spacer', 'button']);
+
+const PickersArrowSwitcherRoot = styled('div', {
+  name: 'MuiPickersArrowSwitcher',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{
   ownerState: ArrowSwitcherProps;
 }>({
   display: 'flex',
 });
 
-const PickersArrowSwitcherSpacer = styled('div')<{
+const PickersArrowSwitcherSpacer = styled('div', {
+  name: 'MuiPickersArrowSwitcher',
+  slot: 'Spacer',
+  overridesResolver: (props, styles) => styles.spacer,
+})<{
   ownerState: ArrowSwitcherProps;
 }>(({ theme }) => ({
   width: theme.spacing(3),
 }));
 
-const PickersArrowSwitcherButton = styled(IconButton)<{
+const PickersArrowSwitcherButton = styled(IconButton, {
+  name: 'MuiPickersArrowSwitcher',
+  slot: 'Button',
+  overridesResolver: (props, styles) => styles.button,
+})<{
   ownerState: ArrowSwitcherProps;
 }>(({ ownerState }) => ({
   ...(ownerState.hidden && {
@@ -101,7 +117,12 @@ export const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitch
   const ownerState = props;
 
   return (
-    <PickersArrowSwitcherRoot ref={ref} className={className} ownerState={ownerState} {...other}>
+    <PickersArrowSwitcherRoot
+      ref={ref}
+      className={clsx(classes.root, className)}
+      ownerState={ownerState}
+      {...other}
+    >
       <PickersArrowSwitcherButton
         as={components.LeftArrowButton}
         size="small"
@@ -111,7 +132,7 @@ export const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitch
         edge="end"
         onClick={onLeftClick}
         {...leftArrowButtonProps}
-        className={leftArrowButtonProps.className}
+        className={clsx(classes.button, leftArrowButtonProps.className)}
         ownerState={{ ...ownerState, ...leftArrowButtonProps, hidden: isLeftHidden }}
       >
         {isRtl ? <RightArrowIcon /> : <LeftArrowIcon />}
@@ -121,7 +142,7 @@ export const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitch
           {children}
         </Typography>
       ) : (
-        <PickersArrowSwitcherSpacer ownerState={ownerState} />
+        <PickersArrowSwitcherSpacer className={classes.spacer} ownerState={ownerState} />
       )}
       <PickersArrowSwitcherButton
         as={components.RightArrowButton}
@@ -132,7 +153,7 @@ export const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitch
         disabled={isRightDisabled}
         onClick={onRightClick}
         {...rightArrowButtonProps}
-        className={rightArrowButtonProps.className}
+        className={clsx(classes.button, rightArrowButtonProps.className)}
         ownerState={{ ...ownerState, ...rightArrowButtonProps, hidden: isRightHidden }}
       >
         {isRtl ? <LeftArrowIcon /> : <RightArrowIcon />}


### PR DESCRIPTION
Preview: https://deploy-preview-4672--material-ui-x.netlify.app/x/react-date-pickers/date-picker/

An example for #4669 

My goal was to only restore the capability to provide overrides via the theme and add meaningful class names. I didn't add the `classes` prop. 

Some components have "private" class names. Do you agree to make them public? In the DataGrid every new class is public.

https://github.com/mui/mui-x/blob/0d8a55d4f460767942c01398a373028ef2e1e7da/packages/x-date-pickers/src/CalendarPicker/PickersSlideTransition.tsx#L18

Before:

![image](https://user-images.githubusercontent.com/42154031/165542925-9536cba5-cda6-4361-9d78-5d5d79e6341b.png)

After:

![image](https://user-images.githubusercontent.com/42154031/165543081-2317cb2b-8b4c-4fec-9064-a1467ff367c7.png)
