### PR TITLE
[docs] FIx typo in the sorting page

### DIFF
--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -82,7 +82,7 @@ A comparator determines how two cell values should be sorted.
 Each column type comes with a default comparator method.
 You can re-use them by importing the following functions:
 
-- `gridStringNumberComparator` (used by the `string` and `singleSelect` columns)
+- `gridStringOrNumberComparator` (used by the `string` and `singleSelect` columns)
 - `gridNumberComparator` (used by the `number` and `boolean` columns)
 - `gridDateComparator` (used by the `date` and `date-time` columns)
 


### PR DESCRIPTION
Fix typo in docs to reflect the correct function name:
https://github.com/mui/mui-x/blob/47bb0c8c0f2e0880aabbe1399442d826fe55ba06/packages/grid/x-data-grid/src/hooks/features/sorting/gridSortingUtils.ts#L170