### PR TITLE
[docs] Instruction to deal with v2 invalid license message

### DIFF
--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -97,7 +97,6 @@ To use the v2 licenses, you'll need to update the MUI X packages to the latest o
 If updating is not practicable or viable, please contact our support at sales@mui.com
 :::
 
-
 ### How and where to install the key?
 
 ```jsx

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -86,16 +86,25 @@ You will need to purchase a commercial license in order to remove the watermarks
 
 ## License key installation
 
-When you purchase a commercial license, you'll receive a license key by email.
+When you purchase a commercial license, you'll receive your license key by email.
 This key removes all watermarks and console warnings.
+
+:::warning
+⚠️ If you purchased your license **after May 13, 2022**, You'll obtain a **v2** license key.
+
+To use the v2 licenses, you'll need to update the MUI X packages to the latest or at least the `5.11` version.
+
+If updating is not practicable or viable, please contact our support at sales@mui.com
+:::
+
+
+### How and where to install the key?
 
 ```jsx
 import { LicenseInfo } from '@mui/x-license-pro';
 
 LicenseInfo.setLicenseKey('YOUR_LICENSE_KEY');
 ```
-
-### Where to install the key?
 
 You must call `setLicenseKey` before React renders the first component.
 You only need to install the key once in your application.
@@ -143,7 +152,7 @@ But you will not be able to install a newer version released two years from now,
 
 #### Invalid license key
 
-This error indicates that your license key doesn't match what was issued by MUI—this is likely a typo.
+This error indicates that your license key doesn't match what was issued by MUI (this is likely a typo) or that you may be trying to validate a [v2 license key with an older package](#license-key-installation).
 
 ## Support
 

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -90,7 +90,7 @@ When you purchase a commercial license, you'll receive your license key by email
 This key removes all watermarks and console warnings.
 
 :::warning
-⚠️ Licenses purchased after **May 13, 2022** are only compatible with MUI X version `5.11` or later.
+Licenses purchased after **May 13, 2022** are only compatible with MUI X version `5.11` or later.
 
 Please update your packages if you are using an earlier version.
 

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -90,9 +90,9 @@ When you purchase a commercial license, you'll receive your license key by email
 This key removes all watermarks and console warnings.
 
 :::warning
-⚠️ All licenses purchased after **May 13, 2022** are _v2_ licenses.
+⚠️ Licenses purchased after **May 13, 2022** are only compatible with MUI X version `5.11` or later.
 
-The v2 license key is only compatible with MUI X version `5.11` or later.
+Please update your packages if you are using an earlier version.
 
 If this is not a viable solution for your use case, please contact sales@mui.com.
 :::
@@ -153,7 +153,21 @@ But you will not be able to install a newer version released two years from now,
 
 #### Invalid license key
 
-This error indicates that your license key doesn't match what was issued by MUI (this is likely a typo) or that you may be trying to validate a [v2 license key with an older package](#license-key-installation).
+This error indicates that your license key doesn't match what was issued by MUI (this is likely a typo).
+
+#### Invalid license key (Error: extracting license expiry timestamp)
+
+This is a more specific version of the error above. If additionally to the invalid license message, you see an error on the console that looks like:
+
+:::error
+Error extracting license expiry timestamp.
+
+TypeError: Cannot read properties of null (reading '1') at verifyLicense.
+:::
+
+It indicates that you may be trying to validate [the new license's key format on an older package](#license-key-installation).
+
+In this case, please update to MUI X `5.11` or later.
 
 ## Support
 

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -121,7 +121,7 @@ The license key is checked without making any network requests—it's designed t
 In fact, it's expected for the license key to be exposed in a JavaScript bundle.
 We just ask our licensed users not to publicize their license keys.
 
-### Validation errors
+### Validation failures
 
 If the validation of the license key fails, the component displays a watermark and provides a console warning in both development and production.
 End users can still use the component.

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -157,7 +157,7 @@ This error indicates that your license key doesn't match what was issued by MUI 
 
 #### Invalid license key (Error: extracting license expiry timestamp)
 
-This is a more specific version of the error above. If additionally to the invalid license message, you see an error on the console that looks like:
+This is a more specific situation of the error above. If additionally to the invalid license message, you see an error on the console that looks like:
 
 :::error
 Error extracting license expiry timestamp.

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -86,11 +86,11 @@ You will need to purchase a commercial license in order to remove the watermarks
 
 ## License key installation
 
-When you purchase a commercial license, you'll receive your license key by email.
+When you purchase a commercial license, you'll receive a license key by email.
 This key removes all watermarks and console warnings.
 
 :::warning
-Licenses purchased after **May 13, 2022** are only compatible with MUI X version `5.11` or later.
+Licenses purchased after **May 13, 2022** are only compatible with MUI X `v5.11.0` or later.
 
 Please update your packages if you are using an earlier version.
 
@@ -155,9 +155,9 @@ But you will not be able to install a newer version released two years from now,
 
 This error indicates that your license key doesn't match what was issued by MUI (this is likely a typo).
 
-#### Invalid license key (Error: extracting license expiry timestamp)
+#### Invalid license key (TypeError: extracting license expiry timestamp)
 
-This is a more specific situation of the error above. If additionally to the invalid license message, you see an error on the console that looks like:
+The following JavaScript exception indicates that you may be trying to validate [the new license's key format on an older version of the npm package](#license-key-installation).
 
 :::error
 Error extracting license expiry timestamp.
@@ -167,7 +167,7 @@ TypeError: Cannot read properties of null (reading '1') at verifyLicense.
 
 It indicates that you may be trying to validate [the new license's key format on an older package](#license-key-installation).
 
-In this case, please update to MUI X `5.11` or later.
+If your license key is correct, you can solve this error by updating MUI X to `v5.11.0` or later.
 
 ## Support
 

--- a/docs/data/advanced-components/overview.md
+++ b/docs/data/advanced-components/overview.md
@@ -90,14 +90,14 @@ When you purchase a commercial license, you'll receive your license key by email
 This key removes all watermarks and console warnings.
 
 :::warning
-⚠️ If you purchased your license **after May 13, 2022**, You'll obtain a **v2** license key.
+⚠️ All licenses purchased after **May 13, 2022** are _v2_ licenses.
 
-To use the v2 licenses, you'll need to update the MUI X packages to the latest or at least the `5.11` version.
+The v2 license key is only compatible with MUI X version `5.11` or later.
 
-If updating is not practicable or viable, please contact our support at sales@mui.com
+If this is not a viable solution for your use case, please contact sales@mui.com.
 :::
 
-### How and where to install the key?
+### How to install the key?
 
 ```jsx
 import { LicenseInfo } from '@mui/x-license-pro';
@@ -105,8 +105,10 @@ import { LicenseInfo } from '@mui/x-license-pro';
 LicenseInfo.setLicenseKey('YOUR_LICENSE_KEY');
 ```
 
+### Where to install the key?
+
 You must call `setLicenseKey` before React renders the first component.
-You only need to install the key once in your application.
+You only need to install the key **once** in your application.
 
 ### Does each developer need its own key?
 


### PR DESCRIPTION
* Add warning in the license documentation to instruct about the issue with v2-v1 licenses

https://deploy-preview-5074--material-ui-x.netlify.app/x/advanced-components/#license-key-installation