### PR TITLE
[DataGrid] Update quick filter input when model is modified

### DIFF
--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -368,7 +368,9 @@ The values used by the quick filter are obtained by splitting with space.
 If you want to implement a more advanced logic, the `<GridToolbarQuickFilter/>` component accepts a prop `quickFilterParser`.
 This function takes the string from the search text field and returns an array of values.
 
-If you control the `quickFilterValues` either by controlling `filterModel` or with the initial state, you should provide a `quickFilterFormatter` which will be used to update the content of the input.
+If you control the `quickFilterValues` either by controlling `filterModel` or with the initial state, the content of the input must be updated to reflect the new values.
+By default, values are joint with a spaces. You can customize this behavior by providing `quickFilterFormatter`.
+This formatter can be seen as the inverse of the `quickFilterParser`.
 
 For example, the following parser allows to search words containing a space by using the `','` to split values.
 

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -368,6 +368,8 @@ The values used by the quick filter are obtained by splitting with space.
 If you want to implement a more advanced logic, the `<GridToolbarQuickFilter/>` component accepts a prop `quickFilterParser`.
 This function takes the string from the search text field and returns an array of values.
 
+If you control the `quickFilterValues` either by controlling `filterModel` or with the initial state, you should provide a `quickFilterFormatter` which will be used to update the content of the input.
+
 For example, the following parser allows to search words containing a space by using the `','` to split values.
 
 ```jsx
@@ -375,6 +377,7 @@ For example, the following parser allows to search words containing a space by u
   quickFilterParser={(searchInput) =>
     searchInput.split(',').map((value) => value.trim())
   }
+  quickFilterFormatter={(quickFilterValues) => quickFilterValues.join(', ')}
   debounceMs={200} // time before applying the new quick filter value
 />
 ```

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -290,6 +290,7 @@
     "Pagination": { "default": "Pagination", "type": { "name": "elementType | null" } },
     "Panel": { "default": "GridPanel", "type": { "name": "elementType" } },
     "PreferencesPanel": { "default": "GridPreferencesPanel", "type": { "name": "elementType" } },
+    "QuickFilterClearIcon": { "default": "GridCloseIcon", "type": { "name": "elementType" } },
     "QuickFilterIcon": { "default": "GridSearchIcon", "type": { "name": "elementType" } },
     "Row": { "default": "GridRow", "type": { "name": "elementType" } },
     "RowReorderIcon": { "default": "GridDragIcon", "type": { "name": "elementType" } },

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -245,6 +245,7 @@
     "Pagination": { "default": "Pagination", "type": { "name": "elementType | null" } },
     "Panel": { "default": "GridPanel", "type": { "name": "elementType" } },
     "PreferencesPanel": { "default": "GridPreferencesPanel", "type": { "name": "elementType" } },
+    "QuickFilterClearIcon": { "default": "GridCloseIcon", "type": { "name": "elementType" } },
     "QuickFilterIcon": { "default": "GridSearchIcon", "type": { "name": "elementType" } },
     "Row": { "default": "GridRow", "type": { "name": "elementType" } },
     "RowReorderIcon": { "default": "GridDragIcon", "type": { "name": "elementType" } },

--- a/docs/pages/x/api/data-grid/selectors.json
+++ b/docs/pages/x/api/data-grid/selectors.json
@@ -234,6 +234,13 @@
     "supportsApiRef": false
   },
   {
+    "name": "gridQuickFilterValuesSelector",
+    "returnType": "any[] | undefined",
+    "category": "Filtering",
+    "description": "Get the current quick filter values.",
+    "supportsApiRef": true
+  },
+  {
     "name": "gridResizingColumnFieldSelector",
     "returnType": "string",
     "description": "",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
@@ -608,6 +608,7 @@
     "DetailPanelCollapseIcon": "Icon displayed on the detail panel toggle column when expanded.",
     "FilterPanelDeleteIcon": "Icon displayed for deleting the filter from filter Panel.",
     "RowReorderIcon": "Icon displayed on the <code>reorder</code> column type to reorder a row.",
-    "QuickFilterIcon": "Icon displayed on the quick filter input."
+    "QuickFilterIcon": "Icon displayed on the quick filter input.",
+    "QuickFilterClearIcon": "Icon displayed on the quick filter reset input."
   }
 }

