### PR TITLE
[DataGrid] Add `sort` prop to columns panel slot

### DIFF
--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -66,6 +66,8 @@ export interface GridColumnsPanelProps extends GridPanelWrapperProps {
   sort?: 'asc' | 'desc';
 }
 
+const collator = new Intl.Collator();
+
 export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const apiRef = useGridApiContext();
   const searchInputRef = React.useRef<HTMLInputElement>(null);
@@ -81,11 +83,11 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
     switch (sort) {
       case 'asc':
         return [...columns].sort((a, b) =>
-          (a.headerName || a.field) > (b.headerName || b.field) ? 1 : -1,
+          collator.compare(a.headerName || a.field, b.headerName || b.field),
         );
       case 'desc':
-        return [...columns].sort((a, b) =>
-          (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
+        return [...columns].sort(
+          (a, b) => -collator.compare(a.headerName || a.field, b.headerName || b.field),
         );
       default:
         return columns;

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -80,6 +80,7 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
   const classes = useUtilityClasses(ownerState);
 
   const { sort } = props;
+
   const sortedColumns = React.useMemo(() => {
     switch (sort) {
       case 'asc':

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -79,9 +79,8 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
       return [...columns].sort((a, b) =>
         (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
       );
-    } else {
-      return columns;
-    }
+    } 
+    return columns;
   }, [columns, rootProps.componentsProps?.columnsPanel.sort]);
 
   const toggleColumn = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -70,6 +70,20 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const ownerState = { classes: rootProps.classes };
   const classes = useUtilityClasses(ownerState);
 
+  const sortedColumns = React.useMemo(() => {
+        if (rootProps.componentsProps?.columnsPanel.sort === 'asc') {
+          return [...columns].sort((a, b) =>
+            (a.headerName || a.field) > (b.headerName || b.field) ? 1 : -1,
+         );
+        } else if (rootProps.componentsProps?.columnsPanel.sort === 'desc') {
+          return [...columns].sort((a, b) =>
+            (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
+          );
+        } else {
+          return columns;
+        }
+      }, [columns, rootProps.componentsProps?.columnsPanel.sort]);
+
   const toggleColumn = (event: React.MouseEvent<HTMLButtonElement>) => {
     const { name: field } = event.target as HTMLInputElement;
     apiRef.current.setColumnVisibility(field, columnVisibilityModel[field] === false);
@@ -112,14 +126,14 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
 
   const currentColumns = React.useMemo(() => {
     if (!searchValue) {
-      return columns;
+      return sortedColumns;
     }
     const searchValueToCheck = searchValue.toLowerCase();
-    return columns.filter(
+    return sortedColumns.filter(
       (column) =>
         (column.headerName || column.field).toLowerCase().indexOf(searchValueToCheck) > -1,
     );
-  }, [columns, searchValue]);
+  }, [sortedColumns, searchValue]);
 
   React.useEffect(() => {
     searchInputRef.current!.focus();

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import { switchClasses } from '@mui/material/Switch';
@@ -59,7 +60,7 @@ const GridIconButtonRoot = styled(IconButton)({
 });
 
 export interface GridColumnsPanelProps extends GridPanelWrapperProps {
-  /**
+  /*
    * Changes how the options in the columns selector should be ordered.
    * If not specified, the order is derived from the `columns` prop.
    */
@@ -68,7 +69,7 @@ export interface GridColumnsPanelProps extends GridPanelWrapperProps {
 
 const collator = new Intl.Collator();
 
-export function GridColumnsPanel(props: GridColumnsPanelProps) {
+function GridColumnsPanel(props: GridColumnsPanelProps) {
   const apiRef = useGridApiContext();
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const columns = useGridSelector(apiRef, gridColumnDefinitionsSelector);
@@ -85,10 +86,12 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
         return [...columns].sort((a, b) =>
           collator.compare(a.headerName || a.field, b.headerName || b.field),
         );
+
       case 'desc':
         return [...columns].sort(
           (a, b) => -collator.compare(a.headerName || a.field, b.headerName || b.field),
         );
+
       default:
         return columns;
     }
@@ -212,3 +215,13 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
     </GridPanelWrapper>
   );
 }
+
+GridColumnsPanel.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // | To update them edit the TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  sort: PropTypes.oneOf(['asc', 'desc']),
+} as any;
+
+export { GridColumnsPanel };

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -79,7 +79,7 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
   const ownerState = { classes: rootProps.classes };
   const classes = useUtilityClasses(ownerState);
 
-  const { sort } = props;
+  const { sort, ...other } = props;
 
   const sortedColumns = React.useMemo(() => {
     switch (sort) {
@@ -154,7 +154,7 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
   }, []);
 
   return (
-    <GridPanelWrapper {...props}>
+    <GridPanelWrapper {...other}>
       <GridPanelHeader>
         <rootProps.components.BaseTextField
           label={apiRef.current.getLocaleText('columnsPanelTextFieldLabel')}

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -58,7 +58,13 @@ const GridIconButtonRoot = styled(IconButton)({
   justifyContent: 'flex-end',
 });
 
-export interface GridColumnsPanelProps extends GridPanelWrapperProps {}
+export interface GridColumnsPanelProps extends GridPanelWrapperProps {
+  /**
+   * Changes how the options in the columns selector should be ordered.
+   * If not specified, the order is derived from the `columns` prop.
+   */
+  sort?: 'asc' | 'desc';
+}
 
 export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const apiRef = useGridApiContext();
@@ -70,18 +76,21 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const ownerState = { classes: rootProps.classes };
   const classes = useUtilityClasses(ownerState);
 
+  const { sort } = props;
   const sortedColumns = React.useMemo(() => {
-    if (rootProps.componentsProps?.columnsPanel.sort === 'asc') {
-      return [...columns].sort((a, b) =>
-        (a.headerName || a.field) > (b.headerName || b.field) ? 1 : -1,
-      );
-    } else if (rootProps.componentsProps?.columnsPanel.sort === 'desc') {
-      return [...columns].sort((a, b) =>
-        (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
-      );
+    switch (sort) {
+      case 'asc':
+        return [...columns].sort((a, b) =>
+          (a.headerName || a.field) > (b.headerName || b.field) ? 1 : -1,
+        );
+      case 'desc':
+        return [...columns].sort((a, b) =>
+          (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
+        );
+      default:
+        return columns;
     }
-    return columns;
-  }, [columns, rootProps.componentsProps?.columnsPanel.sort]);
+  }, [columns, sort]);
 
   const toggleColumn = (event: React.MouseEvent<HTMLButtonElement>) => {
     const { name: field } = event.target as HTMLInputElement;

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -58,7 +58,7 @@ const GridIconButtonRoot = styled(IconButton)({
   justifyContent: 'flex-end',
 });
 
-export interface GridColumnsPanelProps extends GridPanelWrapperProps {}
+export interface GridColumnsPanelProps extends GridPanelWrapperProps { }
 
 export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const apiRef = useGridApiContext();
@@ -71,18 +71,18 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const classes = useUtilityClasses(ownerState);
 
   const sortedColumns = React.useMemo(() => {
-        if (rootProps.componentsProps?.columnsPanel.sort === 'asc') {
-          return [...columns].sort((a, b) =>
-            (a.headerName || a.field) > (b.headerName || b.field) ? 1 : -1,
-         );
-        } else if (rootProps.componentsProps?.columnsPanel.sort === 'desc') {
-          return [...columns].sort((a, b) =>
-            (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
-          );
-        } else {
-          return columns;
-        }
-      }, [columns, rootProps.componentsProps?.columnsPanel.sort]);
+    if (rootProps.componentsProps?.columnsPanel.sort === 'asc') {
+      return [...columns].sort((a, b) =>
+        (a.headerName || a.field) > (b.headerName || b.field) ? 1 : -1,
+      );
+    } else if (rootProps.componentsProps?.columnsPanel.sort === 'desc') {
+      return [...columns].sort((a, b) =>
+        (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
+      );
+    } else {
+      return columns;
+    }
+  }, [columns, rootProps.componentsProps?.columnsPanel.sort]);
 
   const toggleColumn = (event: React.MouseEvent<HTMLButtonElement>) => {
     const { name: field } = event.target as HTMLInputElement;

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -58,7 +58,7 @@ const GridIconButtonRoot = styled(IconButton)({
   justifyContent: 'flex-end',
 });
 
-export interface GridColumnsPanelProps extends GridPanelWrapperProps { }
+export interface GridColumnsPanelProps extends GridPanelWrapperProps {}
 
 export function GridColumnsPanel(props: GridColumnsPanelProps) {
   const apiRef = useGridApiContext();

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -79,7 +79,7 @@ export function GridColumnsPanel(props: GridColumnsPanelProps) {
       return [...columns].sort((a, b) =>
         (a.headerName || a.field) < (b.headerName || b.field) ? 1 : -1,
       );
-    } 
+    }
     return columns;
   }, [columns, rootProps.componentsProps?.columnsPanel.sort]);
 


### PR DESCRIPTION
Fix #5830

Adds ability to specify a sort order for display of columns in column picker, without changing the order of the columns themselves.