### PR TITLE
[DataGrid] Hide vertical scrollbar if `autoHeight` is enabled

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -472,6 +472,9 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
   if (!needsHorizontalScrollbar) {
     rootStyle.overflowX = 'hidden';
   }
+  if (rootProps.autoHeight) {
+    rootStyle.overflowY = 'hidden';
+  }
 
   const getRenderContext = React.useCallback((): GridRenderContext => {
     return prevRenderContext.current!;


### PR DESCRIPTION
Preview: https://deploy-preview-5164--material-ui-x.netlify.app/x/react-data-grid/layout/#auto-height

The scrollbar is appearing for a brief moment when a new row is added in https://mui.com/x/react-data-grid/layout/. This demo uses `autoHeight`, meaning that it should never have scrollbar so we're safe to apply `overflow-y: hidden`. I noticed this problem in https://deploy-preview-5163--material-ui-x.netlify.app/x/react-data-grid/master-detail/#infer-height-from-the-content

https://user-images.githubusercontent.com/42154031/172937562-c5b8da89-1ee6-4a1d-be93-72fe0162b558.mp4

