### PR TITLE
[test] Reset cleanup tracking on Karma tests

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.test.tsx
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.test.tsx
@@ -28,9 +28,9 @@ describe('useGridApiEventHandler', () => {
         this.skip();
       }
 
-      const useGridApiEventHandler = createUseGridApiEventHandler(
-        new FinalizationRegistryBasedCleanupTracking(),
-      );
+      const useGridApiEventHandler = createUseGridApiEventHandler({
+        registry: new FinalizationRegistryBasedCleanupTracking(),
+      });
       const unsubscribe = spy();
       const apiRef = {
         current: { subscribeEvent: spy(() => unsubscribe) },
@@ -60,9 +60,9 @@ describe('useGridApiEventHandler', () => {
 
   describe('Timer-based implementation', () => {
     it('should unsubscribe event listeners registered by uncommitted components', async () => {
-      const useGridApiEventHandler = createUseGridApiEventHandler(
-        new TimerBasedCleanupTracking(50),
-      );
+      const useGridApiEventHandler = createUseGridApiEventHandler({
+        registry: new TimerBasedCleanupTracking(50),
+      });
       const unsubscribe = spy();
       const apiRef = {
         current: { subscribeEvent: spy(() => unsubscribe) },

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.ts
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.ts
@@ -15,12 +15,16 @@ enum GridSignature {
   DataGridPro = 'DataGridPro',
 }
 
+interface RegistryContainer {
+  registry: CleanupTracking | null;
+}
+
 // We use class to make it easier to detect in heap snapshots by name
 class ObjectToBeRetainedByReact {}
 
 // Based on https://github.com/Bnaya/use-dispose-uncommitted/blob/main/src/finalization-registry-based-impl.ts
 // Check https://github.com/facebook/react/issues/15317 to get more information
-export function createUseGridApiEventHandler(registry: CleanupTracking) {
+export function createUseGridApiEventHandler(registryContainer: RegistryContainer) {
   let cleanupTokensCounter = 0;
 
   return function useGridApiEventHandler<Api extends GridApiCommon, E extends GridEventsStr>(
@@ -29,6 +33,13 @@ export function createUseGridApiEventHandler(registry: CleanupTracking) {
     handler?: GridEventListener<E>,
     options?: EventListenerOptions,
   ) {
+    if (registryContainer.registry === null) {
+      registryContainer.registry =
+        typeof FinalizationRegistry !== 'undefined'
+          ? new FinalizationRegistryBasedCleanupTracking()
+          : new TimerBasedCleanupTracking();
+    }
+
     const [objectRetainedByReact] = React.useState(new ObjectToBeRetainedByReact());
     const subscription = React.useRef<(() => void) | null>(null);
     const handlerRef = React.useRef<GridEventListener<E> | undefined>();
@@ -47,7 +58,7 @@ export function createUseGridApiEventHandler(registry: CleanupTracking) {
       cleanupTokensCounter += 1;
       cleanupTokenRef.current = { cleanupToken: cleanupTokensCounter };
 
-      registry.register(
+      registryContainer.registry.register(
         objectRetainedByReact, // The callback below will be called once this reference stops being retained
         () => {
           subscription.current?.();
@@ -61,7 +72,7 @@ export function createUseGridApiEventHandler(registry: CleanupTracking) {
       subscription.current = null;
 
       if (cleanupTokenRef.current) {
-        registry.unregister(cleanupTokenRef.current);
+        registryContainer.registry.unregister(cleanupTokenRef.current);
         cleanupTokenRef.current = null;
       }
     }
@@ -77,10 +88,10 @@ export function createUseGridApiEventHandler(registry: CleanupTracking) {
         subscription.current = apiRef.current.subscribeEvent(eventName, enhancedHandler, options);
       }
 
-      if (cleanupTokenRef.current && registry) {
+      if (cleanupTokenRef.current && registryContainer.registry) {
         // If the effect was called, it means that this render was committed
         // so we can trust the cleanup function to remove the listener.
-        registry.unregister(cleanupTokenRef.current);
+        registryContainer.registry.unregister(cleanupTokenRef.current);
         cleanupTokenRef.current = null;
       }
 
@@ -92,15 +103,15 @@ export function createUseGridApiEventHandler(registry: CleanupTracking) {
   };
 }
 
-const registry =
-  typeof FinalizationRegistry !== 'undefined'
-    ? new FinalizationRegistryBasedCleanupTracking()
-    : new TimerBasedCleanupTracking();
+const registryContainer: RegistryContainer = { registry: null };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const unstable_resetCleanupTracking = () => registry.reset();
+export const unstable_resetCleanupTracking = () => {
+  registryContainer.registry?.reset();
+  registryContainer.registry = null;
+};
 
-export const useGridApiEventHandler = createUseGridApiEventHandler(registry);
+export const useGridApiEventHandler = createUseGridApiEventHandler(registryContainer!);
 
 const optionsSubscriberOptions: EventListenerOptions = { isFirst: true };
 

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.ts
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.ts
@@ -105,6 +105,7 @@ export function createUseGridApiEventHandler(registryContainer: RegistryContaine
 
 const registryContainer: RegistryContainer = { registry: null };
 
+// TODO: move to @mui/x-data-grid/internals
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const unstable_resetCleanupTracking = () => {
   registryContainer.registry?.reset();

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridSelector.ts
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridSelector.ts
@@ -6,7 +6,7 @@ import { buildWarning } from '../../utils/warning';
 function isOutputSelector<Api extends GridApiCommon, T>(
   selector: any,
 ): selector is OutputSelector<Api['state'], T> {
-  return selector.cache;
+  return selector.acceptsApiRef;
 }
 
 const stateNotInitializedWarning = buildWarning([

--- a/packages/grid/x-data-grid/src/internals/index.ts
+++ b/packages/grid/x-data-grid/src/internals/index.ts
@@ -80,7 +80,7 @@ export type {
   DataGridPropsWithComplexDefaultValueBeforeProcessing,
 } from '../models/props/DataGridProps';
 
-export { createSelector } from '../utils/createSelector';
+export { createSelector, unstable_resetCreateSelectorCache } from '../utils/createSelector';
 export { findParentElementFromClassName } from '../utils/domUtils';
 export { isNavigationKey } from '../utils/keyboardUtils';
 export { clamp, isDeepEqual } from '../utils/utils';

--- a/packages/grid/x-data-grid/src/utils/createSelector.ts
+++ b/packages/grid/x-data-grid/src/utils/createSelector.ts
@@ -2,11 +2,15 @@ import * as React from 'react';
 import { createSelector as reselectCreateSelector, Selector, SelectorResultArray } from 'reselect';
 import { buildWarning } from './warning';
 
+interface CacheContainer {
+  cache: Record<number | string, Map<any[], any>> | null;
+}
+
 export interface OutputSelector<State, Result> {
   (apiRef: React.MutableRefObject<{ state: State; instanceId: number }>): Result;
   // TODO v6: make instanceId require
   (state: State, instanceId?: number): Result;
-  cache: object;
+  acceptsApiRef: boolean;
 }
 
 type StateFromSelector<T> = T extends (first: infer F, ...args: any[]) => any
@@ -17,7 +21,7 @@ type StateFromSelector<T> = T extends (first: infer F, ...args: any[]) => any
 
 type StateFromSelectorList<Selectors extends readonly any[]> = Selectors extends [
   f: infer F,
-  ...rest: infer R
+  ...rest: infer R,
 ]
   ? StateFromSelector<F> extends StateFromSelectorList<R>
     ? StateFromSelector<F>
@@ -34,7 +38,7 @@ type CreateSelectorFunction = <Selectors extends ReadonlyArray<Selector<any>>, R
   ...items: SelectorArgs<Selectors, Result>
 ) => OutputSelector<StateFromSelectorList<Selectors>, Result>;
 
-const cache: Record<number | string, Map<any[], any>> = {};
+const cacheContainer: CacheContainer = { cache: null };
 
 const missingInstanceIdWarning = buildWarning([
   'MUI: A selector was called without passing the instance ID, which may impact the performance of the grid.',
@@ -42,6 +46,10 @@ const missingInstanceIdWarning = buildWarning([
 ]);
 
 export const createSelector: CreateSelectorFunction = (...args: any) => {
+  if (cacheContainer.cache === null) {
+    cacheContainer.cache = {};
+  }
+
   const selector = (...selectorArgs: any[]) => {
     const [stateOrApiRef, instanceId] = selectorArgs;
     const isApiRef = !!stateOrApiRef.current;
@@ -53,6 +61,12 @@ export const createSelector: CreateSelectorFunction = (...args: any) => {
         missingInstanceIdWarning();
       }
     }
+
+    if (cacheContainer.cache === null) {
+      cacheContainer.cache = {};
+    }
+
+    const { cache } = cacheContainer;
 
     if (cache[cacheKey] && cache[cacheKey].get(args)) {
       // We pass the cache key because the called selector might have as
@@ -72,7 +86,12 @@ export const createSelector: CreateSelectorFunction = (...args: any) => {
 
   // We use this property to detect if the selector was created with createSelector
   // or it's only a simple function the receives the state and returns part of it.
-  selector.cache = cache;
+  selector.acceptsApiRef = true;
 
   return selector;
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_resetCreateSelectorCache = () => {
+  cacheContainer.cache = null;
 };

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -2,12 +2,12 @@
 import './utils/init';
 import '@mui/monorepo/test/utils/setupKarma';
 import { unstable_resetCleanupTracking } from '@mui/x-data-grid';
-import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingPro } from '@mui/x-data-grid-pro';
+import { unstable_resetCreateSelectorCache } from '@mui/x-data-grid/internals';
 
 const packagesContext = require.context('../packages', true, /\.test\.tsx$/);
 packagesContext.keys().forEach(packagesContext);
 
 afterEach(function afterEach() {
   unstable_resetCleanupTracking();
-  unstable_resetCleanupTrackingPro();
+  unstable_resetCreateSelectorCache();
 });

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,6 +1,13 @@
 /* eslint-env mocha */
 import './utils/init';
 import '@mui/monorepo/test/utils/setupKarma';
+import { unstable_resetCleanupTracking } from '@mui/x-data-grid';
+import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingPro } from '@mui/x-data-grid-pro';
 
 const packagesContext = require.context('../packages', true, /\.test\.tsx$/);
 packagesContext.keys().forEach(packagesContext);
+
+afterEach(function afterEach() {
+  unstable_resetCleanupTracking();
+  unstable_resetCleanupTrackingPro();
+});


### PR DESCRIPTION
In https://github.com/mui/mui-x/pull/4031 I ignored karma tests because I was under the assumption that, due to the fact that `FinalizationRegistry` is available, the memory would be cleaned by itself. This is partially correct, the memory is cleaned indeed, but the reference to `FinalizationRegistry` is never garbage-collected. This PR fixes this bug by explicitly setting it to `null`.