### PR TITLE
[data grid] Fix the default filter operator fallback on state initialization

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -10,7 +10,7 @@ import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridStateCommunity } from '../../../models/gridStateCommunity';
 import { GridAggregatedFilterItemApplier } from './gridFilterState';
 import { buildWarning } from '../../../utils/warning';
-import { gridColumnFieldsSelector } from '../columns';
+import { gridColumnFieldsSelector, gridColumnLookupSelector } from '../columns';
 
 type GridFilterItemApplier = {
   fn: (rowId: GridRowId) => boolean;
@@ -35,8 +35,9 @@ export const cleanFilterItem = (
   }
 
   if (cleanItem.operatorValue == null) {
-    // we select a default operator
-    const column = apiRef.current.getColumn(cleanItem.columnField);
+    // Selects a default operator
+    // We don't use `apiRef.current.getColumn` because it is not ready during state initialization
+    const column = gridColumnLookupSelector(apiRef)[cleanItem.columnField];
     cleanItem.operatorValue = column && column!.filterOperators![0].value!;
   }
 

--- a/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -141,6 +141,32 @@ describe('<DataGrid /> - Filter', () => {
       });
       expect(getColumnValues(0)).to.deep.equal(['France']);
     });
+
+    it('should pick a default operator when none provided on an item', () => {
+      expect(() => {
+        render(
+          <TestCase
+            filterModel={{ items: [{ columnField: 'brand', value: 'a' }] }}
+            rows={[
+              {
+                id: 3,
+                brand: 'Asics',
+              },
+              {
+                id: 4,
+                brand: 'RedBull',
+              },
+              {
+                id: 5,
+                brand: 'Hugo',
+              },
+            ]}
+          />,
+        );
+      }).toWarnDev('MUI: One of your filtering item have no `operatorValue` provided.');
+
+      expect(getColumnValues(0)).to.deep.equal(['Asics']);
+    });
   });
 
   describe('prop: initialState.filter', () => {


### PR DESCRIPTION
Fixes #5229 