### PR TITLE
[TimePicker] Disable and invalidate date with minutes not matching `minutesStep`

### DIFF
--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.test.tsx
@@ -318,6 +318,21 @@ describe('<ClockPicker />', () => {
       expect(handleChange.callCount).to.equal(0);
     });
 
+    it('should visually disable the dates not matching minutesStep', () => {
+      render(
+        <ClockPicker
+          ampm={false}
+          date={adapterToUse.date('2018-01-01T13:20:00.000')}
+          minutesStep={15}
+          onChange={() => {}}
+          view="minutes"
+        />,
+      );
+
+      expect(screen.getByLabelText('25 minutes')).to.have.class('Mui-disabled');
+      expect(screen.getByLabelText('30 minutes')).not.to.have.class('Mui-disabled');
+    });
+
     it('should select enabled second', () => {
       const handleChange = spy();
       const handleViewChange = spy();

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -34,11 +34,6 @@ export interface ExportedClockPickerProps<TDate> extends ExportedTimeValidationP
    */
   ampm?: boolean;
   /**
-   * Step over minutes.
-   * @default 1
-   */
-  minutesStep?: number;
-  /**
    * Display ampm controls under the clock (instead of in the toolbar).
    * @default false
    */

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -262,10 +262,6 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
 
   const isTimeDisabled = React.useCallback(
     (rawValue: number, viewType: ClockPickerView) => {
-      if (date === null) {
-        return false;
-      }
-
       const isAfter = createIsAfterIgnoreDatePart(disableIgnoringDatePartForTimeValidation, utils);
 
       const containsValidTime = ({ start, end }: { start: TDate; end: TDate }) => {
@@ -280,7 +276,11 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
         return true;
       };
 
-      const isValidValue = (value: number) => {
+      const isValidValue = (value: number, step = 1) => {
+        if (value % step !== 0) {
+          return false;
+        }
+
         if (shouldDisableTime) {
           return !shouldDisableTime(value, viewType);
         }
@@ -291,6 +291,11 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
       switch (viewType) {
         case 'hours': {
           const value = convertValueToMeridiem(rawValue, meridiemMode, ampm);
+
+          if (date == null) {
+            return !isValidValue(value);
+          }
+
           const dateWithNewHours = utils.setHours(date, value);
           const start = utils.setSeconds(utils.setMinutes(dateWithNewHours, 0), 0);
           const end = utils.setSeconds(utils.setMinutes(dateWithNewHours, 59), 59);
@@ -299,14 +304,22 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
         }
 
         case 'minutes': {
+          if (date == null) {
+            return !isValidValue(rawValue, minutesStep);
+          }
+
           const dateWithNewMinutes = utils.setMinutes(date, rawValue);
           const start = utils.setSeconds(dateWithNewMinutes, 0);
           const end = utils.setSeconds(dateWithNewMinutes, 59);
 
-          return !containsValidTime({ start, end }) || !isValidValue(rawValue);
+          return !containsValidTime({ start, end }) || !isValidValue(rawValue, minutesStep);
         }
 
         case 'seconds': {
+          if (date == null) {
+            return !isValidValue(rawValue);
+          }
+
           const dateWithNewSeconds = utils.setSeconds(date, rawValue);
           const start = dateWithNewSeconds;
           const end = dateWithNewSeconds;

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -338,6 +338,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
       maxTime,
       meridiemMode,
       minTime,
+      minutesStep,
       shouldDisableTime,
       utils,
     ],

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -28,7 +28,6 @@ export interface PickersDayProps<TDate> extends ExtendMui<ButtonBaseProps> {
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<PickersDayClasses>;
-
   /**
    * The date to show.
    */

--- a/packages/x-date-pickers/src/internals/hooks/validation/useTimeValidation.ts
+++ b/packages/x-date-pickers/src/internals/hooks/validation/useTimeValidation.ts
@@ -14,6 +14,11 @@ export interface ExportedTimeValidationProps<TDate> {
    */
   maxTime?: TDate;
   /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep?: number;
+  /**
    * Dynamically check if time is disabled or not.
    * If returns `false` appropriate time point will ot be acceptable.
    * @param {number} timeValue The value to check.
@@ -34,6 +39,7 @@ export interface TimeValidationProps<TInputDate, TDate>
 
 export type TimeValidationError =
   | 'invalidDate'
+  | 'minutesStep'
   | 'minTime'
   | 'maxTime'
   | 'shouldDisableTime-hours'
@@ -44,7 +50,7 @@ export type TimeValidationError =
 export const validateTime: Validator<any, TimeValidationProps<any, any>> = (
   utils,
   value,
-  { minTime, maxTime, shouldDisableTime, disableIgnoringDatePartForTimeValidation },
+  { minTime, maxTime, minutesStep, shouldDisableTime, disableIgnoringDatePartForTimeValidation },
 ): TimeValidationError => {
   const date = utils.date(value);
   const isAfter = createIsAfterIgnoreDatePart(disableIgnoringDatePartForTimeValidation, utils);
@@ -71,6 +77,9 @@ export const validateTime: Validator<any, TimeValidationProps<any, any>> = (
 
     case Boolean(shouldDisableTime && shouldDisableTime(utils.getSeconds(date!), 'seconds')):
       return 'shouldDisableTime-seconds';
+
+    case Boolean(minutesStep && utils.getMinutes(date!) % minutesStep !== 0):
+      return 'minutesStep';
 
     default:
       return null;


### PR DESCRIPTION
Closes #4604

- [x] Visually disable the minutes not matching `minutesStep` in the clock
- [x] Mark the value as invalid if the current minute does not match the `minutesStep` (e.g minute = 34 when minutesStep = 5)
 

[Example](https://codesandbox.io/s/basictimepicker-material-demo-forked-ml8br3?file=/demo.js)