### PR TITLE
[test] Fix path to detect DataGrid tests

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -163,7 +163,7 @@ function App() {
           }
 
           let isDataGridTest = false;
-          if (path.indexOf('/docs-components-data-grid') === 0 || path.indexOf('/stories-') === 0) {
+          if (path.indexOf('/docs-data-grid') === 0 || path.indexOf('/stories-') === 0) {
             isDataGridTest = true;
           }
 


### PR DESCRIPTION
Follow-up to #4575

All argos screenshots are different because now they have a fixed width, instead of `100%`. It's weird #4575 didn't generate the base screenshots.