### PR TITLE
[core] Stop renovate PR updates when PR is on hold

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "rebaseWhen": "conflicted",
   "ignoreDeps": [],
   "labels": ["dependencies"],
+  "stopUpdatingLabel": "On hold",
   "packageRules": [
     {
       "matchDepTypes": ["peerDependencies"],


### PR DESCRIPTION
We have some dependencies updates that are blocked by nodejs upgrade (https://github.com/mui/mui-x/pull/4999).
I've put them on hold and there's we don't need them updated until the blocker is resolved.