### PR TITLE
[pickers] Add Spanish (es-ES) locale

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -110,6 +110,7 @@ import bgLocale from 'date-fns/locale/bg';
 | English (United States) | en-US               | `enUS`      |
 | French                  | fr-FR               | `frFR`      |
 | German                  | de-DE               | `deDE`      |
+| Spanish                 | es-ES               | `esES`      |
 | Swedish                 | sv-SE               | `svSE`      |
 | Turkish                 | tr-TR               | `trTr`      |
 | Dutch                   | nl-NL               | `nlNL`      |

--- a/packages/x-date-pickers/src/locales/esES.ts
+++ b/packages/x-date-pickers/src/locales/esES.ts
@@ -1,0 +1,62 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { getPickersLocalization } from './utils/getPickersLocalization';
+import { CalendarPickerView } from '../internals/models';
+
+const views = {
+  hours: 'las horas',
+  minutes: 'los minutos',
+  seconds: 'los segundos',
+};
+
+// This object is not Partial<PickersLocaleText> because it is the default values
+
+const esESPickers: PickersLocaleText<any> = {
+  // Calendar navigation
+  previousMonth: 'Último mes',
+  nextMonth: 'Próximo mes',
+
+  // View navigation
+  openPreviousView: 'abrir la última vista',
+  openNextView: 'abrir la siguiente vista',
+  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+    view === 'year'
+      ? 'la vista del año está abierta, cambie a la vista de calendario'
+      : 'la vista de calendario está abierta, cambie a la vista del año',
+
+  // DateRange placeholders
+  start: 'Empezar',
+  end: 'Terminar',
+
+  // Action bar
+  cancelButtonLabel: 'Cancelar',
+  clearButtonLabel: 'Limpia',
+  okButtonLabel: 'OK',
+  todayButtonLabel: 'Hoy',
+
+  // Clock labels
+  clockLabelText: (view, time, adapter) =>
+    `Seleccione ${views[view]}. ${
+      time === null
+        ? 'Sin tiempo seleccionado'
+        : `El tiempo seleccionado es ${adapter.format(time, 'fullTime')}`
+    }`,
+  hoursClockNumberText: (hours) => `${hours} horas`,
+  minutesClockNumberText: (minutes) => `${minutes} minutos`,
+  secondsClockNumberText: (seconds) => `${seconds} segundos`,
+
+  // Open picker labels
+  openDatePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `Elige la fecha, la fecha elegida es ${utils.format(utils.date(rawValue)!, 'fullDate')}`
+      : 'Elige la fecha',
+  openTimePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `Elige la hora, la hora elegido es ${utils.format(utils.date(rawValue)!, 'fullTime')}`
+      : 'Elige la hora',
+
+  // Table labels
+  timeTableLabel: 'elige la fecha',
+  dateTableLabel: 'elige la hora',
+};
+
+export const esES = getPickersLocalization(esESPickers);

--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -2,6 +2,7 @@ export * from './nlNL';
 export * from './ptBR';
 export * from './trTR';
 export * from './deDE';
+export * from './esES';
 export * from './frFR';
 export * from './enUS';
 export * from './svSE';

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -49,6 +49,7 @@
   { "name": "DesktopTimePickerSlotsComponent", "kind": "Interface" },
   { "name": "DesktopTimePickerSlotsComponentsProps", "kind": "Interface" },
   { "name": "enUS", "kind": "Variable" },
+  { "name": "esES", "kind": "Variable" },
   { "name": "frFR", "kind": "Variable" },
   { "name": "getCalendarPickerSkeletonUtilityClass", "kind": "Variable" },
   { "name": "getCalendarPickerUtilityClass", "kind": "Variable" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -37,6 +37,7 @@
   { "name": "DesktopTimePickerSlotsComponent", "kind": "Interface" },
   { "name": "DesktopTimePickerSlotsComponentsProps", "kind": "Interface" },
   { "name": "enUS", "kind": "Variable" },
+  { "name": "esES", "kind": "Variable" },
   { "name": "frFR", "kind": "Variable" },
   { "name": "getCalendarPickerSkeletonUtilityClass", "kind": "Variable" },
   { "name": "getCalendarPickerUtilityClass", "kind": "Variable" },


### PR DESCRIPTION
Following up on https://github.com/mui/mui-x/issues/3211, I'd like to provide Spanish translations for the Date Picker component.