### PR TITLE
[docs] Fix demo currency format

### DIFF
--- a/docs/data/data-grid/column-definition/CustomColumnTypesGrid.js
+++ b/docs/data/data-grid/column-definition/CustomColumnTypesGrid.js
@@ -32,7 +32,7 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
 const usdPrice = {
   type: 'number',
   width: 130,
-  valueFormatter: ({ value }) => currencyFormatter.format(Number(value)),
+  valueFormatter: ({ value }) => currencyFormatter.format(value),
   cellClassName: 'font-tabular-nums',
 };
 

--- a/docs/data/data-grid/column-definition/CustomColumnTypesGrid.tsx
+++ b/docs/data/data-grid/column-definition/CustomColumnTypesGrid.tsx
@@ -32,7 +32,7 @@ const currencyFormatter = new Intl.NumberFormat('en-US', {
 const usdPrice: GridColTypeDef = {
   type: 'number',
   width: 130,
-  valueFormatter: ({ value }) => currencyFormatter.format(Number(value)),
+  valueFormatter: ({ value }) => currencyFormatter.format(value),
   cellClassName: 'font-tabular-nums',
 };
 

--- a/packages/grid/x-data-grid-generator/src/hooks/useMovieData.ts
+++ b/packages/grid/x-data-grid-generator/src/hooks/useMovieData.ts
@@ -23,7 +23,7 @@ const COLUMNS: GridColumns = [
       if (!value) {
         return '';
       }
-      return `${value.toLocaleString()}$`;
+      return `$${value.toLocaleString('en-US')}`;
     },
   } as GridColDef<any, number, string>,
   {

--- a/packages/grid/x-data-grid-generator/src/hooks/useMovieData.ts
+++ b/packages/grid/x-data-grid-generator/src/hooks/useMovieData.ts
@@ -11,6 +11,13 @@ export type Movie = {
   cinematicUniverse?: string;
 };
 
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
 const COLUMNS: GridColumns = [
   { field: 'title', headerName: 'Title', width: 200, groupable: false },
   {
@@ -23,7 +30,7 @@ const COLUMNS: GridColumns = [
       if (!value) {
         return '';
       }
-      return `$${value.toLocaleString('en-US')}`;
+      return currencyFormatter.format(value);
     },
   } as GridColDef<any, number, string>,
   {


### PR DESCRIPTION
My locale is configured to be en-US, which is the locale [we use](https://www.notion.so/mui-org/Technical-writing-7e55b517ac2e489a9ddb6d0f6dd765de#9494c1a7521146c2ab571969b21955ce) to write the documentation. In this context, when opening https://mui.com/x/react-data-grid/row-grouping/, you will see:

<img width="370" alt="Screenshot 2022-05-27 at 23 34 52" src="https://user-images.githubusercontent.com/3165635/170792110-17b5242b-0415-4ab4-81cd-a14f41b0214c.png">

which I think is wrong:

```jsx
new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(2847246203);
// = $2,847,246,203
```

https://deploy-preview-5034--material-ui-x.netlify.app/x/react-data-grid/row-grouping/