### PR TITLE
[DataGrid] Fix Enter causing Select to re-open when commiting value

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/editComponents.DataGridPro.new.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/editComponents.DataGridPro.new.test.tsx
@@ -573,6 +573,30 @@ describe('<DataGridPro /> - Edit Components', () => {
       expect(onValueChange.callCount).to.equal(1);
       expect(onValueChange.lastCall.args[1]).to.equal('Adidas');
     });
+
+    it('should not open the suggestions when Enter is pressed', async () => {
+      let resolveCallback: () => void;
+      const processRowUpdate = (newRow: any) =>
+        new Promise((resolve) => {
+          resolveCallback = () => resolve(newRow);
+        });
+
+      defaultData.columns[0].renderEditCell = (params) => renderEditSingleSelectCell(params);
+
+      render(<TestCase processRowUpdate={processRowUpdate} />);
+
+      const cell = getCell(0, 0);
+      fireEvent.doubleClick(cell);
+      fireEvent.mouseUp(screen.queryAllByRole('option')[1]);
+      fireEvent.click(screen.queryAllByRole('option')[1]);
+      clock.runToLast();
+      expect(screen.queryByRole('listbox')).to.equal(null);
+      fireEvent.keyDown(screen.queryByRole('button', { name: 'Adidas' }), { key: 'Enter' });
+      expect(screen.queryByRole('listbox')).to.equal(null);
+
+      resolveCallback!();
+      await act(() => Promise.resolve());
+    });
   });
 
   describe('column type: boolean', () => {

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -44,6 +44,10 @@ export interface GridEditSingleSelectCellProps
   initialOpen?: boolean;
 }
 
+function isKeyboardEvent(event: any): event is React.KeyboardEvent {
+  return !!event.key;
+}
+
 function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
   const rootProps = useGridRootProps();
   const {
@@ -152,7 +156,10 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
     }
   };
 
-  const handleOpen = () => {
+  const handleOpen: SelectProps['onOpen'] = (event) => {
+    if (isKeyboardEvent(event) && event.key === 'Enter') {
+      return;
+    }
     setOpen(true);
   };
 


### PR DESCRIPTION
Before: https://codesandbox.io/s/data-grid-community-forked-377psb?file=/src/App.tsx
After: https://codesandbox.io/s/data-grid-community-forked-j4g4y9?file=/src/App.tsx

Fixes #4702