### PR TITLE
[docs] Using data grid with date pickers

### DIFF
--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -48,8 +48,6 @@ function buildApplyDateFilterFn(filterItem, compareFn, showTime = false) {
 }
 
 function getDateFilterOperators(showTime = false) {
-  const InputComponent = showTime ? GridFilterDateTimeInput : GridFilterDateInput;
-
   return [
     {
       value: 'is',
@@ -60,7 +58,8 @@ function getDateFilterOperators(showTime = false) {
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'not',
@@ -71,7 +70,8 @@ function getDateFilterOperators(showTime = false) {
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'after',
@@ -82,7 +82,8 @@ function getDateFilterOperators(showTime = false) {
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'onOrAfter',
@@ -93,7 +94,8 @@ function getDateFilterOperators(showTime = false) {
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'before',
@@ -104,7 +106,8 @@ function getDateFilterOperators(showTime = false) {
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'onOrBefore',
@@ -115,7 +118,8 @@ function getDateFilterOperators(showTime = false) {
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'isEmpty',
@@ -189,14 +193,16 @@ GridEditDateCell.propTypes = {
 };
 
 function GridFilterDateInput(props) {
-  const { item, applyValue, apiRef } = props;
+  const { item, showTime, applyValue, apiRef } = props;
+
+  const Component = showTime ? DateTimePicker : DatePicker;
 
   const handleFilterChange = (newValue) => {
     applyValue({ ...item, value: newValue });
   };
 
   return (
-    <DatePicker
+    <Component
       value={item.value || null}
       renderInput={(params) => (
         <TextField
@@ -205,6 +211,13 @@ function GridFilterDateInput(props) {
           label={apiRef.current.getLocaleText('filterPanelInputLabel')}
         />
       )}
+      InputAdornmentProps={{
+        sx: {
+          '& .MuiButtonBase-root': {
+            marginRight: -1,
+          },
+        },
+      }}
       onChange={handleFilterChange}
     />
   );
@@ -238,6 +251,7 @@ GridFilterDateInput.propTypes = {
      */
     value: PropTypes.any,
   }).isRequired,
+  showTime: PropTypes.bool,
 };
 
 const dateTimeColumnType = {
@@ -284,54 +298,6 @@ GridEditDateTimeCell.propTypes = {
    * The cell value, but if the column has valueGetter, use getValue.
    */
   value: PropTypes.instanceOf(Date),
-};
-
-function GridFilterDateTimeInput(props) {
-  const { item, applyValue, apiRef } = props;
-
-  const handleFilterChange = (newValue) => {
-    applyValue({ ...item, value: newValue });
-  };
-
-  return (
-    <DateTimePicker
-      value={item.value || null}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-        />
-      )}
-      onChange={handleFilterChange}
-    />
-  );
-}
-
-GridFilterDateTimeInput.propTypes = {
-  apiRef: PropTypes.any.isRequired,
-  applyValue: PropTypes.func.isRequired,
-  item: PropTypes.shape({
-    /**
-     * The column from which we want to filter the rows.
-     */
-    columnField: PropTypes.string.isRequired,
-    /**
-     * Must be unique.
-     * Only useful when the model contains several items.
-     */
-    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    /**
-     * The name of the operator we want to apply.
-     * Will become required on `@mui/x-data-grid@6.X`.
-     */
-    operatorValue: PropTypes.string,
-    /**
-     * The filtering value.
-     * The operator filtering function will decide for each row if the row values is correct compared to this value.
-     */
-    value: PropTypes.any,
-  }).isRequired,
 };
 
 const columns = [

--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -160,9 +160,9 @@ const dateColumnType = {
 function GridEditDateCell({ id, field, value }) {
   const apiRef = useGridApiContext();
 
-  function handleChange(newValue) {
+  const handleChange = (newValue) => {
     apiRef.current.setEditCellValue({ id, field, value: newValue });
-  }
+  };
 
   return (
     <DatePicker
@@ -258,9 +258,9 @@ const dateTimeColumnType = {
 function GridEditDateTimeCell({ id, field, value }) {
   const apiRef = useGridApiContext();
 
-  function handleChange(newValue) {
+  const handleChange = (newValue) => {
     apiRef.current.setEditCellValue({ id, field, value: newValue });
-  }
+  };
 
   return (
     <DateTimePicker

--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -18,138 +18,7 @@ import {
 } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
-
-function GridEditDateCell({ id, field, value }) {
-  const apiRef = useGridApiContext();
-
-  function handleChange(newValue) {
-    apiRef.current.setEditCellValue({ id, field, value: newValue });
-  }
-
-  return (
-    <DatePicker
-      value={value}
-      renderInput={(params) => <TextField {...params} />}
-      onChange={handleChange}
-    />
-  );
-}
-
-GridEditDateCell.propTypes = {
-  /**
-   * The column field of the cell that triggered the event.
-   */
-  field: PropTypes.string.isRequired,
-  /**
-   * The grid row id.
-   */
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-  /**
-   * The cell value, but if the column has valueGetter, use getValue.
-   */
-  value: PropTypes.instanceOf(Date),
-};
-
-const renderDateEditCell = (params) => {
-  return <GridEditDateCell {...params} />;
-};
-
-function GridFilterDateInput(props) {
-  const { item, applyValue, apiRef } = props;
-
-  const handleFilterChange = (newValue) => {
-    applyValue({ ...item, value: newValue });
-  };
-
-  return (
-    <DatePicker
-      value={item.value || null}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-        />
-      )}
-      onChange={handleFilterChange}
-    />
-  );
-}
-
-GridFilterDateInput.propTypes = {
-  apiRef: PropTypes.any.isRequired,
-  applyValue: PropTypes.func.isRequired,
-  item: PropTypes.shape({
-    /**
-     * The column from which we want to filter the rows.
-     */
-    columnField: PropTypes.string.isRequired,
-    /**
-     * Must be unique.
-     * Only useful when the model contains several items.
-     */
-    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    /**
-     * The name of the operator we want to apply.
-     * Will become required on `@mui/x-data-grid@6.X`.
-     */
-    operatorValue: PropTypes.string,
-    /**
-     * The filtering value.
-     * The operator filtering function will decide for each row if the row values is correct compared to this value.
-     */
-    value: PropTypes.any,
-  }).isRequired,
-};
-
-function GridFilterDateTimeInput(props) {
-  const { item, applyValue, apiRef } = props;
-
-  const handleFilterChange = (newValue) => {
-    applyValue({ ...item, value: newValue });
-  };
-
-  return (
-    <DateTimePicker
-      value={item.value || null}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-        />
-      )}
-      onChange={handleFilterChange}
-      ampm={false}
-    />
-  );
-}
-
-GridFilterDateTimeInput.propTypes = {
-  apiRef: PropTypes.any.isRequired,
-  applyValue: PropTypes.func.isRequired,
-  item: PropTypes.shape({
-    /**
-     * The column from which we want to filter the rows.
-     */
-    columnField: PropTypes.string.isRequired,
-    /**
-     * Must be unique.
-     * Only useful when the model contains several items.
-     */
-    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    /**
-     * The name of the operator we want to apply.
-     * Will become required on `@mui/x-data-grid@6.X`.
-     */
-    operatorValue: PropTypes.string,
-    /**
-     * The filtering value.
-     * The operator filtering function will decide for each row if the row values is correct compared to this value.
-     */
-    value: PropTypes.any,
-  }).isRequired,
-};
+import locale from 'date-fns/locale/en-US';
 
 function buildApplyDateFilterFn(filterItem, compareFn, showTime = false) {
   if (!filterItem.value) {
@@ -267,10 +136,123 @@ function getDateFilterOperators(showTime = false) {
   ];
 }
 
+const dateAdapter = new AdapterDateFns({ locale });
+
+/**
+ * `date` column
+ */
+
 const dateColumnType = {
   ...GRID_DATE_COL_DEF,
-  renderEditCell: renderDateEditCell,
+  resizable: false,
+  renderEditCell: (params) => {
+    return <GridEditDateCell {...params} />;
+  },
   filterOperators: getDateFilterOperators(),
+  valueFormatter: (params) => {
+    if (params.value) {
+      return dateAdapter.format(params.value, 'keyboardDate');
+    }
+    return '';
+  },
+};
+
+function GridEditDateCell({ id, field, value }) {
+  const apiRef = useGridApiContext();
+
+  function handleChange(newValue) {
+    apiRef.current.setEditCellValue({ id, field, value: newValue });
+  }
+
+  return (
+    <DatePicker
+      value={value}
+      renderInput={(params) => <TextField {...params} />}
+      onChange={handleChange}
+    />
+  );
+}
+
+GridEditDateCell.propTypes = {
+  /**
+   * The column field of the cell that triggered the event.
+   */
+  field: PropTypes.string.isRequired,
+  /**
+   * The grid row id.
+   */
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  /**
+   * The cell value, but if the column has valueGetter, use getValue.
+   */
+  value: PropTypes.instanceOf(Date),
+};
+
+function GridFilterDateInput(props) {
+  const { item, applyValue, apiRef } = props;
+
+  const handleFilterChange = (newValue) => {
+    applyValue({ ...item, value: newValue });
+  };
+
+  return (
+    <DatePicker
+      value={item.value || null}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
+        />
+      )}
+      onChange={handleFilterChange}
+    />
+  );
+}
+
+/**
+ * `dateTime` column
+ */
+
+GridFilterDateInput.propTypes = {
+  apiRef: PropTypes.any.isRequired,
+  applyValue: PropTypes.func.isRequired,
+  item: PropTypes.shape({
+    /**
+     * The column from which we want to filter the rows.
+     */
+    columnField: PropTypes.string.isRequired,
+    /**
+     * Must be unique.
+     * Only useful when the model contains several items.
+     */
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /**
+     * The name of the operator we want to apply.
+     * Will become required on `@mui/x-data-grid@6.X`.
+     */
+    operatorValue: PropTypes.string,
+    /**
+     * The filtering value.
+     * The operator filtering function will decide for each row if the row values is correct compared to this value.
+     */
+    value: PropTypes.any,
+  }).isRequired,
+};
+
+const dateTimeColumnType = {
+  ...GRID_DATETIME_COL_DEF,
+  resizable: false,
+  renderEditCell: (params) => {
+    return <GridEditDateTimeCell {...params} />;
+  },
+  filterOperators: getDateFilterOperators(true),
+  valueFormatter: (params) => {
+    if (params.value) {
+      return dateAdapter.format(params.value, 'keyboardDateTime');
+    }
+    return '';
+  },
 };
 
 function GridEditDateTimeCell({ id, field, value }) {
@@ -285,7 +267,6 @@ function GridEditDateTimeCell({ id, field, value }) {
       value={value}
       renderInput={(params) => <TextField {...params} />}
       onChange={handleChange}
-      ampm={false}
     />
   );
 }
@@ -305,14 +286,52 @@ GridEditDateTimeCell.propTypes = {
   value: PropTypes.instanceOf(Date),
 };
 
-const renderDateTimeEditCell = (params) => {
-  return <GridEditDateTimeCell {...params} />;
-};
+function GridFilterDateTimeInput(props) {
+  const { item, applyValue, apiRef } = props;
 
-const dateTimeColumnType = {
-  ...GRID_DATETIME_COL_DEF,
-  renderEditCell: renderDateTimeEditCell,
-  filterOperators: getDateFilterOperators(true),
+  const handleFilterChange = (newValue) => {
+    applyValue({ ...item, value: newValue });
+  };
+
+  return (
+    <DateTimePicker
+      value={item.value || null}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
+        />
+      )}
+      onChange={handleFilterChange}
+    />
+  );
+}
+
+GridFilterDateTimeInput.propTypes = {
+  apiRef: PropTypes.any.isRequired,
+  applyValue: PropTypes.func.isRequired,
+  item: PropTypes.shape({
+    /**
+     * The column from which we want to filter the rows.
+     */
+    columnField: PropTypes.string.isRequired,
+    /**
+     * Must be unique.
+     * Only useful when the model contains several items.
+     */
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /**
+     * The name of the operator we want to apply.
+     * Will become required on `@mui/x-data-grid@6.X`.
+     */
+    operatorValue: PropTypes.string,
+    /**
+     * The filtering value.
+     * The operator filtering function will decide for each row if the row values is correct compared to this value.
+     */
+    value: PropTypes.any,
+  }).isRequired,
 };
 
 const columns = [
@@ -329,7 +348,7 @@ const columns = [
     field: 'lastLogin',
     ...dateTimeColumnType,
     headerName: 'Last Login',
-    width: 220,
+    width: 230,
     editable: true,
   },
 ];
@@ -337,7 +356,7 @@ const columns = [
 export default function EditingWithDatePickers() {
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
         <DataGrid
           rows={rows}
           columns={columns}

--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { DataGrid, useGridApiContext, GRID_DATE_COL_DEF } from '@mui/x-data-grid';
+import {
+  randomCreatedDate,
+  randomTraderName,
+  randomUpdatedDate,
+} from '@mui/x-data-grid-generator';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import TextField from '@mui/material/TextField';
+
+function GridEditDateCell({ id, field, value }) {
+  const apiRef = useGridApiContext();
+
+  function handleChange(newValue) {
+    apiRef.current.setEditCellValue({ id, field, value: newValue });
+  }
+
+  return (
+    <DatePicker
+      value={value}
+      renderInput={(params) => <TextField {...params} />}
+      onChange={handleChange}
+    />
+  );
+}
+
+GridEditDateCell.propTypes = {
+  /**
+   * The column field of the cell that triggered the event.
+   */
+  field: PropTypes.string.isRequired,
+  /**
+   * The grid row id.
+   */
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  /**
+   * The cell value, but if the column has valueGetter, use getValue.
+   */
+  value: PropTypes.instanceOf(Date),
+};
+
+const renderDateEditCell = (params) => {
+  return <GridEditDateCell {...params} />;
+};
+
+const dateColumnType = {
+  ...GRID_DATE_COL_DEF,
+  renderEditCell: renderDateEditCell,
+};
+
+const columns = [
+  { field: 'name', headerName: 'Name', width: 180, editable: true },
+  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'dateCreated',
+    ...dateColumnType,
+    headerName: 'Date Created',
+    width: 180,
+    editable: true,
+  },
+];
+
+export default function EditingWithDatePickers() {
+  return (
+    <div style={{ height: 300, width: '100%' }}>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          experimentalFeatures={{ newEditingApi: true }}
+        />
+      </LocalizationProvider>
+    </div>
+  );
+}
+
+const rows = [
+  {
+    id: 1,
+    name: randomTraderName(),
+    age: 25,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 2,
+    name: randomTraderName(),
+    age: 36,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 3,
+    name: randomTraderName(),
+    age: 19,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 4,
+    name: randomTraderName(),
+    age: 28,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 5,
+    name: randomTraderName(),
+    age: 23,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+];

--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -1,12 +1,21 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { DataGrid, useGridApiContext, GRID_DATE_COL_DEF } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  useGridApiContext,
+  GRID_DATE_COL_DEF,
+  GRID_DATETIME_COL_DEF,
+} from '@mui/x-data-grid';
 import {
   randomCreatedDate,
   randomTraderName,
   randomUpdatedDate,
 } from '@mui/x-data-grid-generator';
-import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import {
+  DatePicker,
+  DateTimePicker,
+  LocalizationProvider,
+} from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
 
@@ -45,9 +54,197 @@ const renderDateEditCell = (params) => {
   return <GridEditDateCell {...params} />;
 };
 
+function GridFilterDateInput(props) {
+  const { item, applyValue, apiRef } = props;
+
+  const handleFilterChange = (newValue) => {
+    applyValue({ ...item, value: newValue });
+  };
+
+  return (
+    <DatePicker
+      value={item.value || null}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
+        />
+      )}
+      onChange={handleFilterChange}
+    />
+  );
+}
+
+GridFilterDateInput.propTypes = {
+  apiRef: PropTypes.any.isRequired,
+  applyValue: PropTypes.func.isRequired,
+  item: PropTypes.shape({
+    /**
+     * The column from which we want to filter the rows.
+     */
+    columnField: PropTypes.string.isRequired,
+    /**
+     * Must be unique.
+     * Only useful when the model contains several items.
+     */
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /**
+     * The name of the operator we want to apply.
+     * Will become required on `@mui/x-data-grid@6.X`.
+     */
+    operatorValue: PropTypes.string,
+    /**
+     * The filtering value.
+     * The operator filtering function will decide for each row if the row values is correct compared to this value.
+     */
+    value: PropTypes.any,
+  }).isRequired,
+};
+
+function buildApplyDateFilterFn(filterItem, compareFn) {
+  if (!filterItem.value) {
+    return null;
+  }
+
+  const filterValueMs = filterItem.value.getTime();
+
+  return ({ value }) => {
+    if (!value) {
+      return false;
+    }
+
+    // Make a copy of the date to not reset the hours in the original object
+    const dateCopy = new Date(value);
+    dateCopy.setHours(0, 0, 0, 0);
+    const cellValueMs = dateCopy.getTime();
+
+    return compareFn(cellValueMs, filterValueMs);
+  };
+}
+
 const dateColumnType = {
   ...GRID_DATE_COL_DEF,
   renderEditCell: renderDateEditCell,
+  filterOperators: [
+    {
+      value: 'is',
+      getApplyFilterFn: (filterItem) => {
+        return buildApplyDateFilterFn(
+          filterItem,
+          (value1, value2) => value1 === value2,
+        );
+      },
+      InputComponent: GridFilterDateInput,
+    },
+    {
+      value: 'not',
+      getApplyFilterFn: (filterItem) => {
+        return buildApplyDateFilterFn(
+          filterItem,
+          (value1, value2) => value1 !== value2,
+        );
+      },
+      InputComponent: GridFilterDateInput,
+    },
+    {
+      value: 'after',
+      getApplyFilterFn: (filterItem) => {
+        return buildApplyDateFilterFn(
+          filterItem,
+          (value1, value2) => value1 > value2,
+        );
+      },
+      InputComponent: GridFilterDateInput,
+    },
+    {
+      value: 'onOrAfter',
+      getApplyFilterFn: (filterItem) => {
+        return buildApplyDateFilterFn(
+          filterItem,
+          (value1, value2) => value1 >= value2,
+        );
+      },
+      InputComponent: GridFilterDateInput,
+    },
+    {
+      value: 'before',
+      getApplyFilterFn: (filterItem) => {
+        return buildApplyDateFilterFn(
+          filterItem,
+          (value1, value2) => value1 < value2,
+        );
+      },
+      InputComponent: GridFilterDateInput,
+    },
+    {
+      value: 'onOrBefore',
+      getApplyFilterFn: (filterItem) => {
+        return buildApplyDateFilterFn(
+          filterItem,
+          (value1, value2) => value1 <= value2,
+        );
+      },
+      InputComponent: GridFilterDateInput,
+    },
+    {
+      value: 'isEmpty',
+      getApplyFilterFn: () => {
+        return ({ value }) => {
+          return value == null;
+        };
+      },
+    },
+    {
+      value: 'isNotEmpty',
+      getApplyFilterFn: () => {
+        return ({ value }) => {
+          return value != null;
+        };
+      },
+    },
+  ],
+};
+
+function GridEditDateTimeCell({ id, field, value }) {
+  const apiRef = useGridApiContext();
+
+  function handleChange(newValue) {
+    apiRef.current.setEditCellValue({ id, field, value: newValue });
+  }
+
+  return (
+    <DateTimePicker
+      value={value}
+      renderInput={(params) => <TextField {...params} />}
+      onChange={handleChange}
+      ampm={false}
+    />
+  );
+}
+
+GridEditDateTimeCell.propTypes = {
+  /**
+   * The column field of the cell that triggered the event.
+   */
+  field: PropTypes.string.isRequired,
+  /**
+   * The grid row id.
+   */
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  /**
+   * The cell value, but if the column has valueGetter, use getValue.
+   */
+  value: PropTypes.instanceOf(Date),
+};
+
+const renderDateTimeEditCell = (params) => {
+  return <GridEditDateTimeCell {...params} />;
+};
+
+const dateTimeColumnType = {
+  ...GRID_DATETIME_COL_DEF,
+  renderEditCell: renderDateTimeEditCell,
 };
 
 const columns = [
@@ -58,6 +255,13 @@ const columns = [
     ...dateColumnType,
     headerName: 'Date Created',
     width: 180,
+    editable: true,
+  },
+  {
+    field: 'lastLogin',
+    ...dateTimeColumnType,
+    headerName: 'Last Login',
+    width: 220,
     editable: true,
   },
 ];

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -205,6 +205,13 @@ function GridFilterDateInput(props: GridFilterInputValueProps) {
           label={apiRef.current.getLocaleText('filterPanelInputLabel')}
         />
       )}
+      InputAdornmentProps={{
+        sx: {
+          '& .MuiButtonBase-root': {
+            marginRight: -1,
+          },
+        },
+      }}
       onChange={handleFilterChange}
     />
   );

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
+import locale from 'date-fns/locale/en-US';
 
 function GridEditDateCell({
   id,
@@ -90,7 +91,6 @@ function GridFilterDateTimeInput(props: GridFilterInputValueProps) {
         />
       )}
       onChange={handleFilterChange}
-      ampm={false}
     />
   );
 }
@@ -216,10 +216,19 @@ function getDateFilterOperators(
   ];
 }
 
+const dateAdapter = new AdapterDateFns({ locale });
+
 const dateColumnType: GridColTypeDef = {
   ...GRID_DATE_COL_DEF,
+  resizable: false,
   renderEditCell: renderDateEditCell,
   filterOperators: getDateFilterOperators(),
+  valueFormatter: (params) => {
+    if (params.value) {
+      return dateAdapter.format(params.value, 'keyboardDate');
+    }
+    return '';
+  },
 };
 
 function GridEditDateTimeCell({
@@ -238,7 +247,6 @@ function GridEditDateTimeCell({
       value={value}
       renderInput={(params) => <TextField {...params} />}
       onChange={handleChange}
-      ampm={false}
     />
   );
 }
@@ -247,10 +255,17 @@ const renderDateTimeEditCell: GridColDef['renderEditCell'] = (params) => {
   return <GridEditDateTimeCell {...params} />;
 };
 
-const dateTimeColumnType: GridColTypeDef = {
+const dateTimeColumnType: GridColTypeDef<Date | string, string> = {
   ...GRID_DATETIME_COL_DEF,
+  resizable: false,
   renderEditCell: renderDateTimeEditCell,
   filterOperators: getDateFilterOperators(true),
+  valueFormatter: (params) => {
+    if (params.value) {
+      return dateAdapter.format(params.value, 'keyboardDateTime');
+    }
+    return '';
+  },
 };
 
 const columns: GridColumns = [
@@ -267,7 +282,7 @@ const columns: GridColumns = [
     field: 'lastLogin',
     ...dateTimeColumnType,
     headerName: 'Last Login',
-    width: 220,
+    width: 230,
     editable: true,
   },
 ];
@@ -275,7 +290,7 @@ const columns: GridColumns = [
 export default function EditingWithDatePickers() {
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
         <DataGrid
           rows={rows}
           columns={columns}

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  GridColumns,
+  GridRowsProp,
+  useGridApiContext,
+  GridColDef,
+  GridRenderEditCellParams,
+  GRID_DATE_COL_DEF,
+} from '@mui/x-data-grid';
+import {
+  randomCreatedDate,
+  randomTraderName,
+  randomUpdatedDate,
+} from '@mui/x-data-grid-generator';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import TextField from '@mui/material/TextField';
+
+function GridEditDateCell({
+  id,
+  field,
+  value,
+}: GridRenderEditCellParams<Date | null>) {
+  const apiRef = useGridApiContext();
+
+  function handleChange(newValue: unknown) {
+    apiRef.current.setEditCellValue({ id, field, value: newValue });
+  }
+
+  return (
+    <DatePicker
+      value={value}
+      renderInput={(params) => <TextField {...params} />}
+      onChange={handleChange}
+    />
+  );
+}
+
+const renderDateEditCell: GridColDef['renderEditCell'] = (params) => {
+  return <GridEditDateCell {...params} />;
+};
+
+const dateColumnType = {
+  ...GRID_DATE_COL_DEF,
+  renderEditCell: renderDateEditCell,
+};
+
+const columns: GridColumns = [
+  { field: 'name', headerName: 'Name', width: 180, editable: true },
+  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'dateCreated',
+    ...dateColumnType,
+    headerName: 'Date Created',
+    width: 180,
+    editable: true,
+  },
+];
+
+export default function EditingWithDatePickers() {
+  return (
+    <div style={{ height: 300, width: '100%' }}>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          experimentalFeatures={{ newEditingApi: true }}
+        />
+      </LocalizationProvider>
+    </div>
+  );
+}
+
+const rows: GridRowsProp = [
+  {
+    id: 1,
+    name: randomTraderName(),
+    age: 25,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 2,
+    name: randomTraderName(),
+    age: 36,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 3,
+    name: randomTraderName(),
+    age: 19,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 4,
+    name: randomTraderName(),
+    age: 28,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+  {
+    id: 5,
+    name: randomTraderName(),
+    age: 23,
+    dateCreated: randomCreatedDate(),
+    lastLogin: randomUpdatedDate(),
+  },
+];

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -4,7 +4,6 @@ import {
   GridColumns,
   GridRowsProp,
   useGridApiContext,
-  GridColDef,
   GridRenderEditCellParams,
   GRID_DATE_COL_DEF,
   GRID_DATETIME_COL_DEF,
@@ -26,74 +25,6 @@ import {
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
 import locale from 'date-fns/locale/en-US';
-
-function GridEditDateCell({
-  id,
-  field,
-  value,
-}: GridRenderEditCellParams<Date | null>) {
-  const apiRef = useGridApiContext();
-
-  function handleChange(newValue: unknown) {
-    apiRef.current.setEditCellValue({ id, field, value: newValue });
-  }
-
-  return (
-    <DatePicker
-      value={value}
-      renderInput={(params) => <TextField {...params} />}
-      onChange={handleChange}
-    />
-  );
-}
-
-const renderDateEditCell: GridColDef['renderEditCell'] = (params) => {
-  return <GridEditDateCell {...params} />;
-};
-
-function GridFilterDateInput(props: GridFilterInputValueProps) {
-  const { item, applyValue, apiRef } = props;
-
-  const handleFilterChange = (newValue: unknown) => {
-    applyValue({ ...item, value: newValue });
-  };
-
-  return (
-    <DatePicker
-      value={item.value || null}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-        />
-      )}
-      onChange={handleFilterChange}
-    />
-  );
-}
-
-function GridFilterDateTimeInput(props: GridFilterInputValueProps) {
-  const { item, applyValue, apiRef } = props;
-
-  const handleFilterChange = (newValue: unknown) => {
-    applyValue({ ...item, value: newValue });
-  };
-
-  return (
-    <DateTimePicker
-      value={item.value || null}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-        />
-      )}
-      onChange={handleFilterChange}
-    />
-  );
-}
 
 function buildApplyDateFilterFn(
   filterItem: GridFilterItem,
@@ -218,14 +149,81 @@ function getDateFilterOperators(
 
 const dateAdapter = new AdapterDateFns({ locale });
 
+/**
+ * `date` column
+ */
+
 const dateColumnType: GridColTypeDef = {
   ...GRID_DATE_COL_DEF,
   resizable: false,
-  renderEditCell: renderDateEditCell,
+  renderEditCell: (params) => {
+    return <GridEditDateCell {...params} />;
+  },
   filterOperators: getDateFilterOperators(),
   valueFormatter: (params) => {
     if (params.value) {
       return dateAdapter.format(params.value, 'keyboardDate');
+    }
+    return '';
+  },
+};
+
+function GridEditDateCell({
+  id,
+  field,
+  value,
+}: GridRenderEditCellParams<Date | null>) {
+  const apiRef = useGridApiContext();
+
+  function handleChange(newValue: unknown) {
+    apiRef.current.setEditCellValue({ id, field, value: newValue });
+  }
+
+  return (
+    <DatePicker
+      value={value}
+      renderInput={(params) => <TextField {...params} />}
+      onChange={handleChange}
+    />
+  );
+}
+
+function GridFilterDateInput(props: GridFilterInputValueProps) {
+  const { item, applyValue, apiRef } = props;
+
+  const handleFilterChange = (newValue: unknown) => {
+    applyValue({ ...item, value: newValue });
+  };
+
+  return (
+    <DatePicker
+      value={item.value || null}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
+        />
+      )}
+      onChange={handleFilterChange}
+    />
+  );
+}
+
+/**
+ * `dateTime` column
+ */
+
+const dateTimeColumnType: GridColTypeDef<Date | string, string> = {
+  ...GRID_DATETIME_COL_DEF,
+  resizable: false,
+  renderEditCell: (params) => {
+    return <GridEditDateTimeCell {...params} />;
+  },
+  filterOperators: getDateFilterOperators(true),
+  valueFormatter: (params) => {
+    if (params.value) {
+      return dateAdapter.format(params.value, 'keyboardDateTime');
     }
     return '';
   },
@@ -251,22 +249,27 @@ function GridEditDateTimeCell({
   );
 }
 
-const renderDateTimeEditCell: GridColDef['renderEditCell'] = (params) => {
-  return <GridEditDateTimeCell {...params} />;
-};
+function GridFilterDateTimeInput(props: GridFilterInputValueProps) {
+  const { item, applyValue, apiRef } = props;
 
-const dateTimeColumnType: GridColTypeDef<Date | string, string> = {
-  ...GRID_DATETIME_COL_DEF,
-  resizable: false,
-  renderEditCell: renderDateTimeEditCell,
-  filterOperators: getDateFilterOperators(true),
-  valueFormatter: (params) => {
-    if (params.value) {
-      return dateAdapter.format(params.value, 'keyboardDateTime');
-    }
-    return '';
-  },
-};
+  const handleFilterChange = (newValue: unknown) => {
+    applyValue({ ...item, value: newValue });
+  };
+
+  return (
+    <DateTimePicker
+      value={item.value || null}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          variant="standard"
+          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
+        />
+      )}
+      onChange={handleFilterChange}
+    />
+  );
+}
 
 const columns: GridColumns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -179,9 +179,9 @@ function GridEditDateCell({
 }: GridRenderEditCellParams<Date | null>) {
   const apiRef = useGridApiContext();
 
-  function handleChange(newValue: unknown) {
+  const handleChange = (newValue: unknown) => {
     apiRef.current.setEditCellValue({ id, field, value: newValue });
-  }
+  };
 
   return (
     <DatePicker
@@ -251,9 +251,9 @@ function GridEditDateTimeCell({
 }: GridRenderEditCellParams<Date | null>) {
   const apiRef = useGridApiContext();
 
-  function handleChange(newValue: unknown) {
+  const handleChange = (newValue: unknown) => {
     apiRef.current.setEditCellValue({ id, field, value: newValue });
-  }
+  };
 
   return (
     <DateTimePicker

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -59,8 +59,6 @@ function buildApplyDateFilterFn(
 function getDateFilterOperators(
   showTime: boolean = false,
 ): GridColTypeDef['filterOperators'] {
-  const InputComponent = showTime ? GridFilterDateTimeInput : GridFilterDateInput;
-
   return [
     {
       value: 'is',
@@ -71,7 +69,8 @@ function getDateFilterOperators(
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'not',
@@ -82,7 +81,8 @@ function getDateFilterOperators(
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'after',
@@ -93,7 +93,8 @@ function getDateFilterOperators(
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'onOrAfter',
@@ -104,7 +105,8 @@ function getDateFilterOperators(
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'before',
@@ -115,7 +117,8 @@ function getDateFilterOperators(
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'onOrBefore',
@@ -126,7 +129,8 @@ function getDateFilterOperators(
           showTime,
         );
       },
-      InputComponent,
+      InputComponent: GridFilterDateInput,
+      InputComponentProps: { showTime },
     },
     {
       value: 'isEmpty',
@@ -188,15 +192,19 @@ function GridEditDateCell({
   );
 }
 
-function GridFilterDateInput(props: GridFilterInputValueProps) {
-  const { item, applyValue, apiRef } = props;
+function GridFilterDateInput(
+  props: GridFilterInputValueProps & { showTime?: boolean },
+) {
+  const { item, showTime, applyValue, apiRef } = props;
+
+  const Component = showTime ? DateTimePicker : DatePicker;
 
   const handleFilterChange = (newValue: unknown) => {
     applyValue({ ...item, value: newValue });
   };
 
   return (
-    <DatePicker
+    <Component
       value={item.value || null}
       renderInput={(params) => (
         <TextField
@@ -252,28 +260,6 @@ function GridEditDateTimeCell({
       value={value}
       renderInput={(params) => <TextField {...params} />}
       onChange={handleChange}
-    />
-  );
-}
-
-function GridFilterDateTimeInput(props: GridFilterInputValueProps) {
-  const { item, applyValue, apiRef } = props;
-
-  const handleFilterChange = (newValue: unknown) => {
-    applyValue({ ...item, value: newValue });
-  };
-
-  return (
-    <DateTimePicker
-      value={item.value || null}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-        />
-      )}
-      onChange={handleFilterChange}
     />
   );
 }

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -7,13 +7,18 @@ import {
   GridColDef,
   GridRenderEditCellParams,
   GRID_DATE_COL_DEF,
+  GRID_DATETIME_COL_DEF,
 } from '@mui/x-data-grid';
 import {
   randomCreatedDate,
   randomTraderName,
   randomUpdatedDate,
 } from '@mui/x-data-grid-generator';
-import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import {
+  DatePicker,
+  DateTimePicker,
+  LocalizationProvider,
+} from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
 
@@ -46,6 +51,36 @@ const dateColumnType = {
   renderEditCell: renderDateEditCell,
 };
 
+function GridEditDateTimeCell({
+  id,
+  field,
+  value,
+}: GridRenderEditCellParams<Date | null>) {
+  const apiRef = useGridApiContext();
+
+  function handleChange(newValue: unknown) {
+    apiRef.current.setEditCellValue({ id, field, value: newValue });
+  }
+
+  return (
+    <DateTimePicker
+      value={value}
+      renderInput={(params) => <TextField {...params} />}
+      onChange={handleChange}
+      ampm={false}
+    />
+  );
+}
+
+const renderDateTimeEditCell: GridColDef['renderEditCell'] = (params) => {
+  return <GridEditDateTimeCell {...params} />;
+};
+
+const dateTimeColumnType = {
+  ...GRID_DATETIME_COL_DEF,
+  renderEditCell: renderDateTimeEditCell,
+};
+
 const columns: GridColumns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
   { field: 'age', headerName: 'Age', type: 'number', editable: true },
@@ -54,6 +89,13 @@ const columns: GridColumns = [
     ...dateColumnType,
     headerName: 'Date Created',
     width: 180,
+    editable: true,
+  },
+  {
+    field: 'lastLogin',
+    ...dateTimeColumnType,
+    headerName: 'Last Login',
+    width: 220,
     editable: true,
   },
 ];

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx.preview
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx.preview
@@ -1,0 +1,7 @@
+<LocalizationProvider dateAdapter={AdapterDateFns}>
+  <DataGrid
+    rows={rows}
+    columns={columns}
+    experimentalFeatures={{ newEditingApi: true }}
+  />
+</LocalizationProvider>

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx.preview
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx.preview
@@ -1,4 +1,4 @@
-<LocalizationProvider dateAdapter={AdapterDateFns}>
+<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locale}>
   <DataGrid
     rows={rows}
     columns={columns}

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -540,6 +540,10 @@ Note that the `onCellEditStart` and `onCellEditStop` props also have to be used 
 
 {{"demo": "LinkedFieldsCellEditing.js", "bg": "inline", "defaultCodeOpen": false}}
 
+### Usage with `@mui/x-date-pickers`
+
+{{"demo": "EditingWithDatePickers.js", "bg": "inline", "defaultCodeOpen": false }}
+
 ## apiRef [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 {{"demo": "EditApiNoSnap.js", "bg": "inline", "hideToolbar": true}}

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -544,7 +544,9 @@ Note that the `onCellEditStart` and `onCellEditStop` props also have to be used 
 
 By default, data grid uses native browser inputs for editing `date` and `dateTime` columns.
 
-While [MUI X Date / Time Pickers](/x/react-date-pickers/getting-started/) are not supported by data grid out of the box yet, the example below shows how to integrate them with data grid:
+While [MUI X Date / Time Pickers](/x/react-date-pickers/getting-started/) are not supported by data grid out of the box yet, it is easy to integrate them by creating [custom edit components](/x/react-data-grid/editing/#create-your-own-edit-component) and [custom filter operators](/x/react-data-grid/filtering/#create-a-custom-operator).
+
+The example below uses `@mui/x-date-pickers` for both `date` and `dateTime` column types:
 
 {{"demo": "EditingWithDatePickers.js", "bg": "inline", "defaultCodeOpen": false }}
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -550,6 +550,11 @@ The example below uses `@mui/x-date-pickers` for both `date` and `dateTime` colu
 
 {{"demo": "EditingWithDatePickers.js", "bg": "inline", "defaultCodeOpen": false }}
 
+:::warning
+You can change date format by importing different locale (`en-US` locale is used in the example above).
+See [Localization](/x/react-date-pickers/localization/) for more information.
+:::
+
 ## apiRef [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 {{"demo": "EditApiNoSnap.js", "bg": "inline", "hideToolbar": true}}

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -542,9 +542,9 @@ Note that the `onCellEditStart` and `onCellEditStop` props also have to be used 
 
 ### Usage with `@mui/x-date-pickers`
 
-By default, data grid uses native browser inputs for editing `date` and `dateTime` columns.
+By default, the grid uses native browser inputs for editing `date` and `dateTime` columns.
 
-While [MUI X Date / Time Pickers](/x/react-date-pickers/getting-started/) are not supported by data grid out of the box yet, it is easy to integrate them by creating [custom edit components](/x/react-data-grid/editing/#create-your-own-edit-component) and [custom filter operators](/x/react-data-grid/filtering/#create-a-custom-operator).
+While [MUI X Date / Time Pickers](/x/react-date-pickers/getting-started/) are not supported by the grid out of the box yet, it is easy to integrate them by creating [custom edit components](/x/react-data-grid/editing/#create-your-own-edit-component) and [custom filter operators](/x/react-data-grid/filtering/#create-a-custom-operator).
 
 The example below uses `@mui/x-date-pickers` for both `date` and `dateTime` column types:
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -542,6 +542,10 @@ Note that the `onCellEditStart` and `onCellEditStop` props also have to be used 
 
 ### Usage with `@mui/x-date-pickers`
 
+By default, data grid uses native browser inputs for editing `date` and `dateTime` columns.
+
+While [MUI X Date / Time Pickers](/x/react-date-pickers/getting-started/) are not supported by data grid out of the box yet, the example below shows how to integrate them with data grid:
+
 {{"demo": "EditingWithDatePickers.js", "bg": "inline", "defaultCodeOpen": false }}
 
 ## apiRef [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/4909 until we provide out of the box support for pickers in data grid

Preview: https://deploy-preview-5053--material-ui-x.netlify.app/x/react-data-grid/editing/#usage-with-mui-x-date-pickers

- [x] Use `DatePicker` for `date` column type
- [x] Use `DatePicker` for `date` column filter input
- [x] Use `DateTimePicker` for `dateTime` column type
- [x] Use `DateTimePicker` for `dateTime` column filter input