### PR TITLE
[docs] New location for the legal content

### DIFF
--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -148,8 +148,8 @@ Please pay attention to the license.
 The component comes [in different plans](https://mui.com/pricing/):
 
 - **Community** Plan: [`@mui/x-data-grid`](https://www.npmjs.com/package/@mui/x-data-grid), published under the [MIT license](https://tldrlegal.com/license/mit-license) and [free forever](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd).
-- **Pro** Plan: [`@mui/x-data-grid-pro`](https://www.npmjs.com/package/@mui/x-data-grid-pro) published under a [Commercial license](https://mui.com/store/legal/mui-x-eula/).
-- **Premium** Plan: [`@mui/x-data-grid-premium`](https://www.npmjs.com/package/@mui/x-data-grid-premium) published under a [Commercial license](https://mui.com/store/legal/mui-x-eula/).
+- **Pro** Plan: [`@mui/x-data-grid-pro`](https://www.npmjs.com/package/@mui/x-data-grid-pro) published under a [Commercial license](https://mui.com/legal/mui-x-eula/).
+- **Premium** Plan: [`@mui/x-data-grid-premium`](https://www.npmjs.com/package/@mui/x-data-grid-premium) published under a [Commercial license](https://mui.com/legal/mui-x-eula/).
 
 You can find more information about the plans in [the Licensing page](/x/introduction/licensing/).
 

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -64,7 +64,7 @@ Please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%2
 
 ## Evaluation (trial) licenses
 
-In accordance with our [End User License Agreement](https://mui.com/store/legal/mui-x-eula/#evaluation-trial-licenses), you can use the Pro and Premium components without a commercial license for 30 days without restrictions.
+In accordance with our [End User License Agreement](https://mui.com/legal/mui-x-eula/#evaluation-trial-licenses), you can use the Pro and Premium components without a commercial license for 30 days without restrictions.
 You don't need to contact us to use these components for evaluation purposes.
 
 You will need to purchase a commercial license in order to remove the watermarks and console warnings, and after the 30-day evaluation period.
@@ -88,7 +88,7 @@ The team working on 'AppA' uses the new library and so does the team working on 
 There are two front-end developers on the UI development team.
 Company 'B' purchases ten licenses.
 
-This is [the relevant clause in the EULA.](https://mui.com/store/legal/mui-x-eula/#required-quantity-of-licenses)
+This is [the relevant clause in the EULA.](https://mui.com/legal/mui-x-eula/#required-quantity-of-licenses)
 
 ## License key installation
 
@@ -133,7 +133,7 @@ export default MyApp;
 
 ### What is the key for?
 
-The license key is meant to help you [stay compliant](https://mui.com/store/legal/mui-x-eula/#license-key) with the EULA of the commercial licenses.
+The license key is meant to help you [stay compliant](https://mui.com/legal/mui-x-eula/#license-key) with the EULA of the commercial licenses.
 While each developer needs to be licensed, the license key is set once per project, where the components are used.
 
 ### Security

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -29,7 +29,6 @@
 /:lang/x/advanced-components/ /:lang/x/introduction/ 301
 /x/react-data-grid/rows/ /x/react-data-grid/row-definition/ 301
 /:lang/x/react-data-grid/rows/ /:lang/x/react-data-grid/row-definition/ 301
-
 # 2023
 
 # Proxies

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -7,7 +7,7 @@
 /r/x-get-license scope=pro https://mui.com/store/items/mui-x-pro/ 302
 /r/x-get-license scope=premium https://mui.com/store/items/mui-x-premium/ 302
 /r/x-get-license https://mui.com/pricing/ 302
-/r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 302
+/r/x-license-eula https://mui.com/legal/mui-x-eula/ 302
 /r/x-license-key-installation https://mui.com/x/introduction/licensing/#license-key-installation 302
 /r/x-data-grid-no-dimensions https://mui.com/x/react-data-grid/layout/ 302
 /r/x-technical-support https://mui.com/x/introduction/support/#technical-support 302
@@ -20,8 +20,7 @@
 /de/* /:splat 200
 /ja/* /:splat 200
 # 2022
-
-/x/license/ https://mui.com/store/legal/mui-x-eula/ 301
+/x/license/ https://mui.com/legal/mui-x-eula/ 301
 /x/react-data-grid/group-pivot/ /x/react-data-grid/tree-data/ 301
 /:lang/x/react-data-grid/group-pivot/ /:lang/x/react-data-grid/tree-data/ 301
 /x/react-data-grid/columns/ /x/react-data-grid/column-definition/ 301


### PR DESCRIPTION
A continuation of https://github.com/mui/mui-store/pull/196. We can merge and deploy this one independently from the previous linked PR and https://github.com/mui/material-ui/pull/33650 as there is already a redirection in place. I think that this /store/ in the URL to link legal content for MUI X was confusing. The store is an implementation detail of how we allow customers to procure the software.