### PR TITLE
[core] Prevent out-of-memory when type-checking in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
           command: git add -A && git diff --exit-code --staged
       - run:
           name: Tests TypeScript definitions
-          command: yarn typescript
+          command: yarn typescript:ci
   test_e2e:
     <<: *defaults
     docker:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.js",
     "typescript": "lerna run --no-bail --parallel typescript",
+    "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "release:changelog": "node scripts/releaseChangelog",
     "release:version": "lerna version --exact --no-changelog --no-push --no-git-tag-version",


### PR DESCRIPTION
Copy of https://github.com/mui/material-ui/pull/24933 which solves the exact same problem on the core
The issue likely comes from the creation of `@mui/x-data-grid-premium` which added an additional parallel run.