### PR TITLE
[data grid] Stop using `GridEvents` enum in `@mui/x-data-grid-pro`

### DIFF
--- a/packages/grid/x-data-grid-pro/src/components/DataGridProColumnHeaders.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/DataGridProColumnHeaders.tsx
@@ -7,7 +7,6 @@ import {
   useGridSelector,
   useGridApiEventHandler,
   gridVisibleColumnFieldsSelector,
-  GridEvents,
   GridColumnHeaderSeparatorSides,
 } from '@mui/x-data-grid';
 import {
@@ -113,11 +112,7 @@ export const DataGridProColumnHeaders = React.forwardRef<
     setScrollbarSize(newScrollbarSize);
   }, [apiRef]);
 
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.virtualScrollerContentSizeChange,
-    handleContentSizeChange,
-  );
+  useGridApiEventHandler(apiRef, 'virtualScrollerContentSizeChange', handleContentSizeChange);
 
   const pinnedColumns = useGridSelector(apiRef, gridPinnedColumnsSelector);
   const [leftPinnedColumns, rightPinnedColumns] = filterColumns(pinnedColumns, visibleColumnFields);

--- a/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
@@ -9,7 +9,6 @@ import {
   gridVisibleColumnFieldsSelector,
   gridRowsMetaSelector,
   useGridApiEventHandler,
-  GridEvents,
   GridRowId,
 } from '@mui/x-data-grid';
 import {
@@ -207,9 +206,9 @@ const DataGridProVirtualScroller = React.forwardRef<
     }
   }, [renderContext, updateRenderZonePosition]);
 
-  useGridApiEventHandler(apiRef, GridEvents.columnWidthChange, refreshRenderZonePosition);
-  useGridApiEventHandler(apiRef, GridEvents.columnOrderChange, refreshRenderZonePosition);
-  useGridApiEventHandler(apiRef, GridEvents.rowOrderChange, refreshRenderZonePosition);
+  useGridApiEventHandler(apiRef, 'columnWidthChange', refreshRenderZonePosition);
+  useGridApiEventHandler(apiRef, 'columnOrderChange', refreshRenderZonePosition);
+  useGridApiEventHandler(apiRef, 'rowOrderChange', refreshRenderZonePosition);
 
   const leftRenderContext =
     renderContext && leftPinnedColumns.length > 0

