### PR TITLE
[docs] Avoid confusion with license key installation

### DIFF
--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -92,9 +92,7 @@ This key removes all watermarks and console warnings.
 ```jsx
 import { LicenseInfo } from '@mui/x-license-pro';
 
-LicenseInfo.setLicenseKey(
-  '61628ce74db2c1b62783a6d438593bc5Tz1NVUktRG9jLEU9MTY4MzQ0NzgyMTI4NCxTPXByZW1pdW0sTE09c3Vic2NyaXB0aW9uLEtWPTI=',
-);
+LicenseInfo.setLicenseKey('YOUR_LICENSE_KEY');
 ```
 
 ### Where to install the key?

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -54,9 +54,7 @@ You must set the license key before rendering the first component.
 ```jsx
 import { LicenseInfo } from '@mui/x-license-pro';
 
-LicenseInfo.setLicenseKey(
-  '61628ce74db2c1b62783a6d438593bc5Tz1NVUktRG9jLEU9MTY4MzQ0NzgyMTI4NCxTPXByZW1pdW0sTE09c3Vic2NyaXB0aW9uLEtWPTI=',
-);
+LicenseInfo.setLicenseKey('YOUR_LICENSE_KEY');
 ```
 
 More information [here](/x/advanced-components/#license-key-installation)


### PR DESCRIPTION
My initial trigger to work on this PR is that the license we share in https://mui.com/x/advanced-components/#license-key-installation is a working one, proof:

<img width="502" alt="Screenshot 2022-05-15 at 22 34 15" src="https://user-images.githubusercontent.com/3165635/168492759-96b8f166-3fda-4340-8d94-9484e65ed3d8.png">

https://master--toolpad.mui.com/_toolpad/app/cl1c2j0l512939zo6a43575en/editor/pages/cl2kfa28r00013f69amqv1prv

Now considering #1364, I think that it makes it too easy to cheat and more importantly will lead to many customers to install **the wrong key**. I think that the change I propose here will make things clear. Note that I have used a key that can be quicky double-clicked selected for replacement:

https://user-images.githubusercontent.com/3165635/168492813-72522ed8-68df-47be-b704-043a0fe45231.mp4

e.g. [not like done here](https://www.ag-grid.com/react-data-grid/licensing/#via-grid-packages-2)…

*This PR is a part of a larger effort to polish the angles of the infrastructure to support selling MUI X, post Premium plan launch.*