### PR TITLE
[DataGrid] Restore focus after dismissing column menu

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
@@ -214,5 +214,57 @@ describe('<DataGridPro /> - Column Headers', () => {
       clock.runToLast(); // Wait for the transition to run
       expect(menuIconButton?.parentElement).not.to.have.class(gridClasses.menuOpen);
     });
+
+    it('should restore focus to the column header when dismissing the menu by selecting any item', () => {
+      const Test = (props: Partial<DataGridProProps>) => {
+        return (
+          <div style={{ width: 300, height: 500 }}>
+            <DataGridPro
+              {...baselineProps}
+              columns={[{ field: 'brand' }]}
+              initialState={{ sorting: { sortModel: [{ field: 'brand', sort: 'asc' }] } }}
+              {...props}
+            />
+          </div>
+        );
+      };
+      render(<Test />);
+      const columnCell = getColumnHeaderCell(0);
+      const menuIconButton = columnCell.querySelector('button[aria-label="Menu"]');
+      fireEvent.click(menuIconButton);
+      clock.runToLast();
+
+      const menu = screen.queryByRole('menu');
+      const unsortMenuitem = screen.queryByRole('menuitem', { name: /unsort/i });
+      expect(menu).toHaveFocus();
+
+      fireEvent.keyDown(menu, { key: 'ArrowDown' });
+      expect(unsortMenuitem).toHaveFocus();
+      fireEvent.keyDown(unsortMenuitem, { key: 'Enter' });
+
+      expect(columnCell).toHaveFocus();
+    });
+
+    it('should restore focus to the column header when dismissing the menu without selecting any item', () => {
+      const Test = (props: Partial<DataGridProProps>) => {
+        return (
+          <div style={{ width: 300, height: 500 }}>
+            <DataGridPro {...baselineProps} columns={[{ field: 'brand' }]} {...props} />
+          </div>
+        );
+      };
+      render(<Test />);
+      const columnCell = getColumnHeaderCell(0);
+      const menuIconButton = columnCell.querySelector('button[aria-label="Menu"]');
+      fireEvent.click(menuIconButton);
+      clock.runToLast();
+
+      const menu = screen.queryByRole('menu');
+      expect(menu).toHaveFocus();
+      fireEvent.keyDown(menu, { key: 'Escape' });
+
+      expect(menu).not.toHaveFocus();
+      expect(columnCell).toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
Preview: https://deploy-preview-5027--material-ui-x.netlify.app/x/react-data-grid/demo/

Fixes #1873

This bug happens because, when the column menu is closed, the browser puts focus back to the menu button. However, this button only appears on hover. The problem is that as soon as it receives focus it becomes invisible and the focus is moved to the `<body>`. The solution I used is to focus the column header when I detect that the menu button was focused because the column menu was closed (checking `event.relatedTarget`). Like #1873, we also have problem in the panels (columns and filters). We don't restore the focus to any element, making it difficult to navigate via keyboard. I'll open another issue for them.