### PR TITLE
[pickers] Include `community` package `themeAugmentation` in `pro` package types

### DIFF
--- a/packages/x-date-pickers-pro/src/themeAugmentation/index.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/index.ts
@@ -1,3 +1,4 @@
+export * from '@mui/x-date-pickers/themeAugmentation';
 export * from './overrides';
 export * from './props';
 export * from './components';


### PR DESCRIPTION
Fixes #5965

In [docs we mention](https://mui.com/x/react-date-pickers/getting-started/#typescript) that it's enough to import `pro` package types to include augmentation for all pickers, but that's not the case at the moment.