### PR TITLE
[TimePicker] Don't merge with previous value when new value is not valid

### DIFF
--- a/packages/x-date-pickers/src/TimePicker/shared.ts
+++ b/packages/x-date-pickers/src/TimePicker/shared.ts
@@ -87,11 +87,11 @@ export const timePickerValueManager: PickerStateValueManager<any, any, any> = {
   parseInput: parsePickerInputValue,
   getTodayValue: (utils) => utils.date()!,
   areValuesEqual: (utils, a, b) => utils.isEqual(a, b),
-  valueReducer: (utils, prevValue, newValue) => {
-    if (prevValue == null || newValue == null) {
+  valueReducer: (utils, lastValidValue, newValue) => {
+    if (!lastValidValue || !utils.isValid(newValue)) {
       return newValue;
     }
-
-    return utils.mergeDateAndTime(prevValue, newValue);
+    
+    return utils.mergeDateAndTime(lastValidValue, newValue);
   },
 };

--- a/packages/x-date-pickers/src/TimePicker/shared.ts
+++ b/packages/x-date-pickers/src/TimePicker/shared.ts
@@ -91,7 +91,7 @@ export const timePickerValueManager: PickerStateValueManager<any, any, any> = {
     if (!lastValidValue || !utils.isValid(newValue)) {
       return newValue;
     }
-    
+
     return utils.mergeDateAndTime(lastValidValue, newValue);
   },
 };

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -41,11 +41,11 @@ export interface PickerStateValueManager<TInputValue, TValue, TDate> {
    * Generates the new value, given the previous value and the new proposed value.
    * @template TDate, TValue
    * @param {MuiPickersAdapter<TDate>} utils The adapter.
-   * @param {TValue} prevValue The previous value.
+   * @param {TValue} lastValidDateValue The last valid value.
    * @param {TValue} value The proposed value.
    * @returns {TValue} The new value.
    */
-  valueReducer?: (utils: MuiPickersAdapter<TDate>, prevValue: TValue, value: TValue) => TValue;
+  valueReducer?: (utils: MuiPickersAdapter<TDate>, lastValidDateValue: TValue, value: TValue) => TValue;
 }
 
 export type PickerSelectionState = 'partial' | 'shallow' | 'finish';
@@ -231,10 +231,11 @@ export const usePickerState = <TInputValue, TValue, TDate>(
   );
 
   React.useEffect(() => {
-    if (parsedDateValue != null) {
+    if (utils.isValid(parsedDateValue)) {
+      console.log('VALID', parsedDateValue)
       setLastValidDateValue(parsedDateValue);
     }
-  }, [parsedDateValue]);
+  }, [utils, parsedDateValue]);
 
   React.useEffect(() => {
     if (isOpen) {

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -232,7 +232,6 @@ export const usePickerState = <TInputValue, TValue, TDate>(
 
   React.useEffect(() => {
     if (utils.isValid(parsedDateValue)) {
-      console.log('VALID', parsedDateValue)
       setLastValidDateValue(parsedDateValue);
     }
   }, [utils, parsedDateValue]);

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -45,7 +45,11 @@ export interface PickerStateValueManager<TInputValue, TValue, TDate> {
    * @param {TValue} value The proposed value.
    * @returns {TValue} The new value.
    */
-  valueReducer?: (utils: MuiPickersAdapter<TDate>, lastValidDateValue: TValue, value: TValue) => TValue;
+  valueReducer?: (
+    utils: MuiPickersAdapter<TDate>,
+    lastValidDateValue: TValue,
+    value: TValue,
+  ) => TValue;
 }
 
 export type PickerSelectionState = 'partial' | 'shallow' | 'finish';


### PR DESCRIPTION
Fixes #4751

[Behavior before](https://codesandbox.io/s/date-and-time-pickers-forked-cxyxoq?file=/src/App.tsx)
[Behavior after](https://codesandbox.io/s/date-and-time-pickers-forked-yeomeg?file=/src/App.tsx)

To test it fully:

1. Focus the end of the input
2. Press the back key until you remove the `3`
3. Type `2 AM`

The date logged below should still be in 2018