### PR TITLE
[core] Update monorepo & version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,8 +2600,8 @@
     react-transition-group "^4.4.2"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.6.3"
-  resolved "https://github.com/mui/material-ui.git#f622fa9efeea553a1f250ef28b884953b96c1543"
+  version "5.6.4"
+  resolved "https://github.com/mui/material-ui.git#a09acabfc4affd241b227ebb9418c271fba873b8"
 
 "@mui/private-theming@^5.6.2":
   version "5.6.2"


### PR DESCRIPTION
#4625 broke the master branch, we couldn't develop anymore.

```
./node_modules/@mui/monorepo/docs/packages/markdown/prism.js
Module parse failed: Cannot use 'import.meta' outside a module (87:16)
File was processed with these loaders:
 * ../node_modules/next/dist/compiled/@next/react-refresh-utils/loader.js
 * ../node_modules/next/dist/build/babel/loader/index.js
You may need an additional loader to handle the result of these loaders.
|                 // still a Refresh Boundary later.
|                 // @ts-ignore importMeta is replaced in the loader
>                 import.meta.webpackHot.accept();
|                 // This field is set when the previous version of this module was a
|                 // Refresh Boundary, letting us know we need to check for invalidation or
```

#4772 is meant to solve the issue, but for some reason, it didn't work on my end on master, I might have missed something with the cache. Anyway, I'm updating the version, it never harms.