### PR TITLE
[DataGrid] Improve accessibility of Export menu in the toolbar

### DIFF
--- a/packages/grid/x-data-grid-premium/src/components/GridExcelExportMenuItem.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridExcelExportMenuItem.tsx
@@ -9,7 +9,7 @@ export type GridExcelExportMenuItemProps = GridExportMenuItemProps<GridExcelExpo
 
 const GridExcelExportMenuItem = (props: GridExcelExportMenuItemProps) => {
   const apiRef = useGridApiContext();
-  const { hideMenu, options } = props;
+  const { hideMenu, options, ...other } = props;
 
   return (
     <MenuItem
@@ -17,6 +17,7 @@ const GridExcelExportMenuItem = (props: GridExcelExportMenuItemProps) => {
         apiRef.current.exportDataAsExcel(options);
         hideMenu?.();
       }}
+      {...other}
     >
       {apiRef.current.getLocaleText('toolbarExportExcel')}
     </MenuItem>

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
@@ -31,7 +31,7 @@ export interface GridToolbarExportProps extends ButtonProps {
 
 export const GridCsvExportMenuItem = (props: GridCsvExportMenuItemProps) => {
   const apiRef = useGridApiContext();
-  const { hideMenu, options } = props;
+  const { hideMenu, options, ...other } = props;
 
   return (
     <MenuItem
@@ -39,6 +39,7 @@ export const GridCsvExportMenuItem = (props: GridCsvExportMenuItemProps) => {
         apiRef.current.exportDataAsCsv(options);
         hideMenu?.();
       }}
+      {...other}
     >
       {apiRef.current.getLocaleText('toolbarExportCSV')}
     </MenuItem>
@@ -47,7 +48,7 @@ export const GridCsvExportMenuItem = (props: GridCsvExportMenuItemProps) => {
 
 export const GridPrintExportMenuItem = (props: GridPrintExportMenuItemProps) => {
   const apiRef = useGridApiContext();
-  const { hideMenu, options } = props;
+  const { hideMenu, options, ...other } = props;
 
   return (
     <MenuItem
@@ -55,6 +56,7 @@ export const GridPrintExportMenuItem = (props: GridPrintExportMenuItemProps) => 
         apiRef.current.exportDataAsPrint(options);
         hideMenu?.();
       }}
+      {...other}
     >
       {apiRef.current.getLocaleText('toolbarExportPrint')}
     </MenuItem>


### PR DESCRIPTION
Preview: https://deploy-preview-5486--material-ui-x.netlify.app/x/react-data-grid/demo/

Fixes #5476

On 7/12/22 I reported an accessibility issue related to the Export menu in DataGrid Toolbar ([#5476](https://github.com/mui/mui-x/issues/5476)). As a response from the MUI team, I was suggested to forward remaining props to the root element of MenuList to make the Toolbar Export Menu accessible for keyboard users.