### PR TITLE
[pickers] Drop `allowSameDateSelection` prop

### DIFF
--- a/docs/pages/x/api/date-pickers/calendar-picker.json
+++ b/docs/pages/x/api/date-pickers/calendar-picker.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "onChange": { "type": { "name": "func" }, "required": true },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "components": { "type": { "name": "object" }, "default": "{}" },
     "componentsProps": { "type": { "name": "object" }, "default": "{}" },
     "defaultCalendarMonth": { "type": { "name": "any" } },

--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "cancelText": { "type": { "name": "node" }, "default": "'Cancel'" },
     "className": { "type": { "name": "string" } },
     "clearable": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/date-pickers/date-range-picker-day.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-day.json
@@ -8,7 +8,6 @@
     "isStartOfHighlighting": { "type": { "name": "bool" }, "required": true },
     "isStartOfPreviewing": { "type": { "name": "bool" }, "required": true },
     "outsideCurrentMonth": { "type": { "name": "bool" }, "required": true },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
     "disabled": { "type": { "name": "bool" } },
     "disableHighlightToday": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -7,7 +7,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "calendars": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "cancelText": { "type": { "name": "node" }, "default": "'Cancel'" },

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "clearable": { "type": { "name": "bool" } },
     "clearText": { "type": { "name": "node" }, "default": "'Clear'" },

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -7,7 +7,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "calendars": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "cancelText": { "type": { "name": "node" }, "default": "'Cancel'" },
     "className": { "type": { "name": "string" } },
     "clearable": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -7,7 +7,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "calendars": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "cancelText": { "type": { "name": "node" }, "default": "'Cancel'" },

--- a/docs/pages/x/api/date-pickers/pickers-day.json
+++ b/docs/pages/x/api/date-pickers/pickers-day.json
@@ -2,7 +2,6 @@
   "props": {
     "day": { "type": { "name": "any" }, "required": true },
     "outsideCurrentMonth": { "type": { "name": "bool" }, "required": true },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" } },
     "disabled": { "type": { "name": "bool" } },
     "disableHighlightToday": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/date-pickers/static-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -7,7 +7,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "calendars": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.json
@@ -6,7 +6,6 @@
       "type": { "name": "instanceOf", "description": "RegExp" },
       "default": "/\\dap/gi"
     },
-    "allowSameDateSelection": { "type": { "name": "bool" } },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },

--- a/docs/translations/api-docs/date-pickers/calendar-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/calendar-picker-pt.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "components": "The components used for each slot. Either a string to use an HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "defaultCalendarMonth": "Default calendar month displayed when <code>value={null}</code>.",

--- a/docs/translations/api-docs/date-pickers/calendar-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/calendar-picker-zh.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "components": "The components used for each slot. Either a string to use an HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "defaultCalendarMonth": "Default calendar month displayed when <code>value={null}</code>.",

--- a/docs/translations/api-docs/date-pickers/calendar-picker.json
+++ b/docs/translations/api-docs/date-pickers/calendar-picker.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "components": "The components used for each slot. Either a string to use an HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "defaultCalendarMonth": "Default calendar month displayed when <code>value={null}</code>.",

--- a/docs/translations/api-docs/date-pickers/date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/date-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/date-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/date-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker-day-pt.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-day-pt.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "day": "The date to show.",
     "disabled": "If <code>true</code>, renders as disabled.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker-day-zh.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-day-zh.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "day": "The date to show.",
     "disabled": "If <code>true</code>, renders as disabled.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker-day.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-day.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "day": "The date to show.",
     "disabled": "If <code>true</code>, renders as disabled.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/date-pickers/date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/date-pickers/date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
     "clearText": "Clear text message.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
     "clearText": "Clear text message.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
     "clearText": "Clear text message.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-time-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-time-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",
     "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "cancelText": "Cancel text message.",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-time-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-time-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "cancelText": "Cancel text message.",

--- a/docs/translations/api-docs/date-pickers/pickers-day-pt.json
+++ b/docs/translations/api-docs/date-pickers/pickers-day-pt.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "day": "The date to show.",
     "disabled": "If <code>true</code>, renders as disabled.",

--- a/docs/translations/api-docs/date-pickers/pickers-day-zh.json
+++ b/docs/translations/api-docs/date-pickers/pickers-day-zh.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "day": "The date to show.",
     "disabled": "If <code>true</code>, renders as disabled.",

--- a/docs/translations/api-docs/date-pickers/pickers-day.json
+++ b/docs/translations/api-docs/date-pickers/pickers-day.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "day": "The date to show.",
     "disabled": "If <code>true</code>, renders as disabled.",

