### PR TITLE
[core] Upgrade monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@types/react": "^17.0.48",
     "@types/react-dom": "^18.0.6",
     "@types/requestidlecallback": "^0.3.4",
-    "@types/sinon": "^10.0.12",
+    "@types/sinon": "^10.0.13",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",

--- a/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
+++ b/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
@@ -15,8 +15,6 @@ import {
 export interface YearProps {
   autoFocus?: boolean;
   children: React.ReactNode;
-  // The below line triggers a false-positive ESLint error - `classes` are used below.
-  // eslint-disable-next-line react/no-unused-prop-types
   classes?: {
     root?: string;
     modeDesktop?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4796,10 +4796,10 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/sinon@^10.0.12":
-  version "10.0.12"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.12.tgz#fb7009ea71f313a9da4644ba73b94e44d6b84f7f"
-  integrity sha512-uWf4QJ4oky/GckJ1MYQxU52cgVDcXwBhDkpvLbi4EKoLPqLE4MOH6T/ttM33l3hi0oZ882G6oIzWv/oupRYSxQ==
+"@types/sinon@^10.0.13":
+  version "10.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.13.tgz#60a7a87a70d9372d0b7b38cc03e825f46981fb83"
+  integrity sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,8 +2670,8 @@
     react-transition-group "^4.4.2"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.9.1"
-  resolved "https://github.com/mui/material-ui.git#ac89270144071abde6b40ca4e80c961889f8734a"
+  version "5.10.0"
+  resolved "https://github.com/mui/material-ui.git#7b945c739335dfe741f068d1199f16d3155e3a5e"
 
 "@mui/private-theming@^5.8.0", "@mui/private-theming@^5.9.3":
   version "5.9.3"


### PR DESCRIPTION
To pull https://github.com/mui/material-ui/pull/33756 and potentially other fixes

This PR upgrades `@types/sinon` for TS to compile without errors, so it supersedes https://github.com/mui/mui-x/pull/5571