### PR TITLE
[docs] LICENSE max 80 char per line

### DIFF
--- a/packages/grid/x-data-grid-premium/LICENSE
+++ b/packages/grid/x-data-grid-premium/LICENSE
@@ -2,9 +2,9 @@ Commercial License
 
 Copyright (c) 2020 Material-UI SAS
 
-MUI X Premium (https://mui.com/pricing/) is commercial software. You must purchase
-a license and agree to the End User License Agreement (EULA: https://mui.com/r/x-license-eula)
-to be able to use the software.
+MUI X Premium (https://mui.com/pricing/) is commercial software.
+You must purchase a license and agree to the End User License Agreement
+(EULA: https://mui.com/r/x-license-eula) to be able to use the software.
 
 Commercial licenses can be obtained at https://mui.com/r/x-get-license?scope=premium.
 You are free to install and try the software without a license key as long as it

--- a/packages/grid/x-data-grid-pro/LICENSE
+++ b/packages/grid/x-data-grid-pro/LICENSE
@@ -2,9 +2,9 @@ Commercial License
 
 Copyright (c) 2020 Material-UI SAS
 
-MUI X Pro (https://mui.com/pricing/) is commercial software. You must purchase
-a license and agree to the End User License Agreement (EULA: https://mui.com/r/x-license-eula)
-to be able to use the software.
+MUI X Pro (https://mui.com/pricing/) is commercial software.
+You must purchase a license and agree to the End User License Agreement
+(EULA: https://mui.com/r/x-license-eula) to be able to use the software.
 
 Commercial licenses can be obtained at https://mui.com/r/x-get-license?scope=pro.
 You are free to install and try the software without a license key as long as it

--- a/packages/x-date-pickers-pro/LICENSE
+++ b/packages/x-date-pickers-pro/LICENSE
@@ -2,9 +2,9 @@ Commercial License
 
 Copyright (c) 2020 Material-UI SAS
 
-MUI X Pro (https://mui.com/pricing/) is commercial software. You must purchase
-a license and agree to the End User License Agreement (EULA: https://mui.com/r/x-license-eula)
-to be able to use the software.
+MUI X Pro (https://mui.com/pricing/) is commercial software.
+You must purchase a license and agree to the End User License Agreement
+(EULA: https://mui.com/r/x-license-eula) to be able to use the software.
 
 Commercial licenses can be obtained at https://mui.com/r/x-get-license?scope=pro.
 You are free to install and try the software without a license key as long as it

--- a/packages/x-license-pro/LICENSE
+++ b/packages/x-license-pro/LICENSE
@@ -2,9 +2,9 @@ Commercial License
 
 Copyright (c) 2020 Material-UI SAS
 
-MUI X Pro (https://mui.com/pricing/) is commercial software. You must purchase
-a license and agree to the End User License Agreement (EULA: https://mui.com/r/x-license-eula)
-to be able to use the software.
+MUI X Pro (https://mui.com/pricing/) is commercial software.
+You must purchase a license and agree to the End User License Agreement
+(EULA: https://mui.com/r/x-license-eula) to be able to use the software.
 
 Commercial licenses can be obtained at https://mui.com/r/x-get-license?scope=pro.
 You are free to install and try the software without a license key as long as it


### PR DESCRIPTION
We are not respecting the 80 chars per line rule on our commercial license file. This leads to a scrollbar in https://unpkg.com/browse/@mui/x-license-pro@5.11.0/LICENSE, I have to scroll horizontally to read everything. It's annoying.

<img width="946" alt="Screenshot 2022-05-15 at 02 31 36" src="https://user-images.githubusercontent.com/3165635/168452481-4c03425e-046d-4f7f-b957-3332770b086f.png">

Compare it to the MIT license: https://unpkg.com/browse/@mui/x-data-grid@5.11.0/LICENSE.

With this fix it feels like this 😌:
<img width="942" alt="Screenshot 2022-05-15 at 00 57 37" src="https://user-images.githubusercontent.com/3165635/168450609-51023f30-2201-49ca-9068-618e46747dd2.png">