### PR TITLE
[pickers] Export adapters from both `@mui/x-date-pickers` and `@mui/x-date-pickers-pro`

### DIFF
--- a/docs/data/date-pickers/date-range-picker/BasicDateRangePicker.js
+++ b/docs/data/date-pickers/date-range-picker/BasicDateRangePicker.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import Box from '@mui/material/Box';
 
 export default function BasicDateRangePicker() {

--- a/docs/data/date-pickers/date-range-picker/BasicDateRangePicker.tsx
+++ b/docs/data/date-pickers/date-range-picker/BasicDateRangePicker.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
 import { DateRangePicker, DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import Box from '@mui/material/Box';
 
 export default function BasicDateRangePicker() {

--- a/docs/data/date-pickers/date-range-picker/CalendarsDateRangePicker.js
+++ b/docs/data/date-pickers/date-range-picker/CalendarsDateRangePicker.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import Box from '@mui/material/Box';
 

--- a/docs/data/date-pickers/date-range-picker/CalendarsDateRangePicker.tsx
+++ b/docs/data/date-pickers/date-range-picker/CalendarsDateRangePicker.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { DateRangePicker, DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
 import Box from '@mui/material/Box';
 

--- a/docs/data/date-pickers/date-range-picker/CustomDateRangePickerDay.js
+++ b/docs/data/date-pickers/date-range-picker/CustomDateRangePickerDay.js
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
 import { DateRangePickerDay as MuiDateRangePickerDay } from '@mui/x-date-pickers-pro/DateRangePickerDay';

--- a/docs/data/date-pickers/date-range-picker/CustomDateRangePickerDay.tsx
+++ b/docs/data/date-pickers/date-range-picker/CustomDateRangePickerDay.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
 import {

--- a/docs/data/date-pickers/date-range-picker/FormPropsDateRangePickers.js
+++ b/docs/data/date-pickers/date-range-picker/FormPropsDateRangePickers.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 

--- a/docs/data/date-pickers/date-range-picker/FormPropsDateRangePickers.tsx
+++ b/docs/data/date-pickers/date-range-picker/FormPropsDateRangePickers.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import { DateRangePicker, DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 

--- a/docs/data/date-pickers/date-range-picker/MinMaxDateRangePicker.js
+++ b/docs/data/date-pickers/date-range-picker/MinMaxDateRangePicker.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import addWeeks from 'date-fns/addWeeks';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import Box from '@mui/material/Box';
 

--- a/docs/data/date-pickers/date-range-picker/MinMaxDateRangePicker.tsx
+++ b/docs/data/date-pickers/date-range-picker/MinMaxDateRangePicker.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import addWeeks from 'date-fns/addWeeks';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { DateRangePicker, DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
 import Box from '@mui/material/Box';
 

--- a/docs/data/date-pickers/date-range-picker/ResponsiveDateRangePicker.js
+++ b/docs/data/date-pickers/date-range-picker/ResponsiveDateRangePicker.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 

--- a/docs/data/date-pickers/date-range-picker/ResponsiveDateRangePicker.tsx
+++ b/docs/data/date-pickers/date-range-picker/ResponsiveDateRangePicker.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 import { DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';

--- a/docs/data/date-pickers/date-range-picker/StaticDateRangePickerDemo.js
+++ b/docs/data/date-pickers/date-range-picker/StaticDateRangePickerDemo.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+
 import Box from '@mui/material/Box';
 
 export default function StaticDateRangePickerDemo() {

--- a/docs/data/date-pickers/date-range-picker/StaticDateRangePickerDemo.tsx
+++ b/docs/data/date-pickers/date-range-picker/StaticDateRangePickerDemo.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
+import { LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import Box from '@mui/material/Box';
 import { DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
+import Box from '@mui/material/Box';
 
 export default function StaticDateRangePickerDemo() {
   const [value, setValue] = React.useState<DateRange<Date>>([null, null]);

--- a/packages/x-date-pickers-pro/src/AdapterDateFns/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterDateFns/index.ts
@@ -1,0 +1,1 @@
+export { default as AdapterDateFns } from '@date-io/date-fns';

--- a/packages/x-date-pickers-pro/src/AdapterDayjs/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterDayjs/index.ts
@@ -1,0 +1,1 @@
+export { default as AdapterDayjs } from '@date-io/dayjs';

--- a/packages/x-date-pickers-pro/src/AdapterLuxon/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterLuxon/index.ts
@@ -1,0 +1,1 @@
+export { default as AdapterLuxon } from '@date-io/luxon';

--- a/packages/x-date-pickers-pro/src/AdapterMoment/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterMoment/index.ts
@@ -1,0 +1,1 @@
+export { default as AdapterMoment } from '@date-io/moment';


### PR DESCRIPTION
Fixes #5132

My comment on the issue above

> The basic idea was: we don't want to create dozens of folders inside the pro package just re-exporting the community components just to be able to do `import { DatePicker } from '@mui/x-date-pickers-pro/DatePicker'`. Users could do `import { DatePicker } from '@mui/x-date-pickers-pro'` or if they really want dev tree shaking `import { DatePicker } from '@mui/x-date-pickers/DatePicker'`.
>
> But the adapters (I think they are the only one), we don't export them from the root of `@mui/x-date-pickers` and thus they are not re-exported from the root of `@mui/x-date-pickers-pro`.