### PR TITLE
[core] Drop usage of `GRID_EXPERIMENTAL_ENABLED` env variable

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -48,8 +48,6 @@ module.exports = {
     PULL_REQUEST: process.env.PULL_REQUEST === 'true',
     REACT_STRICT_MODE: reactStrictMode,
     FEEDBACK_URL: process.env.FEEDBACK_URL,
-    // Set by Netlify
-    GRID_EXPERIMENTAL_ENABLED: process.env.PULL_REQUEST === 'false' ? 'false' : 'true',
     // #default-branch-switch
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui/mui-x/blob/master',
     SOURCE_CODE_REPO: 'https://github.com/mui/mui-x',

--- a/packages/grid/x-data-grid/src/constants/envConstants.ts
+++ b/packages/grid/x-data-grid/src/constants/envConstants.ts
@@ -18,17 +18,4 @@ import { localStorageAvailable } from '../utils/utils';
 // Developers (users) are discouraged to enable the experimental feature by setting the GRID_EXPERIMENTAL_ENABLED env.
 // Instead, prefer exposing experimental APIs, for instance, a prop or a new `unstable_` module.
 
-let experimentalEnabled = false;
-
-if (
-  typeof process !== 'undefined' &&
-  process.env?.GRID_EXPERIMENTAL_ENABLED !== undefined &&
-  localStorageAvailable() &&
-  window.localStorage.getItem('GRID_EXPERIMENTAL_ENABLED')
-) {
-  experimentalEnabled = window.localStorage.getItem('GRID_EXPERIMENTAL_ENABLED') === 'true';
-} else if (typeof process !== 'undefined') {
-  experimentalEnabled = process.env?.GRID_EXPERIMENTAL_ENABLED === 'true';
-}
-
-export const GRID_EXPERIMENTAL_ENABLED = experimentalEnabled as boolean;
+export const GRID_EXPERIMENTAL_ENABLED = false;

--- a/packages/grid/x-data-grid/src/constants/envConstants.ts
+++ b/packages/grid/x-data-grid/src/constants/envConstants.ts
@@ -1,6 +1,4 @@
-import { localStorageAvailable } from '../utils/utils';
-
-// A guide to feature toggling.
+// A guide to feature toggling (deprecated)
 //
 // The feature toggle is:
 // - independent from the NODE_ENV

--- a/packages/grid/x-data-grid/src/constants/envConstants.ts
+++ b/packages/grid/x-data-grid/src/constants/envConstants.ts
@@ -22,13 +22,13 @@ let experimentalEnabled = false;
 
 if (
   typeof process !== 'undefined' &&
-  process.env.GRID_EXPERIMENTAL_ENABLED !== undefined &&
+  process.env?.GRID_EXPERIMENTAL_ENABLED !== undefined &&
   localStorageAvailable() &&
   window.localStorage.getItem('GRID_EXPERIMENTAL_ENABLED')
 ) {
   experimentalEnabled = window.localStorage.getItem('GRID_EXPERIMENTAL_ENABLED') === 'true';
 } else if (typeof process !== 'undefined') {
-  experimentalEnabled = process.env.GRID_EXPERIMENTAL_ENABLED === 'true';
+  experimentalEnabled = process.env?.GRID_EXPERIMENTAL_ENABLED === 'true';
 }
 
 export const GRID_EXPERIMENTAL_ENABLED = experimentalEnabled as boolean;

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -62,17 +62,6 @@ const config: StorybookConfig = {
       },
     });
 
-    config.plugins.push(
-      new webpack.DefinePlugin({
-        'process.env': {
-          GRID_EXPERIMENTAL_ENABLED: JSON.stringify(
-            // Set by Netlify
-            process.env.PULL_REQUEST === 'false' ? 'false' : 'true',
-          ),
-        },
-      }),
-    );
-
     config.optimization = {
       splitChunks: {
         chunks: 'all',


### PR DESCRIPTION
Fixes #5673

When using cypress with `vite`, envConstants.ts fails cause it assumes `process.env` is defined, where it might be undefined.