### PR TITLE
[pickers] fix to trigger `onChange` when clearing not empty value

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -536,6 +536,31 @@ describe('<DesktopDatePicker />', () => {
       expect(onChange.callCount).to.equal(2);
     });
 
+    it('should call onChange only once with empty value and reset input value when pressing the "OK" (accept) button after entering invalid date manually', () => {
+      const onChange = spy();
+      const initialValue = adapterToUse.date(new Date(2018, 0, 1));
+
+      render(
+        <WrappedDesktopDatePicker
+          onChange={onChange}
+          initialValue={initialValue}
+          componentsProps={{ actionBar: { actions: ['accept'] } }}
+        />,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '13/01/2018' } });
+
+      openPicker({ type: 'date', variant: 'desktop' });
+      fireEvent.click(screen.getByText(/ok/i));
+      expect(onChange.callCount).to.equal(2);
+      expect(onChange.lastCall.args[0]).to.equal(null);
+      expect(screen.getByRole('textbox')).to.have.value('');
+
+      openPicker({ type: 'date', variant: 'desktop' });
+      fireEvent.click(screen.getByText(/ok/i));
+      expect(onChange.callCount).to.equal(2);
+    });
+
     it('should not call onChange or onAccept when pressing "Clear" button with an already null value', () => {
       const onChange = spy();
       const onAccept = spy();

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -511,6 +511,31 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
 
+    it('should call onChange only once with empty value and reset input value when pressing the "Clear" button after entering invalid date manually', () => {
+      const onChange = spy();
+      const initialValue = adapterToUse.date(new Date(2018, 0, 1));
+
+      render(
+        <WrappedDesktopDatePicker
+          onChange={onChange}
+          initialValue={initialValue}
+          componentsProps={{ actionBar: { actions: ['clear'] } }}
+        />,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: '13/01/2018' } });
+
+      openPicker({ type: 'date', variant: 'desktop' });
+      fireEvent.click(screen.getByText(/clear/i));
+      expect(onChange.callCount).to.equal(2);
+      expect(onChange.lastCall.args[0]).to.equal(null);
+      expect(screen.getByRole('textbox')).to.have.value('');
+
+      openPicker({ type: 'date', variant: 'desktop' });
+      fireEvent.click(screen.getByText(/clear/i));
+      expect(onChange.callCount).to.equal(2);
+    });
+
     it('should not call onChange or onAccept when pressing "Clear" button with an already null value', () => {
       const onChange = spy();
       const onAccept = spy();

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -277,7 +277,12 @@ export const usePickerState = <TInputValue, TValue, TDate>(
       },
       onAccept: () => {
         // Set all date in state to equal the current draft value and close picker.
-        setDate({ value: dateState.draft, action: 'acceptAndClose' });
+        setDate({
+          value: dateState.draft,
+          action: 'acceptAndClose',
+          // force `onChange` in cases like input (value) === `Invalid date`
+          forceOnChangeCall: !valueManager.areValuesEqual(utils, value as any, parsedDateValue),
+        });
       },
       onDismiss: () => {
         // Set all dates in state to equal the last committed date.
@@ -294,16 +299,7 @@ export const usePickerState = <TInputValue, TValue, TDate>(
         setDate({ value: valueManager.getTodayValue(utils), action: 'acceptAndClose' });
       },
     }),
-    [
-      isOpen,
-      setDate,
-      valueManager,
-      value,
-      dateState.draft,
-      dateState.committed,
-      dateState.resetFallback,
-      utils,
-    ],
+    [setDate, isOpen, utils, dateState, valueManager, value, parsedDateValue],
   );
 
   // Mobile keyboard view is a special case.


### PR DESCRIPTION
Fixes #5690 

Force trigger an `onChange` call when clicking `clear` button with not empty `value`.
Covers case, when date picker has `Invalid date` due to manual entry, but internally the state is saved as `null` already.

Simply adding a check in `setDate` function causes inconsistent behaviour, where simply closing the picker would also reset an invalid value.