### PR TITLE
[DataGrid] Fix dynamic row height not working if `borderBoxSize` is not supported

### DIFF
--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -162,9 +162,10 @@ function GridRow(props: React.HTMLAttributes<HTMLDivElement> & GridRowProps) {
 
     const resizeObserver = new ResizeObserver((entries) => {
       const [entry] = entries;
-      const height = entry.borderBoxSize
-        ? entry.borderBoxSize[0].blockSize
-        : entry.contentRect.height;
+      const height =
+        entry.borderBoxSize && entry.borderBoxSize.length > 0
+          ? entry.borderBoxSize[0].blockSize
+          : entry.contentRect.height;
       apiRef.current.unstable_storeRowHeightMeasurement(rowId, height);
     });
 


### PR DESCRIPTION
I've noticed this failing test in Firefox 78 on master https://app.circleci.com/pipelines/github/mui/mui-x/19228/workflows/3d948d3e-98ea-47a0-97da-db6f12d14680/jobs/111821

```sh
Firefox 78.0 (Windows 10)  "after each" hook for "should measure all rows and update the content size" FAILED
	entry.borderBoxSize[0] is undefined
```

Turns out that checking `borderBoxSize` presence is not enough.
Support for `borderBoxSize` in Firefox was added in v92 https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/borderBoxSize

I've tested it locally through BrowserStack.