--- a/docs/translations/api-docs/date-pickers/static-date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/static-date-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",
     "components": "The components used for each slot. Either a string to use an HTML element or a component.",

--- a/docs/translations/api-docs/date-pickers/static-date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/static-date-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",
     "components": "The components used for each slot. Either a string to use an HTML element or a component.",

--- a/docs/translations/api-docs/date-pickers/static-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",
     "components": "The components used for each slot. Either a string to use an HTML element or a component.",

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",

--- a/docs/translations/api-docs/date-pickers/static-date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/static-date-time-picker-pt.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/static-date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/static-date-time-picker-zh.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/docs/translations/api-docs/date-pickers/static-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-time-picker.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
-    "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -89,11 +89,6 @@ DateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -254,7 +254,6 @@ const DateRangePickerDayRaw = React.forwardRef(function DateRangePickerDay<TDate
           {...other}
           ref={ref}
           disableMargin
-          allowSameDateSelection
           day={day}
           selected={selected}
           outsideCurrentMonth={outsideCurrentMonth}
@@ -272,11 +271,6 @@ DateRangePickerDayRaw.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
    */

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -105,11 +105,6 @@ DesktopDateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -110,11 +110,6 @@ MobileDateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -93,11 +93,6 @@ StaticDateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -362,11 +362,6 @@ CalendarPicker.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   classes: PropTypes.object,
   className: PropTypes.string,

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -15,7 +15,7 @@ import {
 export interface ExportedDayPickerProps<TDate>
   extends Pick<
     PickersDayProps<TDate>,
-    'disableHighlightToday' | 'showDaysOutsideCurrentMonth' | 'allowSameDateSelection'
+    'disableHighlightToday' | 'showDaysOutsideCurrentMonth'
   > {
   autoFocus?: boolean;
   /**
@@ -109,7 +109,6 @@ const PickersCalendarWeek = styled('div')({
  */
 export function DayPicker<TDate, TValue>(props: DayPickerProps<TDate, TValue>) {
   const {
-    allowSameDateSelection,
     autoFocus,
     onFocusedDayChange: changeFocusedDay,
     className,
@@ -200,7 +199,6 @@ export function DayPicker<TDate, TValue>(props: DayPickerProps<TDate, TValue>) {
                     day,
                     isAnimating: isMonthSwitchingAnimating,
                     disabled: disabled || isDateDisabled(day),
-                    allowSameDateSelection,
                     autoFocus: autoFocus && focusedDay !== null && utils.isSameDay(day, focusedDay),
                     today: utils.isSameDay(day, now),
                     outsideCurrentMonth: utils.getMonth(day) !== currentMonthNumber,

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -13,10 +13,7 @@ import {
 } from './PickersSlideTransition';
 
 export interface ExportedDayPickerProps<TDate>
-  extends Pick<
-    PickersDayProps<TDate>,
-    'disableHighlightToday' | 'showDaysOutsideCurrentMonth'
-  > {
+  extends Pick<PickersDayProps<TDate>, 'disableHighlightToday' | 'showDaysOutsideCurrentMonth'> {
   autoFocus?: boolean;
   /**
    * If `true` renders `LoadingComponent` in calendar instead of calendar view.

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -84,11 +84,6 @@ DatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * Cancel text message.

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -85,11 +85,6 @@ DateTimePicker.propTypes = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */

--- a/packages/x-date-pickers/src/DateTimePicker/shared.ts
+++ b/packages/x-date-pickers/src/DateTimePicker/shared.ts
@@ -121,7 +121,6 @@ export function useDateTimePickerDefaultizedProps<
     views: ['year', 'day', 'hours', 'minutes'],
     ampmInClock: true,
     showToolbar: false,
-    allowSameDateSelection: true,
     mask: ampm ? '__/__/____ __:__ _m' : '__/__/____ __:__',
     acceptRegex: ampm ? /[\dap]/gi : /\d/gi,
     disableMaskedInput: false,

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -497,7 +497,7 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    it.only('should not call onAccept when selecting the same date', () => {
+    it('should not call onAccept when selecting the same date', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -497,7 +497,40 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    // TODO: Write test once the `allowSameDateSelection` behavior is cleaned
-    // it('should not (?) call onChange and onAccept if same date selected', () => {});
+    it.only('should call onAccept when selecting the same date after changing the year', () => {
+      const onChange = spy();
+      const onAccept = spy();
+      const onClose = spy();
+
+      render(
+          <WrappedDesktopDatePicker
+              onChange={onChange}
+              onAccept={onAccept}
+              onClose={onClose}
+              initialValue={adapterToUse.date('2018-01-01T00:00:00.000')}
+              openTo='year'
+          />,
+      );
+
+      openPicker({ type: 'date', variant: 'desktop' });
+
+      // Select year
+      userEvent.mousePress(screen.getByRole('button', { name: '2025' }));
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.lastCall.args[0]).toEqualDateTime(
+          adapterToUse.date('2025-01-01T00:00:00.000'),
+      );
+      expect(onAccept.callCount).to.equal(0);
+      expect(onClose.callCount).to.equal(0);
+
+      // Change the date (same date)
+      userEvent.mousePress(screen.getByLabelText('Jan 1, 2025'));
+      expect(onChange.callCount).to.equal(1); // Don't call onClose again since the date did not change
+      expect(onAccept.callCount).to.equal(1);
+      expect(onAccept.lastCall.args[0]).toEqualDateTime(
+          adapterToUse.date('2025-01-01T00:00:00.000'),
+      );
+      expect(onClose.callCount).to.equal(1);
+    });
   });
 });

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -497,19 +497,19 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    it.only('should call onAccept when selecting the same date after changing the year', () => {
+    it('should call onAccept when selecting the same date after changing the year', () => {
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();
 
       render(
-          <WrappedDesktopDatePicker
-              onChange={onChange}
-              onAccept={onAccept}
-              onClose={onClose}
-              initialValue={adapterToUse.date('2018-01-01T00:00:00.000')}
-              openTo='year'
-          />,
+        <WrappedDesktopDatePicker
+          onChange={onChange}
+          onAccept={onAccept}
+          onClose={onClose}
+          initialValue={adapterToUse.date('2018-01-01T00:00:00.000')}
+          openTo="year"
+        />,
       );
 
       openPicker({ type: 'date', variant: 'desktop' });
@@ -518,17 +518,17 @@ describe('<DesktopDatePicker />', () => {
       userEvent.mousePress(screen.getByRole('button', { name: '2025' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(
-          adapterToUse.date('2025-01-01T00:00:00.000'),
+        adapterToUse.date('2025-01-01T00:00:00.000'),
       );
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
 
-      // Change the date (same date)
+      // Change the date (same value)
       userEvent.mousePress(screen.getByLabelText('Jan 1, 2025'));
-      expect(onChange.callCount).to.equal(1); // Don't call onClose again since the date did not change
+      expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
       expect(onAccept.callCount).to.equal(1);
       expect(onAccept.lastCall.args[0]).toEqualDateTime(
-          adapterToUse.date('2025-01-01T00:00:00.000'),
+        adapterToUse.date('2025-01-01T00:00:00.000'),
       );
       expect(onClose.callCount).to.equal(1);
     });

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -497,6 +497,29 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
+    it.only('should not call onAccept when selecting the same date', () => {
+      const onChange = spy();
+      const onAccept = spy();
+      const onClose = spy();
+
+      render(
+        <WrappedDesktopDatePicker
+          onChange={onChange}
+          onAccept={onAccept}
+          onClose={onClose}
+          initialValue={adapterToUse.date('2018-01-01T00:00:00.000')}
+        />,
+      );
+
+      openPicker({ type: 'date', variant: 'desktop' });
+
+      // Change the date (same value)
+      userEvent.mousePress(screen.getByLabelText('Jan 1, 2018'));
+      expect(onChange.callCount).to.equal(0); // Don't call onChange since the value did not change
+      expect(onAccept.callCount).to.equal(0);
+      expect(onClose.callCount).to.equal(1);
+    });
+
     it('should call onAccept when selecting the same date after changing the year', () => {
       const onChange = spy();
       const onAccept = spy();

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -92,11 +92,6 @@ DesktopDatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -482,7 +482,54 @@ describe('<DesktopDateTimePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
-    // TODO: Write test once the `allowSameDateSelection` behavior is cleaned
-    // it('should not (?) call onChange and onAccept if same date selected', () => {});
+    it('should call onAccept when selecting the same date and time after changing the year', () => {
+      const onChange = spy();
+      const onAccept = spy();
+      const onClose = spy();
+
+      render(
+        <WrappedDesktopDateTimePicker
+          onChange={onChange}
+          onAccept={onAccept}
+          onClose={onClose}
+          initialValue={adapterToUse.date('2018-01-01T11:53:00.000')}
+          openTo="year"
+        />,
+      );
+
+      openPicker({ type: 'date', variant: 'desktop' });
+
+      // Select year
+      userEvent.mousePress(screen.getByRole('button', { name: '2025' }));
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.lastCall.args[0]).toEqualDateTime(
+        adapterToUse.date('2025-01-01T11:53:00.000'),
+      );
+      expect(onAccept.callCount).to.equal(0);
+      expect(onClose.callCount).to.equal(0);
+
+      // Change the date (same value)
+      userEvent.mousePress(screen.getByLabelText('Jan 1, 2025'));
+      expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
+      expect(onAccept.callCount).to.equal(0);
+      expect(onClose.callCount).to.equal(0);
+
+      // Change the hours (same value)
+      fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mousemove'));
+      fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mouseup'));
+      expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
+      expect(onAccept.callCount).to.equal(0);
+      expect(onClose.callCount).to.equal(0);
+
+      // Change the minutes (same value)
+      fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mousemove'));
+      fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mouseup'));
+      expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
+      expect(onAccept.callCount).to.equal(1);
+      expect(onAccept.lastCall.args[0]).toEqualDateTime(
+        adapterToUse.date('2025-01-01T11:53:00.000'),
+      );
+      expect(onClose.callCount).to.equal(1);
+    });
   });
 });

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -97,11 +97,6 @@ DesktopDateTimePicker.propTypes = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -535,11 +535,5 @@ describe('<DesktopTimePicker />', () => {
       expect(onAccept.lastCall.args[0]).to.equal(null);
       expect(onClose.callCount).to.equal(1);
     });
-
-    // TODO: Write test once the `allowSameDateSelection` behavior is cleaned
-    // it('should not (?) call onChange and onAccept if same hour selected', () => {});
-
-    // TODO: Write test once the `allowSameDateSelection` behavior is cleaned
-    // it('should not (?) call onChange and onAccept if same minute selected', () => {});
   });
 });

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -77,11 +77,6 @@ MobileDatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * Cancel text message.

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -81,11 +81,6 @@ MobileDateTimePicker.propTypes = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.spec.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.spec.tsx
@@ -1,8 +1,4 @@
 import * as React from 'react';
 import { PickersDay } from '@mui/x-date-pickers/PickersDay';
 
-<PickersDay<Date>
-  day={new Date()}
-  outsideCurrentMonth
-  onDaySelect={(date) => date?.getDay()}
-/>;
+<PickersDay<Date> day={new Date()} outsideCurrentMonth onDaySelect={(date) => date?.getDay()} />;

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.spec.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.spec.tsx
@@ -3,7 +3,6 @@ import { PickersDay } from '@mui/x-date-pickers/PickersDay';
 
 <PickersDay<Date>
   day={new Date()}
-  allowSameDateSelection
   outsideCurrentMonth
   onDaySelect={(date) => date?.getDay()}
 />;

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -20,11 +20,6 @@ import {
 
 export interface PickersDayProps<TDate> extends ExtendMui<ButtonBaseProps> {
   /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection?: boolean;
-  /**
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<PickersDayClasses>;
@@ -200,7 +195,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
   });
 
   const {
-    allowSameDateSelection = false,
     autoFocus = false,
     className,
     day,
@@ -223,7 +217,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
   } = props;
   const ownerState = {
     ...props,
-    allowSameDateSelection,
     autoFocus,
     disabled,
     disableHighlightToday,
@@ -259,10 +252,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
   };
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (!allowSameDateSelection && selected) {
-      return;
-    }
-
     if (!disabled) {
       onDaySelect(day, 'finish');
     }
@@ -371,11 +360,6 @@ PickersDayRaw.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
    */

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -78,11 +78,6 @@ StaticDatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
   autoFocus: PropTypes.bool,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -79,11 +79,6 @@ StaticDateTimePicker.propTypes = {
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
   /**
-   * If `true`, `onChange` is fired on click even if the same date is selected.
-   * @default false
-   */
-  allowSameDateSelection: PropTypes.bool,
-  /**
    * 12h/24h view for hour selection clock.
    * @default false
    */


### PR DESCRIPTION
Fixes #4456
Fixes #4727 
Part of #4728

Now that we don't fire `onChange` when the new value is equal to the old one, I don't see any reason to keep this prop.

- On `DateTimePicker` it is set to `true` (equivalent to not having it)
- On `DatePicker` it is set to `false` and it causes the bug of #4456 
- On `DateRangePicker` it is not used
- On `TimePicker` it is not used

## Behavior

If we click on the current date, it validate just like another date
It will never call `onClose` since the value did not change since the last value update
It will only call `onAccept` if another view value has changed

## What's next ?

I will prepare a follow up PR to implement https://github.com/mui/material-ui-pickers/issues/1759#issuecomment-628894726