### PR TITLE
[core] Upgrade monorepo

### DIFF
--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -280,7 +280,7 @@ You can customize the rendering of the filter panel as shown in [the component s
 
 ### Customize the filter panel content
 
-The customization of the filter panel content can be performed by passing props to the default [`<GridFilterPanel />`](/x/api/data-grid/grid-filter-panel) component.
+The customization of the filter panel content can be performed by passing props to the default [`<GridFilterPanel />`](/x/api/data-grid/grid-filter-panel/) component.
 The available props allow overriding:
 
 - The `linkOperators` (can contains `GridLinkOperator.And` and `GridLinkOperator.Or`)

--- a/docs/data/data-grid/rows/rows.md
+++ b/docs/data/data-grid/rows/rows.md
@@ -19,7 +19,7 @@ Otherwise, the grid will re-apply heavy work like sorting and filtering.
 
 :::warning
 Each row object should have a field that uniquely identifies the row.
-By default, the grid will use the `id` property of the row. Note that [column definition](/x/react-data-grid/column-definition) for `id` field is not required.
+By default, the grid will use the `id` property of the row. Note that [column definition](/x/react-data-grid/column-definition/) for `id` field is not required.
 
 When using dataset without a unique `id` property, you can use the `getRowId` prop to specify a custom id for each row.
 

--- a/test/e2e-website/data-grid.spec.ts
+++ b/test/e2e-website/data-grid.spec.ts
@@ -23,7 +23,7 @@ test.describe('DataGrid docs', () => {
     test('should have correct link for API section', async ({ page }) => {
       await page.goto(`/x/react-data-grid/`);
 
-      const anchors = page.locator('div > h2#heading-api ~ ul a');
+      const anchors = page.locator('div > h2#api ~ ul a');
 
       const firstAnchor = anchors.first();
       const textContent = await firstAnchor.textContent();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,8 +2516,8 @@
     react-transition-group "^4.4.2"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.7.0"
-  resolved "https://github.com/mui/material-ui.git#40643a8a32d93d6a838ed50851d48239ee4a7d28"
+  version "5.8.2"
+  resolved "https://github.com/mui/material-ui.git#0fa01accc92c2945f24d4d6f15f0f269cf6e17e8"
 
 "@mui/private-theming@^5.8.0":
   version "5.8.0"


### PR DESCRIPTION
Try https://github.com/mui/material-ui/pull/32939 out. 

An example of a problem this solves: search for "column definition" in Algolia: you will get a duplicate result:

<img width="734" alt="Screenshot 2022-06-04 at 00 50 27" src="https://user-images.githubusercontent.com/3165635/171964039-8391dfae-9b15-4402-b8b1-1c0d6c8a7b56.png">

one with the leading slash, the other without, proof: https://www.algolia.com/apps/TZGZ85B9TB/explorer/browse/material-ui?query=column%20definition&searchMode=search 🙃.