### PR TITLE
[core] Add missing comments on zh-TW translation

### DIFF
--- a/packages/grid/x-data-grid/src/locales/zhTW.ts
+++ b/packages/grid/x-data-grid/src/locales/zhTW.ts
@@ -138,6 +138,14 @@ const zhTWGrid: Partial<GridLocaleText> = {
 
   // Row reordering text
   rowReorderingHeaderName: '排序',
+
+  // Aggregation
+  // aggregationMenuItemHeader: 'Aggregation',
+  // aggregationFunctionLabelSum: 'sum',
+  // aggregationFunctionLabelAvg: 'avg',
+  // aggregationFunctionLabelMin: 'min',
+  // aggregationFunctionLabelMax: 'max',
+  // aggregationFunctionLabelSize: 'size',
 };
 
 export const zhTW: Localization = getGridLocalization(zhTWGrid, zhTWCore);


### PR DESCRIPTION
I merged #5498 without rebasing on master so it missed some untranslated comments.

Will auto-merge