### PR TITLE
[pickers] Add Italian (it-IT) locale

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -110,6 +110,7 @@ import bgLocale from 'date-fns/locale/bg';
 | English (United States) | en-US               | `enUS`      |
 | French                  | fr-FR               | `frFR`      |
 | German                  | de-DE               | `deDE`      |
+| Italian                 | it-IT               | `itIT`      |
 | Spanish                 | es-ES               | `esES`      |
 | Swedish                 | sv-SE               | `svSE`      |
 | Turkish                 | tr-TR               | `trTr`      |

--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -6,4 +6,5 @@ export * from './esES';
 export * from './frFR';
 export * from './enUS';
 export * from './svSE';
+export * from './itIT';
 export * from './utils/pickersLocaleTextApi';

--- a/packages/x-date-pickers/src/locales/itIT.ts
+++ b/packages/x-date-pickers/src/locales/itIT.ts
@@ -1,0 +1,62 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { getPickersLocalization } from './utils/getPickersLocalization';
+import { CalendarPickerView } from '../internals/models';
+
+const views = {
+  hours: 'le ore',
+  minutes: 'i minuti',
+  seconds: 'i secondi',
+};
+
+// This object is not Partial<PickersLocaleText> because it is the default values
+
+const itITPickers: PickersLocaleText<any> = {
+  // Calendar navigation
+  previousMonth: 'Mese precedente',
+  nextMonth: 'Mese successivo',
+
+  // View navigation
+  openPreviousView: 'apri la vista precedente',
+  openNextView: 'apri la vista successiva',
+  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+    view === 'year'
+      ? "la vista dell'anno è aperta, passare alla vista del calendario"
+      : "la vista dell'calendario è aperta, passare alla vista dell'anno",
+
+  // DateRange placeholders
+  start: 'Inizio',
+  end: 'Fine',
+
+  // Action bar
+  cancelButtonLabel: 'Cancellare',
+  clearButtonLabel: 'Sgomberare',
+  okButtonLabel: 'OK',
+  todayButtonLabel: 'Oggi',
+
+  // Clock labels
+  clockLabelText: (view, time, adapter) =>
+    `Seleziona ${views[view]}. ${
+      time === null
+        ? 'Nessun orario selezionato'
+        : `L'ora selezionata è ${adapter.format(time, 'fullTime')}`
+    }`,
+  hoursClockNumberText: (hours) => `${hours} ore`,
+  minutesClockNumberText: (minutes) => `${minutes} minuti`,
+  secondsClockNumberText: (seconds) => `${seconds} secondi`,
+
+  // Open picker labels
+  openDatePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `Scegli la data, la data selezionata è ${utils.format(utils.date(rawValue)!, 'fullDate')}`
+      : 'Scegli la data',
+  openTimePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `Scegli l'ora, l'ora selezionata è ${utils.format(utils.date(rawValue)!, 'fullTime')}`
+      : "Scegli l'ora",
+
+  // Table labels
+  timeTableLabel: 'scegli un ora',
+  dateTableLabel: 'scegli una data',
+};
+
+export const itIT = getPickersLocalization(itITPickers);

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -58,6 +58,7 @@
   { "name": "getMonthPickerUtilityClass", "kind": "Function" },
   { "name": "getPickersDayUtilityClass", "kind": "Function" },
   { "name": "getYearPickerUtilityClass", "kind": "Function" },
+  { "name": "itIT", "kind": "Variable" },
   { "name": "LicenseInfo", "kind": "Class" },
   { "name": "LocalizationProvider", "kind": "Function" },
   { "name": "LocalizationProviderProps", "kind": "Interface" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -45,6 +45,7 @@
   { "name": "getMonthPickerUtilityClass", "kind": "Function" },
   { "name": "getPickersDayUtilityClass", "kind": "Function" },
   { "name": "getYearPickerUtilityClass", "kind": "Function" },
+  { "name": "itIT", "kind": "Variable" },
   { "name": "LocalizationProvider", "kind": "Function" },
   { "name": "LocalizationProviderProps", "kind": "Interface" },
   { "name": "MobileDatePicker", "kind": "Variable" },


### PR DESCRIPTION
Following up on https://github.com/mui/mui-x/issues/3211, I'd like to provide Italian translations for the Date Picker component.