### PR TITLE
[time picker] set clock focus outline to `none`

### DIFF
--- a/packages/x-date-pickers/src/ClockPicker/Clock.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/Clock.tsx
@@ -53,6 +53,12 @@ const ClockClock = styled('div')({
   pointerEvents: 'none',
 });
 
+const ClockWrapper = styled('div')({
+  '&:focus': {
+    outline: 'none',
+  },
+});
+
 type ClockSquareMaskOwnerState = {
   disabled?: ClockProps<any>['disabled'];
 };
@@ -285,7 +291,7 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
             )}
           </React.Fragment>
         )}
-        <div
+        <ClockWrapper
           aria-activedescendant={selectedId}
           aria-label={getClockLabelText(type, date, utils)}
           ref={listboxRef}
@@ -294,7 +300,7 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
           tabIndex={0}
         >
           {children}
-        </div>
+        </ClockWrapper>
       </ClockClock>
       {ampm && (wrapperVariant === 'desktop' || ampmInClock) && (
         <React.Fragment>


### PR DESCRIPTION
Fixes #5694 

Safari sometimes (like toggling element inspector with keyboard shortcut) shows focus outline on time picker clock numbers.

Explicitly specifying
```css
:focus: {
  outline: 'none';
}
```
on clock root element (listbox) avoids this unwanted behaviour.

See the attached video with comparison example.

https://user-images.githubusercontent.com/4941090/184104388-0621ef53-3bd8-460a-a30c-90752c31fb8e.mov

