### PR TITLE
[DX] Allows having multiple playgrounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __diff_output__
 /coverage
 /docs/.next
 /docs/pages/playground.tsx
+/docs/pages/playground
 /docs/export
 /test/regressions/screenshots
 build


### PR DESCRIPTION
I most of the time have multiple playground examples:
- One for the feature under development
- On for doing debugging (or answer example) on locale

Ignoring a full folder should simplify switching between PR by keeping examples at different URLs. For example 
- http://localhost:3001/playground/columnGrouping
- http://localhost:3001/playground/datePickerFix