### PR TITLE
[DataGridPro] Fix the depth of nodes when switching from a non-flat tree to a flat tree

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsPreProcessors.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsPreProcessors.tsx
@@ -17,7 +17,12 @@ const flatRowTreeCreationMethod: GridStrategyProcessor<'rowTreeCreation'> = ({
   for (let i = 0; i < ids.length; i += 1) {
     const rowId = ids[i];
 
-    if (previousTree && previousTree[rowId] && previousTree[rowId].depth === 0) {
+    if (
+      previousTree &&
+      previousTree[rowId] &&
+      previousTree[rowId].depth === 0 &&
+      previousTree[rowId].parent == null
+    ) {
       tree[rowId] = previousTree[rowId];
     } else {
       tree[rowId] = { id: rowId, depth: 0, parent: null, groupingKey: '', groupingField: null };

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsPreProcessors.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsPreProcessors.tsx
@@ -17,7 +17,7 @@ const flatRowTreeCreationMethod: GridStrategyProcessor<'rowTreeCreation'> = ({
   for (let i = 0; i < ids.length; i += 1) {
     const rowId = ids[i];
 
-    if (previousTree && previousTree[rowId]) {
+    if (previousTree && previousTree[rowId] && previousTree[rowId].depth === 0) {
       tree[rowId] = previousTree[rowId];
     } else {
       tree[rowId] = { id: rowId, depth: 0, parent: null, groupingKey: '', groupingField: null };


### PR DESCRIPTION
Will be fixed by #4927 in a clean way
The problem is that when the flat tree creator receives a tree from row grouping or tree data it just keeps its nodes, so the depth is wrong.

FIxes #5363