### PR TITLE
[core] Isolate asset loading under /x/

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -24,10 +24,14 @@ if (reactStrictMode) {
   console.log(`Using React.StrictMode.`);
 }
 
+const isDeployment = process.env.NETLIFY === 'true';
+
 module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
+  assetPrefix: isDeployment ? '/x' : '',
   typescript: {
     // Motivated by https://github.com/zeit/next.js/issues/7687
     ignoreDevErrors: true,

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,4 +1,6 @@
 / /x/introduction/ 301
+# Avoid conflicts with the other Next.js apps hosted under https://mui.com/
+/x/_next/* /_next/:splat
 
 # For links that we can't edit later on, e.g. hosted in the code published on npm or sent by email
 # should all be prefixed with x-


### PR DESCRIPTION
Same as https://github.com/mui/mui-toolpad/pull/661. It will be cleaner going forward, help us scale the shared folder structure of https://mui.com/.

https://github.com/mui/material-ui/pull/33649 needs to be deployed before this PR can be merged, we would break the documentation in production otherwise.

https://deploy-preview-5594--material-ui-x.netlify.app/x/introduction/