### PR TITLE
[docs] Stop using `GridEvents` enum in documentation

### DIFF
--- a/docs/data/data-grid/editing-legacy/CatchEditingEventsGrid.js
+++ b/docs/data/data-grid/editing-legacy/CatchEditingEventsGrid.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Alert from '@mui/material/Alert';
-import { GridEvents, useGridApiRef, DataGridPro } from '@mui/x-data-grid-pro';
+import { useGridApiRef, DataGridPro } from '@mui/x-data-grid-pro';
 import {
   randomCreatedDate,
   randomTraderName,
@@ -12,18 +12,15 @@ export default function CatchEditingEventsGrid() {
   const [message, setMessage] = React.useState('');
 
   React.useEffect(() => {
-    return apiRef.current.subscribeEvent(
-      GridEvents.cellEditStart,
-      (params, event) => {
-        setMessage(
-          `Editing cell with value: ${params.value} and row id: ${params.id}, column: ${params.field}, triggered by ${event.type}.`,
-        );
-      },
-    );
+    return apiRef.current.subscribeEvent('cellEditStart', (params, event) => {
+      setMessage(
+        `Editing cell with value: ${params.value} and row id: ${params.id}, column: ${params.field}, triggered by ${event.type}.`,
+      );
+    });
   }, [apiRef]);
 
   React.useEffect(() => {
-    return apiRef.current.subscribeEvent(GridEvents.cellEditStop, () => {
+    return apiRef.current.subscribeEvent('cellEditStop', () => {
       setMessage('');
     });
   }, [apiRef]);

--- a/docs/data/data-grid/editing-legacy/CatchEditingEventsGrid.tsx
+++ b/docs/data/data-grid/editing-legacy/CatchEditingEventsGrid.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Alert from '@mui/material/Alert';
 import {
-  GridEvents,
   GridColumns,
   GridRowsProp,
   useGridApiRef,
@@ -18,22 +17,19 @@ export default function CatchEditingEventsGrid() {
   const [message, setMessage] = React.useState('');
 
   React.useEffect(() => {
-    return apiRef.current.subscribeEvent(
-      GridEvents.cellEditStart,
-      (params, event) => {
-        setMessage(
-          `Editing cell with value: ${params.value} and row id: ${
-            params.id
-          }, column: ${params.field}, triggered by ${
-            (event as React.SyntheticEvent)!.type
-          }.`,
-        );
-      },
-    );
+    return apiRef.current.subscribeEvent('cellEditStart', (params, event) => {
+      setMessage(
+        `Editing cell with value: ${params.value} and row id: ${
+          params.id
+        }, column: ${params.field}, triggered by ${
+          (event as React.SyntheticEvent)!.type
+        }.`,
+      );
+    });
   }, [apiRef]);
 
   React.useEffect(() => {
-    return apiRef.current.subscribeEvent(GridEvents.cellEditStop, () => {
+    return apiRef.current.subscribeEvent('cellEditStop', () => {
       setMessage('');
     });
   }, [apiRef]);

--- a/docs/data/data-grid/editing-legacy/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing-legacy/FullFeaturedCrudGrid.tsx
@@ -17,7 +17,6 @@ import {
   GridToolbarContainer,
   GridActionsCellItem,
   GridEventListener,
-  GridEvents,
   GridRowId,
 } from '@mui/x-data-grid-pro';
 import {
@@ -104,17 +103,11 @@ export default function FullFeaturedCrudGrid() {
     event.defaultMuiPrevented = true;
   };
 
-  const handleRowEditStop: GridEventListener<GridEvents.rowEditStop> = (
-    params,
-    event,
-  ) => {
+  const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
     event.defaultMuiPrevented = true;
   };
 
-  const handleCellFocusOut: GridEventListener<GridEvents.cellFocusOut> = (
-    params,
-    event,
-  ) => {
+  const handleCellFocusOut: GridEventListener<'cellFocusOut'> = (params, event) => {
     event.defaultMuiPrevented = true;
   };
 

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -17,7 +17,6 @@ import {
   GridToolbarContainer,
   GridActionsCellItem,
   GridEventListener,
-  GridEvents,
   GridRowId,
   GridRowModel,
 } from '@mui/x-data-grid-pro';
@@ -106,10 +105,7 @@ export default function FullFeaturedCrudGrid() {
     event.defaultMuiPrevented = true;
   };
 
-  const handleRowEditStop: GridEventListener<GridEvents.rowEditStop> = (
-    params,
-    event,
-  ) => {
+  const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
     event.defaultMuiPrevented = true;
   };
 

--- a/docs/data/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/data/data-grid/editing/StartEditButtonGrid.tsx
@@ -8,7 +8,6 @@ import {
   GridCellParams,
   GridEventListener,
   MuiEvent,
-  GridEvents,
   useGridApiContext,
 } from '@mui/x-data-grid';
 import {
@@ -81,10 +80,7 @@ export default function StartEditButtonGrid() {
     event.defaultMuiPrevented = true;
   };
 
-  const handleCellEditStop: GridEventListener<GridEvents.cellEditStop> = (
-    params,
-    event,
-  ) => {
+  const handleCellEditStop: GridEventListener<'cellEditStop'> = (params, event) => {
     event.defaultMuiPrevented = true;
   };
 

--- a/docs/data/data-grid/events/CatalogOfEventsNoSnap.js
+++ b/docs/data/data-grid/events/CatalogOfEventsNoSnap.js
@@ -32,18 +32,18 @@ const EventRow = ({ event }) => {
     }
 
     return `
-const onEvent: GridEventListener<GridEvents.${event.name}> = (
+const onEvent: GridEventListener<'${event.name}'> = (
   ${args.join('\n  ')}
 ) => {...}    
   
 // Imperative subscription    
 apiRef.current.subscribeEvent(
-  GridEvents.${event.name},
+  '${event.name}',
   onEvent,
 );
 
 // Hook subscription (only available inside the scope of the grid)
-useGridApiEventHandler(GridEvents.${event.name}, onEvent);    
+useGridApiEventHandler('${event.name}', onEvent);    
 `;
   }, [event]);
 

--- a/docs/data/data-grid/master-detail/FullWidthDetailPanel.js
+++ b/docs/data/data-grid/master-detail/FullWidthDetailPanel.js
@@ -8,7 +8,6 @@ import {
   DataGridPro,
   useGridApiContext,
   GRID_DETAIL_PANEL_TOGGLE_FIELD,
-  GridEvents,
 } from '@mui/x-data-grid-pro';
 import {
   randomCreatedDate,
@@ -36,7 +35,7 @@ function DetailPanelContent({ row: rowProp }) {
 
   React.useEffect(() => {
     return apiRef.current.subscribeEvent(
-      GridEvents.viewportInnerSizeChange,
+      'viewportInnerSizeChange',
       handleViewportInnerSizeChange,
     );
   }, [apiRef, handleViewportInnerSizeChange]);

--- a/docs/data/data-grid/master-detail/FullWidthDetailPanel.tsx
+++ b/docs/data/data-grid/master-detail/FullWidthDetailPanel.tsx
@@ -8,7 +8,6 @@ import {
   GridColumns,
   useGridApiContext,
   GRID_DETAIL_PANEL_TOGGLE_FIELD,
-  GridEvents,
 } from '@mui/x-data-grid-pro';
 import {
   randomCreatedDate,
@@ -36,7 +35,7 @@ function DetailPanelContent({ row: rowProp }: { row: Customer }) {
 
   React.useEffect(() => {
     return apiRef.current.subscribeEvent(
-      GridEvents.viewportInnerSizeChange,
+      'viewportInnerSizeChange',
       handleViewportInnerSizeChange,
     );
   }, [apiRef, handleViewportInnerSizeChange]);

--- a/docs/data/data-grid/row-grouping/RowGroupingGetRowGroupChildren.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingGetRowGroupChildren.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   DataGridPremium,
   gridColumnVisibilityModelSelector,
-  GridEvents,
   useGridApiRef,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
@@ -14,7 +13,7 @@ const useKeepGroupingColumnsHidden = (apiRef, columns, initialModel, leafField) 
   const prevModel = React.useRef(initialModel);
 
   React.useEffect(() => {
-    apiRef.current.subscribeEvent(GridEvents.rowGroupingModelChange, (newModel) => {
+    apiRef.current.subscribeEvent('rowGroupingModelChange', (newModel) => {
       const columnVisibilityModel = {
         ...gridColumnVisibilityModelSelector(apiRef),
       };

--- a/docs/data/data-grid/row-grouping/RowGroupingGetRowGroupChildren.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingGetRowGroupChildren.tsx
@@ -5,7 +5,6 @@ import {
   GridColumns,
   gridColumnVisibilityModelSelector,
   GridEventListener,
-  GridEvents,
   GridRowGroupingModel,
   useGridApiRef,
 } from '@mui/x-data-grid-premium';
@@ -23,7 +22,7 @@ const useKeepGroupingColumnsHidden = (
   const prevModel = React.useRef(initialModel);
 
   React.useEffect(() => {
-    apiRef.current.subscribeEvent(GridEvents.rowGroupingModelChange, (newModel) => {
+    apiRef.current.subscribeEvent('rowGroupingModelChange', (newModel) => {
       const columnVisibilityModel = {
         ...gridColumnVisibilityModelSelector(apiRef),
       };
@@ -68,7 +67,7 @@ export default function RowGroupingGetRowGroupChildren() {
     INITIAL_GROUPING_COLUMN_MODEL,
   );
 
-  const handleRowClick = React.useCallback<GridEventListener<GridEvents.rowClick>>(
+  const handleRowClick = React.useCallback<GridEventListener<'rowClick'>>(
     (params) => {
       // Only log groups
       if (!apiRef.current.getRowNode(params.id)?.children) {

--- a/docs/data/data-grid/tree-data/TreeDataCustomGroupingColumn.js
+++ b/docs/data/data-grid/tree-data/TreeDataCustomGroupingColumn.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   DataGridPro,
   useGridApiContext,
-  GridEvents,
   useGridSelector,
   gridFilteredDescendantCountLookupSelector,
 } from '@mui/x-data-grid-pro';
@@ -32,7 +31,7 @@ const CustomGridTreeDataGroupingCell = (props) => {
       event.stopPropagation();
     }
     if (isNavigationKey(event.key) && !event.shiftKey) {
-      apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, props, event);
+      apiRef.current.publishEvent('cellNavigationKeyDown', props, event);
     }
   };
 

--- a/docs/data/data-grid/tree-data/TreeDataCustomGroupingColumn.tsx
+++ b/docs/data/data-grid/tree-data/TreeDataCustomGroupingColumn.tsx
@@ -3,7 +3,6 @@ import {
   DataGridPro,
   GridRenderCellParams,
   useGridApiContext,
-  GridEvents,
   GridColumns,
   GridRowsProp,
   DataGridProProps,
@@ -35,7 +34,7 @@ const CustomGridTreeDataGroupingCell = (props: GridRenderCellParams) => {
       event.stopPropagation();
     }
     if (isNavigationKey(event.key) && !event.shiftKey) {
-      apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, props, event);
+      apiRef.current.publishEvent('cellNavigationKeyDown', props, event);
     }
   };
 

--- a/docs/data/data-grid/tree-data/TreeDataLazyLoading.js
+++ b/docs/data/data-grid/tree-data/TreeDataLazyLoading.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   DataGridPro,
   getDataGridUtilityClass,
-  GridEvents,
   useGridApiContext,
   useGridApiRef,
   useGridRootProps,
@@ -178,7 +177,7 @@ const GroupingCellWithLazyLoading = (props) => {
       event.stopPropagation();
     }
     if (isNavigationKey(event.key) && !event.shiftKey) {
-      apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, props, event);
+      apiRef.current.publishEvent('cellNavigationKeyDown', props, event);
     }
   };
 
@@ -344,12 +343,8 @@ export default function TreeDataLazyLoading() {
       }
     };
 
-    apiRef.current.subscribeEvent(
-      GridEvents.rowExpansionChange,
-      handleRowExpansionChange,
-    );
-
-    apiRef.current.subscribeEvent(GridEvents.cellKeyDown, handleCellKeyDown, {
+    apiRef.current.subscribeEvent('rowExpansionChange', handleRowExpansionChange);
+    apiRef.current.subscribeEvent('cellKeyDown', handleCellKeyDown, {
       isFirst: true,
     });
   }, [apiRef]);

--- a/docs/data/data-grid/tree-data/TreeDataLazyLoading.tsx
+++ b/docs/data/data-grid/tree-data/TreeDataLazyLoading.tsx
@@ -5,7 +5,6 @@ import {
   GridColumns,
   DataGridProProps,
   GridEventListener,
-  GridEvents,
   GridGroupingColDefOverride,
   GridRenderCellParams,
   GridRowModel,
@@ -196,7 +195,7 @@ const GroupingCellWithLazyLoading = (props: GroupingCellWithLazyLoadingProps) =>
       event.stopPropagation();
     }
     if (isNavigationKey(event.key) && !event.shiftKey) {
-      apiRef.current.publishEvent(GridEvents.cellNavigationKeyDown, props, event);
+      apiRef.current.publishEvent('cellNavigationKeyDown', props, event);
     }
   };
 
@@ -246,9 +245,9 @@ export default function TreeDataLazyLoading() {
   React.useEffect(() => {
     fakeDataFetcher().then(setRows);
 
-    const handleRowExpansionChange: GridEventListener<
-      GridEvents.rowExpansionChange
-    > = async (node) => {
+    const handleRowExpansionChange: GridEventListener<'rowExpansionChange'> = async (
+      node,
+    ) => {
       const row = apiRef.current.getRow(node.id) as Row | null;
 
       if (!node.childrenExpanded || !row || row.childrenFetched) {
@@ -278,10 +277,7 @@ export default function TreeDataLazyLoading() {
      * By default, the grid does not toggle the expansion of rows with 0 children
      * We need to override the `cellKeyDown` event listener to force the expansion if there are children on the server
      */
-    const handleCellKeyDown: GridEventListener<GridEvents.cellKeyDown> = (
-      params,
-      event,
-    ) => {
+    const handleCellKeyDown: GridEventListener<'cellKeyDown'> = (params, event) => {
       const cellParams = apiRef.current.getCellParams(params.id, params.field);
       if (cellParams.colDef.type === 'treeDataGroup' && event.key === ' ') {
         event.stopPropagation();
@@ -295,11 +291,8 @@ export default function TreeDataLazyLoading() {
       }
     };
 
-    apiRef.current.subscribeEvent(
-      GridEvents.rowExpansionChange,
-      handleRowExpansionChange,
-    );
-    apiRef.current.subscribeEvent(GridEvents.cellKeyDown, handleCellKeyDown, {
+    apiRef.current.subscribeEvent('rowExpansionChange', handleRowExpansionChange);
+    apiRef.current.subscribeEvent('cellKeyDown', handleCellKeyDown, {
       isFirst: true,
     });
   }, [apiRef]);

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -123,7 +123,7 @@ Alternatively, you can achieve a similar behavior by implementing this feature o
 This implementation does not support every feature of the grid but can be a good starting point for large datasets.
 
 The idea is to add a property `descendantCount` on the row and to use it instead of the internal grid state.
-To do so, we need to override both the `renderCell` of the grouping column and to manually open the rows by listening to `'rowExpansionChange'`.
+To do so, we need to override both the `renderCell` of the grouping column and to manually open the rows by listening to `rowExpansionChange` event.
 
 {{"demo": "TreeDataLazyLoading.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -123,7 +123,7 @@ Alternatively, you can achieve a similar behavior by implementing this feature o
 This implementation does not support every feature of the grid but can be a good starting point for large datasets.
 
 The idea is to add a property `descendantCount` on the row and to use it instead of the internal grid state.
-To do so, we need to override both the `renderCell` of the grouping column and to manually open the rows by listening to `GridEvents.rowExpansionChange`.
+To do so, we need to override both the `renderCell` of the grouping column and to manually open the rows by listening to `'rowExpansionChange'`.
 
 {{"demo": "TreeDataLazyLoading.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/packages/storybook/src/stories/grid-rows.stories.tsx
+++ b/packages/storybook/src/stories/grid-rows.stories.tsx
@@ -15,7 +15,6 @@ import {
   GridRowModel,
   useGridApiRef,
   DataGridPro,
-  GridEvents,
   MuiEvent,
   GridEventListener,
   GridRenderCellParams,
@@ -488,7 +487,7 @@ export function EditRowsControl() {
     setEditRowsModel(updatedModel);
   }, []);
 
-  const onCellEditCommit = React.useCallback<GridEventListener<GridEvents.cellEditCommit>>(
+  const onCellEditCommit = React.useCallback<GridEventListener<'cellEditCommit'>>(
     (params, event) => {
       const { id, field, value } = params;
       (event as React.SyntheticEvent)?.persist();
@@ -511,7 +510,7 @@ export function EditRowsControl() {
       setTimeout(() => {
         apiRef.current.updateRows([cellUpdate]);
         apiRef.current.publishEvent(
-          GridEvents.cellEditStop,
+          'cellEditStop',
           apiRef.current.getCellParams(id, field) as GridCellEditStopParams,
           event,
         );
@@ -673,9 +672,7 @@ export function EditBooleanCellSnap() {
 export function ValidateEditValueWithApiRefGrid() {
   const apiRef = useGridApiRef();
 
-  const onEditCellPropsChange = React.useCallback<
-    GridEventListener<GridEvents.editCellPropsChange>
-  >(
+  const onEditCellPropsChange = React.useCallback<GridEventListener<'editCellPropsChange'>>(
     ({ id, field, props }, event) => {
       if (field === 'email') {
         const isValid = validateEmail(props.value);
@@ -750,9 +747,7 @@ export function ValidateEditValueServerSide() {
   const apiRef = useGridApiRef();
   const keyStrokeTimeoutRef = React.useRef<any>();
 
-  const handleCellEditPropChange = React.useCallback<
-    GridEventListener<GridEvents.editCellPropsChange>
-  >(
+  const handleCellEditPropChange = React.useCallback<GridEventListener<'editCellPropsChange'>>(
     async ({ id, field, props }, event) => {
       if (field === 'username') {
         // TODO refactor this block
@@ -852,7 +847,7 @@ export function EditCellUsingExternalButtonGrid() {
   }, []);
 
   // Prevent from committing on focus out
-  const handleCellFocusOut = React.useCallback<GridEventListener<GridEvents.cellFocusOut>>(
+  const handleCellFocusOut = React.useCallback<GridEventListener<'cellFocusOut'>>(
     (params, event) => {
       if (params.cellMode === 'edit' && event) {
         event.defaultMuiPrevented = true;
@@ -904,15 +899,11 @@ export function EditCellWithModelGrid() {
 export function EditCellWithCellClickGrid() {
   const apiRef = useGridApiRef();
 
-  const handleCellClick = React.useCallback<GridEventListener<GridEvents.cellClick>>(
+  const handleCellClick = React.useCallback<GridEventListener<'cellClick'>>(
     (params, event) => {
       // Or you can use the editRowModel prop, but I find it easier
       // apiRef.current.setCellMode(params.id, params.field, 'edit');
-      apiRef.current.publishEvent(
-        GridEvents.cellEditStart,
-        params as GridCellEditStartParams,
-        event,
-      );
+      apiRef.current.publishEvent('cellEditStart', params as GridCellEditStartParams, event);
 
       // if I want to prevent selection I can do
       event.defaultMuiPrevented = true;
@@ -939,7 +930,7 @@ export function EditCellWithMessageGrid() {
   const [message, setMessage] = React.useState('');
 
   React.useEffect(() => {
-    return apiRef.current.subscribeEvent(GridEvents.cellEditStart, (params, event) => {
+    return apiRef.current.subscribeEvent('cellEditStart', (params, event) => {
       setMessage(`Editing cell with value: ${params.value} at row: ${params.id}, column: ${
         params.field
       },


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/4684
Follow up on https://github.com/mui/mui-x/pull/4685

Will automerge, I don't think it's worth reviewing since it does not change anything concrete and https://github.com/mui/mui-x/pull/4685 has been approved.