### PR TITLE
[docs] Fix description for "Striped rows" example

### DIFF
--- a/docs/data/data-grid/style/style.md
+++ b/docs/data/data-grid/style/style.md
@@ -121,15 +121,15 @@ You must use `headerAlign` to align the content of the header.
 
 ## Striped rows
 
-The following demo illustrates how the rows of the grid can be stripped.
+You can use the `indexRelativeToCurrentPage` param passed to `getRowClassName` to apply alternating styles to the rows.
+
+The following demo illustrates how this can be achieved.
 
 {{"demo": "StripedGrid.js", "bg": "inline"}}
 
 ## Custom theme
 
-You can use the `indexRelativeToCurrentPage` param passed to `getRowClassName` to apply alternating styles to the rows.
-
-The following demo illustrates how this can be achieved.
+The following demo leverages the CSS customization API to match the Ant Design specification.
 
 {{"demo": "AntDesignGrid.js", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
This PR fixes a mistake introduced in #3882

### Mistake

The description for the "Custom theme" example contains text that is meant for the "Striped rows" example:
![image](https://user-images.githubusercontent.com/28965286/178056030-453d944b-8a79-4810-a0f5-30a83ea3d4f0.png)

While the "Striped rows" example description has a typo ("stripped" instead of "striped"):
![image](https://user-images.githubusercontent.com/28965286/178055835-cd9503ee-b3ab-45e9-a7f5-d6f573acec5c.png)

### Source

The mistake happened in [this commit](https://github.com/mui/mui-x/commit/4f2c9a5a4a88fba0ae6091efcbcdf1c556d9ec3b#diff-cdc05bc9f3c8c0f4cff91c069e3f8959221bf1cf18082e28e8990762735adab4).
![image](https://user-images.githubusercontent.com/28965286/178056311-f4dbe146-fcef-49e4-93e6-54a0ddb2f2ec.png)

### Fix

- Re-applied the previous (pre-#3882) description for the "Custom theme" example.
- Moved the current "Custom theme" description to "Striped rows".