### PR TITLE
[core] Memoize `columns` in `useDemoData` hook

### DIFF
--- a/packages/grid/x-data-grid-generator/src/hooks/useDemoData.ts
+++ b/packages/grid/x-data-grid-generator/src/hooks/useDemoData.ts
@@ -128,7 +128,7 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
   const [index, setIndex] = React.useState(0);
   const [loading, setLoading] = React.useState(true);
 
-  const getColumns = React.useCallback(() => {
+  const columns = React.useMemo(() => {
     return getColumnsFromOptions({
       dataSet: options.dataSet,
       editable: options.editable,
@@ -138,8 +138,6 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
   }, [options.dataSet, options.editable, options.maxColumns, options.visibleFields]);
 
   const [data, setData] = React.useState<DemoTreeDataValue>(() => {
-    const columns = getColumns();
-
     return addTreeDataOptionsToDemoData(
       {
         columns,
@@ -169,10 +167,10 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
 
       let newData: DemoTreeDataValue;
       if (rowLength > 1000) {
-        newData = await getRealGridData(1000, getColumns());
+        newData = await getRealGridData(1000, columns);
         newData = await extrapolateSeed(rowLength, newData);
       } else {
-        newData = await getRealGridData(rowLength, getColumns());
+        newData = await getRealGridData(rowLength, columns);
       }
 
       if (!active) {
@@ -206,7 +204,7 @@ export const useDemoData = (options: UseDemoDataOptions): DemoDataReturnType => 
     options.treeData?.groupingField,
     options.treeData?.averageChildren,
     index,
-    getColumns,
+    columns,
   ]);
 
   return {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/5418#issuecomment-1220583110
Before: https://codesandbox.io/s/restorestateapiref-demo-mui-x-forked-283wi9?file=/demo.js
After: https://codesandbox.io/s/restorestateapiref-demo-mui-x-forked-8kuncw?file=/demo.js

To reproduce:
1. Reorder a column
2. Click "Save state to localStorage"
3. Reload the demo