### PR TITLE
[Pickers] Add `className` prop to `PickersActionBar`

### DIFF
--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -22,10 +22,11 @@ export interface PickersActionBarProps {
   onClear: () => void;
   onCancel: () => void;
   onSetToday: () => void;
+  className?: string;
 }
 
 export const PickersActionBar = (props: PickersActionBarProps) => {
-  const { onAccept, onClear, onCancel, onSetToday, actions } = props;
+  const { onAccept, onClear, onCancel, onSetToday, actions, className } = props;
   const wrapperVariant = React.useContext(WrapperVariantContext);
 
   const localeText = useLocaleText();
@@ -67,5 +68,5 @@ export const PickersActionBar = (props: PickersActionBarProps) => {
     }
   });
 
-  return <DialogActions>{buttons}</DialogActions>;
+  return <DialogActions className={className}>{buttons}</DialogActions>;
 };

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Button from '@mui/material/Button';
-import DialogActions from '@mui/material/DialogActions';
+import DialogActions, { DialogActionsProps } from '@mui/material/DialogActions';
 import { useLocaleText } from '../internals/hooks/useUtils';
 import {
   WrapperVariant,
@@ -9,7 +9,7 @@ import {
 
 export type PickersActionBarAction = 'clear' | 'cancel' | 'accept' | 'today';
 
-export interface PickersActionBarProps {
+export interface PickersActionBarProps extends DialogActionsProps {
   /**
    * Ordered array of actions to display.
    * If empty, does not display that action bar.
@@ -22,11 +22,10 @@ export interface PickersActionBarProps {
   onClear: () => void;
   onCancel: () => void;
   onSetToday: () => void;
-  className?: string;
 }
 
 export const PickersActionBar = (props: PickersActionBarProps) => {
-  const { onAccept, onClear, onCancel, onSetToday, actions, className } = props;
+  const { onAccept, onClear, onCancel, onSetToday, actions, ...other } = props;
   const wrapperVariant = React.useContext(WrapperVariantContext);
 
   const localeText = useLocaleText();
@@ -68,5 +67,5 @@ export const PickersActionBar = (props: PickersActionBarProps) => {
     }
   });
 
-  return <DialogActions className={className}>{buttons}</DialogActions>;
+  return <DialogActions {...other}>{buttons}</DialogActions>;
 };


### PR DESCRIPTION
Fix #5779 

The component did not support accepting `className` and was unable to process usages of `styled(PickersActionBar)` correctly.

Enables using `styled(PickersActionBar)` to provide custom styles