### PR TITLE
[docs] Update mono repo to get copy code block

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -21,6 +21,7 @@ import { ThemeProvider } from 'docs/src/modules/components/ThemeContext';
 import { pathnameToLanguage, getCookie } from 'docs/src/modules/utils/helpers';
 import { LANGUAGES } from 'docs/src/modules/constants';
 import { CodeVariantProvider } from 'docs/src/modules/utils/codeVariant';
+import { CodeCopyProvider } from 'docs/src/modules/utils/CodeCopy';
 import {
   UserLanguageProvider,
   useSetUserLanguage,
@@ -259,17 +260,19 @@ function AppWrapper(props) {
         ))}
       </NextHead>
       <UserLanguageProvider defaultUserLanguage={pageProps.userLanguage}>
-        <CodeVariantProvider>
-          <PageContext.Provider value={{ activePage, pages: productPages }}>
-            <ThemeProvider>
-              <DocsStyledEngineProvider cacheLtr={emotionCache}>
-                {children}
-                <GoogleAnalytics />
-              </DocsStyledEngineProvider>
-            </ThemeProvider>
-          </PageContext.Provider>
-          <LanguageNegotiation />
-        </CodeVariantProvider>
+        <CodeCopyProvider>
+          <CodeVariantProvider>
+            <PageContext.Provider value={{ activePage, pages: productPages }}>
+              <ThemeProvider>
+                <DocsStyledEngineProvider cacheLtr={emotionCache}>
+                  {children}
+                  <GoogleAnalytics />
+                </DocsStyledEngineProvider>
+              </ThemeProvider>
+            </PageContext.Provider>
+            <LanguageNegotiation />
+          </CodeVariantProvider>
+        </CodeCopyProvider>
       </UserLanguageProvider>
     </React.Fragment>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2575,8 +2575,8 @@
     react-transition-group "^4.4.2"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.6.0"
-  resolved "https://github.com/mui/material-ui.git#06bf2dbda9a493732d81c19f20e7bc5e8ebd2b4b"
+  version "5.6.3"
+  resolved "https://github.com/mui/material-ui.git#ab60e53526bf85dd28a64c926839c1fd7ffec6df"
 
 "@mui/private-theming@^5.6.1", "@mui/private-theming@^5.6.2":
   version "5.6.2"


### PR DESCRIPTION
X docs will benefit from these improvements:

1. **Code copy**
2. **Callouts**:
    in markdown, use this syntax to render callout
    
    ```md
    :::info
    Hello test
    :::
    
    :::success
    Hello test
    :::
    
    :::warning
    Hello test
    :::
    
    :::error
    Hello test
    :::
    ```