--- a/packages/grid/x-data-grid-pro/src/components/GridRowReorderCell.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/GridRowReorderCell.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import {
-  GridEvents,
   GridRenderCellParams,
   GridRowEventLookup,
   gridRowTreeDepthSelector,
@@ -80,9 +79,9 @@ const GridRowReorderCell = (params: GridRenderCellParams) => {
   );
 
   const draggableEventHandlers = {
-    onDragStart: publish(GridEvents.rowDragStart),
-    onDragOver: publish(GridEvents.rowDragOver),
-    onDragEnd: publish(GridEvents.rowDragEnd),
+    onDragStart: publish('rowDragStart'),
+    onDragOver: publish('rowDragOver'),
+    onDragEnd: publish('rowDragEnd'),
   };
 
   return (

--- a/packages/grid/x-data-grid-pro/src/components/GridTreeDataGroupingCell.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/GridTreeDataGroupingCell.tsx
@@ -7,7 +7,6 @@ import {
   useGridSelector,
   gridFilteredDescendantCountLookupSelector,
   getDataGridUtilityClass,
-  GridEvents,
   GridRenderCellParams,
 } from '@mui/x-data-grid';
 import { isNavigationKey } from '@mui/x-data-grid/internals';
@@ -55,7 +54,7 @@ const GridTreeDataGroupingCell = (props: GridTreeDataGroupingCellProps) => {
       event.stopPropagation();
     }
     if (isNavigationKey(event.key) && !event.shiftKey) {
-      apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, props, event);
+      apiRef.current.publishEvent('cellNavigationKeyDown', props, event);
     }
   };
 

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
@@ -7,7 +7,6 @@ import {
   gridColumnPositionsSelector,
   gridVisibleColumnFieldsSelector,
   gridClasses,
-  GridEvents,
   useGridApiMethod,
   useGridApiEventHandler,
   GridEventListener,
@@ -104,22 +103,22 @@ export const useGridColumnPinning = (
     [apiRef, pinnedColumns.left, pinnedColumns.right, props.disableColumnPinning],
   );
 
-  const handleMouseEnter = React.useCallback<GridEventListener<GridEvents.rowMouseEnter>>(
+  const handleMouseEnter = React.useCallback<GridEventListener<'rowMouseEnter'>>(
     (params, event) => {
       updateHoveredClassOnSiblingRows(event);
     },
     [updateHoveredClassOnSiblingRows],
   );
 
-  const handleMouseLeave = React.useCallback<GridEventListener<GridEvents.rowMouseLeave>>(
+  const handleMouseLeave = React.useCallback<GridEventListener<'rowMouseLeave'>>(
     (params, event) => {
       updateHoveredClassOnSiblingRows(event);
     },
     [updateHoveredClassOnSiblingRows],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.rowMouseEnter, handleMouseEnter);
-  useGridApiEventHandler(apiRef, GridEvents.rowMouseLeave, handleMouseLeave);
+  useGridApiEventHandler(apiRef, 'rowMouseEnter', handleMouseEnter);
+  useGridApiEventHandler(apiRef, 'rowMouseLeave', handleMouseLeave);
 
   /**
    * PRE-PROCESSING
@@ -249,7 +248,7 @@ export const useGridColumnPinning = (
     propModel: props.pinnedColumns,
     propOnChange: props.onPinnedColumnsChange,
     stateSelector: gridPinnedColumnsSelector,
-    changeEvent: GridEvents.pinnedColumnsChange,
+    changeEvent: 'pinnedColumnsChange',
   });
 
   const checkIfEnabled = React.useCallback(

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx
@@ -4,7 +4,6 @@ import {
   CursorCoordinates,
   useGridApiEventHandler,
   getDataGridUtilityClass,
-  GridEvents,
   GridEventListener,
   useGridLogger,
 } from '@mui/x-data-grid';
@@ -73,7 +72,7 @@ export const useGridColumnReorder = (
     };
   }, []);
 
-  const handleDragStart = React.useCallback<GridEventListener<GridEvents.columnHeaderDragStart>>(
+  const handleDragStart = React.useCallback<GridEventListener<'columnHeaderDragStart'>>(
     (params, event) => {
       if (props.disableColumnReorder || params.colDef.disableReorder) {
         return;
@@ -103,7 +102,7 @@ export const useGridColumnReorder = (
   );
 
   const handleDragEnter = React.useCallback<
-    GridEventListener<GridEvents.cellDragEnter | GridEvents.columnHeaderDragEnter>
+    GridEventListener<'cellDragEnter' | 'columnHeaderDragEnter'>
   >((params, event) => {
     event.preventDefault();
     // Prevent drag events propagation.
@@ -112,7 +111,7 @@ export const useGridColumnReorder = (
   }, []);
 
   const handleDragOver = React.useCallback<
-    GridEventListener<GridEvents.cellDragOver | GridEvents.columnHeaderDragOver>
+    GridEventListener<'cellDragOver' | 'columnHeaderDragOver'>
   >(
     (params, event) => {
       const dragColField = gridColumnReorderDragColSelector(apiRef);
@@ -174,7 +173,7 @@ export const useGridColumnReorder = (
     [apiRef, logger],
   );
 
-  const handleDragEnd = React.useCallback<GridEventListener<GridEvents.columnHeaderDragEnd>>(
+  const handleDragEnd = React.useCallback<GridEventListener<'columnHeaderDragEnd'>>(
     (params, event): void => {
       const dragColField = gridColumnReorderDragColSelector(apiRef);
       if (props.disableColumnReorder || !dragColField) {
@@ -206,10 +205,10 @@ export const useGridColumnReorder = (
     [props.disableColumnReorder, logger, apiRef],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragStart, handleDragStart);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragEnter, handleDragEnter);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragOver, handleDragOver);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragEnd, handleDragEnd);
-  useGridApiEventHandler(apiRef, GridEvents.cellDragEnter, handleDragEnter);
-  useGridApiEventHandler(apiRef, GridEvents.cellDragOver, handleDragOver);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragStart', handleDragStart);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragEnter', handleDragEnter);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragOver', handleDragOver);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragEnd', handleDragEnd);
+  useGridApiEventHandler(apiRef, 'cellDragEnter', handleDragEnter);
+  useGridApiEventHandler(apiRef, 'cellDragOver', handleDragOver);
 };

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ownerDocument, useEventCallback } from '@mui/material/utils';
 import {
-  GridEvents,
   GridEventListener,
   gridClasses,
   CursorCoordinates,
@@ -170,10 +169,10 @@ export const useGridColumnResize = (
 
     clearTimeout(stopResizeEventTimeout.current);
     stopResizeEventTimeout.current = setTimeout(() => {
-      apiRef.current.publishEvent(GridEvents.columnResizeStop, null, nativeEvent);
+      apiRef.current.publishEvent('columnResizeStop', null, nativeEvent);
       if (colDefRef.current) {
         apiRef.current.publishEvent(
-          GridEvents.columnWidthChange,
+          'columnWidthChange',
           {
             element: colElementRef.current,
             colDef: colDefRef.current,
@@ -211,10 +210,10 @@ export const useGridColumnResize = (
       colDef: colDefRef.current!,
       width: newWidth,
     };
-    apiRef.current.publishEvent(GridEvents.columnResize, params, nativeEvent);
+    apiRef.current.publishEvent('columnResize', params, nativeEvent);
   });
 
-  const handleColumnResizeMouseDown: GridEventListener<GridEvents.columnSeparatorMouseDown> =
+  const handleColumnResizeMouseDown: GridEventListener<'columnSeparatorMouseDown'> =
     useEventCallback(({ colDef }, event) => {
       // Only handle left clicks
       if (event.button !== 0) {
@@ -230,7 +229,7 @@ export const useGridColumnResize = (
       event.preventDefault();
 
       logger.debug(`Start Resize on col ${colDef.field}`);
-      apiRef.current.publishEvent(GridEvents.columnResizeStart, { field: colDef.field }, event);
+      apiRef.current.publishEvent('columnResizeStart', { field: colDef.field }, event);
 
       colDefRef.current = colDef as GridStateColDef;
       colElementRef.current =
@@ -272,7 +271,7 @@ export const useGridColumnResize = (
 
     clearTimeout(stopResizeEventTimeout.current);
     stopResizeEventTimeout.current = setTimeout(() => {
-      apiRef.current.publishEvent(GridEvents.columnResizeStop, null, nativeEvent);
+      apiRef.current.publishEvent('columnResizeStop', null, nativeEvent);
     });
 
     logger.debug(
@@ -307,7 +306,7 @@ export const useGridColumnResize = (
       colDef: colDefRef.current!,
       width: newWidth,
     };
-    apiRef.current.publishEvent(GridEvents.columnResize, params, nativeEvent);
+    apiRef.current.publishEvent('columnResize', params, nativeEvent);
   });
 
   const handleTouchStart = useEventCallback((event: any) => {
@@ -338,7 +337,7 @@ export const useGridColumnResize = (
     const colDef = apiRef.current.getColumn(field);
 
     logger.debug(`Start Resize on col ${colDef.field}`);
-    apiRef.current.publishEvent(GridEvents.columnResizeStart, { field }, event);
+    apiRef.current.publishEvent('columnResizeStart', { field }, event);
 
     colDefRef.current = colDef as GridStateColDef;
     colElementRef.current = findHeaderElementFromField(
@@ -369,7 +368,7 @@ export const useGridColumnResize = (
     doc.removeEventListener('touchend', handleTouchEnd);
   }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd]);
 
-  const handleResizeStart = React.useCallback<GridEventListener<GridEvents.columnResizeStart>>(
+  const handleResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
     ({ field }) => {
       apiRef.current.setState((state) => ({
         ...state,
@@ -380,7 +379,7 @@ export const useGridColumnResize = (
     [apiRef],
   );
 
-  const handleResizeStop = React.useCallback<GridEventListener<GridEvents.columnResizeStop>>(() => {
+  const handleResizeStop = React.useCallback<GridEventListener<'columnResizeStop'>>(() => {
     apiRef.current.setState((state) => ({
       ...state,
       columnResize: { ...state.columnResize, resizingColumnField: '' },
@@ -403,10 +402,10 @@ export const useGridColumnResize = (
     { passive: doesSupportTouchActionNone() },
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.columnSeparatorMouseDown, handleColumnResizeMouseDown);
-  useGridApiEventHandler(apiRef, GridEvents.columnResizeStart, handleResizeStart);
-  useGridApiEventHandler(apiRef, GridEvents.columnResizeStop, handleResizeStop);
+  useGridApiEventHandler(apiRef, 'columnSeparatorMouseDown', handleColumnResizeMouseDown);
+  useGridApiEventHandler(apiRef, 'columnResizeStart', handleResizeStart);
+  useGridApiEventHandler(apiRef, 'columnResizeStop', handleResizeStop);
 
-  useGridApiOptionHandler(apiRef, GridEvents.columnResize, props.onColumnResize);
-  useGridApiOptionHandler(apiRef, GridEvents.columnWidthChange, props.onColumnWidthChange);
+  useGridApiOptionHandler(apiRef, 'columnResize', props.onColumnResize);
+  useGridApiOptionHandler(apiRef, 'columnWidthChange', props.onColumnWidthChange);
 };

--- a/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  GridEvents,
   GridEventListener,
   GridRowId,
   useGridSelector,
@@ -51,7 +50,7 @@ export const useGridDetailPanel = (
   const expandedRowIds = useGridSelector(apiRef, gridDetailPanelExpandedRowIdsSelector);
   const contentCache = useGridSelector(apiRef, gridDetailPanelExpandedRowsContentCacheSelector);
 
-  const handleCellClick = React.useCallback<GridEventListener<GridEvents.cellClick>>(
+  const handleCellClick = React.useCallback<GridEventListener<'cellClick'>>(
     (params: GridCellParams, event: React.MouseEvent) => {
       if (params.field !== GRID_DETAIL_PANEL_TOGGLE_FIELD || props.getDetailPanelContent == null) {
         return;
@@ -72,7 +71,7 @@ export const useGridDetailPanel = (
     [apiRef, contentCache, props.getDetailPanelContent],
   );
 
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       if (props.getDetailPanelContent == null) {
         return;
@@ -91,8 +90,8 @@ export const useGridDetailPanel = (
     [apiRef, props.getDetailPanelContent],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.cellClick, handleCellClick);
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, handleCellKeyDown);
+  useGridApiEventHandler(apiRef, 'cellClick', handleCellClick);
+  useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
 
   const addDetailHeight = React.useCallback<GridPipeProcessor<'rowHeight'>>(
     (initialValue, row) => {
@@ -115,7 +114,7 @@ export const useGridDetailPanel = (
     propModel: props.detailPanelExpandedRowIds,
     propOnChange: props.onDetailPanelExpandedRowIdsChange,
     stateSelector: gridDetailPanelExpandedRowIdsSelector,
-    changeEvent: GridEvents.detailPanelsExpandedRowIdsChange,
+    changeEvent: 'detailPanelsExpandedRowIdsChange',
   });
 
   const toggleDetailPanel = React.useCallback<GridDetailPanelApi['toggleDetailPanel']>(

--- a/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanelCache.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanelCache.ts
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  useGridApiEventHandler,
-  gridRowIdsSelector,
-  GridEvents,
-  GridRowId,
-} from '@mui/x-data-grid';
+import { useGridApiEventHandler, gridRowIdsSelector, GridRowId } from '@mui/x-data-grid';
 import { GridApiPro } from '../../../models/gridApiPro';
 import { DataGridProProcessedProps } from '../../../models/dataGridProProps';
 
@@ -61,7 +56,7 @@ export const useGridDetailPanelCache = (
     apiRef.current.forceUpdate();
   }, [apiRef, props.getDetailPanelContent, props.getDetailPanelHeight]);
 
-  useGridApiEventHandler(apiRef, GridEvents.sortedRowsSet, updateCaches);
+  useGridApiEventHandler(apiRef, 'sortedRowsSet', updateCaches);
 
   const isFirstRender = React.useRef(true);
   if (isFirstRender.current) {

--- a/packages/grid/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   useGridSelector,
-  GridEvents,
   GridEventListener,
   GridScrollParams,
   useGridApiEventHandler,
@@ -56,20 +55,20 @@ export const useGridInfiniteLoader = (
           viewportPageSize,
           virtualRowsCount: currentPage.rows.length,
         };
-        apiRef.current.publishEvent(GridEvents.rowsScrollEnd, rowScrollEndParam);
+        apiRef.current.publishEvent('rowsScrollEnd', rowScrollEndParam);
         isInScrollBottomArea.current = true;
       }
     },
     [contentHeight, props.scrollEndThreshold, visibleColumns, apiRef, currentPage.rows.length],
   );
 
-  const handleGridScroll = React.useCallback<GridEventListener<GridEvents.rowsScroll>>(
+  const handleGridScroll = React.useCallback<GridEventListener<'rowsScroll'>>(
     ({ left, top }) => {
       handleRowsScrollEnd({ left, top });
     },
     [handleRowsScrollEnd],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.rowsScroll, handleGridScroll);
-  useGridApiOptionHandler(apiRef, GridEvents.rowsScrollEnd, props.onRowsScrollEnd);
+  useGridApiEventHandler(apiRef, 'rowsScroll', handleGridScroll);
+  useGridApiOptionHandler(apiRef, 'rowsScrollEnd', props.onRowsScrollEnd);
 };

--- a/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import {
   useGridLogger,
-  GridEvents,
   useGridApiEventHandler,
   GridEventListener,
   getDataGridUtilityClass,
@@ -59,7 +58,7 @@ export const useGridRowReorder = (
     return !props.rowReordering || !!sortModel.length || treeDepth !== 1;
   }, [props.rowReordering, sortModel, treeDepth]);
 
-  const handleDragStart = React.useCallback<GridEventListener<GridEvents.rowDragStart>>(
+  const handleDragStart = React.useCallback<GridEventListener<'rowDragStart'>>(
     (params, event) => {
       // Call the gridEditRowsStateSelector directly to avoid infnite loop
       const editRowsState = gridEditRowsStateSelector(apiRef.current.state);
@@ -86,9 +85,7 @@ export const useGridRowReorder = (
     [isRowReorderDisabled, classes.rowDragging, logger, apiRef],
   );
 
-  const handleDragOver = React.useCallback<
-    GridEventListener<GridEvents.cellDragOver | GridEvents.rowDragOver>
-  >(
+  const handleDragOver = React.useCallback<GridEventListener<'cellDragOver' | 'rowDragOver'>>(
     (params, event) => {
       logger.debug(`Dragging over row ${params.id}`);
       event.preventDefault();
@@ -104,7 +101,7 @@ export const useGridRowReorder = (
     [apiRef, logger, dragRowId],
   );
 
-  const handleDragEnd = React.useCallback<GridEventListener<GridEvents.rowDragEnd>>(
+  const handleDragEnd = React.useCallback<GridEventListener<'rowDragEnd'>>(
     (params, event): void => {
       // Call the gridEditRowsStateSelector directly to avoid infnite loop
       const editRowsState = gridEditRowsStateSelector(apiRef.current.state);
@@ -134,7 +131,7 @@ export const useGridRowReorder = (
           oldIndex: originRowIndex.current!,
         };
 
-        apiRef.current.publishEvent(GridEvents.rowOrderChange, rowOrderChangeParams);
+        apiRef.current.publishEvent('rowOrderChange', rowOrderChangeParams);
       }
 
       setDragRowId('');
@@ -142,9 +139,9 @@ export const useGridRowReorder = (
     [isRowReorderDisabled, logger, apiRef, dragRowId],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.rowDragStart, handleDragStart);
-  useGridApiEventHandler(apiRef, GridEvents.rowDragOver, handleDragOver);
-  useGridApiEventHandler(apiRef, GridEvents.rowDragEnd, handleDragEnd);
-  useGridApiEventHandler(apiRef, GridEvents.cellDragOver, handleDragOver);
-  useGridApiOptionHandler(apiRef, GridEvents.rowOrderChange, props.onRowOrderChange);
+  useGridApiEventHandler(apiRef, 'rowDragStart', handleDragStart);
+  useGridApiEventHandler(apiRef, 'rowDragOver', handleDragOver);
+  useGridApiEventHandler(apiRef, 'rowDragEnd', handleDragEnd);
+  useGridApiEventHandler(apiRef, 'cellDragOver', handleDragOver);
+  useGridApiOptionHandler(apiRef, 'rowOrderChange', props.onRowOrderChange);
 };

--- a/packages/grid/x-data-grid-pro/src/hooks/features/treeData/useGridTreeData.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/treeData/useGridTreeData.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   useGridApiEventHandler,
   GridEventListener,
-  GridEvents,
   gridFilteredDescendantCountLookupSelector,
 } from '@mui/x-data-grid';
 import { GridApiPro } from '../../../models/gridApiPro';
@@ -11,7 +10,7 @@ export const useGridTreeData = (apiRef: React.MutableRefObject<GridApiPro>) => {
   /**
    * EVENTS
    */
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       const cellParams = apiRef.current.getCellParams(params.id, params.field);
       if (cellParams.colDef.type === 'treeDataGroup' && event.key === ' ' && !event.shiftKey) {
@@ -28,5 +27,5 @@ export const useGridTreeData = (apiRef: React.MutableRefObject<GridApiPro>) => {
     [apiRef],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, handleCellKeyDown);
+  useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
 };

--- a/packages/grid/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/grid/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   GridRowTreeNodeConfig,
   GridEventListener,
-  GridEvents,
   GridCallbackDetails,
   GridRowParams,
   GridRowId,
@@ -137,21 +136,21 @@ export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnResize?: GridEventListener<GridEvents.columnResize>;
+  onColumnResize?: GridEventListener<'columnResize'>;
   /**
    * Callback fired when the width of a column is changed.
    * @param {GridColumnResizeParams} params With all properties from [[GridColumnResizeParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnWidthChange?: GridEventListener<GridEvents.columnWidthChange>;
+  onColumnWidthChange?: GridEventListener<'columnWidthChange'>;
   /**
    * Callback fired when scrolling to the bottom of the grid viewport.
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onRowsScrollEnd?: GridEventListener<GridEvents.rowsScrollEnd>;
+  onRowsScrollEnd?: GridEventListener<'rowsScrollEnd'>;
   /**
    * The column fields to display pinned to left or right.
    */
@@ -192,5 +191,5 @@ export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onRowOrderChange?: GridEventListener<GridEvents.rowOrderChange>;
+  onRowOrderChange?: GridEventListener<'rowOrderChange'>;
 }

--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
@@ -3,7 +3,6 @@ import {
   GridApi,
   DataGridProProps,
   useGridApiRef,
-  GridEvents,
   DataGridPro,
   GridRenderEditCellParams,
   GridValueSetterParams,
@@ -514,7 +513,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStart' with reason=cellDoubleClick`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         expect(listener.lastCall.args[0].reason).to.equal('cellDoubleClick');
@@ -523,7 +522,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.doubleClick(cell);
         expect(listener.callCount).to.equal(0);
@@ -542,7 +541,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStart' with reason=enterKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -553,7 +552,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -576,7 +575,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStart' with reason=deleteKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -587,7 +586,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -624,7 +623,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -635,7 +634,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should not publish 'cellEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+        apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -647,7 +646,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
         it(`should not publish 'cellEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
           const listener = spy();
-          apiRef.current.subscribeEvent(GridEvents.cellEditStart, listener);
+          apiRef.current.subscribeEvent('cellEditStart', listener);
           const cell = getCell(0, 1);
           fireEvent.mouseUp(cell);
           fireEvent.click(cell);
@@ -687,7 +686,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStop' with reason=cellFocusOut`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStop, listener);
+        apiRef.current.subscribeEvent('cellEditStop', listener);
         fireEvent.doubleClick(getCell(0, 1));
         expect(listener.callCount).to.equal(0);
         fireEvent.click(getCell(1, 1));
@@ -725,7 +724,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStop' with reason=escapeKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStop, listener);
+        apiRef.current.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -757,7 +756,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStop' with reason=enterKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStop, listener);
+        apiRef.current.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -804,7 +803,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
       it(`should publish 'cellEditStop' with reason=tabKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.cellEditStop, listener);
+        apiRef.current.subscribeEvent('cellEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);

--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.old.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.old.test.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  GridEvents,
-  GridApi,
-  DataGridProProps,
-  useGridApiRef,
-  DataGridPro,
-} from '@mui/x-data-grid-pro';
+import { GridApi, DataGridProProps, useGridApiRef, DataGridPro } from '@mui/x-data-grid-pro';
 import Portal from '@mui/base/Portal';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, fireEvent, screen, waitFor } from '@mui/monorepo/test/utils';
@@ -338,7 +332,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
     fireClickEvent(cell);
     expect(cell).to.have.text('Adidas');
     const params = apiRef.current.getCellParams(1, 'brand');
-    apiRef.current.publishEvent(GridEvents.cellKeyDown, params, {
+    apiRef.current.publishEvent('cellKeyDown', params, {
       key: 'a',
       code: 1,
       target: cell,

--- a/packages/grid/x-data-grid-pro/src/tests/events.DataGridPro.spec.ts
+++ b/packages/grid/x-data-grid-pro/src/tests/events.DataGridPro.spec.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   useGridApiContext,
   useGridApiEventHandler,
-  GridEvents,
   GridRowParams,
   GridCellParams,
 } from '@mui/x-data-grid-pro';
@@ -10,23 +9,23 @@ import {
 const TestEvents = () => {
   const apiRef = useGridApiContext();
 
-  // @ts-expect-error Argument of type '(params: GridRowParams) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
-  useGridApiEventHandler(apiRef, GridEvents.cellClick, (params: GridRowParams) => {});
+  // @ts-expect-error Argument of type '(params: GridRowParams) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
+  useGridApiEventHandler(apiRef, 'cellClick', (params: GridRowParams) => {});
 
-  // @ts-expect-error Argument of type '(params: GridRowParams) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
+  // @ts-expect-error Argument of type '(params: GridRowParams) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
   useGridApiEventHandler(apiRef, 'cellClick', (params: GridRowParams) => {});
 
   useGridApiEventHandler(
     apiRef,
-    GridEvents.cellClick,
-    // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
+    'cellClick',
+    // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
     (params: GridCellParams, event: React.KeyboardEvent<HTMLElement>) => {},
   );
 
   useGridApiEventHandler(
     apiRef,
     'cellClick',
-    // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
+    // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
     (params: GridCellParams, event: React.KeyboardEvent<HTMLElement>) => {},
   );
 
@@ -36,16 +35,16 @@ const TestEvents = () => {
     event: React.KeyboardEvent<HTMLElement>,
   ) => {};
 
-  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
-  useGridApiEventHandler(apiRef, GridEvents.cellClick, handleCellClickWrongParams);
-
-  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
+  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
   useGridApiEventHandler(apiRef, 'cellClick', handleCellClickWrongParams);
 
-  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
-  useGridApiEventHandler(apiRef, GridEvents.cellClick, handleCellClickWrongEvents);
+  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
+  useGridApiEventHandler(apiRef, 'cellClick', handleCellClickWrongParams);
 
-  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<GridEvents.cellClick>'.
+  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
+  useGridApiEventHandler(apiRef, 'cellClick', handleCellClickWrongEvents);
+
+  // @ts-expect-error Argument of type '(params: GridCellParams, event: React.KeyboardEvent<HTMLEvent>) => void' is not assignable to parameter of type 'GridEventListener<'cellClick'>'.
   useGridApiEventHandler(apiRef, 'cellClick', handleCellClickWrongEvents);
 
   // @ts-expect-error  Argument of type '"cellTripleClick"' is not assignable to parameter of type '"resize" | "debouncedResize" | "componentError" | "unmount" | "cellModeChange" | "cellClick" | "cellDoubleClick" | "cellMouseDown" | "cellMouseUp" | "cellKeyDown" | "cellFocusIn" | ... 49 more ... | "columnVisibilityChange"'
@@ -55,7 +54,7 @@ const TestEvents = () => {
   useGridApiEventHandler(apiRef, 'cellClick', () => {});
 
   // should work with enum event name
-  useGridApiEventHandler(apiRef, GridEvents.cellClick, () => {});
+  useGridApiEventHandler(apiRef, 'cellClick', () => {});
 
   return null;
 };

--- a/packages/grid/x-data-grid-pro/src/tests/events.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/events.DataGridPro.test.tsx
@@ -11,7 +11,6 @@ import {
   GridCellParams,
   GridRowsProp,
   GridColumns,
-  GridEvents,
   gridClasses,
   GridActionsCellItem,
   GridApi,
@@ -330,7 +329,7 @@ describe('<DataGridPro /> - Events Params', () => {
   it('publishing GRID_ROWS_SCROLL should call onRowsScrollEnd callback', () => {
     const handleRowsScrollEnd = spy();
     render(<TestEvents onRowsScrollEnd={handleRowsScrollEnd} />);
-    apiRef.current.publishEvent(GridEvents.rowsScroll, { left: 0, top: 3 * 52 });
+    apiRef.current.publishEvent('rowsScroll', { left: 0, top: 3 * 52 });
     expect(handleRowsScrollEnd.callCount).to.equal(1);
   });
 
@@ -379,7 +378,7 @@ describe('<DataGridPro /> - Events Params', () => {
     expect(handleRowsScrollEnd.callCount).to.equal(2);
   });
 
-  it('should publish GridEvents.unmount when unmounting the Grid', () => {
+  it('should publish "unmount" event when unmounting the Grid', () => {
     const onUnmount = spy();
 
     const { unmount } = render(<TestEvents />);

--- a/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
@@ -3,7 +3,6 @@ import {
   GridApi,
   DataGridProProps,
   useGridApiRef,
-  GridEvents,
   DataGridPro,
   GridRenderEditCellParams,
   GridValueSetterParams,
@@ -533,7 +532,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStart' with reason=cellDoubleClick`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.doubleClick(cell);
         expect(listener.lastCall.args[0].reason).to.equal('cellDoubleClick');
@@ -542,7 +541,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.doubleClick(cell);
         expect(listener.callCount).to.equal(0);
@@ -561,7 +560,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStart' with reason=enterKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -572,7 +571,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -599,7 +598,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStart' with reason=deleteKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -610,7 +609,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -651,7 +650,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -662,7 +661,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should not publish 'rowEditStart' if the cell is not editable`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+        apiRef.current.subscribeEvent('rowEditStart', listener);
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -674,7 +673,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         it(`should not publish 'rowEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
           const listener = spy();
-          apiRef.current.subscribeEvent(GridEvents.rowEditStart, listener);
+          apiRef.current.subscribeEvent('rowEditStart', listener);
           const cell = getCell(0, 1);
           fireEvent.mouseUp(cell);
           fireEvent.click(cell);
@@ -720,7 +719,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStop' with reason=rowFocusOut`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStop, listener);
+        apiRef.current.subscribeEvent('rowEditStop', listener);
         fireEvent.doubleClick(getCell(0, 1));
         expect(listener.callCount).to.equal(0);
         fireEvent.click(getCell(1, 1));
@@ -761,7 +760,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStop' with reason=escapeKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStop, listener);
+        apiRef.current.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -793,7 +792,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStop' with reason=enterKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStop, listener);
+        apiRef.current.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -840,7 +839,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStop' with reason=tabKeyDown if on the last column`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStop, listener);
+        apiRef.current.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 2);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
@@ -853,7 +852,7 @@ describe('<DataGridPro /> - Row Editing', () => {
       it(`should publish 'rowEditStop' with reason=shiftTabKeyDown if on the first column and Shift is pressed`, () => {
         render(<TestCase />);
         const listener = spy();
-        apiRef.current.subscribeEvent(GridEvents.rowEditStop, listener);
+        apiRef.current.subscribeEvent('rowEditStop', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);

--- a/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
@@ -8,7 +8,6 @@ import {
   GridApi,
   useGridApiRef,
   DataGridPro,
-  GridEvents,
   DataGridProProps,
   GridSelectionModel,
 } from '@mui/x-data-grid-pro';
@@ -404,7 +403,7 @@ describe('<DataGridPro /> - Selection', () => {
       const handleSelectionChange = spy();
       const selectionModel: GridSelectionModel = [];
       render(<TestDataGridSelection selectionModel={selectionModel} />);
-      apiRef.current.subscribeEvent(GridEvents.selectionChange, handleSelectionChange);
+      apiRef.current.subscribeEvent('selectionChange', handleSelectionChange);
       apiRef.current.setSelectionModel(selectionModel);
       expect(handleSelectionChange.callCount).to.equal(0);
     });


### PR DESCRIPTION
Part of #4684 
Follow up on #4685

Will automerge, I don't think it's worth reviewing since it does not change anything concrete and #4685 has been approved.