### PR TITLE
[DataGrid] Mention Premium plan in error messages and docs warnings

### DIFF
--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -23,7 +23,7 @@ _See [the dedicated section](#customize-the-operators) to learn how to create yo
 :::warning
 The `DataGrid` can only filter the rows according to one criterion at the time.
 
-To use multi-filtering, you need to upgrade to the [Pro plan](https://mui.com/store/items/mui-x-pro/).
+To use multi-filtering, you need to upgrade to [Pro](https://mui.com/store/items/mui-x-pro/) or [Premium](https://mui.com/store/items/mui-x-premium/) plan.
 :::
 
 ## Multi-filtering [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -17,7 +17,7 @@ The default pagination behavior depends on your plan.
 ## Size of the page
 
 The MIT `DataGrid` is limited to pages of up to 100 rows.
-If you want larger pages, you will need to migrate to the [Pro plan](https://mui.com/store/items/mui-x-pro/).
+If you want larger pages, you will need to upgrade to [Pro](https://mui.com/store/items/mui-x-pro/) or [Premium](https://mui.com/store/items/mui-x-premium/) plan.
 
 By default, each page contains 100 rows. The user can change the size of the page through the selector in the footer.
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -17,7 +17,7 @@ Following clicks change the column's sorting direction. You can see the applied 
 :::warning
 The `DataGrid` can only sort the rows according to one criterion at a time.
 
-To use multi-sorting, you need to upgrade to the [Pro plan](https://mui.com/store/items/mui-x-pro/).
+To use multi-sorting, you need to upgrade to [Pro](https://mui.com/store/items/mui-x-pro/) or [Premium](https://mui.com/store/items/mui-x-premium/) plan.
 :::
 
 ## Multi-sorting [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -100,7 +100,7 @@ DataGridRaw.propTypes = {
           `MUI: \`column.resizable = true\` is not a valid prop.`,
           'Column resizing is not available in the MIT version.',
           '',
-          'You need to upgrade to the DataGridPro component to unlock this feature.',
+          'You need to upgrade to DataGridPro or DataGridPremium component to unlock this feature.',
         ].join('\n'),
       );
     }
@@ -599,7 +599,7 @@ DataGridRaw.propTypes = {
           `MUI: \`<DataGrid pageSize={${props.pageSize}} />\` is not a valid prop.`,
           `Only page size below ${MAX_PAGE_SIZE} is available in the MIT version.`,
           '',
-          'You need to upgrade to the DataGridPro component to unlock this feature.',
+          'You need to upgrade to DataGridPro or DataGridPremium component to unlock this feature.',
         ].join('\n'),
       );
     }
@@ -612,7 +612,7 @@ DataGridRaw.propTypes = {
           'MUI: `<DataGrid pagination={false} />` is not a valid prop.',
           'Infinite scrolling is not available in the MIT version.',
           '',
-          'You need to upgrade to the DataGridPro component to disable the pagination.',
+          'You need to upgrade to DataGridPro or DataGridPremium component to disable the pagination.',
         ].join('\n'),
       );
     }
@@ -694,7 +694,7 @@ DataGridRaw.propTypes = {
             )}} />\` is not a valid prop.`,
             'selectionModel can only be of 1 item in DataGrid.',
             '',
-            'You need to upgrade to the DataGridPro component to unlock multiple selection.',
+            'You need to upgrade to DataGridPro or DataGridPremium component to unlock multiple selection.',
           ].join('\n'),
         );
       }

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -152,7 +152,7 @@ export const useGridRows = (
         throw new Error(
           [
             "MUI: You can't update several rows at once in `apiRef.current.updateRows` on the DataGrid.",
-            'You need to upgrade to the DataGridPro component to unlock this feature.',
+            'You need to upgrade to DataGridPro or DataGridPremium component to unlock this feature.',
           ].join('\n'),
         );
       }

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridApiContext.ts
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridApiContext.ts
@@ -12,7 +12,7 @@ export function useGridApiContext<
     throw new Error(
       [
         'MUI: Could not find the data grid context.',
-        'It looks like you rendered your component outside of a DataGrid or DataGridPro parent component.',
+        'It looks like you rendered your component outside of a DataGrid, DataGridPro or DataGridPremium parent component.',
         'This can also happen if you are bundling multiple versions of the data grid.',
       ].join('\n'),
     );

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridRootProps.ts
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridRootProps.ts
@@ -7,7 +7,7 @@ export const useGridRootProps = () => {
 
   if (!contextValue) {
     throw new Error(
-      'MUI: useGridRootProps should only be used inside the DataGrid/DataGridPro component.',
+      'MUI: useGridRootProps should only be used inside the DataGrid, DataGridPro or DataGridPremium component.',
     );
   }
 

--- a/packages/grid/x-data-grid/src/tests/components.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/components.DataGrid.test.tsx
@@ -149,7 +149,7 @@ describe('<DataGrid /> - Components', () => {
         </ErrorBoundary>,
       );
     }).toErrorDev([
-      'MUI: useGridRootProps should only be used inside the DataGrid/DataGridPro component.',
+      'MUI: useGridRootProps should only be used inside the DataGrid, DataGridPro or DataGridPremium component.',
       'The above error occurred in the <ForwardRef(GridOverlay)> component',
     ]);
   });


### PR DESCRIPTION
In https://github.com/mui/mui-x/issues/5317#issue-1284430266 I've noticed that `DataGridPremium` is not mentioned in the error message, so I've updated error messages.
I've also noticed that Premium plan is not mentioned on some docs pages, so I've added it there as well.