### PR TITLE
[docs] Fix docs feedback widget not working

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -43,6 +43,7 @@ module.exports = {
     DATE_PICKERS_VERSION: datePickersPkg.version,
     PULL_REQUEST: process.env.PULL_REQUEST === 'true',
     REACT_STRICT_MODE: reactStrictMode,
+    FEEDBACK_URL: process.env.FEEDBACK_URL,
     // Set by Netlify
     GRID_EXPERIMENTAL_ENABLED: process.env.PULL_REQUEST === 'false' ? 'false' : 'true',
     // #default-branch-switch


### PR DESCRIPTION
I've noticed that feedback widget on MUI X docs website doesn't work:

<img width="1405" alt="Screenshot 2022-05-16 at 12 50 10" src="https://user-images.githubusercontent.com/13808724/168631109-748973f0-ae24-4ad7-87ab-2141aabae1e0.png">

The reason is missing `FEEDBACK_URL` was missing in MUI X env.

Preview: https://deploy-preview-4905--material-ui-x.netlify.app/x/advanced-components/