### PR TITLE
[DatePicker] Make month year order changeable in header

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -39,8 +39,7 @@ describe('<CalendarPicker />', () => {
       <CalendarPicker date={adapterToUse.date('2019-01-01T00:00:00.000')} onChange={() => {}} />,
     );
 
-    expect(screen.getByText('January')).toBeVisible();
-    expect(screen.getByText('2019')).toBeVisible();
+    expect(screen.getByText('January 2019')).toBeVisible();
     expect(screen.getAllByMuiTest('day')).to.have.length(31);
     // It should follow https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
     expect(
@@ -98,7 +97,7 @@ describe('<CalendarPicker />', () => {
     fireEvent.click(screen.getByLabelText(/Jan 5, 2019/i));
     expect(onChangeMock.callCount).to.equal(0);
 
-    fireEvent.click(screen.getByText('January'));
+    fireEvent.click(screen.getByText('January 2019'));
     expect(screen.queryByLabelText('year view is open, switch to calendar view')).toBeVisible();
   });
 
@@ -114,8 +113,8 @@ describe('<CalendarPicker />', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('January'));
-    expect(screen.queryByText('January')).toBeVisible();
+    fireEvent.click(screen.getByText('January 2019'));
+    expect(screen.queryByText('January 2019')).toBeVisible();
     expect(screen.queryByLabelText('year view is open, switch to calendar view')).to.equal(null);
 
     fireEvent.click(screen.getByTitle('Previous month'));

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -6,7 +6,9 @@ import {
   CalendarPicker,
   calendarPickerClasses as classes,
 } from '@mui/x-date-pickers/CalendarPicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import {
+  AdapterClassToUse,
   adapterToUse,
   wrapPickerMount,
   createPickerRenderer,
@@ -125,5 +127,18 @@ describe('<CalendarPicker />', () => {
 
     fireEvent.click(screen.getByLabelText(/Jan 5, 2019/i));
     expect(onChangeMock.callCount).to.equal(0);
+  });
+
+  it('renders header label text according to monthAndYear format', () => {
+    render(
+      <LocalizationProvider
+        dateAdapter={AdapterClassToUse}
+        dateFormats={{ monthAndYear: 'yyyy/MM' }}
+      >
+        <CalendarPicker date={adapterToUse.date('2019-01-01T00:00:00.000')} onChange={() => {}} />,
+      </LocalizationProvider>,
+    );
+
+    expect(screen.getByText('2019/01')).toBeVisible();
   });
 });

--- a/packages/x-date-pickers/src/CalendarPicker/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/PickersCalendarHeader.tsx
@@ -190,26 +190,14 @@ export function PickersCalendarHeader<TDate>(props: PickersCalendarHeaderProps<T
       >
         <PickersFadeTransitionGroup
           reduceAnimations={reduceAnimations}
-          transKey={utils.format(month, 'month')}
+          transKey={utils.format(month, 'monthAndYear')}
         >
           <PickersCalendarHeaderLabelItem
             aria-live="polite"
-            data-mui-test="calendar-month-text"
+            data-mui-test="calendar-month-and-year-text"
             ownerState={ownerState}
           >
-            {utils.format(month, 'month')}
-          </PickersCalendarHeaderLabelItem>
-        </PickersFadeTransitionGroup>
-        <PickersFadeTransitionGroup
-          reduceAnimations={reduceAnimations}
-          transKey={utils.format(month, 'year')}
-        >
-          <PickersCalendarHeaderLabelItem
-            aria-live="polite"
-            data-mui-test="calendar-year-text"
-            ownerState={ownerState}
-          >
-            {utils.format(month, 'year')}
+            {utils.format(month, 'monthAndYear')}
           </PickersCalendarHeaderLabelItem>
         </PickersFadeTransitionGroup>
         {views.length > 1 && !disabled && (

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -52,8 +52,7 @@ describe('<MobileDatePicker />', () => {
       />,
     );
 
-    expect(screen.getAllByMuiTest('calendar-year-text')[0]).to.have.text('2018');
-    expect(screen.getByMuiTest('calendar-month-text')).to.have.text('January');
+    expect(screen.getAllByMuiTest('calendar-month-and-year-text')[0]).to.have.text('January 2018');
 
     // onChange must be dispatched with newly selected date
     expect(onChangeMock.callCount).to.equal(
@@ -77,7 +76,7 @@ describe('<MobileDatePicker />', () => {
     fireEvent.click(screen.getByLabelText(/switch to year view/i));
     fireEvent.click(screen.getByText('2010', { selector: 'button' }));
 
-    expect(screen.getAllByMuiTest('calendar-year-text')[0]).to.have.text('2010');
+    expect(screen.getAllByMuiTest('calendar-month-and-year-text')[0]).to.have.text('January 2010');
     expect(onChangeMock.callCount).to.equal(1);
   });
 
@@ -265,7 +264,7 @@ describe('<MobileDatePicker />', () => {
       />,
     );
 
-    expect(screen.getByText('July')).toBeVisible();
+    expect(screen.getByText('July 2018')).toBeVisible();
   });
 
   it('prop `showTodayButton` – accept current date when "today" button is clicked', () => {

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.test.tsx
@@ -17,8 +17,7 @@ describe('<StaticDatePicker />', () => {
       />,
     );
 
-    expect(screen.getByText('January')).toBeVisible();
-    expect(screen.getByText('2019')).toBeVisible();
+    expect(screen.getByText('January 2019')).toBeVisible();
     expect(screen.getAllByMuiTest('day')).to.have.length(31);
   });
 
@@ -32,7 +31,7 @@ describe('<StaticDatePicker />', () => {
       />,
     );
 
-    expect(screen.getByMuiTest('calendar-month-text')).to.have.text('January');
+    expect(screen.getByMuiTest('calendar-month-and-year-text')).to.have.text('January 2019');
 
     const nextMonth = screen.getByLabelText('Next month');
     const previousMonth = screen.getByLabelText('Previous month');
@@ -43,7 +42,7 @@ describe('<StaticDatePicker />', () => {
     fireEvent.click(previousMonth);
     fireEvent.click(previousMonth);
 
-    expect(screen.getByMuiTest('calendar-month-text')).to.have.text('December');
+    expect(screen.getByMuiTest('calendar-month-and-year-text')).to.have.text('December 2018');
   });
 
   it('prop `shouldDisableYear` – disables years dynamically', () => {


### PR DESCRIPTION
Fixes mui/mui-x#4463.

Allow changing the order of month and year in PickersCalendarHeader by using `monthAndYear` format instead of using `month` and `year` format separately.

Ref https://github.com/mui/material-ui/pull/31888