### PR TITLE
[data grid] Only publish `preferencePanelClose` event once when closing panel by clicking on another panel button

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/preferencesPanel/useGridPreferencesPanel.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/preferencesPanel/useGridPreferencesPanel.ts
@@ -29,7 +29,7 @@ export const useGridPreferencesPanel = (apiRef: React.MutableRefObject<GridApiCo
    */
   const hidePreferences = React.useCallback(() => {
     logger.debug('Hiding Preferences Panel');
-    const preferencePanelState = gridPreferencePanelStateSelector(apiRef.current.state)
+    const preferencePanelState = gridPreferencePanelStateSelector(apiRef.current.state);
     if (preferencePanelState.openedPanelValue) {
       apiRef.current.publishEvent('preferencePanelClose', {
         openedPanelValue: preferencePanelState.openedPanelValue,

--- a/packages/grid/x-data-grid/src/hooks/features/preferencesPanel/useGridPreferencesPanel.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/preferencesPanel/useGridPreferencesPanel.ts
@@ -7,7 +7,6 @@ import { GridPipeProcessor, useGridRegisterPipeProcessor } from '../../core/pipe
 import { gridPreferencePanelStateSelector } from './gridPreferencePanelSelector';
 import { GridPreferencesPanelApi } from '../../../models/api/gridPreferencesPanelApi';
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
-import { useGridSelector } from '../../utils/useGridSelector';
 
 export const preferencePanelStateInitializer: GridStateInitializer<
   Pick<DataGridProcessedProps, 'initialState'>
@@ -22,8 +21,6 @@ export const preferencePanelStateInitializer: GridStateInitializer<
 export const useGridPreferencesPanel = (apiRef: React.MutableRefObject<GridApiCommunity>): void => {
   const logger = useGridLogger(apiRef, 'useGridPreferencesPanel');
 
-  const preferencePanelState = useGridSelector(apiRef, gridPreferencePanelStateSelector);
-
   const hideTimeout = React.useRef<any>();
   const immediateTimeout = React.useRef<any>();
 
@@ -32,6 +29,7 @@ export const useGridPreferencesPanel = (apiRef: React.MutableRefObject<GridApiCo
    */
   const hidePreferences = React.useCallback(() => {
     logger.debug('Hiding Preferences Panel');
+    const preferencePanelState = gridPreferencePanelStateSelector(apiRef.current.state)
     if (preferencePanelState.openedPanelValue) {
       apiRef.current.publishEvent('preferencePanelClose', {
         openedPanelValue: preferencePanelState.openedPanelValue,
@@ -39,7 +37,7 @@ export const useGridPreferencesPanel = (apiRef: React.MutableRefObject<GridApiCo
     }
     apiRef.current.setState((state) => ({ ...state, preferencePanel: { open: false } }));
     apiRef.current.forceUpdate();
-  }, [apiRef, logger, preferencePanelState.openedPanelValue]);
+  }, [apiRef, logger]);
 
   // This is to prevent the preferences from closing when you open a select box or another panel,
   // The issue is in MUI core V4 => Fixed in V5


### PR DESCRIPTION
Part of #4737

The check in `hidePreferences` to know if the panel is opened was based on the state from the state render.
When calling `hidePreferences` synchronously after `showPreferences`, we could have an outdated state and thus an invalid check leading to an unwanted event publication.