### PR TITLE
[DataGrid] Start editing with uppercase letter and Ctrl+V

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
@@ -689,7 +689,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
         expect(listener.callCount).to.equal(0);
       });
 
-      ['shiftKey', 'ctrlKey', 'metaKey', 'altKey'].forEach((key) => {
+      ['ctrlKey', 'metaKey', 'altKey'].forEach((key) => {
         it(`should not publish 'cellEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
           const listener = spy();
@@ -700,6 +700,39 @@ describe('<DataGridPro /> - Cell Editing', () => {
           fireEvent.keyDown(cell, { key: 'a', [key]: true });
           expect(listener.callCount).to.equal(0);
         });
+      });
+
+      it(`should call startCellEditMod if shiftKey is pressed with a letter`, () => {
+        render(<TestCase />);
+        const listener = spy();
+        apiRef.current.subscribeEvent('cellEditStart', listener);
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'a', shiftKey: true });
+        expect(listener.callCount).to.equal(1);
+      });
+
+      it(`should call startCellEditMod if ctrl+V is pressed`, () => {
+        render(<TestCase />);
+        const listener = spy();
+        apiRef.current.subscribeEvent('cellEditStart', listener);
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'v', ctrlKey: true });
+        expect(listener.callCount).to.equal(1);
+      });
+
+      it(`should call startCellEditMod if meta+V is pressed`, () => {
+        render(<TestCase />);
+        const listener = spy();
+        apiRef.current.subscribeEvent('cellEditStart', listener);
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'v', metaKey: true });
+        expect(listener.callCount).to.equal(1);
       });
 
       it('should call startCellEditMode', () => {

--- a/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
@@ -701,7 +701,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         expect(listener.callCount).to.equal(0);
       });
 
-      ['shiftKey', 'ctrlKey', 'metaKey', 'altKey'].forEach((key) => {
+      ['ctrlKey', 'metaKey', 'altKey'].forEach((key) => {
         it(`should not publish 'rowEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
           const listener = spy();
@@ -712,6 +712,39 @@ describe('<DataGridPro /> - Row Editing', () => {
           fireEvent.keyDown(cell, { key: 'a', [key]: true });
           expect(listener.callCount).to.equal(0);
         });
+      });
+
+      it(`should call startRowEditMode if shiftKey is pressed with a letter`, () => {
+        render(<TestCase />);
+        const listener = spy();
+        apiRef.current.subscribeEvent('rowEditStart', listener);
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'a', shiftKey: true });
+        expect(listener.callCount).to.equal(1);
+      });
+
+      it(`should call startRowEditMode if ctrl+V is pressed`, () => {
+        render(<TestCase />);
+        const listener = spy();
+        apiRef.current.subscribeEvent('rowEditStart', listener);
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'v', ctrlKey: true });
+        expect(listener.callCount).to.equal(1);
+      });
+
+      it(`should call startRowEditMode if meta+V is pressed`, () => {
+        render(<TestCase />);
+        const listener = spy();
+        apiRef.current.subscribeEvent('rowEditStart', listener);
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'v', metaKey: true });
+        expect(listener.callCount).to.equal(1);
       });
 
       it('should call startRowEditMode passing fieldToFocus and deleteValue', () => {

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
@@ -152,7 +152,7 @@ export const useGridCellEditing = (
         let reason: GridCellEditStartReasons | undefined;
 
         if (isPrintableKey(event.key)) {
-          if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) {
+          if ((event.ctrlKey && event.key !== 'v') || event.metaKey || event.altKey) {
             return;
           }
           reason = GridCellEditStartReasons.printableKeyDown;

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
@@ -152,7 +152,11 @@ export const useGridCellEditing = (
         let reason: GridCellEditStartReasons | undefined;
 
         if (isPrintableKey(event.key)) {
-          if ((event.ctrlKey && event.key !== 'v') || event.metaKey || event.altKey) {
+          if (
+            (event.ctrlKey && event.key !== 'v') ||
+            (event.metaKey && event.key !== 'v') ||
+            event.altKey
+          ) {
             return;
           }
           reason = GridCellEditStartReasons.printableKeyDown;

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
@@ -212,7 +212,7 @@ export const useGridRowEditing = (
         let reason: GridRowEditStartReasons | undefined;
 
         if (isPrintableKey(event.key)) {
-          if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) {
+          if ((event.ctrlKey && event.key !== 'v') || event.metaKey || event.altKey) {
             return;
           }
           reason = GridRowEditStartReasons.printableKeyDown;

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
@@ -212,7 +212,11 @@ export const useGridRowEditing = (
         let reason: GridRowEditStartReasons | undefined;
 
         if (isPrintableKey(event.key)) {
-          if ((event.ctrlKey && event.key !== 'v') || event.metaKey || event.altKey) {
+          if (
+            (event.ctrlKey && event.key !== 'v') ||
+            (event.metaKey && event.key !== 'v') ||
+            event.altKey
+          ) {
             return;
           }
           reason = GridRowEditStartReasons.printableKeyDown;


### PR DESCRIPTION
Fix #5228

The editing can now be start with 

- <kbd>Shift</kbd> + a letter
- <kbd>Ctrl</kbd> + V