### PR TITLE
[DataGrid] Fix `date`/`dateTime` edit input font size to match view mode

### DIFF
--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -19,6 +19,7 @@ import {
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
 import locale from 'date-fns/locale/en-US';
+import { styled } from '@mui/material/styles';
 
 function buildApplyDateFilterFn(filterItem, compareFn, showTime = false) {
   if (!filterItem.value) {
@@ -164,6 +165,12 @@ const dateColumnType = {
   },
 };
 
+const GridEditDateTextField = styled(TextField)({
+  '& .MuiInputBase-root': {
+    fontSize: 'inherit',
+  },
+});
+
 function GridEditDateCell({ id, field, value, colDef }) {
   const apiRef = useGridApiContext();
 
@@ -176,19 +183,7 @@ function GridEditDateCell({ id, field, value, colDef }) {
   return (
     <Component
       value={value}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          fullWidth
-          InputProps={{
-            ...params.InputProps,
-            sx: {
-              fontSize: 'inherit',
-              ...params.InputProps?.sx,
-            },
-          }}
-        />
-      )}
+      renderInput={(params) => <GridEditDateTextField fullWidth {...params} />}
       onChange={handleChange}
     />
   );

--- a/docs/data/data-grid/editing/EditingWithDatePickers.js
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.js
@@ -164,23 +164,41 @@ const dateColumnType = {
   },
 };
 
-function GridEditDateCell({ id, field, value }) {
+function GridEditDateCell({ id, field, value, colDef }) {
   const apiRef = useGridApiContext();
+
+  const Component = colDef.type === 'dateTime' ? DateTimePicker : DatePicker;
 
   const handleChange = (newValue) => {
     apiRef.current.setEditCellValue({ id, field, value: newValue });
   };
 
   return (
-    <DatePicker
+    <Component
       value={value}
-      renderInput={(params) => <TextField {...params} />}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          fullWidth
+          InputProps={{
+            ...params.InputProps,
+            sx: {
+              fontSize: 'inherit',
+              ...params.InputProps?.sx,
+            },
+          }}
+        />
+      )}
       onChange={handleChange}
     />
   );
 }
 
 GridEditDateCell.propTypes = {
+  /**
+   * The column of the row that the current cell belongs to.
+   */
+  colDef: PropTypes.object.isRequired,
   /**
    * The column field of the cell that triggered the event.
    */
@@ -261,7 +279,7 @@ const dateTimeColumnType = {
   ...GRID_DATETIME_COL_DEF,
   resizable: false,
   renderEditCell: (params) => {
-    return <GridEditDateTimeCell {...params} />;
+    return <GridEditDateCell {...params} />;
   },
   filterOperators: getDateFilterOperators(true),
   valueFormatter: (params) => {
@@ -273,37 +291,6 @@ const dateTimeColumnType = {
     }
     return '';
   },
-};
-
-function GridEditDateTimeCell({ id, field, value }) {
-  const apiRef = useGridApiContext();
-
-  const handleChange = (newValue) => {
-    apiRef.current.setEditCellValue({ id, field, value: newValue });
-  };
-
-  return (
-    <DateTimePicker
-      value={value}
-      renderInput={(params) => <TextField {...params} />}
-      onChange={handleChange}
-    />
-  );
-}
-
-GridEditDateTimeCell.propTypes = {
-  /**
-   * The column field of the cell that triggered the event.
-   */
-  field: PropTypes.string.isRequired,
-  /**
-   * The grid row id.
-   */
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-  /**
-   * The cell value, but if the column has valueGetter, use getValue.
-   */
-  value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
 };
 
 const columns = [

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -25,6 +25,7 @@ import {
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
 import locale from 'date-fns/locale/en-US';
+import { styled } from '@mui/material/styles';
 
 function buildApplyDateFilterFn(
   filterItem: GridFilterItem,
@@ -175,6 +176,12 @@ const dateColumnType: GridColTypeDef<Date | string, string> = {
   },
 };
 
+const GridEditDateTextField = styled(TextField)({
+  '& .MuiInputBase-root': {
+    fontSize: 'inherit',
+  },
+});
+
 function GridEditDateCell({
   id,
   field,
@@ -192,19 +199,7 @@ function GridEditDateCell({
   return (
     <Component
       value={value}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          fullWidth
-          InputProps={{
-            ...params.InputProps,
-            sx: {
-              fontSize: 'inherit',
-              ...params.InputProps?.sx,
-            },
-          }}
-        />
-      )}
+      renderInput={(params) => <GridEditDateTextField fullWidth {...params} />}
       onChange={handleChange}
     />
   );

--- a/docs/data/data-grid/editing/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/editing/EditingWithDatePickers.tsx
@@ -179,17 +179,32 @@ function GridEditDateCell({
   id,
   field,
   value,
+  colDef,
 }: GridRenderEditCellParams<Date | string | null>) {
   const apiRef = useGridApiContext();
+
+  const Component = colDef.type === 'dateTime' ? DateTimePicker : DatePicker;
 
   const handleChange = (newValue: unknown) => {
     apiRef.current.setEditCellValue({ id, field, value: newValue });
   };
 
   return (
-    <DatePicker
+    <Component
       value={value}
-      renderInput={(params) => <TextField {...params} />}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          fullWidth
+          InputProps={{
+            ...params.InputProps,
+            sx: {
+              fontSize: 'inherit',
+              ...params.InputProps?.sx,
+            },
+          }}
+        />
+      )}
       onChange={handleChange}
     />
   );
@@ -236,7 +251,7 @@ const dateTimeColumnType: GridColTypeDef<Date | string, string> = {
   ...GRID_DATETIME_COL_DEF,
   resizable: false,
   renderEditCell: (params) => {
-    return <GridEditDateTimeCell {...params} />;
+    return <GridEditDateCell {...params} />;
   },
   filterOperators: getDateFilterOperators(true),
   valueFormatter: (params) => {
@@ -249,26 +264,6 @@ const dateTimeColumnType: GridColTypeDef<Date | string, string> = {
     return '';
   },
 };
-
-function GridEditDateTimeCell({
-  id,
-  field,
-  value,
-}: GridRenderEditCellParams<Date | string | null>) {
-  const apiRef = useGridApiContext();
-
-  const handleChange = (newValue: unknown) => {
-    apiRef.current.setEditCellValue({ id, field, value: newValue });
-  };
-
-  return (
-    <DateTimePicker
-      value={value}
-      renderInput={(params) => <TextField {...params} />}
-      onChange={handleChange}
-    />
-  );
-}
 
 const columns: GridColumns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },

--- a/packages/grid/x-data-grid/src/components/cell/GridEditDateCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditDateCell.tsx
@@ -152,6 +152,10 @@ function GridEditDateCell(props: GridEditDateCellProps) {
       value={valueState.formatted}
       onChange={handleChange}
       {...other}
+      sx={{
+        fontSize: 'inherit',
+        ...other.sx,
+      }}
     />
   );
 }

--- a/packages/grid/x-data-grid/src/components/cell/GridEditDateCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditDateCell.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/material/utils';
 import InputBase, { InputBaseProps } from '@mui/material/InputBase';
+import { styled } from '@mui/material/styles';
 import { GridRenderEditCellParams } from '../../models/params/gridCellParams';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
@@ -10,6 +11,10 @@ import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };
+
+const StyledInputBase = styled(InputBase)({
+  fontSize: 'inherit',
+});
 
 const useUtilityClasses = (ownerState: OwnerState) => {
   const { classes } = ownerState;
@@ -140,7 +145,7 @@ function GridEditDateCell(props: GridEditDateCellProps) {
   }, [hasFocus]);
 
   return (
-    <InputBase
+    <StyledInputBase
       inputRef={inputRef}
       fullWidth
       className={classes.root}
@@ -152,10 +157,6 @@ function GridEditDateCell(props: GridEditDateCellProps) {
       value={valueState.formatted}
       onChange={handleChange}
       {...other}
-      sx={{
-        fontSize: 'inherit',
-        ...other.sx,
-      }}
     />
   );
 }


### PR DESCRIPTION
Fixes: https://github.com/mui/mui-x/pull/5053#issuecomment-1160448614

Preview: https://deploy-preview-5304--material-ui-x.netlify.app/x/react-data-grid/editing/

Before: 
<img width="306" alt="Screenshot 2022-06-20 at 15 25 38" src="https://user-images.githubusercontent.com/3165635/174611827-033578b1-fb0b-4c6a-a0ab-12f0e5c842a2.png">

<img width="263" alt="Screenshot 2022-06-20 at 15 25 47" src="https://user-images.githubusercontent.com/3165635/174611826-a4948ede-48fd-46d1-8baf-e1c51777fbe9.png">

After:
<img width="304" alt="Screenshot 2022-06-23 at 19 28 59" src="https://user-images.githubusercontent.com/13808724/175359213-4a79680a-57c2-4da7-89e2-e7db59b6e279.png">
<img width="252" alt="Screenshot 2022-06-23 at 19 28 26" src="https://user-images.githubusercontent.com/13808724/175359208-3acc1927-68de-49b4-a082-383ac81f8f2a.png">

