### PR TITLE
[test] Throw if date adapter is not found

### DIFF
--- a/test/utils/pickers-utils.tsx
+++ b/test/utils/pickers-utils.tsx
@@ -8,8 +8,14 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 
-const availableAdapters = ['date-fns', 'day-js', 'luxon', 'moment'];
-let adapter = 'date-fns';
+const availableAdapters = {
+  'date-fns': AdapterDateFns,
+  dayjs: AdapterDayjs,
+  luxon: AdapterLuxon,
+  moment: AdapterMoment,
+};
+
+let AdapterClassToExtend = availableAdapters['date-fns'];
 
 // Check if we are in unit tests
 if (/jsdom/.test(window.navigator.userAgent)) {
@@ -17,30 +23,24 @@ if (/jsdom/.test(window.navigator.userAgent)) {
   // adapter available : date-fns (default one), day-js, luxon, moment
   const args = process.argv.slice(2);
   const flagIndex = args.findIndex((element) => element === '--date-adapter');
-  const potentialAdapter = flagIndex + 1 < args.length ? args[flagIndex + 1] : null;
-  if (potentialAdapter && availableAdapters.includes(potentialAdapter)) {
-    adapter = potentialAdapter;
+  if (flagIndex !== -1 && flagIndex + 1 < args.length) {
+    const potentialAdapter = args[flagIndex + 1];
+    if (potentialAdapter) {
+      if (availableAdapters[potentialAdapter]) {
+        AdapterClassToExtend = availableAdapters[potentialAdapter];
+      } else {
+        const supportedAdapters = Object.keys(availableAdapters);
+        const message = `Error: Invalid --date-adapter value "${potentialAdapter}". Supported date adapters: ${supportedAdapters
+          .map((key) => `"${key}"`)
+          .join(', ')}`;
+        // eslint-disable-next-line no-console
+        console.log(message);
+        throw new Error(message);
+      }
+    }
   }
 }
 
-let AdapterClassToExtend;
-switch (adapter) {
-  case 'day-js':
-    AdapterClassToExtend = AdapterDayjs;
-    break;
-
-  case 'luxon':
-    AdapterClassToExtend = AdapterLuxon;
-    break;
-
-  case 'moment':
-    AdapterClassToExtend = AdapterMoment;
-    break;
-
-  default:
-    AdapterClassToExtend = AdapterDateFns;
-    break;
-}
 export class AdapterClassToUse extends AdapterClassToExtend {}
 
 export const adapterToUse = new AdapterClassToUse();

--- a/test/utils/pickers-utils.tsx
+++ b/test/utils/pickers-utils.tsx
@@ -20,7 +20,7 @@ let AdapterClassToExtend = availableAdapters['date-fns'];
 // Check if we are in unit tests
 if (/jsdom/.test(window.navigator.userAgent)) {
   // Add parameter `--date-adapter luxon` to use AdapterLuxon for running tests
-  // adapter available : date-fns (default one), day-js, luxon, moment
+  // adapter available : date-fns (default one), dayjs, luxon, moment
   const args = process.argv.slice(2);
   const flagIndex = args.findIndex((element) => element === '--date-adapter');
   if (flagIndex !== -1 && flagIndex + 1 < args.length) {
@@ -34,7 +34,7 @@ if (/jsdom/.test(window.navigator.userAgent)) {
           .map((key) => `"${key}"`)
           .join(', ')}`;
         // eslint-disable-next-line no-console
-        console.log(message);
+        console.log(message); // log message explicitly, because error message gets swallowed by mocha
         throw new Error(message);
       }
     }


### PR DESCRIPTION
Follow up on #5055

Before:

```
$ yarn test:unit --date-adapter moments
yarn run v1.22.17
$ cross-env NODE_ENV=test node --expose_gc ./node_modules/.bin/mocha 'packages/**/*.test.{js,ts,tsx}' --exclude '**/node_modules/**' --timeout 3000 --date-adapter moments
including inaccessible elements by default

  1335 passing (1m)
  195 pending
```
`moments` adapter was not found, so `date-fns` was used by default. There's no indication of adapter used in tests and if you didn't notice the typo ("moment**s**") it looks like tests passed with `moment` adapter

After:

```
$ yarn test:unit --date-adapter moments
yarn run v1.22.17
$ cross-env NODE_ENV=test node --expose_gc ./node_modules/.bin/mocha 'packages/**/*.test.{js,ts,tsx}' --exclude '**/node_modules/**' --timeout 3000 --date-adapter moments
including inaccessible elements by default
Error: Invalid --date-adapter value "moments". Supported date adapters: "date-fns", "dayjs", "luxon", "moment"
error Command failed with exit code 1.
```
If adapter is not found - it will just throw.
