### PR TITLE
[DataGrid] Fix rendering of the no rows overlay when the `loading` prop is changed

### DIFF
--- a/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
@@ -73,7 +73,7 @@ export function GridOverlays() {
     );
   }
 
-  if (rootProps.loading) {
+  if (loading) {
     overlay = (
       <rootProps.components.LoadingOverlay {...rootProps.componentsProps?.loadingOverlay} />
     );

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsState.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsState.ts
@@ -34,6 +34,10 @@ export interface GridRowsInternalCache {
    * It is used to avoid processing several time the same set of rows
    */
   rowsBeforePartialUpdates: GridRowsProp;
+  /**
+   * The value of the `loading` prop since the last time that the rows state was updated.
+   */
+  loadingPropBeforePartialUpdates?: boolean;
 }
 
 export interface GridRowsState extends GridRowTreeCreationValue {

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1111,4 +1111,18 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     setProps({ loading: false, rows: [{ id: 1 }] });
     expect(NoRowsOverlay.callCount).to.equal(0);
   });
+
+  it('should render the "no rows" overlay when changing the loading to false but not changing the rows prop', () => {
+    const NoRowsOverlay = spy(() => null);
+    const TestCase = (props: Partial<DataGridProps>) => (
+      <div style={{ width: 300, height: 500 }}>
+        <DataGrid {...baselineProps} components={{ NoRowsOverlay }} {...props} />
+      </div>
+    );
+    const rows: DataGridProps['rows'] = [];
+    const { setProps } = render(<TestCase rows={rows} loading />);
+    expect(NoRowsOverlay.callCount).to.equal(0);
+    setProps({ loading: false });
+    expect(NoRowsOverlay.callCount).not.to.equal(0);
+  });
 });


### PR DESCRIPTION
Fixes #4788

Before: https://codesandbox.io/s/data-grid-pro-forked-764v9x?file=/src/App.jsx

<img width="500" src="https://user-images.githubusercontent.com/42154031/168713961-d2aa85c7-4482-44e9-9933-e104af180998.png" alt="image" style="max-width: 100%;">

After: https://codesandbox.io/s/data-grid-pro-forked-98q8be?file=/src/App.jsx

<img width="500" src="https://user-images.githubusercontent.com/42154031/168714110-0c59088e-c3a7-4ce0-a184-3f6ca6aa4788.png" alt="image" style="max-width: 100%;">

