### PR TITLE
[DateRangePicker] Open view on click, Enter or Space instead of focus

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
@@ -3,11 +3,11 @@ import { styled } from '@mui/material/styles';
 import {
   useUtils,
   executeInTheNextEventLoopTick,
-  WrapperVariantContext,
   DateInputProps,
   ExportedDateInputProps,
   MuiTextFieldProps,
   useMaskedInput,
+  onSpaceOrEnter,
 } from '@mui/x-date-pickers/internals';
 import { CurrentlySelectingRangeEndProps, DateRange } from '../internal/models/dateRange';
 import { DateRangeValidationError } from '../internal/hooks/validation/useDateRangeValidation';
@@ -94,7 +94,6 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
   const utils = useUtils<TDate>();
   const startRef = React.useRef<HTMLInputElement>(null);
   const endRef = React.useRef<HTMLInputElement>(null);
-  const wrapperVariant = React.useContext(WrapperVariantContext);
 
   React.useEffect(() => {
     if (!open) {
@@ -142,7 +141,17 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     }
   };
 
-  const openOnFocus = wrapperVariant === 'desktop';
+  const focusOnRangeEnd = () => {
+    if (open && setCurrentlySelectingRangeEnd) {
+      setCurrentlySelectingRangeEnd('end');
+    }
+  };
+
+  const focusOnRangeStart = () => {
+    if (open && setCurrentlySelectingRangeEnd) {
+      setCurrentlySelectingRangeEnd('start');
+    }
+  };
   const startInputProps = useMaskedInput({
     ...other,
     readOnly,
@@ -156,8 +165,9 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
       focused: open && currentlySelectingRangeEnd === 'start',
     },
     inputProps: {
-      onClick: !openOnFocus ? openRangeStartSelection : undefined,
-      onFocus: openOnFocus ? openRangeStartSelection : undefined,
+      onClick: openRangeStartSelection,
+      onKeyDown: onSpaceOrEnter(openRangeStartSelection),
+      onFocus: focusOnRangeStart,
     },
   });
 
