### PR TITLE
[core] Fix naming collision

### DIFF
--- a/packages/x-date-pickers-pro/src/themeAugmentation/components.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/components.d.ts
@@ -1,6 +1,6 @@
 import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@mui/material/styles';
 
-export interface PickerComponents {
+export interface PickersProComponents {
   MuiDateRangePickerDay?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
     styleOverrides?: ComponentsOverrides['MuiDateRangePickerDay'];
@@ -9,5 +9,5 @@ export interface PickerComponents {
 }
 
 declare module '@mui/material/styles' {
-  interface Components extends PickerComponents {}
+  interface Components extends PickersProComponents {}
 }

--- a/packages/x-date-pickers-pro/src/themeAugmentation/overrides.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/overrides.d.ts
@@ -1,12 +1,12 @@
 import { DateRangePickerDayClassKey } from '../DateRangePickerDay';
 
 // prettier-ignore
-export interface LabComponentNameToClassKey {
+export interface PickersProComponentNameToClassKey {
   MuiDateRangePickerDay: DateRangePickerDayClassKey;
 }
 
 declare module '@mui/material/styles' {
-  interface ComponentNameToClassKey extends LabComponentNameToClassKey {}
+  interface ComponentNameToClassKey extends PickersProComponentNameToClassKey {}
 }
 
 // disable automatic export

--- a/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
@@ -1,11 +1,11 @@
 import { DateRangePickerDayProps } from '../DateRangePickerDay';
 
-export interface LabComponentsPropsList {
+export interface PickersProComponentsPropsList {
   MuiDateRangePickerDay: DateRangePickerDayProps<unknown>;
 }
 
 declare module '@mui/material/styles' {
-  interface ComponentsPropsList extends LabComponentsPropsList {}
+  interface ComponentsPropsList extends PickersProComponentsPropsList {}
 }
 
 // disable automatic export

--- a/packages/x-date-pickers/src/themeAugmentation/overrides.d.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/overrides.d.ts
@@ -7,7 +7,7 @@ import { YearPickerClassKey } from '../YearPicker';
 import { PickerStaticWrapperClassKey } from '../internals/components/PickerStaticWrapper';
 
 // prettier-ignore
-export interface LabComponentNameToClassKey {
+export interface PickersComponentNameToClassKey {
   MuiCalendarPicker: CalendarPickerClassKey;
   MuiCalendarPickerSkeleton: CalendarPickerSkeletonClassKey;
   MuiClockPicker: ClockPickerClassKey;
@@ -20,7 +20,7 @@ export interface LabComponentNameToClassKey {
 }
 
 declare module '@mui/material/styles' {
-  interface ComponentNameToClassKey extends LabComponentNameToClassKey {}
+  interface ComponentNameToClassKey extends PickersComponentNameToClassKey {}
 }
 
 // disable automatic export

--- a/packages/x-date-pickers/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/props.d.ts
@@ -17,7 +17,7 @@ import { TimePickerProps } from '../TimePicker';
 import { YearPickerProps } from '../YearPicker';
 import { PickerStaticWrapperProps } from '../internals/components/PickerStaticWrapper';
 
-export interface LabComponentsPropsList {
+export interface PickersComponentsPropsList {
   MuiCalendarPicker: CalendarPickerProps<unknown>;
   MuiCalendarPickerSkeleton: CalendarPickerSkeletonProps;
   MuiClockPicker: ClockPickerProps<unknown>;
@@ -39,7 +39,7 @@ export interface LabComponentsPropsList {
 }
 
 declare module '@mui/material/styles' {
-  interface ComponentsPropsList extends LabComponentsPropsList {}
+  interface ComponentsPropsList extends PickersComponentsPropsList {}
 }
 
 // disable automatic export


### PR DESCRIPTION
Fix #4762

The error seems to come from reusing the same naming for the exported interface so I renamed them with `Pickers` and `PickersPro` prefix

I set `PickersPro` to be sure that when both pro and community packages are installed, both naming do not collide

I don't know how to test this issue. Maybe using creat-react-app add the lab and pickers package generated by the CI, and run `tsc`. Do you have a better idea?