### PR TITLE
[core] Simplify rows cache management

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/core/useGridApiInitialization.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridApiInitialization.ts
@@ -20,7 +20,7 @@ export function useGridApiInitialization<Api extends GridApiCommon>(
   if (!apiRef.current) {
     apiRef.current = {
       unstable_eventManager: new EventManager(),
-      unstable_caches: {},
+      unstable_caches: {} as Api['unstable_caches'],
       state: {} as Api['state'],
       instanceId: globalId,
     } as Api;

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsState.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsState.ts
@@ -25,10 +25,7 @@ export interface GridRowTreeCreationValue {
   idToIdLookup: Record<string, GridRowId>;
 }
 
-export type GridRowInternalCacheValue = Omit<GridRowTreeCreationParams, 'previousTree'>;
-
-export interface GridRowsInternalCache {
-  value: GridRowInternalCacheValue;
+export interface GridRowsInternalCache extends Omit<GridRowTreeCreationParams, 'previousTree'> {
   /**
    * The rows as they were the last time all the rows have been updated at once
    * It is used to avoid processing several time the same set of rows

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsState.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsState.ts
@@ -1,9 +1,5 @@
-import {
-  GridRowId,
-  GridRowsLookup,
-  GridRowsProp,
-  GridRowTreeConfig,
-} from '../../../models/gridRows';
+import { GridRowId, GridRowsLookup, GridRowTreeConfig } from '../../../models/gridRows';
+import type { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 
 export interface GridRowTreeCreationParams {
   ids: GridRowId[];
@@ -30,11 +26,11 @@ export interface GridRowsInternalCache extends Omit<GridRowTreeCreationParams, '
    * The rows as they were the last time all the rows have been updated at once
    * It is used to avoid processing several time the same set of rows
    */
-  rowsBeforePartialUpdates: GridRowsProp;
+  rowsBeforePartialUpdates: DataGridProcessedProps['rows'];
   /**
    * The value of the `loading` prop since the last time that the rows state was updated.
    */
-  loadingPropBeforePartialUpdates?: boolean;
+  loadingPropBeforePartialUpdates: DataGridProcessedProps['loading'];
 }
 
 export interface GridRowsState extends GridRowTreeCreationValue {

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -1,4 +1,14 @@
-import { GridRowId, GridRowModel, GridRowTreeConfig } from '../../../models';
+import * as React from 'react';
+import {
+  GridRowId,
+  GridRowIdGetter,
+  GridRowModel,
+  GridRowsProp,
+  GridRowTreeConfig,
+} from '../../../models';
+import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
+import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
+import { GridRowsInternalCache, GridRowsState } from './gridRowsState';
 
 /**
  * A helper function to check if the id provided is valid.
@@ -22,6 +32,81 @@ export function checkGridRowIdIsValid(
     );
   }
 }
+
+export const getRowIdFromRowModel = (
+  rowModel: GridRowModel,
+  getRowId?: GridRowIdGetter,
+  detailErrorMessage?: string,
+): GridRowId => {
+  const id = getRowId ? getRowId(rowModel) : rowModel.id;
+  checkGridRowIdIsValid(id, rowModel, detailErrorMessage);
+  return id;
+};
+
+interface ConvertRowsPropToStateParams {
+  getRowId: DataGridProcessedProps['getRowId'];
+  rows: GridRowsProp;
+}
+
+export const createRowsInternalCache = ({
+  rows,
+  getRowId,
+}: ConvertRowsPropToStateParams): GridRowsInternalCache => {
+  const cache: GridRowsInternalCache = {
+    rowsBeforePartialUpdates: rows,
+    idRowsLookup: {},
+    idToIdLookup: {},
+    ids: [],
+  };
+
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i];
+    const id = getRowIdFromRowModel(row, getRowId);
+    cache.idRowsLookup[id] = row;
+    cache.idToIdLookup[id] = id;
+    cache.ids.push(id);
+  }
+
+  return cache;
+};
+
+export const getRowsStateFromCache = ({
+  apiRef,
+  previousTree,
+  rowCountProp,
+  loadingProp,
+}: {
+  apiRef: React.MutableRefObject<GridApiCommunity>;
+  previousTree: GridRowTreeConfig | null;
+  rowCountProp: number | undefined;
+  loadingProp: boolean | undefined;
+}): GridRowsState => {
+  const { rowsBeforePartialUpdates, ...cacheForGrouping } = apiRef.current.unstable_caches.rows;
+  const rowCount = rowCountProp ?? 0;
+
+  const groupingResponse = apiRef.current.unstable_applyStrategyProcessor('rowTreeCreation', {
+    ...cacheForGrouping,
+    previousTree,
+  });
+
+  const processedGroupingResponse = apiRef.current.unstable_applyPipeProcessors(
+    'hydrateRows',
+    groupingResponse,
+  );
+
+  const dataTopLevelRowCount =
+    processedGroupingResponse.treeDepth === 1
+      ? processedGroupingResponse.ids.length
+      : Object.values(processedGroupingResponse.tree).filter((node) => node.parent == null).length;
+
+  return {
+    ...processedGroupingResponse,
+    groupingResponseBeforeRowHydration: groupingResponse,
+    loading: loadingProp,
+    totalRowCount: Math.max(rowCount, processedGroupingResponse.ids.length),
+    totalTopLevelRowCount: Math.max(rowCount, dataTopLevelRowCount),
+  };
+};
 
 export const getTreeNodeDescendants = (
   tree: GridRowTreeConfig,

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -43,17 +43,15 @@ export const getRowIdFromRowModel = (
   return id;
 };
 
-interface ConvertRowsPropToStateParams {
-  getRowId: DataGridProcessedProps['getRowId'];
-  loadingProp: DataGridProcessedProps['loading'];
-  rows: GridRowsProp;
-}
-
 export const createRowsInternalCache = ({
   rows,
   getRowId,
   loadingProp,
-}: ConvertRowsPropToStateParams): GridRowsInternalCache => {
+}: {
+  getRowId: DataGridProcessedProps['getRowId'];
+  loadingProp: DataGridProcessedProps['loading'];
+  rows: GridRowsProp;
+}): GridRowsInternalCache => {
   const cache: GridRowsInternalCache = {
     rowsBeforePartialUpdates: rows,
     loadingPropBeforePartialUpdates: loadingProp,

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  GridRowId,
-  GridRowIdGetter,
-  GridRowModel,
-  GridRowsProp,
-  GridRowTreeConfig,
-} from '../../../models';
+import { GridRowId, GridRowIdGetter, GridRowModel, GridRowTreeConfig } from '../../../models';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridRowsInternalCache, GridRowsState } from './gridRowsState';
@@ -46,15 +40,11 @@ export const getRowIdFromRowModel = (
 export const createRowsInternalCache = ({
   rows,
   getRowId,
-  loadingProp,
-}: {
-  getRowId: DataGridProcessedProps['getRowId'];
-  loadingProp: DataGridProcessedProps['loading'];
-  rows: GridRowsProp;
-}): GridRowsInternalCache => {
+  loading,
+}: Pick<DataGridProcessedProps, 'rows' | 'getRowId' | 'loading'>): GridRowsInternalCache => {
   const cache: GridRowsInternalCache = {
     rowsBeforePartialUpdates: rows,
-    loadingPropBeforePartialUpdates: loadingProp,
+    loadingPropBeforePartialUpdates: loading,
     idRowsLookup: {},
     idToIdLookup: {},
     ids: [],

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -33,7 +33,7 @@ export const rowsStateInitializer: GridStateInitializer<
   apiRef.current.unstable_caches.rows = createRowsInternalCache({
     rows: props.rows,
     getRowId: props.getRowId,
-    loadingProp: props.loading,
+    loading: props.loading,
   });
 
   return {
@@ -137,7 +137,7 @@ export const useGridRows = (
         createRowsInternalCache({
           rows,
           getRowId: props.getRowId,
-          loadingProp: props.loading,
+          loading: props.loading,
         }),
         true,
       );
@@ -356,7 +356,7 @@ export const useGridRows = (
       cache = createRowsInternalCache({
         rows: props.rows,
         getRowId: props.getRowId,
-        loadingProp: props.loading,
+        loading: props.loading,
       });
     }
     throttledRowsChange(cache, false);
@@ -443,7 +443,7 @@ export const useGridRows = (
       createRowsInternalCache({
         rows: props.rows,
         getRowId: props.getRowId,
-        loadingProp: props.loading,
+        loading: props.loading,
       }),
       false,
     );

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -343,10 +343,10 @@ export const useGridRows = (
     logger.info(`Row grouping pre-processing have changed, regenerating the row tree`);
 
     let cache: GridRowsInternalCache;
-    if (apiRef.current.unstable_caches.rows!.rowsBeforePartialUpdates === props.rows) {
-      // The `props.rows` has not changed since the last row grouping
-      // We can keep the potential updates stored in `inputRowsAfterUpdates` on the new grouping
-      cache = apiRef.current.unstable_caches.rows!;
+    if (apiRef.current.unstable_caches.rows.rowsBeforePartialUpdates === props.rows) {
+      // The `props.rows` did not change since the last row grouping
+      // We can use the current rows cache which contains the partial updates done recently.
+      cache = apiRef.current.unstable_caches.rows;
     } else {
       // The `props.rows` has changed since the last row grouping
       // We must use the new `props.rows` on the new grouping
@@ -428,7 +428,7 @@ export const useGridRows = (
     }
 
     // The new rows have already been applied (most likely in the `'rowGroupsPreProcessingChange'` listener)
-    if (apiRef.current.unstable_caches.rows!.rowsBeforePartialUpdates === props.rows) {
+    if (apiRef.current.unstable_caches.rows.rowsBeforePartialUpdates === props.rows) {
       return;
     }
 

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -179,6 +179,7 @@ export const useGridRows = (
       const prevCache = apiRef.current.unstable_caches.rows;
       const newCache: GridRowsInternalCache = {
         rowsBeforePartialUpdates: prevCache.rowsBeforePartialUpdates,
+        loadingPropBeforePartialUpdates: prevCache.loadingPropBeforePartialUpdates,
         idRowsLookup: { ...prevCache.idRowsLookup },
         idToIdLookup: { ...prevCache.idToIdLookup },
         ids: [...prevCache.ids],

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -3,14 +3,7 @@ import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridRowApi } from '../../../models/api/gridRowApi';
-import {
-  GridRowModel,
-  GridRowId,
-  GridRowsProp,
-  GridRowIdGetter,
-  GridRowTreeNodeConfig,
-  GridRowTreeConfig,
-} from '../../../models/gridRows';
+import { GridRowModel, GridRowId, GridRowTreeNodeConfig } from '../../../models/gridRows';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { useGridLogger } from '../../utils/useGridLogger';
 import {
@@ -25,114 +18,31 @@ import { GridStateInitializer } from '../../utils/useGridInitializeState';
 import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
 import { gridSortedRowIdsSelector } from '../sorting/gridSortingSelector';
 import { gridFilteredRowsLookupSelector } from '../filter/gridFilterSelector';
-import { GridRowInternalCacheValue, GridRowsInternalCache, GridRowsState } from './gridRowsState';
-import { checkGridRowIdIsValid, getTreeNodeDescendants } from './gridRowsUtils';
+import { GridRowsInternalCache } from './gridRowsState';
+import {
+  getTreeNodeDescendants,
+  createRowsInternalCache,
+  getRowsStateFromCache,
+  getRowIdFromRowModel,
+} from './gridRowsUtils';
 import { useGridRegisterPipeApplier } from '../../core/pipeProcessing';
-
-interface ConvertRowsPropToStateParams {
-  prevCache: GridRowsInternalCache;
-  getRowId: DataGridProcessedProps['getRowId'];
-  rows?: GridRowsProp;
-}
-
-function getGridRowId(
-  rowModel: GridRowModel,
-  getRowId?: GridRowIdGetter,
-  detailErrorMessage?: string,
-): GridRowId {
-  const id = getRowId ? getRowId(rowModel) : rowModel.id;
-  checkGridRowIdIsValid(id, rowModel, detailErrorMessage);
-  return id;
-}
-
-const convertRowsPropToState = ({
-  prevCache: prevState,
-  rows,
-  getRowId,
-}: ConvertRowsPropToStateParams): GridRowsInternalCache => {
-  let value: GridRowInternalCacheValue;
-  if (rows) {
-    value = {
-      idRowsLookup: {},
-      idToIdLookup: {},
-      ids: [],
-    };
-    for (let i = 0; i < rows.length; i += 1) {
-      const row = rows[i];
-      const id = getGridRowId(row, getRowId);
-      value.idRowsLookup[id] = row;
-      value.idToIdLookup[id] = id;
-      value.ids.push(id);
-    }
-  } else {
-    value = prevState.value;
-  }
-
-  return {
-    value,
-    rowsBeforePartialUpdates: rows ?? prevState.rowsBeforePartialUpdates,
-  };
-};
-
-const getRowsStateFromCache = (
-  rowsCache: GridRowsInternalCache,
-  previousTree: GridRowTreeConfig | null,
-  apiRef: React.MutableRefObject<GridApiCommunity>,
-  rowCountProp: number | undefined,
-  loadingProp: boolean | undefined,
-): GridRowsState => {
-  const { value } = rowsCache;
-  const rowCount = rowCountProp ?? 0;
-
-  const groupingResponse = apiRef.current.unstable_applyStrategyProcessor('rowTreeCreation', {
-    ...value,
-    previousTree,
-  });
-
-  const processedGroupingResponse = apiRef.current.unstable_applyPipeProcessors(
-    'hydrateRows',
-    groupingResponse,
-  );
-
-  const dataTopLevelRowCount =
-    processedGroupingResponse.treeDepth === 1
-      ? processedGroupingResponse.ids.length
-      : Object.values(processedGroupingResponse.tree).filter((node) => node.parent == null).length;
-
-  return {
-    ...processedGroupingResponse,
-    groupingResponseBeforeRowHydration: groupingResponse,
-    loading: loadingProp,
-    totalRowCount: Math.max(rowCount, processedGroupingResponse.ids.length),
-    totalTopLevelRowCount: Math.max(rowCount, dataTopLevelRowCount),
-  };
-};
 
 export const rowsStateInitializer: GridStateInitializer<
   Pick<DataGridProcessedProps, 'rows' | 'rowCount' | 'getRowId' | 'loading'>
 > = (state, props, apiRef) => {
-  apiRef.current.unstable_caches.rows = convertRowsPropToState({
+  apiRef.current.unstable_caches.rows = createRowsInternalCache({
     rows: props.rows,
     getRowId: props.getRowId,
-    prevCache: {
-      value: {
-        idRowsLookup: {},
-        idToIdLookup: {},
-        ids: [],
-      },
-      rowsBeforePartialUpdates: [],
-    },
   });
 
   return {
     ...state,
-    rows: getRowsStateFromCache(
-      apiRef.current.unstable_caches.rows,
-      null,
+    rows: getRowsStateFromCache({
       apiRef,
-      props.rowCount,
-      props.loading,
-    ),
+      previousTree: null,
+      rowCountProp: props.rowCount,
+      loadingProp: props.loading,
+    }),
   };
 };
 
@@ -182,13 +92,12 @@ export const useGridRows = (
         lastUpdateMs.current = Date.now();
         apiRef.current.setState((state) => ({
           ...state,
-          rows: getRowsStateFromCache(
-            apiRef.current.unstable_caches.rows!,
-            gridRowTreeSelector(apiRef),
+          rows: getRowsStateFromCache({
             apiRef,
-            props.rowCount,
-            props.loading,
-          ),
+            previousTree: gridRowTreeSelector(apiRef),
+            rowCountProp: props.rowCount,
+            loadingProp: props.loading,
+          }),
         }));
         apiRef.current.publishEvent('rowsSet');
         apiRef.current.forceUpdate();
@@ -224,15 +133,14 @@ export const useGridRows = (
     (rows) => {
       logger.debug(`Updating all rows, new length ${rows.length}`);
       throttledRowsChange(
-        convertRowsPropToState({
+        createRowsInternalCache({
           rows,
-          prevCache: apiRef.current.unstable_caches.rows!,
           getRowId: props.getRowId,
         }),
         true,
       );
     },
-    [apiRef, logger, props.getRowId, throttledRowsChange],
+    [logger, props.getRowId, throttledRowsChange],
   );
 
   const updateRows = React.useCallback<GridRowApi['updateRows']>(
@@ -251,7 +159,7 @@ export const useGridRows = (
       const uniqUpdates = new Map<GridRowId, GridRowModel>();
 
       updates.forEach((update) => {
-        const id = getGridRowId(
+        const id = getRowIdFromRowModel(
           update,
           props.getRowId,
           'A row was provided without id when calling updateRows():',
@@ -266,42 +174,39 @@ export const useGridRows = (
 
       const deletedRowIds: GridRowId[] = [];
 
-      const newStateValue: GridRowInternalCacheValue = {
-        idRowsLookup: { ...apiRef.current.unstable_caches.rows!.value.idRowsLookup },
-        idToIdLookup: { ...apiRef.current.unstable_caches.rows!.value.idToIdLookup },
-        ids: [...apiRef.current.unstable_caches.rows!.value.ids],
+      const prevCache = apiRef.current.unstable_caches.rows;
+      const newCache: GridRowsInternalCache = {
+        rowsBeforePartialUpdates: prevCache.rowsBeforePartialUpdates,
+        idRowsLookup: { ...prevCache.idRowsLookup },
+        idToIdLookup: { ...prevCache.idToIdLookup },
+        ids: [...prevCache.ids],
       };
 
       uniqUpdates.forEach((partialRow, id) => {
         // eslint-disable-next-line no-underscore-dangle
         if (partialRow._action === 'delete') {
-          delete newStateValue.idRowsLookup[id];
-          delete newStateValue.idToIdLookup[id];
+          delete newCache.idRowsLookup[id];
+          delete newCache.idToIdLookup[id];
           deletedRowIds.push(id);
           return;
         }
 
         const oldRow = apiRef.current.getRow(id);
         if (!oldRow) {
-          newStateValue.idRowsLookup[id] = partialRow;
-          newStateValue.idToIdLookup[id] = id;
-          newStateValue.ids.push(id);
+          newCache.idRowsLookup[id] = partialRow;
+          newCache.idToIdLookup[id] = id;
+          newCache.ids.push(id);
           return;
         }
 
-        newStateValue.idRowsLookup[id] = { ...apiRef.current.getRow(id), ...partialRow };
+        newCache.idRowsLookup[id] = { ...apiRef.current.getRow(id), ...partialRow };
       });
 
       if (deletedRowIds.length > 0) {
-        newStateValue.ids = newStateValue.ids.filter((id) => !deletedRowIds.includes(id));
+        newCache.ids = newCache.ids.filter((id) => !deletedRowIds.includes(id));
       }
 
-      const state: GridRowsInternalCache = {
-        ...apiRef.current.unstable_caches.rows!,
-        value: newStateValue,
-      };
-
-      throttledRowsChange(state, true);
+      throttledRowsChange(newCache, true);
     },
     [props.signature, props.getRowId, throttledRowsChange, apiRef],
   );
@@ -437,25 +342,21 @@ export const useGridRows = (
   const groupRows = React.useCallback(() => {
     logger.info(`Row grouping pre-processing have changed, regenerating the row tree`);
 
-    let rows: GridRowsProp | undefined;
+    let cache: GridRowsInternalCache;
     if (apiRef.current.unstable_caches.rows!.rowsBeforePartialUpdates === props.rows) {
       // The `props.rows` has not changed since the last row grouping
       // We can keep the potential updates stored in `inputRowsAfterUpdates` on the new grouping
-      rows = undefined;
+      cache = apiRef.current.unstable_caches.rows!;
     } else {
       // The `props.rows` has changed since the last row grouping
       // We must use the new `props.rows` on the new grouping
       // This occurs because this event is triggered before the `useEffect` on the rows when both the grouping pre-processing and the rows changes on the same render
-      rows = props.rows;
-    }
-    throttledRowsChange(
-      convertRowsPropToState({
-        rows,
+      cache = createRowsInternalCache({
+        rows: props.rows,
         getRowId: props.getRowId,
-        prevCache: apiRef.current.unstable_caches.rows!,
-      }),
-      false,
-    );
+      });
+    }
+    throttledRowsChange(cache, false);
   }, [logger, apiRef, props.rows, props.getRowId, throttledRowsChange]);
 
   const handleStrategyProcessorChange = React.useCallback<
@@ -533,10 +434,9 @@ export const useGridRows = (
 
     logger.debug(`Updating all rows, new length ${props.rows.length}`);
     throttledRowsChange(
-      convertRowsPropToState({
+      createRowsInternalCache({
         rows: props.rows,
         getRowId: props.getRowId,
-        prevCache: apiRef.current.unstable_caches.rows!,
       }),
       false,
     );

--- a/packages/grid/x-data-grid/src/models/api/gridCoreApi.ts
+++ b/packages/grid/x-data-grid/src/models/api/gridCoreApi.ts
@@ -5,7 +5,7 @@ import { GridRowsInternalCache } from '../../hooks/features/rows/gridRowsState';
 
 // TODO: Export and make it augmentable
 interface Caches {
-  rows?: GridRowsInternalCache;
+  rows: GridRowsInternalCache;
 }
 
 /**


### PR DESCRIPTION
While working on #4927, I noticed that our cache structure had some complex legacy structure that was not useful anymore.

- [x] Rename `convertRowsPropToState` into `createRowsInternalCache`
- [x] Don't have branch behavior in `createRowsInternalCache` that was basically "do nothing", only call it when we do want to regenerate the cache
- [x] Move all the utils in `gridRowUtils`
- [x] Make `apiRef.current.unstable_caches.rows` non nullable, like for the state we can rely on the fact that the stat init is being done before the rest
- [x] Flatten `GridRowsInternalCache` instead of having a `value` key storing almost everything
- [x] Clean the naming, no variable related to the cache should be named `state` (otherwise we can have misunderstandings between what leaves in the state and in the cache)