### PR TITLE
[DataGrid] Do not publish `cellFocusOut` event if the row was removed

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
@@ -798,6 +798,24 @@ describe('<DataGridPro /> - Rows', () => {
         fireEvent.mouseLeave(cell);
       }).not.to.throw();
     });
+
+    // See https://github.com/mui/mui-x/issues/5742
+    it('should not crash when focusing header after row is removed during the click', () => {
+      expect(() => {
+        render(
+          <TestCase
+            rows={baselineProps.rows}
+            onCellClick={() => {
+              apiRef.current.updateRows([{ id: 1, _action: 'delete' }]);
+            }}
+          />,
+        );
+        const cell = getCell(0, 0);
+        userEvent.mousePress(cell);
+        const columnHeaderCell = getColumnHeaderCell(0);
+        fireEvent.focus(columnHeaderCell);
+      }).not.to.throw();
+    });
   });
 
   describe('apiRef: setRowHeight', () => {

--- a/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -228,11 +228,6 @@ export const useGridFocus = (
         return;
       }
 
-      // The row might have been deleted during the click
-      if (!apiRef.current.getRow(focusedCell.id)) {
-        return;
-      }
-
       if (cellParams) {
         apiRef.current.setCellFocus(cellParams.id, cellParams.field);
       } else {

--- a/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ownerDocument } from '@mui/material/utils';
-import { GridEventListener } from '../../../models/events';
+import { GridEventListener, GridEventLookup } from '../../../models/events';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridFocusApi } from '../../../models/api/gridFocusApi';
 import { GridCellParams } from '../../../models/params/gridCellParams';
@@ -14,6 +14,7 @@ import { GridStateInitializer } from '../../utils/useGridInitializeState';
 import { gridVisibleColumnDefinitionsSelector } from '../columns/gridColumnsSelector';
 import { getVisibleRows } from '../../utils/useGridVisibleRows';
 import { clamp } from '../../../utils/utils';
+import { GridCellIdentifier } from './gridFocusState';
 
 export const focusStateInitializer: GridStateInitializer = (state) => ({
   ...state,
@@ -33,6 +34,22 @@ export const useGridFocus = (
   const logger = useGridLogger(apiRef, 'useGridFocus');
 
   const lastClickedCell = React.useRef<GridCellParams | null>(null);
+
+  const publishCellFocusOut = React.useCallback(
+    (cell: GridCellIdentifier | null, event: GridEventLookup['cellFocusOut']['event']) => {
+      if (cell) {
+        // The row might have been deleted
+        if (apiRef.current.getRow(cell.id)) {
+          apiRef.current.publishEvent(
+            'cellFocusOut',
+            apiRef.current.getCellParams(cell.id, cell.field),
+            event,
+          );
+        }
+      }
+    },
+    [apiRef],
+  );
 
   const setCellFocus = React.useCallback<GridFocusApi['setCellFocus']>(
     (id, field) => {
@@ -59,27 +76,18 @@ export const useGridFocus = (
       if (focusedCell) {
         // There's a focused cell but another cell was clicked
         // Publishes an event to notify that the focus was lost
-        apiRef.current.publishEvent(
-          'cellFocusOut',
-          apiRef.current.getCellParams(focusedCell.id, focusedCell.field),
-        );
+        publishCellFocusOut(focusedCell, {});
       }
 
       apiRef.current.publishEvent('cellFocusIn', apiRef.current.getCellParams(id, field));
     },
-    [apiRef, logger],
+    [apiRef, logger, publishCellFocusOut],
   );
 
   const setColumnHeaderFocus = React.useCallback<GridFocusApi['setColumnHeaderFocus']>(
     (field, event = {}) => {
       const cell = gridFocusCellSelector(apiRef);
-      if (cell) {
-        apiRef.current.publishEvent(
-          'cellFocusOut',
-          apiRef.current.getCellParams(cell.id, cell.field),
-          event,
-        );
-      }
+      publishCellFocusOut(cell, event);
 
       apiRef.current.setState((state) => {
         logger.debug(`Focusing on column header with colIndex=${field}`);
@@ -93,7 +101,7 @@ export const useGridFocus = (
 
       apiRef.current.forceUpdate();
     },
-    [apiRef, logger],
+    [apiRef, logger, publishCellFocusOut],
   );
 
   const moveFocusToRelativeCell = React.useCallback<
@@ -236,14 +244,10 @@ export const useGridFocus = (
 
         // There's a focused cell but another element (not a cell) was clicked
         // Publishes an event to notify that the focus was lost
-        apiRef.current.publishEvent(
-          'cellFocusOut',
-          apiRef.current.getCellParams(focusedCell.id, focusedCell.field),
-          event,
-        );
+        publishCellFocusOut(focusedCell, event);
       }
     },
-    [apiRef],
+    [apiRef, publishCellFocusOut],
   );
 
   const handleCellModeChange = React.useCallback<GridEventListener<'cellModeChange'>>(


### PR DESCRIPTION
Fixes #5742

Before: https://codesandbox.io/s/fullfeaturedcrudgrid-demo-mui-x-forked-9eis2n
After: https://codesandbox.io/s/fullfeaturedcrudgrid-demo-mui-x-forked-1uy5xu

- [ ] backported to `master` branch