### PR TITLE
[TimePicker] Fix time validation when current date is null

### DIFF
--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.test.tsx
@@ -361,12 +361,48 @@ describe('<ClockPicker />', () => {
       expect(handleChange.callCount).to.equal(0);
     });
 
+    it('should not select minute when time is disabled (no current value)', () => {
+      const handleChange = spy();
+      render(
+        <ClockPicker
+          ampm={false}
+          date={null}
+          minTime={adapterToUse.date('2018-01-01T12:15:00.000')}
+          maxTime={adapterToUse.date('2018-01-01T15:45:30.000')}
+          onChange={handleChange}
+          view="minutes"
+        />,
+      );
+
+      fireTouchChangedEvent(screen.getByMuiTest('clock'), 'touchmove', clockTouchEvent['--:20']);
+
+      expect(handleChange.callCount).to.equal(0);
+    });
+
     it('should not select disabled hour', () => {
       const handleChange = spy();
       render(
         <ClockPicker
           ampm={false}
           date={adapterToUse.date('2018-01-01T13:00:00.000')}
+          minTime={adapterToUse.date('2018-01-01T12:15:00.000')}
+          maxTime={adapterToUse.date('2018-01-01T15:45:30.000')}
+          onChange={handleChange}
+          view="hours"
+        />,
+      );
+
+      fireTouchChangedEvent(screen.getByMuiTest('clock'), 'touchmove', clockTouchEvent['20:--']);
+
+      expect(handleChange.callCount).to.equal(0);
+    });
+
+    it('should not select disabled hour (no current value)', () => {
+      const handleChange = spy();
+      render(
+        <ClockPicker
+          ampm={false}
+          date={null}
           minTime={adapterToUse.date('2018-01-01T12:15:00.000')}
           maxTime={adapterToUse.date('2018-01-01T15:45:30.000')}
           onChange={handleChange}
@@ -424,6 +460,24 @@ describe('<ClockPicker />', () => {
         <ClockPicker
           ampm={false}
           date={adapterToUse.date('2018-01-01T00:00:00.000')}
+          minTime={adapterToUse.date('2018-01-01T12:15:00.000')}
+          maxTime={adapterToUse.date('2018-01-01T15:45:30.000')}
+          onChange={handleChange}
+          view="seconds"
+        />,
+      );
+
+      fireTouchChangedEvent(screen.getByMuiTest('clock'), 'touchmove', clockTouchEvent['--:20']);
+
+      expect(handleChange.callCount).to.equal(0);
+    });
+
+    it('should not select second when time is disabled (no current value)', () => {
+      const handleChange = spy();
+      render(
+        <ClockPicker
+          ampm={false}
+          date={null}
           minTime={adapterToUse.date('2018-01-01T12:15:00.000')}
           maxTime={adapterToUse.date('2018-01-01T15:45:30.000')}
           onChange={handleChange}

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -258,8 +258,8 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
 
   const now = useNow<TDate>();
   const utils = useUtils<TDate>();
-  const midnight = utils.setSeconds(utils.setMinutes(utils.setHours(now, 0), 0), 0);
-  const dateOrMidnight = date || midnight;
+
+  const dateOrMidnight = date || utils.setSeconds(utils.setMinutes(utils.setHours(now, 0), 0), 0);
 
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode<TDate>(
     dateOrMidnight,
@@ -298,12 +298,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
       switch (viewType) {
         case 'hours': {
           const value = convertValueToMeridiem(rawValue, meridiemMode, ampm);
-
-          if (date == null) {
-            return !isValidValue(value);
-          }
-
-          const dateWithNewHours = utils.setHours(date, value);
+          const dateWithNewHours = utils.setHours(dateOrMidnight, value);
           const start = utils.setSeconds(utils.setMinutes(dateWithNewHours, 0), 0);
           const end = utils.setSeconds(utils.setMinutes(dateWithNewHours, 59), 59);
 
@@ -311,11 +306,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
         }
 
         case 'minutes': {
-          if (date == null) {
-            return !isValidValue(rawValue, minutesStep);
-          }
-
-          const dateWithNewMinutes = utils.setMinutes(date, rawValue);
+          const dateWithNewMinutes = utils.setMinutes(dateOrMidnight, rawValue);
           const start = utils.setSeconds(dateWithNewMinutes, 0);
           const end = utils.setSeconds(dateWithNewMinutes, 59);
 
@@ -323,11 +314,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
         }
 
         case 'seconds': {
-          if (date == null) {
-            return !isValidValue(rawValue);
-          }
-
-          const dateWithNewSeconds = utils.setSeconds(date, rawValue);
+          const dateWithNewSeconds = utils.setSeconds(dateOrMidnight, rawValue);
           const start = dateWithNewSeconds;
           const end = dateWithNewSeconds;
 
@@ -340,7 +327,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
     },
     [
       ampm,
-      date,
+      dateOrMidnight,
       disableIgnoringDatePartForTimeValidation,
       maxTime,
       meridiemMode,

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -259,7 +259,10 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
   const now = useNow<TDate>();
   const utils = useUtils<TDate>();
 
-  const dateOrMidnight = date || utils.setSeconds(utils.setMinutes(utils.setHours(now, 0), 0), 0);
+  const dateOrMidnight = React.useMemo(
+    () => date || utils.setSeconds(utils.setMinutes(utils.setHours(now, 0), 0), 0),
+    [date, now, utils],
+  );
 
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode<TDate>(
     dateOrMidnight,


### PR DESCRIPTION
Fixes #4866

When we migrated the project, there was 0 validation on `ClockPicker` if the current time was null.
In #4726 I applied the value validity check (is hours "5" valid).
And in this PR I apply the full date validity (is 24th of May 2022 at 5PM valid)


## What's next ?

- Refacto `ClockPicker.test.tsx` to group the validity tests