### PR TITLE
Fix column grouping in DataGridPremium

### DIFF
--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
@@ -59,6 +59,7 @@ import {
   useGridRowPinning,
   useGridRowPinningPreProcessors,
   rowPinningStateInitializer,
+  useGridColumnGrouping,
 } from '@mui/x-data-grid-pro/internals';
 import { GridApiPremium } from '../models/gridApiPremium';
 import { DataGridPremiumProcessedProps } from '../models/dataGridPremiumProps';
@@ -138,6 +139,7 @@ export const useDataGridPremiumComponent = (
   useGridParamsApi(apiRef);
   useGridDetailPanel(apiRef, props);
   useGridColumnSpanning(apiRef);
+  useGridColumnGrouping(apiRef, props);
 
   const useGridEditing = props.experimentalFeatures?.newEditingApi
     ? useGridEditing_new


### PR DESCRIPTION
I forget a `useGridColumnGrouping(...)` in Premium hooks, leading to crashing the component because methods were called but not defined since the hook was not here