### PR TITLE
[data grid] Add an id to the filter item created when opening the filter panel

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/filterPanel.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filterPanel.DataGridPro.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import {
+  DataGridPro,
+  DataGridProProps,
+  gridFilterModelSelector,
+  GridApi,
+  useGridApiRef,
+} from '@mui/x-data-grid-pro';
+// @ts-ignore Remove once the test utils are typed
+import { createRenderer } from '@mui/monorepo/test/utils';
+
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
+describe('<DataGrid /> - Filter panel', () => {
+  const { render } = createRenderer();
+
+  const baselineProps: DataGridProProps = {
+    autoHeight: isJSDOM,
+    disableVirtualization: true,
+    rows: [],
+    columns: [{ field: 'brand' }],
+  };
+
+  let apiRef: React.MutableRefObject<GridApi>;
+
+  const TestCase = (props: Partial<DataGridProProps>) => {
+    apiRef = useGridApiRef();
+    return (
+      <div style={{ width: 300, height: 300 }}>
+        <DataGridPro apiRef={apiRef} {...baselineProps} {...props} />
+      </div>
+    );
+  };
+
+  it('should add an id and operatorValue to the filter item created when opening the filter panel', () => {
+    render(<TestCase />);
+    apiRef.current.showFilterPanel('brand');
+    const model = gridFilterModelSelector(apiRef);
+    expect(model.items).to.have.length(1);
+    expect(model.items[0].id).to.not.equal(null);
+    expect(model.items[0].operatorValue).to.not.equal(null);
+  });
+});

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -24,7 +24,7 @@ type GridFilterItemApplier = {
  * @return {GridFilterItem} The clean filter item with an uniq ID and an always-defined operatorValue.
  * TODO: Make the typing reflect the different between GridFilterInputItem and GridFilterItem.
  */
-const cleanFilterItem = (
+export const cleanFilterItem = (
   item: GridFilterItem,
   apiRef: React.MutableRefObject<GridApiCommunity>,
 ) => {

--- a/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
@@ -25,6 +25,7 @@ import {
   buildAggregatedFilterApplier,
   sanitizeFilterModel,
   mergeStateWithFilterModel,
+  cleanFilterItem,
 } from './gridFilterUtils';
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
 import { isDeepEqual } from '../../../utils/utils';
@@ -148,9 +149,12 @@ export const useGridFilter = (
         if (filterItemOnTarget) {
           newFilterItems = filterItemsWithValue;
         } else if (props.disableMultipleColumnsFiltering) {
-          newFilterItems = [{ columnField: targetColumnField }];
+          newFilterItems = [cleanFilterItem({ columnField: targetColumnField }, apiRef)];
         } else {
-          newFilterItems = [...filterItemsWithValue, { columnField: targetColumnField }];
+          newFilterItems = [
+            ...filterItemsWithValue,
+            cleanFilterItem({ columnField: targetColumnField }, apiRef),
+          ];
         }
 
         apiRef.current.setFilterModel({


### PR DESCRIPTION
Fixes #4943

I also added it to the single filtering to handle switch between single and multi filtering (even if it's a very marginal use case)