### PR TITLE
[DateRangePicker] Display shortcuts

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
@@ -38,26 +38,25 @@ import { DateRangeShortCutWrapper } from '../DateRangeShortCutWrapper';
 
 const releaseInfo = getReleaseInfo();
 
-export interface DateRangePickerViewSlotsComponent
-  extends DateRangePickerViewMobileSlotsComponent {
+export interface DateRangePickerViewSlotsComponent extends DateRangePickerViewMobileSlotsComponent {
   ShortCutWrapper: React.ElementType;
 }
 
 export interface DateRangePickerViewSlotsComponentsProps
   extends DateRangePickerViewMobileSlotsComponentsProps {
-  shortCutWrapper?: any
+  shortCutWrapper?: any;
 }
 
 export interface ExportedDateRangePickerViewProps<TDate>
   extends ExportedDesktopDateRangeCalendarProps<TDate>,
-  DayRangeValidationProps<TDate>,
-  Omit<
-  ExportedCalendarPickerProps<TDate>,
-  | 'onYearChange'
-  | 'renderDay'
-  | keyof BaseDateValidationProps<TDate>
-  | keyof DayValidationProps<TDate>
-  > {
+    DayRangeValidationProps<TDate>,
+    Omit<
+      ExportedCalendarPickerProps<TDate>,
+      | 'onYearChange'
+      | 'renderDay'
+      | keyof BaseDateValidationProps<TDate>
+      | keyof DayValidationProps<TDate>
+    > {
   /**
    * Overrideable components.
    * @default {}
@@ -94,9 +93,9 @@ export interface ExportedDateRangePickerViewProps<TDate>
 
 interface DateRangePickerViewProps<TInputDate, TDate>
   extends CurrentlySelectingRangeEndProps,
-  ExportedDateRangePickerViewProps<TDate>,
-  PickerStatePickerProps<DateRange<TDate>>,
-  Required<BaseDateValidationProps<TDate>> {
+    ExportedDateRangePickerViewProps<TDate>,
+    PickerStatePickerProps<DateRange<TDate>>,
+    Required<BaseDateValidationProps<TDate>> {
   calendars: 1 | 2 | 3;
   open: boolean;
   startText: React.ReactNode;
@@ -109,10 +108,10 @@ type DateRangePickerViewComponent = (<TInputDate, TDate = TInputDate>(
   props: DateRangePickerViewProps<TInputDate, TDate>,
 ) => JSX.Element) & { propTypes?: any };
 
-
 const DateRangePickerViewContent = styled('div')({
-  display: 'flex', flexDirection: 'column'
-})
+  display: 'flex',
+  flexDirection: 'column',
+});
 
 /**
  * @ignore - internal component.
@@ -205,7 +204,7 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
         currentlySelectingRangeEnd === 'start'
           ? currentlySelectedDate
           : // If need to focus end, scroll to the state when "end" is displaying in the last calendar
-          utils.addMonths(currentlySelectedDate, -displayingMonthRange);
+            utils.addMonths(currentlySelectedDate, -displayingMonthRange);
 
       changeMonth(newMonth);
     }
@@ -281,10 +280,15 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
     }
   };
 
-  const ShortCutWrapper = components?.ShortCutWrapper ?? DateRangeShortCutWrapper
+  const ShortCutWrapper = components?.ShortCutWrapper ?? DateRangeShortCutWrapper;
   return (
     <div className={className}>
-      <ShortCutWrapper isDateDisabled={isDateDisabled} onSetValue={onSetValue} position={wrapperVariant === 'desktop' ? 'start' : 'bottom'}  {...componentsProps?.shortCutWrapper}>
+      <ShortCutWrapper
+        isDateDisabled={isDateDisabled}
+        onSetValue={onSetValue}
+        position={wrapperVariant === 'desktop' ? 'start' : 'bottom'}
+        {...componentsProps?.shortCutWrapper}
+      >
         <DateRangePickerViewContent>
           <Watermark packageName="x-date-pickers-pro" releaseInfo={releaseInfo} />
           {toShowToolbar && (

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
@@ -12,6 +12,7 @@ import {
   DayPickerProps,
   BaseDateValidationProps,
   DayValidationProps,
+  PickerStateWrapperProps,
 } from '@mui/x-date-pickers/internals';
 import {
   DateRange,
@@ -32,25 +33,30 @@ import {
   ExportedDesktopDateRangeCalendarProps,
 } from './DateRangePickerViewDesktop';
 import { getReleaseInfo } from '../internal/utils/releaseInfo';
+import { DateRangeShortCutWrapper } from '../DateRangeShortCutWrapper';
 
 const releaseInfo = getReleaseInfo();
 
 export interface DateRangePickerViewSlotsComponent
-  extends DateRangePickerViewMobileSlotsComponent {}
+  extends DateRangePickerViewMobileSlotsComponent {
+  ShortCutWrapper: React.ElementType;
+}
 
 export interface DateRangePickerViewSlotsComponentsProps
-  extends DateRangePickerViewMobileSlotsComponentsProps {}
+  extends DateRangePickerViewMobileSlotsComponentsProps {
+  shortCutWrapper?: any
+}
 
 export interface ExportedDateRangePickerViewProps<TDate>
   extends ExportedDesktopDateRangeCalendarProps<TDate>,
-    DayRangeValidationProps<TDate>,
-    Omit<
-      ExportedCalendarPickerProps<TDate>,
-      | 'onYearChange'
-      | 'renderDay'
-      | keyof BaseDateValidationProps<TDate>
-      | keyof DayValidationProps<TDate>
-    > {
+  DayRangeValidationProps<TDate>,
+  Omit<
+  ExportedCalendarPickerProps<TDate>,
+  | 'onYearChange'
+  | 'renderDay'
+  | keyof BaseDateValidationProps<TDate>
+  | keyof DayValidationProps<TDate>
+  > {
   /**
    * Overrideable components.
    * @default {}
@@ -87,14 +93,15 @@ export interface ExportedDateRangePickerViewProps<TDate>
 
 interface DateRangePickerViewProps<TInputDate, TDate>
   extends CurrentlySelectingRangeEndProps,
-    ExportedDateRangePickerViewProps<TDate>,
-    PickerStatePickerProps<DateRange<TDate>>,
-    Required<BaseDateValidationProps<TDate>> {
+  ExportedDateRangePickerViewProps<TDate>,
+  PickerStatePickerProps<DateRange<TDate>>,
+  Required<BaseDateValidationProps<TDate>> {
   calendars: 1 | 2 | 3;
   open: boolean;
   startText: React.ReactNode;
   endText: React.ReactNode;
   DateInputProps: DateRangeInputProps<TInputDate, TDate>;
+  onSetValue: PickerStateWrapperProps['onSetValue'];
 }
 
 type DateRangePickerViewComponent = (<TInputDate, TDate = TInputDate>(
@@ -133,6 +140,9 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
     toggleMobileKeyboardView,
     toolbarFormat,
     toolbarTitle,
+    onSetValue,
+    components,
+    componentsProps,
     ...other
   } = props;
 
@@ -189,7 +199,7 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
         currentlySelectingRangeEnd === 'start'
           ? currentlySelectedDate
           : // If need to focus end, scroll to the state when "end" is displaying in the last calendar
-            utils.addMonths(currentlySelectedDate, -displayingMonthRange);
+          utils.addMonths(currentlySelectedDate, -displayingMonthRange);
 
       changeMonth(newMonth);
     }
@@ -249,6 +259,8 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
       maxDate,
       shouldDisableDate: wrappedShouldDisableDate,
       ...calendarState,
+      components,
+      componentsProps,
       ...other,
     };
 
@@ -263,30 +275,33 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
     }
   };
 
+  const ShortCutWrapper = components?.ShortCutWrapper ?? DateRangeShortCutWrapper
   return (
     <div className={className}>
-      <Watermark packageName="x-date-pickers-pro" releaseInfo={releaseInfo} />
-      {toShowToolbar && (
-        <DateRangePickerToolbar
-          parsedValue={parsedValue}
-          isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
-          toggleMobileKeyboardView={toggleMobileKeyboardView}
-          currentlySelectingRangeEnd={currentlySelectingRangeEnd}
-          setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}
-          startText={startText}
-          endText={endText}
-          toolbarTitle={toolbarTitle}
-          toolbarFormat={toolbarFormat}
-        />
-      )}
+      <ShortCutWrapper isDateDisabled={isDateDisabled} onSetValue={onSetValue} position={wrapperVariant === 'desktop' ? 'start' : 'bottom'}  {...componentsProps?.shortCutWrapper}>
+        <Watermark packageName="x-date-pickers-pro" releaseInfo={releaseInfo} />
+        {toShowToolbar && (
+          <DateRangePickerToolbar
+            parsedValue={parsedValue}
+            isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
+            toggleMobileKeyboardView={toggleMobileKeyboardView}
+            currentlySelectingRangeEnd={currentlySelectingRangeEnd}
+            setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}
+            startText={startText}
+            endText={endText}
+            toolbarTitle={toolbarTitle}
+            toolbarFormat={toolbarFormat}
+          />
+        )}
 
-      {isMobileKeyboardViewOpen ? (
-        <MobileKeyboardInputView>
-          <DateRangePickerInput disableOpenPicker ignoreInvalidInputs {...DateInputProps} />
-        </MobileKeyboardInputView>
-      ) : (
-        renderView()
-      )}
+        {isMobileKeyboardViewOpen ? (
+          <MobileKeyboardInputView>
+            <DateRangePickerInput disableOpenPicker ignoreInvalidInputs {...DateInputProps} />
+          </MobileKeyboardInputView>
+        ) : (
+          renderView()
+        )}
+      </ShortCutWrapper>
     </div>
   );
 }

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Watermark } from '@mui/x-license-pro';
+import { styled } from '@mui/material/styles';
 import {
   useUtils,
   WrapperVariantContext,
@@ -107,6 +108,11 @@ interface DateRangePickerViewProps<TInputDate, TDate>
 type DateRangePickerViewComponent = (<TInputDate, TDate = TInputDate>(
   props: DateRangePickerViewProps<TInputDate, TDate>,
 ) => JSX.Element) & { propTypes?: any };
+
+
+const DateRangePickerViewContent = styled('div')({
+  display: 'flex', flexDirection: 'column'
+})
 
 /**
  * @ignore - internal component.
@@ -279,28 +285,30 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
   return (
     <div className={className}>
       <ShortCutWrapper isDateDisabled={isDateDisabled} onSetValue={onSetValue} position={wrapperVariant === 'desktop' ? 'start' : 'bottom'}  {...componentsProps?.shortCutWrapper}>
-        <Watermark packageName="x-date-pickers-pro" releaseInfo={releaseInfo} />
-        {toShowToolbar && (
-          <DateRangePickerToolbar
-            parsedValue={parsedValue}
-            isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
-            toggleMobileKeyboardView={toggleMobileKeyboardView}
-            currentlySelectingRangeEnd={currentlySelectingRangeEnd}
-            setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}
-            startText={startText}
-            endText={endText}
-            toolbarTitle={toolbarTitle}
-            toolbarFormat={toolbarFormat}
-          />
-        )}
+        <DateRangePickerViewContent>
+          <Watermark packageName="x-date-pickers-pro" releaseInfo={releaseInfo} />
+          {toShowToolbar && (
+            <DateRangePickerToolbar
+              parsedValue={parsedValue}
+              isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
+              toggleMobileKeyboardView={toggleMobileKeyboardView}
+              currentlySelectingRangeEnd={currentlySelectingRangeEnd}
+              setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}
+              startText={startText}
+              endText={endText}
+              toolbarTitle={toolbarTitle}
+              toolbarFormat={toolbarFormat}
+            />
+          )}
 
-        {isMobileKeyboardViewOpen ? (
-          <MobileKeyboardInputView>
-            <DateRangePickerInput disableOpenPicker ignoreInvalidInputs {...DateInputProps} />
-          </MobileKeyboardInputView>
-        ) : (
-          renderView()
-        )}
+          {isMobileKeyboardViewOpen ? (
+            <MobileKeyboardInputView>
+              <DateRangePickerInput disableOpenPicker ignoreInvalidInputs {...DateInputProps} />
+            </MobileKeyboardInputView>
+          ) : (
+            renderView()
+          )}
+        </DateRangePickerViewContent>
       </ShortCutWrapper>
     </div>
   );

--- a/packages/x-date-pickers-pro/src/DateRangeShortCutWrapper/DateRangeShortCutWrapper.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeShortCutWrapper/DateRangeShortCutWrapper.tsx
@@ -12,7 +12,7 @@ import Stack from '@mui/material/Stack';
 export interface DateRangeShortCutWrapperProps {
   children?: React.ReactNode;
   isDateDisabled: any;
-  position: 'start' | 'end' | 'top' | 'bottom',
+  position: 'start' | 'end' | 'top' | 'bottom';
   onSetValue: any;
 }
 
@@ -25,9 +25,12 @@ const DateRangeShortCutWrapperRoot = styled('div')<{
 
 const DateRangeShortCutWrapperContainer = styled('div')<{
   ownerState: Pick<DateRangeShortCutWrapperProps, 'position'>;
-}>(({ theme, ownerState }) => ({ padding: ['start', 'end'].includes(ownerState.position) ? theme.spacing(2) : theme.spacing(1) }));
+}>(({ theme, ownerState }) => ({
+  padding: ['start', 'end'].includes(ownerState.position) ? theme.spacing(2) : theme.spacing(1),
+}));
 
-export interface RangeItem<TValue> extends Omit<DateRangeShortCutWrapperProps, 'children' | 'position'> {
+export interface RangeItem<TValue>
+  extends Omit<DateRangeShortCutWrapperProps, 'children' | 'position'> {
   label: string;
   value: TValue;
   closeOnSelect?: boolean;
@@ -48,53 +51,53 @@ const DateRangeShortCutItem = (props: RangeItem<any>) => {
 const DateRangeShortCutButton = (props: RangeItem<any>) => {
   const { label, value, onSetValue, closeOnSelect = false } = props;
 
-  return (
-    <Button onClick={() => onSetValue(value, closeOnSelect)}>
-      {label}
-    </Button>
-  );
+  return <Button onClick={() => onSetValue(value, closeOnSelect)}>{label}</Button>;
 };
 
 const DateRangeVerticalShortcut = (props: Omit<DateRangeShortCutWrapperProps, 'children'>) => {
-  const { onSetValue, isDateDisabled, position } = props
-  return <React.Fragment> <DateRangeShortCutWrapperContainer ownerState={{ position }}>
-    <Typography variant="overline">Date range shortcuts</Typography>
-    <List>
-      {[{ label: 'clear', value: [null, null] }].map((options) => (
-        <DateRangeShortCutItem
-          key={options.label}
-          {...options}
-          onSetValue={onSetValue}
-          isDateDisabled={isDateDisabled}
-        />
-      ))}
-    </List>
-  </DateRangeShortCutWrapperContainer>
-    <Divider orientation="vertical" />
-  </React.Fragment>
-}
+  const { onSetValue, isDateDisabled, position } = props;
+  return (
+    <React.Fragment>
+      {' '}
+      <DateRangeShortCutWrapperContainer ownerState={{ position }}>
+        <Typography variant="overline">Date range shortcuts</Typography>
+        <List>
+          {[{ label: 'clear', value: [null, null] }].map((options) => (
+            <DateRangeShortCutItem
+              key={options.label}
+              {...options}
+              onSetValue={onSetValue}
+              isDateDisabled={isDateDisabled}
+            />
+          ))}
+        </List>
+      </DateRangeShortCutWrapperContainer>
+      <Divider orientation="vertical" />
+    </React.Fragment>
+  );
+};
 
 const DateRangeHorizontalShortcut = (props: Omit<DateRangeShortCutWrapperProps, 'children'>) => {
-  const { onSetValue, isDateDisabled, position } = props
+  const { onSetValue, isDateDisabled, position } = props;
 
-  return <React.Fragment>
-    <Divider />
-    <DateRangeShortCutWrapperContainer ownerState={{ position }}>
-      <Stack direction='row' spacing={1}>
-        {[{ label: 'clear', value: [null, null] }].map((options) => (
-          <DateRangeShortCutButton
-            key={options.label}
-            {...options}
-            onSetValue={onSetValue}
-            isDateDisabled={isDateDisabled}
-          />
-        ))}
-      </Stack >
-    </DateRangeShortCutWrapperContainer>
-  </React.Fragment>
-}
-
-
+  return (
+    <React.Fragment>
+      <Divider />
+      <DateRangeShortCutWrapperContainer ownerState={{ position }}>
+        <Stack direction="row" spacing={1}>
+          {[{ label: 'clear', value: [null, null] }].map((options) => (
+            <DateRangeShortCutButton
+              key={options.label}
+              {...options}
+              onSetValue={onSetValue}
+              isDateDisabled={isDateDisabled}
+            />
+          ))}
+        </Stack>
+      </DateRangeShortCutWrapperContainer>
+    </React.Fragment>
+  );
+};
 
 export function DateRangeShortCutWrapper(props: DateRangeShortCutWrapperProps) {
   const {
@@ -105,22 +108,30 @@ export function DateRangeShortCutWrapper(props: DateRangeShortCutWrapperProps) {
     // ...other
   } = props;
 
-  const isVerticalShortcut = ['start', 'end'].includes(position)
-  const isShortcutFirst = ['start', 'top'].includes(position)
+  const isVerticalShortcut = ['start', 'end'].includes(position);
+  const isShortcutFirst = ['start', 'top'].includes(position);
 
-  const ShortCutComponent = isVerticalShortcut ? DateRangeVerticalShortcut : DateRangeHorizontalShortcut
+  const ShortCutComponent = isVerticalShortcut
+    ? DateRangeVerticalShortcut
+    : DateRangeHorizontalShortcut;
 
   return (
     <DateRangeShortCutWrapperRoot ownerState={{ position }}>
-      {isShortcutFirst && <ShortCutComponent
-        onSetValue={onSetValue}
-        isDateDisabled={isDateDisabled}
-        position={position} />}
+      {isShortcutFirst && (
+        <ShortCutComponent
+          onSetValue={onSetValue}
+          isDateDisabled={isDateDisabled}
+          position={position}
+        />
+      )}
       {children}
-      {!isShortcutFirst && <ShortCutComponent
-        onSetValue={onSetValue}
-        isDateDisabled={isDateDisabled}
-        position={position} />}
+      {!isShortcutFirst && (
+        <ShortCutComponent
+          onSetValue={onSetValue}
+          isDateDisabled={isDateDisabled}
+          position={position}
+        />
+      )}
     </DateRangeShortCutWrapperRoot>
   );
 }

--- a/packages/x-date-pickers-pro/src/DateRangeShortCutWrapper/DateRangeShortCutWrapper.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeShortCutWrapper/DateRangeShortCutWrapper.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import Divider from '@mui/material/Divider';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+
+export interface DateRangeShortCutWrapperProps {
+  children?: React.ReactNode;
+  isDateDisabled: any;
+  position: 'start' | 'end' | 'top' | 'bottom',
+  onSetValue: any;
+}
+
+const DateRangeShortCutWrapperRoot = styled('div')<{
+  ownerState: Pick<DateRangeShortCutWrapperProps, 'position'>;
+}>(({ ownerState }) => ({
+  display: 'flex',
+  flexDirection: ['start', 'end'].includes(ownerState.position) ? 'row' : 'column',
+}));
+
+const DateRangeShortCutWrapperContainer = styled('div')<{
+  ownerState: Pick<DateRangeShortCutWrapperProps, 'position'>;
+}>(({ theme, ownerState }) => ({ padding: ['start', 'end'].includes(ownerState.position) ? theme.spacing(2) : theme.spacing(1) }));
+
+export interface RangeItem<TValue> extends Omit<DateRangeShortCutWrapperProps, 'children' | 'position'> {
+  label: string;
+  value: TValue;
+  closeOnSelect?: boolean;
+}
+
+const DateRangeShortCutItem = (props: RangeItem<any>) => {
+  const { label, value, onSetValue, closeOnSelect = false } = props;
+
+  return (
+    <ListItem disablePadding>
+      <ListItemButton onClick={() => onSetValue(value, closeOnSelect)}>
+        <ListItemText primary={label} />
+      </ListItemButton>
+    </ListItem>
+  );
+};
+
+const DateRangeShortCutButton = (props: RangeItem<any>) => {
+  const { label, value, onSetValue, closeOnSelect = false } = props;
+
+  return (
+    <Button onClick={() => onSetValue(value, closeOnSelect)}>
+      {label}
+    </Button>
+  );
+};
+
+const DateRangeVerticalShortcut = (props: Omit<DateRangeShortCutWrapperProps, 'children'>) => {
+  const { onSetValue, isDateDisabled, position } = props
+  return <React.Fragment> <DateRangeShortCutWrapperContainer ownerState={{ position }}>
+    <Typography variant="overline">Date range shortcuts</Typography>
+    <List>
+      {[{ label: 'clear', value: [null, null] }].map((options) => (
+        <DateRangeShortCutItem
+          key={options.label}
+          {...options}
+          onSetValue={onSetValue}
+          isDateDisabled={isDateDisabled}
+        />
+      ))}
+    </List>
+  </DateRangeShortCutWrapperContainer>
+    <Divider orientation="vertical" />
+  </React.Fragment>
+}
+
+const DateRangeHorizontalShortcut = (props: Omit<DateRangeShortCutWrapperProps, 'children'>) => {
+  const { onSetValue, isDateDisabled, position } = props
+
+  return <React.Fragment>
+    <Divider />
+    <DateRangeShortCutWrapperContainer ownerState={{ position }}>
+      <Stack direction='row' spacing={1}>
+        {[{ label: 'clear', value: [null, null] }].map((options) => (
+          <DateRangeShortCutButton
+            key={options.label}
+            {...options}
+            onSetValue={onSetValue}
+            isDateDisabled={isDateDisabled}
+          />
+        ))}
+      </Stack >
+    </DateRangeShortCutWrapperContainer>
+  </React.Fragment>
+}
+
+
+
+export function DateRangeShortCutWrapper(props: DateRangeShortCutWrapperProps) {
+  const {
+    children,
+    isDateDisabled,
+    onSetValue,
+    position,
+    // ...other
+  } = props;
+
+  const isVerticalShortcut = ['start', 'end'].includes(position)
+  const isShortcutFirst = ['start', 'top'].includes(position)
+
+  const ShortCutComponent = isVerticalShortcut ? DateRangeVerticalShortcut : DateRangeHorizontalShortcut
+
+  return (
+    <DateRangeShortCutWrapperRoot ownerState={{ position }}>
+      {isShortcutFirst && <ShortCutComponent
+        onSetValue={onSetValue}
+        isDateDisabled={isDateDisabled}
+        position={position} />}
+      {children}
+      {!isShortcutFirst && <ShortCutComponent
+        onSetValue={onSetValue}
+        isDateDisabled={isDateDisabled}
+        position={position} />}
+    </DateRangeShortCutWrapperRoot>
+  );
+}

--- a/packages/x-date-pickers-pro/src/DateRangeShortCutWrapper/index.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeShortCutWrapper/index.ts
@@ -1,0 +1,2 @@
+export { DateRangeShortCutWrapper } from './DateRangeShortCutWrapper';
+export type { DateRangeShortCutWrapperProps } from './DateRangeShortCutWrapper';

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -123,6 +123,7 @@ export const DesktopDateRangePicker = React.forwardRef(function DesktopDateRange
     >
       <DateRangePickerView<TInputDate, TDate>
         open={wrapperProps.open}
+        onSetValue={wrapperProps.onSetValue}
         DateInputProps={DateInputProps}
         currentlySelectingRangeEnd={currentlySelectingRangeEnd}
         setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -119,6 +119,7 @@ export const MobileDateRangePicker = React.forwardRef(function MobileDateRangePi
     >
       <DateRangePickerView
         open={wrapperProps.open}
+        onSetValue={wrapperProps.onSetValue}
         DateInputProps={DateInputProps}
         currentlySelectingRangeEnd={currentlySelectingRangeEnd}
         setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -113,6 +113,7 @@ export const StaticDateRangePicker = React.forwardRef(function StaticDateRangePi
     >
       <DateRangePickerView
         open={wrapperProps.open}
+        onSetValue={wrapperProps.onSetValue}
         DateInputProps={DateInputProps}
         currentlySelectingRangeEnd={currentlySelectingRangeEnd}
         setCurrentlySelectingRangeEnd={setCurrentlySelectingRangeEnd}

--- a/packages/x-date-pickers/src/internals/components/PickerStaticWrapper/PickerStaticWrapper.test.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerStaticWrapper/PickerStaticWrapper.test.tsx
@@ -16,6 +16,7 @@ describe('<PickerStaticWrapper />', () => {
       onSetToday={() => {}}
       onAccept={() => {}}
       onClear={() => {}}
+      onSetValue={() => {}}
     />,
     () => ({
       classes,

--- a/packages/x-date-pickers/src/internals/components/PickerStaticWrapper/PickerStaticWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerStaticWrapper/PickerStaticWrapper.tsx
@@ -140,6 +140,7 @@ PickerStaticWrapper.propTypes = {
   onClear: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
   onSetToday: PropTypes.func.isRequired,
+  onSetValue: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
 } as any;
 

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -10,7 +10,7 @@ import { PickersActionBar, PickersActionBarProps } from '../../PickersActionBar'
 import { PickersSlotsComponent } from './wrappers/WrapperProps';
 import { PickerStateWrapperProps } from '../hooks/usePickerState';
 
-export interface PickersPopperSlotsComponent extends PickersSlotsComponent { }
+export interface PickersPopperSlotsComponent extends PickersSlotsComponent {}
 
 export interface PickersPopperSlotsComponentsProps {
   actionBar: Omit<PickersActionBarProps, 'onAccept' | 'onClear' | 'onCancel' | 'onSetToday'>;
@@ -37,8 +37,8 @@ export interface ExportedPickerPopperProps {
 
 export interface PickerPopperProps
   extends ExportedPickerPopperProps,
-  ExportedPickerPaperProps,
-  Omit<PickerStateWrapperProps, 'onDismiss'> {
+    ExportedPickerPaperProps,
+    Omit<PickerStateWrapperProps, 'onDismiss'> {
   role: 'tooltip' | 'dialog';
   TrapFocusProps?: Partial<MuiTrapFocusProps>;
   anchorEl: MuiPopperProps['anchorEl'];

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -8,8 +8,9 @@ import { styled } from '@mui/material/styles';
 import { TransitionProps as MuiTransitionProps } from '@mui/material/transitions';
 import { PickersActionBar, PickersActionBarProps } from '../../PickersActionBar';
 import { PickersSlotsComponent } from './wrappers/WrapperProps';
+import { PickerStateWrapperProps } from '../hooks/usePickerState';
 
-export interface PickersPopperSlotsComponent extends PickersSlotsComponent {}
+export interface PickersPopperSlotsComponent extends PickersSlotsComponent { }
 
 export interface PickersPopperSlotsComponentsProps {
   actionBar: Omit<PickersActionBarProps, 'onAccept' | 'onClear' | 'onCancel' | 'onSetToday'>;
@@ -34,19 +35,17 @@ export interface ExportedPickerPopperProps {
   TransitionComponent?: React.JSXElementConstructor<MuiTransitionProps>;
 }
 
-export interface PickerPopperProps extends ExportedPickerPopperProps, ExportedPickerPaperProps {
+export interface PickerPopperProps
+  extends ExportedPickerPopperProps,
+  ExportedPickerPaperProps,
+  Omit<PickerStateWrapperProps, 'onDismiss'> {
   role: 'tooltip' | 'dialog';
   TrapFocusProps?: Partial<MuiTrapFocusProps>;
   anchorEl: MuiPopperProps['anchorEl'];
-  open: MuiPopperProps['open'];
   containerRef?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
   onClose: () => void;
   onBlur?: () => void;
-  onClear: () => void;
-  onCancel: () => void;
-  onAccept: () => void;
-  onSetToday: () => void;
   components?: Partial<PickersPopperSlotsComponent>;
   componentsProps?: Partial<PickersPopperSlotsComponentsProps>;
 }

--- a/packages/x-date-pickers/src/internals/components/wrappers/DesktopTooltipWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/DesktopTooltipWrapper.tsx
@@ -19,6 +19,7 @@ export function DesktopTooltipWrapper(props: InternalDesktopWrapperProps) {
     onCancel,
     onAccept,
     onSetToday,
+    onSetValue,
     components,
     componentsProps,
   } = props;
@@ -57,6 +58,7 @@ export function DesktopTooltipWrapper(props: InternalDesktopWrapperProps) {
         onCancel={onCancel}
         onAccept={onAccept}
         onSetToday={onSetToday}
+        onSetValue={onSetValue}
         components={components}
         componentsProps={componentsProps}
       >

--- a/packages/x-date-pickers/src/internals/components/wrappers/DesktopWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/DesktopWrapper.tsx
@@ -22,9 +22,7 @@ export interface DesktopWrapperSlotsComponent
 
 export interface DesktopWrapperSlotsComponentsProps extends PickersPopperSlotsComponentsProps {}
 
-export interface InternalDesktopWrapperProps
-  extends DesktopWrapperProps,
-    PickerStateWrapperProps {
+export interface InternalDesktopWrapperProps extends DesktopWrapperProps, PickerStateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
   KeyboardDateInputComponent: React.JSXElementConstructor<
     DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> }

--- a/packages/x-date-pickers/src/internals/components/wrappers/DesktopWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/DesktopWrapper.tsx
@@ -22,7 +22,9 @@ export interface DesktopWrapperSlotsComponent
 
 export interface DesktopWrapperSlotsComponentsProps extends PickersPopperSlotsComponentsProps {}
 
-export interface InternalDesktopWrapperProps extends DesktopWrapperProps, PickerStateWrapperProps {
+export interface InternalDesktopWrapperProps
+  extends DesktopWrapperProps,
+    PickerStateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
   KeyboardDateInputComponent: React.JSXElementConstructor<
     DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> }
@@ -49,6 +51,7 @@ export function DesktopWrapper(props: InternalDesktopWrapperProps) {
     onCancel,
     onAccept,
     onSetToday,
+    onSetValue,
     open,
     PopperProps,
     PaperProps,
@@ -74,6 +77,7 @@ export function DesktopWrapper(props: InternalDesktopWrapperProps) {
         onClear={onClear}
         onAccept={onAccept}
         onSetToday={onSetToday}
+        onSetValue={onSetValue}
         components={components}
         componentsProps={componentsProps}
       >

--- a/packages/x-date-pickers/src/internals/components/wrappers/MobileWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/MobileWrapper.tsx
@@ -16,9 +16,9 @@ export interface MobileWrapperProps extends ExportedPickerModalProps {
 
 export interface MobileWrapperSlotsComponent
   extends PickersModalDialogSlotsComponent,
-  DateInputSlotsComponent { }
+    DateInputSlotsComponent {}
 
-export interface MobileWrapperSlotsComponentsProps extends PickersModalDialogSlotsComponentsProps { }
+export interface MobileWrapperSlotsComponentsProps extends PickersModalDialogSlotsComponentsProps {}
 
 export interface InternalMobileWrapperProps extends MobileWrapperProps, PickerStateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };

--- a/packages/x-date-pickers/src/internals/components/wrappers/MobileWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/MobileWrapper.tsx
@@ -16,9 +16,9 @@ export interface MobileWrapperProps extends ExportedPickerModalProps {
 
 export interface MobileWrapperSlotsComponent
   extends PickersModalDialogSlotsComponent,
-    DateInputSlotsComponent {}
+  DateInputSlotsComponent { }
 
-export interface MobileWrapperSlotsComponentsProps extends PickersModalDialogSlotsComponentsProps {}
+export interface MobileWrapperSlotsComponentsProps extends PickersModalDialogSlotsComponentsProps { }
 
 export interface InternalMobileWrapperProps extends MobileWrapperProps, PickerStateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
@@ -37,6 +37,7 @@ export function MobileWrapper(props: InternalMobileWrapperProps) {
     onDismiss,
     onCancel,
     onSetToday,
+    onSetValue,
     open,
     PureDateInputComponent,
     components,
@@ -54,6 +55,7 @@ export function MobileWrapper(props: InternalMobileWrapperProps) {
         onDismiss={onDismiss}
         onCancel={onCancel}
         onSetToday={onSetToday}
+        onSetValue={onSetValue}
         open={open}
         components={components}
         componentsProps={componentsProps}

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -163,19 +163,20 @@ export interface PickerStatePickerProps<TValue> {
   ) => void;
 }
 
-export interface PickerStateWrapperProps {
+export interface PickerStateWrapperProps<TValue=any> {
   onAccept: () => void;
   onClear: () => void;
   onDismiss: () => void;
   onCancel: () => void;
   onSetToday: () => void;
+  onSetValue: (newValue: TValue, acceptAndClose?: boolean) => void;
   open: boolean;
 }
 
 interface PickerState<TInputValue, TValue> {
   inputProps: PickerStateInputProps<TInputValue, TValue>;
   pickerProps: PickerStatePickerProps<TValue>;
-  wrapperProps: PickerStateWrapperProps;
+  wrapperProps: PickerStateWrapperProps<TValue>;
 }
 
 export const usePickerState = <TInputValue, TValue, TDate>(
@@ -259,7 +260,7 @@ export const usePickerState = <TInputValue, TValue, TDate>(
     setDate({ action: 'setCommitted', value: parsedDateValue, skipOnChangeCall: true });
   }
 
-  const wrapperProps = React.useMemo<PickerStateWrapperProps>(
+  const wrapperProps = React.useMemo<PickerStateWrapperProps<TValue>>(
     () => ({
       open: isOpen,
       onClear: () => {
@@ -297,6 +298,10 @@ export const usePickerState = <TInputValue, TValue, TDate>(
       onSetToday: () => {
         // Set all dates in state to equal today and close picker.
         setDate({ value: valueManager.getTodayValue(utils), action: 'acceptAndClose' });
+      },
+      onSetValue: (newValue: TValue, acceptAndClose: boolean = false) => {
+        // Set any value, and optiomnaly accept and close the picker after.
+        setDate({ value: newValue, action: acceptAndClose ? 'acceptAndClose' : 'setCommitted' });
       },
     }),
     [setDate, isOpen, utils, dateState, valueManager, value, parsedDateValue],

--- a/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePickerState.ts
@@ -163,7 +163,7 @@ export interface PickerStatePickerProps<TValue> {
   ) => void;
 }
 
-export interface PickerStateWrapperProps<TValue=any> {
+export interface PickerStateWrapperProps<TValue = any> {
   onAccept: () => void;
   onClear: () => void;
   onDismiss: () => void;

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -34,7 +34,11 @@ export { DAY_MARGIN } from './constants/dimensions';
 
 export { useMaskedInput } from './hooks/useMaskedInput';
 export { usePickerState } from './hooks/usePickerState';
-export type { PickerStateProps, PickerStatePickerProps } from './hooks/usePickerState';
+export type {
+  PickerStateProps,
+  PickerStatePickerProps,
+  PickerStateWrapperProps,
+} from './hooks/usePickerState';
 export type { PickerStateValueManager, PickerSelectionState } from './hooks/usePickerState';
 export { useDefaultDates, useUtils, useLocaleText } from './hooks/useUtils';
 export type { BaseDateValidationProps, DayValidationProps } from './hooks/validation/models';


### PR DESCRIPTION
### Technical Decisions:

The wrapper already have way to modify the state: `onAccept`, `onClear`, .... I propose to add `onSetValue: (newValue: TValue, acceptAndClose?: boolean)` which will set the new value (and call `onChange` if necessary) and potentially behave like `onAccept` according to the second parameter.

Access to this method should let dev create custom shortcuts easily.

Shortcut creation would also require `isDateDisabled` method to be able to know if "last week" shortcut should be disabled. because one of the day in the considered range is disabled

### API

I think we can go with the same behavior as the action bar: an array of string `shortcuts: ['last-week', 'next weekend']`

### Where to place the component

I see two places where the component can be placed:
- `DateRangePickerView` (where the calendar view and the toolbar are put together): 
	- Pros: add the shortcut only for range pickers (I don't see any use case for other pickers)
	- Cons: Don't have access to the `ActionBar` which will necessary be full-width bellow
- The 3 wrappers (where the view is combined with the app bar and wrapped into either a modal/popper/div):
	- Pro: That's where most of the layout is done
	- cons: Add shortcuts for all pickers which ones do not make sens

For now, I went to the `DateRangePickerView`. Which allows having either layout A or C. I think we have to choose either one or the other, but it will not be possible for users to switch between them.

For now,w it's C that is implemented on desktop

![image](https://user-images.githubusercontent.com/45398769/188126626-156455ca-9ea5-4237-bf68-1cfee38a9cb5.png)


I tried to let the option to put the shortcut at any cardinal points (start, end, top, bottom). But after experimenting, I'm not convinced but the top/bottom options. For horizontal display, it could be done by adding buttons in the app bar if we provide the necessary methods to the app bar.

### Examples 

![image](https://user-images.githubusercontent.com/45398769/188123085-ae8ae5f5-b90a-42dc-8fdb-8178ee67e7b3.png)
  
![image](https://user-images.githubusercontent.com/45398769/188113169-607cc3fb-3ca7-4e6f-8546-e1141eee4849.png)


## V6

It sounds that we have a large room for improvement about how to customize display