### PR TITLE
[license] Remove support for UTF-8

### DIFF
--- a/packages/x-license-pro/src/encoding/base64.test.ts
+++ b/packages/x-license-pro/src/encoding/base64.test.ts
@@ -6,18 +6,18 @@ describe('License: base64', () => {
   const encodedStr1 = 'SEVMTE8gbXkgbmFtZSBpcyBCcnlhbiBhbWQgSSdtIGF3ZXNvbWUh';
   const clearStr2 = 'COMPANY=DAMIEN_INC,EXPIRY=20/08/2021,VERSION=1.1.31';
   const encodedStr2 = 'Q09NUEFOWT1EQU1JRU5fSU5DLEVYUElSWT0yMC8wOC8yMDIxLFZFUlNJT049MS4xLjMx';
-  const clearStr3 = '✓ à la mode';
-  const encodedStr3 = '4pyTIMOgIGxhIG1vZGU=';
 
   it('should encode string properly', () => {
     expect(base64Encode(clearStr1)).to.equal(encodedStr1);
     expect(base64Encode(clearStr2)).to.equal(encodedStr2);
-    expect(base64Encode(clearStr3)).to.equal(encodedStr3);
   });
 
   it('should decode string properly', () => {
     expect(base64Decode(encodedStr1)).to.equal(clearStr1);
     expect(base64Decode(encodedStr2)).to.equal(clearStr2);
-    expect(base64Decode(encodedStr3)).to.equal(clearStr3);
+  });
+
+  it('should fail if using none ASCII string', () => {
+    expect(() => base64Encode('✓ à la mode')).to.throw(/ASCII only support/);
   });
 });

--- a/packages/x-license-pro/src/encoding/base64.ts
+++ b/packages/x-license-pro/src/encoding/base64.ts
@@ -2,52 +2,15 @@
 const _keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
 function utf8Encode(str: string) {
-  str = str.replace(/\r\n/g, '\n');
-  let utftext = '';
-
   for (let n = 0; n < str.length; n++) {
     const c = str.charCodeAt(n);
 
-    if (c < 128) {
-      utftext += String.fromCharCode(c);
-    } else if (c > 127 && c < 2048) {
-      utftext += String.fromCharCode((c >> 6) | 192);
-      utftext += String.fromCharCode((c & 63) | 128);
-    } else {
-      utftext += String.fromCharCode((c >> 12) | 224);
-      utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-      utftext += String.fromCharCode((c & 63) | 128);
+    if (c >= 128) {
+      throw new Error('ASCII only support');
     }
   }
 
-  return utftext;
-}
-
-function utf8Decode(utftext: string) {
-  let string = '';
-  let i = 0;
-  let c, c2, c3;
-  c = c2 = c3 = 0;
-
-  while (i < utftext.length) {
-    c = utftext.charCodeAt(i);
-
-    if (c < 128) {
-      string += String.fromCharCode(c);
-      i++;
-    } else if (c > 191 && c < 224) {
-      c2 = utftext.charCodeAt(i + 1);
-      string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-      i += 2;
-    } else {
-      c2 = utftext.charCodeAt(i + 1);
-      c3 = utftext.charCodeAt(i + 2);
-      string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-      i += 3;
-    }
-  }
-
-  return string;
+  return str;
 }
 
 export const base64Decode = (input: string): string => {
@@ -77,8 +40,6 @@ export const base64Decode = (input: string): string => {
       output = output + String.fromCharCode(chr3);
     }
   }
-
-  output = utf8Decode(output);
 
   return output;
 };


### PR DESCRIPTION
We always use ASCII for the license key, so no need for this logic. I think that we could go further in bundle size saving, but I don't have time for it: #4894.