### PR TITLE
[l10n] Add deDE translations for x-date-pickers

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -103,6 +103,7 @@ import bgLocale from 'date-fns/locale/bg';
 | :---------------------- | :------------------ | :---------- |
 | English (United States) | en-US               | `enUS`      |
 | French                  | fr-FR               | `frFR`      |
+| German                  | de-DE               | `deDE`      |
 
 You can [find the source](https://github.com/mui/mui-x/tree/HEAD/packages/grid/x-date-pickers/src/locales) in the GitHub repository.
 

--- a/packages/x-date-pickers/src/locales/deDE.ts
+++ b/packages/x-date-pickers/src/locales/deDE.ts
@@ -1,0 +1,17 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { getPickersLocalization } from './utils/getPickersLocalization';
+
+const deDEPickers: Partial<PickersLocaleText> = {
+  previousMonth: 'Letzter Monat',
+  nextMonth: 'Nächster Monat',
+  openPreviousView: 'Letzte Ansicht öffnen',
+  openNextView: 'Nächste Ansicht öffnen',
+  cancelButtonLabel: 'Abbrechen',
+  clearButtonLabel: 'Löschen',
+  okButtonLabel: 'OK',
+  todayButtonLabel: 'Heute',
+  start: 'Beginn',
+  end: 'Ende',
+};
+
+export const deDE = getPickersLocalization(deDEPickers);

--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -1,3 +1,4 @@
+export * from './deDE';
 export * from './frFR';
 export * from './enUS';
 export * from './utils/pickersLocaleTextApi';

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -30,6 +30,7 @@
   { "name": "DateRangePickerProps", "kind": "Interface" },
   { "name": "DateTimePicker", "kind": "Variable" },
   { "name": "DateTimePickerProps", "kind": "Interface" },
+  { "name": "deDE", "kind": "Variable" },
   { "name": "DEFAULT_LOCALE", "kind": "Variable" },
   { "name": "DesktopDatePicker", "kind": "Variable" },
   { "name": "DesktopDatePickerProps", "kind": "Interface" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -22,6 +22,7 @@
   { "name": "DatePickerProps", "kind": "Interface" },
   { "name": "DateTimePicker", "kind": "Variable" },
   { "name": "DateTimePickerProps", "kind": "Interface" },
+  { "name": "deDE", "kind": "Variable" },
   { "name": "DEFAULT_LOCALE", "kind": "Variable" },
   { "name": "DesktopDatePicker", "kind": "Variable" },
   { "name": "DesktopDatePickerProps", "kind": "Interface" },


### PR DESCRIPTION
Following up on https://github.com/mui/mui-x/issues/3211, I'd like to provide German translations for the Date Picker component.