### PR TITLE
[core] Fix Typescript error on field hooks

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeField/DateRangeField.interfaces.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeField/DateRangeField.interfaces.ts
@@ -8,7 +8,7 @@ import {
 
 export interface UseDateRangeFieldProps<TInputDate, TDate>
   extends UseFieldProps<DateRange<TInputDate>, DateRange<TDate>, DateRangeValidationError>,
-    Omit<DateRangeValidationProps<TInputDate, TDate>, 'value'> {}
+    Partial<Omit<DateRangeValidationProps<TInputDate, TDate>, 'value'>> {}
 
 export type DateRangeFieldProps<TInputDate, TDate> = Omit<
   TextFieldProps,

--- a/packages/x-date-pickers-pro/src/DateRangeField/useDateRangeField.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeField/useDateRangeField.ts
@@ -136,6 +136,6 @@ export const useDateRangeField = <
     props: inProps,
     valueManager: dateRangePickerValueManager,
     fieldValueManager: dateRangeFieldValueManager,
-    validator: validateDateRange,
+    validator: validateDateRange as any,
   });
 };

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/useMultiInputDateRangeField.ts
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/useMultiInputDateRangeField.ts
@@ -68,7 +68,11 @@ export const useMultiInputDateRangeField = <TInputDate, TDate>(
     firstDefaultValue.current ??
     (dateRangePickerValueManager.emptyValue as unknown as DateRange<TInputDate>);
 
-  const validationError = useValidation({ ...inProps as any, value }, validateDateRange, () => true);
+  const validationError = useValidation(
+    { ...(inProps as any), value },
+    validateDateRange,
+    () => true,
+  );
   const inputError = React.useMemo(
     () => dateRangeFieldValueManager.hasError(validationError),
     [validationError],

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/useMultiInputDateRangeField.ts
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/useMultiInputDateRangeField.ts
@@ -68,7 +68,7 @@ export const useMultiInputDateRangeField = <TInputDate, TDate>(
     firstDefaultValue.current ??
     (dateRangePickerValueManager.emptyValue as unknown as DateRange<TInputDate>);
 
-  const validationError = useValidation({ ...inProps, value }, validateDateRange, () => true);
+  const validationError = useValidation({ ...inProps as any, value }, validateDateRange, () => true);
   const inputError = React.useMemo(
     () => dateRangeFieldValueManager.hasError(validationError),
     [validationError],

--- a/packages/x-date-pickers/src/DateField/DateField.interfaces.ts
+++ b/packages/x-date-pickers/src/DateField/DateField.interfaces.ts
@@ -7,7 +7,7 @@ import {
 
 export interface UseDateFieldProps<TInputDate, TDate>
   extends UseFieldProps<TInputDate | null, TDate | null, DateValidationError>,
-    Omit<DateValidationProps<TInputDate, TDate>, 'value'> {}
+    Partial<Omit<DateValidationProps<TInputDate, TDate>, 'value'>> {}
 
 export interface DateFieldProps<TInputDate, TDate>
   extends Omit<TextFieldProps, 'value' | 'defaultValue' | 'onChange' | 'onError'>,

--- a/packages/x-date-pickers/src/DateField/useDateField.ts
+++ b/packages/x-date-pickers/src/DateField/useDateField.ts
@@ -42,6 +42,6 @@ export const useDateField = <
     valueManager: datePickerValueManager,
     fieldValueManager: dateRangeFieldValueManager,
     // TODO: Support time validation.
-    validator: validateDate,
+    validator: validateDate as any,
   });
 };


### PR DESCRIPTION
#5397 broke the typing of the fields
The fix is not trivial so I just added some type casting to avoid the error and unlock master.

Will automerge