### PR TITLE
[DataGrid] Add generics to `GridActionsColDef` to match `GridColDef`

### DIFF
--- a/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
@@ -249,7 +249,8 @@ export interface GridColDef<R extends GridValidRowModel = any, V = any, F = V> {
   colSpan?: number | ((params: GridCellParams<V, R, F>) => number | undefined);
 }
 
-export interface GridActionsColDef extends GridColDef {
+export interface GridActionsColDef<R extends GridValidRowModel = any, V = any, F = V>
+  extends GridColDef<R, V, F> {
   /**
    * Type allows to merge this object with a default definition [[GridColDef]].
    * @default 'actions'
@@ -260,12 +261,12 @@ export interface GridActionsColDef extends GridColDef {
    * @param {GridRowParams} params The params for each row.
    * @returns {React.ReactElement<GridActionsCellItemProps>[]} An array of [[GridActionsCell]] elements.
    */
-  getActions: (params: GridRowParams) => React.ReactElement<GridActionsCellItemProps>[];
+  getActions: (params: GridRowParams<R>) => React.ReactElement<GridActionsCellItemProps>[];
 }
 
 export type GridEnrichedColDef<R extends GridValidRowModel = any, V = any, F = V> =
   | GridColDef<R, V, F>
-  | GridActionsColDef;
+  | GridActionsColDef<R, V, F>;
 
 export type GridColumns<R extends GridValidRowModel = any> = GridEnrichedColDef<R>[];
 

--- a/packages/grid/x-data-grid/src/tests/columns.spec.tsx
+++ b/packages/grid/x-data-grid/src/tests/columns.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DataGrid, GridRenderCellParams } from '@mui/x-data-grid';
 import { GridCellParams } from '../models/params/gridCellParams';
+import { GridActionsColDef, GridColDef, GridColumns, GridRowParams } from '../models';
 
 const RenderCellParamsExplicitTyping = () => {
   return (
@@ -40,9 +41,66 @@ const RenderCellParamsExplicitTyping = () => {
             return params.formattedValue.toUpperCase();
           },
         },
+        {
+          field: 'price6',
+          type: 'actions',
+          // @ts-expect-error `price` is expected to be a number because of GridEnrichedCallDef
+          getActions: (params: GridRowParams<{ price: string }>) => {
+            return params.row.price.toUpperCase();
+          },
+        },
+        {
+          field: 'price7',
+          type: 'actions',
+          getActions: (params: GridRowParams<{ price: number }>) => {
+            // @ts-expect-error `toUpperCase` doesn't exist in number
+            return params.row.price.toUpperCase();
+          },
+        },
       ]}
     />
   );
+};
+
+const CellParamsFromRowModel = () => {
+  type PriceRowModel = { price1: number; price2: string };
+
+  const actionColumn: GridActionsColDef<PriceRowModel> = {
+    field: 'price1',
+    type: 'actions',
+    getActions: (params) => {
+      // @ts-expect-error `toUpperCase` does not exist on number
+      return params.row.price1.toUpperCase(); // fails
+    },
+  };
+
+  const priceCol: GridColDef<PriceRowModel> = {
+    field: 'price2',
+    renderCell: (params) => {
+      // @ts-expect-error `toExponential` does not exist on string
+      return params.row.price2.toExponential();
+    },
+  };
+
+  const columns: GridColumns<PriceRowModel> = [
+    {
+      field: 'price1',
+      type: 'actions',
+      getActions: (params) => {
+        // @ts-expect-error `toUpperCase` does not exist on number
+        return params.row.price1.toUpperCase(); // fails
+      },
+    },
+    {
+      field: 'price2',
+      renderCell: (params) => {
+        // @ts-expect-error `toExponential` does not exist on string
+        return params.row.price2.toExponential();
+      },
+    },
+  ];
+
+  return <DataGrid rows={[]} columns={columns} />;
 };
 
 const CellParamsValue = () => {


### PR DESCRIPTION
Closes #4660 

This adds generic arguments to the `GridActionsColDef` interface. They match those provided to `GridValidRowModel` and feed into it in the definition as well as in the params given to the `getActions` callback.

The immediate benefit here is that it provides an added layer of type safety to `getActions` and anywhere else in the base `GridColDef` that those arguments are used. It should be fully backwards compatible with all existing uses of this interface since the generics are optional and default to `any`. 

I added a simple test that puts the compiler through some very basic paces and also tests a `getActions` callback that makes use of those arguments. I see there is another test that also checks the `getActions` callback params, so maybe this second portion isn't necessary, but I figured I might as well demonstrate the connection between the interface and the implementation.