### PR TITLE
[pickers] Add Korean (ko-KR) locale

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -122,6 +122,7 @@ import bgLocale from 'date-fns/locale/bg';
 | French                  | fr-FR               | `frFR`      |
 | German                  | de-DE               | `deDE`      |
 | Italian                 | it-IT               | `itIT`      |
+| Korean                  | ko-KR               | `koKR`      |
 | Norwegian (Bokmål)      | nb-NO               | `nbNO`      |
 | Polish                  | pl-PL               | `plPL`      |
 | Spanish                 | es-ES               | `esES`      |

--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -10,4 +10,5 @@ export * from './nbNO';
 export * from './svSE';
 export * from './itIT';
 export * from './zhCN';
+export * from './koKR';
 export * from './utils/pickersLocaleTextApi';

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -1,0 +1,60 @@
+import { PickersLocaleText } from './utils/pickersLocaleTextApi';
+import { getPickersLocalization } from './utils/getPickersLocalization';
+import { CalendarPickerView } from '../internals/models';
+
+const views = {
+  hours: '시간을',
+  minutes: '분을',
+  seconds: '초를',
+};
+
+// This object is not Partial<PickersLocaleText> because it is the default values
+
+const koKRPickers: PickersLocaleText<any> = {
+  // Calendar navigation
+  previousMonth: '이전 달',
+  nextMonth: '다음 달',
+
+  // View navigation
+  openPreviousView: '이전 화면 보기',
+  openNextView: '다음 화면 보기',
+  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+    view === 'year'
+      ? '연도 선택 화면에서 달력 화면으로 전환하기'
+      : '달력 화면에서 연도 선택 화면으로 전환하기',
+
+  // DateRange placeholders
+  start: '시작',
+  end: '종료',
+
+  // Action bar
+  cancelButtonLabel: '취소',
+  clearButtonLabel: '초기화',
+  okButtonLabel: '확인',
+  todayButtonLabel: '오늘',
+
+  // Clock labels
+  clockLabelText: (view, time, adapter) =>
+    `${views[view]} 선택하세요. ${
+      time === null ? '시간을 선택하지 않았습니다.' : `현재 선택된 시간은 ${adapter.format(time, 'fullTime')}입니다.`
+    }`,
+  hoursClockNumberText: (hours) => `${hours}시간`,
+  minutesClockNumberText: (minutes) => `${minutes}분`,
+  secondsClockNumberText: (seconds) => `${seconds}초`,
+
+  // Open picker labels
+  openDatePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `날짜를 선택하세요. 현재 선택된 날짜는 ${utils.format(utils.date(rawValue)!, 'fullDate')}입니다.`
+      : '날짜를 선택하세요',
+  openTimePickerDialogue: (rawValue, utils) =>
+    rawValue && utils.isValid(utils.date(rawValue))
+      ? `시간을 선택하세요. 현재 선택된 시간은 ${utils.format(utils.date(rawValue)!, 'fullTime')}입니다.`
+      : '시간을 선택하세요',
+
+  // Table labels
+  timeTableLabel: '선택한 시간',
+  dateTableLabel: '선택한 날짜',
+};
+
+export const koKR = getPickersLocalization(koKRPickers);

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -8,9 +8,7 @@ const views = {
   seconds: '초를',
 };
 
-// This object is not Partial<PickersLocaleText> because it is the default values
-
-const koKRPickers: PickersLocaleText<any> = {
+const koKRPickers: Partial<PickersLocaleText<any>> = {
   // Calendar navigation
   previousMonth: '이전 달',
   nextMonth: '다음 달',

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -36,7 +36,9 @@ const koKRPickers: PickersLocaleText<any> = {
   // Clock labels
   clockLabelText: (view, time, adapter) =>
     `${views[view]} 선택하세요. ${
-      time === null ? '시간을 선택하지 않았습니다.' : `현재 선택된 시간은 ${adapter.format(time, 'fullTime')}입니다.`
+      time === null
+        ? '시간을 선택하지 않았습니다.'
+        : `현재 선택된 시간은 ${adapter.format(time, 'fullTime')}입니다.`
     }`,
   hoursClockNumberText: (hours) => `${hours}시간`,
   minutesClockNumberText: (minutes) => `${minutes}분`,
@@ -45,11 +47,17 @@ const koKRPickers: PickersLocaleText<any> = {
   // Open picker labels
   openDatePickerDialogue: (rawValue, utils) =>
     rawValue && utils.isValid(utils.date(rawValue))
-      ? `날짜를 선택하세요. 현재 선택된 날짜는 ${utils.format(utils.date(rawValue)!, 'fullDate')}입니다.`
+      ? `날짜를 선택하세요. 현재 선택된 날짜는 ${utils.format(
+          utils.date(rawValue)!,
+          'fullDate',
+        )}입니다.`
       : '날짜를 선택하세요',
   openTimePickerDialogue: (rawValue, utils) =>
     rawValue && utils.isValid(utils.date(rawValue))
-      ? `시간을 선택하세요. 현재 선택된 시간은 ${utils.format(utils.date(rawValue)!, 'fullTime')}입니다.`
+      ? `시간을 선택하세요. 현재 선택된 시간은 ${utils.format(
+          utils.date(rawValue)!,
+          'fullTime',
+        )}입니다.`
       : '시간을 선택하세요',
 
   // Table labels

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -59,6 +59,7 @@
   { "name": "getPickersDayUtilityClass", "kind": "Function" },
   { "name": "getYearPickerUtilityClass", "kind": "Function" },
   { "name": "itIT", "kind": "Variable" },
+  { "name": "koKR", "kind": "Variable" },
   { "name": "LicenseInfo", "kind": "Class" },
   { "name": "LocalizationProvider", "kind": "Function" },
   { "name": "LocalizationProviderProps", "kind": "Interface" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -46,6 +46,7 @@
   { "name": "getPickersDayUtilityClass", "kind": "Function" },
   { "name": "getYearPickerUtilityClass", "kind": "Function" },
   { "name": "itIT", "kind": "Variable" },
+  { "name": "koKR", "kind": "Variable" },
   { "name": "LocalizationProvider", "kind": "Function" },
   { "name": "LocalizationProviderProps", "kind": "Interface" },
   { "name": "MobileDatePicker", "kind": "Variable" },


### PR DESCRIPTION
Following up on #3211, I'd like to provide Korean translations for the Date Picker component.