### PR TITLE
[pickers] Do not hardcode date-fns elements in field components

### DIFF
--- a/docs/data/date-pickers/date-field/BasicDateField.js
+++ b/docs/data/date-pickers/date-field/BasicDateField.js
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 
 export default function BasicDateField() {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DateField label="Basic date field" />
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-field/BasicDateField.tsx
+++ b/docs/data/date-pickers/date-field/BasicDateField.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 
 export default function BasicDateField() {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DateField label="Basic date field" />
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-field/BasicDateField.tsx.preview
+++ b/docs/data/date-pickers/date-field/BasicDateField.tsx.preview
@@ -1,3 +1,3 @@
-<LocalizationProvider dateAdapter={AdapterDateFns}>
+<LocalizationProvider dateAdapter={AdapterDayjs}>
   <DateField label="Basic date field" />
 </LocalizationProvider>

--- a/docs/data/date-pickers/date-field/CustomDateFormat.js
+++ b/docs/data/date-pickers/date-field/CustomDateFormat.js
@@ -1,44 +1,45 @@
 import * as React from 'react';
+import dayjs from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 
 export default function CustomDateFormat() {
-  const [value, setValue] = React.useState(new Date());
+  const [value, setValue] = React.useState(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
         <DateField
           label="Dash separator"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="dd-MM-yyyy"
+          format="DD-MM-YYYY"
         />
         <DateField
           label="Dash and white space separator"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="dd / MM / yyyy"
+          format="DD / MM / YYYY"
         />
         <DateField
           label="Full letter month"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="dd MMMM yyyy"
+          format="DD MMMM YYYY"
         />
         <DateField
           label="Date and time format"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="Pp"
+          format="L LT"
         />
         <DateField
           label="Time format"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="p"
+          format="LT"
         />
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/date-field/CustomDateFormat.tsx
+++ b/docs/data/date-pickers/date-field/CustomDateFormat.tsx
@@ -1,44 +1,45 @@
 import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 
 export default function CustomDateFormat() {
-  const [value, setValue] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
         <DateField
           label="Dash separator"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="dd-MM-yyyy"
+          format="DD-MM-YYYY"
         />
         <DateField
           label="Dash and white space separator"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="dd / MM / yyyy"
+          format="DD / MM / YYYY"
         />
         <DateField
           label="Full letter month"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="dd MMMM yyyy"
+          format="DD MMMM YYYY"
         />
         <DateField
           label="Date and time format"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="Pp"
+          format="L LT"
         />
         <DateField
           label="Time format"
           value={value}
           onChange={(newValue) => setValue(newValue)}
-          format="p"
+          format="LT"
         />
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/date-field/CustomInputProps.js
+++ b/docs/data/date-pickers/date-field/CustomInputProps.js
@@ -1,16 +1,17 @@
 import * as React from 'react';
+import dayjs from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
 import CancelIcon from '@mui/icons-material/Close';
 
 export default function CustomInputProps() {
-  const [value, setValue] = React.useState(new Date());
+  const [value, setValue] = React.useState(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
         <DateField
           label="Custom variant"

--- a/docs/data/date-pickers/date-field/CustomInputProps.tsx
+++ b/docs/data/date-pickers/date-field/CustomInputProps.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 import IconButton from '@mui/material/IconButton';
 import CancelIcon from '@mui/icons-material/Close';
 
 export default function CustomInputProps() {
-  const [value, setValue] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
         <DateField
           label="Custom variant"

--- a/docs/data/date-pickers/date-field/CustomUIDateField.js
+++ b/docs/data/date-pickers/date-field/CustomUIDateField.js
@@ -33,7 +33,10 @@ const UnstyledDateField = (props) => {
 };
 
 const BrowserInputDateField = (props) => {
-  const { inputRef, inputProps } = useDateField(props);
+  const {
+    inputRef,
+    inputProps: { error, ...inputProps },
+  } = useDateField(props);
 
   return <input {...inputProps} ref={inputRef} />;
 };

--- a/docs/data/date-pickers/date-field/CustomUIDateField.js
+++ b/docs/data/date-pickers/date-field/CustomUIDateField.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import dayjs from 'dayjs';
 import { CssVarsProvider } from '@mui/joy/styles';
 import Stack from '@mui/material/Stack';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -6,7 +7,7 @@ import FormLabel from '@mui/joy/FormLabel';
 import JoyTextField from '@mui/joy/TextField';
 import InputUnstyled from '@mui/base/InputUnstyled';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
 
 const JoyDateField = (props) => {
@@ -38,13 +39,13 @@ const BrowserInputDateField = (props) => {
 };
 
 export default function CustomUIDateField() {
-  const [value, setValue] = React.useState(new Date());
+  const [value, setValue] = React.useState(dayjs());
 
   const handleChange = (newValue) => setValue(newValue);
 
   return (
     <CssVarsProvider>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <Stack spacing={2}>
           <JoyDateField
             label="Using @mui/joy TextField"

--- a/docs/data/date-pickers/date-field/CustomUIDateField.tsx
+++ b/docs/data/date-pickers/date-field/CustomUIDateField.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
 import { CssVarsProvider } from '@mui/joy/styles';
 import Stack from '@mui/material/Stack';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -8,16 +9,16 @@ import JoyTextField, {
 } from '@mui/joy/TextField';
 import InputUnstyled, { InputUnstyledProps } from '@mui/base/InputUnstyled';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import {
   unstable_useDateField as useDateField,
   UseDateFieldComponentProps,
 } from '@mui/x-date-pickers/DateField';
 
-type JoyDateFieldProps = UseDateFieldComponentProps<Date, Date, JoyTextFieldProps>;
+type JoyDateFieldProps = UseDateFieldComponentProps<Dayjs, Dayjs, JoyTextFieldProps>;
 
 const JoyDateField = (props: JoyDateFieldProps) => {
-  const { inputRef, inputProps } = useDateField<Date, Date, JoyDateFieldProps>(
+  const { inputRef, inputProps } = useDateField<Dayjs, Dayjs, JoyDateFieldProps>(
     props,
   );
 
@@ -30,15 +31,17 @@ const JoyDateField = (props: JoyDateFieldProps) => {
 };
 
 type UnstyledDateFieldProps = UseDateFieldComponentProps<
-  Date,
-  Date,
+  Dayjs,
+  Dayjs,
   InputUnstyledProps
 >;
 
 const UnstyledDateField = (props: UnstyledDateFieldProps) => {
-  const { inputRef, inputProps } = useDateField<Date, Date, UnstyledDateFieldProps>(
-    props,
-  );
+  const { inputRef, inputProps } = useDateField<
+    Dayjs,
+    Dayjs,
+    UnstyledDateFieldProps
+  >(props);
 
   return (
     <InputUnstyled
@@ -49,15 +52,15 @@ const UnstyledDateField = (props: UnstyledDateFieldProps) => {
 };
 
 type BrowserInputDateFieldProps = UseDateFieldComponentProps<
-  Date,
-  Date,
+  Dayjs,
+  Dayjs,
   React.HTMLAttributes<HTMLInputElement>
 >;
 
 const BrowserInputDateField = (props: BrowserInputDateFieldProps) => {
   const { inputRef, inputProps } = useDateField<
-    Date,
-    Date,
+    Dayjs,
+    Dayjs,
     BrowserInputDateFieldProps
   >(props);
 
@@ -65,13 +68,13 @@ const BrowserInputDateField = (props: BrowserInputDateFieldProps) => {
 };
 
 export default function CustomUIDateField() {
-  const [value, setValue] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
-  const handleChange = (newValue: Date | null) => setValue(newValue);
+  const handleChange = (newValue: Dayjs | null) => setValue(newValue);
 
   return (
     <CssVarsProvider>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <Stack spacing={2}>
           <JoyDateField
             label="Using @mui/joy TextField"

--- a/docs/data/date-pickers/date-field/CustomUIDateField.tsx
+++ b/docs/data/date-pickers/date-field/CustomUIDateField.tsx
@@ -58,11 +58,10 @@ type BrowserInputDateFieldProps = UseDateFieldComponentProps<
 >;
 
 const BrowserInputDateField = (props: BrowserInputDateFieldProps) => {
-  const { inputRef, inputProps } = useDateField<
-    Dayjs,
-    Dayjs,
-    BrowserInputDateFieldProps
-  >(props);
+  const {
+    inputRef,
+    inputProps: { error, ...inputProps },
+  } = useDateField<Dayjs, Dayjs, BrowserInputDateFieldProps>(props);
 
   return <input {...inputProps} ref={inputRef} />;
 };

--- a/docs/data/date-pickers/date-field/DateFieldValidation.js
+++ b/docs/data/date-pickers/date-field/DateFieldValidation.js
@@ -1,35 +1,40 @@
 import * as React from 'react';
-import addDays from 'date-fns/addDays';
-import isWeekend from 'date-fns/isWeekend';
+import dayjs from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 
-const today = new Date();
+const today = dayjs();
+
+const isWeekend = (date) => {
+  const day = date.day();
+
+  return day === 0 || day === 6;
+};
 
 export default function DateFieldValidation() {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2}>
         <DateField
           label="props.minDate = today"
-          defaultValue={addDays(today, -1)}
+          defaultValue={today.subtract(1, 'day')}
           minDate={today}
         />
         <DateField
           label="props.maxDate = today"
-          defaultValue={addDays(today, 1)}
+          defaultValue={today.add(1, 'day')}
           maxDate={today}
         />
         <DateField
           label="props.disablePast = true"
-          defaultValue={addDays(today, -1)}
+          defaultValue={today.subtract(1, 'day')}
           disablePast
         />
         <DateField
           label="props.disableFuture = true"
-          defaultValue={addDays(today, 1)}
+          defaultValue={today.add(1, 'day')}
           disableFuture
         />
         <DateField

--- a/docs/data/date-pickers/date-field/DateFieldValidation.tsx
+++ b/docs/data/date-pickers/date-field/DateFieldValidation.tsx
@@ -1,35 +1,40 @@
 import * as React from 'react';
-import addDays from 'date-fns/addDays';
-import isWeekend from 'date-fns/isWeekend';
+import dayjs, { Dayjs } from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 
-const today = new Date();
+const today = dayjs();
+
+const isWeekend = (date: Dayjs) => {
+  const day = date.day();
+
+  return day === 0 || day === 6;
+};
 
 export default function DateFieldValidation() {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2}>
         <DateField
           label="props.minDate = today"
-          defaultValue={addDays(today, -1)}
+          defaultValue={today.subtract(1, 'day')}
           minDate={today}
         />
         <DateField
           label="props.maxDate = today"
-          defaultValue={addDays(today, 1)}
+          defaultValue={today.add(1, 'day')}
           maxDate={today}
         />
         <DateField
           label="props.disablePast = true"
-          defaultValue={addDays(today, -1)}
+          defaultValue={today.subtract(1, 'day')}
           disablePast
         />
         <DateField
           label="props.disableFuture = true"
-          defaultValue={addDays(today, 1)}
+          defaultValue={today.add(1, 'day')}
           disableFuture
         />
         <DateField

--- a/docs/data/date-pickers/date-field/DateFieldValue.js
+++ b/docs/data/date-pickers/date-field/DateFieldValue.js
@@ -1,16 +1,17 @@
 import * as React from 'react';
+import dayjs from 'dayjs';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 
 export default function DateFieldValue() {
-  const [value, setValue] = React.useState(new Date());
+  const [value, setValue] = React.useState(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} direction="row">
-        <DateField label="Uncontrolled field" defaultValue={new Date()} />
+        <DateField label="Uncontrolled field" defaultValue={dayjs()} />
         <DateField
           label="Controlled field"
           value={value}

--- a/docs/data/date-pickers/date-field/DateFieldValue.tsx
+++ b/docs/data/date-pickers/date-field/DateFieldValue.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 
 export default function DateFieldValue() {
-  const [value, setValue] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} direction="row">
-        <DateField label="Uncontrolled field" defaultValue={new Date()} />
+        <DateField label="Uncontrolled field" defaultValue={dayjs()} />
         <DateField
           label="Controlled field"
           value={value}

--- a/docs/data/date-pickers/date-field/DateFieldValue.tsx.preview
+++ b/docs/data/date-pickers/date-field/DateFieldValue.tsx.preview
@@ -1,6 +1,6 @@
-<LocalizationProvider dateAdapter={AdapterDateFns}>
+<LocalizationProvider dateAdapter={AdapterDayjs}>
   <Stack spacing={2} direction="row">
-    <DateField label="Uncontrolled field" defaultValue={new Date()} />
+    <DateField label="Uncontrolled field" defaultValue={dayjs()} />
     <DateField
       label="Controlled field"
       value={value}

--- a/docs/data/date-pickers/date-field/DebouncedDateField.js
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.js
@@ -1,28 +1,26 @@
 import * as React from 'react';
-import addWeeks from 'date-fns/addWeeks';
+import dayjs from 'dayjs';
 import { debounce } from '@mui/material/utils';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import format from 'date-fns/format';
-import isEqual from 'date-fns/isEqual';
 
-const today = new Date();
+const today = dayjs();
 
 export default function DebouncedDateField() {
-  const [value, setValue] = React.useState(() => addWeeks(today, 1));
+  const [value, setValue] = React.useState(() => today.add(1, 'week'));
 
   const debounceSetValue = React.useMemo(() => debounce(setValue, 500), []);
 
   return (
     <Stack spacing={2}>
       <Typography>
-        Value outside the field: {value == null ? 'null' : format(value, 'P')}
+        Value outside the field: {value == null ? 'null' : value.format('P')}
       </Typography>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DateField
           value={value}
           onChange={(newValue) => debounceSetValue(newValue)}
@@ -30,7 +28,7 @@ export default function DebouncedDateField() {
       </LocalizationProvider>
       <Button
         onClick={() => setValue(today)}
-        disabled={!!value && isEqual(value, today)}
+        disabled={!!value && value.isSame(today)}
       >
         Set to today
       </Button>

--- a/docs/data/date-pickers/date-field/DebouncedDateField.js
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.js
@@ -18,7 +18,7 @@ export default function DebouncedDateField() {
   return (
     <Stack spacing={2}>
       <Typography>
-        Value outside the field: {value == null ? 'null' : value.format('LT')}
+        Value outside the field: {value == null ? 'null' : value.format('P')}
       </Typography>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DateField

--- a/docs/data/date-pickers/date-field/DebouncedDateField.js
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.js
@@ -18,7 +18,7 @@ export default function DebouncedDateField() {
   return (
     <Stack spacing={2}>
       <Typography>
-        Value outside the field: {value == null ? 'null' : value.format('P')}
+        Value outside the field: {value == null ? 'null' : value.format('L')}
       </Typography>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DateField

--- a/docs/data/date-pickers/date-field/DebouncedDateField.tsx
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.tsx
@@ -1,28 +1,26 @@
 import * as React from 'react';
-import addWeeks from 'date-fns/addWeeks';
+import dayjs, { Dayjs } from 'dayjs';
 import { debounce } from '@mui/material/utils';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import format from 'date-fns/format';
-import isEqual from 'date-fns/isEqual';
 
-const today = new Date();
+const today = dayjs();
 
 export default function DebouncedDateField() {
-  const [value, setValue] = React.useState<Date | null>(() => addWeeks(today, 1));
+  const [value, setValue] = React.useState<Dayjs | null>(() => today.add(1, 'week'));
 
   const debounceSetValue = React.useMemo(() => debounce(setValue, 500), []);
 
   return (
     <Stack spacing={2}>
       <Typography>
-        Value outside the field: {value == null ? 'null' : format(value, 'P')}
+        Value outside the field: {value == null ? 'null' : value.format('P')}
       </Typography>
-      <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DateField
           value={value}
           onChange={(newValue) => debounceSetValue(newValue)}
@@ -30,7 +28,7 @@ export default function DebouncedDateField() {
       </LocalizationProvider>
       <Button
         onClick={() => setValue(today)}
-        disabled={!!value && isEqual(value, today)}
+        disabled={!!value && value.isSame(today)}
       >
         Set to today
       </Button>

--- a/docs/data/date-pickers/date-field/DebouncedDateField.tsx
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.tsx
@@ -18,7 +18,7 @@ export default function DebouncedDateField() {
   return (
     <Stack spacing={2}>
       <Typography>
-        Value outside the field: {value == null ? 'null' : value.format('P')}
+        Value outside the field: {value == null ? 'null' : value.format('L')}
       </Typography>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DateField

--- a/docs/data/date-pickers/date-field/DebouncedDateField.tsx.preview
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.tsx.preview
@@ -1,5 +1,5 @@
 <Typography>
-  Value outside the field: {value == null ? 'null' : value.format('P')}
+  Value outside the field: {value == null ? 'null' : value.format('L')}
 </Typography>
 <LocalizationProvider dateAdapter={AdapterDayjs}>
   <DateField

--- a/docs/data/date-pickers/date-field/DebouncedDateField.tsx.preview
+++ b/docs/data/date-pickers/date-field/DebouncedDateField.tsx.preview
@@ -1,7 +1,7 @@
 <Typography>
-  Value outside the field: {value == null ? 'null' : format(value, 'P')}
+  Value outside the field: {value == null ? 'null' : value.format('P')}
 </Typography>
-<LocalizationProvider dateAdapter={AdapterDateFns}>
+<LocalizationProvider dateAdapter={AdapterDayjs}>
   <DateField
     value={value}
     onChange={(newValue) => debounceSetValue(newValue)}
@@ -9,7 +9,7 @@
 </LocalizationProvider>
 <Button
   onClick={() => setValue(today)}
-  disabled={!!value && isEqual(value, today)}
+  disabled={!!value && value.isSame(today)}
 >
   Set to today
 </Button>

--- a/docs/data/date-pickers/date-field/LocalizedDateField.js
+++ b/docs/data/date-pickers/date-field/LocalizedDateField.js
@@ -1,29 +1,28 @@
 import * as React from 'react';
+import dayjs from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
-import frFR from 'date-fns/locale/fr';
+import 'dayjs/locale/fr';
 
 export default function LocalizedDateField() {
-  const [value, setValue] = React.useState(new Date());
+  const [value, setValue] = React.useState(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="fr">
       <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
-        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={frFR}>
-          <DateField
-            label="French locale (default format)"
-            value={value}
-            onChange={(newValue) => setValue(newValue)}
-          />
-          <DateField
-            label="French locale (full letter month)"
-            value={value}
-            onChange={(newValue) => setValue(newValue)}
-            format="dd MMMM yyyy"
-          />
-        </LocalizationProvider>
+        <DateField
+          label="French locale (default format)"
+          value={value}
+          onChange={(newValue) => setValue(newValue)}
+        />
+        <DateField
+          label="French locale (full letter month)"
+          value={value}
+          onChange={(newValue) => setValue(newValue)}
+          format="DD MMMM YYYY"
+        />
       </Stack>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-field/LocalizedDateField.tsx
+++ b/docs/data/date-pickers/date-field/LocalizedDateField.tsx
@@ -1,29 +1,28 @@
 import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 import Stack from '@mui/material/Stack';
-import frFR from 'date-fns/locale/fr';
+import 'dayjs/locale/fr';
 
 export default function LocalizedDateField() {
-  const [value, setValue] = React.useState<Date | null>(new Date());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="fr">
       <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
-        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={frFR}>
-          <DateField
-            label="French locale (default format)"
-            value={value}
-            onChange={(newValue) => setValue(newValue)}
-          />
-          <DateField
-            label="French locale (full letter month)"
-            value={value}
-            onChange={(newValue) => setValue(newValue)}
-            format="dd MMMM yyyy"
-          />
-        </LocalizationProvider>
+        <DateField
+          label="French locale (default format)"
+          value={value}
+          onChange={(newValue) => setValue(newValue)}
+        />
+        <DateField
+          label="French locale (full letter month)"
+          value={value}
+          onChange={(newValue) => setValue(newValue)}
+          format="DD MMMM YYYY"
+        />
       </Stack>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-field/LocalizedDateField.tsx.preview
+++ b/docs/data/date-pickers/date-field/LocalizedDateField.tsx.preview
@@ -1,0 +1,15 @@
+<LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="fr">
+  <Stack spacing={2} sx={(theme) => ({ width: theme.spacing(48) })}>
+    <DateField
+      label="French locale (default format)"
+      value={value}
+      onChange={(newValue) => setValue(newValue)}
+    />
+    <DateField
+      label="French locale (full letter month)"
+      value={value}
+      onChange={(newValue) => setValue(newValue)}
+      format="DD MMMM YYYY"
+    />
+  </Stack>
+</LocalizationProvider>

--- a/docs/data/date-pickers/date-range-field/BasicDateRangeField.js
+++ b/docs/data/date-pickers/date-range-field/BasicDateRangeField.js
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_MultiInputDateRangeField as MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { Unstable_SingleInputDateRangeField as SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 
 export default function BasicDateRangeField() {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <MultiInputDateRangeField />
         <SingleInputDateRangeField />

--- a/docs/data/date-pickers/date-range-field/BasicDateRangeField.tsx
+++ b/docs/data/date-pickers/date-range-field/BasicDateRangeField.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_MultiInputDateRangeField as MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { Unstable_SingleInputDateRangeField as SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 
 export default function BasicDateRangeField() {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <MultiInputDateRangeField />
         <SingleInputDateRangeField />

--- a/docs/data/date-pickers/date-range-field/BasicDateRangeField.tsx.preview
+++ b/docs/data/date-pickers/date-range-field/BasicDateRangeField.tsx.preview
@@ -1,4 +1,4 @@
-<LocalizationProvider dateAdapter={AdapterDateFns}>
+<LocalizationProvider dateAdapter={AdapterDayjs}>
   <Stack spacing={4}>
     <MultiInputDateRangeField />
     <SingleInputDateRangeField />

--- a/docs/data/date-pickers/date-range-field/DateRangeFieldValue.js
+++ b/docs/data/date-pickers/date-range-field/DateRangeFieldValue.js
@@ -1,23 +1,22 @@
 import * as React from 'react';
-import addWeeks from 'date-fns/addWeeks';
+import dayjs from 'dayjs';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_SingleInputDateRangeField as SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 
+const today = dayjs();
+
 export default function DateRangeFieldValue() {
-  const [value, setValue] = React.useState(() => [
-    new Date(),
-    addWeeks(new Date(), 1),
-  ]);
+  const [value, setValue] = React.useState(() => [today, today.add(1, 'week')]);
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} direction="row">
         <SingleInputDateRangeField
           label="Uncontrolled field"
-          defaultValue={[new Date(), addWeeks(new Date(), 1)]}
+          defaultValue={[today, today.add(1, 'week')]}
         />
         <SingleInputDateRangeField
           label="Controlled field"

--- a/docs/data/date-pickers/date-range-field/DateRangeFieldValue.tsx
+++ b/docs/data/date-pickers/date-range-field/DateRangeFieldValue.tsx
@@ -1,23 +1,25 @@
 import * as React from 'react';
-import addWeeks from 'date-fns/addWeeks';
+import dayjs, { Dayjs } from 'dayjs';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { Unstable_SingleInputDateRangeField as SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 
+const today = dayjs();
+
 export default function DateRangeFieldValue() {
-  const [value, setValue] = React.useState<DateRange<Date>>(() => [
-    new Date(),
-    addWeeks(new Date(), 1),
+  const [value, setValue] = React.useState<DateRange<Dayjs>>(() => [
+    today,
+    today.add(1, 'week'),
   ]);
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={2} direction="row">
         <SingleInputDateRangeField
           label="Uncontrolled field"
-          defaultValue={[new Date(), addWeeks(new Date(), 1)]}
+          defaultValue={[today, today.add(1, 'week')]}
         />
         <SingleInputDateRangeField
           label="Controlled field"

--- a/docs/data/date-pickers/date-range-field/DateRangeFieldValue.tsx.preview
+++ b/docs/data/date-pickers/date-range-field/DateRangeFieldValue.tsx.preview
@@ -1,8 +1,8 @@
-<LocalizationProvider dateAdapter={AdapterDateFns}>
+<LocalizationProvider dateAdapter={AdapterDayjs}>
   <Stack spacing={2} direction="row">
     <SingleInputDateRangeField
       label="Uncontrolled field"
-      defaultValue={[new Date(), addWeeks(new Date(), 1)]}
+      defaultValue={[today, today.add(1, 'week')]}
     />
     <SingleInputDateRangeField
       label="Controlled field"

--- a/docs/data/date-pickers/localization/LocalizedDatePicker.js
+++ b/docs/data/date-pickers/localization/LocalizedDatePicker.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import frLocale from 'dayjs/locale/fr';
-import ruLocale from 'dayjs/locale/ru';
-import deLocale from 'dayjs/locale/de';
-import arSaLocale from 'dayjs/locale/ar-sa';
+import 'dayjs/locale/fr';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/de';
+import 'dayjs/locale/ar-sa';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -13,13 +13,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 
-const localeMap = {
-  en: undefined,
-  fr: frLocale,
-  de: deLocale,
-  ru: ruLocale,
-  ar: arSaLocale,
-};
+const locales = ['en', 'fr', 'de', 'ru', 'ar-sa'];
 
 export default function LocalizedDatePicker() {
   const [locale, setLocale] = React.useState('ru');
@@ -32,13 +26,10 @@ export default function LocalizedDatePicker() {
   };
 
   return (
-    <LocalizationProvider
-      dateAdapter={AdapterDayjs}
-      adapterLocale={localeMap[locale]}
-    >
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={locale}>
       <Stack spacing={3}>
         <ToggleButtonGroup value={locale} exclusive sx={{ mb: 2, display: 'block' }}>
-          {Object.keys(localeMap).map((localeItem) => (
+          {locales.map((localeItem) => (
             <ToggleButton
               key={localeItem}
               value={localeItem}

--- a/docs/data/date-pickers/localization/LocalizedDatePicker.tsx
+++ b/docs/data/date-pickers/localization/LocalizedDatePicker.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import frLocale from 'dayjs/locale/fr';
-import ruLocale from 'dayjs/locale/ru';
-import deLocale from 'dayjs/locale/de';
-import arSaLocale from 'dayjs/locale/ar-sa';
+import 'dayjs/locale/fr';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/de';
+import 'dayjs/locale/ar-sa';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -13,16 +13,10 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 
-const localeMap = {
-  en: undefined,
-  fr: frLocale,
-  de: deLocale,
-  ru: ruLocale,
-  ar: arSaLocale,
-};
+const locales = ['en', 'fr', 'de', 'ru', 'ar-sa'] as const;
 
 export default function LocalizedDatePicker() {
-  const [locale, setLocale] = React.useState<keyof typeof localeMap>('ru');
+  const [locale, setLocale] = React.useState<typeof locales[number]>('ru');
   const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(
     dayjs(),
   );
@@ -35,13 +29,10 @@ export default function LocalizedDatePicker() {
   };
 
   return (
-    <LocalizationProvider
-      dateAdapter={AdapterDayjs}
-      adapterLocale={localeMap[locale]}
-    >
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={locale}>
       <Stack spacing={3}>
         <ToggleButtonGroup value={locale} exclusive sx={{ mb: 2, display: 'block' }}>
-          {Object.keys(localeMap).map((localeItem) => (
+          {locales.map((localeItem) => (
             <ToggleButton
               key={localeItem}
               value={localeItem}

--- a/docs/data/date-pickers/localization/LocalizedTimePicker.js
+++ b/docs/data/date-pickers/localization/LocalizedTimePicker.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import ruLocale from 'dayjs/locale/ru';
-import arSaLocale from 'dayjs/locale/ar-sa';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/ar-sa';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -15,11 +15,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 
-const localeMap = {
-  en: undefined,
-  ru: ruLocale,
-  ar: arSaLocale,
-};
+const locales = ['en', 'ru', 'ar-sa'];
 
 // prettier-ignore
 const ampmOptions = {
@@ -44,14 +40,11 @@ export default function LocalizedTimePicker() {
   };
 
   return (
-    <LocalizationProvider
-      dateAdapter={AdapterDayjs}
-      adapterLocale={localeMap[locale]}
-    >
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={locale}>
       <Stack spacing={3}>
         <Stack direction="row" spacing={3}>
           <ToggleButtonGroup value={locale} exclusive sx={{ display: 'block' }}>
-            {Object.keys(localeMap).map((localeItem) => (
+            {locales.map((localeItem) => (
               <ToggleButton
                 key={localeItem}
                 value={localeItem}

--- a/docs/data/date-pickers/localization/LocalizedTimePicker.tsx
+++ b/docs/data/date-pickers/localization/LocalizedTimePicker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import ruLocale from 'dayjs/locale/ru';
-import arSaLocale from 'dayjs/locale/ar-sa';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/ar-sa';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -15,11 +15,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 
-const localeMap = {
-  en: undefined,
-  ru: ruLocale,
-  ar: arSaLocale,
-};
+const locales = ['en', 'ru', 'ar-sa'] as const;
 
 // prettier-ignore
 const ampmOptions: { [key: string]: undefined | boolean } = {
@@ -29,7 +25,7 @@ const ampmOptions: { [key: string]: undefined | boolean } = {
 };
 
 export default function LocalizedTimePicker() {
-  const [locale, setLocale] = React.useState<keyof typeof localeMap>('ru');
+  const [locale, setLocale] = React.useState<typeof locales[number]>('ru');
   const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   const [ampm, setAmpm] = React.useState<boolean | undefined>(undefined);
@@ -45,14 +41,11 @@ export default function LocalizedTimePicker() {
   };
 
   return (
-    <LocalizationProvider
-      dateAdapter={AdapterDayjs}
-      adapterLocale={localeMap[locale]}
-    >
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={locale}>
       <Stack spacing={3}>
         <Stack direction="row" spacing={3}>
           <ToggleButtonGroup value={locale} exclusive sx={{ display: 'block' }}>
-            {Object.keys(localeMap).map((localeItem) => (
+            {locales.map((localeItem) => (
               <ToggleButton
                 key={localeItem}
                 value={localeItem}

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
@@ -60,6 +60,7 @@ import {
   useGridRowPinningPreProcessors,
   rowPinningStateInitializer,
   useGridColumnGrouping,
+  columnGroupsStateInitializer,
 } from '@mui/x-data-grid-pro/internals';
 import { GridApiPremium } from '../models/gridApiPremium';
 import { DataGridPremiumProcessedProps } from '../models/dataGridPremiumProps';
@@ -126,6 +127,7 @@ export const useDataGridPremiumComponent = (
   useGridInitializeState(paginationStateInitializer, apiRef, props);
   useGridInitializeState(rowsMetaStateInitializer, apiRef, props);
   useGridInitializeState(columnMenuStateInitializer, apiRef, props);
+  useGridInitializeState(columnGroupsStateInitializer, apiRef, props);
 
   useGridRowGrouping(apiRef, props);
   useGridTreeData(apiRef);

--- a/packages/x-date-pickers-pro/src/AdapterDateFns/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterDateFns/index.ts
@@ -1,1 +1,1 @@
-export { default as AdapterDateFns } from '@date-io/date-fns';
+export { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';

--- a/packages/x-date-pickers-pro/src/AdapterDayjs/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterDayjs/index.ts
@@ -1,1 +1,1 @@
-export { default as AdapterDayjs } from '@date-io/dayjs';
+export { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';

--- a/packages/x-date-pickers-pro/src/AdapterLuxon/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterLuxon/index.ts
@@ -1,1 +1,1 @@
-export { default as AdapterLuxon } from '@date-io/luxon';
+export { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';

--- a/packages/x-date-pickers-pro/src/AdapterMoment/index.ts
+++ b/packages/x-date-pickers-pro/src/AdapterMoment/index.ts
@@ -1,1 +1,1 @@
-export { default as AdapterMoment } from '@date-io/moment';
+export { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';

--- a/packages/x-date-pickers/src/AdapterDateFns/index.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/index.ts
@@ -11,6 +11,8 @@ const formatTokenMap: MuiFormatTokenMap = {
   yyyy: 'year',
   MMMM: 'month',
   MM: 'month',
+  DD: 'day',
+  d: 'day',
   dd: 'day',
   H: 'hour',
   HH: 'hour',

--- a/packages/x-date-pickers/src/AdapterDateFns/index.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/index.ts
@@ -1,1 +1,53 @@
-export { default as AdapterDateFns } from '@date-io/date-fns';
+import BaseAdapterDateFns from '@date-io/date-fns';
+import defaultLocale from 'date-fns/locale/en-US';
+// @ts-ignore
+import longFormatters from 'date-fns/_lib/format/longFormatters';
+import { MuiFormatTokenMap, MuiPickerFieldAdapter } from '../internals/models';
+
+const formatTokenMap: MuiFormatTokenMap = {
+  y: 'year',
+  yy: 'year',
+  yyy: 'year',
+  yyyy: 'year',
+  MMMM: 'month',
+  MM: 'month',
+  dd: 'day',
+  H: 'hour',
+  HH: 'hour',
+  h: 'hour',
+  hh: 'hour',
+  mm: 'minute',
+  ss: 'second',
+  a: 'am-pm',
+  aa: 'am-pm',
+  aaa: 'am-pm',
+};
+
+export class AdapterDateFns extends BaseAdapterDateFns implements MuiPickerFieldAdapter<Date> {
+  public formatTokenMap = formatTokenMap;
+
+  public expandFormat = (format: string) => {
+    const longFormatRegexp = /P+p+|P+|p+|''|'(''|[^'])+('|$)|./g;
+
+    // @see https://github.com/date-fns/date-fns/blob/master/src/format/index.js#L31
+    return format
+      .match(longFormatRegexp)!
+      .map((token: string) => {
+        const firstCharacter = token[0];
+        if (firstCharacter === 'p' || firstCharacter === 'P') {
+          const longFormatter = longFormatters[firstCharacter];
+          const locale = this.locale || defaultLocale;
+          return longFormatter(token, locale.formatLong, {});
+        }
+        return token;
+      })
+      .join('');
+  };
+
+  // Redefined here just to show how it can be written using expandFormat
+  public getFormatHelperText = (format: string) => {
+    return this.expandFormat(format)
+      .replace(/(aaa|aa|a)/g, '(a|p)m')
+      .toLocaleLowerCase();
+  };
+}

--- a/packages/x-date-pickers/src/AdapterDayjs/index.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/index.ts
@@ -1,1 +1,60 @@
-export { default as AdapterDayjs } from '@date-io/dayjs';
+import { Dayjs } from 'dayjs';
+import BaseAdapterDayjs from '@date-io/dayjs';
+import { MuiFormatTokenMap, MuiPickerFieldAdapter } from '../internals/models';
+
+const formatTokenMap: MuiFormatTokenMap = {
+  YY: 'year',
+  YYYY: 'year',
+  M: 'month',
+  MM: 'month',
+  MMM: 'month',
+  MMMM: 'month',
+  D: 'day',
+  DD: 'day',
+  H: 'hour',
+  HH: 'hour',
+  h: 'hour',
+  hh: 'hour',
+  m: 'minute',
+  mm: 'minute',
+  s: 'second',
+  ss: 'second',
+  A: 'am-pm',
+  a: 'am-pm',
+};
+
+export class AdapterDayjs extends BaseAdapterDayjs implements MuiPickerFieldAdapter<Dayjs> {
+  public formatTokenMap = formatTokenMap;
+
+  /**
+   * The current getFormatHelperText method uses an outdated format parsing logic.
+   * We should use this one in the future to support all localized formats.
+   */
+  public expandFormat = (format: string) => {
+    const localeFormats = this.rawDayJsInstance.Ls[this.locale || 'en']?.formats;
+
+    // @see https://github.com/iamkun/dayjs/blob/dev/src/plugin/localizedFormat/index.js
+    const t = (formatBis: string) =>
+      formatBis.replace(
+        /(\[[^\]]+])|(MMMM|MM|DD|dddd)/g,
+        (_: string, a: string, b: string) => a || b.slice(1),
+      );
+
+    return format.replace(
+      /(\[[^\]]+])|(LTS?|l{1,4}|L{1,4})/g,
+      (_: string, a: string, b: string) => {
+        const B = b && b.toUpperCase();
+        return (
+          a ||
+          localeFormats[b as keyof typeof localeFormats] ||
+          t(localeFormats[B as keyof typeof localeFormats] as string)
+        );
+      },
+    );
+  };
+
+  // Redefined here just to show how it can be written using expandFormat
+  public getFormatHelperText = (format: string) => {
+    return this.expandFormat(format).replace(/a/gi, '(a|p)m').toLocaleLowerCase();
+  };
+}

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
@@ -1,9 +1,7 @@
 import * as React from 'react';
-import { MuiPickersAdapter } from '../../models';
+import { MuiDateSectionName, MuiPickerFieldAdapter } from '../../models';
 import { PickerStateValueManager } from '../usePickerState';
 import { InferError, Validator } from '../validation/useValidation';
-
-export type DateSectionName = 'day' | 'month' | 'year' | 'hour' | 'minute' | 'second' | 'am-pm';
 
 export interface UseFieldParams<
   TInputValue,
@@ -57,21 +55,21 @@ export interface FieldSection {
   value: string;
   emptyValue: string;
   separator: string | null;
-  dateSectionName: DateSectionName;
+  dateSectionName: MuiDateSectionName;
   formatValue: string;
   query: string | null;
 }
 
 export interface FieldValueManager<TValue, TDate, TSection extends FieldSection, TError> {
   getSectionsFromValue: (
-    utils: MuiPickersAdapter<TDate>,
+    utils: MuiPickerFieldAdapter<TDate>,
     prevSections: TSection[] | null,
     value: TValue,
     format: string,
   ) => TSection[];
   getValueStrFromSections: (sections: TSection[]) => string;
   getValueFromSections: (
-    utils: MuiPickersAdapter<TDate>,
+    utils: MuiPickerFieldAdapter<TDate>,
     prevSections: TSection[],
     sections: TSection[],
     format: string,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import useEventCallback from '@mui/utils/useEventCallback';
+import { MuiPickerFieldAdapter } from '../../models/muiPickersAdapter';
 import { useValidation } from '../validation/useValidation';
 import { useUtils } from '../useUtils';
 import {
@@ -30,7 +31,11 @@ export const useField = <
 >(
   params: UseFieldParams<TInputValue, TValue, TDate, TSection, TProps>,
 ): UseFieldResponse<TProps> => {
-  const utils = useUtils<TDate>();
+  const utils = useUtils<TDate>() as MuiPickerFieldAdapter<TDate>;
+  if (!utils.formatTokenMap) {
+    throw new Error('This adapter is not compatible with the field components');
+  }
+
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -9,7 +9,7 @@ export const getDateSectionNameFromFormatToken = <TDate>(
   const dateSectionName = utils.formatTokenMap[formatToken];
 
   if (dateSectionName == null) {
-    throw new Error(`getDatePartNameFromFormat don't understand the format ${formatToken}`);
+    throw new Error(`getDatePartNameFromFormat doesn't understand the format ${formatToken}`);
   }
 
   return dateSectionName;

--- a/packages/x-date-pickers/src/internals/models/muiPickersAdapter.ts
+++ b/packages/x-date-pickers/src/internals/models/muiPickersAdapter.ts
@@ -1,3 +1,13 @@
 import { IUtils } from '@date-io/core/IUtils';
 
 export type MuiPickersAdapter<TDate> = IUtils<TDate>;
+
+export type MuiDateSectionName = 'day' | 'month' | 'year' | 'hour' | 'minute' | 'second' | 'am-pm';
+
+export type MuiFormatTokenMap = { [formatToken: string]: MuiDateSectionName };
+
+export interface MuiPickerFieldAdapter<TDate> extends MuiPickersAdapter<TDate> {
+  formatTokenMap: MuiFormatTokenMap;
+
+  expandFormat: (format: string) => string;
+}


### PR DESCRIPTION
[Doc preview](https://deploy-preview-5975--material-ui-x.netlify.app/x/react-date-pickers/date-field/)

- [x] Extend `AdapterDateFns` and `AdapterDayjs` with field-related elements to avoid having to touch `@date-io` during the unstable phase of the fields
- [x] Use adapters instead of hardcoded `date-fns` elements in the field codebase
- [x] Migrate the fields examples to `dayjs`