### PR TITLE
[DatePicker] Support click on day outside of current month

### DIFF
--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -209,7 +209,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
     onFocus,
     onKeyDown,
     onMouseDown,
-    onMouseUp,
     outsideCurrentMonth,
     selected = false,
     showDaysOutsideCurrentMonth = false,
@@ -256,6 +255,10 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!disabled) {
       onDaySelect(day, 'finish');
+    }
+
+    if (outsideCurrentMonth) {
+      event.currentTarget.focus();
     }
 
     if (onClick) {
@@ -327,14 +330,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       event.preventDefault();
     }
   };
-  const handleMouseUp = (event) => {
-    if (onMouseUp) {
-      onMouseUp(event);
-    }
-    if (outsideCurrentMonth) {
-      event.target.focus();
-    }
-  };
 
   return (
     <PickersDayRoot
@@ -350,7 +345,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       onKeyDown={handleKeyDown}
       onClick={handleClick}
       onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
       {...other}
     >
       {!children ? utils.format(day, 'dayOfMonth') : children}

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -208,6 +208,8 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
     onDaySelect,
     onFocus,
     onKeyDown,
+    onMouseDown,
+    onMouseUp,
     outsideCurrentMonth,
     selected = false,
     showDaysOutsideCurrentMonth = false,
@@ -315,6 +317,25 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
     );
   }
 
+  // For day outside of current month, move focus from mouseDown to mouseUp
+  // Goal: have the onClick ends before sliding to the new month
+  const handleMouseDown = (event) => {
+    if (onMouseDown) {
+      onMouseDown(event);
+    }
+    if (outsideCurrentMonth) {
+      event.preventDefault();
+    }
+  };
+  const handleMouseUp = (event) => {
+    if (onMouseUp) {
+      onMouseUp(event);
+    }
+    if (outsideCurrentMonth) {
+      event.target.focus();
+    }
+  };
+
   return (
     <PickersDayRoot
       className={clsx(classes.root, className)}
@@ -328,6 +349,8 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       onFocus={handleFocus}
       onKeyDown={handleKeyDown}
       onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
       {...other}
     >
       {!children ? utils.format(day, 'dayOfMonth') : children}

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -252,6 +252,17 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
     }
   };
 
+  // For day outside of current month, move focus from mouseDown to mouseUp
+  // Goal: have the onClick ends before sliding to the new month
+  const handleMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (onMouseDown) {
+      onMouseDown(event);
+    }
+    if (outsideCurrentMonth) {
+      event.preventDefault();
+    }
+  };
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!disabled) {
       onDaySelect(day, 'finish');
@@ -319,17 +330,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       />
     );
   }
-
-  // For day outside of current month, move focus from mouseDown to mouseUp
-  // Goal: have the onClick ends before sliding to the new month
-  const handleMouseDown = (event) => {
-    if (onMouseDown) {
-      onMouseDown(event);
-    }
-    if (outsideCurrentMonth) {
-      event.preventDefault();
-    }
-  };
 
   return (
     <PickersDayRoot


### PR DESCRIPTION
Fix #5570

It's a simpler alternative to PR #5598

This issue is a bit tricky because it has animations

The problem is the following:

When pressing mousse down, the focus moves to the day, which triggers the sliding of the month (that's logical)
When mouse up occurs, the element under the mouse might not be the same (due to the sliding of the calendar) so the click event is not triggered (click = down and up on the same element)

Proposed solution:

Prevent the default behavior on move down to avoid putting focus on the day, which triggers the scrolling
The focus is restored to the new button when finishing the `click`