### PR TITLE
[data grid] Should not call setRowIndex when dragging a column over a row

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
@@ -87,6 +87,10 @@ export const useGridRowReorder = (
 
   const handleDragOver = React.useCallback<GridEventListener<'cellDragOver' | 'rowDragOver'>>(
     (params, event) => {
+      if (dragRowId === '') {
+        return;
+      }
+
       logger.debug(`Dragging over row ${params.id}`);
       event.preventDefault();
       // Prevent drag events propagation.
@@ -105,7 +109,7 @@ export const useGridRowReorder = (
     (params, event): void => {
       // Call the gridEditRowsStateSelector directly to avoid infnite loop
       const editRowsState = gridEditRowsStateSelector(apiRef.current.state);
-      if (isRowReorderDisabled || Object.keys(editRowsState).length !== 0) {
+      if (dragRowId === '' || isRowReorderDisabled || Object.keys(editRowsState).length !== 0) {
         return;
       }
 


### PR DESCRIPTION
Currently if `props.rowReorder = true`, when dragging a column over a row, we call `setRowIndex` with `rowId === ''`
This does not cause any bug, but `setRowIndex` is doing an useless lookup over the rows to find the index of the non existing row we are trying to move. 