### PR TITLE
[docs] Make a clear difference between the license and license key

### DIFF
--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -96,7 +96,7 @@ When you purchase a commercial license, you'll receive a license key by email.
 This key removes all watermarks and console warnings.
 
 :::warning
-Licenses purchased after **May 13, 2022** are only compatible with MUI X `v5.11.0` or later.
+The orders placed after **May 13, 2022** come with a license key by default that is only compatible with MUI X from `v5.11.0` and upwards.
 
 Please update your package if you're using an earlier version.
 


### PR DESCRIPTION
The issues I'm trying to solve:

1. **A license is not a license key. Instead, we can distinguish an order and a license key.**
2. "or later" can be confused with "or older", I think that it depends on how you consider the direction of time. Instead, we can focus on the version number, not when it was released.
3. Saying "only compatible" is not accurate. It the default behavior, but we can work around it. Instead, we can say it's the default behavior.

https://mui.com/x/advanced-components/#license-key-installation
