### PR TITLE
[core] Remove dead logic

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -162,15 +162,5 @@ module.exports = {
       destination: '/x/react-data-grid/',
       permanent: false,
     },
-    {
-      source: '/components/data-grid/:path*',
-      destination: '/x/react-data-grid/:path*',
-      permanent: false,
-    },
-    {
-      source: '/api/data-grid/:path*',
-      destination: '/x/api/data-grid/:path*',
-      permanent: false,
-    },
   ],
 };


### PR DESCRIPTION
Redirects only take effect in the development, not production (because of `next export`). I would argue it was never needed in the first place for the migration, and since it's done, not anymore.

I have found this doing a quick review on something unrelated.