### PR TITLE
[core] Avoid Order ID to refer to GitHub issues/PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -71,4 +71,4 @@ body:
     attributes:
       label: Order ID 💳 (optional)
       description: The [Pro plan](https://mui.com/pricing/) comes with priority over the Community plan. Providing your order ID might give your problem more attention.
-      placeholder: 'ex. #11111'
+      placeholder: 'ex. 11111'

--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -71,4 +71,4 @@ body:
     attributes:
       label: Order ID 💳 (optional)
       description: The [Pro plan](https://mui.com/pricing/) comes with priority over the Community plan. Providing your order ID might give your problem more attention.
-      placeholder: 'ex. 11111'
+      placeholder: 'e.g. 11111'

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -39,4 +39,4 @@ body:
     attributes:
       label: Order ID 💳 (optional)
       description:  The [Pro plan](https://mui.com/pricing/) comes with priority over the Community plan. Providing your order ID might give your problem more attention.
-      placeholder: 'ex. #11111'
+      placeholder: 'ex. 11111'

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -39,4 +39,4 @@ body:
     attributes:
       label: Order ID 💳 (optional)
       description:  The [Pro plan](https://mui.com/pricing/) comes with priority over the Community plan. Providing your order ID might give your problem more attention.
-      placeholder: 'ex. 11111'
+      placeholder: 'e.g. 11111'

--- a/.github/ISSUE_TEMPLATE/3.pro-support.yml
+++ b/.github/ISSUE_TEMPLATE/3.pro-support.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Order ID 💳
       description: The order ID of the purchased Pro plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
-      placeholder: 'ex. #11111'
+      placeholder: 'ex. 11111'
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/3.pro-support.yml
+++ b/.github/ISSUE_TEMPLATE/3.pro-support.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Order ID 💳
       description: The order ID of the purchased Pro plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
-      placeholder: 'ex. 11111'
+      placeholder: 'e.g. 11111'
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/4.premium-support.yml
+++ b/.github/ISSUE_TEMPLATE/4.premium-support.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Order ID 💳
       description: The order ID of the purchased Premium plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
-      placeholder: 'ex. #11111'
+      placeholder: 'ex. 11111'
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/4.premium-support.yml
+++ b/.github/ISSUE_TEMPLATE/4.premium-support.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Order ID 💳
       description: The order ID of the purchased Premium plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
-      placeholder: 'ex. 11111'
+      placeholder: 'e.g. 11111'
     validations:
       required: true
   - type: checkboxes


### PR DESCRIPTION
The problem:

<img width="854" alt="Screenshot 2022-05-24 at 23 33 37" src="https://user-images.githubusercontent.com/3165635/170136213-36c5a0c8-ce05-4598-baf6-f0c30d5f1014.png">

https://github.com/mui/material-ui/pull/32742

I had to edit the issue to avoid confusion:

<img width="579" alt="Screenshot 2022-05-24 at 23 34 24" src="https://user-images.githubusercontent.com/3165635/170136293-aeae998c-280c-46fb-8a94-7b8c62cf1cd8.png">
