### PR TITLE
[pickers] Add missing type dependencies

### DIFF
--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -45,11 +45,13 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.2",
+    "@date-io/core": "^2.14.0",
     "@date-io/date-fns": "^2.14.0",
     "@date-io/dayjs": "^2.14.0",
     "@date-io/luxon": "^2.14.0",
     "@date-io/moment": "^2.14.0",
     "@mui/utils": "^5.4.1",
+    "@types/react-transition-group": "^4.4.4",
     "clsx": "^1.1.1",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.4.2",


### PR DESCRIPTION
The TypeScript declaration files for `@mui/x-date-pickers` import from `@types/react-transition-group` and `@date-io/core`, so those packages should be added as a dependency of `@mui/x-date-pickers`.

```
TS7016: Could not find a declaration file for module 'react-transition-group/CSSTransition'.
    1 | import * as React from 'react';
  > 2 | import { CSSTransitionProps } from 'react-transition-group/CSSTransition';
      |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 | export declare type SlideDirection = 'right' | 'left';
    4 | export interface SlideTransitionProps extends Omit<CSSTransitionProps, 'timeout'> {
    5 |     children: React.ReactElement;

TS2307: Cannot find module '@date-io/core/IUtils' or its corresponding type declarations.
  > 1 | import { IUtils } from '@date-io/core/IUtils';
      |                        ^^^^^^^^^^^^^^^^^^^^^^
    2 | export declare type MuiPickersAdapter<TDate> = IUtils<TDate>;
    3 |

TS2307: Cannot find module '@date-io/core/IUtils' or its corresponding type declarations.
    1 | import * as React from 'react';
  > 2 | import { DateIOFormats } from '@date-io/core/IUtils';
      |                               ^^^^^^^^^^^^^^^^^^^^^^
    3 | import { MuiPickersAdapter } from '../internals/models';
    4 | import { PickersLocaleText } from '../locales';
    5 | export interface MuiPickersAdapterContextValue<TDate> {
```