### PR TITLE
[DatePicker] Improve `a11y` support

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -180,7 +180,10 @@ export function DateRangePickerViewDesktop<TDate>(props: DesktopDateRangeCalenda
         const monthOnIteration = utils.setMonth(currentMonth, utils.getMonth(currentMonth) + index);
 
         return (
-          <DateRangePickerViewDesktopContainer key={index}>
+          <DateRangePickerViewDesktopContainer
+            key={index}
+            data-mui-test={`date-range-picker-${index}`}
+          >
             <DateRangePickerViewDesktopArrowSwitcher
               onLeftClick={selectPreviousMonth}
               onRightClick={selectNextMonth}

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -180,10 +180,7 @@ export function DateRangePickerViewDesktop<TDate>(props: DesktopDateRangeCalenda
         const monthOnIteration = utils.setMonth(currentMonth, utils.getMonth(currentMonth) + index);
 
         return (
-          <DateRangePickerViewDesktopContainer
-            key={index}
-            data-mui-test={`date-range-picker-${index}`}
-          >
+          <DateRangePickerViewDesktopContainer key={index}>
             <DateRangePickerViewDesktopArrowSwitcher
               onLeftClick={selectPreviousMonth}
               onRightClick={selectNextMonth}

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -245,7 +245,6 @@ const DateRangePickerDayRaw = React.forwardRef(function DateRangePickerDay<TDate
       ownerState={ownerState}
     >
       <DateRangePickerDayRangeIntervalPreview
-        role="cell"
         data-mui-test={shouldRenderPreview ? 'DateRangePreview' : undefined}
         className={classes.rangeIntervalPreview}
         ownerState={ownerState}

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, screen, fireEvent, userEvent, act } from '@mui/monorepo/test/utils';
+import {
+  describeConformance,
+  screen,
+  fireEvent,
+  userEvent,
+  act,
+  getByRole,
+} from '@mui/monorepo/test/utils';
 import TextField from '@mui/material/TextField';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
@@ -25,6 +32,9 @@ const WrappedDesktopDateRangePicker = withPickerControls(DesktopDateRangePicker)
     </React.Fragment>
   ),
 });
+
+const getPickerDay = (name: string, picker = '0') =>
+  getByRole(screen.getByMuiTest(`date-range-picker-${picker}`), 'gridcell', { name });
 
 describe('<DesktopDateRangePicker />', () => {
   const { render, clock } = createPickerRenderer({
@@ -116,14 +126,15 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      fireEvent.click(screen.getByLabelText('Jan 1, 2019'));
+      fireEvent.click(getPickerDay('1'));
       // FIXME use `getByRole(role, {hidden: false})` and skip JSDOM once this suite can run in JSDOM
       const [visibleButton] = screen.getAllByRole('button', {
         hidden: true,
         name: 'Next month',
       });
       fireEvent.click(visibleButton);
-      fireEvent.click(screen.getByLabelText('Mar 19, 2019'));
+      clock.runToLast();
+      fireEvent.click(getPickerDay('19', '1'));
 
       expect(handleChange.callCount).to.equal(1);
       const [changedRange] = handleChange.lastCall.args;
@@ -143,12 +154,12 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      fireEvent.click(screen.getByLabelText('Jan 30, 2019'));
-      fireEvent.click(screen.getByLabelText('Jan 19, 2019'));
+      fireEvent.click(getPickerDay('30'));
+      fireEvent.click(getPickerDay('19'));
 
       expect(screen.queryByMuiTest('DateRangeHighlight')).to.equal(null);
 
-      fireEvent.click(screen.getByLabelText('Jan 30, 2019'));
+      fireEvent.click(getPickerDay('30'));
 
       expect(handleChange.callCount).to.equal(3);
       const [changedRange] = handleChange.lastCall.args;
@@ -472,13 +483,13 @@ describe('<DesktopDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the start date
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(getPickerDay('3'));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(initialValue[1]);
 
       // Change the end date
-      userEvent.mousePress(screen.getByLabelText('Jan 5, 2018'));
+      userEvent.mousePress(getPickerDay('5'));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 5));
@@ -514,7 +525,7 @@ describe('<DesktopDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the end date
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(getPickerDay('3'));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(initialValue[0]);
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 3));
@@ -544,7 +555,7 @@ describe('<DesktopDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'end' });
 
       // Change the end date
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(getPickerDay('3'));
 
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
@@ -571,7 +582,7 @@ describe('<DesktopDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
       // Change the start date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(getPickerDay('3'));
 
       // Dismiss the picker
       // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target -- don't care
@@ -629,7 +640,7 @@ describe('<DesktopDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
       // Change the start date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(getPickerDay('3'));
 
       // Dismiss the picker
       userEvent.mousePress(document.body);
@@ -713,7 +724,7 @@ describe('<DesktopDateRangePicker />', () => {
       expect(screen.getByRole('tooltip')).toBeVisible();
 
       // Change the start date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(getPickerDay('3'));
 
       fireEvent.blur(screen.getAllByRole('textbox')[0]);
       clock.runToLast();
@@ -844,11 +855,11 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      expect(screen.getByLabelText('Jan 8, 2018')).to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 9, 2018')).to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 10, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 11, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 11, 2018')).not.to.have.attribute('disabled');
+      expect(getPickerDay('8')).to.have.attribute('disabled');
+      expect(getPickerDay('9')).to.have.attribute('disabled');
+      expect(getPickerDay('10')).not.to.have.attribute('disabled');
+      expect(getPickerDay('11')).not.to.have.attribute('disabled');
+      expect(getPickerDay('12')).not.to.have.attribute('disabled');
     });
 
     it('should respect the disableFuture prop', () => {
@@ -856,11 +867,11 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      expect(screen.getByLabelText('Jan 8, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 9, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 10, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 11, 2018')).to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 12, 2018')).to.have.attribute('disabled');
+      expect(getPickerDay('8')).not.to.have.attribute('disabled');
+      expect(getPickerDay('9')).not.to.have.attribute('disabled');
+      expect(getPickerDay('10')).not.to.have.attribute('disabled');
+      expect(getPickerDay('11')).to.have.attribute('disabled');
+      expect(getPickerDay('12')).to.have.attribute('disabled');
     });
 
     it('should respect the minDate prop', () => {
@@ -873,11 +884,11 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      expect(screen.getByLabelText('Jan 13, 2018')).to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 14, 2018')).to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 15, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 16, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 17, 2018')).not.to.have.attribute('disabled');
+      expect(getPickerDay('13')).to.have.attribute('disabled');
+      expect(getPickerDay('14')).to.have.attribute('disabled');
+      expect(getPickerDay('15')).not.to.have.attribute('disabled');
+      expect(getPickerDay('16')).not.to.have.attribute('disabled');
+      expect(getPickerDay('17')).not.to.have.attribute('disabled');
     });
 
     it('should respect the maxDate prop', () => {
@@ -890,11 +901,11 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      expect(screen.getByLabelText('Jan 13, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 14, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 15, 2018')).not.to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 16, 2018')).to.have.attribute('disabled');
-      expect(screen.getByLabelText('Jan 17, 2018')).to.have.attribute('disabled');
+      expect(getPickerDay('13')).not.to.have.attribute('disabled');
+      expect(getPickerDay('14')).not.to.have.attribute('disabled');
+      expect(getPickerDay('15')).not.to.have.attribute('disabled');
+      expect(getPickerDay('16')).to.have.attribute('disabled');
+      expect(getPickerDay('17')).to.have.attribute('disabled');
     });
   });
 });

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -33,8 +33,8 @@ const WrappedDesktopDateRangePicker = withPickerControls(DesktopDateRangePicker)
   ),
 });
 
