### PR TITLE
[test] Restore sinon sandbox after each karma test

### DIFF
--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 import './utils/init';
 import '@mui/monorepo/test/utils/setupKarma';
+import sinon from 'sinon';
 import { unstable_resetCleanupTracking } from '@mui/x-data-grid';
 import { unstable_resetCreateSelectorCache } from '@mui/x-data-grid/internals';
 
@@ -10,4 +11,8 @@ packagesContext.keys().forEach(packagesContext);
 afterEach(function afterEach() {
   unstable_resetCleanupTracking();
   unstable_resetCreateSelectorCache();
+
+  // Restore Sinon default sandbox to avoid memory leak
+  // See https://github.com/sinonjs/sinon/issues/1866
+  sinon.restore();
 });


### PR DESCRIPTION
Apply

https://github.com/mui/mui-x/blob/aefd2fc9b63bf0537a526ccb702e003691193f72/test/utils/setup.js#L76-L80

to karma tests too.

[Before](https://app.circleci.com/pipelines/github/mui/mui-x/17377/workflows/f31b9348-8636-42a1-a1d6-937f92aed1c6/jobs/101321/resources):

![image](https://user-images.githubusercontent.com/42154031/165793668-e21fa12f-1e46-472f-8c1c-627518adc89d.png)

[After](https://app.circleci.com/pipelines/github/mui/mui-x/17441/workflows/d8fb5a0d-e9f7-49b4-8af9-a6600e3c01e3/jobs/101697/resources):

![image](https://user-images.githubusercontent.com/42154031/165794397-bc54ca0e-edfc-4bd4-aa77-11218223a98e.png)
