### PR TITLE
[data grid] Stop using GridEvents enum in `@mui/x-data-grid`

### DIFF
--- a/packages/grid/x-data-grid-generator/src/renderer/renderEditIncoterm.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderEditIncoterm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridRenderEditCellParams, GridEvents } from '@mui/x-data-grid-premium';
+import { GridRenderEditCellParams } from '@mui/x-data-grid-premium';
 import Select, { SelectProps } from '@mui/material/Select';
 import { MenuProps } from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -19,7 +19,7 @@ function EditIncoterm(props: GridRenderEditCellParams<string | null>) {
       // TODO v6: remove once we stop ignoring events fired from portals
       const params = api.getCellParams(id, field);
       api.publishEvent(
-        GridEvents.cellNavigationKeyDown,
+        'cellNavigationKeyDown',
         params,
         event as any as React.KeyboardEvent<HTMLElement>,
       );

--- a/packages/grid/x-data-grid-generator/src/renderer/renderEditStatus.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderEditStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridRenderEditCellParams, GridEvents } from '@mui/x-data-grid-premium';
+import { GridRenderEditCellParams } from '@mui/x-data-grid-premium';
 import Select, { SelectProps } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import { MenuProps } from '@mui/material/Menu';
@@ -23,7 +23,7 @@ function EditStatus(props: GridRenderEditCellParams<string>) {
       // TODO v6: remove once we stop ignoring events fired from portals
       const params = api.getCellParams(id, field);
       api.publishEvent(
-        GridEvents.cellNavigationKeyDown,
+        'cellNavigationKeyDown',
         params,
         event as any as React.KeyboardEvent<HTMLElement>,
       );

--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { GridRowEventLookup, GridEvents } from '../models/events';
+import { GridRowEventLookup } from '../models/events';
 import { GridRowId, GridRowModel } from '../models/gridRows';
 import {
   GridEditModes,
@@ -194,7 +194,7 @@ function GridRow(props: React.HTMLAttributes<HTMLDivElement> & GridRowProps) {
         }
       }
 
-      publish(GridEvents.rowClick, onClick)(event);
+      publish('rowClick', onClick)(event);
     },
     [apiRef, onClick, publish, rowId],
   );
@@ -349,9 +349,9 @@ function GridRow(props: React.HTMLAttributes<HTMLDivElement> & GridRowProps) {
       aria-selected={selected}
       style={style}
       onClick={publishClick}
-      onDoubleClick={publish(GridEvents.rowDoubleClick, onDoubleClick)}
-      onMouseEnter={publish(GridEvents.rowMouseEnter, onMouseEnter)}
-      onMouseLeave={publish(GridEvents.rowMouseLeave, onMouseLeave)}
+      onDoubleClick={publish('rowDoubleClick', onDoubleClick)}
+      onMouseEnter={publish('rowMouseEnter', onMouseEnter)}
+      onMouseLeave={publish('rowMouseLeave', onMouseLeave)}
       {...other}
     >
       {cells}

--- a/packages/grid/x-data-grid/src/components/GridScrollArea.tsx
+++ b/packages/grid/x-data-grid/src/components/GridScrollArea.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { GridEvents, GridEventListener } from '../models/events';
+import { GridEventListener } from '../models/events';
 import { useGridApiEventHandler } from '../hooks/utils/useGridApiEventHandler';
 import { GridScrollParams } from '../models/params/gridScrollParams';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
@@ -115,9 +115,9 @@ function GridScrollAreaRaw(props: ScrollAreaProps) {
     setDragging((prevDragging) => !prevDragging);
   }, []);
 
