### PR TITLE
[DataGrid] Fix columnHeaderDrag uses cellDragOver

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -386,7 +386,7 @@ export const useGridRows = (
     (rowId, targetIndex) => {
       const allRows = gridRowIdsSelector(apiRef);
       const oldIndex = allRows.findIndex((row) => row === rowId);
-      if (oldIndex === targetIndex) {
+      if (oldIndex === -1 || oldIndex === targetIndex) {
         return;
       }
 


### PR DESCRIPTION
Fix columnHeaderDrag uses cellDragOver and cellDragOver run infinite scroll

https://user-images.githubusercontent.com/8194467/166219804-e2abc8a5-62bf-40d9-b2f1-7206a3ababe0.mov

 