### PR TITLE
[docs] Keep columns section expanded when switching between pages

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -17,16 +17,7 @@ const pages = [
       { pathname: '/x/react-data-grid/layout' },
       {
         pathname: '/x/react-data-grid/columns',
-        scopePathnames: [
-          '/x/react-data-grid/column-definition',
-          '/x/react-data-grid/column-dimensions',
-          '/x/react-data-grid/column-visibility',
-          '/x/react-data-grid/column-header',
-          '/x/react-data-grid/column-ordering',
-          '/x/react-data-grid/column-pinning',
-          '/x/react-data-grid/column-spanning',
-          '/x/react-data-grid/column-groups',
-        ],
+        scopePathnames: ['/x/react-data-grid/column-'],
         children: [
           { pathname: '/x/react-data-grid/column-definition' },
           { pathname: '/x/react-data-grid/column-dimensions' },


### PR DESCRIPTION
Quick followup on #4600

Before:

https://user-images.githubusercontent.com/13808724/167468001-5e7c4965-de4b-4155-9cf0-1c2b21faee31.mov

After:

https://user-images.githubusercontent.com/13808724/167468024-3eb3aded-b576-4fe8-ac76-431b46a8e688.mov


