### PR TITLE
[data grid] Use column visibility model on Hide All / Show All when enabled

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
@@ -15,7 +15,7 @@ import {
   GridRowsProp,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import { getCell, getColumnHeaderCell, getColumnHeadersTextContent } from 'test/utils/helperFn';
+import { getColumnHeadersTextContent } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -221,7 +221,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
     });
   });
 
-  it.only('should not hide column when resizing a column after hiding it and showing it again ', () => {
+  it('should not hide column when resizing a column after hiding it and showing it again ', () => {
     const { getByText } = render(
       <TestDataGridPro
         initialState={{

--- a/packages/grid/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
@@ -2,17 +2,20 @@ import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 // @ts-ignore Remove once the test utils are typed
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent } from '@mui/monorepo/test/utils';
 import {
   DataGridPro,
-  useGridApiRef,
   DataGridProProps,
-  GridRowsProp,
-  GridColumns,
-  gridColumnLookupSelector,
-  gridColumnVisibilityModelSelector,
   GridApi,
+  gridClasses,
+  gridColumnLookupSelector,
+  GridColumns,
+  gridColumnVisibilityModelSelector,
+  GridPreferencePanelsValue,
+  GridRowsProp,
+  useGridApiRef,
 } from '@mui/x-data-grid-pro';
+import { getCell, getColumnHeaderCell, getColumnHeadersTextContent } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -216,5 +219,28 @@ describe('<DataGridPro /> - Columns Visibility', () => {
       expect(onColumnVisibilityModelChange.callCount).to.equal(1);
       expect(onColumnVisibilityModelChange.lastCall.firstArg).to.deep.equal({});
     });
+  });
+
+  it.only('should not hide column when resizing a column after hiding it and showing it again ', () => {
+    const { getByText } = render(
+      <TestDataGridPro
+        initialState={{
+          columns: { columnVisibilityModel: {} },
+          preferencePanel: { open: true, openedPanelValue: GridPreferencePanelsValue.columns },
+        }}
+      />,
+    );
+
+    fireEvent.click(getByText('Hide all'));
+    expect(getColumnHeadersTextContent()).to.deep.equal([]);
+    fireEvent.click(document.querySelector('[role="tooltip"] [name="id"]'));
+    expect(getColumnHeadersTextContent()).to.deep.equal(['id']);
+
+    const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`);
+    fireEvent.mouseDown(separator, { clientX: 100 });
+    fireEvent.mouseMove(separator, { clientX: 110, buttons: 1 });
+    fireEvent.mouseUp(separator);
+
+    expect(getColumnHeadersTextContent()).to.deep.equal(['id']);
   });
 });

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -77,8 +77,18 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
 
   const toggleAllColumns = React.useCallback(
     (isVisible: boolean) => {
-      // TODO v6: call `setColumnVisibilityModel` directly
-      apiRef.current.updateColumns(
+      if (apiRef.current.unstable_caches.columns.isUsingColumnVisibilityModel) {
+        if (isVisible) {
+          return apiRef.current.setColumnVisibilityModel({});
+        }
+
+        return apiRef.current.setColumnVisibilityModel(
+          Object.fromEntries(columns.map((col) => [col.field, false])),
+        );
+      }
+
+      // TODO v6: Remove
+      return apiRef.current.updateColumns(
         columns.map((col) => {
           if (col.hideable !== false) {
             return { field: col.field, hide: !isVisible };

--- a/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsInterfaces.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsInterfaces.ts
@@ -19,6 +19,10 @@ export interface GridColumnsState {
   columnVisibilityModel: GridColumnVisibilityModel;
 }
 
+export interface GridColumnsInternalCache {
+  isUsingColumnVisibilityModel: boolean;
+}
+
 export type GridColumnDimensions = { [key in GridColumnDimensionProperties]?: number };
 
 export interface GridColumnsInitialState {

--- a/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
@@ -48,6 +48,10 @@ export const columnsStateInitializer: GridStateInitializer<
   const isUsingColumnVisibilityModel =
     !!props.columnVisibilityModel || !!props.initialState?.columns?.columnVisibilityModel;
 
+  apiRef.current.unstable_caches.columns = {
+    isUsingColumnVisibilityModel,
+  };
+
   const columnsTypes = computeColumnTypes(props.columnTypes);
 
   const columnsState = createColumnsState({
@@ -96,14 +100,6 @@ export function useGridColumns(
 
   const previousColumnsProp = React.useRef(props.columns);
   const previousColumnTypesProp = React.useRef(columnTypes);
-
-  /**
-   * If `initialState.columns.columnVisibilityModel` or `columnVisibilityModel` was defined during the 1st render, we are directly updating the model
-   * If not, we keep the old behavior and update the `GridColDef.hide` option (which will update the state model through the `GridColDef.hide` => `columnVisibilityModel` sync in `createColumnsState`
-   */
-  const isUsingColumnVisibilityModel = React.useRef(
-    !!props.columnVisibilityModel || !!props.initialState?.columns?.columnVisibilityModel,
-  );
 
   apiRef.current.unstable_updateControlState({
     stateId: 'visibleColumns',
@@ -213,7 +209,7 @@ export function useGridColumns(
       // We keep updating the `hide` option of `GridColDef` when not controlling the model to avoid any breaking change.
       // `updateColumns` take care of updating the model itself if needs be.
       // TODO v6: stop using the `hide` field even when the model is not defined
-      if (isUsingColumnVisibilityModel.current) {
+      if (apiRef.current.unstable_caches.columns.isUsingColumnVisibilityModel) {
         const columnVisibilityModel = gridColumnVisibilityModelSelector(apiRef);
         const isCurrentlyVisible: boolean = columnVisibilityModel[field] ?? true;
         if (isVisible !== isCurrentlyVisible) {
@@ -307,7 +303,7 @@ export function useGridColumns(
     (prevState) => {
       const columnsStateToExport: GridColumnsInitialState = {};
 
-      if (isUsingColumnVisibilityModel.current) {
+      if (apiRef.current.unstable_caches.columns.isUsingColumnVisibilityModel) {
         const columnVisibilityModelToExport = gridColumnVisibilityModelSelector(apiRef);
         const hasHiddenColumns = Object.values(columnVisibilityModelToExport).some(
           (value) => value === false,
@@ -350,7 +346,8 @@ export function useGridColumns(
 
   const stateRestorePreProcessing = React.useCallback<GridPipeProcessor<'restoreState'>>(
     (params, context) => {
-      const columnVisibilityModelToImport = isUsingColumnVisibilityModel.current
+      const columnVisibilityModelToImport = apiRef.current.unstable_caches.columns
+        .isUsingColumnVisibilityModel
         ? context.stateToRestore.columns?.columnVisibilityModel
         : undefined;
       const initialState = context.stateToRestore.columns;
@@ -364,7 +361,8 @@ export function useGridColumns(
         columnTypes,
         columnsToUpsert: [],
         initialState,
-        shouldRegenColumnVisibilityModelFromColumns: !isUsingColumnVisibilityModel.current,
+        shouldRegenColumnVisibilityModelFromColumns:
+          !apiRef.current.unstable_caches.columns.isUsingColumnVisibilityModel,
         currentColumnVisibilityModel: columnVisibilityModelToImport,
         keepOnlyColumnsToUpsert: false,
       });
@@ -425,7 +423,8 @@ export function useGridColumns(
       columnTypes,
       columnsToUpsert: [],
       initialState: undefined,
-      shouldRegenColumnVisibilityModelFromColumns: !isUsingColumnVisibilityModel.current,
+      shouldRegenColumnVisibilityModelFromColumns:
+        !apiRef.current.unstable_caches.columns.isUsingColumnVisibilityModel,
       keepOnlyColumnsToUpsert: false,
     });
     setGridColumnsState(columnsState);
@@ -459,7 +458,8 @@ export function useGridColumns(
       columnTypes,
       initialState: undefined,
       // If the user provides a model, we don't want to set it in the state here because it has it's dedicated `useEffect` which calls `setColumnVisibilityModel`
-      shouldRegenColumnVisibilityModelFromColumns: !isUsingColumnVisibilityModel.current,
+      shouldRegenColumnVisibilityModelFromColumns:
+        !apiRef.current.unstable_caches.columns.isUsingColumnVisibilityModel,
       columnsToUpsert: props.columns,
       keepOnlyColumnsToUpsert: true,
     });

--- a/packages/grid/x-data-grid/src/models/gridApiCaches.ts
+++ b/packages/grid/x-data-grid/src/models/gridApiCaches.ts
@@ -1,5 +1,7 @@
 import { GridRowsInternalCache } from '../hooks/features/rows/gridRowsState';
+import { GridColumnsInternalCache } from '../hooks/features/columns/gridColumnsInterfaces';
 
 export interface GridApiCaches {
   rows: GridRowsInternalCache;
+  columns: GridColumnsInternalCache;
 }

--- a/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
@@ -129,7 +129,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
 
       fireEvent.click(screen.getByText('Show all'));
       expect(onColumnVisibilityModelChange.callCount).to.equal(2);
-      expect(onColumnVisibilityModelChange.lastCall.firstArg).to.deep.equal({ idBis: true });
+      expect(onColumnVisibilityModelChange.lastCall.firstArg).to.deep.equal({});
     });
   });
 


### PR DESCRIPTION
Fixes #5047

- [x] Add test

@m4theushw it's a temporary fix before v6
The problem was that we were updating `colDef.hide` when clicking on "Hide All", even when using the column visibility model.
So the next time the column was updated (when resizing in #5047), it was re-syncinq the column (which had `hide: true`) and the visibility model.

My solution is to update directly the visibility model instead of calling `updateColumns` when we are using the visibility model.
It requires to expose the `isUsingColumnVisibilityModel` ref or to expose a new private method to have this logic internally in `useGridColumns`.
I think exposing the ref is better.

If you can confirm that the logic seems good to you, I'll add a test after.