### PR TITLE
[test] Fix time zone sensitive test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,8 @@ jobs:
       - run:
           name: Tests real browsers
           command: yarn test:karma
+          environment:
+            BROWSERSTACK_FORCE: 'true'
       - store_artifacts:
           # hardcoded in karma-webpack
           path: /tmp/_karma_webpack_

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,6 @@ jobs:
       - run:
           name: Tests real browsers
           command: yarn test:karma
-          environment:
-            BROWSERSTACK_FORCE: 'true'
       - store_artifacts:
           # hardcoded in karma-webpack
           path: /tmp/_karma_webpack_

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -55,11 +55,12 @@ describe('<DesktopDatePicker />', () => {
         </div>
       );
     }
+    const testDate = adapterToUse.date(new Date(2000, 0, 1));
     render(
       <DesktopDatePicker
         renderInput={(params) => <TextField {...params} />}
         onChange={() => {}}
-        value={null}
+        value={testDate}
         components={{
           PaperContent: CustomPaperContent,
         }}
@@ -69,7 +70,7 @@ describe('<DesktopDatePicker />', () => {
     openPicker({ type: 'date', variant: 'desktop' });
 
     expect(screen.getByText('test custom content')).not.equal(null);
-    expect(screen.getByText('January 1970')).not.equal(null);
+    expect(screen.getByText(adapterToUse.format(testDate, 'monthAndYear'))).not.equal(null);
   });
 
   ['readOnly', 'disabled'].forEach((prop) => {


### PR DESCRIPTION
Try fixing [test failing in Edge](https://app.circleci.com/pipelines/github/mui/mui-x/22866/workflows/37f63ea3-e1d3-4e26-827b-b907ea8a875a/jobs/131884) due to different timezone [mentioned here](https://github.com/mui/mui-x/pull/5801#discussion_r957389819).
Tested locally by [setting explicit process](https://blog.liprandi.net/2020/10/running-karma-in-specific-timezone.html) `TZ` of `America/Los_Angeles`.
Another change that could work and potentially reduce future issues - setting explicit time zone for karma tests.