### PR TITLE
[DataGrid] add TypeScript support for pass-through sx prop

### DIFF
--- a/packages/grid/x-data-grid/src/components/GridRowCount.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRowCount.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
 import { getDataGridUtilityClass } from '../constants/gridClasses';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
@@ -13,7 +13,10 @@ interface RowCountProps {
   visibleRowCount: number;
 }
 
-type GridRowCountProps = React.HTMLAttributes<HTMLDivElement> & RowCountProps;
+type GridRowCountProps = React.HTMLAttributes<HTMLDivElement> &
+  RowCountProps & {
+    sx?: SxProps<Theme>;
+  };
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };
 

--- a/packages/grid/x-data-grid/src/components/GridSelectedRowCount.tsx
+++ b/packages/grid/x-data-grid/src/components/GridSelectedRowCount.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
 import { getDataGridUtilityClass } from '../constants/gridClasses';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
@@ -12,7 +12,10 @@ interface SelectedRowCountProps {
   selectedRowCount: number;
 }
 
-type GridSelectedRowCountProps = React.HTMLAttributes<HTMLDivElement> & SelectedRowCountProps;
+type GridSelectedRowCountProps = React.HTMLAttributes<HTMLDivElement> &
+  SelectedRowCountProps & {
+    sx?: SxProps<Theme>;
+  };
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };
 

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaders.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { styled, alpha, lighten, darken } from '@mui/material/styles';
+import { styled, alpha, lighten, darken, SxProps, Theme } from '@mui/material/styles';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
@@ -44,7 +44,9 @@ const GridColumnHeadersRoot = styled('div', {
   };
 });
 
-interface GridColumnHeadersProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface GridColumnHeadersProps extends React.HTMLAttributes<HTMLDivElement> {
+  sx?: SxProps<Theme>;
+}
 
 export const GridColumnHeaders = React.forwardRef<HTMLDivElement, GridColumnHeadersProps>(
   function GridColumnHeaders(props, ref) {

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeadersInner.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeadersInner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { gridClasses, getDataGridUtilityClass } from '../../constants/gridClasses';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
@@ -47,6 +47,7 @@ const GridColumnHeadersInnerRoot = styled('div', {
 
 interface GridColumnHeadersInnerProps extends React.HTMLAttributes<HTMLDivElement> {
   isDragging: boolean;
+  sx?: SxProps<Theme>;
 }
 
 export const GridColumnHeadersInner = React.forwardRef<HTMLDivElement, GridColumnHeadersInnerProps>(

--- a/packages/grid/x-data-grid/src/components/containers/GridFooterContainer.tsx
+++ b/packages/grid/x-data-grid/src/components/containers/GridFooterContainer.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import { styled, alpha, lighten, darken } from '@mui/material/styles';
+import { styled, alpha, lighten, darken, SxProps, Theme } from '@mui/material/styles';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 
-export type GridFooterContainerProps = React.HTMLAttributes<HTMLDivElement>;
+export type GridFooterContainerProps = React.HTMLAttributes<HTMLDivElement> & {
+  sx?: SxProps<Theme>;
+};
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };
 

--- a/packages/grid/x-data-grid/src/components/containers/GridToolbarContainer.tsx
+++ b/packages/grid/x-data-grid/src/components/containers/GridToolbarContainer.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 
-export type GridToolbarContainerProps = React.HTMLAttributes<HTMLDivElement>;
+export type GridToolbarContainerProps = React.HTMLAttributes<HTMLDivElement> & {
+  sx?: SxProps<Theme>;
+};
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };
 

--- a/packages/grid/x-data-grid/src/components/panel/GridPanelContent.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPanelContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
@@ -31,7 +31,7 @@ const GridPanelContentRoot = styled('div', {
 });
 
 export function GridPanelContent(
-  props: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>,
+  props: React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> },
 ) {
   const { className, ...other } = props;
   const rootProps = useGridRootProps();

--- a/packages/grid/x-data-grid/src/components/panel/GridPanelFooter.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPanelFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
@@ -29,7 +29,7 @@ const GridPanelFooterRoot = styled('div', {
 }));
 
 export function GridPanelFooter(
-  props: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>,
+  props: React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> },
 ) {
   const { className, ...other } = props;
   const rootProps = useGridRootProps();

--- a/packages/grid/x-data-grid/src/components/panel/GridPanelHeader.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPanelHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
@@ -27,7 +27,7 @@ const GridPanelHeaderRoot = styled('div', {
 }));
 
 export function GridPanelHeader(
-  props: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>,
+  props: React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> },
 ) {
   const { className, ...other } = props;
   const rootProps = useGridRootProps();

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
@@ -31,15 +31,16 @@ const VirtualScrollerRoot = styled('div', {
   },
 });
 
-const GridVirtualScroller = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  function GridVirtualScroller(props, ref) {
-    const { className, ...other } = props;
-    const rootProps = useGridRootProps();
-    const ownerState = { classes: rootProps.classes };
-    const classes = useUtilityClasses(ownerState);
+const GridVirtualScroller = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> }
+>(function GridVirtualScroller(props, ref) {
+  const { className, ...other } = props;
+  const rootProps = useGridRootProps();
+  const ownerState = { classes: rootProps.classes };
+  const classes = useUtilityClasses(ownerState);
 
-    return <VirtualScrollerRoot ref={ref} className={clsx(classes.root, className)} {...other} />;
-  },
-);
+  return <VirtualScrollerRoot ref={ref} className={clsx(classes.root, className)} {...other} />;
+});
 
 export { GridVirtualScroller };

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerContent.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerContent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
@@ -26,7 +26,7 @@ const VirtualScrollerContentRoot = styled('div', {
 
 const GridVirtualScrollerContent = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
+  React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> }
 >(function GridVirtualScrollerContent(props, ref) {
   const { className, style, ...other } = props;
   const rootProps = useGridRootProps();

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
@@ -30,7 +30,7 @@ const VirtualScrollerRenderZoneRoot = styled('div', {
 
 const GridVirtualScrollerRenderZone = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
+  React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> }
 >(function GridVirtualScrollerRenderZone(props, ref) {
   const { className, ...other } = props;
   const rootProps = useGridRootProps();


### PR DESCRIPTION
Fixes #4742 

I made this PR to fix the TypeScript issue that I was having where using the prop `sx` on `GridToolbarContainer` causes a TS error (but styles correctly).

I realized that this issue is widespread.  Styling via `sx` is supported in the JavaScript anywhere that `{...other}` is passed down to a ` styled('div')`.  I have found a bunch (but not all) of these places and added `{ sx?: SxProps<Theme> }` to the props type so that it will be supported in the types.