### PR TITLE
[DatePicker] Fix selection of day outside current month

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -116,14 +116,14 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      fireEvent.click(screen.getByLabelText('Jan 1, 2019'));
+      fireEvent.mouseDown(screen.getByLabelText('Jan 1, 2019'));
       // FIXME use `getByRole(role, {hidden: false})` and skip JSDOM once this suite can run in JSDOM
       const [visibleButton] = screen.getAllByRole('button', {
         hidden: true,
         name: 'Next month',
       });
       fireEvent.click(visibleButton);
-      fireEvent.click(screen.getByLabelText('Mar 19, 2019'));
+      fireEvent.mouseDown(screen.getByLabelText('Mar 19, 2019'));
 
       expect(handleChange.callCount).to.equal(1);
       const [changedRange] = handleChange.lastCall.args;
@@ -143,12 +143,12 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      fireEvent.click(screen.getByLabelText('Jan 30, 2019'));
-      fireEvent.click(screen.getByLabelText('Jan 19, 2019'));
+      fireEvent.mouseDown(screen.getByLabelText('Jan 30, 2019'));
+      fireEvent.mouseDown(screen.getByLabelText('Jan 19, 2019'));
 
       expect(screen.queryByMuiTest('DateRangeHighlight')).to.equal(null);
 
-      fireEvent.click(screen.getByLabelText('Jan 30, 2019'));
+      fireEvent.mouseDown(screen.getByLabelText('Jan 30, 2019'));
 
       expect(handleChange.callCount).to.equal(3);
       const [changedRange] = handleChange.lastCall.args;

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -177,6 +177,32 @@ describe('<CalendarPicker />', () => {
     expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 1));
   });
 
+  it('should select the closest enabled date in the month if the current date is disabled', () => {
+    // Check that onChange is triggered on mouseDown to avoid bug related to animation such as in https://github.com/mui/mui-x/issues/5570
+    const onChange = spy();
+    const Test = () => {
+      const [date, setDate] = React.useState<Date | null>(adapterToUse.date(new Date(2018, 6, 29)));
+
+      return (
+        <CalendarPicker
+          date={date}
+          onChange={(newDate) => {
+            onChange(newDate);
+            setDate(newDate);
+          }}
+          showDaysOutsideCurrentMonth
+          views={['day']}
+          openTo="day"
+        />
+      );
+    };
+
+    render(<Test />);
+    fireEvent.mouseDown(screen.getByLabelText('Aug 4, 2018'));
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 7, 4));
+  });
+
   describe('view: day', () => {
     it('renders day calendar standalone', () => {
       render(<CalendarPicker date={adapterToUse.date(new Date(2019, 0, 1))} onChange={() => {}} />);

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -177,7 +177,7 @@ describe('<CalendarPicker />', () => {
     expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 1));
   });
 
-  it('should select the closest enabled date in the month if the current date is disabled', () => {
+  it('should select day outside of month if `showDaysOutsideCurrentMonth`', () => {
     // Check that onChange is triggered on mouseDown to avoid bug related to animation such as in https://github.com/mui/mui-x/issues/5570
     const onChange = spy();
     const Test = () => {

--- a/packages/x-date-pickers/src/CalendarPicker/useCalendarState.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/useCalendarState.tsx
@@ -34,6 +34,10 @@ export const createCalendarStateReducer =
   ): CalendarState<TDate> => {
     switch (action.type) {
       case 'changeMonth':
+        if (state.currentMonth === action.newMonth) {
+          return state;
+        }
+
         return {
           ...state,
           slideDirection: action.direction,
@@ -64,14 +68,19 @@ export const createCalendarStateReducer =
         return {
           ...state,
           focusedDay: action.focusedDay,
-          isMonthSwitchingAnimating: needMonthSwitch && !reduceAnimations,
-          currentMonth: needMonthSwitch
-            ? utils.startOfMonth(action.focusedDay!)
-            : state.currentMonth,
-          slideDirection:
-            action.focusedDay != null && utils.isAfterDay(action.focusedDay, state.currentMonth)
-              ? 'left'
-              : 'right',
+          ...(needMonthSwitch
+            ? {
+                isMonthSwitchingAnimating: needMonthSwitch && !reduceAnimations,
+                currentMonth: needMonthSwitch
+                  ? utils.startOfMonth(action.focusedDay!)
+                  : state.currentMonth,
+                slideDirection:
+                  action.focusedDay != null &&
+                  utils.isAfterDay(action.focusedDay, state.currentMonth)
+                    ? 'left'
+                    : 'right',
+              }
+            : {}),
         };
       }
 

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -313,7 +313,7 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the date
-      fireEvent.click(screen.getByLabelText('Jan 8, 2018'));
+      fireEvent.mouseDown(screen.getByLabelText('Jan 8, 2018'));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 8));
       expect(onAccept.callCount).to.equal(1);

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
@@ -47,7 +47,7 @@ describe('<PickersDay />', () => {
     // - fireEvent.keyUp(targetDay, { key: 'Space' })
     expect(targetDay.tagName).to.equal('BUTTON');
 
-    fireEvent.click(targetDay);
+    fireEvent.mouseDown(targetDay);
 
     expect(handleDaySelect.callCount).to.equal(1);
     expect(handleDaySelect.args[0][0]).toEqualDateTime(day);

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -251,7 +251,7 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
     }
   };
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!disabled) {
       onDaySelect(day, 'finish');
     }
@@ -327,7 +327,7 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       tabIndex={selected ? 0 : -1}
       onFocus={handleFocus}
       onKeyDown={handleKeyDown}
-      onClick={handleClick}
+      onMouseDown={handleMouseDown}
       {...other}
     >
       {!children ? utils.format(day, 'dayOfMonth') : children}

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.test.tsx
@@ -19,7 +19,7 @@ describe('<StaticDateTimePicker />', () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText('Jan 1, 2018'));
+    fireEvent.mouseDown(screen.getByLabelText('Jan 1, 2018'));
     expect(onChangeMock.callCount).to.equal(0);
 
     expect(screen.getByLabelText(/Selected time/)).toBeVisible();


### PR DESCRIPTION
Fix #5570

This issue is a bit tricky because it has animations

The problem is the following:

When pressing mousse down, the focus move to the day, which triggers the sliding of the month (that's logical)
When mouse up occurs, the element under the mouse might not be the same (due to the sliding of the calendar) so the click event is not triggered (click = down and up on the same element)

The proposed solution is to use `onMouseDown` instead of `onClick`, and modify the reducer for focus ùodification such that it's animation does not conflict with others

 About testing, I'm checking that the event is triggered by mouseDown event with a comment. I did not found better solution