### PR TITLE
[data grid] Improve start edit UX

### DIFF
--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -99,7 +99,7 @@ Use the arrow keys to move the focus.
 |                                  <kbd class="key">Shift</kbd>+ Click on cell | Select the range of rows between the first and the last clicked rows |
 |              <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">A</kbd></kbd> | Select all rows                                                      |
 |              <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s)                                   |
-|               <kbd><kbd class="key">ALT</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s) including headers                 |
+|               <kbd><kbd class="key">Alt</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s) including headers                 |
 |                                   <kbd class="key">Ctrl</kbd>+ Click on cell | Enable multi-selection                                               |
 |                         <kbd class="key">Ctrl</kbd>+ Click on a selected row | Deselect the row                                                     |
 
@@ -125,7 +125,7 @@ The above key assignments are for Windows and Linux.
 On macOS:
 
 - replace <kbd class="key">Ctrl</kbd> with <kbd class="key">⌘ Command</kbd>
-- replace <kbd class="key">ALT</kbd> with <kbd class="key">⌥ Option</kbd>
+- replace <kbd class="key">Alt</kbd> with <kbd class="key">⌥ Option</kbd>
 
 ## API
 

--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
@@ -730,7 +730,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'v', ctrlKey: true }); // Ctrl+V / ⌘ Command+V
+        fireEvent.keyDown(cell, { key: 'v', ctrlKey: true }); // Ctrl+V
         expect(listener.callCount).to.equal(1);
       });
 

--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.new.test.tsx
@@ -667,6 +667,16 @@ describe('<DataGridPro /> - Cell Editing', () => {
     });
 
     describe('by pressing a printable character', () => {
+      it('should call startCellEditMode', () => {
+        render(<TestCase />);
+        const spiedStartCellEditMode = spy(apiRef.current, 'startCellEditMode');
+        const cell = getCell(0, 1);
+        fireEvent.mouseUp(cell);
+        fireEvent.click(cell);
+        fireEvent.keyDown(cell, { key: 'a' }); // A
+        expect(spiedStartCellEditMode.callCount).to.equal(1);
+      });
+
       it(`should publish 'cellEditStart' with reason=printableKeyDown`, () => {
         render(<TestCase />);
         const listener = spy();
@@ -674,7 +684,7 @@ describe('<DataGridPro /> - Cell Editing', () => {
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'a' });
+        fireEvent.keyDown(cell, { key: 'a' }); // A
         expect(listener.lastCall.args[0].reason).to.equal('printableKeyDown');
       });
 
@@ -685,11 +695,11 @@ describe('<DataGridPro /> - Cell Editing', () => {
         const cell = getCell(0, 0);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'a' });
+        fireEvent.keyDown(cell, { key: 'a' }); // A
         expect(listener.callCount).to.equal(0);
       });
 
