### PR TITLE
[docs] Fix TS typo in ColumnSpanningFunction example

### DIFF
--- a/docs/data/data-grid/column-spanning/ColumnSpanningFunction.tsx
+++ b/docs/data/data-grid/column-spanning/ColumnSpanningFunction.tsx
@@ -13,7 +13,7 @@ type Item = typeof items[number];
 interface SubtotalHeader {
   id: 'SUBTOTAL';
   label: string;
-  subtotal: 624;
+  subtotal: number;
 }
 
 interface TaxHeader {


### PR DESCRIPTION
Change TypeScript type of `subtotal` from number literal `624` to type `number`.