-const getPickerDay = (name: string, picker = '0') =>
-  getByRole(screen.getByMuiTest(`date-range-picker-${picker}`), 'gridcell', { name });
+const getPickerDay = (name: string, picker = 'January 2018') =>
+  getByRole(screen.getByText(picker)?.parentElement?.parentElement, 'gridcell', { name });
 
 describe('<DesktopDateRangePicker />', () => {
   const { render, clock } = createPickerRenderer({
@@ -126,7 +126,7 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      fireEvent.click(getPickerDay('1'));
+      fireEvent.click(getPickerDay('1', 'January 2019'));
       // FIXME use `getByRole(role, {hidden: false})` and skip JSDOM once this suite can run in JSDOM
       const [visibleButton] = screen.getAllByRole('button', {
         hidden: true,
@@ -134,7 +134,7 @@ describe('<DesktopDateRangePicker />', () => {
       });
       fireEvent.click(visibleButton);
       clock.runToLast();
-      fireEvent.click(getPickerDay('19', '1'));
+      fireEvent.click(getPickerDay('19', 'March 2019'));
 
       expect(handleChange.callCount).to.equal(1);
       const [changedRange] = handleChange.lastCall.args;
@@ -154,12 +154,12 @@ describe('<DesktopDateRangePicker />', () => {
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
-      fireEvent.click(getPickerDay('30'));
-      fireEvent.click(getPickerDay('19'));
+      fireEvent.click(getPickerDay('30', 'January 2019'));
+      fireEvent.click(getPickerDay('19', 'January 2019'));
 
       expect(screen.queryByMuiTest('DateRangeHighlight')).to.equal(null);
 
-      fireEvent.click(getPickerDay('30'));
+      fireEvent.click(getPickerDay('30', 'January 2019'));
 
       expect(handleChange.callCount).to.equal(3);
       const [changedRange] = handleChange.lastCall.args;

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
@@ -99,13 +99,13 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the start date
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '3' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(initialValue[1]);
 
       // Change the end date
-      userEvent.mousePress(screen.getByLabelText('Jan 5, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '5' }));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(new Date(2018, 0, 3));
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 5));
@@ -139,7 +139,7 @@ describe('<MobileDateRangePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the end date
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '3' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0][0]).toEqualDateTime(initialValue[0]);
       expect(onChange.lastCall.args[0][1]).toEqualDateTime(new Date(2018, 0, 3));
@@ -167,7 +167,7 @@ describe('<MobileDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'end' });
 
       // Change the end date
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '3' }));
 
       expect(onAccept.callCount).to.equal(1);
       expect(onAccept.lastCall.args[0][0]).toEqualDateTime(initialValue[0]);
@@ -197,7 +197,7 @@ describe('<MobileDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
 
       // Change the start date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '3' }));
 
       // Cancel the modifications
       userEvent.mousePress(screen.getByText(/cancel/i));
@@ -229,7 +229,7 @@ describe('<MobileDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
 
       // Change the start date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 3, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '3' }));
 
       // Accept the modifications
       userEvent.mousePress(screen.getByText(/ok/i));

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -75,7 +75,9 @@ describe('<StaticDateRangePicker />', () => {
 
     // It should follow https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html
     expect(
-      document.querySelector('[role="grid"] > [role="row"] [role="cell"] > button'),
+      document.querySelector(
+        '[role="grid"] [role="rowgroup"] > [role="row"] button[role="gridcell"]',
+      ),
     ).to.have.text('1');
   });
 });

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  fireEvent,
-  userEvent,
-  screen,
-  describeConformance,
-  getAllByRole,
-} from '@mui/monorepo/test/utils';
+import { fireEvent, userEvent, screen, describeConformance } from '@mui/monorepo/test/utils';
 import {
   CalendarPicker,
   calendarPickerClasses as classes,
@@ -77,7 +71,9 @@ describe('<CalendarPicker />', () => {
     fireEvent.click(screen.getByTitle('Next month'));
     expect(onMonthChangeMock.callCount).to.equal(2);
 
-    fireEvent.click(screen.getByLabelText(/Jan 5, 2019/i));
+    clock.runToLast();
+
+    fireEvent.click(screen.getByRole('gridcell', { name: '5' }));
     expect(onChangeMock.callCount).to.equal(0);
 
     fireEvent.click(screen.getByText('January 2019'));
@@ -106,7 +102,7 @@ describe('<CalendarPicker />', () => {
     fireEvent.click(screen.getByTitle('Next month'));
     expect(onMonthChangeMock.callCount).to.equal(0);
 
-    fireEvent.click(screen.getByLabelText(/Jan 5, 2019/i));
+    fireEvent.click(screen.getByRole('gridcell', { name: '5' }));
     expect(onChangeMock.callCount).to.equal(0);
   });
 
@@ -123,11 +119,12 @@ describe('<CalendarPicker />', () => {
     );
 
     // days are disabled
-    const daysContainer = screen.getByRole('grid');
-    const days = getAllByRole(daysContainer, 'button');
-    const disabledDays = days.filter((day) => day.getAttribute('disabled') !== null);
+    const cells = screen.getAllByRole('gridcell');
+    const disabledDays = cells.filter(
+      (cell) => cell.getAttribute('disabled') !== null && cell.tagName === 'BUTTON',
+    );
 
-    expect(days.length).to.equal(31);
+    expect(cells.length).to.equal(35);
     expect(disabledDays.length).to.equal(31);
   });
 
@@ -185,7 +182,9 @@ describe('<CalendarPicker />', () => {
       expect(screen.getAllByMuiTest('day')).to.have.length(31);
       // It should follow https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html
       expect(
-        document.querySelector('[role="grid"] > [role="row"] > [role="cell"] > button'),
+        document.querySelector(
+          '[role="grid"] [role="rowgroup"] > [role="row"] button[role="gridcell"]',
+        ),
       ).to.have.text('1');
     });
 
@@ -201,7 +200,7 @@ describe('<CalendarPicker />', () => {
         />,
       );
 
-      userEvent.mousePress(screen.getByLabelText('Jan 2, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '2' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 2));
     });
@@ -218,7 +217,7 @@ describe('<CalendarPicker />', () => {
         />,
       );
 
-      userEvent.mousePress(screen.getByLabelText('Jan 2, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '2' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(
         adapterToUse.date(new Date(2018, 0, 2, 11, 11, 11)),

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
-import useId from '@mui/utils/useId';
+import { unstable_useId as useId } from '@mui/material/utils';
 import { MonthPicker, MonthPickerProps } from '../MonthPicker/MonthPicker';
 import { useCalendarState } from './useCalendarState';
 import { useDefaultDates, useUtils } from '../internals/hooks/useUtils';

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
+import useId from '@mui/utils/useId';
 import { MonthPicker, MonthPickerProps } from '../MonthPicker/MonthPicker';
 import { useCalendarState } from './useCalendarState';
 import { useDefaultDates, useUtils } from '../internals/hooks/useUtils';
@@ -177,6 +178,7 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const utils = useUtils<TDate>();
+  const id = useId();
   const defaultDates = useDefaultDates<TDate>();
 
   const props = useThemeProps({
@@ -381,6 +383,8 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
     disabled,
   };
 
+  const gridLabelId = `${id}-grid-label`;
+
   return (
     <CalendarPickerRoot ref={ref} className={clsx(classes.root, className)} ownerState={ownerState}>
       <PickersCalendarHeader
@@ -396,6 +400,7 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
         disablePast={disablePast}
         disableFuture={disableFuture}
         reduceAnimations={reduceAnimations}
+        labelId={gridLabelId}
       />
       <CalendarPickerViewTransitionContainer
         reduceAnimations={reduceAnimations}
@@ -442,6 +447,7 @@ const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
               loading={loading}
               renderLoading={renderLoading}
               shouldDisableDate={shouldDisableDate}
+              gridLabelId={gridLabelId}
             />
           )}
         </div>

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -213,13 +213,14 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
                   const isSelected = validSelectedDays.some((selectedDay) =>
                     utils.isSameDay(selectedDay, day),
                   );
+                  const isToday = utils.isSameDay(day, now);
                   const pickersDayProps: PickersDayProps<TDate> = {
                     key: (day as any)?.toString(),
                     day,
                     isAnimating: isMonthSwitchingAnimating,
                     disabled: disabled || isDateDisabled(day),
                     autoFocus: autoFocus && focusedDay !== null && utils.isSameDay(day, focusedDay),
-                    today: utils.isSameDay(day, now),
+                    today: isToday,
                     outsideCurrentMonth: utils.getMonth(day) !== currentMonthNumber,
                     selected: isSelected,
                     disableHighlightToday,
@@ -229,6 +230,9 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
                     role: 'gridcell',
                     'aria-selected': isSelected,
                   };
+                  if (isToday) {
+                    pickersDayProps['aria-current'] = 'date';
+                  }
 
                   return renderDay ? (
                     renderDay(day, validSelectedDays, pickersDayProps)

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -67,6 +67,7 @@ export interface DayPickerProps<TDate> extends ExportedDayPickerProps<TDate> {
   reduceAnimations: boolean;
   slideDirection: SlideDirection;
   TransitionProps?: Partial<SlideTransitionProps>;
+  gridLabelId?: string;
 }
 
 const defaultDayOfWeekFormatter = (day: string) => day.charAt(0).toUpperCase();
@@ -141,6 +142,7 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
     maxDate,
     shouldDisableDate,
     dayOfWeekFormatter = defaultDayOfWeekFormatter,
+    gridLabelId,
   } = props;
 
   const isDateDisabled = useIsDayDisabled({
@@ -171,12 +173,18 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
   const transitionKey = currentMonthNumber;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const slideNodeRef = React.useMemo(() => React.createRef<HTMLDivElement>(), [transitionKey]);
+  const startOfCurrentWeek = utils.startOfWeek(now);
 
   return (
-    <React.Fragment>
-      <PickersCalendarDayHeader>
+    <div role="grid" aria-labelledby={gridLabelId}>
+      <PickersCalendarDayHeader role="row">
         {utils.getWeekdays().map((day, i) => (
-          <PickersCalendarWeekDayLabel aria-hidden key={day + i.toString()} variant="caption">
+          <PickersCalendarWeekDayLabel
+            key={day + i.toString()}
+            variant="caption"
+            role="columnheader"
+            aria-label={utils.format(utils.addDays(startOfCurrentWeek, i), 'weekday')}
+          >
             {dayOfWeekFormatter?.(day) ?? day}
           </PickersCalendarWeekDayLabel>
         ))}
@@ -197,11 +205,14 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
           <PickersCalendarWeekContainer
             data-mui-test="pickers-calendar"
             ref={slideNodeRef}
-            role="grid"
+            role="rowgroup"
           >
             {utils.getWeekArray(currentMonth).map((week) => (
               <PickersCalendarWeek role="row" key={`week-${week[0]}`}>
                 {week.map((day) => {
+                  const isSelected = validSelectedDays.some((selectedDay) =>
+                    utils.isSameDay(selectedDay, day),
+                  );
                   const pickersDayProps: PickersDayProps<TDate> = {
                     key: (day as any)?.toString(),
                     day,
@@ -210,21 +221,19 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
                     autoFocus: autoFocus && focusedDay !== null && utils.isSameDay(day, focusedDay),
                     today: utils.isSameDay(day, now),
                     outsideCurrentMonth: utils.getMonth(day) !== currentMonthNumber,
-                    selected: validSelectedDays.some((selectedDay) =>
-                      utils.isSameDay(selectedDay, day),
-                    ),
+                    selected: isSelected,
                     disableHighlightToday,
                     showDaysOutsideCurrentMonth,
                     onDayFocus: onFocusedDayChange,
                     onDaySelect: handleDaySelect,
+                    role: 'gridcell',
+                    'aria-selected': isSelected,
                   };
 
                   return renderDay ? (
                     renderDay(day, validSelectedDays, pickersDayProps)
                   ) : (
-                    <div role="cell" key={pickersDayProps.key}>
-                      <PickersDay {...pickersDayProps} />
-                    </div>
+                    <PickersDay key={pickersDayProps.key} {...pickersDayProps} />
                   );
                 })}
               </PickersCalendarWeek>
@@ -232,6 +241,6 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
           </PickersCalendarWeekContainer>
         </PickersCalendarSlideTransition>
       )}
-    </React.Fragment>
+    </div>
   );
 }

--- a/packages/x-date-pickers/src/CalendarPicker/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/PickersCalendarHeader.tsx
@@ -66,6 +66,7 @@ export interface PickersCalendarHeaderProps<TDate>
   openView: CalendarPickerView;
   reduceAnimations: boolean;
   onViewChange?: (view: CalendarPickerView) => void;
+  labelId?: string;
 }
 
 const PickersCalendarHeaderRoot = styled('div')<{
@@ -141,6 +142,7 @@ export function PickersCalendarHeader<TDate>(props: PickersCalendarHeaderProps<T
     reduceAnimations,
     rightArrowButtonText: rightArrowButtonTextProp,
     views,
+    labelId,
   } = props;
 
   deprecatedPropsWarning({
@@ -199,13 +201,15 @@ export function PickersCalendarHeader<TDate>(props: PickersCalendarHeaderProps<T
         role="presentation"
         onClick={handleToggleView}
         ownerState={ownerState}
+        // putting this on the label item element below breaks when using transition
+        aria-live="polite"
       >
         <PickersFadeTransitionGroup
           reduceAnimations={reduceAnimations}
           transKey={utils.format(month, 'monthAndYear')}
         >
           <PickersCalendarHeaderLabelItem
-            aria-live="polite"
+            id={labelId}
             data-mui-test="calendar-month-and-year-text"
             ownerState={ownerState}
           >

--- a/packages/x-date-pickers/src/CalendarPicker/PickersSlideTransition.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/PickersSlideTransition.tsx
@@ -110,6 +110,7 @@ export const PickersSlideTransition = ({
           classNames: transitionClasses,
         })
       }
+      role="presentation"
     >
       <CSSTransition
         mountOnEnter

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { unstable_useId as useId } from '@mui/utils';
+import { unstable_useId as useId } from '@mui/material/utils';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { Clock } from './Clock';

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -313,7 +313,7 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the date
-      fireEvent.click(screen.getByLabelText('Jan 8, 2018'));
+      fireEvent.click(screen.getByRole('gridcell', { name: '8' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 8));
       expect(onAccept.callCount).to.equal(1);
@@ -339,14 +339,14 @@ describe('<DesktopDatePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 8));
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 6, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '6' }));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 6));
       expect(onAccept.callCount).to.equal(0);
@@ -372,7 +372,7 @@ describe('<DesktopDatePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
 
       // Dismiss the picker
       // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target -- don't care
@@ -427,7 +427,7 @@ describe('<DesktopDatePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
 
       // Dismiss the picker
       userEvent.mousePress(document.body);
@@ -602,7 +602,7 @@ describe('<DesktopDatePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
 
       // Change the date (same value)
-      userEvent.mousePress(screen.getByLabelText('Jan 1, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '1' }));
       expect(onChange.callCount).to.equal(0); // Don't call onChange since the value did not change
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(1);
@@ -633,7 +633,7 @@ describe('<DesktopDatePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the date (same value)
-      userEvent.mousePress(screen.getByLabelText('Jan 1, 2025'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '1' }));
       expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
       expect(onAccept.callCount).to.equal(1);
       expect(onAccept.lastCall.args[0]).toEqualDateTime(new Date(2025, 0, 1));

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -250,7 +250,7 @@ describe('<DesktopDateTimePicker />', () => {
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2010, 0, 1));
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2010'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2010, 0, 15));
 
@@ -292,7 +292,7 @@ describe('<DesktopDateTimePicker />', () => {
       openPicker({ type: 'date-time', variant: 'desktop' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
 
       // Change the hours (already tested)
       fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mousemove'));
@@ -324,7 +324,7 @@ describe('<DesktopDateTimePicker />', () => {
       openPicker({ type: 'date-time', variant: 'desktop' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
 
       // Change the hours (already tested)
       fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mousemove'));
@@ -381,7 +381,7 @@ describe('<DesktopDateTimePicker />', () => {
       openPicker({ type: 'date-time', variant: 'desktop' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
 
       // Change the hours (already tested)
       fireEvent(screen.getByMuiTest('clock'), getClockMouseEvent('mousemove'));
@@ -493,7 +493,7 @@ describe('<DesktopDateTimePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the date (same value)
-      userEvent.mousePress(screen.getByLabelText('Jan 1, 2025'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '1' }));
       expect(onChange.callCount).to.equal(1); // Don't call onChange again since the value did not change
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -282,14 +282,14 @@ describe('<MobileDatePicker />', () => {
       expect(onClose.callCount).to.equal(0);
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 8));
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 6, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '6' }));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 6));
       expect(onAccept.callCount).to.equal(0);
@@ -315,7 +315,7 @@ describe('<MobileDatePicker />', () => {
       openPicker({ type: 'date', variant: 'mobile' });
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 8));
       expect(onAccept.callCount).to.equal(1);
@@ -341,7 +341,7 @@ describe('<MobileDatePicker />', () => {
       openPicker({ type: 'date', variant: 'mobile' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
 
       // Cancel the modifications
       userEvent.mousePress(screen.getByText(/cancel/i));
@@ -369,7 +369,7 @@ describe('<MobileDatePicker />', () => {
       openPicker({ type: 'date', variant: 'mobile' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 8, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '8' }));
 
       // Accept the modifications
       userEvent.mousePress(screen.getByText(/ok/i));

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -126,7 +126,7 @@ describe('<MobileDateTimePicker />', () => {
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2010, 0, 1));
 
       // Change the date
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2010'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
       expect(onChange.callCount).to.equal(2);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2010, 0, 15));
 
@@ -171,7 +171,7 @@ describe('<MobileDateTimePicker />', () => {
       openPicker({ type: 'date-time', variant: 'mobile' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
 
       // Change the hours (already tested)
       const hourClockEvent = getClockTouchEvent();
@@ -212,7 +212,7 @@ describe('<MobileDateTimePicker />', () => {
       openPicker({ type: 'date-time', variant: 'mobile' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
 
       // Change the hours (already tested)
       const hourClockEvent = getClockTouchEvent();
@@ -249,7 +249,7 @@ describe('<MobileDateTimePicker />', () => {
       openPicker({ type: 'date-time', variant: 'mobile' });
 
       // Change the date (already tested)
-      userEvent.mousePress(screen.getByLabelText('Jan 15, 2018'));
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '15' }));
 
       // Change the hours (already tested)
       const hourClockEvent = getClockTouchEvent();

--- a/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx
+++ b/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx
@@ -140,6 +140,8 @@ export const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
     onChange(newDate, 'finish');
   };
 
+  const currentMonthNumber = utils.getMonth(now);
+
   return (
     <MonthPickerRoot
       ref={ref}
@@ -158,6 +160,7 @@ export const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
             selected={monthNumber === focusedMonth}
             onSelect={onMonthSelect}
             disabled={disabled || isMonthDisabled(month)}
+            aria-current={currentMonthNumber === monthNumber ? 'date' : undefined}
           >
             {monthText}
           </PickersMonth>

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
@@ -36,9 +36,7 @@ describe('<PickersDay />', () => {
     const handleDaySelect = spy();
     const day = adapterToUse.date();
     render(<PickersDay day={day} outsideCurrentMonth={false} onDaySelect={handleDaySelect} />);
-    const targetDay = screen.getByRole('button', {
-      name: `${adapterToUse.format(day, 'fullDate')}`,
-    });
+    const targetDay = screen.getByRole('button', { name: adapterToUse.format(day, 'dayOfMonth') });
 
     // A native button implies Enter and Space keydown behavior
     // These keydown events only trigger click behavior if they're trusted (programmatically dispatched events aren't trusted).
@@ -63,10 +61,8 @@ describe('<PickersDay />', () => {
     );
 
     const day = screen.getByRole('button');
-    // TODO: This can be disorienting if the accessible name is not the same as the visible label
-    // Investigate if we can drop `aria-label` and let screenreaders announce the full date in a calendar picker.
     expect(day).to.have.text('2');
-    expect(day).toHaveAccessibleName('Feb 2, 2020');
+    expect(day).toHaveAccessibleName('2');
   });
 
   it('should render children instead of the day of the month when children prop is present', () => {

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -176,7 +176,8 @@ const PickersDayFiller = styled('div', {
   overridesResolver,
 })<{ ownerState: OwnerState }>(({ theme, ownerState }) => ({
   ...styleArg({ theme, ownerState }),
-  visibility: 'hidden',
+  // visibility: 'hidden' does not work here as it hides the element from screen readers as well
+  opacity: 0,
 }));
 
 const noop = () => {};
@@ -327,6 +328,7 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       <PickersDayFiller
         className={clsx(classes.root, classes.hiddenDaySpacingFiller, className)}
         ownerState={ownerState}
+        role={other.role}
       />
     );
   }
@@ -339,7 +341,6 @@ const PickersDayRaw = React.forwardRef(function PickersDay<TDate>(
       centerRipple
       data-mui-test="day"
       disabled={disabled}
-      aria-label={!children ? utils.format(day, 'fullDate') : undefined}
       tabIndex={selected ? 0 : -1}
       onFocus={handleFocus}
       onKeyDown={handleKeyDown}

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePickerKeyboard.test.tsx
@@ -46,8 +46,8 @@ describe('<StaticDatePicker /> keyboard interactions', () => {
         // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
         fireEvent.keyDown(document.activeElement!, { keyCode, key });
 
-        // static analysis can't calculate the final grid cell label connected with day of week `columnheader`
-        // resulting in `<Week day> <number>` being the actual accessible name for each picker day
+        // Based on column header, screen reader should pronounce <Day Number> <Week Day>
+        // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
         expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);
       });
     });

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePickerKeyboard.test.tsx
@@ -20,16 +20,16 @@ describe('<StaticDatePicker /> keyboard interactions', () => {
         />,
       );
 
-      expect(screen.getByLabelText('Aug 13, 2020')).toHaveFocus();
+      expect(screen.getByRole('gridcell', { name: '13' })).toHaveFocus();
     });
 
     [
-      { keyCode: 35, key: 'End', expectFocusedDay: 'Aug 15, 2020' },
-      { keyCode: 36, key: 'Home', expectFocusedDay: 'Aug 9, 2020' },
-      { keyCode: 37, key: 'ArrowLeft', expectFocusedDay: 'Aug 12, 2020' },
-      { keyCode: 38, key: 'ArrowUp', expectFocusedDay: 'Aug 6, 2020' },
-      { keyCode: 39, key: 'ArrowRight', expectFocusedDay: 'Aug 14, 2020' },
-      { keyCode: 40, key: 'ArrowDown', expectFocusedDay: 'Aug 20, 2020' },
+      { keyCode: 35, key: 'End', expectFocusedDay: '15' },
+      { keyCode: 36, key: 'Home', expectFocusedDay: '9' },
+      { keyCode: 37, key: 'ArrowLeft', expectFocusedDay: '12' },
+      { keyCode: 38, key: 'ArrowUp', expectFocusedDay: '6' },
+      { keyCode: 39, key: 'ArrowRight', expectFocusedDay: '14' },
+      { keyCode: 40, key: 'ArrowDown', expectFocusedDay: '20' },
     ].forEach(({ key, keyCode, expectFocusedDay }) => {
       it(key, () => {
         render(
@@ -46,6 +46,8 @@ describe('<StaticDatePicker /> keyboard interactions', () => {
         // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
         fireEvent.keyDown(document.activeElement!, { keyCode, key });
 
+        // static analysis can't calculate the final grid cell label connected with day of week `columnheader`
+        // resulting in `<Week day> <number>` being the actual accessible name for each picker day
         expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);
       });
     });
@@ -63,7 +65,7 @@ describe('<StaticDatePicker /> keyboard interactions', () => {
       />,
     );
 
-    expect(document.activeElement).toHaveAccessibleName('Aug 13, 2020');
+    expect(document.activeElement).toHaveAccessibleName('13');
 
     for (let i = 0; i < 3; i += 1) {
       // Don't care about what's focused.
@@ -72,7 +74,7 @@ describe('<StaticDatePicker /> keyboard interactions', () => {
     }
 
     // leaves focus on the same date
-    expect(document.activeElement).toHaveAccessibleName('Aug 13, 2020');
+    expect(document.activeElement).toHaveAccessibleName('13');
   });
 
   describe('YearPicker keyboard navigation', () => {

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.test.tsx
@@ -19,7 +19,7 @@ describe('<StaticDateTimePicker />', () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText('Jan 1, 2018'));
+    fireEvent.click(screen.getByRole('gridcell', { name: '1' }));
     expect(onChangeMock.callCount).to.equal(0);
 
     expect(screen.getByLabelText(/Selected time/)).toBeVisible();

--- a/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
+++ b/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
@@ -100,7 +100,17 @@ export const PickersYear = React.forwardRef<HTMLButtonElement, YearProps>(functi
   props,
   forwardedRef,
 ) {
-  const { autoFocus, className, children, disabled, onClick, onKeyDown, selected, value, ...other } = props;
+  const {
+    autoFocus,
+    className,
+    children,
+    disabled,
+    onClick,
+    onKeyDown,
+    selected,
+    value,
+    ...other
+  } = props;
   const ref = React.useRef<HTMLButtonElement>(null);
   const refHandle = useForkRef(ref, forwardedRef as React.Ref<HTMLButtonElement>);
   const wrapperVariant = React.useContext(WrapperVariantContext);

--- a/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
+++ b/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
@@ -100,7 +100,7 @@ export const PickersYear = React.forwardRef<HTMLButtonElement, YearProps>(functi
   props,
   forwardedRef,
 ) {
-  const { autoFocus, className, children, disabled, onClick, onKeyDown, selected, value } = props;
+  const { autoFocus, className, children, disabled, onClick, onKeyDown, selected, value, ...other } = props;
   const ref = React.useRef<HTMLButtonElement>(null);
   const refHandle = useForkRef(ref, forwardedRef as React.Ref<HTMLButtonElement>);
   const wrapperVariant = React.useContext(WrapperVariantContext);
@@ -136,6 +136,7 @@ export const PickersYear = React.forwardRef<HTMLButtonElement, YearProps>(functi
         onKeyDown={(event) => onKeyDown(event, value)}
         className={classes.yearButton}
         ownerState={ownerState}
+        {...other}
       >
         {children}
       </PickersYearButton>

--- a/packages/x-date-pickers/src/YearPicker/YearPicker.tsx
+++ b/packages/x-date-pickers/src/YearPicker/YearPicker.tsx
@@ -169,6 +169,8 @@ export const YearPicker = React.forwardRef(function YearPicker<TDate>(
     }
   };
 
+  const nowYear = utils.getYear(now);
+
   return (
     <YearPickerRoot ref={ref} className={clsx(classes.root, className)} ownerState={ownerState}>
       {utils.getYearRange(minDate, maxDate).map((year) => {
@@ -185,6 +187,7 @@ export const YearPicker = React.forwardRef(function YearPicker<TDate>(
             autoFocus={autoFocus && yearNumber === focusedYear}
             ref={selected ? selectedYearRef : undefined}
             disabled={disabled || isYearDisabled(year)}
+            aria-current={nowYear === yearNumber ? 'date' : undefined}
           >
             {utils.format(year, 'year')}
           </PickersYear>

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -305,6 +305,10 @@ export const PickersPopper = (props: PickerPopperProps) => {
         <TrapFocus
           open={open}
           disableAutoFocus
+          // pickers are managing focus position manually
+          // without this prop the focus is returned to the button before `aria-label` is updated
+          // which would force screen readers to read too old label
+          disableRestoreFocus
           disableEnforceFocus={role === 'tooltip'}
           isEnabled={() => true}
           {...TrapFocusProps}

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -256,7 +256,13 @@ export const PickersPopper = (props: PickerPopperProps) => {
       lastFocusedElementRef.current &&
       lastFocusedElementRef.current instanceof HTMLElement
     ) {
-      lastFocusedElementRef.current.focus();
+      // make sure the button is flushed with updated label, before returning focus to it
+      // avoids issue, where screen reader could fail to announce selected date after selection
+      setTimeout(() => {
+        if (lastFocusedElementRef.current instanceof HTMLElement) {
+          lastFocusedElementRef.current.focus();
+        }
+      });
     }
   }, [open, role]);
 


### PR DESCRIPTION
Fixes #4470

Superseedes #4472 
Closes #4472 

Adjust date pickers a11y implementation bringing it more in line with [w3 aria example](https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog)

Tested changes on Windows with NVDA making sure that implementation works as similar to the example as possible.