### PR TITLE
[DataGrid] Fix focused cell if column is spanned and new editing API is used

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -136,8 +136,21 @@ export const useGridFocus = (
       }
 
       rowIndexToFocus = clamp(rowIndexToFocus, 0, currentPage.rows.length - 1);
-      columnIndexToFocus = clamp(columnIndexToFocus, 0, visibleColumns.length - 1);
       const rowToFocus = currentPage.rows[rowIndexToFocus];
+
+      const colSpanInfo = apiRef.current.unstable_getCellColSpanInfo(
+        rowToFocus.id,
+        columnIndexToFocus,
+      );
+      if (colSpanInfo && colSpanInfo.spannedByColSpan) {
+        if (direction === 'left' || direction === 'below') {
+          columnIndexToFocus = colSpanInfo.leftVisibleCellIndex;
+        } else if (direction === 'right') {
+          columnIndexToFocus = colSpanInfo.rightVisibleCellIndex;
+        }
+      }
+
+      columnIndexToFocus = clamp(columnIndexToFocus, 0, visibleColumns.length - 1);
       const columnToFocus = visibleColumns[columnIndexToFocus];
       apiRef.current.setCellFocus(rowToFocus.id, columnToFocus.field);
     },

--- a/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
@@ -50,6 +50,7 @@ export const useGridKeyboardNavigation = (
    * @param {number} colIndex Index of the column to focus
    * @param {number} rowIndex index of the row to focus
    * @param {string} closestColumnToUse Which closest column cell to use when the cell is spanned by `colSpan`.
+   * TODO replace with apiRef.current.unstable_moveFocusToRelativeCell()
    */
   const goToCell = React.useCallback(
     (colIndex: number, rowId: GridRowId, closestColumnToUse: 'left' | 'right' = 'left') => {
@@ -115,6 +116,7 @@ export const useGridKeyboardNavigation = (
       switch (event.key) {
         case 'ArrowDown':
         case 'Enter': {
+          // TODO v6: Remove Enter case because `cellNavigationKeyDown` is not fired by the new editing API
           // "Enter" is only triggered by the row / cell editing feature
           if (rowIndexBefore < lastRowIndexInPage) {
             goToCell(colIndexBefore, getRowIdFromIndex(rowIndexBefore + 1));

--- a/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
-import { createRenderer, fireEvent, screen, within } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, within, userEvent } from '@mui/monorepo/test/utils';
 import { expect } from 'chai';
 import { DataGrid, gridClasses, GridColDef } from '@mui/x-data-grid';
 import { getCell, getActiveCell, getColumnHeaderCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
@@ -213,7 +213,7 @@ describe('<DataGrid /> - Column Spanning', () => {
       expect(getActiveCell()).to.equal('0-0');
     });
 
-    it('should move to the cell below when pressing "Enter" after editing', async () => {
+    it('should move to the cell below when pressing "Enter" after editing', () => {
       const editableColumns = columns.map((column) => ({ ...column, editable: true }));
       render(
         <div style={{ width: 500, height: 300 }}>
@@ -222,6 +222,7 @@ describe('<DataGrid /> - Column Spanning', () => {
             columns={editableColumns}
             autoHeight={isJSDOM}
             disableVirtualization={isJSDOM}
+            experimentalFeatures={{ newEditingApi: true }}
           />
         </div>,
       );
@@ -234,16 +235,19 @@ describe('<DataGrid /> - Column Spanning', () => {
 
       // commit
       fireEvent.keyDown(getCell(1, 3).querySelector('input'), { key: 'Enter' });
-      await waitFor(() => {
-        expect(getActiveCell()).to.equal('2-2');
-      });
+      expect(getActiveCell()).to.equal('2-2');
     });
 
-    it('should move to the cell on the right when pressing "Tab" after editing', async () => {
+    it('should move to the cell on the right when pressing "Tab" after editing', () => {
       const editableColumns = columns.map((column) => ({ ...column, editable: true }));
       render(
         <div style={{ width: 500, height: 300 }}>
-          <DataGrid {...baselineProps} columns={editableColumns} disableVirtualization={isJSDOM} />
+          <DataGrid
+            {...baselineProps}
+            columns={editableColumns}
+            disableVirtualization={isJSDOM}
+            experimentalFeatures={{ newEditingApi: true }}
+          />
         </div>,
       );
 
@@ -254,16 +258,19 @@ describe('<DataGrid /> - Column Spanning', () => {
       fireEvent.keyDown(getCell(1, 1), { key: 'Enter' });
 
       fireEvent.keyDown(getCell(1, 1).querySelector('input'), { key: 'Tab' });
-      await waitFor(() => {
-        expect(getActiveCell()).to.equal('1-3');
-      });
+      expect(getActiveCell()).to.equal('1-3');
     });
 
     it('should move to the cell on the left when pressing "Shift+Tab" after editing', async () => {
       const editableColumns = columns.map((column) => ({ ...column, editable: true }));
       render(
         <div style={{ width: 500, height: 300 }}>
-          <DataGrid {...baselineProps} columns={editableColumns} disableVirtualization={isJSDOM} />
+          <DataGrid
+            {...baselineProps}
+            columns={editableColumns}
+            disableVirtualization={isJSDOM}
+            experimentalFeatures={{ newEditingApi: true }}
+          />
         </div>,
       );
 
@@ -274,9 +281,7 @@ describe('<DataGrid /> - Column Spanning', () => {
       fireEvent.keyDown(getCell(0, 2), { key: 'Enter' });
 
       fireEvent.keyDown(getCell(0, 2).querySelector('input'), { key: 'Tab', shiftKey: true });
-      await waitFor(() => {
-        expect(getActiveCell()).to.equal('0-0');
-      });
+      expect(getActiveCell()).to.equal('0-0');
     });
 
     it('should work with row virtualization', function test() {

--- a/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
-import { createRenderer, fireEvent, waitFor, screen, within } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, within } from '@mui/monorepo/test/utils';
 import { expect } from 'chai';
 import { DataGrid, gridClasses, GridColDef } from '@mui/x-data-grid';
 import { getCell, getActiveCell, getColumnHeaderCell } from 'test/utils/helperFn';


### PR DESCRIPTION
While fixing the tests for #5911 I noticed that, when using the new editing API, if a cell is committed with Enter and the cell below is spanned, the focus is not moved to the correct cell.

Before: https://codesandbox.io/s/keen-christian-ipv4v4?file=/demo.tsx
After: https://codesandbox.io/s/serverless-microservice-8hbnoe?file=/demo.tsx

### How to reproduce:

- Press <kbd>Enter</kbd> in the Rating column in the 2nd row (Adidas)
- <kbd>Enter</kbd> again

### Expected behavior

It should move focus to the price column in the last row but it doesn't. In the legacy API it works as expected.