### PR TITLE
[DataGrid] Fix for cosmetic bug on column filter badge

### DIFF
--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -131,7 +131,7 @@ export const GridRootStyles = styled('div', {
       minWidth: 0,
       flex: 1,
       whiteSpace: 'nowrap',
-      overflow: 'hidden',
+      overflowX: 'hidden',
     },
     [`& .${gridClasses.columnHeaderTitleContainerContent}`]: {
       overflow: 'hidden',


### PR DESCRIPTION
Fixes #5159 

Fix filter badge being cut off when the table's density is set to compact mode.