### PR TITLE
[DateTimePicker] Infinite loop in TrapFocus

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -285,6 +285,10 @@ export const PickersPopper = (props: PickerPopperProps) => {
     ...otherPaperProps
   } = PaperProps;
 
+  const openRef = React.useRef(true);
+  openRef.current = open;
+  const isTrapFocusEnabled = React.useCallback(() => openRef.current, []);
+
   return (
     <PickersPopperRoot
       transition
@@ -294,46 +298,48 @@ export const PickersPopper = (props: PickerPopperProps) => {
       ownerState={ownerState}
       {...PopperProps}
     >
-      {({ TransitionProps, placement }) => (
-        <TrapFocus
-          open={open}
-          disableAutoFocus
-          disableEnforceFocus={role === 'tooltip'}
-          isEnabled={() => true}
-          {...TrapFocusProps}
-        >
-          <TransitionComponent {...TransitionProps}>
-            <PickersPopperPaper
-              tabIndex={-1}
-              elevation={8}
-              ref={handlePaperRef}
-              onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-                onPaperClick(event);
-                if (onPaperClickProp) {
-                  onPaperClickProp(event);
-                }
-              }}
-              onTouchStart={(event: React.TouchEvent<HTMLDivElement>) => {
-                onPaperTouchStart(event);
-                if (onPaperTouchStartProp) {
-                  onPaperTouchStartProp(event);
-                }
-              }}
-              ownerState={{ ...ownerState, placement }}
-              {...otherPaperProps}
-            >
-              {children}
-              <PickersPopperAction ownerState={ownerState}>
-                {clearable && (
-                  <Button data-mui-test="clear-action-button" onClick={onClear}>
-                    {clearText}
-                  </Button>
-                )}
-              </PickersPopperAction>
-            </PickersPopperPaper>
-          </TransitionComponent>
-        </TrapFocus>
-      )}
+      {({ TransitionProps, placement }) => {
+        return (
+          <TrapFocus
+            open={open}
+            disableAutoFocus
+            disableEnforceFocus={role === 'tooltip'}
+            isEnabled={isTrapFocusEnabled}
+            {...TrapFocusProps}
+          >
+            <TransitionComponent {...TransitionProps}>
+              <PickersPopperPaper
+                tabIndex={-1}
+                elevation={8}
+                ref={handlePaperRef}
+                onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+                  onPaperClick(event);
+                  if (onPaperClickProp) {
+                    onPaperClickProp(event);
+                  }
+                }}
+                onTouchStart={(event: React.TouchEvent<HTMLDivElement>) => {
+                  onPaperTouchStart(event);
+                  if (onPaperTouchStartProp) {
+                    onPaperTouchStartProp(event);
+                  }
+                }}
+                ownerState={{ ...ownerState, placement }}
+                {...otherPaperProps}
+              >
+                {children}
+                <PickersPopperAction ownerState={ownerState}>
+                  {clearable && (
+                    <Button data-mui-test="clear-action-button" onClick={onClear}>
+                      {clearText}
+                    </Button>
+                  )}
+                </PickersPopperAction>
+              </PickersPopperPaper>
+            </TransitionComponent>
+          </TrapFocus>
+        );
+      }}
     </PickersPopperRoot>
   );
 };

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -298,48 +298,46 @@ export const PickersPopper = (props: PickerPopperProps) => {
       ownerState={ownerState}
       {...PopperProps}
     >
-      {({ TransitionProps, placement }) => {
-        return (
-          <TrapFocus
-            open={open}
-            disableAutoFocus
-            disableEnforceFocus={role === 'tooltip'}
-            isEnabled={isTrapFocusEnabled}
-            {...TrapFocusProps}
-          >
-            <TransitionComponent {...TransitionProps}>
-              <PickersPopperPaper
-                tabIndex={-1}
-                elevation={8}
-                ref={handlePaperRef}
-                onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-                  onPaperClick(event);
-                  if (onPaperClickProp) {
-                    onPaperClickProp(event);
-                  }
-                }}
-                onTouchStart={(event: React.TouchEvent<HTMLDivElement>) => {
-                  onPaperTouchStart(event);
-                  if (onPaperTouchStartProp) {
-                    onPaperTouchStartProp(event);
-                  }
-                }}
-                ownerState={{ ...ownerState, placement }}
-                {...otherPaperProps}
-              >
-                {children}
-                <PickersPopperAction ownerState={ownerState}>
-                  {clearable && (
-                    <Button data-mui-test="clear-action-button" onClick={onClear}>
-                      {clearText}
-                    </Button>
-                  )}
-                </PickersPopperAction>
-              </PickersPopperPaper>
-            </TransitionComponent>
-          </TrapFocus>
-        );
-      }}
+      {({ TransitionProps, placement }) => (
+        <TrapFocus
+          open={open}
+          disableAutoFocus
+          disableEnforceFocus={role === 'tooltip'}
+          isEnabled={isTrapFocusEnabled}
+          {...TrapFocusProps}
+        >
+          <TransitionComponent {...TransitionProps}>
+            <PickersPopperPaper
+              tabIndex={-1}
+              elevation={8}
+              ref={handlePaperRef}
+              onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+                onPaperClick(event);
+                if (onPaperClickProp) {
+                  onPaperClickProp(event);
+                }
+              }}
+              onTouchStart={(event: React.TouchEvent<HTMLDivElement>) => {
+                onPaperTouchStart(event);
+                if (onPaperTouchStartProp) {
+                  onPaperTouchStartProp(event);
+                }
+              }}
+              ownerState={{ ...ownerState, placement }}
+              {...otherPaperProps}
+            >
+              {children}
+              <PickersPopperAction ownerState={ownerState}>
+                {clearable && (
+                  <Button data-mui-test="clear-action-button" onClick={onClear}>
+                    {clearText}
+                  </Button>
+                )}
+              </PickersPopperAction>
+            </PickersPopperPaper>
+          </TransitionComponent>
+        </TrapFocus>
+      )}
     </PickersPopperRoot>
   );
 };


### PR DESCRIPTION
Fixes #4595

[Behavior before](https://tbmhyd.csb.app/)
[Behavior after](https://3jikig.csb.app/)

To test you need to open the picker, select a date to go to the hour view, then click on "Click me".
You should then have dozens of log in the console.

___

Working with `TrapFocus` is always the far-west.
From what I understood, when closing the picker while on clock view and opening a `Dialog` (with it own `TrapFocus`) at the same time, then we ended up in a situation where 2 `TrapFocus` were fighting for the focus.

The problem being that in `TrapFocus`, the `useEffect` tracking `isEnabled` and `open` is not fired after the infinite loop.

My fix is just to use `isEnabled` with a ref to have the latest version of `open` and break this infinite chain.

___

I guess in the future we could ask users to use `React.useEvent` for `isEnabled` rather than relying on a `useEffect` update.
(not sure if it will work, it depends on the implementation on React I guess)

@michaldudak if you have some insights.