--- a/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
@@ -608,6 +608,7 @@
     "DetailPanelCollapseIcon": "Icon displayed on the detail panel toggle column when expanded.",
     "FilterPanelDeleteIcon": "Icon displayed for deleting the filter from filter Panel.",
     "RowReorderIcon": "Icon displayed on the <code>reorder</code> column type to reorder a row.",
-    "QuickFilterIcon": "Icon displayed on the quick filter input."
+    "QuickFilterIcon": "Icon displayed on the quick filter input.",
+    "QuickFilterClearIcon": "Icon displayed on the quick filter reset input."
   }
 }

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -608,6 +608,7 @@
     "DetailPanelCollapseIcon": "Icon displayed on the detail panel toggle column when expanded.",
     "FilterPanelDeleteIcon": "Icon displayed for deleting the filter from filter Panel.",
     "RowReorderIcon": "Icon displayed on the <code>reorder</code> column type to reorder a row.",
-    "QuickFilterIcon": "Icon displayed on the quick filter input."
+    "QuickFilterIcon": "Icon displayed on the quick filter input.",
+    "QuickFilterClearIcon": "Icon displayed on the quick filter reset input."
   }
 }

--- a/docs/translations/api-docs/data-grid/data-grid-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pt.json
@@ -579,6 +579,7 @@
     "DetailPanelCollapseIcon": "Icon displayed on the detail panel toggle column when expanded.",
     "FilterPanelDeleteIcon": "Icon displayed for deleting the filter from filter Panel.",
     "RowReorderIcon": "Icon displayed on the <code>reorder</code> column type to reorder a row.",
-    "QuickFilterIcon": "Icon displayed on the quick filter input."
+    "QuickFilterIcon": "Icon displayed on the quick filter input.",
+    "QuickFilterClearIcon": "Icon displayed on the quick filter reset input."
   }
 }

--- a/docs/translations/api-docs/data-grid/data-grid-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-zh.json
@@ -579,6 +579,7 @@
     "DetailPanelCollapseIcon": "Icon displayed on the detail panel toggle column when expanded.",
     "FilterPanelDeleteIcon": "Icon displayed for deleting the filter from filter Panel.",
     "RowReorderIcon": "Icon displayed on the <code>reorder</code> column type to reorder a row.",
-    "QuickFilterIcon": "Icon displayed on the quick filter input."
+    "QuickFilterIcon": "Icon displayed on the quick filter input.",
+    "QuickFilterClearIcon": "Icon displayed on the quick filter reset input."
   }
 }

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -579,6 +579,7 @@
     "DetailPanelCollapseIcon": "Icon displayed on the detail panel toggle column when expanded.",
     "FilterPanelDeleteIcon": "Icon displayed for deleting the filter from filter Panel.",
     "RowReorderIcon": "Icon displayed on the <code>reorder</code> column type to reorder a row.",
