### PR TITLE
[DataGrid] Add `initialOpen` prop to `GridEditSingleSelectCell` to allow overriding default behavior on cell edit mode

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -38,9 +38,11 @@ export interface GridEditSingleSelectCellProps
    * @returns {Promise<void> | void} A promise to be awaited before calling `apiRef.current.setEditCellValue`
    */
   onValueChange?: (event: SelectChangeEvent<any>, newValue: any) => Promise<void> | void;
+  initialOpen?: boolean;
 }
 
 function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
+  const rootProps = useGridRootProps();
   const {
     id,
     value,
@@ -60,14 +62,14 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
     isProcessingProps,
     error,
     onValueChange,
+    initialOpen = rootProps.editMode === 'cell',
     ...other
   } = props;
 
   const apiRef = useGridApiContext();
   const ref = React.useRef<any>();
   const inputRef = React.useRef<any>();
-  const rootProps = useGridRootProps();
-  const [open, setOpen] = React.useState(rootProps.editMode === 'cell');
+  const [open, setOpen] = React.useState(initialOpen);
 
   const baseSelectProps = rootProps.componentsProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? false;
@@ -223,6 +225,10 @@ GridEditSingleSelectCell.propTypes = {
    * The grid row id.
    */
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  /**
+   * If true, the select opens by default.
+   */
+  initialOpen: PropTypes.bool,
   /**
    * If true, the cell is editable.
    */

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -38,6 +38,9 @@ export interface GridEditSingleSelectCellProps
    * @returns {Promise<void> | void} A promise to be awaited before calling `apiRef.current.setEditCellValue`
    */
   onValueChange?: (event: SelectChangeEvent<any>, newValue: any) => Promise<void> | void;
+  /**
+   * If true, the select opens by default.
+   */
   initialOpen?: boolean;
 }
 
@@ -225,6 +228,9 @@ GridEditSingleSelectCell.propTypes = {
    * The grid row id.
    */
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  /**
+   * If true, the select opens by default.
+   */
   initialOpen: PropTypes.bool,
   /**
    * If true, the cell is editable.

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -62,7 +62,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
     isProcessingProps,
     error,
     onValueChange,
-    initialOpen = rootProps.editMode === 'cell',
+    initialOpen = rootProps.editMode === GridEditModes.Cell,
     ...other
   } = props;
 
@@ -225,9 +225,6 @@ GridEditSingleSelectCell.propTypes = {
    * The grid row id.
    */
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-  /**
-   * If true, the select opens by default.
-   */
   initialOpen: PropTypes.bool,
   /**
    * If true, the cell is editable.


### PR DESCRIPTION
This PR fixes #5502