### PR TITLE
[DataGridPro] Allow to scroll detail panel content if it overflows the panel

### DIFF
--- a/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
@@ -113,6 +113,7 @@ const VirtualScrollerDetailPanel = styled(Box, {
   width: '100%',
   position: 'absolute',
   backgroundColor: theme.palette.background.default,
+  overflow: 'auto',
 }));
 
 const VirtualScrollerPinnedColumns = styled('div', {


### PR DESCRIPTION
Low-hanging fruit extracted from https://github.com/mui/mui-x/issues/4955#issuecomment-1134543900

If detail panel content needs more space than provided by `getDetailPanelHeight` - it makes more sense to scroll instead of overflow

Before: https://codesandbox.io/s/basicdetailpanels-material-demo-forked-g8zynr
After: https://codesandbox.io/s/basicdetailpanels-material-demo-forked-pbqh6l