### PR TITLE
[DataGrid] Update deprecation note for `GridColDef` `hide` property

### DIFF
--- a/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
@@ -70,7 +70,13 @@ export interface GridColDef<R extends GridValidRowModel = any, V = any, F = V> {
   maxWidth?: number;
   /**
    * If `true`, hide the column.
-   * @deprecated Use the `columnVisibility` prop instead.
+   * @deprecated Use the `initialState` prop to hide columns:
+   * ```jsx
+   * // Hide `id` column, the other columns will remain visible
+   * <DataGrid initialState={{ columns: { columnVisibilityModel: { id: false } } }} />
+   * ```
+   * Or use `columnVisibilityModel` prop to fully control column visibility.
+   * @link https://mui.com/x/react-data-grid/column-visibility/
    * @default false
    */
   hide?: boolean;


### PR DESCRIPTION
Closes #5885 by making deprecation note less confusing.

Before:
<img width="582" alt="Screenshot 2022-08-23 at 18 35 56" src="https://user-images.githubusercontent.com/13808724/186213454-68b12f39-cdda-4ab2-b876-d9d2b3f4d5ee.png">

After:
<img width="569" alt="Screenshot 2022-08-23 at 18 35 39" src="https://user-images.githubusercontent.com/13808724/186213475-20706134-7b7e-472d-ba6b-9a8759f986e6.png">