@@ -174,8 +184,9 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
       focused: open && currentlySelectingRangeEnd === 'end',
     },
     inputProps: {
-      onClick: !openOnFocus ? openRangeEndSelection : undefined,
-      onFocus: openOnFocus ? openRangeEndSelection : undefined,
+      onClick: openRangeEndSelection,
+      onKeyDown: onSpaceOrEnter(openRangeEndSelection),
+      onFocus: focusOnRangeEnd,
     },
   });
 

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -154,6 +154,7 @@ describe('<DesktopDateRangePicker />', () => {
     );
 
     fireEvent.focus(screen.getAllByRole('textbox')[1]);
+    fireEvent.click(screen.getAllByRole('textbox')[1]);
 
     fireEvent.click(screen.getByLabelText('Jan 30, 2019'));
     fireEvent.click(screen.getByLabelText('Jan 19, 2019'));
@@ -178,7 +179,7 @@ describe('<DesktopDateRangePicker />', () => {
       </React.Fragment>,
     );
 
-    fireEvent.focus(screen.getAllByRole('textbox')[0]);
+    openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
     expect(screen.getByRole('tooltip')).toBeVisible();
 
     fireEvent.focus(screen.getByText('focus me'));
@@ -231,7 +232,7 @@ describe('<DesktopDateRangePicker />', () => {
       />,
     );
 
-    fireEvent.focus(screen.getAllByRole('textbox')[0]);
+    openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
     expect(screen.getByText('May 2019')).toBeVisible();
 
     fireEvent.focus(screen.getAllByRole('textbox')[1]);
@@ -253,7 +254,7 @@ describe('<DesktopDateRangePicker />', () => {
       />,
     );
 
-    fireEvent.focus(screen.getAllByRole('textbox')[0]);
+    openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
     expect(screen.getByRole('tooltip')).toBeVisible();
   });
 
@@ -355,7 +356,7 @@ describe('<DesktopDateRangePicker />', () => {
   });
 
   describe('picker state', () => {
-    it('should open when focusing the start input', () => {
+    it('should open when clicking the start input', () => {
       const onOpen = spy();
 
       render(<WrappedDesktopDateRangePicker onOpen={onOpen} initialValue={[null, null]} />);
@@ -366,7 +367,7 @@ describe('<DesktopDateRangePicker />', () => {
       expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
-    it('should open when focusing the end input', () => {
+    it('should open when clicking the end input', () => {
       const onOpen = spy();
 
       render(<WrappedDesktopDateRangePicker onOpen={onOpen} initialValue={[null, null]} />);
@@ -376,6 +377,36 @@ describe('<DesktopDateRangePicker />', () => {
       expect(onOpen.callCount).to.equal(1);
       expect(screen.getByRole('tooltip')).toBeVisible();
     });
+
+    ['Enter', ' '].forEach((key) =>
+      it(`should open when pressing "${key}" in the start input`, () => {
+        const onOpen = spy();
+
+        render(<WrappedDesktopDateRangePicker onOpen={onOpen} initialValue={[null, null]} />);
+
+        const startInput = screen.getAllByRole('textbox')[0];
+        startInput.focus();
+        fireEvent.keyDown(startInput, { key });
+
+        expect(onOpen.callCount).to.equal(1);
+        expect(screen.getByRole('tooltip')).toBeVisible();
+      }),
+    );
+
+    ['Enter', ' '].forEach((key) =>
+      it(`should open when pressing "${key}" in the end input`, () => {
+        const onOpen = spy();
+
+        render(<WrappedDesktopDateRangePicker onOpen={onOpen} initialValue={[null, null]} />);
+
+        const endInput = screen.getAllByRole('textbox')[1];
+        endInput.focus();
+        fireEvent.keyDown(endInput, { key });
+
+        expect(onOpen.callCount).to.equal(1);
+        expect(screen.getByRole('tooltip')).toBeVisible();
+      }),
+    );
 
     it('should call onChange with updated start date then call onChange with updated end date, onClose and onAccept with update date range when opening from start input', () => {
       const onChange = spy();

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -308,7 +308,9 @@ export const usePickerState = <TInputValue, TValue, TDate>(
       onChange: handleInputChange,
       open: isOpen,
       rawValue: value,
-      openPicker: () => setIsOpen(true),
+      openPicker: () => {
+        setIsOpen(true);
+      },
     }),
     [handleInputChange, isOpen, value, setIsOpen],
   );

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -39,7 +39,7 @@ export type { BasePickerProps } from './models/props/basePickerProps';
 export type { BaseToolbarProps } from './models/props/baseToolbarProps';
 export type { MuiPickersAdapter } from './models/muiPickersAdapter';
 
-export { executeInTheNextEventLoopTick } from './utils/utils';
+export { executeInTheNextEventLoopTick, onSpaceOrEnter } from './utils/utils';
 export { defaultReduceAnimations } from './utils/defaultReduceAnimations';
 
 export { PickersCalendarHeader } from '../CalendarPicker/PickersCalendarHeader';

--- a/test/utils/pickers-utils.tsx
+++ b/test/utils/pickers-utils.tsx
@@ -4,8 +4,8 @@ import {
   createRenderer,
   screen,
   RenderOptions,
-  fireEvent,
   userEvent,
+  fireEvent,
 } from '@mui/monorepo/test/utils';
 import { CreateRendererOptions } from '@mui/monorepo/test/utils/createRenderer';
 import { TransitionProps } from '@mui/material/transitions';
@@ -94,11 +94,8 @@ type OpenPickerParams =
 export const openPicker = (params: OpenPickerParams) => {
   if (params.type === 'date-range') {
     const target = screen.getAllByRole('textbox')[params.initialFocus === 'start' ? 0 : 1];
-    if (params.variant === 'mobile') {
-      return userEvent.mousePress(target);
-    }
 
-    return fireEvent.focus(target);
+    return userEvent.mousePress(target);
   }
 
   if (params.variant === 'mobile') {


### PR DESCRIPTION
Fix #4439

The view did not close on select, because the focus goes back to the input and DateRangePickerInput open the view when focussed, So `onOpen` was called just after `onClose`

I took the same behavior as mobile components: open the view on the click event, or when space/Enter is pressed

I did not managed to test the bug. I thought testing how many times `onOpen` is called would be enough because the bug add a `onOpen` after closing on select, but when running `yarn test:karma` I did not get the last call to `onOpen`