### PR TITLE
[pickers] Allow to reset the input when the previous date was invalid

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -13,6 +13,7 @@ import {
   withPickerControls,
   openPicker,
 } from '../../../../test/utils/pickers-utils';
+import { DatePickerProps } from '@mui/x-date-pickers';
 
 const WrappedDesktopDatePicker = withPickerControls(DesktopDatePicker)({
   DialogProps: { TransitionComponent: FakeTransitionComponent },
@@ -89,6 +90,38 @@ describe('<DesktopDatePicker />', () => {
 
     expect(screen.getByRole('textbox')).to.have.value('10/11/2018');
     expect(onChangeMock.callCount).to.equal(1);
+  });
+
+  it('should allow to switch from invalid date to null date in the input', () => {
+    const Test = () => {
+      const [value, setValue] = React.useState(null);
+
+      return (
+        <React.Fragment>
+          <DesktopDatePicker
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+            renderInput={(inputProps) => <TextField {...inputProps} />}
+            inputFormat="dd/MM/yyyy"
+          />
+          <button data-mui-test="reset" onClick={() => setValue(null)}>
+            Clear
+          </button>
+        </React.Fragment>
+      );
+    };
+
+    render(<Test />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: {
+        value: '33/33/2022',
+      },
+    });
+    expect(screen.getByRole('textbox')).to.have.value('33/33/2022');
+
+    fireEvent.click(screen.getByMuiTest('reset'));
+    expect(screen.getByRole('textbox')).to.have.value('');
   });
 
   it('prop `showToolbar` – renders toolbar in desktop mode', () => {

--- a/packages/x-date-pickers/src/internals/hooks/useMaskedInput.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMaskedInput.tsx
@@ -9,7 +9,7 @@ import {
   checkMaskIsValidForCurrentFormat,
 } from '../utils/text-field-helper';
 
-type MaskedInputProps<TInputDate, TDate> = Omit<
+export type MaskedInputProps<TInputDate, TDate> = Omit<
   DateInputProps<TInputDate, TDate>,
   | 'adornmentPosition'
   | 'disableOpenPicker'
@@ -65,13 +65,14 @@ export const useMaskedInput = <TInputDate, TDate>({
   React.useEffect(() => {
     previousInputValueRef.current = currentInputValue;
   }, [currentInputValue]);
-  const notTyping = !isFocused;
-  const valueChanged = previousInputValueRef.current !== currentInputValue;
+
   // Update the input value only if the value changed outside of typing
-  if (notTyping && valueChanged && (rawValue === null || utils.isValid(rawValue))) {
-    if (currentInputValue !== innerInputValue) {
-      setInnerInputValue(currentInputValue);
-    }
+  if (
+    !isFocused &&
+    currentInputValue !== innerInputValue &&
+    (rawValue === null || utils.isValid(rawValue))
+  ) {
+    setInnerInputValue(currentInputValue);
   }
 
   const handleChange = (text: string) => {

--- a/packages/x-date-pickers/src/internals/hooks/useUtils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useUtils.ts
@@ -4,7 +4,7 @@ import {
   MuiPickersAdapterContextValue,
 } from '../../LocalizationProvider/LocalizationProvider';
 
-const useLocalizationContext = <T>() => {
+const useLocalizationContext = <TDate>() => {
   const localization = React.useContext(MuiPickersAdapterContext);
   if (localization === null) {
     throw new Error(
@@ -12,12 +12,12 @@ const useLocalizationContext = <T>() => {
     );
   }
 
-  return localization as MuiPickersAdapterContextValue<T>;
+  return localization as MuiPickersAdapterContextValue<TDate>;
 };
 
-export const useUtils = <T>() => useLocalizationContext<T>().utils;
+export const useUtils = <TDate>() => useLocalizationContext<TDate>().utils;
 
-export const useDefaultDates = <T>() => useLocalizationContext<T>().defaultDates;
+export const useDefaultDates = <TDate>() => useLocalizationContext<TDate>().defaultDates;
 
 export const useNow = <TDate>(): TDate => {
   const utils = useUtils<TDate>();


### PR DESCRIPTION
Related to #4486
Fixes #4870

@alexfauquette I don't see why we are comparing `currentInputValue` with `previousInputValueRef.current` (which is essentially the previous version of `currentInputValue`.

This variables holds the stringified version of the date. So for an invalid date it is an empty string, like for a null date.
But when we type by hand an invalid date, there is a de-synchronization between `currentInputValue` (which has an empty string) and `innerInputValue` which has the invalid date (`33/33/3333` for instance).

Is there a scenario where we don't have the input focus AND when the `props.date` changes we don't want to update the input with the stringified version ?

It breaks all the tests where we don't focus the input, but in a real usage, it will be focused.

____

If you feel like it is to tightly linked to #4486, I can remove the behavior change and just add a `.skip` to the new test (your PR would have to remove the `.skip`).