### PR TITLE
[data grid] Fix ellipsis style convention

### DIFF
--- a/packages/grid/x-data-grid/src/constants/localeTextConstants.ts
+++ b/packages/grid/x-data-grid/src/constants/localeTextConstants.ts
@@ -26,7 +26,7 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
     count !== 1 ? `${count} active filters` : `${count} active filter`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Search...',
+  toolbarQuickFilterPlaceholder: 'Search…',
   toolbarQuickFilterLabel: 'Search',
   toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/arSD.ts
+++ b/packages/grid/x-data-grid/src/locales/arSD.ts
@@ -28,7 +28,7 @@ const arSDGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} من المرشِحات النشطة` : `مرشِح نشط`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/bgBG.ts
+++ b/packages/grid/x-data-grid/src/locales/bgBG.ts
@@ -27,7 +27,7 @@ const bgBGGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count} активни филтри`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/csCZ.ts
+++ b/packages/grid/x-data-grid/src/locales/csCZ.ts
@@ -37,7 +37,7 @@ const csCZGrid: Partial<GridLocaleText> = {
   },
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/daDK.ts
+++ b/packages/grid/x-data-grid/src/locales/daDK.ts
@@ -28,7 +28,7 @@ const daDKGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} aktive filtre` : `${count} aktivt filter`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/deDE.ts
+++ b/packages/grid/x-data-grid/src/locales/deDE.ts
@@ -28,7 +28,7 @@ const deDEGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} aktive Filter` : `${count} aktiver Filter`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Suchen...',
+  toolbarQuickFilterPlaceholder: 'Suchen…',
   toolbarQuickFilterLabel: 'Suchen',
   toolbarQuickFilterDeleteIconLabel: 'Löschen',
 

--- a/packages/grid/x-data-grid/src/locales/elGR.ts
+++ b/packages/grid/x-data-grid/src/locales/elGR.ts
@@ -27,7 +27,7 @@ const elGRGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} ενεργά φίλτρα` : `${count} ενεργό φίλτρο`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/esES.ts
+++ b/packages/grid/x-data-grid/src/locales/esES.ts
@@ -28,7 +28,7 @@ const esESGrid: Partial<GridLocaleText> = {
     count > 1 ? `${count} filtros activos` : `${count} filtro activo`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/faIR.ts
+++ b/packages/grid/x-data-grid/src/locales/faIR.ts
@@ -28,7 +28,7 @@ const faIRGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} فیلترهای فعال` : `${count} فیلتر فعال`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/fiFI.ts
+++ b/packages/grid/x-data-grid/src/locales/fiFI.ts
@@ -28,7 +28,7 @@ const fiFIGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} aktiivista suodatinta` : `${count} aktiivinen suodatin`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/frFR.ts
+++ b/packages/grid/x-data-grid/src/locales/frFR.ts
@@ -28,7 +28,7 @@ const frFRGrid: Partial<GridLocaleText> = {
     count > 1 ? `${count} filtres actifs` : `${count} filtre actif`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Recherche...',
+  toolbarQuickFilterPlaceholder: 'Recherche…',
   toolbarQuickFilterLabel: 'Recherche',
   toolbarQuickFilterDeleteIconLabel: 'Supprimer',
 

--- a/packages/grid/x-data-grid/src/locales/heIL.ts
+++ b/packages/grid/x-data-grid/src/locales/heIL.ts
@@ -28,7 +28,7 @@ const heILGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} מסננים פעילים` : `מסנן אחד פעיל`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'חיפוש...',
+  toolbarQuickFilterPlaceholder: 'חיפוש…',
   toolbarQuickFilterLabel: 'חיפוש',
   toolbarQuickFilterDeleteIconLabel: 'ניקוי',
 

