### PR TITLE
[data grid] Fix implicit dependency on react-dom

### DIFF
--- a/benchmark/browser/index.js
+++ b/benchmark/browser/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 // Get all the scenarios
 const requirePerfScenarios = require.context('./scenarios', true, /(js|ts|tsx)$/);

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -56,7 +56,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -54,7 +54,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -55,7 +55,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import TestViewer from './TestViewer';
 

--- a/test/performance/index.js
+++ b/test/performance/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import TestViewer from './TestViewer';
 

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
 import TestViewer from 'test/regressions/TestViewer';


### PR DESCRIPTION
I was on https://github.com/mui/material-ui/pull/33015#issuecomment-1146631891, having a quick look at what could explain the jump in bundle size in the data grid at version v5.9.0. We went [from 78.1 to 122.1 KB](https://bundlephobia.com/package/@mui/x-data-grid@5.12.0). Compared to react-table [15.7 KB](https://bundlephobia.com/package/react-table@7.8.0) it can be intimidating. I could identify the origin down to #4332, we depend on `react-dom`:

https://github.com/mui/mui-x/blob/23aaa6bad1a0398ebc7677337d1d46226c2b70f6/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx#L2

but we don't list the dependency.