### PR TITLE
[data grid] Stop using GridEvents enum in `@mui/x-data-grid-premium`

### DIFF
--- a/packages/grid/x-data-grid-premium/src/components/GridGroupingCriteriaCell.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridGroupingCriteriaCell.tsx
@@ -6,7 +6,6 @@ import {
   useGridSelector,
   gridFilteredDescendantCountLookupSelector,
   getDataGridUtilityClass,
-  GridEvents,
   GridRenderCellParams,
 } from '@mui/x-data-grid-pro';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
@@ -51,7 +50,7 @@ export const GridGroupingCriteriaCell = (props: GridGroupingCriteriaCellProps) =
     if (event.key === ' ') {
       event.stopPropagation();
     }
-    apiRef.current.publishEvent(GridEvents.cellKeyDown, props, event);
+    apiRef.current.publishEvent('cellKeyDown', props, event);
   };
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/packages/grid/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Divider from '@mui/material/Divider';
 import {
-  GridEvents,
   GridEventListener,
   useGridApiEventHandler,
   useGridApiMethod,
@@ -67,7 +66,7 @@ export const useGridRowGrouping = (
     propModel: props.rowGroupingModel,
     propOnChange: props.onRowGroupingModelChange,
     stateSelector: gridRowGroupingModelSelector,
-    changeEvent: GridEvents.rowGroupingModelChange,
+    changeEvent: 'rowGroupingModelChange',
   });
 
   /**
@@ -216,7 +215,7 @@ export const useGridRowGrouping = (
   /**
    * EVENTS
    */
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       const cellParams = apiRef.current.getCellParams(params.id, params.field);
       if (isGroupingColumn(cellParams.field) && event.key === ' ' && !event.shiftKey) {
@@ -240,7 +239,7 @@ export const useGridRowGrouping = (
   );
 
   const checkGroupingColumnsModelDiff = React.useCallback<
-    GridEventListener<GridEvents.columnsChange>
+    GridEventListener<'columnsChange'>
   >(() => {
     const rowGroupingModel = gridRowGroupingSanitizedModelSelector(apiRef);
     const lastGroupingColumnsModelApplied = gridRowGroupingStateSelector(
@@ -262,14 +261,14 @@ export const useGridRowGrouping = (
       // Refresh the row tree creation strategy processing
       // TODO: Add a clean way to re-run a strategy processing without publishing a private event
       if (apiRef.current.unstable_getActiveStrategy('rowTree') === ROW_GROUPING_STRATEGY) {
-        apiRef.current.publishEvent(GridEvents.activeStrategyProcessorChange, 'rowTreeCreation');
+        apiRef.current.publishEvent('activeStrategyProcessorChange', 'rowTreeCreation');
       }
     }
   }, [apiRef, props.disableRowGrouping]);
 
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, handleCellKeyDown);
-  useGridApiEventHandler(apiRef, GridEvents.columnsChange, checkGroupingColumnsModelDiff);
-  useGridApiEventHandler(apiRef, GridEvents.rowGroupingModelChange, checkGroupingColumnsModelDiff);
+  useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
+  useGridApiEventHandler(apiRef, 'columnsChange', checkGroupingColumnsModelDiff);
+  useGridApiEventHandler(apiRef, 'rowGroupingModelChange', checkGroupingColumnsModelDiff);
 
   /**
    * EFFECTS


### PR DESCRIPTION
Part of #4684

This PR demonstrated what I want to do in #4684 but only on `@mui/x-data-grid-premium` to give a small example.
If you are ok with it, I can apply it to all our codebase.