--- a/packages/grid/x-data-grid/src/locales/huHU.ts
+++ b/packages/grid/x-data-grid/src/locales/huHU.ts
@@ -27,7 +27,7 @@ const huHUGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count} aktív szűrő`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/itIT.ts
+++ b/packages/grid/x-data-grid/src/locales/itIT.ts
@@ -28,7 +28,7 @@ const itITGrid: Partial<GridLocaleText> = {
     count > 1 ? `${count} filtri attivi` : `${count} filtro attivo`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/jaJP.ts
+++ b/packages/grid/x-data-grid/src/locales/jaJP.ts
@@ -27,7 +27,7 @@ const jaJPGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count}件のフィルターを適用中`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: '検索...',
+  toolbarQuickFilterPlaceholder: '検索…',
   toolbarQuickFilterLabel: '検索',
   toolbarQuickFilterDeleteIconLabel: 'クリア',
 
@@ -40,7 +40,7 @@ const jaJPGrid: Partial<GridLocaleText> = {
 
   // Columns panel text
   columnsPanelTextFieldLabel: '列検索',
-  columnsPanelTextFieldPlaceholder: '検索クエリを入力...',
+  columnsPanelTextFieldPlaceholder: '検索クエリを入力…',
   columnsPanelDragIconLabel: '列並べ替え',
   columnsPanelShowAllButton: 'すべて表示',
   columnsPanelHideAllButton: 'すべて非表示',
@@ -56,7 +56,7 @@ const jaJPGrid: Partial<GridLocaleText> = {
   filterPanelOperatorOr: 'Or',
   filterPanelColumns: '列',
   filterPanelInputLabel: '値',
-  filterPanelInputPlaceholder: '値を入力...',
+  filterPanelInputPlaceholder: '値を入力…',
 
   // Filter operators text
   filterOperatorContains: '...を含む',

--- a/packages/grid/x-data-grid/src/locales/koKR.ts
+++ b/packages/grid/x-data-grid/src/locales/koKR.ts
@@ -27,7 +27,7 @@ const koKRGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count}건의 필터를 적용중`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/nbNO.ts
+++ b/packages/grid/x-data-grid/src/locales/nbNO.ts
@@ -28,7 +28,7 @@ const nbNOGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} aktive filter` : `${count} aktivt filter`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Søk...',
+  toolbarQuickFilterPlaceholder: 'Søk…',
   toolbarQuickFilterLabel: 'Søk',
   toolbarQuickFilterDeleteIconLabel: 'Slett',
 

--- a/packages/grid/x-data-grid/src/locales/nlNL.ts
+++ b/packages/grid/x-data-grid/src/locales/nlNL.ts
@@ -28,7 +28,7 @@ const nlNLGrid: Partial<GridLocaleText> = {
     count > 1 ? `${count} actieve filters` : `${count} filter actief`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Zoeken...',
+  toolbarQuickFilterPlaceholder: 'Zoeken…',
   toolbarQuickFilterLabel: 'Zoeken',
   toolbarQuickFilterDeleteIconLabel: 'Wissen',
 

--- a/packages/grid/x-data-grid/src/locales/plPL.ts
+++ b/packages/grid/x-data-grid/src/locales/plPL.ts
@@ -27,7 +27,7 @@ const plPLGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `Liczba aktywnych filtrów: ${count}`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/ptBR.ts
+++ b/packages/grid/x-data-grid/src/locales/ptBR.ts
@@ -28,7 +28,7 @@ const ptBRGrid: Partial<GridLocaleText> = {
     `${count} ${count !== 1 ? 'filtros' : 'filtro'} ${count !== 1 ? 'ativos' : 'ativo'}`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Procurar...',
+  toolbarQuickFilterPlaceholder: 'Procurar…',
   toolbarQuickFilterLabel: 'Procurar',
   toolbarQuickFilterDeleteIconLabel: 'Limpar',
 

--- a/packages/grid/x-data-grid/src/locales/roRO.ts
+++ b/packages/grid/x-data-grid/src/locales/roRO.ts
@@ -28,7 +28,7 @@ const roROGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} filtru activ` : `${count} filtru activ`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Căutare...',
+  toolbarQuickFilterPlaceholder: 'Căutare…',
   toolbarQuickFilterLabel: 'Căutare',
   toolbarQuickFilterDeleteIconLabel: 'Ștergere',
 

--- a/packages/grid/x-data-grid/src/locales/ruRU.ts
+++ b/packages/grid/x-data-grid/src/locales/ruRU.ts
@@ -38,7 +38,7 @@ const ruRUGrid: Partial<GridLocaleText> = {
   },
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Поиск...',
+  toolbarQuickFilterPlaceholder: 'Поиск…',
   toolbarQuickFilterLabel: 'Поиск',
   toolbarQuickFilterDeleteIconLabel: 'Очистить',
 

--- a/packages/grid/x-data-grid/src/locales/skSK.ts
+++ b/packages/grid/x-data-grid/src/locales/skSK.ts
@@ -37,7 +37,7 @@ const skSKGrid: Partial<GridLocaleText> = {
   },
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Vyhľadať...',
+  toolbarQuickFilterPlaceholder: 'Vyhľadať…',
   toolbarQuickFilterLabel: 'Vyhľadať',
   toolbarQuickFilterDeleteIconLabel: 'Vymazať',
 

--- a/packages/grid/x-data-grid/src/locales/svSE.ts
+++ b/packages/grid/x-data-grid/src/locales/svSE.ts
@@ -28,7 +28,7 @@ const svSEGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} aktiva filter` : `${count} aktivt filter`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Sök...',
+  toolbarQuickFilterPlaceholder: 'Sök…',
   toolbarQuickFilterLabel: 'Sök',
   toolbarQuickFilterDeleteIconLabel: 'Rensa',
 

--- a/packages/grid/x-data-grid/src/locales/trTR.ts
+++ b/packages/grid/x-data-grid/src/locales/trTR.ts
@@ -27,7 +27,7 @@ const trTRGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count} aktif filtre`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Ara...',
+  toolbarQuickFilterPlaceholder: 'Ara…',
   toolbarQuickFilterLabel: 'Ara',
   toolbarQuickFilterDeleteIconLabel: 'Temizle',
 

--- a/packages/grid/x-data-grid/src/locales/ukUA.ts
+++ b/packages/grid/x-data-grid/src/locales/ukUA.ts
@@ -51,7 +51,7 @@ const ukUAGrid: Partial<GridLocaleText> = {
     }),
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/viVN.ts
+++ b/packages/grid/x-data-grid/src/locales/viVN.ts
@@ -28,7 +28,7 @@ const viVNGrid: Partial<GridLocaleText> = {
     count > 1 ? `${count} bộ lọc hoạt động` : `${count} bộ lọc hoạt động`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/zhCN.ts
+++ b/packages/grid/x-data-grid/src/locales/zhCN.ts
@@ -27,7 +27,7 @@ const zhCNGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count} 个筛选器`,
 
   // Quick filter toolbar field
-  // toolbarQuickFilterPlaceholder: 'Search...',
+  // toolbarQuickFilterPlaceholder: 'Search…',
   // toolbarQuickFilterLabel: 'Search',
   // toolbarQuickFilterDeleteIconLabel: 'Clear',
 

--- a/packages/grid/x-data-grid/src/locales/zhTW.ts
+++ b/packages/grid/x-data-grid/src/locales/zhTW.ts
@@ -27,7 +27,7 @@ const zhTWGrid: Partial<GridLocaleText> = {
   toolbarFiltersTooltipActive: (count) => `${count} 個篩選器`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: '搜尋...',
+  toolbarQuickFilterPlaceholder: '搜尋…',
   toolbarQuickFilterLabel: '搜尋',
   toolbarQuickFilterDeleteIconLabel: '清除',
 


### PR DESCRIPTION
Apply https://mui-org.notion.site/Style-guide-2a957a4168a54d47b14bae026d06a24b#a08d92bbbb8249ff8b95431514ab9903.

I have noticed it while having a quick look at #5584. It's also what GitHub uses:

<img width="401" alt="Screenshot 2022-07-24 at 21 44 56" src="https://user-images.githubusercontent.com/3165635/180663330-efe963fd-d95e-4960-bc37-6633ff72636a.png">
 