### PR TITLE
[DataGridPro] Fix crash when using `pinnedRows` + `getRowClassName` props and `rows=[]`

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
@@ -765,4 +765,15 @@ describe('<DataGridPro /> - Row pinning', () => {
 
     expect(screen.getByRole('grid').getAttribute('aria-rowcount')).to.equal(`${rowCount + 1}`); // +1 for header row
   });
+
+  // https://github.com/mui/mui-x/issues/5845
+  it('should work with `getCellClassName` when `rows=[]`', () => {
+    const className = 'test-class-name';
+    render(
+      <BaselineTestCase rowCount={2} colCount={1} rows={[]} getRowClassName={() => className} />,
+    );
+
+    expect(getRowById(0)!.classList.contains(className)).to.equal(true);
+    expect(getRowById(1)!.classList.contains(className)).to.equal(true);
+  });
 });

--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -272,7 +272,7 @@ function GridRow(props: React.HTMLAttributes<HTMLDivElement> & GridRowProps) {
   let rowClassName: string | null = null;
 
   if (typeof rootProps.getRowClassName === 'function') {
-    const indexRelativeToCurrentPage = index - currentPage.range!.firstRowIndex;
+    const indexRelativeToCurrentPage = index - (currentPage.range?.firstRowIndex || 0);
     const rowParams: GridRowClassNameParams = {
       ...apiRef.current.getRowParams(rowId),
       isFirstVisible: indexRelativeToCurrentPage === 0,


### PR DESCRIPTION
Fixes #5845