### PR TITLE
[l10n] Add Traditional Chinese (zh-TW) locale

### DIFF
--- a/docs/data/data-grid/localization/localization.md
+++ b/docs/data/data-grid/localization/localization.md
@@ -125,6 +125,7 @@ import { DataGrid, nlNL } from '@mui/x-data-grid';
 | Turkish                 | tr-TR               | `trTR`      |
 | Ukraine                 | uk-UA               | `ukUA`      |
 | Simplified Chinese      | zh-CN               | `zhCN`      |
+| Traditional Chinese     | zh-TW               | `zhTW`      |
 
 You can [find the source](https://github.com/mui/mui-x/tree/HEAD/packages/grid/x-data-grid/src/locales) in the GitHub repository.
 

--- a/packages/grid/x-data-grid/src/locales/index.ts
+++ b/packages/grid/x-data-grid/src/locales/index.ts
@@ -27,3 +27,4 @@ export * from './trTR';
 export * from './ukUA';
 export * from './viVN';
 export * from './zhCN';
+export * from './zhTW';

--- a/packages/grid/x-data-grid/src/locales/zhTW.ts
+++ b/packages/grid/x-data-grid/src/locales/zhTW.ts
@@ -1,0 +1,143 @@
+import { zhTW as zhTWCore } from '@mui/material/locale';
+import { GridLocaleText } from '../models/api/gridLocaleTextApi';
+import { getGridLocalization, Localization } from '../utils/getGridLocalization';
+
+const zhTWGrid: Partial<GridLocaleText> = {
+  // Root
+  noRowsLabel: '沒有資料',
+  noResultsOverlayLabel: '沒有結果',
+  errorOverlayDefaultLabel: '發生錯誤',
+
+  // Density selector toolbar button text
+  toolbarDensity: '表格密度',
+  toolbarDensityLabel: '表格密度',
+  toolbarDensityCompact: '緊湊',
+  toolbarDensityStandard: '標準',
+  toolbarDensityComfortable: '舒適',
+
+  // Columns selector toolbar button text
+  toolbarColumns: '欄位',
+  toolbarColumnsLabel: '選擇欄位',
+
+  // Filters toolbar button text
+  toolbarFilters: '篩選器',
+  toolbarFiltersLabel: '顯示篩選器',
+  toolbarFiltersTooltipHide: '隱藏篩選器',
+  toolbarFiltersTooltipShow: '顯示篩選器',
+  toolbarFiltersTooltipActive: (count) => `${count} 個篩選器`,
+
+  // Quick filter toolbar field
+  toolbarQuickFilterPlaceholder: '搜尋...',
+  toolbarQuickFilterLabel: '搜尋',
+  toolbarQuickFilterDeleteIconLabel: '清除',
+
+  // Export selector toolbar button text
+  toolbarExport: '匯出',
+  toolbarExportLabel: '匯出',
+  toolbarExportCSV: '匯出 CSV',
+  toolbarExportPrint: '列印',
+  toolbarExportExcel: '匯出 Excel',
+
+  // Columns panel text
+  columnsPanelTextFieldLabel: '欄位搜尋',
+  columnsPanelTextFieldPlaceholder: '欄位名稱',
+  columnsPanelDragIconLabel: '排序欄位',
+  columnsPanelShowAllButton: '顯示所有',
+  columnsPanelHideAllButton: '隱藏所有',
+
+  // Filter panel text
+  filterPanelAddFilter: '增加篩選器',
+  filterPanelDeleteIconLabel: '刪除',
+  filterPanelLinkOperator: '邏輯運算子',
+  filterPanelOperators: '運算子',
+
+  // TODO v6: rename to filterPanelOperator
+  filterPanelOperatorAnd: '且',
+  filterPanelOperatorOr: '或',
+  filterPanelColumns: '欄位',
+  filterPanelInputLabel: '值',
+  filterPanelInputPlaceholder: '篩選值',
+
+  // Filter operators text
+  filterOperatorContains: '包含',
+  filterOperatorEquals: '等於',
+  filterOperatorStartsWith: '以...開頭',
+  filterOperatorEndsWith: '以...結束',
+  filterOperatorIs: '為',
+  filterOperatorNot: '不為',
+  filterOperatorAfter: '...之後',
+  filterOperatorOnOrAfter: '...(含)之後',
+  filterOperatorBefore: '...之前',
+  filterOperatorOnOrBefore: '...(含)之前',
+  filterOperatorIsEmpty: '為空',
+  filterOperatorIsNotEmpty: '不為空',
+  filterOperatorIsAnyOf: '是其中之一',
+
+  // Filter values text
+  filterValueAny: '任何值',
+  filterValueTrue: '真',
+  filterValueFalse: '假',
+
+  // Column menu text
+  columnMenuLabel: '選單',
+  columnMenuShowColumns: '顯示欄位',
+  columnMenuFilter: '篩選器',
+  columnMenuHideColumn: '隱藏',
+  columnMenuUnsort: '預設排序',
+  columnMenuSortAsc: '升序',
+  columnMenuSortDesc: '降序',
+
+  // Column header text
+  columnHeaderFiltersTooltipActive: (count) => `${count} 個篩選器`,
+  columnHeaderFiltersLabel: '顯示篩選器',
+  columnHeaderSortIconLabel: '排序',
+
+  // Rows selected footer text
+  footerRowSelected: (count) => `已選取 ${count.toLocaleString()} 個`,
+
+  // Total row amount footer text
+  footerTotalRows: '總數:',
+
+  // Total visible row amount footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} / ${totalCount.toLocaleString()}`,
+
+  // Checkbox selection text
+  checkboxSelectionHeaderName: '核取方塊',
+  checkboxSelectionSelectAllRows: '全選',
+  checkboxSelectionUnselectAllRows: '取消全選',
+  checkboxSelectionSelectRow: '選取',
+  checkboxSelectionUnselectRow: '取消選取',
+
+  // Boolean cell text
+  booleanCellTrueLabel: '真',
+  booleanCellFalseLabel: '假',
+
+  // Actions cell more text
+  actionsCellMore: '查看更多',
+
+  // Column pinning text
+  pinToLeft: '釘選在左側',
+  pinToRight: '釘選在右側',
+  unpin: '取消釘選',
+
+  // Tree Data
+  treeDataGroupingHeaderName: '群組',
+  treeDataExpand: '查看子項目',
+  treeDataCollapse: '隱藏子項目',
+
+  // Grouping columns
+  groupingColumnHeaderName: '群組',
+  groupColumn: (name) => `以 ${name} 分組`,
+  unGroupColumn: (name) => `取消以 ${name} 分組`,
+
+  // Master/detail
+  detailPanelToggle: '切換顯示詳細資訊',
+  expandDetailPanel: '展開',
+  collapseDetailPanel: '摺疊',
+
+  // Row reordering text
+  rowReorderingHeaderName: '排序',
+};
+
+export const zhTW: Localization = getGridLocalization(zhTWGrid, zhTWCore);

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -540,5 +540,6 @@
   { "name": "visibleGridColumnsLengthSelector", "kind": "Variable" },
   { "name": "visibleGridColumnsSelector", "kind": "Variable" },
   { "name": "viVN", "kind": "Variable" },
-  { "name": "zhCN", "kind": "Variable" }
+  { "name": "zhCN", "kind": "Variable" },
+  { "name": "zhTW", "kind": "Variable" }
 ]

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -522,5 +522,6 @@
   { "name": "visibleGridColumnsLengthSelector", "kind": "Variable" },
   { "name": "visibleGridColumnsSelector", "kind": "Variable" },
   { "name": "viVN", "kind": "Variable" },
-  { "name": "zhCN", "kind": "Variable" }
+  { "name": "zhCN", "kind": "Variable" },
+  { "name": "zhTW", "kind": "Variable" }
 ]

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -492,5 +492,6 @@
   { "name": "visibleGridColumnsLengthSelector", "kind": "Variable" },
   { "name": "visibleGridColumnsSelector", "kind": "Variable" },
   { "name": "viVN", "kind": "Variable" },
-  { "name": "zhCN", "kind": "Variable" }
+  { "name": "zhCN", "kind": "Variable" },
+  { "name": "zhTW", "kind": "Variable" }
 ]


### PR DESCRIPTION
Add Traditional Chinese locale to data grid.
> In this PR, I translate "rows/columns" as "個/欄" to avoid the indefinite translation that could be "列/行" or "行/列" in a different context [1][2].
> [1] [Translations in Localized Microsoft Products](https://www.microsoft.com/en-us/language/Search?&searchTerm=columns&langID=129&Source=true&productid=0)
> [2] [The determinant in linear algebra](https://ccjou.wordpress.com/2012/04/17/)