### PR TITLE
[DataGrid] Fix container width change on React 18

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -218,10 +218,8 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     setContainerWidth(rootRef.current!.clientWidth);
   }, [rowsMeta.currentPageTotalHeight]);
 
-  const handleResize = React.useCallback<GridEventListener<'resize'>>(() => {
-    if (rootRef.current) {
-      setContainerWidth(rootRef.current.clientWidth);
-    }
+  const handleResize = React.useCallback<GridEventListener<'resize'>>((params) => {
+    setContainerWidth(params.width);
   }, []);
 
   useGridApiEventHandler(apiRef, 'resize', handleResize);

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, screen, ErrorBoundary, waitFor } from '@mui/monorepo/test/utils';
-import { SinonStub, stub, spy } from 'sinon';
+import { stub, spy } from 'sinon';
 import { expect } from 'chai';
 import {
   DataGrid,
@@ -17,7 +17,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { getColumnHeaderCell, getColumnValues, getCell, getRow } from 'test/utils/helperFn';
 
 describe('<DataGrid /> - Layout & Warnings', () => {
-  const { clock, render } = createRenderer({ clock: 'fake' });
+  const { clock, render } = createRenderer({ clock: 'real' });
 
   const baselineProps = {
     rows: [
@@ -59,14 +59,10 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     });
 
     it('should resize the width of the columns', async () => {
-      // Using a fake clock also affects `requestAnimationFrame`.
-      // Calling clock.tick() should call the callback passed, but it doesn't work.
-      stub(window, 'requestAnimationFrame').callsFake((fn: any) => fn());
-      stub(window, 'cancelAnimationFrame');
-
       interface TestCaseProps {
         width?: number;
       }
+
       const TestCase = (props: TestCaseProps) => {
         const { width = 300 } = props;
         return (
@@ -87,9 +83,6 @@ describe('<DataGrid /> - Layout & Warnings', () => {
         rect = container.querySelector('[role="row"][data-rowindex="0"]').getBoundingClientRect();
         expect(rect.width).to.equal(400 - 2);
       });
-
-      (window.requestAnimationFrame as SinonStub).restore();
-      (window.cancelAnimationFrame as SinonStub).restore();
     });
 
     // Adaptation of describeConformance()
@@ -203,6 +196,8 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     });
 
     describe('warnings', () => {
+      clock.withFakeTimers();
+
       it('should error if the container has no intrinsic height', () => {
         expect(() => {
           render(
@@ -257,6 +252,8 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     });
 
     describe('swallow warnings', () => {
+      clock.withFakeTimers();
+
       beforeEach(() => {
         stub(console, 'error');
       });


### PR DESCRIPTION
Fixes #5085 

Related to #5192

I saw this bug when working in #4155 and one of the tests was failing with React 18 but passing with React 17. By debugging, I noticed that `rootRef.current` was null when the `resize` event is fired. I suppose this is happening because the event is triggered while the ref is unmounted. With React 17, the event is fired after the ref is mounted.

Before: https://codesandbox.io/s/datagriddemo-demo-mui-x-forked-hw2hd1?file=/demo.tsx
After: https://codesandbox.io/s/datagriddemo-demo-mui-x-forked-s2p48r?file=/package.json

How to reproduce:

<img width="400" src="https://user-images.githubusercontent.com/42154031/180339851-da3af651-0fde-4778-9c85-ffe09db2ba18.gif" alt="msedge_bl8ELjzZqH" style="max-width: 100%; display: inline-block;" data-target="animated-image.originalImage">

