### PR TITLE
[data grid] Fix detail panel on DataGridPremium

### DIFF
--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
@@ -118,11 +118,11 @@ export const useDataGridPremiumComponent = (
   useGridTreeData(apiRef);
   useGridKeyboardNavigation(apiRef, props);
   useGridSelection(apiRef, props);
-  useGridDetailPanel(apiRef, props);
   useGridColumnPinning(apiRef, props);
   useGridColumns(apiRef, props);
   useGridRows(apiRef, props);
   useGridParamsApi(apiRef);
+  useGridDetailPanel(apiRef, props);
   useGridColumnSpanning(apiRef);
 
   const useGridEditing = props.experimentalFeatures?.newEditingApi


### PR DESCRIPTION
Fixes #5262

In #5110 the plugin order was only changed for the pro plan