### PR TITLE
[DataGrid] Improve resize performance

### DIFF
--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -446,4 +446,6 @@ GridRow.propTypes = {
   visibleColumns: PropTypes.arrayOf(PropTypes.object).isRequired,
 } as any;
 
-export { GridRow };
+const MemoizedRow = React.memo(GridRow);
+
+export { MemoizedRow as GridRow };

--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -45,7 +45,6 @@ export interface GridRowProps {
   firstColumnToRender: number;
   lastColumnToRender: number;
   visibleColumns: GridStateColDef[];
-  renderedColumns: GridStateColDef[];
   cellFocus: GridCellIdentifier | null;
   cellTabIndex: GridCellIdentifier | null;
   editRowsState: GridEditRowsModel;
@@ -100,7 +99,6 @@ function GridRow(props: React.HTMLAttributes<HTMLDivElement> & GridRowProps) {
     rowHeight,
     className,
     visibleColumns,
-    renderedColumns,
     containerWidth,
     firstColumnToRender,
     lastColumnToRender,
@@ -285,9 +283,9 @@ function GridRow(props: React.HTMLAttributes<HTMLDivElement> & GridRowProps) {
 
   const cells: JSX.Element[] = [];
 
-  for (let i = 0; i < renderedColumns.length; i += 1) {
-    const column = renderedColumns[i];
-    const indexRelativeToAllColumns = firstColumnToRender + i;
+  for (let i = firstColumnToRender; i < lastColumnToRender; i += 1) {
+    const indexRelativeToAllColumns = i;
+    const column = visibleColumns[indexRelativeToAllColumns];
 
     const isLastColumn = indexRelativeToAllColumns === visibleColumns.length - 1;
     const removeLastBorderRight = isLastColumn && hasScrollX && !hasScrollY;
@@ -438,7 +436,6 @@ GridRow.propTypes = {
   index: PropTypes.number.isRequired,
   isLastVisible: PropTypes.bool,
   lastColumnToRender: PropTypes.number.isRequired,
-  renderedColumns: PropTypes.arrayOf(PropTypes.object).isRequired,
   row: PropTypes.object.isRequired,
   rowHeight: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]).isRequired,
   rowId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -218,11 +218,11 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     setContainerWidth(rootRef.current!.clientWidth);
   }, [rowsMeta.currentPageTotalHeight]);
 
-  const handleResize = React.useCallback<GridEventListener<'resize'>>((params) => {
+  const handleResize = React.useCallback<GridEventListener<'debouncedResize'>>((params) => {
     setContainerWidth(params.width);
   }, []);
 
-  useGridApiEventHandler(apiRef, 'resize', handleResize);
+  useGridApiEventHandler(apiRef, 'debouncedResize', handleResize);
 
   const updateRenderZonePosition = React.useCallback(
     (nextRenderContext: GridRenderContext) => {

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -440,8 +440,6 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
       visibleRows: currentPage.rows,
     });
 
-    const renderedColumns = visibleColumns.slice(firstColumnToRender, lastColumnToRender);
-
     const rows: JSX.Element[] = [];
 
     for (let i = 0; i < renderedRows.length; i += 1) {
@@ -468,7 +466,6 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
           cellFocus={cellFocus} // TODO move to inside the row
           cellTabIndex={cellTabIndex} // TODO move to inside the row
           editRowsState={editRowsState} // TODO move to inside the row
-          renderedColumns={renderedColumns}
           visibleColumns={visibleColumns}
           firstColumnToRender={firstColumnToRender}
           lastColumnToRender={lastColumnToRender}

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -395,7 +395,7 @@
   { "name": "GridRoot", "kind": "Variable" },
   { "name": "GridRootContainerRef", "kind": "TypeAlias" },
   { "name": "GridRootProps", "kind": "Interface" },
-  { "name": "GridRow", "kind": "Function" },
+  { "name": "GridRow", "kind": "Variable" },
   { "name": "GridRowApi", "kind": "Interface" },
   { "name": "GridRowClassNameParams", "kind": "Interface" },
   { "name": "GridRowCount", "kind": "Variable" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -366,7 +366,7 @@
   { "name": "GridRoot", "kind": "Variable" },
   { "name": "GridRootContainerRef", "kind": "TypeAlias" },
   { "name": "GridRootProps", "kind": "Interface" },
-  { "name": "GridRow", "kind": "Function" },
+  { "name": "GridRow", "kind": "Variable" },
   { "name": "GridRowApi", "kind": "Interface" },
   { "name": "GridRowClassNameParams", "kind": "Interface" },
   { "name": "GridRowCount", "kind": "Variable" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -338,7 +338,7 @@
   { "name": "GridRoot", "kind": "Variable" },
   { "name": "GridRootContainerRef", "kind": "TypeAlias" },
   { "name": "GridRootProps", "kind": "Interface" },
-  { "name": "GridRow", "kind": "Function" },
+  { "name": "GridRow", "kind": "Variable" },
   { "name": "GridRowApi", "kind": "Interface" },
   { "name": "GridRowClassNameParams", "kind": "Interface" },
   { "name": "GridRowCount", "kind": "Variable" },


### PR DESCRIPTION
Fixes #3894

Before: https://codesandbox.io/s/datagriddemo-rendercell-call-count-v5-forked-gbk73
After: https://codesandbox.io/s/datagriddemo-rendercell-call-count-v5-forked-g8p003
To see visual performance difference - try with 6x CPU throttling