-    "QuickFilterIcon": "Icon displayed on the quick filter input."
+    "QuickFilterIcon": "Icon displayed on the quick filter input.",
+    "QuickFilterClearIcon": "Icon displayed on the quick filter reset input."
   }
 }

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -131,6 +131,12 @@ GridToolbarQuickFilter.propTypes = {
    */
   debounceMs: PropTypes.number,
   /**
+   * Function responsible for formatting values of quick filter in a string when the model is modified
+   * @param {any[]} values The new values passed to the quick filter model
+   * @returns {string} The string to display in the text field
+   */
+  quickFilterFormatter: PropTypes.func,
+  /**
    * Function responsible for parsing text input in an array of independent values for quick filtering.
    * @param {string} input The value entered by the user
    * @returns {any[]} The array of value on which quick filter is applied

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -61,7 +61,9 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
   const rootProps = useGridRootProps();
   const quickFilterValues = gridQuickFilterValuesSelector(apiRef);
 
-  const [searchValue, setSearchValue] = React.useState('');
+  const [searchValue, setSearchValue] = React.useState(
+    quickFilterFormatter(quickFilterValues ?? []),
+  );
   const [prevQuickFilterValues, setPrevQuickFilterValues] = React.useState(quickFilterValues);
 
   React.useEffect(() => {

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -162,9 +162,9 @@ GridToolbarQuickFilter.propTypes = {
    */
   debounceMs: PropTypes.number,
   /**
-   * Function responsible for formatting values of the quick filter into a string when the model is modified.
-   * @param {any[]} values The new values passed to the quick filter model.
-   * @returns {string} The string to display in the text field.
+   * Function responsible for formatting values of quick filter in a string when the model is modified
+   * @param {any[]} values The new values passed to the quick filter model
+   * @returns {string} The string to display in the text field
    */
   quickFilterFormatter: PropTypes.func,
   /**

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
 import { styled } from '@mui/material/styles';
 import { debounce } from '@mui/material/utils';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
@@ -16,11 +17,25 @@ const GridToolbarQuickFilterRoot = styled(TextField, {
 })(({ theme }) => ({
   width: 'auto',
   paddingBottom: theme.spacing(0.5),
-  '& .MuiSvgIcon-root': {
-    marginRight: theme.spacing(0.5),
+  '& input': {
+    marginLeft: theme.spacing(0.5),
   },
   '& .MuiInput-underline:before': {
     borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  [`& input[type=search]::-ms-clear,
+& input[type=search]::-ms-reveal`]: {
+    /* clears the 'X' icon from IE */
+    display: 'none',
+    width: 0,
+    height: 0,
+  },
+  [`& input[type="search"]::-webkit-search-decoration,
+  & input[type="search"]::-webkit-search-cancel-button,
+  & input[type="search"]::-webkit-search-results-button,
+  & input[type="search"]::-webkit-search-results-decoration`]: {
+    /* clears the 'X' icon from Chrome */
+    display: 'none',
   },
 }));
 
@@ -104,6 +119,11 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
     [debouncedUpdateSearchValue],
   );
 
