### PR TITLE
[data grid] Do not regenerate the row tree when props.loading changes

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
@@ -64,28 +64,6 @@ describe('<DataGridPro /> - Rows', () => {
       );
     });
 
-    describe('updateRows', () => {
-      it('should apply getRowId before updating rows', () => {
-        const getRowId: DataGridProProps['getRowId'] = (row) => `${row.clientId}`;
-        let apiRef: React.MutableRefObject<GridApi>;
-        const Test = () => {
-          apiRef = useGridApiRef();
-          return (
-            <div style={{ width: 300, height: 300 }}>
-              <DataGridPro {...baselineProps} getRowId={getRowId} apiRef={apiRef} />
-            </div>
-          );
-        };
-        render(<Test />);
-        expect(getColumnValues(0)).to.deep.equal(['c1', 'c2', 'c3']);
-        apiRef!.current.updateRows([
-          { clientId: 'c2', age: 30 },
-          { clientId: 'c3', age: 31 },
-        ]);
-        expect(getColumnValues(2)).to.deep.equal(['11', '30', '31']);
-      });
-    });
-
     it('should allow to switch between cell mode', () => {
       let apiRef: React.MutableRefObject<GridApi>;
       const editableProps = { ...baselineProps };
@@ -277,6 +255,25 @@ describe('<DataGridPro /> - Rows', () => {
         { idField: 5, brand: 'Atari' },
       ]);
       expect(getColumnValues(0)).to.deep.equal(['Apple', 'Atari']);
+    });
+
+    it('should not loose partial updates after a props.loading switch', () => {
+      const Test = (props: Partial<DataGridProProps>) => {
+        apiRef = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGridPro {...baselineProps} apiRef={apiRef} {...props} />
+          </div>
+        );
+      };
+
+      const { setProps } = render(<Test />);
+      expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas', 'Puma']);
+
+      setProps({ loading: true });
+      apiRef.current.updateRows([{ id: 0, brand: 'Nike 2' }]);
+      setProps({ loading: false });
+      expect(getColumnValues(0)).to.deep.equal(['Nike 2', 'Adidas', 'Puma']);
     });
   });
 

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -431,11 +431,23 @@ export const useGridRows = (
       return;
     }
 
+    const areNewRowsAlreadyInState =
+      apiRef.current.unstable_caches.rows.rowsBeforePartialUpdates === props.rows;
+    const isNewLoadingAlreadyInState =
+      apiRef.current.unstable_caches.rows!.loadingPropBeforePartialUpdates === props.loading;
+
     // The new rows have already been applied (most likely in the `'rowGroupsPreProcessingChange'` listener)
-    if (
-      apiRef.current.unstable_caches.rows.rowsBeforePartialUpdates === props.rows &&
-      apiRef.current.unstable_caches.rows!.loadingPropBeforePartialUpdates === props.loading
-    ) {
+    if (areNewRowsAlreadyInState) {
+      // If the loading prop has changed, we need to update its value in the state because it won't be done by `throttledRowsChange`
+      if (!isNewLoadingAlreadyInState) {
+        apiRef.current.setState((state) => ({
+          ...state,
+          rows: { ...state.rows, loading: props.loading },
+        }));
+        apiRef.current.unstable_caches.rows!.loadingPropBeforePartialUpdates = props.loading;
+        apiRef.current.forceUpdate();
+      }
+
       return;
     }
 


### PR DESCRIPTION
Fixes #5208

[Before before](https://codesandbox.io/s/data-grid-pro-forked-946vlv?file=/package.json)
[Behavior after](https://codesandbox.io/s/data-grid-pro-forked-qr8wpk?file=/package.json)

The username should go from `fault` to `okay` and remain `okay` after the end of the loading.


Since https://github.com/mui/mui-x/pull/4910, we were regenerating the whole row tree whenever `props.loading` changed.

This leads to two issues:

- performance-wise, it's an useless regeneration,what we want to do is just to update the `state.rows.loading` if `props.loading` changed but not `props.rows`

- if you do partial updates with `apiRef.current.updateRows` then changes `props.loading`, then you loose your partial updates
