### PR TITLE
[core] Add technical support link to _redirects

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -8,6 +8,7 @@
 /r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 302
 /r/x-license-key-installation https://mui.com/x/introduction/licensing/#license-key-installation 302
 /r/x-data-grid-no-dimensions https://mui.com/x/react-data-grid/layout/ 302
+/r/x-professional-support https://mui.com/x/introduction/support/#professional-support 302
 
 # Legacy redirection
 # 2021

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -8,7 +8,7 @@
 /r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 302
 /r/x-license-key-installation https://mui.com/x/introduction/licensing/#license-key-installation 302
 /r/x-data-grid-no-dimensions https://mui.com/x/react-data-grid/layout/ 302
-/r/x-professional-support https://mui.com/x/introduction/support/#professional-support 302
+/r/x-technical-support https://mui.com/x/introduction/support/#technical-support 302
 
 # Legacy redirection
 # 2021


### PR DESCRIPTION
The link will be initially used on the store's keymailer.

More on: https://github.com/mui/mui-store/pull/187