### PR TITLE
[docs] Fix API anchor link scroll top

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -197,13 +197,11 @@ function getTranslatedHeader(t, header) {
 function Heading(props) {
   const { hash, level: Level = 'h2' } = props;
   const t = useTranslate();
-  const headingId = `heading-${hash}`;
 
   return (
-    <Level id={headingId}>
-      <span className="anchor-link" id={hash} />
+    <Level id={hash}>
       {getTranslatedHeader(t, hash)}
-      <a aria-labelledby={headingId} className="anchor-link-style" href={`#${hash}`} tabIndex={-1}>
+      <a aria-labelledby={hash} className="anchor-link-style" href={`#${hash}`} tabIndex={-1}>
         <svg>
           <use xlinkHref="#anchor-link-icon" />
         </svg>


### PR DESCRIPTION
Open https://mui.com/x/api/data-grid/data-grid/#slots and see how the scroll top is wrong:

<img width="1098" alt="Screenshot 2022-08-15 at 01 02 35" src="https://user-images.githubusercontent.com/3165635/184558058-c4d4d696-42c2-41b6-989e-17ffb06617f8.png">

I broke it in https://github.com/mui/material-ui/pull/32844. The solution is to replace the same changes here.

Preview: https://deploy-preview-5795--material-ui-x.netlify.app/x/api/data-grid/data-grid/#slots