-      ['ctrlKey', 'metaKey', 'altKey'].forEach((key) => {
+      ['ctrlKey', 'metaKey'].forEach((key) => {
         it(`should not publish 'cellEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
           const listener = spy();
@@ -697,52 +707,42 @@ describe('<DataGridPro /> - Cell Editing', () => {
           const cell = getCell(0, 1);
           fireEvent.mouseUp(cell);
           fireEvent.click(cell);
-          fireEvent.keyDown(cell, { key: 'a', [key]: true });
+          fireEvent.keyDown(cell, { key: 'a', [key]: true }); // e.g. Ctrl + A, copy
           expect(listener.callCount).to.equal(0);
         });
       });
 
-      it(`should call startCellEditMod if shiftKey is pressed with a letter`, () => {
+      it(`should call startCellEditMode if shiftKey is pressed with a letter`, () => {
         render(<TestCase />);
         const listener = spy();
         apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'a', shiftKey: true });
+        fireEvent.keyDown(cell, { key: 'a', shiftKey: true }); // Print A in uppercase
         expect(listener.callCount).to.equal(1);
       });
 
-      it(`should call startCellEditMod if ctrl+V is pressed`, () => {
+      it(`should call startCellEditMode if the paste shortcut is pressed`, () => {
         render(<TestCase />);
         const listener = spy();
         apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'v', ctrlKey: true });
+        fireEvent.keyDown(cell, { key: 'v', ctrlKey: true }); // Ctrl+V / ⌘ Command+V
         expect(listener.callCount).to.equal(1);
       });
 
-      it(`should call startCellEditMod if meta+V is pressed`, () => {
+      it(`should call startCellEditMode if a special character on macOS is pressed`, () => {
         render(<TestCase />);
         const listener = spy();
         apiRef.current.subscribeEvent('cellEditStart', listener);
         const cell = getCell(0, 1);
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'v', metaKey: true });
+        fireEvent.keyDown(cell, { key: 'π', altKey: true }); // ⌥ Option + P
         expect(listener.callCount).to.equal(1);
-      });
-
-      it('should call startCellEditMode', () => {
-        render(<TestCase />);
-        const spiedStartCellEditMode = spy(apiRef.current, 'startCellEditMode');
-        const cell = getCell(0, 1);
-        fireEvent.mouseUp(cell);
-        fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'a' });
-        expect(spiedStartCellEditMode.callCount).to.equal(1);
       });
 
       it('should empty the cell', () => {

--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.old.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.old.test.tsx
@@ -337,6 +337,8 @@ describe('<DataGridPro /> - Cell Editing', () => {
       code: 1,
       target: cell,
       currentTarget: cell,
+      ctrlKey: false,
+      metaKey: false,
       isPropagationStopped: () => false,
     } as any);
     // fireEvent.keyDown(cell, { key: 'a', code: 1, target: cell });

--- a/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.new.test.tsx
@@ -701,7 +701,7 @@ describe('<DataGridPro /> - Row Editing', () => {
         expect(listener.callCount).to.equal(0);
       });
 
-      ['ctrlKey', 'metaKey', 'altKey'].forEach((key) => {
+      ['ctrlKey', 'metaKey'].forEach((key) => {
         it(`should not publish 'rowEditStart' if ${key} is pressed`, () => {
           render(<TestCase />);
           const listener = spy();
@@ -733,17 +733,6 @@ describe('<DataGridPro /> - Row Editing', () => {
         fireEvent.mouseUp(cell);
         fireEvent.click(cell);
         fireEvent.keyDown(cell, { key: 'v', ctrlKey: true });
-        expect(listener.callCount).to.equal(1);
-      });
-
-      it(`should call startRowEditMode if meta+V is pressed`, () => {
-        render(<TestCase />);
-        const listener = spy();
-        apiRef.current.subscribeEvent('rowEditStart', listener);
-        const cell = getCell(0, 1);
-        fireEvent.mouseUp(cell);
-        fireEvent.click(cell);
-        fireEvent.keyDown(cell, { key: 'v', metaKey: true });
         expect(listener.callCount).to.equal(1);
       });
 

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
@@ -153,7 +153,7 @@ export const useGridCellEditing = (
 
         if (isPrintableKey(event)) {
           reason = GridCellEditStartReasons.printableKeyDown;
-        } else if (event.ctrlKey && event.key === 'v') {
+        } else if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
           reason = GridCellEditStartReasons.printableKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridCellEditStartReasons.enterKeyDown;

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.new.ts
@@ -151,18 +151,14 @@ export const useGridCellEditing = (
       } else if (params.isEditable) {
         let reason: GridCellEditStartReasons | undefined;
 
-        if (isPrintableKey(event.key)) {
-          if (
-            (event.ctrlKey && event.key !== 'v') ||
-            (event.metaKey && event.key !== 'v') ||
-            event.altKey
-          ) {
-            return;
-          }
+        if (isPrintableKey(event)) {
+          reason = GridCellEditStartReasons.printableKeyDown;
+        } else if (event.ctrlKey && event.key === 'v') {
           reason = GridCellEditStartReasons.printableKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridCellEditStartReasons.enterKeyDown;
-        } else if (event.key === 'Delete') {
+        } else if (event.key === 'Delete' || event.key === 'Backspace') {
+          // Delete on Windows, Backspace on macOS
           reason = GridCellEditStartReasons.deleteKeyDown;
         }
 

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.old.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridCellEditing.old.ts
@@ -224,7 +224,7 @@ export const useCellEditing = (
 
       if (
         !isEditMode &&
-        isCellEnterEditModeKeys(event.key) &&
+        isCellEnterEditModeKeys(event) &&
         !isModifierKeyPressed &&
         !(event.key === ' ' && event.shiftKey)
       ) {
@@ -292,7 +292,7 @@ export const useCellEditing = (
 
       apiRef.current.setCellMode(params.id, params.field, GridCellModes.Edit);
 
-      if (isKeyboardEvent(event) && isPrintableKey(event.key)) {
+      if (isKeyboardEvent(event) && isPrintableKey(event)) {
         apiRef.current.unstable_setEditCellProps({
           id: params.id,
           field: params.field,

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
@@ -213,7 +213,7 @@ export const useGridRowEditing = (
 
         if (isPrintableKey(event)) {
           reason = GridRowEditStartReasons.printableKeyDown;
-        } else if (event.ctrlKey && event.key === 'v') {
+        } else if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
           reason = GridRowEditStartReasons.printableKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridRowEditStartReasons.enterKeyDown;

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
@@ -211,18 +211,14 @@ export const useGridRowEditing = (
       } else if (params.isEditable) {
         let reason: GridRowEditStartReasons | undefined;
 
-        if (isPrintableKey(event.key)) {
-          if (
-            (event.ctrlKey && event.key !== 'v') ||
-            (event.metaKey && event.key !== 'v') ||
-            event.altKey
-          ) {
-            return;
-          }
+        if (isPrintableKey(event)) {
+          reason = GridRowEditStartReasons.printableKeyDown;
+        } else if (event.ctrlKey && event.key === 'v') {
           reason = GridRowEditStartReasons.printableKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridRowEditStartReasons.enterKeyDown;
-        } else if (event.key === 'Delete') {
+        } else if (event.key === 'Delete' || event.key === 'Backspace') {
+          // Delete on Windows, Backspace on macOS
           reason = GridRowEditStartReasons.deleteKeyDown;
         }
 

--- a/packages/grid/x-data-grid/src/utils/keyboardUtils.ts
+++ b/packages/grid/x-data-grid/src/utils/keyboardUtils.ts
@@ -15,7 +15,9 @@ export const isDeleteKeys = (key: string) => key === 'Delete' || key === 'Backsp
 
 // Non printable keys have a name, e.g. "ArrowRight", see the whole list:
 // https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
-// We need to ignore shortcuts, like select all on Windows: Ctrl+A
+// We need to ignore shortcuts, for example: select all:
+// - Windows: Ctrl+A, event.ctrlKey is true
+// - macOS: ⌘ Command+A, event.metaKey is true
 export function isPrintableKey(event: React.KeyboardEvent<HTMLElement>): boolean {
   return event.key.length === 1 && event.ctrlKey === false && event.metaKey === false;
 }

--- a/packages/grid/x-data-grid/src/utils/keyboardUtils.ts
+++ b/packages/grid/x-data-grid/src/utils/keyboardUtils.ts
@@ -15,7 +15,10 @@ export const isDeleteKeys = (key: string) => key === 'Delete' || key === 'Backsp
 
 // Non printable keys have a name, e.g. "ArrowRight", see the whole list:
 // https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
-export const isPrintableKey = (key: string) => key.length === 1;
+// We need to ignore shortcuts, like select all on Windows: Ctrl+A
+export function isPrintableKey(event: React.KeyboardEvent<HTMLElement>): boolean {
+  return event.key.length === 1 && event.ctrlKey === false && event.metaKey === false;
+}
 
 export const GRID_MULTIPLE_SELECTION_KEYS = ['Meta', 'Control', 'Shift'];
 export const GRID_CELL_EXIT_EDIT_MODE_KEYS = ['Enter', 'Escape', 'Tab'];
@@ -24,8 +27,8 @@ export const GRID_CELL_EDIT_COMMIT_KEYS = ['Enter', 'Tab'];
 export const isMultipleKey = (key: string): boolean =>
   GRID_MULTIPLE_SELECTION_KEYS.indexOf(key) > -1;
 
-export const isCellEnterEditModeKeys = (key: string): boolean =>
-  isEnterKey(key) || isDeleteKeys(key) || isPrintableKey(key);
+export const isCellEnterEditModeKeys = (event: React.KeyboardEvent<HTMLElement>): boolean =>
+  isEnterKey(event.key) || isDeleteKeys(event.key) || isPrintableKey(event);
 
 export const isCellExitEditModeKeys = (key: string): boolean =>
   GRID_CELL_EXIT_EDIT_MODE_KEYS.indexOf(key) > -1;


### PR DESCRIPTION
https://deploy-preview-5511--material-ui-x.netlify.app/x/react-data-grid/editing/

This is a quick follow-up on #5405. I'm going after a couple of problems, all focused on the new edit API, I have ignored the legacy one, no time for the past.

1. <kbd>⌥ Option</kbd> + `P` should trigger the edit mode in macOS, it prints: `π` in the cell.
2. <kbd>Backspace</kbd> should empty the cell in macOS, it's the equivalent of `Delete` for Windows https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#editing_keys
3. "alt" is an abbreviation, not an acronym https://en.wikipedia.org/wiki/Alt_key, so did the same change as in #4707

While I was working on it, I found the potential for a follow-up: #5512.