### PR TITLE
[pickers] Add class slots for toolbar components

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -5,12 +5,15 @@ import { generateUtilityClasses } from '@mui/material';
 import {
   PickersToolbar,
   PickersToolbarButton,
+  pickersToolbarClasses,
   useUtils,
   BaseToolbarProps,
 } from '@mui/x-date-pickers/internals';
 import { DateRange, CurrentlySelectingRangeEndProps } from '../internal/models';
 
-const classes = generateUtilityClasses('PrivateDateRangePickerToolbar', ['penIcon']);
+export const dateRangePickerToolbarClasses = generateUtilityClasses('MuiDateRangePickerToolbar', [
+  'root',
+]);
 
 interface DateRangePickerToolbarProps<TDate>
   extends CurrentlySelectingRangeEndProps,
@@ -26,8 +29,14 @@ interface DateRangePickerToolbarProps<TDate>
   endText: React.ReactNode;
 }
 
-const DateRangePickerToolbarRoot = styled(PickersToolbar)({
-  [`& .${classes.penIcon}`]: {
+const DateRangePickerToolbarRoot = styled(PickersToolbar, {
+  name: 'MuiDateRangePickerToolbar',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{
+  ownerState: DateRangePickerToolbarProps<any>;
+}>({
+  [`& .${pickersToolbarClasses.penIconButton}`]: {
     position: 'relative',
     top: 4,
   },
@@ -40,18 +49,22 @@ const DateRangePickerToolbarContainer = styled('div')({
 /**
  * @ignore - internal component.
  */
-export const DateRangePickerToolbar = <TDate extends unknown>({
-  currentlySelectingRangeEnd,
-  parsedValue: [start, end],
-  endText,
-  isMobileKeyboardViewOpen,
-  setCurrentlySelectingRangeEnd,
-  startText,
-  toggleMobileKeyboardView,
-  toolbarFormat,
-  toolbarTitle = 'Select date range',
-}: DateRangePickerToolbarProps<TDate>) => {
+export const DateRangePickerToolbar = <TDate extends unknown>(
+  props: DateRangePickerToolbarProps<TDate>,
+) => {
   const utils = useUtils<TDate>();
+
+  const {
+    currentlySelectingRangeEnd,
+    parsedValue: [start, end],
+    endText,
+    isMobileKeyboardViewOpen,
+    setCurrentlySelectingRangeEnd,
+    startText,
+    toggleMobileKeyboardView,
+    toolbarFormat,
+    toolbarTitle = 'Select date range',
+  } = props;
 
   const startDateValue = start
     ? utils.formatByString(start, toolbarFormat || utils.formats.shortDate)
@@ -61,13 +74,16 @@ export const DateRangePickerToolbar = <TDate extends unknown>({
     ? utils.formatByString(end, toolbarFormat || utils.formats.shortDate)
     : endText;
 
+  const ownerState = props;
+
   return (
     <DateRangePickerToolbarRoot
       toolbarTitle={toolbarTitle}
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}
       isLandscape={false}
-      penIconClassName={classes.penIcon}
+      className={dateRangePickerToolbarClasses.root}
+      ownerState={ownerState}
     >
       <DateRangePickerToolbarContainer>
         <PickersToolbarButton

--- a/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
@@ -2,22 +2,33 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 import { generateUtilityClasses } from '@mui/material';
-import { PickersToolbar } from '../internals/components/PickersToolbar';
+import { PickersToolbar, pickersToolbarClasses } from '../internals/components/PickersToolbar';
 import { useUtils } from '../internals/hooks/useUtils';
 import { BaseToolbarProps } from '../internals/models/props/baseToolbarProps';
 import { isYearAndMonthViews, isYearOnlyView } from './shared';
 import { CalendarPickerView } from '../internals/models';
 
-const classes = generateUtilityClasses('PrivateDatePickerToolbar', ['penIcon']);
+export const datePickerToolbarClasses = generateUtilityClasses('MuiDatePickerToolbar', [
+  'root',
+  'title',
+]);
 
-const DatePickerToolbarRoot = styled(PickersToolbar)<{ ownerState: any }>({
-  [`& .${classes.penIcon}`]: {
+const DatePickerToolbarRoot = styled(PickersToolbar, {
+  name: 'MuiDatePickerToolbar',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: BaseToolbarProps<any, any> }>({
+  [`& .${pickersToolbarClasses.penIconButton}`]: {
     position: 'relative',
     top: 4,
   },
 });
 
-const DatePickerToolbarTitle = styled(Typography)<{ ownerState: any }>(({ ownerState }) => ({
+const DatePickerToolbarTitle = styled(Typography, {
+  name: 'MuiDatePickerToolbar',
+  slot: 'Title',
+  overridesResolver: (props, styles) => styles.title,
+})<{ ownerState: BaseToolbarProps<any, any> }>(({ ownerState }) => ({
   ...(ownerState.isLandscape && {
     margin: 'auto 16px auto auto',
   }),
@@ -82,8 +93,8 @@ export const DatePickerToolbar = React.forwardRef(function DatePickerToolbar<TDa
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}
       isLandscape={isLandscape}
-      penIconClassName={classes.penIcon}
       ownerState={ownerState}
+      className={datePickerToolbarClasses.root}
       {...other}
     >
       <DatePickerToolbarTitle
@@ -91,6 +102,7 @@ export const DatePickerToolbar = React.forwardRef(function DatePickerToolbar<TDa
         data-mui-test="datepicker-toolbar-date"
         align={isLandscape ? 'left' : 'center'}
         ownerState={ownerState}
+        className={datePickerToolbarClasses.title}
       >
         {dateText}
       </DatePickerToolbarTitle>

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -2,37 +2,60 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import { generateUtilityClasses } from '@mui/material';
 import { PickersToolbarText } from '../internals/components/PickersToolbarText';
-import { PickersToolbar } from '../internals/components/PickersToolbar';
+import { PickersToolbar, pickersToolbarClasses } from '../internals/components/PickersToolbar';
 import { PickersToolbarButton } from '../internals/components/PickersToolbarButton';
 import { DateTimePickerTabs } from './DateTimePickerTabs';
 import { useUtils } from '../internals/hooks/useUtils';
 import { WrapperVariantContext } from '../internals/components/wrappers/WrapperVariantContext';
 import { BaseToolbarProps } from '../internals/models/props/baseToolbarProps';
 
-const classes = generateUtilityClasses('PrivateDateTimePickerToolbar', ['penIcon']);
+export const dateTimePickerToolbarClasses = generateUtilityClasses('MuiDateTimePickerToolbar', [
+  'root',
+  'dateContainer',
+  'timeContainer',
+  'separator',
+]);
 
-const DateTimePickerToolbarRoot = styled(PickersToolbar)({
+const DateTimePickerToolbarRoot = styled(PickersToolbar, {
+  name: 'MuiDateTimePickerToolbar',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: BaseToolbarProps<any, any> }>({
   paddingLeft: 16,
   paddingRight: 16,
   justifyContent: 'space-around',
-  [`& .${classes.penIcon}`]: {
+  [`& .${pickersToolbarClasses.penIconButton}`]: {
     position: 'absolute',
     top: 8,
     right: 8,
   },
 });
 
-const DateTimePickerToolbarDateContainer = styled('div')({
+const DateTimePickerToolbarDateContainer = styled('div', {
+  name: 'MuiDateTimePickerToolbar',
+  slot: 'DateContainer',
+  overridesResolver: (props, styles) => styles.dateContainer,
+})<{ ownerState: BaseToolbarProps<any, any> }>({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
 });
 
-const DateTimePickerToolbarTimeContainer = styled('div')({
+const DateTimePickerToolbarTimeContainer = styled('div', {
+  name: 'MuiDateTimePickerToolbar',
+  slot: 'TimeContainer',
+  overridesResolver: (props, styles) => styles.timeContainer,
+})<{ ownerState: BaseToolbarProps<any, any> }>({
   display: 'flex',
 });
 
-const DateTimePickerToolbarSeparator = styled(PickersToolbarText)({
+const DateTimePickerToolbarSeparator = styled(PickersToolbarText, {
+  name: 'MuiDateTimePickerToolbar',
+  slot: 'Separator',
+  overridesResolver: (props, styles) => styles.separator,
+})<{
+  ownerState: BaseToolbarProps<any, any>;
+}>({
   margin: '0 4px 0 2px',
   cursor: 'default',
 });
@@ -82,18 +105,24 @@ export const DateTimePickerToolbar = <TDate extends unknown>(
     return utils.format(parsedValue, 'shortDate');
   }, [parsedValue, toolbarFormat, toolbarPlaceholder, utils]);
 
+  const ownerState = props;
+
   return (
     <React.Fragment>
       {wrapperVariant !== 'desktop' && (
         <DateTimePickerToolbarRoot
           toolbarTitle={toolbarTitle}
-          penIconClassName={classes.penIcon}
           isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
           toggleMobileKeyboardView={toggleMobileKeyboardView}
+          className={dateTimePickerToolbarClasses.root}
           {...other}
           isLandscape={false}
+          ownerState={ownerState}
         >
-          <DateTimePickerToolbarDateContainer>
+          <DateTimePickerToolbarDateContainer
+            className={dateTimePickerToolbarClasses.dateContainer}
+            ownerState={ownerState}
+          >
             {views.includes('year') && (
               <PickersToolbarButton
                 tabIndex={-1}
@@ -115,7 +144,10 @@ export const DateTimePickerToolbar = <TDate extends unknown>(
               />
             )}
           </DateTimePickerToolbarDateContainer>
-          <DateTimePickerToolbarTimeContainer>
+          <DateTimePickerToolbarTimeContainer
+            className={dateTimePickerToolbarClasses.timeContainer}
+            ownerState={ownerState}
+          >
             {views.includes('hours') && (
               <PickersToolbarButton
                 variant="h3"
@@ -127,7 +159,12 @@ export const DateTimePickerToolbar = <TDate extends unknown>(
             )}
             {views.includes('minutes') && (
               <React.Fragment>
-                <DateTimePickerToolbarSeparator variant="h3" value=":" />
+                <DateTimePickerToolbarSeparator
+                  variant="h3"
+                  value=":"
+                  className={dateTimePickerToolbarClasses.separator}
+                  ownerState={ownerState}
+                />
                 <PickersToolbarButton
                   variant="h3"
                   data-mui-test="minutes"
@@ -139,7 +176,12 @@ export const DateTimePickerToolbar = <TDate extends unknown>(
             )}
             {views.includes('seconds') && (
               <React.Fragment>
-                <DateTimePickerToolbarSeparator variant="h3" value=":" />
+                <DateTimePickerToolbarSeparator
+                  variant="h3"
+                  value=":"
+                  className={dateTimePickerToolbarClasses.separator}
+                  ownerState={ownerState}
+                />
                 <PickersToolbarButton
                   variant="h3"
                   data-mui-test="seconds"

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import clsx from 'clsx';
 import { useTheme, styled, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { PickersToolbarText } from '../internals/components/PickersToolbarText';
 import { PickersToolbarButton } from '../internals/components/PickersToolbarButton';
-import { PickersToolbar } from '../internals/components/PickersToolbar';
+import { PickersToolbar, pickersToolbarClasses } from '../internals/components/PickersToolbar';
 import { arrayIncludes } from '../internals/utils/utils';
 import { useUtils } from '../internals/hooks/useUtils';
 import { useMeridiemMode } from '../internals/hooks/date-helpers-hooks';
@@ -23,7 +22,7 @@ const useUtilityClasses = (ownerState: TimePickerToolbarProps<any> & { theme: Th
   const { theme, isLandscape, classes } = ownerState;
 
   const slots = {
-    penIconLandscape: ['penIconLandscape'],
+    root: ['root'],
     separator: ['separator'],
     hourMinuteLabel: [
       'hourMinuteLabel',
@@ -37,21 +36,33 @@ const useUtilityClasses = (ownerState: TimePickerToolbarProps<any> & { theme: Th
   return composeClasses(slots, getTimePickerToolbarUtilityClass, classes);
 };
 
-const TimePickerToolbarRoot = styled(PickersToolbar)<{
+const TimePickerToolbarRoot = styled(PickersToolbar, {
+  name: 'MuiTimePickerToolbar',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{
   ownerState: TimePickerToolbarProps<any>;
 }>({
-  [`& .${timePickerToolbarClasses.penIconLandscape}`]: {
+  [`& .${pickersToolbarClasses.penIconButtonLandscape}`]: {
     marginTop: 'auto',
   },
 });
 
-const TimePickerToolbarSeparator = styled(PickersToolbarText)({
+const TimePickerToolbarSeparator = styled(PickersToolbarText, {
+  name: 'MuiTimePickerToolbar',
+  slot: 'Separator',
+  overridesResolver: (props, styles) => styles.separator,
+})({
   outline: 0,
   margin: '0 4px 0 2px',
   cursor: 'default',
 });
 
-const TimePickerToolbarHourMinuteLabel = styled('div')<{
+const TimePickerToolbarHourMinuteLabel = styled('div', {
+  name: 'MuiTimePickerToolbar',
+  slot: 'HourMinuteLabel',
+  overridesResolver: (props, styles) => styles.hourMinuteLabel,
+})<{
   ownerState: TimePickerToolbarProps<any>;
 }>(({ theme, ownerState }) => ({
   display: 'flex',
@@ -65,7 +76,11 @@ const TimePickerToolbarHourMinuteLabel = styled('div')<{
   }),
 }));
 
-const TimePickerToolbarAmPmSelection = styled('div')<{
+const TimePickerToolbarAmPmSelection = styled('div', {
+  name: 'MuiTimePickerToolbar',
+  slot: 'AmPmSelection',
+  overridesResolver: (props, styles) => styles.ampmSelection,
+})<{
   ownerState: TimePickerToolbarProps<any>;
 }>(({ ownerState }) => ({
   display: 'flex',
@@ -135,7 +150,7 @@ export const TimePickerToolbar = <TDate extends unknown>(
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}
       ownerState={ownerState}
-      penIconClassName={clsx({ [classes.penIconLandscape]: isLandscape })}
+      className={classes.root}
       {...other}
     >
       <TimePickerToolbarHourMinuteLabel className={classes.hourMinuteLabel} ownerState={ownerState}>

--- a/packages/x-date-pickers/src/TimePicker/timePickerToolbarClasses.ts
+++ b/packages/x-date-pickers/src/TimePicker/timePickerToolbarClasses.ts
@@ -8,18 +8,18 @@ export interface TimePickerToolbarClasses {
   ampmSelection: string;
   ampmLandscape: string;
   ampmLabel: string;
-  penIconLandscape: string;
 }
 
 export type TimePickerToolbarClassKey = keyof TimePickerToolbarClasses;
 
 export function getTimePickerToolbarUtilityClass(slot: string) {
-  return generateUtilityClass('PrivateTimePickerToolbar', slot);
+  return generateUtilityClass('MuiTimePickerToolbar', slot);
 }
 
 export const timePickerToolbarClasses: TimePickerToolbarClasses = generateUtilityClasses(
-  'PrivateTimePickerToolbar',
+  'MuiTimePickerToolbar',
   [
+    'root',
     'separator',
     'hourMinuteLabel',
     'hourMinuteLabelLandscape',
@@ -27,6 +27,5 @@ export const timePickerToolbarClasses: TimePickerToolbarClasses = generateUtilit
     'ampmSelection',
     'ampmLandscape',
     'ampmLabel',
-    'penIconLandscape',
   ],
 );

--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -8,6 +8,13 @@ import { generateUtilityClasses } from '@mui/material';
 import { Pen, Calendar, Clock } from './icons';
 import { BaseToolbarProps } from '../models/props/baseToolbarProps';
 
+export const pickersToolbarClasses = generateUtilityClasses('MuiPickersToolbar', [
+  'root',
+  'content',
+  'penIconButton',
+  'penIconButtonLandscape',
+]);
+
 export interface PickersToolbarProps<TDate, TValue>
   extends Pick<
     BaseToolbarProps<TDate, TValue>,
@@ -17,13 +24,14 @@ export interface PickersToolbarProps<TDate, TValue>
   viewType?: 'calendar' | 'clock';
   isLandscape: boolean;
   landscapeDirection?: 'row' | 'column';
-  penIconClassName?: string;
   toolbarTitle: React.ReactNode;
 }
 
-const classes = generateUtilityClasses('PrivatePickersToolbar', ['root', 'dateTitleContainer']);
-
-const PickersToolbarRoot = styled('div')<{
+const PickersToolbarRoot = styled('div', {
+  name: 'MuiPickersToolbar',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{
   ownerState: PickersToolbarProps<any, any>;
 }>(({ theme, ownerState }) => ({
   display: 'flex',
@@ -40,9 +48,23 @@ const PickersToolbarRoot = styled('div')<{
   }),
 }));
 
-const PickersToolbarGrid = styled(Grid)({
+const PickersToolbarContent = styled(Grid, {
+  name: 'MuiPickersToolbar',
+  slot: 'Content',
+  overridesResolver: (props, styles) => styles.content,
+})<{
+  ownerState: PickersToolbarProps<any, any>;
+}>({
   flex: 1,
 });
+
+const PickersToolbarPenIconButton = styled(IconButton, {
+  name: 'MuiPickersToolbar',
+  slot: 'PenIconButton',
+  overridesResolver: (props, styles) => styles.penIconButton,
+})<{
+  ownerState: PickersToolbarProps<any, any>;
+}>({});
 
 const getViewTypeIcon = (viewType: 'calendar' | 'clock') =>
   viewType === 'clock' ? <Clock color="inherit" /> : <Calendar color="inherit" />;
@@ -72,7 +94,6 @@ export const PickersToolbar = React.forwardRef(function PickersToolbar<TDate, TV
     isLandscape,
     isMobileKeyboardViewOpen,
     landscapeDirection = 'column',
-    penIconClassName,
     toggleMobileKeyboardView,
     toolbarTitle,
     viewType = 'calendar',
@@ -84,30 +105,35 @@ export const PickersToolbar = React.forwardRef(function PickersToolbar<TDate, TV
     <PickersToolbarRoot
       ref={ref}
       data-mui-test="picker-toolbar"
-      className={clsx(classes.root, className)}
+      className={clsx(pickersToolbarClasses.root, className)}
       ownerState={ownerState}
     >
       <Typography data-mui-test="picker-toolbar-title" color="text.secondary" variant="overline">
         {toolbarTitle}
       </Typography>
-      <PickersToolbarGrid
+      <PickersToolbarContent
         container
         justifyContent="space-between"
-        className={classes.dateTitleContainer}
+        className={pickersToolbarClasses.content}
+        ownerState={ownerState}
         direction={isLandscape ? landscapeDirection : 'row'}
         alignItems={isLandscape ? 'flex-start' : 'flex-end'}
       >
         {children}
-        <IconButton
+        <PickersToolbarPenIconButton
           onClick={toggleMobileKeyboardView}
-          className={penIconClassName}
+          className={clsx([
+            pickersToolbarClasses.penIconButton,
+            isLandscape && pickersToolbarClasses.penIconButtonLandscape,
+          ])}
+          ownerState={ownerState}
           color="inherit"
           data-mui-test="toggle-mobile-keyboard-view"
           aria-label={getMobileKeyboardInputViewButtonText(isMobileKeyboardViewOpen, viewType)}
         >
           {isMobileKeyboardViewOpen ? getViewTypeIcon(viewType) : <Pen color="inherit" />}
-        </IconButton>
-      </PickersToolbarGrid>
+        </PickersToolbarPenIconButton>
+      </PickersToolbarContent>
     </PickersToolbarRoot>
   );
 }) as PickersToolbarComponent;

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -6,7 +6,7 @@ export { MobileKeyboardInputView } from './components/CalendarOrClockPicker/Cale
 export { PickersArrowSwitcher } from './components/PickersArrowSwitcher';
 export type { ExportedArrowSwitcherProps } from './components/PickersArrowSwitcher';
 export { PickerStaticWrapper } from './components/PickerStaticWrapper/PickerStaticWrapper';
-export { PickersToolbar } from './components/PickersToolbar';
+export { PickersToolbar, pickersToolbarClasses } from './components/PickersToolbar';
 export { PickersToolbarButton } from './components/PickersToolbarButton';
 export type {
   DateInputProps,


### PR DESCRIPTION
Part of #4669

@m4theushw I am not very familiar yet with the slots so I may have done things wrong.
For instance, I removed the `penIconClassName` in favor of classes inside `PickersToolbar`.