### PR TITLE
[docs] Fix server-side pagination demo

### DIFF
--- a/docs/data/data-grid/pagination/ServerPaginationGrid.js
+++ b/docs/data/data-grid/pagination/ServerPaginationGrid.js
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { DataGrid } from '@mui/x-data-grid';
 import { createFakeServer } from '@mui/x-data-grid-generator';
 
-const { columns, initialState, useQuery } = createFakeServer();
+const SERVER_OPTIONS = {
+  useCursorPagination: false,
+};
+
+const { columns, initialState, useQuery } = createFakeServer({}, SERVER_OPTIONS);
 
 export default function ServerPaginationGrid() {
   const [page, setPage] = React.useState(0);

--- a/docs/data/data-grid/pagination/ServerPaginationGrid.tsx
+++ b/docs/data/data-grid/pagination/ServerPaginationGrid.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { DataGrid } from '@mui/x-data-grid';
 import { createFakeServer } from '@mui/x-data-grid-generator';
 
-const { columns, initialState, useQuery } = createFakeServer();
+const SERVER_OPTIONS = {
+  useCursorPagination: false,
+};
+
+const { columns, initialState, useQuery } = createFakeServer({}, SERVER_OPTIONS);
 
 export default function ServerPaginationGrid() {
   const [page, setPage] = React.useState(0);


### PR DESCRIPTION
I've noticed that in our server-side pagination example after changing page the data do not change: https://mui.com/x/react-data-grid/pagination/#basic-implementation
Turned out that cursor pagination was turned on by default and needed to be disabled for this demo.

Preview: https://deploy-preview-5361--material-ui-x.netlify.app/x/react-data-grid/pagination/#server-side-pagination