### PR TITLE
[docs] Add missing `date-fns` dependency when opening Codesandbox demo

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -40,15 +40,6 @@ ponyfillGlobal.muiDocConfig = {
   csbIncludePeerDependencies: (deps, { versions }) => {
     const newDeps = { ...deps };
 
-    if (newDeps['@mui/x-data-grid']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
-    }
-
-    if (newDeps['@mui/x-data-grid-pro']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
-      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
-    }
-
     if (newDeps['@mui/x-data-grid-premium']) {
       newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
@@ -58,6 +49,15 @@ ponyfillGlobal.muiDocConfig = {
       newDeps.exceljs = versions.exceljs;
     }
 
+    if (newDeps['@mui/x-data-grid-pro']) {
+      newDeps['@mui/material'] = versions['@mui/material'];
+      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
+    }
+
+    if (newDeps['@mui/x-data-grid']) {
+      newDeps['@mui/material'] = versions['@mui/material'];
+    }
+
     if (newDeps['@mui/x-data-grid-generator']) {
       newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
@@ -65,14 +65,14 @@ ponyfillGlobal.muiDocConfig = {
       newDeps['@mui/x-data-grid-pro'] = versions['@mui/x-data-grid-pro']; // Some TS types are imported from @mui/x-data-grid-pro
     }
 
-    if (newDeps['@mui/x-date-pickers']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
-      newDeps['date-fns'] = versions['date-fns'];
-    }
-
     if (newDeps['@mui/x-date-pickers-pro']) {
       newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/x-date-pickers'] = versions['@mui/x-date-pickers'];
+    }
+
+    if (newDeps['@mui/x-date-pickers']) {
+      newDeps['@mui/material'] = versions['@mui/material'];
+      newDeps['date-fns'] = versions['date-fns'];
     }
 
     return newDeps;

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -41,8 +41,6 @@ ponyfillGlobal.muiDocConfig = {
     const newDeps = { ...deps };
 
     if (newDeps['@mui/x-data-grid-premium']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
-      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
       newDeps['@mui/x-data-grid-pro'] = versions['@mui/x-data-grid-pro'];
       // TODO: remove when https://github.com/mui/material-ui/pull/32492 is released
       // use `import 'exceljs'` in demonstrations instead
@@ -50,7 +48,6 @@ ponyfillGlobal.muiDocConfig = {
     }
 
     if (newDeps['@mui/x-data-grid-pro']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
     }
 
@@ -66,7 +63,6 @@ ponyfillGlobal.muiDocConfig = {
     }
 
     if (newDeps['@mui/x-date-pickers-pro']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/x-date-pickers'] = versions['@mui/x-date-pickers'];
     }
 


### PR DESCRIPTION
I've noticed that demos in Codesandbox from https://mui.com/x/react-date-pickers/date-range-picker/ are missing `date-fns` dependency.

For `@mui/x-date-pickers` it was added in https://github.com/mui/mui-x/pull/4508

I've reordered if statements and removed duplicated dependencies across them, so that:
- if demo has `@mui/x-date-pickers-pro` dependency - add `@mui/x-date-pickers` dependency
- if demo has `@mui/x-date-pickers` dependency - add `date-fns` and `@mui/material` dependencies

By entering multiple ifs all necessary dependencies will be gathered.
Same for the data grid packages.

Preview: https://deploy-preview-5692--material-ui-x.netlify.app/x/react-date-pickers/date-range-picker/