### PR TITLE
[docs] Use new edit API in the introduction demos

### DIFF
--- a/docs/data/data-grid/demo/FullFeaturedDemo.js
+++ b/docs/data/data-grid/demo/FullFeaturedDemo.js
@@ -311,6 +311,7 @@ export default function FullFeaturedDemo() {
         checkboxSelection
         disableSelectionOnClick
         rowThreshold={0}
+        experimentalFeatures={{ newEditingApi: true }}
         initialState={{
           ...data.initialState,
           pinnedColumns: { left: [GRID_CHECKBOX_SELECTION_FIELD, 'desk'] },

--- a/docs/data/data-grid/demo/FullFeaturedDemo.tsx
+++ b/docs/data/data-grid/demo/FullFeaturedDemo.tsx
@@ -332,6 +332,7 @@ export default function FullFeaturedDemo() {
         checkboxSelection
         disableSelectionOnClick
         rowThreshold={0}
+        experimentalFeatures={{ newEditingApi: true }}
         initialState={{
           ...data.initialState,
           pinnedColumns: { left: [GRID_CHECKBOX_SELECTION_FIELD, 'desk'] },

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -17,7 +17,7 @@ To use it, add the following flag:
 This additional step is required because the default editing API has a couple of issues that can only be fixed with breaking changes, that will only be possible in v6.
 To avoid having to wait for the next major release window, all breaking changes needed were included inside this flag.
 
-If you are looking for the documentation for the default editing API, visit [this page](/x/react-data-grid/editing-legacy/).
+If you are looking for the documentation for the default editing API, visit [the docs of the legacy API](/x/react-data-grid/editing-legacy/).
 Note that it is encouraged to migrate to the new editing API since it will be enabled by default in v6.
 Although it says "experimental," you can consider it stable.
 :::

--- a/docs/data/data-grid/overview/DataGridDemo.js
+++ b/docs/data/data-grid/overview/DataGridDemo.js
@@ -56,6 +56,7 @@ export default function DataGridDemo() {
         rowsPerPageOptions={[5]}
         checkboxSelection
         disableSelectionOnClick
+        experimentalFeatures={{ newEditingApi: true }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridDemo.tsx
+++ b/docs/data/data-grid/overview/DataGridDemo.tsx
@@ -56,6 +56,7 @@ export default function DataGridDemo() {
         rowsPerPageOptions={[5]}
         checkboxSelection
         disableSelectionOnClick
+        experimentalFeatures={{ newEditingApi: true }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridDemo.tsx.preview
+++ b/docs/data/data-grid/overview/DataGridDemo.tsx.preview
@@ -5,4 +5,5 @@
   rowsPerPageOptions={[5]}
   checkboxSelection
   disableSelectionOnClick
+  experimentalFeatures={{ newEditingApi: true }}
 />

--- a/docs/data/data-grid/overview/DataGridPremiumDemo.js
+++ b/docs/data/data-grid/overview/DataGridPremiumDemo.js
@@ -12,6 +12,7 @@ export default function DataGridPremiumDemo() {
   const { data, loading } = useDemoData({
     dataSet: 'Commodity',
     rowLength: 100,
+    editable: true,
     visibleFields: [
       'commodity',
       'quantity',
@@ -52,6 +53,7 @@ export default function DataGridPremiumDemo() {
         disableSelectionOnClick
         initialState={initialState}
         components={{ Toolbar: GridToolbar }}
+        experimentalFeatures={{ newEditingApi: true }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridPremiumDemo.tsx
+++ b/docs/data/data-grid/overview/DataGridPremiumDemo.tsx
@@ -12,6 +12,7 @@ export default function DataGridPremiumDemo() {
   const { data, loading } = useDemoData({
     dataSet: 'Commodity',
     rowLength: 100,
+    editable: true,
     visibleFields: [
       'commodity',
       'quantity',
@@ -51,6 +52,7 @@ export default function DataGridPremiumDemo() {
         disableSelectionOnClick
         initialState={initialState}
         components={{ Toolbar: GridToolbar }}
+        experimentalFeatures={{ newEditingApi: true }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridPremiumDemo.tsx.preview
+++ b/docs/data/data-grid/overview/DataGridPremiumDemo.tsx.preview
@@ -5,4 +5,5 @@
   disableSelectionOnClick
   initialState={initialState}
   components={{ Toolbar: GridToolbar }}
+  experimentalFeatures={{ newEditingApi: true }}
 />

--- a/docs/data/data-grid/overview/DataGridProDemo.js
+++ b/docs/data/data-grid/overview/DataGridProDemo.js
@@ -18,6 +18,7 @@ export default function DataGridProDemo() {
         rowHeight={38}
         checkboxSelection
         disableSelectionOnClick
+        experimentalFeatures={{ newEditingApi: true }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridProDemo.tsx
+++ b/docs/data/data-grid/overview/DataGridProDemo.tsx
@@ -18,6 +18,7 @@ export default function DataGridProDemo() {
         rowHeight={38}
         checkboxSelection
         disableSelectionOnClick
+        experimentalFeatures={{ newEditingApi: true }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridProDemo.tsx.preview
+++ b/docs/data/data-grid/overview/DataGridProDemo.tsx.preview
@@ -4,4 +4,5 @@
   rowHeight={38}
   checkboxSelection
   disableSelectionOnClick
+  experimentalFeatures={{ newEditingApi: true }}
 />


### PR DESCRIPTION
Considering how much we are burying the demo of the legacy editing API, and that the legacy API is buggy, e.g. with the <kbd>Escape</kbd> key:

https://user-images.githubusercontent.com/3165635/183312070-6a7daf69-1e53-40ac-b0b3-22bfa5808033.mov

https://mui.com/x/react-data-grid/#mit-version

I believe it would make more sense to demo it on the introduction demos. I believe these demos are used by developers to judge whether they will use or not the component.

One step in this direction #5606.

Preview: https://deploy-preview-5728--material-ui-x.netlify.app/x/introduction/