### PR TITLE
[docs] Correctly capitalize Ctrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2404,7 +2404,7 @@ _July 1, 2021_
 Big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
 - 🐞 As a focus of Q2, we have kept fixing bugs
-- 💅 End users are now allowed to copy the selected rows to the clipboard with <kbd>CTRL</kbd> + <kbd>c</kbd> (#1929) @m4theushw
+- 💅 End users are now allowed to copy the selected rows to the clipboard with <kbd>Ctrl</kbd> + <kbd>c</kbd> (#1929) @m4theushw
 - 🐛 We have fixed the `Select all` checkbox. When triggered, it should only select the filtered rows (#1879) @ZeeshanTamboli
 - ⚡️ We have added a new `singleSelect` column type (#1956) @DanailH
 
@@ -2604,7 +2604,7 @@ _June 9, 2021_
 Big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
 - 💅 Allow to customize GridToolbarExport's CSV export (#1695) @michallukowski
-- 🐛 Allow to deselect rows with <kbd>CTRL</kbd> + click (#1813) @ZeeshanTamboli
+- 🐛 Allow to deselect rows with <kbd>Ctrl</kbd> + click (#1813) @ZeeshanTamboli
 - ⚡️ Refactor scroll size detector (#1703) @dtassone
 - 📖 Add [documentation](https://mui.com/x/api/data-grid/) for interfaces and events (#1529) @m4theushw
 - 🐞 Bugfixes
@@ -2631,7 +2631,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 
 - [DataGrid] Add `valueParser` to parse values entered by the user (#1785) @m4theushw
 - [DataGrid] Allow to customize GridToolbarExport's CSV export (#1695) @michallukowski
-- [DataGrid] Allow to deselect rows with <kbd>CTRL</kbd> + click (#1813) @ZeeshanTamboli
+- [DataGrid] Allow to deselect rows with <kbd>Ctrl</kbd> + click (#1813) @ZeeshanTamboli
 - [DataGrid] Improve general architecture to better isolate hooks (#1720) @dtassone
 - [DataGrid] Fix cell height after changing grid density (#1819) @DanailH
 - [DataGrid] Fix fluid columns width when available `viewportWidth` < 0 (#1816) @DanailH

--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -57,8 +57,8 @@ Use the arrow keys to move the focus.
 |                                    <kbd class="key">Arrow Up</kbd> | Navigate between cell elements                              |
 |                                        <kbd class="key">Home</kbd> | Navigate to the first cell of the current row               |
 |                                         <kbd class="key">End</kbd> | Navigate to the last cell of the current row                |
-| <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Home</kbd></kbd> | Navigate to the first cell of the first row                 |
-|  <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">End</kbd></kbd> | Navigate to the last cell of the last row                   |
+| <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">Home</kbd></kbd> | Navigate to the first cell of the first row                 |
+|  <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">End</kbd></kbd> | Navigate to the last cell of the last row                   |
 |                                       <kbd class="key">Space</kbd> | Navigate to the next scrollable page                        |
 |                                     <kbd class="key">Page Up</kbd> | Navigate to the previous scrollable page                    |
 |                                   <kbd class="key">Page Down</kbd> | Navigate to the next scrollable page                        |
@@ -71,34 +71,34 @@ Use the arrow keys to move the focus.
 |         <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Space</kbd></kbd> | Select the current row                                               |
 | <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Arrow Up/Down</kbd></kbd> | Select the current row and the row above or below                    |
 |                                  <kbd class="key">Shift</kbd>+ Click on cell | Select the range of rows between the first and the last clicked rows |
-|              <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">A</kbd></kbd> | Select all rows                                                      |
-|              <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s)                                   |
+|              <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">A</kbd></kbd> | Select all rows                                                      |
+|              <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s)                                   |
 |               <kbd><kbd class="key">ALT</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s) including headers                 |
-|                                   <kbd class="key">CTRL</kbd>+ Click on cell | Enable multi-selection                                               |
-|                         <kbd class="key">CTRL</kbd>+ Click on a selected row | Deselect the row                                                     |
+|                                   <kbd class="key">Ctrl</kbd>+ Click on cell | Enable multi-selection                                               |
+|                         <kbd class="key">Ctrl</kbd>+ Click on a selected row | Deselect the row                                                     |
 
 ### Sorting
 
 |                                                                 Keys | Description                                        |
 | -------------------------------------------------------------------: | :------------------------------------------------- |
-|                         <kbd class="key">CTRL</kbd>+ Click on header | Enable multi-sorting                               |
+|                         <kbd class="key">Ctrl</kbd>+ Click on header | Enable multi-sorting                               |
 |                        <kbd class="key">Shift</kbd>+ Click on header | Enable multi-sorting                               |
 | <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Enter</kbd></kbd> | Enable multi-sorting when column header is focused |
 |                                         <kbd class="key">Enter</kbd> | Sort column when column header is focused          |
-|  <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Enter</kbd></kbd> | Open column menu when column header is focused     |
+|  <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">Enter</kbd></kbd> | Open column menu when column header is focused     |
 
 ### Group & pivot
 
 |                                                                Keys | Description                       |
 | ------------------------------------------------------------------: | :-------------------------------- |
-| <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Enter</kbd></kbd> | Toggles the detail panel of a row |
+| <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">Enter</kbd></kbd> | Toggles the detail panel of a row |
 
 ### Key assignment conventions
 
 The above key assignments are for Windows and Linux.
 On macOS:
 
-- replace <kbd class="key">CTRL</kbd> with <kbd class="key">⌘ Command</kbd>
+- replace <kbd class="key">Ctrl</kbd> with <kbd class="key">⌘ Command</kbd>
 - replace <kbd class="key">ALT</kbd> with <kbd class="key">⌥ Option</kbd>
 
 ## API

--- a/docs/data/data-grid/events/events.md
+++ b/docs/data/data-grid/events/events.md
@@ -48,7 +48,7 @@ Set it to `true` to block the default handling of an event and implement your ow
 ```
 
 Usually, double clicking a cell will put it into [edit mode](/x/react-data-grid/editing/).
-The following example changes this behavior by also requiring <kbd class="key">CTRL</kbd> to be pressed.
+The following example changes this behavior by also requiring <kbd class="key">Ctrl</kbd> to be pressed.
 
 {{"demo": "DoubleClickWithCtrlToEdit.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/selection/selection.md
+++ b/docs/data/data-grid/selection/selection.md
@@ -27,7 +27,7 @@ Row selection can be performed with a simple mouse click, or using the [keyboard
 ### Single row selection
 
 Single row selection is enabled by default with the `DataGrid` component.
-To unselect a row, hold the <kbd class="key">CTRL</kbd> key and click on it.
+To unselect a row, hold the <kbd class="key">Ctrl</kbd> key and click on it.
 
 {{"demo": "SingleRowSelectionGrid.js", "bg": "inline"}}
 
@@ -35,7 +35,7 @@ To unselect a row, hold the <kbd class="key">CTRL</kbd> key and click on it.
 
 On the `DataGridPro` component, you can select multiple rows in two ways:
 
-- To select multiple independent rows, hold the <kbd class="key">CTRL</kbd> key while selecting rows.
+- To select multiple independent rows, hold the <kbd class="key">Ctrl</kbd> key while selecting rows.
 - To select a range of rows, hold the <kbd class="key">SHIFT</kbd> key while selecting rows.
 - To disable multiple row selection, use `disableMultipleSelection={true}`.
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -22,7 +22,7 @@ Following clicks change the column's sorting direction. You can see the applied 
 
 The following demo lets you sort the rows according to several criteria at the same time.
 
-Hold down the <kbd class="key">CTRL</kbd> or <kbd class="key">Shift</kbd> (use <kbd class="key">⌘ Command</kbd> on macOS) key while clicking the column header.
+Hold down the <kbd class="key">Ctrl</kbd> or <kbd class="key">Shift</kbd> (use <kbd class="key">⌘ Command</kbd> on macOS) key while clicking the column header.
 
 {{"demo": "BasicExampleDataGridPro.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/translations/api-docs/data-grid/data-grid-premium-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium-pt.json
@@ -31,7 +31,7 @@
     "disableExtendRowFullWidth": "If <code>true</code>, rows will not be extended to fill the full width of the grid container.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
-    "disableMultipleSelection": "If <code>true</code>, multiple selection using the CTRL or CMD key is disabled.",
+    "disableMultipleSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",
     "disableRowGrouping": "If <code>true</code>, the row grouping is disabled.",
     "disableSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium-zh.json
@@ -31,7 +31,7 @@
     "disableExtendRowFullWidth": "If <code>true</code>, rows will not be extended to fill the full width of the grid container.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
-    "disableMultipleSelection": "If <code>true</code>, multiple selection using the CTRL or CMD key is disabled.",
+    "disableMultipleSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",
     "disableRowGrouping": "If <code>true</code>, the row grouping is disabled.",
     "disableSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium.json
@@ -31,7 +31,7 @@
     "disableExtendRowFullWidth": "If <code>true</code>, rows will not be extended to fill the full width of the grid container.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
-    "disableMultipleSelection": "If <code>true</code>, multiple selection using the CTRL or CMD key is disabled.",
+    "disableMultipleSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",
     "disableRowGrouping": "If <code>true</code>, the row grouping is disabled.",
     "disableSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
@@ -31,7 +31,7 @@
     "disableExtendRowFullWidth": "If <code>true</code>, rows will not be extended to fill the full width of the grid container.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
-    "disableMultipleSelection": "If <code>true</code>, multiple selection using the CTRL or CMD key is disabled.",
+    "disableMultipleSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",
     "disableSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",
     "editMode": "Controls whether to use the cell or row editing.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
@@ -31,7 +31,7 @@
     "disableExtendRowFullWidth": "If <code>true</code>, rows will not be extended to fill the full width of the grid container.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
-    "disableMultipleSelection": "If <code>true</code>, multiple selection using the CTRL or CMD key is disabled.",
+    "disableMultipleSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",
     "disableSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",
     "editMode": "Controls whether to use the cell or row editing.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -31,7 +31,7 @@
     "disableExtendRowFullWidth": "If <code>true</code>, rows will not be extended to fill the full width of the grid container.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
-    "disableMultipleSelection": "If <code>true</code>, multiple selection using the CTRL or CMD key is disabled.",
+    "disableMultipleSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",
     "disableSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",
     "editMode": "Controls whether to use the cell or row editing.",

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -218,7 +218,7 @@ DataGridPremiumRaw.propTypes = {
    */
   disableMultipleColumnsSorting: PropTypes.bool,
   /**
-   * If `true`, multiple selection using the CTRL or CMD key is disabled.
+   * If `true`, multiple selection using the Ctrl or CMD key is disabled.
    * @default false
    */
   disableMultipleSelection: PropTypes.bool,

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -215,7 +215,7 @@ DataGridProRaw.propTypes = {
    */
   disableMultipleColumnsSorting: PropTypes.bool,
   /**
-   * If `true`, multiple selection using the CTRL or CMD key is disabled.
+   * If `true`, multiple selection using the Ctrl or CMD key is disabled.
    * @default false
    */
   disableMultipleSelection: PropTypes.bool,

--- a/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/selection/useGridSelection.ts
@@ -291,7 +291,7 @@ export const useGridSelection = (
       // multiple selection is only allowed if:
       // - it is a checkboxSelection
       // - it is a keyboard selection
-      // - CTRL is pressed
+      // - Ctrl is pressed
 
       const isMultipleSelectionDisabled =
         !checkboxSelection && !hasCtrlKey && !isKeyboardEvent(event);

--- a/packages/grid/x-data-grid/src/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/sorting/useGridSorting.ts
@@ -283,7 +283,7 @@ export const useGridSorting = (
 
   const handleColumnHeaderKeyDown = React.useCallback<GridEventListener<'columnHeaderKeyDown'>>(
     ({ colDef }, event) => {
-      // CTRL + Enter opens the column menu
+      // Ctrl + Enter opens the column menu
       if (isEnterKey(event.key) && !event.ctrlKey && !event.metaKey) {
         sortColumn(colDef, undefined, event.shiftKey);
       }

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -190,7 +190,7 @@ export interface DataGridPropsWithDefaultValues {
    */
   disableMultipleColumnsFiltering: boolean;
   /**
-   * If `true`, multiple selection using the CTRL or CMD key is disabled.
+   * If `true`, multiple selection using the Ctrl or CMD key is disabled.
    * @default false
    */
   disableMultipleSelection: boolean;


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Control_key is an abbreviation, not an acronym, so it makes more sense to write is as Ctrl 