### PR TITLE
[core] Allows to run tests with different date adapters

### DIFF
--- a/packages/x-date-pickers-pro/tsconfig.json
+++ b/packages/x-date-pickers-pro/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
+    // @date-io libraries produce duplicate type `DateType`
+    "skipLibCheck": true,
     "types": ["react", "mocha", "node"]
   },
   "include": ["src/**/*", "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts"]

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -165,7 +165,7 @@ describe('<DesktopDatePicker /> keyboard interactions', () => {
         const onErrorMock = spy();
         // we are running validation on value change
         function DatePickerInput() {
-          const [date, setDate] = React.useState<Date | null>(null);
+          const [date, setDate] = React.useState<number | Date | null>(null);
 
           return (
             <DesktopDatePicker

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -22,7 +22,7 @@ const WrappedDesktopDateTimePicker = withPickerControls(DesktopDateTimePicker)({
 describe('<DesktopDateTimePicker />', () => {
   const { render } = createPickerRenderer({
     clock: 'fake',
-    clockConfig: adapterToUse.date('2018-01-01T00:00:00.000').getTime(),
+    clockConfig: new Date('2018-01-01T00:00:00.000'),
   });
 
   ['readOnly', 'disabled'].forEach((prop) => {

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -21,7 +21,7 @@ const WrappedMobileDateTimePicker = withPickerControls(MobileDateTimePicker)({
 describe('<MobileDateTimePicker />', () => {
   const { render } = createPickerRenderer({
     clock: 'fake',
-    clockConfig: adapterToUse.date('2018-01-01T00:00:00.000').getTime(),
+    clockConfig: new Date('2018-01-01T00:00:00.000'),
   });
 
   it('prop: open – overrides open state', () => {

--- a/packages/x-date-pickers/src/internals/utils/text-field-helper.test.ts
+++ b/packages/x-date-pickers/src/internals/utils/text-field-helper.test.ts
@@ -26,18 +26,42 @@ describe('text-field-helper', () => {
   });
 
   [
-    { mask: '__.__.____', format: adapterToUse.formats.keyboardDate, isValid: false },
-    { mask: '__/__/____', format: adapterToUse.formats.keyboardDate, isValid: true },
-    { mask: '__:__ _m', format: adapterToUse.formats.fullTime, isValid: false },
-    { mask: '__/__/____ __:__ _m', format: adapterToUse.formats.keyboardDateTime, isValid: false },
-    { mask: '__/__/____ __:__', format: adapterToUse.formats.keyboardDateTime24h, isValid: true },
-    { mask: '__/__/____', format: 'MM/dd/yyyy', isValid: true },
-    { mask: '__/__/____', format: 'MMMM yyyy', isValid: false },
+    // Time picker
+    // - with ampm = true
+    { mask: '__:__ _m', format: adapterToUse.formats.fullTime12h, isValid: true },
+    // - with ampm=false
+    { mask: '__:__', format: adapterToUse.formats.fullTime24h, isValid: true },
+    // Date Picker
+    {
+      mask: '__/__/____',
+      format: adapterToUse.formats.keyboardDate,
+      isValid: true,
+    },
+    // - with year only
+    {
+      mask: '____',
+      format: adapterToUse.formats.year,
+      isValid: true,
+    },
+    // DateTimePicker
+    // - with ampm=true
     {
       mask: '__/__/____ __:__ _m',
       format: adapterToUse.formats.keyboardDateTime12h,
       isValid: true,
     },
+    // - with ampm=false
+    {
+      mask: '__/__/____ __:__',
+      format: adapterToUse.formats.keyboardDateTime24h,
+      isValid: true,
+    },
+    // Test rejections
+    { mask: '__.__.____', format: adapterToUse.formats.keyboardDate, isValid: false },
+    { mask: '__:__ _m', format: adapterToUse.formats.fullTime, isValid: false },
+    { mask: '__/__/____ __:__ _m', format: adapterToUse.formats.keyboardDateTime, isValid: false },
+    { mask: '__/__/____', format: 'MM/dd/yyyy', isValid: adapterToUse.lib === 'date-fns' }, // only pass with date-fns
+    { mask: '__/__/____', format: 'MMMM yyyy', isValid: false },
   ].forEach(({ mask, format, isValid }, index) => {
     it(`checkMaskIsValidFormat returns ${isValid} for mask #${index} '${mask}' and format ${format}`, () => {
       const runMaskValidation = () =>

--- a/test/utils/pickers-utils.tsx
+++ b/test/utils/pickers-utils.tsx
@@ -8,16 +8,20 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 
-// Add parameter `--date-adapter luxon` to use AdapterLuxon for running tests
-// adapter available : date-fns (default one), day-js, luxon, moment
-const argv = require('yargs/yargs')(process.argv.slice(2)).argv;
-
 const availableAdapters = ['date-fns', 'day-js', 'luxon', 'moment'];
+let adapter = 'date-fns';
 
-const adapter =
-  argv['date-adapter'] && availableAdapters.includes(argv['date-adapter'])
-    ? argv['date-adapter']
-    : 'date-fns';
+// Check if we are in unit tests
+if (typeof window === 'undefined') {
+  // Add parameter `--date-adapter luxon` to use AdapterLuxon for running tests
+  // adapter available : date-fns (default one), day-js, luxon, moment
+  const args = process.argv.slice(2);
+  const flagIndex = args.findIndex((element) => element === '--date-adapter');
+  const potentialAdapter = flagIndex + 1 < args.length ? args[flagIndex + 1] : null;
+  if (potentialAdapter && availableAdapters.includes(potentialAdapter)) {
+    adapter = potentialAdapter;
+  }
+}
 
 let AdapterClassToExtend;
 switch (adapter) {

--- a/test/utils/pickers-utils.tsx
+++ b/test/utils/pickers-utils.tsx
@@ -12,7 +12,7 @@ const availableAdapters = ['date-fns', 'day-js', 'luxon', 'moment'];
 let adapter = 'date-fns';
 
 // Check if we are in unit tests
-if (typeof window === 'undefined') {
+if (/jsdom/.test(window.navigator.userAgent)) {
   // Add parameter `--date-adapter luxon` to use AdapterLuxon for running tests
   // adapter available : date-fns (default one), day-js, luxon, moment
   const args = process.argv.slice(2);


### PR DESCRIPTION
Allows to test bugs such as #4890 locally for now

to run unit test with a specific adapter, use `yarn test:unit  --date-adapter moment` (or `luxon`, `day-js`, `date-fns`)