### PR TITLE
[core] Upgrade node to v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ defaults: &defaults
     REACT_DIST_TAG: << parameters.react-dist-tag >>
   working_directory: /tmp/mui
   docker:
-    - image: cimg/node:12.22
+    - image: cimg/node:14.20
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "build:codesandbox",
-  "node": "12",
+  "node": "14",
   "packages": [
     "packages/x-license-pro",
     "packages/grid/x-data-grid",

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   command = "yarn docs:build && yarn docs:export && yarn storybook:build && yarn storybook:export"
 
 [build.environment]
-  NODE_VERSION = "12"
+  NODE_VERSION = "14"
   NODE_OPTIONS = "--max_old_space_size=4096"
   # Not using `playwright` when building docs.
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"

--- a/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -43,7 +43,11 @@ describe('<DataGridPro /> - Column pinning', () => {
     );
   };
 
-  it('should scroll when the next cell to focus is covered by the left pinned columns', () => {
+  it('should scroll when the next cell to focus is covered by the left pinned columns', function test() {
+    if (isJSDOM) {
+      // Need layouting
+      this.skip();
+    }
     render(<TestCase initialState={{ pinnedColumns: { left: ['id'] } }} />);
     const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
     virtualScroller.scrollLeft = 100;
@@ -56,7 +60,7 @@ describe('<DataGridPro /> - Column pinning', () => {
   });
 
   it('should scroll when the next cell to focus is covered by the right pinned columns', function test() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
+    if (isJSDOM) {
       // Need layouting
       this.skip();
     }

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.test.tsx
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.test.tsx
@@ -22,7 +22,8 @@ describe('useGridApiEventHandler', () => {
     it('should unsubscribe event listeners registered by uncommitted components', async function test() {
       if (
         !/jsdom/.test(window.navigator.userAgent) ||
-        typeof FinalizationRegistry === 'undefined'
+        typeof FinalizationRegistry === 'undefined' ||
+        typeof global.gc === 'undefined'
       ) {
         // Needs ability to trigger the garbage collector and support for FinalizationRegistry (added in node 14)
         this.skip();
@@ -50,7 +51,7 @@ describe('useGridApiEventHandler', () => {
       expect(apiRef.current.subscribeEvent.callCount).to.equal(2);
 
       unmount();
-      global.gc!(); // Triggers garbage collector
+      global.gc(); // Triggers garbage collector
       await sleep(50);
 
       // Ensure that both event listeners were unsubscribed


### PR DESCRIPTION
[Node 12 support ended on April 30th](https://nodejs.org/en/blog/release/v12.22.12/)
Node 14 is currently Maintenance LTS, Node 16 - Active LTS (see https://nodejs.org/en/about/releases/)

I didn't update [`engines` entry in our packages](https://github.com/mui/mui-x/blob/814b72284d01b9653995b3e05539d88f8ee7cf81/packages/grid/x-data-grid/package.json#L64), because:
- I'm not sure if it should be considered as breaking change
- technically nothing changes in our packages - we'll just use node v14 in CI and deployment environments