### PR TITLE
[core] Improve license description

### DIFF
--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -4,7 +4,7 @@
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
-  "license": "See LICENSE file, commercial",
+  "license": "SEE LICENSE FILE, COMMERCIAL",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -4,7 +4,7 @@
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "See LICENSE file, commercial",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -4,7 +4,7 @@
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
-  "license": "See LICENSE file, commercial",
+  "license": "SEE LICENSE FILE, COMMERCIAL",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -4,7 +4,7 @@
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "See LICENSE file, commercial",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -4,7 +4,7 @@
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "See LICENSE file, commercial",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -4,7 +4,7 @@
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
-  "license": "See LICENSE file, commercial",
+  "license": "SEE LICENSE FILE, COMMERCIAL",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -4,7 +4,7 @@
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",
-  "license": "See LICENSE file, commercial",
+  "license": "SEE LICENSE FILE, COMMERCIAL",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -4,7 +4,7 @@
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "See LICENSE file, commercial",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },


### PR DESCRIPTION
I was looking at a proposed edits on the EULA for a customer:

<img width="621" alt="Screenshot 2022-06-04 at 16 06 26" src="https://user-images.githubusercontent.com/3165635/172004618-3403cbac-a965-4343-ab73-3077a1b1efd8.png">
 
which made me want to check all our dependencies https://npm.anvaka.com/#/view/2d/%2540mui%252Fx-data-grid-pro. On which I landed on this weird license:

<img width="289" alt="Screenshot 2022-06-04 at 16 07 21" src="https://user-images.githubusercontent.com/3165635/172004762-f989bac1-3100-44c1-b2cb-638f5a38f488.png">

### Before

<img width="378" alt="Screenshot 2022-06-04 at 16 07 56" src="https://user-images.githubusercontent.com/3165635/172004923-8df6f18e-54eb-4080-85fc-da8af73ace7f.png">

https://www.npmjs.com/package/@mui/x-data-grid-pro

<img width="284" alt="Screenshot 2022-06-04 at 16 09 37" src="https://user-images.githubusercontent.com/3165635/172005042-99068061-fd16-499e-aa86-15caead5467c.png">

### After

<img width="377" alt="Screenshot 2022-06-04 at 16 08 27" src="https://user-images.githubusercontent.com/3165635/172004981-9adcad0b-714c-4cd9-ae40-b9f88b381cb0.png">

<img width="288" alt="Screenshot 2022-06-04 at 16 08 58" src="https://user-images.githubusercontent.com/3165635/172005009-5a7f4aed-a4cf-44f3-bd1f-95cd203083bb.png">

---

*We have #4251 to get rid of the ISC license, which might help with procurement.*