### PR TITLE
[l10n] Add Brazilian Portuguese (pt-BR) locale for date pickers

### DIFF
--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -1,3 +1,4 @@
+export * from './ptBR';
 export * from './trTR';
 export * from './deDE';
 export * from './frFR';

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -1,0 +1,55 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { getPickersLocalization } from './utils/getPickersLocalization';
+import { CalendarPickerView } from '../internals/models';
+
+const ptBRPickers: Partial<PickersLocaleText<any>> = {
+  // Calendar navigation
+  previousMonth: 'Mês anterior',
+  nextMonth: 'Próximo mês',
+
+  // View navigation
+  openPreviousView: 'Abrir próxima seleção',
+  openNextView: 'Abrir seleção anterior',
+  // calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) => view === 'year' ? 'year view is open, switch to calendar view' : 'calendar view is open, switch to year view',
+  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+    view === 'year'
+      ? 'Seleção de ano está aberta, alternando para seleção de calendário'
+      : 'Seleção de calendários está aberta, alternando para seleção de ano',
+
+
+  // DateRange placeholders
+  start: 'Início',
+  end: 'Fim',
+
+  // Action bar
+  cancelButtonLabel: 'Cancelar',
+  clearButtonLabel: 'Limpar',
+  okButtonLabel: 'OK',
+  todayButtonLabel: 'Hoje',
+
+  // Clock labels
+  clockLabelText: (view, time, adapter) =>
+    `Selecione ${view}. ${
+      time === null ? 'Hora não selecionada' : `Selecionado a hora ${adapter.format(time, 'fullTime')}`
+    }`,
+  hoursClockNumberText: (hours) => `${hours} horas`,
+  minutesClockNumberText: (minutes) => `${minutes} minutos`,
+  secondsClockNumberText: (seconds) => `${seconds} segundos`,
+
+  // Open picker labels
+  openDatePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `Escolha uma data, data selecionada ${utils.format(utils.date(rawValue)!, 'fullDate')}`
+      : 'Escolha uma data',
+  openTimePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `Escolha uma hora, hora selecionada ${utils.format(utils.date(rawValue)!, 'fullTime')}`
+      : 'Escolha uma hora',
+
+  // Table labels
+  timeTableLabel: 'escolha um hora',
+  dateTableLabel: 'escolha uma data',
+
+};
+
+export const ptBR = getPickersLocalization(ptBRPickers);

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -16,7 +16,6 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
       ? 'Seleção de ano está aberta, alternando para seleção de calendário'
       : 'Seleção de calendários está aberta, alternando para seleção de ano',
 
-
   // DateRange placeholders
   start: 'Início',
   end: 'Fim',
@@ -30,7 +29,9 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   // Clock labels
   clockLabelText: (view, time, adapter) =>
     `Selecione ${view}. ${
-      time === null ? 'Hora não selecionada' : `Selecionado a hora ${adapter.format(time, 'fullTime')}`
+      time === null
+        ? 'Hora não selecionada'
+        : `Selecionado a hora ${adapter.format(time, 'fullTime')}`
     }`,
   hoursClockNumberText: (hours) => `${hours} horas`,
   minutesClockNumberText: (minutes) => `${minutes} minutos`,
@@ -49,7 +50,6 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   // Table labels
   timeTableLabel: 'escolha uma hora',
   dateTableLabel: 'escolha uma data',
-
 };
 
 export const ptBR = getPickersLocalization(ptBRPickers);

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -47,7 +47,7 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
       : 'Escolha uma hora',
 
   // Table labels
-  timeTableLabel: 'escolha um hora',
+  timeTableLabel: 'escolha uma hora',
   dateTableLabel: 'escolha uma data',
 
 };

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -10,7 +10,7 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'Abrir próxima seleção',
   openNextView: 'Abrir seleção anterior',
-  // calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) => view === 'year' ? 'year view is open, switch to calendar view' : 'calendar view is open, switch to year view',
+
   calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
     view === 'year'
       ? 'Seleção de ano está aberta, alternando para seleção de calendário'

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -10,7 +10,6 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'Abrir próxima seleção',
   openNextView: 'Abrir seleção anterior',
-
   calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
     view === 'year'
       ? 'Seleção de ano está aberta, alternando para seleção de calendário'

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -90,6 +90,7 @@
   { "name": "PickersLocaleText", "kind": "Interface" },
   { "name": "PickerStaticWrapper", "kind": "Function" },
   { "name": "PickersTranslationKeys", "kind": "TypeAlias" },
+  { "name": "ptBR", "kind": "Variable" },
   { "name": "StaticDatePicker", "kind": "Variable" },
   { "name": "StaticDatePickerProps", "kind": "TypeAlias" },
   { "name": "StaticDateRangePicker", "kind": "Variable" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -72,6 +72,7 @@
   { "name": "PickersLocaleText", "kind": "Interface" },
   { "name": "PickerStaticWrapper", "kind": "Function" },
   { "name": "PickersTranslationKeys", "kind": "TypeAlias" },
+  { "name": "ptBR", "kind": "Variable" },
   { "name": "StaticDatePicker", "kind": "Variable" },
   { "name": "StaticDatePickerProps", "kind": "TypeAlias" },
   { "name": "StaticDateTimePicker", "kind": "Variable" },


### PR DESCRIPTION
More than 210 million people speak Brazilian Portuguese.
More than 70 million people speak European Portuguese.

Supporting pt-BR 'Out of the box' will be nice.

Closes #5099 