### PR TITLE
[pickers] Add a breaking change section in the migration guide

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -131,4 +131,4 @@ import bgLocale from 'date-fns/locale/bg';
 You can [find the source](https://github.com/mui/mui-x/tree/HEAD/packages/x-date-pickers/src/locales) in the GitHub repository.
 
 To create your own translation or to customize the English text, copy this file to your project, make any changes needed and import the locale from there.
-Note that these translations of the Data grid component depend on the [Localization strategy](/material-ui/guides/localization/) of the whole library.
+Note that these translations of the date and time picker components depend on the [Localization strategy](/material-ui/guides/localization/) of the whole library.

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -108,7 +108,7 @@ The props of `MonthPicker`, `YearPicker` and `DayPicker` have been reworked to m
 #### Translation
 
 Props for translation have been either deprecated or removed in favor of a [global localization](/x/react-date-pickers/localization/) similar to the one used by the data grid.
-We already have nine translations provided by the community.
+We already have nine locales provided by the community.
 
 #### Use slot for `ActionBar`
 

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -81,3 +81,60 @@ Which will transform the imports like this:
 
 Components of the Community Plan such as `<DatePicker />` can be imported from both `@mui/x-date-pickers-pro` and `@mui/x-date-pickers`.
 Only [date adapters](/x/react-date-pickers/getting-started/#setup) such as `AdapterDayjs` can only be imported from `@mui/x-date-pickers/[adapterName]`.
+
+### 3. Handle breaking changes introduced in alpha
+
+#### Props renaming
+
+The `disableCloseOnSelect` prop has been replaced by a new `closeOnSelect` prop which has the opposite behavior.
+The default behavior remains the same (close after the last step on desktop but not on mobile).
+
+```diff
+// If you don't want to close after the last step
+-<DatePicker disableCloseOnSelect={false} />
++<DatePicker closeOnSelect />
+
+// If you want to close after the last step
+-<DatePicker disableCloseOnSelect />
++<DatePicker closeOnSelect={false} />
+```
+
+The props of `MonthPicker`, `YearPicker` and `DayPicker` have been reworked to make them more consistent for a standalone usage.
+
+- **MonthPicker**: The prop `onMonthChange` has been removed, you can use `onChange` instead since every change is a month change.
+- **YearPicker**: The prop `onYearPicker` has been removed, you can use `onChange` instead since every change is a year change.
+- **DayPicker**: The prop `isDateDisabled` has been removed, you can now use the same validation props as for the other components (`maxDate`, `minDate`, `shouldDisableDate`, `disableFuture` and `disablePast`).
+
+#### Translation
+
+Props for translation have been either deprecated or removed in favor of a [global localization](/x/react-date-pickers/localization/) similar to the one used by the data grid.
+We already have nine translations provided by the community.
+
+#### Use slot for `ActionBar`
+
+The props related to the action bar buttons (`clearable`, `showTodayButton`, `cancelText`, `okText`) have been removed.
+
+To decide which button must be displayed and in which order, you can now use the `actions` prop of the `actionBar` component slot props.
+
+```jsx
+<DatePicker
+  componentsProps={{
+    actionBar: {
+      // The actions will be the same between desktop and mobile
+      actions: ['clear'],
+
+      // The actions will be different between desktop and mobile
+      actions: (variant) => (variant === 'desktop' ? [] : ['clear']),
+    },
+  }}
+/>
+```
+
+The build-in `ActionBar` component supports 4 different actions: `'clear'`, `'cancel'`, `'accept'`, and `'today'`.
+By default, the pickers will render the cancel and accept button on mobile and no action on desktop.
+
+If you need other actions, you can provide your own component to the `ActionBar` component slot
+
+```jsx
+<DatePicker components={{ ActionBar: CustomActionBar }} />
+```

--- a/docs/data/date-pickers/migration-lab/migration-lab.md
+++ b/docs/data/date-pickers/migration-lab/migration-lab.md
@@ -84,6 +84,11 @@ Only [date adapters](/x/react-date-pickers/getting-started/#setup) such as `Adap
 
 ### 3. Handle breaking changes introduced in alpha
 
+During the migration from `@mui/lab` to MUI X, we've focused on enhancing stability and developer experience.
+Some APIs were improved to be more coherent and customizable.
+
+Please check the complete list of the API changes before migrating from `@mui/x-date-pickers` 5.0.0-alpha.0 to the last v5.0.0.
+
 #### Props renaming
 
 The `disableCloseOnSelect` prop has been replaced by a new `closeOnSelect` prop which has the opposite behavior.
@@ -108,7 +113,7 @@ The props of `MonthPicker`, `YearPicker` and `DayPicker` have been reworked to m
 #### Translation
 
 Props for translation have been either deprecated or removed in favor of a [global localization](/x/react-date-pickers/localization/) similar to the one used by the data grid.
-We already have nine locales provided by the community.
+We already have ten locales provided by the community. (Thank you!)
 
 #### Use slot for `ActionBar`
 


### PR DESCRIPTION
Fix #5599

We introduced breaking changes in alpha phase that should be introduced in the migration guide, otherwise someone doing the migration will get non working code because of them

[Page preview](https://deploy-preview-5805--material-ui-x.netlify.app/x/react-date-pickers/migration-lab/#3-handle-breaking-changes-introduced-in-alpha)