### PR TITLE
[DataGrid] Improve `GridRowModel` typing

### DIFF
--- a/docs/data/data-grid/editing/LinkedFieldsCellEditing.js
+++ b/docs/data/data-grid/editing/LinkedFieldsCellEditing.js
@@ -106,15 +106,15 @@ export default function LinkedFieldsCellEditing() {
   ];
 
   const handleCellEditStart = (params) => {
-    editingRow.current = rows.find((row) => row.id === params.id);
+    editingRow.current = rows.find((row) => row.id === params.id) || null;
   };
 
   const handleCellEditStop = (params) => {
     if (params.reason === GridCellEditStopReasons.escapeKeyDown) {
       setRows((prevRows) =>
         prevRows.map((row) =>
-          row.id === editingRow.current.id
-            ? { ...row, account: editingRow.current.account }
+          row.id === editingRow.current?.id
+            ? { ...row, account: editingRow.current?.account }
             : row,
         ),
       );
@@ -123,7 +123,7 @@ export default function LinkedFieldsCellEditing() {
 
   const processRowUpdate = (newRow) => {
     setRows((prevRows) =>
-      prevRows.map((row) => (row.id === editingRow.current.id ? newRow : row)),
+      prevRows.map((row) => (row.id === editingRow.current?.id ? newRow : row)),
     );
 
     return newRow;

--- a/docs/data/data-grid/editing/LinkedFieldsCellEditing.tsx
+++ b/docs/data/data-grid/editing/LinkedFieldsCellEditing.tsx
@@ -56,7 +56,7 @@ const CustomTypeEditComponent = (props: CustomTypeEditComponentProps) => {
 };
 
 export default function LinkedFieldsCellEditing() {
-  const editingRow = React.useRef<GridRowModel>(null);
+  const editingRow = React.useRef<GridRowModel | null>(null);
   const [rows, setRows] = React.useState(initialRows);
 
   const columns: GridColumns = [
@@ -106,15 +106,15 @@ export default function LinkedFieldsCellEditing() {
   ];
 
   const handleCellEditStart: DataGridProps['onCellEditStart'] = (params) => {
-    editingRow.current = rows.find((row) => row.id === params.id);
+    editingRow.current = rows.find((row) => row.id === params.id) || null;
   };
 
   const handleCellEditStop: DataGridProps['onCellEditStop'] = (params) => {
     if (params.reason === GridCellEditStopReasons.escapeKeyDown) {
       setRows((prevRows) =>
         prevRows.map((row) =>
-          row.id === editingRow.current.id
-            ? { ...row, account: editingRow.current.account }
+          row.id === editingRow.current?.id
+            ? { ...row, account: editingRow.current?.account }
             : row,
         ),
       );
@@ -123,7 +123,7 @@ export default function LinkedFieldsCellEditing() {
 
   const processRowUpdate: DataGridProps['processRowUpdate'] = (newRow) => {
     setRows((prevRows) =>
-      prevRows.map((row) => (row.id === editingRow.current.id ? newRow : row)),
+      prevRows.map((row) => (row.id === editingRow.current?.id ? newRow : row)),
     );
     return newRow;
   };

--- a/docs/pages/x/api/data-grid/selectors.json
+++ b/docs/pages/x/api/data-grid/selectors.json
@@ -143,7 +143,7 @@
   },
   {
     "name": "gridFilteredSortedRowEntriesSelector",
-    "returnType": "{ id: GridRowId; model: any }[]",
+    "returnType": "{ id: GridRowId; model: GridValidRowModel }[]",
     "category": "Filtering",
     "description": "Get the id and the model of the rows accessible after the filtering process.\nContains the collapsed children.",
     "supportsApiRef": true
@@ -196,7 +196,7 @@
   },
   {
     "name": "gridPaginatedVisibleSortedGridRowEntriesSelector",
-    "returnType": "{ id: GridRowId; model: any }[]",
+    "returnType": "{ id: GridRowId; model: GridValidRowModel }[]",
     "category": "Pagination",
     "description": "Get the id and the model of each row to include in the current page if the pagination is enabled.",
     "supportsApiRef": true
@@ -273,7 +273,7 @@
   },
   {
     "name": "gridSortedRowEntriesSelector",
-    "returnType": "{ id: GridRowId; model: any }[]",
+    "returnType": "{ id: GridRowId; model: GridValidRowModel }[]",
     "category": "Sorting",
     "description": "Get the id and the model of the rows after the sorting process.",
     "supportsApiRef": true
@@ -326,7 +326,7 @@
   },
   {
     "name": "gridVisibleSortedRowEntriesSelector",
-    "returnType": "{ id: GridRowId; model: any }[]",
+    "returnType": "{ id: GridRowId; model: GridValidRowModel }[]",
     "category": "Filtering",
     "description": "Get the id and the model of the rows accessible after the filtering process.\nDoes not contain the collapsed children.",
     "supportsApiRef": true
@@ -340,7 +340,7 @@
   },
   {
     "name": "gridVisibleSortedTopLevelRowEntriesSelector",
-    "returnType": "{ id: GridRowId; model: any }[]",
+    "returnType": "{ id: GridRowId; model: GridValidRowModel }[]",
     "category": "Filtering",
     "description": "Get the id and the model of the top level rows accessible after the filtering process.",
     "supportsApiRef": true
@@ -360,7 +360,7 @@
   },
   {
     "name": "selectedGridRowsSelector",
-    "returnType": "Map<GridRowId, any>",
+    "returnType": "Map<GridRowId, GridValidRowModel>",
     "description": "",
     "supportsApiRef": true
   },

--- a/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
@@ -134,7 +134,7 @@ export const useGridRowReorder = (
       } else {
         // Emit the rowOrderChange event only once when the reordering stops.
         const rowOrderChangeParams: GridRowOrderChangeParams = {
-          row: apiRef.current.getRow(dragRowId),
+          row: apiRef.current.getRow(dragRowId)!,
           targetIndex: apiRef.current.getRowIndex(params.id),
           oldIndex: originRowIndex.current!,
         };

--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -436,7 +436,7 @@ GridRow.propTypes = {
   isLastVisible: PropTypes.bool,
   lastColumnToRender: PropTypes.number.isRequired,
   renderedColumns: PropTypes.arrayOf(PropTypes.object).isRequired,
-  row: PropTypes.any.isRequired,
+  row: PropTypes.object.isRequired,
   rowHeight: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]).isRequired,
   rowId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   selected: PropTypes.bool.isRequired,

--- a/packages/grid/x-data-grid/src/models/gridRows.ts
+++ b/packages/grid/x-data-grid/src/models/gridRows.ts
@@ -2,7 +2,7 @@ import type { GridKeyValue } from './colDef/gridColDef';
 
 export type GridValidRowModel = { [key: string]: any };
 
-export type GridRowsProp<R = any> = Readonly<GridRowModel<R>[]>;
+export type GridRowsProp<R = GridValidRowModel> = Readonly<GridRowModel<R>[]>;
 
 /**
  * @deprecated prefer GridRowModel.
@@ -12,7 +12,7 @@ export type GridRowData = GridValidRowModel;
 /**
  * The key value object representing the data of a row.
  */
-export type GridRowModel<R extends GridValidRowModel = any> = R;
+export type GridRowModel<R extends GridValidRowModel = GridValidRowModel> = R;
 
 export type GridUpdateAction = 'delete';
 
@@ -89,14 +89,14 @@ export interface GridRowsMeta {
 
 export type GridRowTreeConfig = Record<GridRowId, GridRowTreeNodeConfig>;
 
-export type GridRowsLookup<R extends GridValidRowModel = any> = Record<GridRowId, R>;
+export type GridRowsLookup<R extends GridValidRowModel = GridValidRowModel> = Record<GridRowId, R>;
 
 /**
  * The type of Id supported by the grid.
  */
 export type GridRowId = string | number;
 
-export interface GridRowEntry<R extends GridValidRowModel = any> {
+export interface GridRowEntry<R extends GridValidRowModel = GridValidRowModel> {
   /**
    * The row id.
    */
@@ -110,4 +110,6 @@ export interface GridRowEntry<R extends GridValidRowModel = any> {
 /**
  * The function to retrieve the id of a [[GridRowModel]].
  */
-export type GridRowIdGetter<R extends GridValidRowModel = any> = (row: R) => GridRowId;
+export type GridRowIdGetter<R extends GridValidRowModel = GridValidRowModel> = (
+  row: R,
+) => GridRowId;


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/pull/5214#discussion_r939047535 

It makes much more sense to always treat grid row model as an object rather than `any`