### PR TITLE
[docs] Disable ads on paid-only pages

### DIFF
--- a/docs/pages/x/react-data-grid/column-pinning.js
+++ b/docs/pages/x/react-data-grid/column-pinning.js
@@ -7,5 +7,5 @@ import {
 } from 'docsx/data/data-grid/column-pinning/column-pinning.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} disableAd />;
 }

--- a/docs/pages/x/react-data-grid/events.js
+++ b/docs/pages/x/react-data-grid/events.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import { demos, docs, demoComponents } from 'docsx/data/data-grid/events/events.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} disableAd />;
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/x/react-data-grid/state.js
+++ b/docs/pages/x/react-data-grid/state.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import { demos, docs, demoComponents } from 'docsx/data/data-grid/state/state.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} disableAd />;
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/x/react-date-pickers/date-range-picker.js
+++ b/docs/pages/x/react-date-pickers/date-range-picker.js
@@ -7,5 +7,5 @@ import {
 } from 'docsx/data/date-pickers/date-range-picker/date-range-picker.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} disableAd />;
 }


### PR DESCRIPTION
Following a discussion on Slack.
I did not remember that we disabled the add on paid-only pages so my recent migration did not respect it.