### PR TITLE
[docs] Fix internal link to `valueParser`

### DIFF
--- a/docs/data/data-grid/column-definition/column-definition.md
+++ b/docs/data/data-grid/column-definition/column-definition.md
@@ -73,7 +73,7 @@ In the following demo, a formatter is used to display the tax rate's decimal val
 
 The value generated is only used for rendering purposes.
 Filtering and sorting do not rely on the formatted value.
-Use the [`valueParser`](/x/react-data-grid/cells/#value-parser) to support filtering.
+Use the [`valueParser`](/x/react-data-grid/editing/#value-parser-and-value-setter) to support filtering.
 
 ## Rendering cells
 


### PR DESCRIPTION
Fix #5176