### PR TITLE
[license] Tweak error messages

### DIFF
--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -16,7 +16,7 @@ export function showInvalidLicenseError() {
   showError([
     'MUI: Invalid license key.',
     '',
-    'Your MUI X license key isn't valid. Please check',
+    "Your MUI X license key isn't valid. Please check",
     'your license key, or visit',
     'https://mui.com/r/x-get-license to purchase a license.',
   ]);
@@ -27,8 +27,8 @@ export function showNotFoundLicenseError() {
     'MUI: License key not found.',
     '',
     'This is a trial-only version of MUI X.',
-    'While all the features are unlocked, it is not licensed for',
-    'development use in projects intended for production.',
+    'See the conditons here:',
+    'https://mui.com/r/x-license-eula#evaluation-trial-licenses.',
     '',
     'To purchase a license, please visit',
     'https://mui.com/r/x-get-license.',
@@ -40,6 +40,6 @@ export function showExpiredLicenseError() {
     'MUI: License key expired.',
     '',
     'Please visit https://mui.com/r/x-get-license to renew',
-    'your subscription and get the latest version of MUI X.',
+    'your subscription of MUI X.',
   ]);
 }

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -14,9 +14,10 @@ function showError(message: string[]) {
 
 export function showInvalidLicenseError() {
   showError([
-    'MUI: Invalid license.',
+    'MUI: Invalid license key.',
     '',
-    'Your license for MUI X is not valid, please visit',
+    'Your MUI X license key isn't valid. Please check',
+    'your license key, or visit
     'https://mui.com/r/x-get-license to get a valid license.',
   ]);
 }
@@ -27,10 +28,10 @@ export function showNotFoundLicenseError() {
     '',
     'This is a trial-only version of MUI X.',
     'While all the features are unlocked, it is not licensed for',
-    'development use on projects intended for production.',
+    'development use in projects intended for production.',
     '',
     'To purchase a license, please visit',
-    'https://mui.com/r/x-get-license to get a valid license.',
+    'https://mui.com/r/x-get-license.',
   ]);
 }
 

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -18,7 +18,7 @@ export function showInvalidLicenseError() {
     '',
     'Your MUI X license key isn't valid. Please check',
     'your license key, or visit',
-    'https://mui.com/r/x-get-license to get a valid license.',
+    'https://mui.com/r/x-get-license to purchase a license.',
   ]);
 }
 

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -16,9 +16,9 @@ export function showInvalidLicenseError() {
   showError([
     'MUI: Invalid license key.',
     '',
-    "Your MUI X license key isn't valid. Please check",
-    'your license key, or visit',
-    'https://mui.com/r/x-get-license to purchase a license.',
+    "Your MUI X license key isn't valid. Please check your license key installation https://mui.com/r/x-license-key-installation.",
+    '',
+    'To purchase a license, please visit https://mui.com/r/x-get-license.',
   ]);
 }
 
@@ -27,11 +27,9 @@ export function showNotFoundLicenseError() {
     'MUI: License key not found.',
     '',
     'This is a trial-only version of MUI X.',
-    'See the conditons here:',
-    'https://mui.com/r/x-license-eula#evaluation-trial-licenses.',
+    'See the conditons here: https://mui.com/r/x-license-eula#evaluation-trial-licenses.',
     '',
-    'To purchase a license, please visit',
-    'https://mui.com/r/x-get-license.',
+    'To purchase a license, please visit https://mui.com/r/x-get-license.',
   ]);
 }
 
@@ -39,7 +37,6 @@ export function showExpiredLicenseError() {
   showError([
     'MUI: License key expired.',
     '',
-    'Please visit https://mui.com/r/x-get-license to renew',
-    'your subscription of MUI X.',
+    'Please visit https://mui.com/r/x-get-license to renew your subscription of MUI X.',
   ]);
 }

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -17,7 +17,7 @@ export function showInvalidLicenseError() {
     'MUI: Invalid license key.',
     '',
     'Your MUI X license key isn't valid. Please check',
-    'your license key, or visit
+    'your license key, or visit',
     'https://mui.com/r/x-get-license to get a valid license.',
   ]);
 }


### PR DESCRIPTION
I only planned to fix one typo: "use on projects" -> "use in projects", but noticed a few other opportunities.