-  useGridApiEventHandler(apiRef, GridEvents.rowsScroll, handleScrolling);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragStart, toggleDragging);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragEnd, toggleDragging);
+  useGridApiEventHandler(apiRef, 'rowsScroll', handleScrolling);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragStart', toggleDragging);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragEnd', toggleDragging);
 
   return dragging ? (
     <GridScrollAreaRawRoot

--- a/packages/grid/x-data-grid/src/components/base/GridBody.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridBody.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { GridEvents } from '../../models/events';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { ElementSize } from '../../models/elementSize';
 import { GridMainContainer } from '../containers/GridMainContainer';
@@ -65,7 +64,7 @@ function GridBody(props: GridBodyProps) {
 
   const handleResize = React.useCallback(
     (size: ElementSize) => {
-      apiRef.current.publishEvent(GridEvents.resize, size);
+      apiRef.current.publishEvent('resize', size);
     },
     [apiRef],
   );

--- a/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
@@ -9,7 +9,6 @@ import {
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { gridDensityHeaderHeightSelector } from '../../hooks/features/density/densitySelector';
-import { GridEvents } from '../../models/events';
 
 function GridOverlayWrapper(props: React.PropsWithChildren<{}>) {
   const apiRef = useGridApiContext();
@@ -25,10 +24,7 @@ function GridOverlayWrapper(props: React.PropsWithChildren<{}>) {
   }, [apiRef]);
 
   useEnhancedEffect(() => {
-    return apiRef.current.subscribeEvent(
-      GridEvents.viewportInnerSizeChange,
-      handleViewportSizeChange,
-    );
+    return apiRef.current.subscribeEvent('viewportInnerSizeChange', handleViewportSizeChange);
   }, [apiRef, handleViewportSizeChange]);
 
   let height: React.CSSProperties['height'] = viewportInnerSize?.height ?? 0;

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -7,7 +7,7 @@ import { ownerDocument, capitalize } from '@mui/material/utils';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import {
   GridCellEventLookup,
-  GridEvents,
+  GridEventsStr,
   GridCellMode,
   GridCellModes,
   GridRowId,
@@ -123,7 +123,7 @@ function GridCell(props: GridCellProps) {
   const classes = useUtilityClasses(ownerState);
 
   const publishMouseUp = React.useCallback(
-    (eventName: GridEvents) => (event: React.MouseEvent<HTMLDivElement>) => {
+    (eventName: GridEventsStr) => (event: React.MouseEvent<HTMLDivElement>) => {
       const params = apiRef.current.getCellParams(rowId, field || '');
       apiRef.current.publishEvent(eventName as any, params as any, event);
 
@@ -241,13 +241,13 @@ function GridCell(props: GridCellProps) {
       aria-colspan={colSpan}
       style={style}
       tabIndex={(cellMode === 'view' || !isEditable) && !managesOwnFocus ? tabIndex : -1}
-      onClick={publish(GridEvents.cellClick, onClick)}
-      onDoubleClick={publish(GridEvents.cellDoubleClick, onDoubleClick)}
-      onMouseDown={publish(GridEvents.cellMouseDown, onMouseDown)}
-      onMouseUp={publishMouseUp(GridEvents.cellMouseUp)}
-      onKeyDown={publish(GridEvents.cellKeyDown, onKeyDown)}
-      onDragEnter={publish(GridEvents.cellDragEnter, onDragEnter)}
-      onDragOver={publish(GridEvents.cellDragOver, onDragOver)}
+      onClick={publish('cellClick', onClick)}
+      onDoubleClick={publish('cellDoubleClick', onDoubleClick)}
+      onMouseDown={publish('cellMouseDown', onMouseDown)}
+      onMouseUp={publishMouseUp('cellMouseUp')}
+      onKeyDown={publish('cellKeyDown', onKeyDown)}
+      onDragEnter={publish('cellDragEnter', onDragEnter)}
+      onDragOver={publish('cellDragOver', onDragOver)}
       {...other}
       onFocus={handleFocus}
     >

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -10,7 +10,6 @@ import {
 import { isEscapeKey } from '../../utils/keyboardUtils';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { GridEditModes } from '../../models/gridEditRowModel';
-import { GridEvents } from '../../models/events/gridEvents';
 import { GridColDef, ValueOptions } from '../../models/colDef/gridColDef';
 import { getValueFromValueOptions } from '../panel/filterPanel/filterPanelUtils';
 
@@ -102,7 +101,7 @@ function GridEditSingleSelectCell(props: GridRenderEditCellParams & Omit<SelectP
       if (event.key) {
         // TODO v6: remove once we stop ignoring events fired from portals
         const params = api.getCellParams(id, field);
-        api.publishEvent(GridEvents.cellNavigationKeyDown, params, event);
+        api.publishEvent('cellNavigationKeyDown', params, event);
       }
     }
   };

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { unstable_useId as useId } from '@mui/material/utils';
-import { GridEvents, GridColumnHeaderEventLookup } from '../../models/events';
+import { GridColumnHeaderEventLookup } from '../../models/events';
 import { GridStateColDef } from '../../models/colDef/gridColDef';
 import { GridSortDirection } from '../../models/gridSortModel';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
@@ -123,22 +123,22 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
   );
 
   const mouseEventsHandlers = {
-    onClick: publish(GridEvents.columnHeaderClick),
-    onDoubleClick: publish(GridEvents.columnHeaderDoubleClick),
-    onMouseOver: publish(GridEvents.columnHeaderOver), // TODO remove as it's not used
-    onMouseOut: publish(GridEvents.columnHeaderOut), // TODO remove as it's not used
-    onMouseEnter: publish(GridEvents.columnHeaderEnter), // TODO remove as it's not used
-    onMouseLeave: publish(GridEvents.columnHeaderLeave), // TODO remove as it's not used
-    onKeyDown: publish(GridEvents.columnHeaderKeyDown),
-    onFocus: publish(GridEvents.columnHeaderFocus),
-    onBlur: publish(GridEvents.columnHeaderBlur),
+    onClick: publish('columnHeaderClick'),
+    onDoubleClick: publish('columnHeaderDoubleClick'),
+    onMouseOver: publish('columnHeaderOver'), // TODO remove as it's not used
+    onMouseOut: publish('columnHeaderOut'), // TODO remove as it's not used
+    onMouseEnter: publish('columnHeaderEnter'), // TODO remove as it's not used
+    onMouseLeave: publish('columnHeaderLeave'), // TODO remove as it's not used
+    onKeyDown: publish('columnHeaderKeyDown'),
+    onFocus: publish('columnHeaderFocus'),
+    onBlur: publish('columnHeaderBlur'),
   };
 
   const draggableEventHandlers = {
-    onDragStart: publish(GridEvents.columnHeaderDragStart),
-    onDragEnter: publish(GridEvents.columnHeaderDragEnter),
-    onDragOver: publish(GridEvents.columnHeaderDragOver),
-    onDragEnd: publish(GridEvents.columnHeaderDragEnd),
+    onDragStart: publish('columnHeaderDragStart'),
+    onDragEnter: publish('columnHeaderDragEnter'),
+    onDragOver: publish('columnHeaderDragOver'),
+    onDragEnd: publish('columnHeaderDragEnd'),
   };
 
   const removeLastBorderRight = isLastColumn && hasScrollX && !hasScrollY;
@@ -257,7 +257,7 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
         resizable={!rootProps.disableColumnResize && !!column.resizable}
         resizing={isResizing}
         height={headerHeight}
-        onMouseDown={publish(GridEvents.columnSeparatorMouseDown)}
+        onMouseDown={publish('columnSeparatorMouseDown')}
         side={separatorSide}
       />
       <GridColumnHeaderMenu

--- a/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { useForkRef } from '@mui/material/utils';
-import { GridEvents } from '../../models/events';
 import { GridRenderCellParams } from '../../models/params/gridCellParams';
 import { isNavigationKey, isSpaceKey } from '../../utils/keyboardUtils';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
@@ -57,7 +56,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const params: GridRowSelectionCheckboxParams = { value: event.target.checked, id };
-      apiRef.current.publishEvent(GridEvents.rowSelectionCheckboxChange, params, event);
+      apiRef.current.publishEvent('rowSelectionCheckboxChange', params, event);
     };
 
     React.useLayoutEffect(() => {
@@ -82,7 +81,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
           event.stopPropagation();
         }
         if (isNavigationKey(event.key) && !event.shiftKey) {
-          apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, props, event);
+          apiRef.current.publishEvent('cellNavigationKeyDown', props, event);
         }
       },
       [apiRef, props],

--- a/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { GridEvents } from '../../models/events';
 import { useGridSelector } from '../../hooks/utils/useGridSelector';
 import { gridTabIndexColumnHeaderSelector } from '../../hooks/features/focus/gridFocusStateSelector';
 import { gridSelectionStateSelector } from '../../hooks/features/selection/gridSelectionSelector';
@@ -95,7 +94,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
         value: event.target.checked,
       };
 
-      apiRef.current.publishEvent(GridEvents.headerSelectionCheckboxChange, params);
+      apiRef.current.publishEvent('headerSelectionCheckboxChange', params);
     };
 
     const tabIndex = tabIndexState !== null && tabIndexState.field === props.field ? 0 : -1;
@@ -110,13 +109,13 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
       (event) => {
         if (event.key === ' ') {
           // imperative toggle the checkbox because Space is disable by some preventDefault
-          apiRef.current.publishEvent(GridEvents.headerSelectionCheckboxChange, {
+          apiRef.current.publishEvent('headerSelectionCheckboxChange', {
             value: !isChecked,
           });
         }
         // TODO v6 remove columnHeaderNavigationKeyDown events which are not used internally anymore
         if (isNavigationKey(event.key) && !event.shiftKey) {
-          apiRef.current.publishEvent(GridEvents.columnHeaderNavigationKeyDown, props, event);
+          apiRef.current.publishEvent('columnHeaderNavigationKeyDown', props, event);
         }
       },
       [apiRef, props, isChecked],
@@ -127,7 +126,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
     }, []);
 
     React.useEffect(() => {
-      return apiRef.current.subscribeEvent(GridEvents.selectionChange, handleSelectionChange);
+      return apiRef.current.subscribeEvent('selectionChange', handleSelectionChange);
     }, [apiRef, handleSelectionChange]);
 
     const label = apiRef.current.getLocaleText(

--- a/packages/grid/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
@@ -8,7 +8,6 @@ import {
   GridStrategyGroup,
 } from './gridStrategyProcessingApi';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
-import { GridEvents } from '../../../models/events';
 
 export const GRID_DEFAULT_STRATEGY = 'none';
 
@@ -39,7 +38,7 @@ type UntypedStrategyProcessors = {
  * The plugin containing the custom logic must use:
  *
  * - `useGridRegisterStrategyProcessor` to register their processor.
- *   When the processor of the active strategy changes, it will fire `GridEvents.activeStrategyProcessorChange` to re-apply the processor.
+ *   When the processor of the active strategy changes, it will fire `"activeStrategyProcessorChange"` to re-apply the processor.
  *
  * - `apiRef.current.unstable_setStrategyAvailability` to tell if their strategy can be used.
  *
@@ -49,12 +48,12 @@ type UntypedStrategyProcessors = {
  *
  * - `apiRef.current.unstable_applyStrategyProcessor` to run the processor of the active strategy for a given processor name.
  *
- * - `GridEvents.strategyAvailabilityChange` to update something when the active strategy changes.
+ * - the "strategyAvailabilityChange" event to update something when the active strategy changes.
  *    Warning: Be careful not to apply the processor several times.
- *    For instance `GridEvents.rowsSet` is fired by `useGridRows` whenever the active strategy changes.
+ *    For instance "rowsSet" is fired by `useGridRows` whenever the active strategy changes.
  *    So listening to both would most likely run your logic twice.
  *
- * - `GridEvents.activeStrategyProcessorChange` to update something when the processor of the active strategy changes.
+ * - The "activeStrategyProcessorChange" event to update something when the processor of the active strategy changes.
  *
  * =====================================================================================================================
  *
@@ -100,7 +99,7 @@ export const useGridStrategyProcessing = (apiRef: React.MutableRefObject<GridApi
         strategyName ===
         apiRef.current.unstable_getActiveStrategy(GRID_STRATEGIES_PROCESSORS[processorName])
       ) {
-        apiRef.current.publishEvent(GridEvents.activeStrategyProcessorChange, processorName);
+        apiRef.current.publishEvent('activeStrategyProcessorChange', processorName);
       }
 
       return cleanup;
@@ -152,7 +151,7 @@ export const useGridStrategyProcessing = (apiRef: React.MutableRefObject<GridApi
   >(
     (strategyGroup, strategyName, isAvailable) => {
       availableStrategies.current.set(strategyName, { group: strategyGroup, isAvailable });
-      apiRef.current.publishEvent(GridEvents.strategyAvailabilityChange);
+      apiRef.current.publishEvent('strategyAvailabilityChange');
     },
     [apiRef],
   );

--- a/packages/grid/x-data-grid/src/hooks/core/useGridApiInitialization.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridApiInitialization.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { GridEvents } from '../../models/events';
 import { useGridApiMethod } from '../utils/useGridApiMethod';
 import { GridSignature } from '../utils/useGridApiEventHandler';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
@@ -57,7 +56,7 @@ export function useGridApiInitialization<Api extends GridApiCommon>(
 
   const showError = React.useCallback<GridCoreApi['showError']>(
     (args) => {
-      apiRef.current.publishEvent(GridEvents.componentError, args);
+      apiRef.current.publishEvent('componentError', args);
     },
     [apiRef],
   );
@@ -68,7 +67,7 @@ export function useGridApiInitialization<Api extends GridApiCommon>(
     const api = apiRef.current;
 
     return () => {
-      api.publishEvent(GridEvents.unmount);
+      api.publishEvent('unmount');
     };
   }, [apiRef]);
 

--- a/packages/grid/x-data-grid/src/hooks/core/useGridErrorHandler.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridErrorHandler.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { GridEvents } from '../../models/events';
 import { GridApiCommunity } from '../../models/api/gridApiCommunity';
 import { useGridApiEventHandler } from '../utils/useGridApiEventHandler';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
@@ -20,5 +19,5 @@ export function useGridErrorHandler(
     handleError(props.error);
   }, [handleError, props.error]);
 
-  useGridApiEventHandler(apiRef, GridEvents.componentError, handleError);
+  useGridApiEventHandler(apiRef, 'componentError', handleError);
 }

--- a/packages/grid/x-data-grid/src/hooks/core/useGridStateInitialization.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridStateInitialization.ts
@@ -4,7 +4,6 @@ import { GridApiCommon } from '../../models/api/gridApiCommon';
 import { GridStateApi } from '../../models/api/gridStateApi';
 import { GridControlStateItem } from '../../models/controlStateItem';
 import { GridSignature } from '../utils/useGridApiEventHandler';
-import { GridEvents } from '../../models/events';
 import { useGridApiMethod } from '../utils';
 import { isFunction } from '../../utils/utils';
 
@@ -86,7 +85,7 @@ export const useGridStateInitialization = <Api extends GridApiCommon>(
         apiRef.current.state = newState;
 
         if (apiRef.current.publishEvent) {
-          apiRef.current.publishEvent(GridEvents.stateChange, newState);
+          apiRef.current.publishEvent('stateChange', newState);
         }
       }
 

--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -20,7 +20,7 @@ import { gridColumnMenuSelector } from '../columnMenu/columnMenuSelector';
 import { useGridRootProps } from '../../utils/useGridRootProps';
 import { GridRenderContext } from '../../../models/params/gridScrollParams';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
-import { GridEventListener, GridEvents } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { GridColumnHeaderItem } from '../../../components/columnHeaders/GridColumnHeaderItem';
 import { getFirstColumnIndexToRender } from '../columns/gridColumnsUtils';
 import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
@@ -114,7 +114,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
     }
   }, [renderContext, updateInnerPosition]);
 
-  const handleScroll = React.useCallback<GridEventListener<GridEvents.rowsScroll>>(
+  const handleScroll = React.useCallback<GridEventListener<'rowsScroll'>>(
     ({ left, renderContext: nextRenderContext = null }, event) => {
       if (!innerRef.current) {
         return;
@@ -161,28 +161,31 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
     [updateInnerPosition],
   );
 
-  const handleColumnResizeStart = React.useCallback<
-    GridEventListener<GridEvents.columnResizeStart>
-  >((params) => setResizeCol(params.field), []);
-  const handleColumnResizeStop = React.useCallback<GridEventListener<GridEvents.columnResizeStop>>(
+  const handleColumnResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
+    (params) => setResizeCol(params.field),
+    [],
+  );
+  const handleColumnResizeStop = React.useCallback<GridEventListener<'columnResizeStop'>>(
     () => setResizeCol(''),
     [],
   );
 
-  const handleColumnReorderStart = React.useCallback<
-    GridEventListener<GridEvents.columnHeaderDragStart>
-  >((params) => setDragCol(params.field), []);
+  const handleColumnReorderStart = React.useCallback<GridEventListener<'columnHeaderDragStart'>>(
+    (params) => setDragCol(params.field),
+    [],
+  );
 
-  const handleColumnReorderStop = React.useCallback<
-    GridEventListener<GridEvents.columnHeaderDragEnd>
-  >(() => setDragCol(''), []);
+  const handleColumnReorderStop = React.useCallback<GridEventListener<'columnHeaderDragEnd'>>(
+    () => setDragCol(''),
+    [],
+  );
 
-  useGridApiEventHandler(apiRef, GridEvents.columnResizeStart, handleColumnResizeStart);
-  useGridApiEventHandler(apiRef, GridEvents.columnResizeStop, handleColumnResizeStop);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragStart, handleColumnReorderStart);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderDragEnd, handleColumnReorderStop);
+  useGridApiEventHandler(apiRef, 'columnResizeStart', handleColumnResizeStart);
+  useGridApiEventHandler(apiRef, 'columnResizeStop', handleColumnResizeStop);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragStart', handleColumnReorderStart);
+  useGridApiEventHandler(apiRef, 'columnHeaderDragEnd', handleColumnReorderStop);
 
-  useGridApiEventHandler(apiRef, GridEvents.rowsScroll, handleScroll);
+  useGridApiEventHandler(apiRef, 'rowsScroll', handleScroll);
 
   const getColumns = (
     params?: {

--- a/packages/grid/x-data-grid/src/hooks/features/columnMenu/useGridColumnMenu.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columnMenu/useGridColumnMenu.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
-import { GridEvents } from '../../../models/events';
 import { useGridLogger, useGridApiMethod, useGridApiEventHandler } from '../../utils';
 import { gridColumnMenuSelector } from './columnMenuSelector';
 import { GridColumnMenuApi } from '../../../models';
@@ -87,11 +86,7 @@ export const useGridColumnMenu = (apiRef: React.MutableRefObject<GridApiCommunit
   /**
    * EVENTS
    */
-  useGridApiEventHandler(apiRef, GridEvents.columnResizeStart, hideColumnMenu);
-  useGridApiEventHandler(apiRef, GridEvents.virtualScrollerWheel, apiRef.current.hideColumnMenu);
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.virtualScrollerTouchMove,
-    apiRef.current.hideColumnMenu,
-  );
+  useGridApiEventHandler(apiRef, 'columnResizeStart', hideColumnMenu);
+  useGridApiEventHandler(apiRef, 'virtualScrollerWheel', apiRef.current.hideColumnMenu);
+  useGridApiEventHandler(apiRef, 'virtualScrollerTouchMove', apiRef.current.hideColumnMenu);
 };

--- a/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumnSpanning.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumnSpanning.ts
@@ -4,7 +4,6 @@ import { GridColumnIndex, GridCellColSpanInfo } from '../../../models/gridColumn
 import { GridRowId } from '../../../models/gridRows';
 import { GridColumnSpanningApi } from '../../../models/api/gridColumnSpanning';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
-import { GridEvents } from '../../../models/events/gridEvents';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 
 /**
@@ -118,5 +117,5 @@ export const useGridColumnSpanning = (apiRef: React.MutableRefObject<GridApiComm
     lookup.current = {};
   }, []);
 
-  useGridApiEventHandler(apiRef, GridEvents.columnOrderChange, handleColumnReorderChange);
+  useGridApiEventHandler(apiRef, 'columnOrderChange', handleColumnReorderChange);
 };

--- a/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridEventListener, GridEvents } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridColumnApi } from '../../../models/api/gridColumnApi';
 import { GridColumnOrderChangeParams } from '../../../models/params/gridColumnOrderChangeParams';
@@ -110,7 +110,7 @@ export function useGridColumns(
     propModel: props.columnVisibilityModel,
     propOnChange: props.onColumnVisibilityModelChange,
     stateSelector: gridColumnVisibilityModelSelector,
-    changeEvent: GridEvents.columnVisibilityModelChange,
+    changeEvent: 'columnVisibilityModelChange',
   });
 
   const setGridColumnsState = React.useCallback(
@@ -119,7 +119,7 @@ export function useGridColumns(
 
       apiRef.current.setState(mergeColumnsState(columnsState));
       apiRef.current.forceUpdate();
-      apiRef.current.publishEvent(GridEvents.columnsChange, columnsState.all);
+      apiRef.current.publishEvent('columnsChange', columnsState.all);
     },
     [logger, apiRef],
   );
@@ -234,7 +234,7 @@ export function useGridColumns(
           isVisible,
         };
 
-        apiRef.current.publishEvent(GridEvents.columnVisibilityChange, params);
+        apiRef.current.publishEvent('columnVisibilityChange', params);
       }
     },
     [apiRef],
@@ -261,7 +261,7 @@ export function useGridColumns(
         targetIndex: targetIndexPosition,
         oldIndex: oldIndexPosition,
       };
-      apiRef.current.publishEvent(GridEvents.columnOrderChange, params);
+      apiRef.current.publishEvent('columnOrderChange', params);
     },
     [apiRef, logger, setGridColumnsState],
   );
@@ -274,7 +274,7 @@ export function useGridColumns(
       const newColumn = { ...column, width };
       apiRef.current.updateColumns([newColumn]);
 
-      apiRef.current.publishEvent(GridEvents.columnWidthChange, {
+      apiRef.current.publishEvent('columnWidthChange', {
         element: apiRef.current.getColumnHeaderElement(field),
         colDef: newColumn,
         width,
@@ -371,7 +371,7 @@ export function useGridColumns(
       apiRef.current.setState(mergeColumnsState(columnsState));
 
       if (initialState != null) {
-        apiRef.current.publishEvent(GridEvents.columnsChange, columnsState.all);
+        apiRef.current.publishEvent('columnsChange', columnsState.all);
       }
 
       return params;
@@ -399,7 +399,7 @@ export function useGridColumns(
    * EVENTS
    */
   const prevInnerWidth = React.useRef<number | null>(null);
-  const handleGridSizeChange: GridEventListener<GridEvents.viewportInnerSizeChange> = (
+  const handleGridSizeChange: GridEventListener<'viewportInnerSizeChange'> = (
     viewportInnerSize,
   ) => {
     if (prevInnerWidth.current !== viewportInnerSize.width) {
@@ -410,13 +410,9 @@ export function useGridColumns(
     }
   };
 
-  useGridApiEventHandler(apiRef, GridEvents.viewportInnerSizeChange, handleGridSizeChange);
+  useGridApiEventHandler(apiRef, 'viewportInnerSizeChange', handleGridSizeChange);
 
-  useGridApiOptionHandler(
-    apiRef,
-    GridEvents.columnVisibilityChange,
-    props.onColumnVisibilityChange,
-  );
+  useGridApiOptionHandler(apiRef, 'columnVisibilityChange', props.onColumnVisibilityChange);
 
   /**
    * APPLIERS

--- a/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -4,7 +4,7 @@ import {
   ownerDocument,
   unstable_useEnhancedEffect as useEnhancedEffect,
 } from '@mui/material/utils';
-import { GridEvents, GridEventListener } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { ElementSize } from '../../../models';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import {
@@ -128,10 +128,7 @@ export function useGridDimensions(
       newFullDimensions.viewportInnerSize.width !== prevDimensions?.viewportInnerSize.width ||
       newFullDimensions.viewportInnerSize.height !== prevDimensions?.viewportInnerSize.height
     ) {
-      apiRef.current.publishEvent(
-        GridEvents.viewportInnerSizeChange,
-        newFullDimensions.viewportInnerSize,
-      );
+      apiRef.current.publishEvent('viewportInnerSizeChange', newFullDimensions.viewportInnerSize);
     }
   }, [
     apiRef,
@@ -143,7 +140,7 @@ export function useGridDimensions(
 
   const resize = React.useCallback<GridDimensionsApi['resize']>(() => {
     updateGridDimensionsRef();
-    apiRef.current.publishEvent(GridEvents.debouncedResize, rootDimensionsRef.current!);
+    apiRef.current.publishEvent('debouncedResize', rootDimensionsRef.current!);
   }, [apiRef, updateGridDimensionsRef]);
 
   const getRootDimensions = React.useCallback<GridDimensionsApi['getRootDimensions']>(
@@ -192,7 +189,7 @@ export function useGridDimensions(
 
   const isFirstSizing = React.useRef(true);
 
-  const handleResize = React.useCallback<GridEventListener<GridEvents.resize>>(
+  const handleResize = React.useCallback<GridEventListener<'resize'>>(
     (size) => {
       rootDimensionsRef.current = size;
 
@@ -247,10 +244,10 @@ export function useGridDimensions(
 
   useEnhancedEffect(() => updateGridDimensionsRef(), [updateGridDimensionsRef]);
 
-  useGridApiOptionHandler(apiRef, GridEvents.sortedRowsSet, updateGridDimensionsRef);
-  useGridApiOptionHandler(apiRef, GridEvents.pageChange, updateGridDimensionsRef);
-  useGridApiOptionHandler(apiRef, GridEvents.pageSizeChange, updateGridDimensionsRef);
-  useGridApiOptionHandler(apiRef, GridEvents.columnsChange, updateGridDimensionsRef);
-  useGridApiEventHandler(apiRef, GridEvents.resize, handleResize);
-  useGridApiOptionHandler(apiRef, GridEvents.debouncedResize, props.onResize);
+  useGridApiOptionHandler(apiRef, 'sortedRowsSet', updateGridDimensionsRef);
+  useGridApiOptionHandler(apiRef, 'pageChange', updateGridDimensionsRef);
+  useGridApiOptionHandler(apiRef, 'pageSizeChange', updateGridDimensionsRef);
+  useGridApiOptionHandler(apiRef, 'columnsChange', updateGridDimensionsRef);
+  useGridApiEventHandler(apiRef, 'resize', handleResize);
+  useGridApiOptionHandler(apiRef, 'debouncedResize', props.onResize);
 }

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
@@ -3,7 +3,6 @@ import {
   useGridApiEventHandler,
   useGridApiOptionHandler,
 } from '../../utils/useGridApiEventHandler';
-import { GridEvents } from '../../../models/events/gridEvents';
 import { GridEventListener } from '../../../models/events/gridEventListener';
 import {
   GridEditModes,
@@ -79,7 +78,7 @@ export const useGridCellEditing = (
     [apiRef],
   );
 
-  const handleCellDoubleClick = React.useCallback<GridEventListener<GridEvents.cellDoubleClick>>(
+  const handleCellDoubleClick = React.useCallback<GridEventListener<'cellDoubleClick'>>(
     (params, event) => {
       if (!params.isEditable) {
         return;
@@ -91,23 +90,23 @@ export const useGridCellEditing = (
         ...params,
         reason: GridCellEditStartReasons.cellDoubleClick,
       };
-      apiRef.current.publishEvent(GridEvents.cellEditStart, newParams, event);
+      apiRef.current.publishEvent('cellEditStart', newParams, event);
     },
     [apiRef],
   );
 
-  const handleCellFocusOut = React.useCallback<GridEventListener<GridEvents.cellFocusOut>>(
+  const handleCellFocusOut = React.useCallback<GridEventListener<'cellFocusOut'>>(
     (params, event) => {
       if (params.cellMode === GridCellModes.View) {
         return;
       }
       const newParams = { ...params, reason: GridCellEditStopReasons.cellFocusOut };
-      apiRef.current.publishEvent(GridEvents.cellEditStop, newParams, event);
+      apiRef.current.publishEvent('cellEditStop', newParams, event);
     },
     [apiRef],
   );
 
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       if (params.cellMode === GridCellModes.Edit) {
         let reason: GridCellEditStopReasons | undefined;
@@ -125,7 +124,7 @@ export const useGridCellEditing = (
 
         if (reason) {
           const newParams: GridCellEditStopParams = { ...params, reason };
-          apiRef.current.publishEvent(GridEvents.cellEditStop, newParams, event);
+          apiRef.current.publishEvent('cellEditStop', newParams, event);
         }
       } else if (params.isEditable) {
         let reason: GridCellEditStartReasons | undefined;
@@ -143,14 +142,14 @@ export const useGridCellEditing = (
 
         if (reason) {
           const newParams: GridCellEditStartParams = { ...params, reason };
-          apiRef.current.publishEvent(GridEvents.cellEditStart, newParams, event);
+          apiRef.current.publishEvent('cellEditStart', newParams, event);
         }
       }
     },
     [apiRef],
   );
 
-  const handleCellEditStart = React.useCallback<GridEventListener<GridEvents.cellEditStart>>(
+  const handleCellEditStart = React.useCallback<GridEventListener<'cellEditStart'>>(
     (params, event) => {
       const { id, field, reason } = params;
 
@@ -166,7 +165,7 @@ export const useGridCellEditing = (
     [apiRef],
   );
 
-  const handleCellEditStop = React.useCallback<GridEventListener<GridEvents.cellEditStop>>(
+  const handleCellEditStop = React.useCallback<GridEventListener<'cellEditStop'>>(
     (params) => {
       const { id, field, reason } = params;
 
@@ -197,23 +196,15 @@ export const useGridCellEditing = (
     [apiRef],
   );
 
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.cellDoubleClick,
-    runIfEditModeIsCell(handleCellDoubleClick),
-  );
-  useGridApiEventHandler(apiRef, GridEvents.cellFocusOut, runIfEditModeIsCell(handleCellFocusOut));
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, runIfEditModeIsCell(handleCellKeyDown));
+  useGridApiEventHandler(apiRef, 'cellDoubleClick', runIfEditModeIsCell(handleCellDoubleClick));
+  useGridApiEventHandler(apiRef, 'cellFocusOut', runIfEditModeIsCell(handleCellFocusOut));
+  useGridApiEventHandler(apiRef, 'cellKeyDown', runIfEditModeIsCell(handleCellKeyDown));
 
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.cellEditStart,
-    runIfEditModeIsCell(handleCellEditStart),
-  );
-  useGridApiEventHandler(apiRef, GridEvents.cellEditStop, runIfEditModeIsCell(handleCellEditStop));
+  useGridApiEventHandler(apiRef, 'cellEditStart', runIfEditModeIsCell(handleCellEditStart));
+  useGridApiEventHandler(apiRef, 'cellEditStop', runIfEditModeIsCell(handleCellEditStop));
 
-  useGridApiOptionHandler(apiRef, GridEvents.cellEditStart, props.onCellEditStart);
-  useGridApiOptionHandler(apiRef, GridEvents.cellEditStop, props.onCellEditStop);
+  useGridApiOptionHandler(apiRef, 'cellEditStart', props.onCellEditStart);
+  useGridApiOptionHandler(apiRef, 'cellEditStop', props.onCellEditStop);
 
   const getCellMode = React.useCallback<GridNewCellEditingApi['getCellMode']>(
     (id, field) => {

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridEditing.old.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridEditing.old.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { GridEvents } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridEditingApi, GridEditingSharedApi } from '../../../models/api/gridEditingApi';
@@ -59,7 +58,7 @@ export function useGridEditing(
     propModel: props.editRowsModel,
     propOnChange: props.onEditRowsModelChange,
     stateSelector: gridEditRowsStateSelector,
-    changeEvent: GridEvents.editRowsModelChange,
+    changeEvent: 'editRowsModelChange',
   });
 
   const isCellEditable = React.useCallback<GridEditingApi['isCellEditable']>(
@@ -139,7 +138,7 @@ export function useGridEditing(
           field: params.field,
           props: { value: params.value },
         };
-        return apiRef.current.publishEvent(GridEvents.editCellPropsChange, newParams, event);
+        return apiRef.current.publishEvent('editCellPropsChange', newParams, event);
       });
     },
     [apiRef, props.editMode, props.experimentalFeatures?.preventCommitWhileValidating],
@@ -190,7 +189,7 @@ export function useGridEditing(
     [apiRef],
   );
 
-  const preventTextSelection = React.useCallback<GridEventListener<GridEvents.cellMouseDown>>(
+  const preventTextSelection = React.useCallback<GridEventListener<'cellMouseDown'>>(
     (params, event) => {
       const isMoreThanOneClick = event.detail > 1;
       if (params.isEditable && params.cellMode === GridCellModes.View && isMoreThanOneClick) {
@@ -201,9 +200,9 @@ export function useGridEditing(
     [],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.cellMouseDown, preventTextSelection);
+  useGridApiEventHandler(apiRef, 'cellMouseDown', preventTextSelection);
 
-  useGridApiOptionHandler(apiRef, GridEvents.editCellPropsChange, props.onEditCellPropsChange); // TODO v6: remove, use `preProcessEditCellProps` instead
+  useGridApiOptionHandler(apiRef, 'editCellPropsChange', props.onEditCellPropsChange); // TODO v6: remove, use `preProcessEditCellProps` instead
 
   const editingSharedApi: GridEditingSharedApi = {
     isCellEditable,

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
@@ -3,7 +3,6 @@ import {
   useGridApiEventHandler,
   useGridApiOptionHandler,
 } from '../../utils/useGridApiEventHandler';
-import { GridEvents } from '../../../models/events/gridEvents';
 import { GridEventListener } from '../../../models/events/gridEventListener';
 import {
   GridEditModes,
@@ -81,7 +80,7 @@ export const useGridRowEditing = (
     [apiRef],
   );
 
-  const handleCellDoubleClick = React.useCallback<GridEventListener<GridEvents.cellDoubleClick>>(
+  const handleCellDoubleClick = React.useCallback<GridEventListener<'cellDoubleClick'>>(
     (params, event) => {
       if (!params.isEditable) {
         return;
@@ -95,19 +94,16 @@ export const useGridRowEditing = (
         field: params.field,
         reason: GridRowEditStartReasons.cellDoubleClick,
       };
-      apiRef.current.publishEvent(GridEvents.rowEditStart, newParams, event);
+      apiRef.current.publishEvent('rowEditStart', newParams, event);
     },
     [apiRef],
   );
 
-  const handleCellFocusIn = React.useCallback<GridEventListener<GridEvents.cellFocusIn>>(
-    (params) => {
-      nextFocusedCell.current = params;
-    },
-    [],
-  );
+  const handleCellFocusIn = React.useCallback<GridEventListener<'cellFocusIn'>>((params) => {
+    nextFocusedCell.current = params;
+  }, []);
 
-  const handleCellFocusOut = React.useCallback<GridEventListener<GridEvents.cellFocusOut>>(
+  const handleCellFocusOut = React.useCallback<GridEventListener<'cellFocusOut'>>(
     (params, event) => {
       if (!params.isEditable) {
         return;
@@ -130,7 +126,7 @@ export const useGridRowEditing = (
             field: params.field,
             reason: GridRowEditStopReasons.rowFocusOut,
           };
-          apiRef.current.publishEvent(GridEvents.rowEditStop, newParams, event);
+          apiRef.current.publishEvent('rowEditStop', newParams, event);
         }
       });
     },
@@ -143,7 +139,7 @@ export const useGridRowEditing = (
     };
   }, []);
 
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       if (params.cellMode === GridRowModes.Edit) {
         let reason: GridRowEditStopReasons | undefined;
@@ -179,7 +175,7 @@ export const useGridRowEditing = (
             reason,
             field: params.field,
           };
-          apiRef.current.publishEvent(GridEvents.rowEditStop, newParams, event);
+          apiRef.current.publishEvent('rowEditStop', newParams, event);
         }
       } else if (params.isEditable) {
         let reason: GridRowEditStartReasons | undefined;
@@ -198,14 +194,14 @@ export const useGridRowEditing = (
         if (reason) {
           const rowParams = apiRef.current.getRowParams(params.id);
           const newParams: GridRowEditStartParams = { ...rowParams, field: params.field, reason };
-          apiRef.current.publishEvent(GridEvents.rowEditStart, newParams, event);
+          apiRef.current.publishEvent('rowEditStart', newParams, event);
         }
       }
     },
     [apiRef],
   );
 
-  const handleRowEditStart = React.useCallback<GridEventListener<GridEvents.rowEditStart>>(
+  const handleRowEditStart = React.useCallback<GridEventListener<'rowEditStart'>>(
     (params, event) => {
       const { id, field, reason } = params;
       apiRef.current.startRowEditMode({ id, fieldToFocus: field });
@@ -220,7 +216,7 @@ export const useGridRowEditing = (
     [apiRef],
   );
 
-  const handleRowEditStop = React.useCallback<GridEventListener<GridEvents.rowEditStop>>(
+  const handleRowEditStop = React.useCallback<GridEventListener<'rowEditStop'>>(
     (params) => {
       const { id, reason, field } = params;
 
@@ -250,20 +246,16 @@ export const useGridRowEditing = (
     [apiRef],
   );
 
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.cellDoubleClick,
-    runIfEditModeIsRow(handleCellDoubleClick),
-  );
-  useGridApiEventHandler(apiRef, GridEvents.cellFocusIn, runIfEditModeIsRow(handleCellFocusIn));
-  useGridApiEventHandler(apiRef, GridEvents.cellFocusOut, runIfEditModeIsRow(handleCellFocusOut));
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, runIfEditModeIsRow(handleCellKeyDown));
+  useGridApiEventHandler(apiRef, 'cellDoubleClick', runIfEditModeIsRow(handleCellDoubleClick));
+  useGridApiEventHandler(apiRef, 'cellFocusIn', runIfEditModeIsRow(handleCellFocusIn));
+  useGridApiEventHandler(apiRef, 'cellFocusOut', runIfEditModeIsRow(handleCellFocusOut));
+  useGridApiEventHandler(apiRef, 'cellKeyDown', runIfEditModeIsRow(handleCellKeyDown));
 
-  useGridApiEventHandler(apiRef, GridEvents.rowEditStart, runIfEditModeIsRow(handleRowEditStart));
-  useGridApiEventHandler(apiRef, GridEvents.rowEditStop, runIfEditModeIsRow(handleRowEditStop));
+  useGridApiEventHandler(apiRef, 'rowEditStart', runIfEditModeIsRow(handleRowEditStart));
+  useGridApiEventHandler(apiRef, 'rowEditStop', runIfEditModeIsRow(handleRowEditStop));
 
-  useGridApiOptionHandler(apiRef, GridEvents.rowEditStart, props.onRowEditStart);
-  useGridApiOptionHandler(apiRef, GridEvents.rowEditStop, props.onRowEditStop);
+  useGridApiOptionHandler(apiRef, 'rowEditStart', props.onRowEditStart);
+  useGridApiOptionHandler(apiRef, 'rowEditStop', props.onRowEditStop);
 
   const getRowMode = React.useCallback<GridNewRowEditingApi['getRowMode']>(
     (id) => {

--- a/packages/grid/x-data-grid/src/hooks/features/events/useGridEvents.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/events/useGridEvents.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
-import { GridEvents } from '../../../models/events';
 import { useGridApiOptionHandler } from '../../utils/useGridApiEventHandler';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 
@@ -31,29 +30,25 @@ export function useGridEvents(
     | 'onStateChange'
   >,
 ): void {
-  useGridApiOptionHandler(apiRef, GridEvents.columnHeaderClick, props.onColumnHeaderClick);
-  useGridApiOptionHandler(
-    apiRef,
-    GridEvents.columnHeaderDoubleClick,
-    props.onColumnHeaderDoubleClick,
-  );
-  useGridApiOptionHandler(apiRef, GridEvents.columnHeaderOver, props.onColumnHeaderOver);
-  useGridApiOptionHandler(apiRef, GridEvents.columnHeaderOut, props.onColumnHeaderOut);
-  useGridApiOptionHandler(apiRef, GridEvents.columnHeaderEnter, props.onColumnHeaderEnter);
-  useGridApiOptionHandler(apiRef, GridEvents.columnHeaderLeave, props.onColumnHeaderLeave);
-  useGridApiOptionHandler(apiRef, GridEvents.columnOrderChange, props.onColumnOrderChange);
+  useGridApiOptionHandler(apiRef, 'columnHeaderClick', props.onColumnHeaderClick);
+  useGridApiOptionHandler(apiRef, 'columnHeaderDoubleClick', props.onColumnHeaderDoubleClick);
+  useGridApiOptionHandler(apiRef, 'columnHeaderOver', props.onColumnHeaderOver);
+  useGridApiOptionHandler(apiRef, 'columnHeaderOut', props.onColumnHeaderOut);
+  useGridApiOptionHandler(apiRef, 'columnHeaderEnter', props.onColumnHeaderEnter);
+  useGridApiOptionHandler(apiRef, 'columnHeaderLeave', props.onColumnHeaderLeave);
+  useGridApiOptionHandler(apiRef, 'columnOrderChange', props.onColumnOrderChange);
 
-  useGridApiOptionHandler(apiRef, GridEvents.cellClick, props.onCellClick);
-  useGridApiOptionHandler(apiRef, GridEvents.cellDoubleClick, props.onCellDoubleClick);
-  useGridApiOptionHandler(apiRef, GridEvents.cellKeyDown, props.onCellKeyDown);
-  useGridApiOptionHandler(apiRef, GridEvents.cellFocusOut, props.onCellFocusOut);
+  useGridApiOptionHandler(apiRef, 'cellClick', props.onCellClick);
+  useGridApiOptionHandler(apiRef, 'cellDoubleClick', props.onCellDoubleClick);
+  useGridApiOptionHandler(apiRef, 'cellKeyDown', props.onCellKeyDown);
+  useGridApiOptionHandler(apiRef, 'cellFocusOut', props.onCellFocusOut);
 
-  useGridApiOptionHandler(apiRef, GridEvents.preferencePanelClose, props.onPreferencePanelClose);
-  useGridApiOptionHandler(apiRef, GridEvents.preferencePanelOpen, props.onPreferencePanelOpen);
+  useGridApiOptionHandler(apiRef, 'preferencePanelClose', props.onPreferencePanelClose);
+  useGridApiOptionHandler(apiRef, 'preferencePanelOpen', props.onPreferencePanelOpen);
 
-  useGridApiOptionHandler(apiRef, GridEvents.rowDoubleClick, props.onRowDoubleClick);
-  useGridApiOptionHandler(apiRef, GridEvents.rowClick, props.onRowClick);
+  useGridApiOptionHandler(apiRef, 'rowDoubleClick', props.onRowDoubleClick);
+  useGridApiOptionHandler(apiRef, 'rowClick', props.onRowClick);
 
-  useGridApiOptionHandler(apiRef, GridEvents.componentError, props.onError);
-  useGridApiOptionHandler(apiRef, GridEvents.stateChange, props.onStateChange);
+  useGridApiOptionHandler(apiRef, 'componentError', props.onError);
+  useGridApiOptionHandler(apiRef, 'stateChange', props.onStateChange);
 }

--- a/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridEventListener, GridEvents } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridFilterApi } from '../../../models/api/gridFilterApi';
@@ -69,7 +69,7 @@ export const useGridFilter = (
     propModel: props.filterModel,
     propOnChange: props.onFilterModelChange,
     stateSelector: gridFilterModelSelector,
-    changeEvent: GridEvents.filterModelChange,
+    changeEvent: 'filterModelChange',
   });
 
   const updateFilteredRows = React.useCallback(() => {
@@ -92,7 +92,7 @@ export const useGridFilter = (
         },
       };
     });
-    apiRef.current.publishEvent(GridEvents.filteredRowsSet);
+    apiRef.current.publishEvent('filteredRowsSet');
   }, [props.filterMode, apiRef]);
 
   /**
@@ -300,7 +300,7 @@ export const useGridFilter = (
   /**
    * EVENTS
    */
-  const handleColumnsChange = React.useCallback<GridEventListener<GridEvents.columnsChange>>(() => {
+  const handleColumnsChange = React.useCallback<GridEventListener<'columnsChange'>>(() => {
     logger.debug('onColUpdated - GridColumns changed, applying filters');
     const filterModel = gridFilterModelSelector(apiRef);
     const filterableColumnsLookup = gridFilterableColumnLookupSelector(apiRef);
@@ -313,7 +313,7 @@ export const useGridFilter = (
   }, [apiRef, logger]);
 
   const handleStrategyProcessorChange = React.useCallback<
-    GridEventListener<GridEvents.activeStrategyProcessorChange>
+    GridEventListener<'activeStrategyProcessorChange'>
   >(
     (methodName) => {
       if (methodName === 'filtering') {
@@ -325,18 +325,10 @@ export const useGridFilter = (
 
   // Do not call `apiRef.current.forceUpdate` to avoid re-render before updating the sorted rows.
   // Otherwise, the state is not consistent during the render
-  useGridApiEventHandler(apiRef, GridEvents.rowsSet, updateFilteredRows);
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.rowExpansionChange,
-    apiRef.current.unstable_applyFilters,
-  );
-  useGridApiEventHandler(apiRef, GridEvents.columnsChange, handleColumnsChange);
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.activeStrategyProcessorChange,
-    handleStrategyProcessorChange,
-  );
+  useGridApiEventHandler(apiRef, 'rowsSet', updateFilteredRows);
+  useGridApiEventHandler(apiRef, 'rowExpansionChange', apiRef.current.unstable_applyFilters);
+  useGridApiEventHandler(apiRef, 'columnsChange', handleColumnsChange);
+  useGridApiEventHandler(apiRef, 'activeStrategyProcessorChange', handleStrategyProcessorChange);
 
   /**
    * 1ST RENDER

--- a/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ownerDocument } from '@mui/material/utils';
-import { GridEvents, GridEventListener } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridFocusApi } from '../../../models/api/gridFocusApi';
 import { GridCellParams } from '../../../models/params/gridCellParams';
@@ -55,7 +55,7 @@ export const useGridFocus = (
         };
       });
       apiRef.current.forceUpdate();
-      apiRef.current.publishEvent(GridEvents.cellFocusIn, apiRef.current.getCellParams(id, field));
+      apiRef.current.publishEvent('cellFocusIn', apiRef.current.getCellParams(id, field));
     },
     [apiRef, logger],
   );
@@ -65,7 +65,7 @@ export const useGridFocus = (
       const cell = gridFocusCellSelector(apiRef);
       if (cell) {
         apiRef.current.publishEvent(
-          GridEvents.cellFocusOut,
+          'cellFocusOut',
           apiRef.current.getCellParams(cell.id, cell.field),
           event,
         );
@@ -134,14 +134,14 @@ export const useGridFocus = (
     [apiRef, props.pagination, props.paginationMode],
   );
 
-  const handleCellDoubleClick = React.useCallback<GridEventListener<GridEvents.cellDoubleClick>>(
+  const handleCellDoubleClick = React.useCallback<GridEventListener<'cellDoubleClick'>>(
     ({ id, field }) => {
       apiRef.current.setCellFocus(id, field);
     },
     [apiRef],
   );
 
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       // GRID_CELL_NAVIGATION_KEY_DOWN handles the focus on Enter, Tab and navigation keys
       if (event.key === 'Enter' || event.key === 'Tab' || isNavigationKey(event.key)) {
@@ -152,9 +152,7 @@ export const useGridFocus = (
     [apiRef],
   );
 
-  const handleColumnHeaderFocus = React.useCallback<
-    GridEventListener<GridEvents.columnHeaderFocus>
-  >(
+  const handleColumnHeaderFocus = React.useCallback<GridEventListener<'columnHeaderFocus'>>(
     ({ field }, event) => {
       if (event.target !== event.currentTarget) {
         return;
@@ -164,7 +162,7 @@ export const useGridFocus = (
     [apiRef],
   );
 
-  const handleBlur = React.useCallback<GridEventListener<GridEvents.columnHeaderBlur>>(() => {
+  const handleBlur = React.useCallback<GridEventListener<'columnHeaderBlur'>>(() => {
     logger.debug(`Clearing focus`);
     apiRef.current.setState((state) => ({
       ...state,
@@ -172,12 +170,9 @@ export const useGridFocus = (
     }));
   }, [logger, apiRef]);
 
-  const handleCellMouseUp = React.useCallback<GridEventListener<GridEvents.cellMouseUp>>(
-    (params) => {
-      lastClickedCell.current = params;
-    },
-    [],
-  );
+  const handleCellMouseUp = React.useCallback<GridEventListener<'cellMouseUp'>>((params) => {
+    lastClickedCell.current = params;
+  }, []);
 
   const handleDocumentClick = React.useCallback(
     (event: MouseEvent) => {
@@ -210,7 +205,7 @@ export const useGridFocus = (
       // There's a focused cell but another cell was clicked
       // Publishes an event to notify that the focus was lost
       apiRef.current.publishEvent(
-        GridEvents.cellFocusOut,
+        'cellFocusOut',
         apiRef.current.getCellParams(focusedCell.id, focusedCell.field),
         event,
       );
@@ -228,7 +223,7 @@ export const useGridFocus = (
     [apiRef],
   );
 
-  const handleCellModeChange = React.useCallback<GridEventListener<GridEvents.cellModeChange>>(
+  const handleCellModeChange = React.useCallback<GridEventListener<'cellModeChange'>>(
     (params) => {
       if (params.cellMode === 'view') {
         return;
@@ -275,10 +270,10 @@ export const useGridFocus = (
     };
   }, [apiRef, handleDocumentClick]);
 
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderBlur, handleBlur);
-  useGridApiEventHandler(apiRef, GridEvents.cellDoubleClick, handleCellDoubleClick);
-  useGridApiEventHandler(apiRef, GridEvents.cellMouseUp, handleCellMouseUp);
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, handleCellKeyDown);
-  useGridApiEventHandler(apiRef, GridEvents.cellModeChange, handleCellModeChange);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderFocus, handleColumnHeaderFocus);
+  useGridApiEventHandler(apiRef, 'columnHeaderBlur', handleBlur);
+  useGridApiEventHandler(apiRef, 'cellDoubleClick', handleCellDoubleClick);
+  useGridApiEventHandler(apiRef, 'cellMouseUp', handleCellMouseUp);
+  useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
+  useGridApiEventHandler(apiRef, 'cellModeChange', handleCellModeChange);
+  useGridApiEventHandler(apiRef, 'columnHeaderFocus', handleColumnHeaderFocus);
 };

--- a/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridEvents, GridEventListener } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridCellParams } from '../../../models/params/gridCellParams';
 import { gridVisibleColumnDefinitionsSelector } from '../columns/gridColumnsSelector';
@@ -65,9 +65,7 @@ export const useGridKeyboardNavigation = (
     [apiRef, logger],
   );
 
-  const handleCellNavigationKeyDown = React.useCallback<
-    GridEventListener<GridEvents.cellNavigationKeyDown>
-  >(
+  const handleCellNavigationKeyDown = React.useCallback<GridEventListener<'cellNavigationKeyDown'>>(
     (params, event) => {
       const dimensions = apiRef.current.getRootDimensions();
       if (!currentPage.range || !dimensions) {
@@ -198,9 +196,7 @@ export const useGridKeyboardNavigation = (
     [apiRef, currentPage, goToCell, goToHeader],
   );
 
-  const handleColumnHeaderKeyDown = React.useCallback<
-    GridEventListener<GridEvents.columnHeaderKeyDown>
-  >(
+  const handleColumnHeaderKeyDown = React.useCallback<GridEventListener<'columnHeaderKeyDown'>>(
     (params, event) => {
       const headerTitleNode = event.currentTarget.querySelector(
         `.${gridClasses.columnHeaderTitleContainerContent}`,
@@ -293,7 +289,7 @@ export const useGridKeyboardNavigation = (
     [apiRef, currentPage, goToCell, goToHeader],
   );
 
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       // Ignore portal
       if (!event.currentTarget.contains(event.target as Element)) {
@@ -304,13 +300,13 @@ export const useGridKeyboardNavigation = (
       const cellParams = apiRef.current.getCellParams(params.id, params.field);
 
       if (cellParams.cellMode !== GridCellModes.Edit && isNavigationKey(event.key)) {
-        apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, cellParams, event);
+        apiRef.current.publishEvent('cellNavigationKeyDown', cellParams, event);
       }
     },
     [apiRef],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.cellNavigationKeyDown, handleCellNavigationKeyDown);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderKeyDown, handleColumnHeaderKeyDown);
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, handleCellKeyDown);
+  useGridApiEventHandler(apiRef, 'cellNavigationKeyDown', handleCellNavigationKeyDown);
+  useGridApiEventHandler(apiRef, 'columnHeaderKeyDown', handleColumnHeaderKeyDown);
+  useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
 };

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPage.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPage.ts
@@ -7,7 +7,7 @@ import {
   useGridApiMethod,
   useGridApiEventHandler,
 } from '../../utils';
-import { GridEvents, GridEventListener } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridPageApi, GridPaginationState } from './gridPaginationInterfaces';
 import { gridVisibleTopLevelRowCountSelector } from '../filter';
@@ -71,7 +71,7 @@ export const useGridPage = (
     propModel: props.page,
     propOnChange: props.onPageChange,
     stateSelector: gridPageSelector,
-    changeEvent: GridEvents.pageChange,
+    changeEvent: 'pageChange',
   });
 
   /**
@@ -138,7 +138,7 @@ export const useGridPage = (
   /**
    * EVENTS
    */
-  const handlePageSizeChange: GridEventListener<GridEvents.pageSizeChange> = (pageSize) => {
+  const handlePageSizeChange: GridEventListener<'pageSizeChange'> = (pageSize) => {
     apiRef.current.setState((state) => {
       const pageCount = getPageCount(state.pagination.rowCount, pageSize);
 
@@ -155,13 +155,13 @@ export const useGridPage = (
     apiRef.current.forceUpdate();
   };
 
-  const handlePageChange: GridEventListener<GridEvents.pageChange> = () =>
+  const handlePageChange: GridEventListener<'pageChange'> = () =>
     apiRef.current.scrollToIndexes({
       rowIndex: gridPageSelector(apiRef) * gridPageSizeSelector(apiRef),
     });
 
-  useGridApiEventHandler(apiRef, GridEvents.pageSizeChange, handlePageSizeChange);
-  useGridApiEventHandler(apiRef, GridEvents.pageChange, handlePageChange);
+  useGridApiEventHandler(apiRef, 'pageSizeChange', handlePageSizeChange);
+  useGridApiEventHandler(apiRef, 'pageChange', handlePageChange);
 
   /**
    * EFFECTS

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPageSize.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPageSize.ts
@@ -3,7 +3,6 @@ import { GridStateCommunity } from '../../../models/gridStateCommunity';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridPageSizeApi } from './gridPaginationInterfaces';
-import { GridEvents } from '../../../models/events';
 import {
   useGridLogger,
   useGridApiMethod,
@@ -44,7 +43,7 @@ export const useGridPageSize = (
     propModel: props.pageSize,
     propOnChange: props.onPageSizeChange,
     stateSelector: gridPageSizeSelector,
-    changeEvent: GridEvents.pageSizeChange,
+    changeEvent: 'pageSizeChange',
   });
 
   /**
@@ -132,7 +131,7 @@ export const useGridPageSize = (
     apiRef.current.setPageSize(maximumPageSizeWithoutScrollBar);
   }, [apiRef, props.autoPageSize, rowHeight]);
 
-  useGridApiEventHandler(apiRef, GridEvents.viewportInnerSizeChange, handleUpdateAutoPageSize);
+  useGridApiEventHandler(apiRef, 'viewportInnerSizeChange', handleUpdateAutoPageSize);
 
   /**
    * EFFECTS

--- a/packages/grid/x-data-grid/src/hooks/features/preferencesPanel/useGridPreferencesPanel.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/preferencesPanel/useGridPreferencesPanel.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
-import { GridEvents } from '../../../models/events';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { useGridLogger } from '../../utils/useGridLogger';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
@@ -34,7 +33,7 @@ export const useGridPreferencesPanel = (apiRef: React.MutableRefObject<GridApiCo
   const hidePreferences = React.useCallback(() => {
     logger.debug('Hiding Preferences Panel');
     if (preferencePanelState.openedPanelValue) {
-      apiRef.current.publishEvent(GridEvents.preferencePanelClose, {
+      apiRef.current.publishEvent('preferencePanelClose', {
         openedPanelValue: preferencePanelState.openedPanelValue,
       });
     }
@@ -64,7 +63,7 @@ export const useGridPreferencesPanel = (apiRef: React.MutableRefObject<GridApiCo
         ...state,
         preferencePanel: { ...state.preferencePanel, open: true, openedPanelValue: newValue },
       }));
-      apiRef.current.publishEvent(GridEvents.preferencePanelOpen, {
+      apiRef.current.publishEvent('preferencePanelOpen', {
         openedPanelValue: newValue,
       });
       apiRef.current.forceUpdate();

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridEventListener, GridEvents } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridRowApi } from '../../../models/api/gridRowApi';
@@ -182,7 +182,7 @@ export const useGridRows = (
             props.loading,
           ),
         }));
-        apiRef.current.publishEvent(GridEvents.rowsSet);
+        apiRef.current.publishEvent('rowsSet');
         apiRef.current.forceUpdate();
       };
 
@@ -332,7 +332,7 @@ export const useGridRows = (
         };
       });
       apiRef.current.forceUpdate();
-      apiRef.current.publishEvent(GridEvents.rowExpansionChange, newNode);
+      apiRef.current.publishEvent('rowExpansionChange', newNode);
     },
     [apiRef],
   );
@@ -449,7 +449,7 @@ export const useGridRows = (
   }, [logger, throttledRowsChange, props.getRowId, props.rows]);
 
   const handleStrategyProcessorChange = React.useCallback<
-    GridEventListener<GridEvents.activeStrategyProcessorChange>
+    GridEventListener<'activeStrategyProcessorChange'>
   >(
     (methodName) => {
       if (methodName === 'rowTreeCreation') {
@@ -460,7 +460,7 @@ export const useGridRows = (
   );
 
   const handleStrategyActivityChange = React.useCallback<
-    GridEventListener<GridEvents.strategyAvailabilityChange>
+    GridEventListener<'strategyAvailabilityChange'>
   >(() => {
     // `rowTreeCreation` is the only processor ran when `strategyAvailabilityChange` is fired.
     // All the other processors listen to `rowsSet` which will be published by the `groupRows` method below.
@@ -471,16 +471,8 @@ export const useGridRows = (
     }
   }, [apiRef, groupRows]);
 
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.activeStrategyProcessorChange,
-    handleStrategyProcessorChange,
-  );
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.strategyAvailabilityChange,
-    handleStrategyActivityChange,
-  );
+  useGridApiEventHandler(apiRef, 'activeStrategyProcessorChange', handleStrategyProcessorChange);
+  useGridApiEventHandler(apiRef, 'strategyAvailabilityChange', handleStrategyActivityChange);
 
   useGridApiMethod(apiRef, rowApi, 'GridRowApi');
 
@@ -505,7 +497,7 @@ export const useGridRows = (
       return;
     }
 
-    // The new rows have already been applied (most likely in the `GridEvents.rowGroupsPreProcessingChange` listener)
+    // The new rows have already been applied (most likely in the `'rowGroupsPreProcessingChange'` listener)
     if (rowsCache.current.state.rowsBeforePartialUpdates === props.rows) {
       return;
     }

--- a/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridEvents, GridEventListener } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridSelectionApi } from '../../../models/api/gridSelectionApi';
@@ -88,7 +88,7 @@ export const useGridSelection = (
     propModel: propSelectionModel,
     propOnChange: props.onSelectionModelChange,
     stateSelector: gridSelectionStateSelector,
-    changeEvent: GridEvents.selectionChange,
+    changeEvent: 'selectionChange',
   });
 
   const {
@@ -308,7 +308,7 @@ export const useGridSelection = (
     [apiRef, canHaveMultipleSelection, checkboxSelection],
   );
 
-  const handleCellClick = React.useCallback<GridEventListener<GridEvents.cellClick>>(
+  const handleCellClick = React.useCallback<GridEventListener<'cellClick'>>(
     (params, event) => {
       if (disableSelectionOnClick) {
         return;
@@ -348,7 +348,7 @@ export const useGridSelection = (
     ],
   );
 
-  const preventSelectionOnShift = React.useCallback<GridEventListener<GridEvents.cellMouseDown>>(
+  const preventSelectionOnShift = React.useCallback<GridEventListener<'cellMouseDown'>>(
     (params, event) => {
       if (canHaveMultipleSelection && event.shiftKey) {
         window.getSelection()?.removeAllRanges();
@@ -358,7 +358,7 @@ export const useGridSelection = (
   );
 
   const handleRowSelectionCheckboxChange = React.useCallback<
-    GridEventListener<GridEvents.rowSelectionCheckboxChange>
+    GridEventListener<'rowSelectionCheckboxChange'>
   >(
     (params, event) => {
       if ((event.nativeEvent as any).shiftKey) {
@@ -371,7 +371,7 @@ export const useGridSelection = (
   );
 
   const handleHeaderSelectionCheckboxChange = React.useCallback<
-    GridEventListener<GridEvents.headerSelectionCheckboxChange>
+    GridEventListener<'headerSelectionCheckboxChange'>
   >(
     (params) => {
       const shouldLimitSelectionToCurrentPage =
@@ -386,7 +386,7 @@ export const useGridSelection = (
     [apiRef, props.checkboxSelectionVisibleOnly, props.pagination],
   );
 
-  const handleCellKeyDown = React.useCallback<GridEventListener<GridEvents.cellKeyDown>>(
+  const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
     (params, event) => {
       // Get the most recent cell mode because it may have been changed by another listener
       if (apiRef.current.getCellMode(params.id, params.field) === GridCellModes.Edit) {
@@ -462,20 +462,16 @@ export const useGridSelection = (
     [apiRef, handleSingleRowSelection, selectRows, visibleRows.rows, canHaveMultipleSelection],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.sortedRowsSet, removeOutdatedSelection);
-  useGridApiEventHandler(apiRef, GridEvents.cellClick, handleCellClick);
+  useGridApiEventHandler(apiRef, 'sortedRowsSet', removeOutdatedSelection);
+  useGridApiEventHandler(apiRef, 'cellClick', handleCellClick);
+  useGridApiEventHandler(apiRef, 'rowSelectionCheckboxChange', handleRowSelectionCheckboxChange);
   useGridApiEventHandler(
     apiRef,
-    GridEvents.rowSelectionCheckboxChange,
-    handleRowSelectionCheckboxChange,
-  );
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.headerSelectionCheckboxChange,
+    'headerSelectionCheckboxChange',
     handleHeaderSelectionCheckboxChange,
   );
-  useGridApiEventHandler(apiRef, GridEvents.cellMouseDown, preventSelectionOnShift);
-  useGridApiEventHandler(apiRef, GridEvents.cellKeyDown, handleCellKeyDown);
+  useGridApiEventHandler(apiRef, 'cellMouseDown', preventSelectionOnShift);
+  useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
 
   /**
    * EFFECTS

--- a/packages/grid/x-data-grid/src/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/sorting/useGridSorting.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GridEventListener, GridEvents } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridSortApi } from '../../../models/api/gridSortApi';
@@ -69,7 +69,7 @@ export const useGridSorting = (
     propModel: props.sortModel,
     propOnChange: props.onSortModelChange,
     stateSelector: gridSortModelSelector,
-    changeEvent: GridEvents.sortModelChange,
+    changeEvent: 'sortModelChange',
   });
 
   const upsertSortModel = React.useCallback(
@@ -143,7 +143,7 @@ export const useGridSorting = (
       };
     });
 
-    apiRef.current.publishEvent(GridEvents.sortedRowsSet);
+    apiRef.current.publishEvent('sortedRowsSet');
     apiRef.current.forceUpdate();
   }, [apiRef, logger, props.sortingMode]);
 
@@ -273,9 +273,7 @@ export const useGridSorting = (
   /**
    * EVENTS
    */
-  const handleColumnHeaderClick = React.useCallback<
-    GridEventListener<GridEvents.columnHeaderClick>
-  >(
+  const handleColumnHeaderClick = React.useCallback<GridEventListener<'columnHeaderClick'>>(
     ({ colDef }, event) => {
       const allowMultipleSorting = event.shiftKey || event.metaKey || event.ctrlKey;
       sortColumn(colDef, undefined, allowMultipleSorting);
@@ -283,9 +281,7 @@ export const useGridSorting = (
     [sortColumn],
   );
 
-  const handleColumnHeaderKeyDown = React.useCallback<
-    GridEventListener<GridEvents.columnHeaderKeyDown>
-  >(
+  const handleColumnHeaderKeyDown = React.useCallback<GridEventListener<'columnHeaderKeyDown'>>(
     ({ colDef }, event) => {
       // CTRL + Enter opens the column menu
       if (isEnterKey(event.key) && !event.ctrlKey && !event.metaKey) {
@@ -295,7 +291,7 @@ export const useGridSorting = (
     [sortColumn],
   );
 
-  const handleColumnsChange = React.useCallback<GridEventListener<GridEvents.columnsChange>>(() => {
+  const handleColumnsChange = React.useCallback<GridEventListener<'columnsChange'>>(() => {
     // When the columns change we check that the sorted columns are still part of the dataset
     const sortModel = gridSortModelSelector(apiRef);
     const latestColumns = gridColumnLookupSelector(apiRef);
@@ -310,7 +306,7 @@ export const useGridSorting = (
   }, [apiRef]);
 
   const handleStrategyProcessorChange = React.useCallback<
-    GridEventListener<GridEvents.activeStrategyProcessorChange>
+    GridEventListener<'activeStrategyProcessorChange'>
   >(
     (methodName) => {
       if (methodName === 'sorting') {
@@ -320,15 +316,11 @@ export const useGridSorting = (
     [apiRef],
   );
 
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderClick, handleColumnHeaderClick);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderKeyDown, handleColumnHeaderKeyDown);
-  useGridApiEventHandler(apiRef, GridEvents.rowsSet, apiRef.current.applySorting);
-  useGridApiEventHandler(apiRef, GridEvents.columnsChange, handleColumnsChange);
-  useGridApiEventHandler(
-    apiRef,
-    GridEvents.activeStrategyProcessorChange,
-    handleStrategyProcessorChange,
-  );
+  useGridApiEventHandler(apiRef, 'columnHeaderClick', handleColumnHeaderClick);
+  useGridApiEventHandler(apiRef, 'columnHeaderKeyDown', handleColumnHeaderKeyDown);
+  useGridApiEventHandler(apiRef, 'rowsSet', apiRef.current.applySorting);
+  useGridApiEventHandler(apiRef, 'columnsChange', handleColumnsChange);
+  useGridApiEventHandler(apiRef, 'activeStrategyProcessorChange', handleStrategyProcessorChange);
 
   /**
    * 1ST RENDER

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -13,7 +13,7 @@ import { gridDensityRowHeightSelector } from '../density/densitySelector';
 import { gridFocusCellSelector, gridTabIndexCellSelector } from '../focus/gridFocusStateSelector';
 import { gridEditRowsStateSelector } from '../editRows/gridEditRowsSelector';
 import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
-import { GridEventListener, GridEvents } from '../../../models/events';
+import { GridEventListener } from '../../../models/events';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { clamp } from '../../../utils/utils';
 import { GridRenderContext, GridRowEntry } from '../../../models';
@@ -154,13 +154,13 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     setContainerWidth(rootRef.current!.clientWidth);
   }, [rowsMeta.currentPageTotalHeight]);
 
-  const handleResize = React.useCallback<GridEventListener<GridEvents.resize>>(() => {
+  const handleResize = React.useCallback<GridEventListener<'resize'>>(() => {
     if (rootRef.current) {
       setContainerWidth(rootRef.current.clientWidth);
     }
   }, []);
 
-  useGridApiEventHandler(apiRef, GridEvents.resize, handleResize);
+  useGridApiEventHandler(apiRef, 'resize', handleResize);
 
   const updateRenderZonePosition = React.useCallback(
     (nextRenderContext: GridRenderContext) => {
@@ -231,7 +231,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
 
     const { top, left } = scrollPosition.current!;
     const params = { top, left, renderContext: initialRenderContext };
-    apiRef.current.publishEvent(GridEvents.rowsScroll, params);
+    apiRef.current.publishEvent('rowsScroll', params);
   }, [apiRef, computeRenderContext, containerWidth, updateRenderContext]);
 
   const handleScroll = (event: React.UIEvent) => {
@@ -272,7 +272,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
 
     // TODO v6: rename event to a wider name, it's not only fired for row scrolling
     apiRef.current.publishEvent(
-      GridEvents.rowsScroll,
+      'rowsScroll',
       {
         top: scrollTop,
         left: scrollLeft,
@@ -291,11 +291,11 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
   };
 
   const handleWheel = (event: React.WheelEvent) => {
-    apiRef.current.publishEvent(GridEvents.virtualScrollerWheel, {}, event);
+    apiRef.current.publishEvent('virtualScrollerWheel', {}, event);
   };
 
   const handleTouchMove = (event: React.TouchEvent) => {
-    apiRef.current.publishEvent(GridEvents.virtualScrollerTouchMove, {}, event);
+    apiRef.current.publishEvent('virtualScrollerTouchMove', {}, event);
   };
 
   const getRows = (
@@ -432,7 +432,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
   ]);
 
   React.useEffect(() => {
-    apiRef.current.publishEvent(GridEvents.virtualScrollerContentSizeChange);
+    apiRef.current.publishEvent('virtualScrollerContentSizeChange');
   }, [apiRef, contentSize]);
 
   if (rootProps.autoHeight && currentPage.rows.length === 0) {

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridNativeEventListener.ts
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridNativeEventListener.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { GridEvents } from '../../models/events';
 import { isFunction } from '../../utils/utils';
 import { useGridLogger } from './useGridLogger';
 import { GridApiCommon } from '../../models';
@@ -43,7 +42,7 @@ export const useGridNativeEventListener = <Api extends GridApiCommon, E extends 
         boundElem.removeEventListener(eventName, wrapHandler, options);
       };
 
-      apiRef.current.subscribeEvent(GridEvents.unmount, unsubscribe);
+      apiRef.current.subscribeEvent('unmount', unsubscribe);
     }
   }, [ref, wrapHandler, eventName, added, logger, options, apiRef]);
 };

--- a/packages/grid/x-data-grid/src/models/events/gridEvents.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEvents.ts
@@ -329,7 +329,7 @@ enum GridEvents {
    * Fired when a column visibility changes.
    * It is not fired when the `columnVisibilityModel` is controlled or initialized.
    * It is not fired when toggling all column's visibility at once.
-   * @deprecated Use `GridEvents.columnVisibilityModelChange` instead.
+   * @deprecated Use `'columnVisibilityModelChange'` instead.
    */
   columnVisibilityChange = 'columnVisibilityChange',
   /**

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -9,7 +9,7 @@ import { Logger } from '../logger';
 import { GridSortDirection, GridSortModel } from '../gridSortModel';
 import { GridSlotsComponent } from '../gridSlotsComponent';
 import { GridRowIdGetter, GridRowsProp, GridValidRowModel } from '../gridRows';
-import { GridEventListener, GridEvents } from '../events';
+import { GridEventListener } from '../events';
 import { GridCallbackDetails, GridLocaleText } from '../api';
 import { GridApiCommunity } from '../api/gridApiCommunity';
 import type { GridColumnTypesRecord } from '../colDef';
@@ -406,128 +406,128 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    * @param {GridCallbackDetails} details Additional details for this callback.
    * @deprecated use `preProcessEditCellProps` from the [`GridColDef`](/x/api/data-grid/grid-col-def/)
    */
-  onEditCellPropsChange?: GridEventListener<GridEvents.editCellPropsChange>;
+  onEditCellPropsChange?: GridEventListener<'editCellPropsChange'>;
   /**
    * Callback fired when the cell changes are committed.
    * @param {GridCellEditCommitParams} params With all properties from [[GridCellEditCommitParams]].
    * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onCellEditCommit?: GridEventListener<GridEvents.cellEditCommit>;
+  onCellEditCommit?: GridEventListener<'cellEditCommit'>;
   /**
    * Callback fired when the cell turns to edit mode.
    * @param {GridCellParams} params With all properties from [[GridCellParams]].
    * @param {MuiEvent<React.KeyboardEvent | React.MouseEvent>} event The event that caused this prop to be called.
    */
-  onCellEditStart?: GridEventListener<GridEvents.cellEditStart>;
+  onCellEditStart?: GridEventListener<'cellEditStart'>;
   /**
    * Callback fired when the cell turns to view mode.
    * @param {GridCellParams} params With all properties from [[GridCellParams]].
    * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
    */
-  onCellEditStop?: GridEventListener<GridEvents.cellEditStop>;
+  onCellEditStop?: GridEventListener<'cellEditStop'>;
   /**
    * Callback fired when the row changes are committed.
    * @param {GridRowId} id The row id.
    * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
    */
-  onRowEditCommit?: GridEventListener<GridEvents.rowEditCommit>;
+  onRowEditCommit?: GridEventListener<'rowEditCommit'>;
   /**
    * Callback fired when the row turns to edit mode.
    * @param {GridRowParams} params With all properties from [[GridRowParams]].
    * @param {MuiEvent<React.KeyboardEvent | React.MouseEvent>} event The event that caused this prop to be called.
    */
-  onRowEditStart?: GridEventListener<GridEvents.rowEditStart>;
+  onRowEditStart?: GridEventListener<'rowEditStart'>;
   /**
    * Callback fired when the row turns to view mode.
    * @param {GridRowParams} params With all properties from [[GridRowParams]].
    * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
    */
-  onRowEditStop?: GridEventListener<GridEvents.rowEditStop>;
+  onRowEditStop?: GridEventListener<'rowEditStop'>;
   /**
    * Callback fired when an exception is thrown in the grid.
    * @param {any} args The arguments passed to the `showError` call.
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onError?: GridEventListener<GridEvents.componentError>;
+  onError?: GridEventListener<'componentError'>;
   /**
    * Callback fired when any cell is clicked.
    * @param {GridCellParams} params With all properties from [[GridCellParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onCellClick?: GridEventListener<GridEvents.cellClick>;
+  onCellClick?: GridEventListener<'cellClick'>;
   /**
    * Callback fired when a double click event comes from a cell element.
    * @param {GridCellParams} params With all properties from [[GridCellParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onCellDoubleClick?: GridEventListener<GridEvents.cellDoubleClick>;
+  onCellDoubleClick?: GridEventListener<'cellDoubleClick'>;
   /**
    * Callback fired when a cell loses focus.
    * @param {GridCellParams} params With all properties from [[GridCellParams]].
    * @param {MuiEvent<MuiBaseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onCellFocusOut?: GridEventListener<GridEvents.cellFocusOut>;
+  onCellFocusOut?: GridEventListener<'cellFocusOut'>;
   /**
    * Callback fired when a keydown event comes from a cell element.
    * @param {GridCellParams} params With all properties from [[GridCellParams]].
    * @param {MuiEvent<React.KeyboardEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onCellKeyDown?: GridEventListener<GridEvents.cellKeyDown>;
+  onCellKeyDown?: GridEventListener<'cellKeyDown'>;
   /**
    * Callback fired when a click event comes from a column header element.
    * @param {GridColumnHeaderParams} params With all properties from [[GridColumnHeaderParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnHeaderClick?: GridEventListener<GridEvents.columnHeaderClick>;
+  onColumnHeaderClick?: GridEventListener<'columnHeaderClick'>;
   /**
    * Callback fired when a double click event comes from a column header element.
    * @param {GridColumnHeaderParams} params With all properties from [[GridColumnHeaderParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnHeaderDoubleClick?: GridEventListener<GridEvents.columnHeaderDoubleClick>;
+  onColumnHeaderDoubleClick?: GridEventListener<'columnHeaderDoubleClick'>;
   /**
    * Callback fired when a mouseover event comes from a column header element.
    * @param {GridColumnHeaderParams} params With all properties from [[GridColumnHeaderParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnHeaderOver?: GridEventListener<GridEvents.columnHeaderOver>;
+  onColumnHeaderOver?: GridEventListener<'columnHeaderOver'>;
   /**
    * Callback fired when a mouseout event comes from a column header element.
    * @param {GridColumnHeaderParams} params With all properties from [[GridColumnHeaderParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnHeaderOut?: GridEventListener<GridEvents.columnHeaderOut>;
+  onColumnHeaderOut?: GridEventListener<'columnHeaderOut'>;
   /**
    * Callback fired when a mouse enter event comes from a column header element.
    * @param {GridColumnHeaderParams} params With all properties from [[GridColumnHeaderParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnHeaderEnter?: GridEventListener<GridEvents.columnHeaderEnter>;
+  onColumnHeaderEnter?: GridEventListener<'columnHeaderEnter'>;
   /**
    * Callback fired when a mouse leave event comes from a column header element.
    * @param {GridColumnHeaderParams} params With all properties from [[GridColumnHeaderParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnHeaderLeave?: GridEventListener<GridEvents.columnHeaderLeave>;
+  onColumnHeaderLeave?: GridEventListener<'columnHeaderLeave'>;
   /**
    * Callback fired when a column is reordered.
    * @param {GridColumnOrderChangeParams} params With all properties from [[GridColumnOrderChangeParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onColumnOrderChange?: GridEventListener<GridEvents.columnOrderChange>;
+  onColumnOrderChange?: GridEventListener<'columnOrderChange'>;
   /**
    * Callback fired when a column visibility changes.
    * Only works when no `columnVisibilityModel` is provided and if we change the visibility of a single column at a time.
@@ -536,7 +536,7 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    * @param {GridCallbackDetails} details Additional details for this callback.
    * @deprecated Use `onColumnVisibilityModelChange` instead.
    */
-  onColumnVisibilityChange?: GridEventListener<GridEvents.columnVisibilityChange>;
+  onColumnVisibilityChange?: GridEventListener<'columnVisibilityChange'>;
   /**
    * Callback fired when a row is clicked.
    * Not called if the target clicked is an interactive element added by the built-in columns.
@@ -544,21 +544,21 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onRowClick?: GridEventListener<GridEvents.rowClick>;
+  onRowClick?: GridEventListener<'rowClick'>;
   /**
    * Callback fired when a double click event comes from a row container element.
    * @param {GridRowParams} params With all properties from [[RowParams]].
    * @param {MuiEvent<React.MouseEvent>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onRowDoubleClick?: GridEventListener<GridEvents.rowDoubleClick>;
+  onRowDoubleClick?: GridEventListener<'rowDoubleClick'>;
   /**
    * Callback fired when the grid is resized.
    * @param {ElementSize} containerSize With all properties from [[ElementSize]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onResize?: GridEventListener<GridEvents.debouncedResize>;
+  onResize?: GridEventListener<'debouncedResize'>;
   /**
    * Callback fired when the state of the grid is updated.
    * @param {GridState} state The new state.
@@ -566,7 +566,7 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    * @param {GridCallbackDetails} details Additional details for this callback.
    * @internal
    */
-  onStateChange?: GridEventListener<GridEvents.stateChange>;
+  onStateChange?: GridEventListener<'stateChange'>;
   /**
    * The zero-based index of the current page.
    * @default 0
@@ -596,14 +596,14 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onPreferencePanelClose?: GridEventListener<GridEvents.preferencePanelClose>;
+  onPreferencePanelClose?: GridEventListener<'preferencePanelClose'>;
   /**
    * Callback fired when the preferences panel is opened.
    * @param {GridPreferencePanelParams} params With all properties from [[GridPreferencePanelParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
    */
-  onPreferencePanelOpen?: GridEventListener<GridEvents.preferencePanelOpen>;
+  onPreferencePanelOpen?: GridEventListener<'preferencePanelOpen'>;
   /**
    * Set the edit rows model of the grid.
    */


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/4684
Follow up on https://github.com/mui/mui-x/pull/4685

Will automerge next week, I don't think it's worth reviewing since it does not change anything concrete and https://github.com/mui/mui-x/pull/4685 has been approved.