### PR TITLE
[license] Give more context in the missing license

### DIFF
--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.ts
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.ts
@@ -32,6 +32,7 @@ export function useLicenseVerifier(
       ? ['premium']
       : ['pro', 'premium'];
 
+    const plan = packageName.includes('premium') ? 'Premium' : 'Pro';
     const licenseStatus = verifyLicense({
       releaseInfo,
       licenseKey,
@@ -44,7 +45,7 @@ export function useLicenseVerifier(
     if (licenseStatus === LicenseStatus.Invalid) {
       showInvalidLicenseError();
     } else if (licenseStatus === LicenseStatus.NotFound) {
-      showNotFoundLicenseError();
+      showNotFoundLicenseError({ plan, packageName: `@mui/${packageName}` });
     } else if (licenseStatus === LicenseStatus.Expired) {
       showExpiredLicenseError();
     }

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -22,11 +22,17 @@ export function showInvalidLicenseError() {
   ]);
 }
 
-export function showNotFoundLicenseError() {
+export function showNotFoundLicenseError({
+  plan,
+  packageName,
+}: {
+  plan: string;
+  packageName: string;
+}) {
   showError([
-    'MUI: License key not found.',
+    `MUI: License key not found for ${packageName}.`,
     '',
-    'This is a trial-only version of MUI X.',
+    `This is a trial-only version of MUI X ${plan}.`,
     'See the conditons here: https://mui.com/r/x-license-eula#evaluation-trial-licenses.',
     '',
     'To purchase a license, please visit https://mui.com/r/x-get-license.',


### PR DESCRIPTION
This is related to #5730. I'm trying to improve the DX from https://codesandbox.io/s/1cm3xe?file=/demo.tsx.

**Before**

<img width="525" alt="Screenshot 2022-08-08 at 01 26 43" src="https://user-images.githubusercontent.com/3165635/183315250-50f52e54-0220-4214-af48-653c60488d79.png">

**After**

<img width="529" alt="Screenshot 2022-08-08 at 01 26 31" src="https://user-images.githubusercontent.com/3165635/183315233-3a52b220-efc0-4a0f-83bf-7e812766a726.png">