+  const handleSearchReset = React.useCallback(() => {
+    setSearchValue('');
+    updateSearchValue('');
+  }, [updateSearchValue]);
+
   return (
     <GridToolbarQuickFilterRoot
       as={rootProps.components.BaseTextField}
@@ -115,6 +135,16 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
       type="search"
       InputProps={{
         startAdornment: <rootProps.components.QuickFilterIcon fontSize="small" />,
+        endAdornment: (
+          <IconButton
+            aria-label={apiRef.current.getLocaleText('toolbarQuickFilterDeleteIconLabel')}
+            size="small"
+            sx={{ visibility: searchValue ? 'visible' : 'hidden' }}
+            onClick={handleSearchReset}
+          >
+            <rootProps.components.QuickFilterClearIcon fontSize="small" />
+          </IconButton>
+        ),
       }}
       {...other}
       {...rootProps.componentsProps?.baseTextField}

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -79,6 +79,7 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
   const [searchValue, setSearchValue] = React.useState(
     quickFilterFormatter(quickFilterValues ?? []),
   );
+
   const [prevQuickFilterValues, setPrevQuickFilterValues] = React.useState(quickFilterValues);
 
   React.useEffect(() => {

--- a/packages/grid/x-data-grid/src/constants/defaultGridSlotsComponents.ts
+++ b/packages/grid/x-data-grid/src/constants/defaultGridSlotsComponents.ts
@@ -71,6 +71,7 @@ const DEFAULT_GRID_ICON_SLOTS_COMPONENTS: GridIconSlotsComponent = {
   DetailPanelCollapseIcon: GridRemoveIcon,
   RowReorderIcon: GridDragIcon,
   QuickFilterIcon: GridSearchIcon,
+  QuickFilterClearIcon: GridCloseIcon,
 };
 
 /**

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts
@@ -20,6 +20,15 @@ export const gridFilterModelSelector = createSelector(
 );
 
 /**
+ * Get the current quick filter values.
+ * @category Filtering
+ */
+export const gridQuickFilterValuesSelector = createSelector(
+  gridFilterModelSelector,
+  (filterModel) => filterModel.quickFilterValues,
+);
+
+/**
  * @category Filtering
  * @ignore - do not document.
  */

--- a/packages/grid/x-data-grid/src/models/gridIconSlotsComponent.ts
+++ b/packages/grid/x-data-grid/src/models/gridIconSlotsComponent.ts
@@ -125,4 +125,9 @@ export interface GridIconSlotsComponent {
    * @default GridSearchIcon
    */
   QuickFilterIcon: React.JSXElementConstructor<any>;
+  /**
+   * Icon displayed on the quick filter reset input.
+   * @default GridCloseIcon
+   */
+  QuickFilterClearIcon: React.JSXElementConstructor<any>;
 }

--- a/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
-import { createRenderer, fireEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, fireEvent } from '@mui/monorepo/test/utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
@@ -47,10 +47,10 @@ describe('<DataGrid /> - Quick Filter', () => {
 
   describe('component', () => {
     it('should apply filter', () => {
-      const { container } = render(<TestCase />);
+      render(<TestCase />);
 
       expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas', 'Puma']);
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'a' },
       });
       clock.runToLast();
@@ -61,7 +61,7 @@ describe('<DataGrid /> - Quick Filter', () => {
     it('should allows to customize input splitting', () => {
       const onFilterModelChange = spy();
 
-      const { container } = render(
+      render(
         <TestCase
           onFilterModelChange={onFilterModelChange}
           componentsProps={{
@@ -75,7 +75,7 @@ describe('<DataGrid /> - Quick Filter', () => {
 
       expect(onFilterModelChange.callCount).to.equal(0);
 
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'adid, nik' },
       });
       clock.runToLast();
@@ -88,20 +88,20 @@ describe('<DataGrid /> - Quick Filter', () => {
     });
 
     it('should no prettify user input', () => {
-      const { container } = render(<TestCase />);
+      render(<TestCase />);
 
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'adidas   nike' },
       });
       clock.runToLast();
 
-      expect(container.querySelector('input[type=search]').value).to.equal('adidas   nike');
+      expect(screen.getByRole('searchbox').value).to.equal('adidas   nike');
     });
 
     it('should update input when the state is modified', () => {
-      const { container, setProps } = render(<TestCase />);
+      const { setProps } = render(<TestCase />);
 
-      expect(container.querySelector('input[type=search]').value).to.equal('');
+      expect(screen.getByRole('searchbox').value).to.equal('');
 
       setProps({
         filterModel: {
@@ -109,7 +109,7 @@ describe('<DataGrid /> - Quick Filter', () => {
           quickFilterValues: ['adidas', 'nike'],
         },
       });
-      expect(container.querySelector('input[type=search]').value).to.equal('adidas nike');
+      expect(screen.getByRole('searchbox').value).to.equal('adidas nike');
 
       setProps({
         filterModel: {
@@ -117,11 +117,11 @@ describe('<DataGrid /> - Quick Filter', () => {
           quickFilterValues: [],
         },
       });
-      expect(container.querySelector('input[type=search]').value).to.equal('');
+      expect(screen.getByRole('searchbox').value).to.equal('');
     });
 
-    it('should allows to customize input formatting', () => {
-      const { container, setProps } = render(
+    it('should allow to customize input formatting', () => {
+      const { setProps } = render(
         <TestCase
           componentsProps={{
             toolbar: {
@@ -131,28 +131,28 @@ describe('<DataGrid /> - Quick Filter', () => {
         />,
       );
 
-      expect(container.querySelector('input[type=search]').value).to.equal('');
+      expect(screen.getByRole('searchbox').value).to.equal('');
       setProps({
         filterModel: {
           items: [],
           quickFilterValues: ['adidas', 'nike'],
         },
       });
-      expect(container.querySelector('input[type=search]').value).to.equal('adidas, nike');
+      expect(screen.getByRole('searchbox').value).to.equal('adidas, nike');
     });
   });
 
   describe('quick filter logic', () => {
     it('should return rows that match all values by default', () => {
-      const { container } = render(<TestCase />);
+      render(<TestCase />);
 
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'adid' },
       });
       clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['Adidas']);
 
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'adid nik' },
       });
       clock.runToLast();
@@ -160,7 +160,7 @@ describe('<DataGrid /> - Quick Filter', () => {
     });
 
     it('should return rows that match some values if quickFilterLogicOperator="or"', () => {
-      const { container } = render(
+      render(
         <TestCase
           initialState={{
             filter: { filterModel: { items: [], quickFilterLogicOperator: GridLinkOperator.Or } },
@@ -168,13 +168,13 @@ describe('<DataGrid /> - Quick Filter', () => {
         />,
       );
 
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'adid' },
       });
       clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['Adidas']);
 
-      fireEvent.change(container.querySelector('input[type=search]'), {
+      fireEvent.change(screen.getByRole('searchbox'), {
         target: { value: 'adid nik' },
       });
       clock.runToLast();

--- a/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -57,6 +57,7 @@ describe('<DataGrid /> - Quick Filter', () => {
 
       expect(getColumnValues(0)).to.deep.equal(['Adidas', 'Puma']);
     });
+
     it('should allows to customize input splitting', () => {
       const onFilterModelChange = spy();
 
@@ -84,6 +85,60 @@ describe('<DataGrid /> - Quick Filter', () => {
         quickFilterValues: ['adid', 'nik'],
         quickFilterLogicOperator: 'and',
       });
+    });
+
+    it('should no prettify user input', () => {
+      const { container } = render(<TestCase />);
+
+      fireEvent.change(container.querySelector('input[type=search]'), {
+        target: { value: 'adidas   nike' },
+      });
+      clock.runToLast();
+
+      expect(container.querySelector('input[type=search]').value).to.equal('adidas   nike');
+    });
+
+    it('should update input when the state is modified', () => {
+      const { container, setProps } = render(<TestCase />);
+
+      expect(container.querySelector('input[type=search]').value).to.equal('');
+
+      setProps({
+        filterModel: {
+          items: [],
+          quickFilterValues: ['adidas', 'nike'],
+        },
+      });
+      expect(container.querySelector('input[type=search]').value).to.equal('adidas nike');
+
+      setProps({
+        filterModel: {
+          items: [],
+          quickFilterValues: [],
+        },
+      });
+      expect(container.querySelector('input[type=search]').value).to.equal('');
+    });
+
+    it('should allows to customize input formatting', () => {
+      const { container, setProps } = render(
+        <TestCase
+          componentsProps={{
+            toolbar: {
+              quickFilterFormatter: (quickFilterValues: string[]) => quickFilterValues.join(', '),
+            },
+          }}
+        />,
+      );
+
+      expect(container.querySelector('input[type=search]').value).to.equal('');
+      setProps({
+        filterModel: {
+          items: [],
+          quickFilterValues: ['adidas', 'nike'],
+        },
+      });
+      expect(container.querySelector('input[type=search]').value).to.equal('adidas, nike');
     });
   });
 

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -344,6 +344,7 @@
   { "name": "GridPrintExportMenuItem", "kind": "Variable" },
   { "name": "GridPrintExportMenuItemProps", "kind": "TypeAlias" },
   { "name": "GridPrintExportOptions", "kind": "Interface" },
+  { "name": "gridQuickFilterValuesSelector", "kind": "Variable" },
   { "name": "GridRemoveIcon", "kind": "Variable" },
   { "name": "GridRenderCellParams", "kind": "Interface" },
   { "name": "GridRenderColumnsProps", "kind": "Interface" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -335,6 +335,7 @@
   { "name": "GridPrintExportMenuItem", "kind": "Variable" },
   { "name": "GridPrintExportMenuItemProps", "kind": "TypeAlias" },
   { "name": "GridPrintExportOptions", "kind": "Interface" },
+  { "name": "gridQuickFilterValuesSelector", "kind": "Variable" },
   { "name": "GridRemoveIcon", "kind": "Variable" },
   { "name": "GridRenderCellParams", "kind": "Interface" },
   { "name": "GridRenderColumnsProps", "kind": "Interface" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -310,6 +310,7 @@
   { "name": "GridPrintExportMenuItem", "kind": "Variable" },
   { "name": "GridPrintExportMenuItemProps", "kind": "TypeAlias" },
   { "name": "GridPrintExportOptions", "kind": "Interface" },
+  { "name": "gridQuickFilterValuesSelector", "kind": "Variable" },
   { "name": "GridRemoveIcon", "kind": "Variable" },
   { "name": "GridRenderCellParams", "kind": "Interface" },
   { "name": "GridRenderColumnsProps", "kind": "Interface" },


### PR DESCRIPTION
Fix #4921

I assume the quick filter value is rarely modified from somewhere else. It can be reset by clicking a button, or when putting back a saved state.

From this, I propose to add a prop to the input named `quickFilterFormatter`. This prop is used only if the quick filter state is updated and does not correspond anymore to the input content. In such a case, we use this `quickFilterFormatter` to update the input content.

