### PR TITLE
[docs] Add note for unsubscribe callback on "Data grid - Events" page

### DIFF
--- a/docs/data/data-grid/events/events.md
+++ b/docs/data/data-grid/events/events.md
@@ -29,6 +29,11 @@ subscribeEvent: (
 ) => () => void;
 ```
 
+:::warning
+The call to `apiRef.current.subscribeEvent` returns a callback that **unsubscribes** the given handler.
+For instance, if the `useEffect` hook is used for event subscription, not returning the unsubscribe callback may cause multiple registrations of the same event handler.
+:::
+
 The following demo shows how to subscribe to the `columnResize` event. Try it by resizing the columns.
 
 {{"demo": "SubscribeToEvents.js", "bg": "inline"}}


### PR DESCRIPTION
The "Subscribing to events" section on the "Data grid - Events" page does not clearly mention how to actually unsubscribe the event handler afterwards. This may lead to bugs, especially when using `apiRef.current.subscribeEvent()` within a `React.useEffect` hook.

The documentation comment for the return `@returns A function to unsubscribe from this event` can easily be overlooked, so a warning or info should emphasise the use of the unsubscribe callback.