### PR TITLE
[docs] Clarify the scope of support for MUI X

### DIFF
--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -24,9 +24,9 @@ Throughout the documentation, Pro- and Premium-only features are denoted with th
 
 - **Ship faster:** Our team has invested thousands of hours into these components so you don't have to. Get up and running in a fraction of the time it would take to build from scratch.
 - **Expand on the power of MUI Core**: MUI X components work seamlessly with MUI Core libraries like Material UI, delivering more advanced functionality, but can also be used standalone.
-- **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or professional support.
+- **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or techical support.
 - **Dedicated maintenance:** MUI X is maintained by a full-time staff of engineers, so you can rest assured that any issues will be addressed in a timely manner.
-- **Professional support (🚧 in the future):** Pro and Premium users will get access to professional support from our team as well as priority for bug fixes and requests.
+- **Technical support:** Pro and Premium users get access to techical support from our team as well as priority for bug fixes and requests.
 
 ## MUI X vs. MUI Core
 

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -26,7 +26,7 @@ Throughout the documentation, Pro- and Premium-only features are denoted with th
 - **Expand on the power of MUI Core**: MUI X components work seamlessly with MUI Core libraries like Material UI, delivering more advanced functionality, but can also be used standalone.
 - **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or technical support.
 - **Dedicated maintenance:** MUI X is maintained by a full-time staff of engineers, so you can rest assured that any issues will be addressed in a timely manner.
-- **Technical support:** Pro and Premium users get access to technical support from our team as well as priority for bug fixes and requests.
+- **Technical support:** Pro and Premium users get access to technical support from our team as well as priority for bug fixes and features requests.
 
 ## MUI X vs. MUI Core
 

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -26,7 +26,7 @@ Throughout the documentation, Pro- and Premium-only features are denoted with th
 - **Expand on the power of MUI Core**: MUI X components work seamlessly with MUI Core libraries like Material UI, delivering more advanced functionality, but can also be used standalone.
 - **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or technical support.
 - **Dedicated maintenance:** MUI X is maintained by a full-time staff of engineers, so you can rest assured that any issues will be addressed in a timely manner.
-- **Technical support:** Pro and Premium users get access to technical support from our team as well as priority for bug fixes and features requests.
+- **Technical support:** Pro and Premium users get access to technical support from our team as well as priority for bug fixes and feature requests.
 
 ## MUI X vs. MUI Core
 

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -24,9 +24,9 @@ Throughout the documentation, Pro- and Premium-only features are denoted with th
 
 - **Ship faster:** Our team has invested thousands of hours into these components so you don't have to. Get up and running in a fraction of the time it would take to build from scratch.
 - **Expand on the power of MUI Core**: MUI X components work seamlessly with MUI Core libraries like Material UI, delivering more advanced functionality, but can also be used standalone.
-- **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or techical support.
+- **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or technical support.
 - **Dedicated maintenance:** MUI X is maintained by a full-time staff of engineers, so you can rest assured that any issues will be addressed in a timely manner.
-- **Technical support:** Pro and Premium users get access to techical support from our team as well as priority for bug fixes and requests.
+- **Technical support:** Pro and Premium users get access to technical support from our team as well as priority for bug fixes and requests.
 
 ## MUI X vs. MUI Core
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -16,12 +16,11 @@ Visit Stack Overflow to ask questions and read crowdsourced answers from expert 
 
 [Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui) on Stack Overflow.
 
-## Professional support
+## Technical support
 
 :::info
-The professional support covers only MUI X components.
+The technical support covers only MUI X components.
 
-Support for MUI Core is provided by [the community](https://mui.com/material-ui/getting-started/support/).
 :::
 
 When purchasing a MUI X Pro or Premium license you get access to professional support until the end of your subscription.

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -1,6 +1,6 @@
 # Support
 
-<p class="description">How to get support for MUI X components, including feature requests, bug fixes, answers to how-to questions, and professional support from the team.</p>
+<p class="description">How to get support for MUI X components, including feature requests, bug fixes, answers to how-to questions, and technical support from the team.</p>
 
 ## GitHub
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -23,7 +23,7 @@ The technical support covers only MUI X components.
 
 :::
 
-When purchasing a MUI X Pro or Premium license you get access to professional support until the end of your subscription.
+When purchasing a MUI X Pro or Premium license you get access to technical support until the end of your subscription.
 Support is available on multiple channels, but the recommended channels are:
 
 - GitHub: You can [open a new issue](https://github.com/mui/mui-x/issues/new/choose) and leave your Order ID, so we can prioritize accordingly.

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -18,6 +18,12 @@ Visit Stack Overflow to ask questions and read crowdsourced answers from expert 
 
 ## Professional support
 
+:::info
+The professional support covers only MUI X components.
+
+Support for MUI Core is provided by the community.
+:::
+
 When purchasing a MUI X Pro or Premium license you get access to professional support until the end of your subscription.
 Support is available on multiple channels, but the recommended channels are:
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -21,7 +21,7 @@ Visit Stack Overflow to ask questions and read crowdsourced answers from expert 
 :::info
 The professional support covers only MUI X components.
 
-Support for MUI Core is provided by the community.
+Support for MUI Core is provided by [the community](https://mui.com/material-ui/getting-started/support/).
 :::
 
 When purchasing a MUI X Pro or Premium license you get access to professional support until the end of your subscription.


### PR DESCRIPTION
### Motivation
It's not clear to users that "Professional support" doesn't include MUI Core.
We're seeing MUI X customers expecting to get professional support extended to MUI Core.

Examples:
- https://mui.zendesk.com/agent/tickets/4072
- https://mui.zendesk.com/agent/tickets/3766

### Preview
https://deploy-preview-5423--material-ui-x.netlify.app/x/introduction/support/#technical-support