### PR TITLE
[docs] Fix contradiction in the free trial clause

### DIFF
--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -67,7 +67,7 @@ Please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%2
 In accordance with the [End User License Agreement](https://mui.com/legal/mui-x-eula/#evaluation-trial-licenses), you can use the Pro and Premium components without a commercial license for 30 days for non-production environments.
 You can also use it for the development of code not intended for production (for example the reproduction of an issue, doing a benchmark).
 
-You don't need to contact us to use these components for evaluation purposes.
+You don't need to contact us to use these components for the above cases.
 You will need to purchase a commercial license in order to remove the watermarks and console warnings.
 
 ## How many developer seats do I need?

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -64,10 +64,11 @@ Please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%2
 
 ## Evaluation (trial) licenses
 
-In accordance with our [End User License Agreement](https://mui.com/legal/mui-x-eula/#evaluation-trial-licenses), you can use the Pro and Premium components without a commercial license for 30 days without restrictions.
-You don't need to contact us to use these components for evaluation purposes.
+In accordance with the [End User License Agreement](https://mui.com/legal/mui-x-eula/#evaluation-trial-licenses), you can use the Pro and Premium components without a commercial license for 30 days for non-production environments.
+You can also use it for the development of code not intended for production (for example the reproduction of an issue, doing a benchmark).
 
-You will need to purchase a commercial license in order to remove the watermarks and console warnings, and after the 30-day evaluation period.
+You don't need to contact us to use these components for evaluation purposes.
+You will need to purchase a commercial license in order to remove the watermarks and console warnings.
 
 ## How many developer seats do I need?
 

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -10,6 +10,7 @@
 /r/x-get-license scope=premium https://mui.com/store/items/mui-x-premium/ 302
 /r/x-get-license https://mui.com/pricing/ 302
 /r/x-license-eula https://mui.com/legal/mui-x-eula/ 302
+/r/x-license-trial https://mui.com/x/introduction/licensing/#evaluation-trial-licenses 302
 /r/x-license-key-installation https://mui.com/x/introduction/licensing/#license-key-installation 302
 /r/x-data-grid-no-dimensions https://mui.com/x/react-data-grid/layout/ 302
 /r/x-technical-support https://mui.com/x/introduction/support/#technical-support 302

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -33,7 +33,7 @@ export function showNotFoundLicenseError({
     `MUI: License key not found for ${packageName}.`,
     '',
     `This is a trial-only version of MUI X ${plan}.`,
-    'See the conditons here: https://mui.com/r/x-license-eula#evaluation-trial-licenses.',
+    'See the conditons here: https://mui.com/r/x-license-trial.',
     '',
     'To purchase a license, please visit https://mui.com/r/x-get-license.',
   ]);


### PR DESCRIPTION
1. https://mui.com/r/x-license-eula#evaluation-trial-licenses is not a permalink. If we change the anchor link, it would break
2. We say "without restrictions" in the docs and "for non-production environments" in the legal area. It's contradictory.

https://deploy-preview-5732--material-ui-x.netlify.app/x/introduction/licensing/#evaluation-trial-licenses
