### PR TITLE
[docs] Improve the getRowId doc section

### DIFF
--- a/docs/data/data-grid/rows/rows.md
+++ b/docs/data/data-grid/rows/rows.md
@@ -17,17 +17,26 @@ Otherwise, the grid will re-apply heavy work like sorting and filtering.
 
 {{"demo": "RowsGrid.js", "bg": "inline"}}
 
-:::warning
-Each row object should have a field that uniquely identifies the row.
-By default, the grid will use the `id` property of the row. Note that [column definition](/x/react-data-grid/column-definition/) for `id` field is not required.
+## Row identifier
 
-When using dataset without a unique `id` property, you can use the `getRowId` prop to specify a custom id for each row.
+Each row must have a unique id.
+
+This id is used internally to identify the row in the various models (for instance the row selection model) and to track the row across updates.
+By default, the grid will use the `id` property of the row.
+
+When using a dataset without a unique `id` property, you can use the `getRowId` prop to specify the id of each row.
+This can be useful if your id is stored in another property like shown below:
 
 ```tsx
 <DataGrid getRowId={(row) => row.internalId} />
 ```
 
 {{"demo": "RowsGridWithGetRowId.js", "bg": "inline", "defaultCodeOpen": false}}
+
+:::warning
+Just like the `rows` prop, the `getRowId` prop should keep the same reference between two renders.
+Otherwise, the grid will re-apply heavy work like sorting and filtering.
+:::
 
 ## Updating rows
 


### PR DESCRIPTION
- Don't talk about "id field" to avoid confusion between the "id column" and the "id property in the row model".

- Create a standalone section instead of putting everything in a warning

- Add a warning saying that getRowId must be memoized

Should we add a note saying that the grid does not require an "id" column ? 
I think it's what the `Note that [column definition](https://mui.com/x/react-data-grid/column-definition) for id field is not required.` tries to say but it's not very comprehensible in its current form.