### PR TITLE
[core] Remove unused dependencies

### DIFF
--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -39,9 +39,7 @@
   },
   "devDependencies": {
     "@types/chance": "^1.1.3",
-    "@types/lru-cache": "^7.10.9",
-    "esm": "^3.2.25",
-    "yargs": "^17.5.1"
+    "@types/lru-cache": "^7.10.9"
   },
   "peerDependencies": {
     "@mui/icons-material": "^5.4.1",

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -31,9 +31,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@mui/utils": "^5.9.3",
-    "esm": "^3.2.25",
-    "yargs": "^17.5.1"
+    "@mui/utils": "^5.9.3"
   },
   "peerDependencies": {
     "react": "^17.0.2 || ^18.0.0"


### PR DESCRIPTION
Closes #4251, this was made possible by #5757. This change removes all the non-MIT licenses, ISC licenses:

<img width="294" alt="Screenshot 2022-08-28 at 11 33 32" src="https://user-images.githubusercontent.com/3165635/187067456-d07298ca-18f8-43c1-83a5-9e3b80352cd9.png">

which makes the evaluation process simpler, as well as solve https://groups.google.com/a/mui.com/g/x/c/5nCzjIIQeDE/m/sEcz_YYvBAAJ.