### PR TITLE
[docs] Fix some capitalization to match the guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4025,9 +4025,9 @@ Big thanks to the 8 contributors who made this release possible. Here are some h
 
 ### Docs
 
-- [docs] Data Grid depends on side effects (#666) @oliviertassinari
+- [docs] Data grid depends on side effects (#666) @oliviertassinari
 - [docs] Clarify the purpose of x-grid-data-generator (#634) @Elius94
-- [docs] Data Grid is in the lab (#612) @oliviertassinari
+- [docs] Data grid is in the lab (#612) @oliviertassinari
 - [docs] Fix Demo app, downgrade webpack-cli, known issue in latest version (#647) @dtassone
 - [docs] Fix typo in columns.md @stojy
 - [docs] Reduce confusion on /export page (#646) @SerdarMustafa1

--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -2,9 +2,9 @@
 title: Data Grid - Accessibility
 ---
 
-# Data Grid - Accessibility
+# Data grid - Accessibility
 
-<p class="description">The Data Grid has complete accessibility support. For instance, every cell is accessible using the keyboard.</p>
+<p class="description">The data grid has complete accessibility support. For instance, every cell is accessible using the keyboard.</p>
 
 ## Guidelines
 

--- a/docs/data/data-grid/aggregation/aggregation.md
+++ b/docs/data/data-grid/aggregation/aggregation.md
@@ -2,7 +2,7 @@
 title: Data Grid - Aggregation
 ---
 
-# Data Grid - Aggregation [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)
+# Data grid - Aggregation [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)
 
 <p class="description">Apply aggregation function to populate the group row with values.</p>
 

--- a/docs/data/data-grid/column-definition/column-definition.md
+++ b/docs/data/data-grid/column-definition/column-definition.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column definition
 ---
 
-# Data Grid - Column definition
+# Data grid - Column definition
 
 <p class="description">Define your columns.</p>
 

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column dimensions
 ---
 
-# Data Grid - Column dimensions
+# Data grid - Column dimensions
 
 <p class="description">Customize the dimensions and resizing behavior of your columns.</p>
 

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column groups 🚧
 ---
 
-# Data Grid - Column groups 🚧
+# Data grid - Column groups 🚧
 
 <p class="description">Group your columns.</p>
 

--- a/docs/data/data-grid/column-header/column-header.md
+++ b/docs/data/data-grid/column-header/column-header.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column header
 ---
 
-# Data Grid - Column header
+# Data grid - Column header
 
 <p class="description">Customize your columns header.</p>
 

--- a/docs/data/data-grid/column-ordering/column-ordering.md
+++ b/docs/data/data-grid/column-ordering/column-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column ordering
 ---
 
-# Data Grid - Column ordering [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Data grid - Column ordering [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 <p class="description">Drag and drop your columns to reorder them.</p>
 

--- a/docs/data/data-grid/column-pinning/column-pinning.md
+++ b/docs/data/data-grid/column-pinning/column-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column pinning
 ---
 
-# Data Grid - Column pinning [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Data grid - Column pinning [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 <p class="description">Pin columns to keep them visible at all time.</p>
 

--- a/docs/data/data-grid/column-spanning/column-spanning.md
+++ b/docs/data/data-grid/column-spanning/column-spanning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column spanning
 ---
 
-# Data Grid - Column spanning
+# Data grid - Column spanning
 
 <p class="description">Span cells across several columns.</p>
 

--- a/docs/data/data-grid/column-visibility/column-visibility.md
+++ b/docs/data/data-grid/column-visibility/column-visibility.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column visibility
 ---
 
-# Data Grid - Column visibility
+# Data grid - Column visibility
 
 <p class="description">Define which columns are visible.</p>
 

--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -2,7 +2,7 @@
 title: Data Grid - Components
 ---
 
-# Data Grid - Components
+# Data grid - Components
 
 <p class="description">The grid is highly customizable. Override components using the <code>components</code> prop.</p>
 

--- a/docs/data/data-grid/demo/demo.md
+++ b/docs/data/data-grid/demo/demo.md
@@ -2,7 +2,7 @@
 title: Data Grid - Demo
 ---
 
-# Data Grid - Demo
+# Data grid - Demo
 
 <p class="description">Use the demo below to explore the available features.</p>
 

--- a/docs/data/data-grid/editing-legacy/editing.md
+++ b/docs/data/data-grid/editing-legacy/editing.md
@@ -2,7 +2,7 @@
 title: Data Grid - Editing (legacy)
 ---
 
-# Data Grid - Editing (legacy)
+# Data grid - Editing (legacy)
 
 <p class="description">The data grid has built-in edit capabilities that you can customize to your needs.</p>
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -2,7 +2,7 @@
 title: Data Grid - Editing
 ---
 
-# Data Grid - Editing
+# Data grid - Editing
 
 <p class="description">The data grid has built-in support for cell and row editing.</p>
 

--- a/docs/data/data-grid/events/events.md
+++ b/docs/data/data-grid/events/events.md
@@ -2,7 +2,7 @@
 title: Data Grid - Events
 ---
 
-# Data Grid - Events [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Data grid - Events [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 <p class="description">The data grid emits events that can be subscribed to attach custom behavior.</p>
 

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -2,7 +2,7 @@
 title: Data Grid - Export
 ---
 
-# Data Grid - Export
+# Data grid - Export
 
 <p class="description">Easily export the rows in various file formats such as CSV, Excel, or PDF.</p>
 

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Filtering
 ---
 
-# Data Grid - Filtering
+# Data grid - Filtering
 
 <p class="description">Easily filter your rows based on one or several criteria.</p>
 

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -2,7 +2,7 @@
 title: Data Grid - Getting started
 ---
 
-# Data Grid - Getting started
+# Data grid - Getting started
 
 <p class="description">Get started with the last React data grid you will need. Install the package, configure the columns, provide rows, and you are set.</p>
 

--- a/docs/data/data-grid/layout/layout.md
+++ b/docs/data/data-grid/layout/layout.md
@@ -2,7 +2,7 @@
 title: Data Grid - Layout
 ---
 
-# Data Grid - Layout
+# Data grid - Layout
 
 <p class="description">The data grid offers multiple layout mode.</p>
 

--- a/docs/data/data-grid/localization/localization.md
+++ b/docs/data/data-grid/localization/localization.md
@@ -2,9 +2,9 @@
 title: Data Grid - Localization
 ---
 
-# Data Grid - Localization
+# Data grid - Localization
 
-<p class="description">The Data Grid allows to support users from different locales, with formatting, RTL, and localized strings.</p>
+<p class="description">The data grid allows to support users from different locales, with formatting, RTL, and localized strings.</p>
 
 The default locale of MUI is English (United States). If you want to use other locales, follow the instructions below.
 

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -2,7 +2,7 @@
 title: Data Grid - Master detail
 ---
 
-# Data Grid - Master detail [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Data grid - Master detail [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 <p class="description">Expand your rows to display additional information.</p>
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -5,7 +5,7 @@ packageName: '@mui/x-data-grid'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 ---
 
-# Data Grid
+# Data grid
 
 <p class="description">A fast and extendable react data table and react data grid. It's a feature-rich component available in MIT or Commercial versions.</p>
 

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -2,7 +2,7 @@
 title: Data Grid - Pagination
 ---
 
-# Data Grid - Pagination
+# Data grid - Pagination
 
 <p class="description">Easily paginate your rows and only fetch what you need.</p>
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -2,7 +2,7 @@
 title: Data Grid - Pivoting
 ---
 
-# Data Grid - Pivoting [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)
+# Data grid - Pivoting [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)
 
 <p class="description">Turn a column values into columns.</p>
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -1,5 +1,5 @@
 ---
-title: Data Grid - Row Grouping
+title: Data Grid - Row grouping
 ---
 
 # Data grid - Row grouping [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row Grouping
 ---
 
-# Data Grid - Row grouping [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)
+# Data grid - Row grouping [<span class="plan-premium"></span>](https://mui.com/store/items/mui-x-premium/)
 
 <p class="description">Group your rows according to some column values.</p>
 

--- a/docs/data/data-grid/rows/rows.md
+++ b/docs/data/data-grid/rows/rows.md
@@ -2,7 +2,7 @@
 title: Data Grid - Rows
 ---
 
-# Data Grid - Rows
+# Data grid - Rows
 
 <p class="description">This section goes in details on the aspects of the rows you need to know.</p>
 

--- a/docs/data/data-grid/scrolling/scrolling.md
+++ b/docs/data/data-grid/scrolling/scrolling.md
@@ -2,7 +2,7 @@
 title: Data Grid - Scrolling
 ---
 
-# Data Grid - Scrolling
+# Data grid - Scrolling
 
 <p class="description">This section presents how to programmatically control the scroll.</p>
 

--- a/docs/data/data-grid/selection/selection.md
+++ b/docs/data/data-grid/selection/selection.md
@@ -2,7 +2,7 @@
 title: Data Grid - Selection
 ---
 
-# Data Grid - Selection
+# Data grid - Selection
 
 <p class="description">Selection allows the user to select and highlight a number of rows that they can then take action on.</p>
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -2,7 +2,7 @@
 title: Data Grid - Sorting
 ---
 
-# Data Grid - Sorting
+# Data grid - Sorting
 
 <p class="description">Easily sort your rows based on one or several criteria.</p>
 

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -2,7 +2,7 @@
 title: Data Grid - State
 ---
 
-# Data Grid - State
+# Data grid - State
 
 <p class="description">Initialize and read the state of the data grid.</p>
 

--- a/docs/data/data-grid/style/style.md
+++ b/docs/data/data-grid/style/style.md
@@ -2,7 +2,7 @@
 title: Data Grid - Styling
 ---
 
-# Data Grid - Styling
+# Data grid - Styling
 
 <p class="description">The grid CSS can be easily overwritten.</p>
 

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -2,7 +2,7 @@
 title: Data Grid - Tree data
 ---
 
-# Data Grid - Tree data [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Data grid - Tree data [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
 <p class="description">Use Tree data to handle rows with parent / child relationship.</p>
 

--- a/docs/data/data-grid/virtualization/virtualization.md
+++ b/docs/data/data-grid/virtualization/virtualization.md
@@ -2,7 +2,7 @@
 title: Data Grid - Virtualization
 ---
 
-# Data Grid - Virtualization
+# Data grid - Virtualization
 
 <p class="description">The grid is high performing thanks to its rows and columns virtualization engine.</p>
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -9,9 +9,9 @@ materialDesign: https://material.io/components/date-pickers
 
 # Date Picker
 
-<p class="description">Date pickers let the user select a date.</p>
+<p class="description">The date picker let the user select a date.</p>
 
-Date pickers let the user select a date. Date pickers are displayed with:
+Date pickers are displayed with:
 
 - Dialogs on mobile
 - Text field dropdowns on desktop

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers
 ---
 
-# Date Picker
+# Date picker
 
 <p class="description">The date picker let the user select a date.</p>
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -1,6 +1,6 @@
 ---
 product: date-pickers
-title: React date range picker component
+title: React Date Range Picker component
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
 githubLabel: 'component: DateRangePicker'
 packageName: '@mui/x-date-pickers'
@@ -9,9 +9,7 @@ materialDesign: https://material.io/components/date-pickers
 
 # Date range picker [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
 
-<p class="description">Date pickers let the user select a range of dates.</p>
-
-The date range pickers let the user select a range of dates.
+<p class="description">The date range picker let the user select a range of dates.</p>
 
 ## Basic usage
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers
 ---
 
-# Date Time Picker
+# Date time picker
 
 <p class="description">This component combines the date & time pickers.</p>
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -9,9 +9,9 @@ materialDesign: https://material.io/components/date-pickers
 
 # Date Time Picker
 
-<p class="description">Combined date & time picker.</p>
+<p class="description">This component combines the date & time pickers.</p>
 
-This component combines the date & time pickers. It allows the user to select both date and time with the same control.
+It allows the user to select both date and time with the same control.
 
 Note that this component is the [DatePicker](/x/react-date-pickers/date-picker/) and [TimePicker](/x/react-date-pickers/time-picker/)
 component combined, so any of these components' props can be passed to the DateTimePicker.

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -1,6 +1,6 @@
 ---
 product: date-pickers
-title: React date time range picker component
+title: React Date Time Range Picker component
 githubLabel: 'component: DateTimeRangePicker'
 packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -1,10 +1,10 @@
 ---
-title: Date and time pickers - Localization
+title: Date and Time pickers - Localization
 ---
 
-# Date and time pickers - Localization
+# Date and Time pickers - Localization
 
-<p class="description">Date and time pickers allow to support users from different locales, with formatting, RTL, and localized strings.</p>
+<p class="description">Date and Time pickers allow to support users from different locales, with formatting, RTL, and localized strings.</p>
 
 The default locale of MUI is English (United States). If you want to use other locales, follow the instructions below.
 

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/time-pickers
 ---
 
-# Time Picker
+# Time picker
 
 <p class="description">Time pickers allow the user to select a single time.</p>
 

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -11,7 +11,6 @@ materialDesign: https://material.io/components/time-pickers
 
 <p class="description">Time pickers allow the user to select a single time.</p>
 
-Time pickers allow the user to select a single time (in the hours:minutes format).
 The selected time is indicated by the filled circle at the end of the clock hand.
 
 ## Basic usage

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -1,6 +1,6 @@
 ---
 product: date-pickers
-title: React time range picker component
+title: React Time Range Picker component
 githubLabel: 'component: TimeRangePicker'
 packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -57,9 +57,9 @@ const pages: MuiPage[] = [
           '/x/react-data-grid/pivoting',
         ],
         children: [
-          { pathname: '/x/react-data-grid/row-grouping', title: 'Row Grouping', plan: 'premium' },
-          { pathname: '/x/react-data-grid/tree-data', title: 'Tree Data', plan: 'pro' },
-          { pathname: '/x/react-data-grid/master-detail', title: 'Master Detail', plan: 'pro' },
+          { pathname: '/x/react-data-grid/row-grouping', plan: 'premium' },
+          { pathname: '/x/react-data-grid/tree-data', plan: 'pro' },
+          { pathname: '/x/react-data-grid/master-detail', plan: 'pro' },
           { pathname: '/x/react-data-grid/aggregation', title: 'Aggregation 🚧', plan: 'premium' },
           { pathname: '/x/react-data-grid/pivoting', title: 'Pivoting 🚧', plan: 'premium' },
         ],

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -9,7 +9,7 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-data-grid',
     scopePathnames: ['/x/api/data-grid'],
-    title: 'Data Grid',
+    title: 'Data grid',
     icon: 'TableViewIcon',
     children: [
       { pathname: '/x/react-data-grid', title: 'Overview' },
@@ -102,7 +102,7 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-date-pickers',
     scopePathnames: ['/x/api/date-pickers'],
-    title: 'Date and Time Pickers',
+    title: 'Date and Time pickers',
     icon: 'DatePickerIcon',
     children: [
       { pathname: '/x/react-date-pickers/getting-started' },

--- a/docs/pages/x/api/data-grid/index.md
+++ b/docs/pages/x/api/data-grid/index.md
@@ -1,4 +1,4 @@
-# Data Grid - API Reference
+# Data grid - API Reference
 
 <p class="description">This page contains an index to the most important APIs of the data grid.</p>
 

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterState.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterState.ts
@@ -30,7 +30,7 @@ export interface GridFilterState {
   /**
    * Amount of descendants that are passing the filters.
    * For the Tree Data, it includes all the intermediate depth levels (= amount of children + amount of grand children + ...).
-   * For the Row Grouping by Column, it does not include the intermediate depth levels (= amount of descendant of maximum depth).
+   * For the Row grouping by column, it does not include the intermediate depth levels (= amount of descendant of maximum depth).
    * If a row is not registered in this lookup, it is supposed to have no descendant passing the filters.
    */
   filteredDescendantCountLookup: Record<GridRowId, number>;

--- a/test/e2e-website/data-grid.spec.ts
+++ b/test/e2e-website/data-grid.spec.ts
@@ -96,7 +96,7 @@ test.describe('DataGrid docs', () => {
 
   //     await page.type('input#docsearch-input', 'datagrid', { delay: 50 });
 
-  //     const anchor = page.locator('.DocSearch-Hits a:has-text("Data Grid - Components")').first();
+  //     const anchor = page.locator('.DocSearch-Hits a:has-text("Data grid - Components")').first();
   //     await anchor.waitFor();
 
   //     await expect(anchor).toHaveAttribute(


### PR DESCRIPTION
https://deploy-preview-5105--material-ui-x.netlify.app/x/react-data-grid/

I didn't update the SEO titles as [Title case](https://www.notion.so/mui-org/Style-guide-2a957a4168a54d47b14bae026d06a24b#d8e9cfb2423c4f83844a9f29d2032e3f) seems to be the convention that Google seeks. Proof:

<img width="1133" alt="Screenshot 2022-06-04 at 12 16 06" src="https://user-images.githubusercontent.com/3165635/171994987-f37ac28d-206c-4585-90c1-9900b0172636.png">

https://app.ahrefs.com/site-audit/3523498/13/data-explorer?columns=pageRating%2Curl%2Ctraffic%2Ctitle%2Cserp_title%2Cis_page_title_used_in_serp%2Ctop_keyword%2Ctop_keyword_position&filterCollapsed=true&filterId=207cf10d892e807e0aaeafdf8fc70712&issueId=d69246c2-225a-11ec-8456-06d2f2f613d8

Otherwise, I'm following https://www.notion.so/mui-org/Style-guide-2a957a4168a54d47b14bae026d06a24b#d8e9cfb2423c4f83844a9f29d2032e3f