### PR TITLE
[core] Execute the pipe-processors in their initialization order

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
@@ -8,7 +8,7 @@ import {
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 
 interface GridPipeGroupCache {
-  processors: Map<string, GridPipeProcessor<any> | null>
+  processors: Map<string, GridPipeProcessor<any> | null>;
   appliers: {
     [applierId: string]: () => void;
   };
@@ -77,7 +77,7 @@ export const useGridPipeProcessing = (apiRef: React.MutableRefObject<GridApiComm
       }
 
       return () => {
-        processorsCache.current[group]!.processors.set(id, null)
+        processorsCache.current[group]!.processors.set(id, null);
       };
     },
     [runAppliers],
@@ -123,7 +123,7 @@ export const useGridPipeProcessing = (apiRef: React.MutableRefObject<GridApiComm
     const preProcessors = Array.from(processorsCache.current[group]!.processors.values());
     return preProcessors.reduce((acc, preProcessor) => {
       if (!preProcessor) {
-        return acc
+        return acc;
       }
 
       return preProcessor(acc, context);

--- a/packages/grid/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
@@ -8,9 +8,7 @@ import {
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 
 interface GridPipeGroupCache {
-  processors: {
-    [processorId: string]: GridPipeProcessor<any>;
-  };
+  processors: Map<string, GridPipeProcessor<any> | null>
   appliers: {
     [applierId: string]: () => void;
   };
@@ -66,22 +64,20 @@ export const useGridPipeProcessing = (apiRef: React.MutableRefObject<GridApiComm
     (group, id, processor) => {
       if (!processorsCache.current[group]) {
         processorsCache.current[group] = {
-          processors: {},
+          processors: new Map(),
           appliers: {},
         };
       }
 
       const groupCache = processorsCache.current[group]!;
-      const oldProcessor = groupCache.processors[id];
+      const oldProcessor = groupCache.processors.get(id);
       if (oldProcessor !== processor) {
-        groupCache.processors[id] = processor;
+        groupCache.processors.set(id, processor);
         runAppliers(groupCache);
       }
 
       return () => {
-        const { [id]: removedGroupProcessor, ...otherProcessors } =
-          processorsCache.current[group]!.processors;
-        processorsCache.current[group]!.processors = otherProcessors;
+        processorsCache.current[group]!.processors.set(id, null)
       };
     },
     [runAppliers],
@@ -92,7 +88,7 @@ export const useGridPipeProcessing = (apiRef: React.MutableRefObject<GridApiComm
   >((group, id, applier) => {
     if (!processorsCache.current[group]) {
       processorsCache.current[group] = {
-        processors: {},
+        processors: new Map(),
         appliers: {},
       };
     }
@@ -124,8 +120,12 @@ export const useGridPipeProcessing = (apiRef: React.MutableRefObject<GridApiComm
       return value;
     }
 
-    const preProcessors = Object.values(processorsCache.current[group]!.processors);
+    const preProcessors = Array.from(processorsCache.current[group]!.processors.values());
     return preProcessors.reduce((acc, preProcessor) => {
+      if (!preProcessor) {
+        return acc
+      }
+
       return preProcessor(acc, context);
     }, value);
   }, []);


### PR DESCRIPTION
## Problem

While working on the aggregation (#4208) I noticed that the execution order of the pipe-processors was from the oldest-updated-processor to the latest-updated-processor.
We should try to always have execution orders respect the order of initialization (ie the order of the hooks in `useDataGridXXXComponent`).

This unstable execution order was causing a double execution of `hydrateColumns` in some scenario when used with aggregation and row grouping.

### Reproduction case

If you change a prop triggering an update of the row grouping processor of `hydrateColumns` (for instance switch `rowGroupingColumnModel` from `single` to `multiple`), then the aggregation processor of `hydrateColumns` will be ran before the row grouping one.
But the aggregation needs the new row grouping columns to decide how to aggregate.
So we have 2 execution of `hydrateColumns`

1. The `hydrateColumns` processor of Row Grouping is updated, firing a 1st `hydrateColumns` execution
2. `hydrateColumns` processor executed: Aggregation does nothing, Row Grouping update its columns
3. `columnsChange` events is fired, Aggregation manually fires a 2nd `hydrateColumns` execution because it needs to update its columns
4. `hydrateColumns` processor executed: Aggregation updates its columns, Row Grouping does nothing

### Expected behavior

1. The `hydrateColumns` processor of Row Grouping is updated, firing a 1st `hydrateColumns` execution
2. `hydrateColumns` processor executed:  Row Grouping update its columns, Aggregation updates its columns based on the new Row Grouping columns,
3. `columnsChange` events is fired, Aggregation do not fires a 2nd `hydrateColumns` because its columns are up to date

## Solution

- [x] Replace the object storing the processors by a `Map` to have a guaranteed key order
- [x] Do not delete the map item when removing a processor but replace it by `null` to keep its position in the execution order

