### PR TITLE
[pickers] Invalid character does not delete last digit

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -142,7 +142,7 @@ describe('<DesktopDatePicker /> keyboard interactions', () => {
 
   describe('input validaiton', () => {
     [
-      { expectedError: 'invalidDate', props: {}, input: 'invalidText' },
+      { expectedError: 'invalidDate', props: { disableMaskedInput: true }, input: 'invalidText' },
       { expectedError: 'disablePast', props: { disablePast: true }, input: '01/01/1900' },
       { expectedError: 'disableFuture', props: { disableFuture: true }, input: '01/01/2050' },
       {

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -140,7 +140,7 @@ describe('<DesktopDatePicker /> keyboard interactions', () => {
     });
   });
 
-  describe('input validaiton', () => {
+  describe('input validation', () => {
     [
       { expectedError: 'invalidDate', props: { disableMaskedInput: true }, input: 'invalidText' },
       { expectedError: 'disablePast', props: { disablePast: true }, input: '01/01/1900' },

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -211,7 +211,7 @@ describe('<DesktopTimePicker />', () => {
       value === 10;
 
     [
-      { expectedError: 'invalidDate', props: {}, input: 'invalidText' },
+      { expectedError: 'invalidDate', props: { disableMaskedInput: true }, input: 'invalidText' },
       {
         expectedError: 'minTime',
         props: { minTime: adapterToUse.date(`2000-01-01T08:00:00.000`) },

--- a/packages/x-date-pickers/src/internals/utils/text-field-helper.test.ts
+++ b/packages/x-date-pickers/src/internals/utils/text-field-helper.test.ts
@@ -14,6 +14,7 @@ describe('text-field-helper', () => {
     expect(formatterFn('21/12/2010')).to.equal('21/12/2010');
     expect(formatterFn('21-12-2010')).to.equal('21/12/2010');
     expect(formatterFn('2f')).to.equal('2');
+    expect(formatterFn('21/1g2/2010')).to.equal('21/12/2010');
   });
 
   it('maskedDateFormatter for time', () => {

--- a/packages/x-date-pickers/src/internals/utils/text-field-helper.ts
+++ b/packages/x-date-pickers/src/internals/utils/text-field-helper.ts
@@ -109,7 +109,6 @@ export const maskedDateFormatter = (mask: string, acceptRegexp: RegExp) => (valu
       const nextMaskChar = mask[outputCharIndex + 1];
 
       const acceptedChar = acceptRegexp.test(char) ? char : '';
-
       const formattedChar =
         maskChar === MASK_USER_INPUT_SYMBOL ? acceptedChar : maskChar + acceptedChar;
 

--- a/packages/x-date-pickers/src/internals/utils/text-field-helper.ts
+++ b/packages/x-date-pickers/src/internals/utils/text-field-helper.ts
@@ -95,23 +95,28 @@ export function checkMaskIsValidForCurrentFormat(
 }
 
 export const maskedDateFormatter = (mask: string, acceptRegexp: RegExp) => (value: string) => {
+  let outputCharIndex = 0;
   return value
     .split('')
-    .map((char, i) => {
+    .map((char, inputCharIndex) => {
       acceptRegexp.lastIndex = 0;
 
-      if (i > mask.length - 1) {
+      if (outputCharIndex > mask.length - 1) {
         return '';
       }
 
-      const maskChar = mask[i];
-      const nextMaskChar = mask[i + 1];
+      const maskChar = mask[outputCharIndex];
+      const nextMaskChar = mask[outputCharIndex + 1];
 
       const acceptedChar = acceptRegexp.test(char) ? char : '';
+
       const formattedChar =
         maskChar === MASK_USER_INPUT_SYMBOL ? acceptedChar : maskChar + acceptedChar;
 
-      if (i === value.length - 1 && nextMaskChar && nextMaskChar !== MASK_USER_INPUT_SYMBOL) {
+      outputCharIndex += formattedChar.length;
+
+      const isLastCharacter = inputCharIndex === value.length - 1;
+      if (isLastCharacter && nextMaskChar && nextMaskChar !== MASK_USER_INPUT_SYMBOL) {
         // when cursor at the end of mask part (e.g. month) prerender next symbol "21" -> "21/"
         return formattedChar ? formattedChar + nextMaskChar : '';
       }


### PR DESCRIPTION
Fix #4838

The problem comes from the classical mistake of deleting elements from an array and making a mix between the original and filtered array.

The bug occurs as follows:
- User type a full date `01/02/1921`
- The press a letter in the middle. Such as the new value to parse is `01/0g2/1921`
- Since `g` is not a valid character it will be removed.
- when arriving at the last character we rely on it's index in the input string to know if it overflow the mask. SInce it's the case, it's deleted

This is a quick fix for the bug
