### PR TITLE
[docs] Fix typo in `migration from lab`

### DIFF
--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -5,7 +5,7 @@
 ## Introduction
 
 This is a reference for migrating your site's pickers from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`.
-This migration only concerns packages and should do not affect the behavior of the components in your app.
+This migration only concerns packages and **should not** affect the behavior of the components in your app.
 
 We explored the reasons of this migration in a [blog post](/blog/lab-date-pickers-to-mui-x/)
 

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -5,7 +5,7 @@
 ## Introduction
 
 This is a reference for migrating your site's pickers from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`.
-This migration only concerns packages and **should not** affect the behavior of the components in your app.
+This migration is about the npm packages used, it **does not** affect the behavior of the components in your application.
 
 We explored the reasons of this migration in a [blog post](/blog/lab-date-pickers-to-mui-x/)
 

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -6,8 +6,7 @@
 
 This is a reference for migrating your site's pickers from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`.
 This migration is about the npm packages used, it **does not** affect the behavior of the components in your application.
-
-We explored the reasons of this migration in a [blog post](/blog/lab-date-pickers-to-mui-x/)
+You can find why we are moving in this direction in the [announcement blog post](/blog/lab-date-pickers-to-mui-x/).
 
 ## License
 


### PR DESCRIPTION
Fix typo "should do not", and bold it so readers can more easily spot what this migration offers