### PR TITLE
[docs] Improve Upgrade plan docs

### DIFF
--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -87,7 +87,7 @@ For example, when you want to upgrade the Data Grid:
 
   :::info
   If you are looking for upgrading from Pro to Premium, please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%20discount%20to%20Premium).
-  We'll provide you with a discount to recoup the remaining time of your Pro license.
+  We'll provide you with a discount based on the remaining time of your current license term.
   :::
 
 For more details on how to install the packages, please check out our [package installation guide](/x/introduction/installation/).

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -58,10 +58,10 @@ The features exclusive to the Premium version are marked with the <span class="p
 
 ## Upgrading
 
-The npm packages of of any given plan is a **superset** of the npm packages of the plan below.
-So to upgrade, replace the [npm packages](#plans) you installed and imported with the ones of the plan above.
+The npm packages of any given plan are a **superset** of the packages on the plan below.
+So to upgrade, replace the [npm packages](#plans) and the components' imports with the ones from the target plan.
 
-For example with the Data Grid:
+For example, when you want to upgrade the Data Grid:
 
 - **Upgrading from Community to Pro.**
 
@@ -78,7 +78,7 @@ For example with the Data Grid:
 
 - **Upgrading from Pro to Premium.**
 
-  `@mui/x-data-grid-premium` is a superset of `@mui/x-data-grid-pro`, so you can upgrade from the Pro to the Pro Premium like this:.
+  `@mui/x-data-grid-premium` is a superset of `@mui/x-data-grid-pro`, so you can upgrade from Pro to Premium like this:
 
   ```diff
   -import { DataGridPro } from '@mui/x-data-grid-pro';

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -56,39 +56,41 @@ Premium npm package:
 The features exclusive to the Premium version are marked with the <span class="plan-premium"></span> icon throughout the documentation.
 :::
 
-## Upgrading from Community
+## Upgrading
 
-When you purchase a license for MUI X (Pro or Premium), it will unlock new [packages](#plans) you can use on your project.
+The npm packages of of any given plan is a **superset** of the npm packages of the plan below.
+So to upgrade, replace the [npm packages](#plans) you installed and imported with the ones of the plan above.
 
-If you're using the data grid, the commercial npm packages (`@mui/x-data-grid-pro` and `@mui/x-data-grid-premium`) are a superset of the community.
+For example with the Data Grid:
 
-You can upgrade the dependency on `@mui/x-data-grid` to the respective package of your plan, and replace all your imports.
+- **Upgrading from Community to Pro.**
 
-```diff
-//diff when upgrading to Pro
+  `@mui/x-data-grid-pro` is a superset of `@mui/x-data-grid`, so you can upgrade from the Community to the Pro plan like this:
 
--import { DataGrid } from '@mui/x-data-grid';
-+import { DataGridPro } from '@mui/x-data-grid-pro';
-```
+  ```diff
+  -import { DataGrid } from '@mui/x-data-grid';
+  +import { DataGridPro } from '@mui/x-data-grid-pro';
+  ```
+
+  :::warning
+  ⚠️ However, there is an exception to the superset rule. The default value of the `pagination` prop changes, [see the docs of the pagination](https://mui.com/x/react-data-grid/pagination/).
+  :::
+
+- **Upgrading from Pro to Premium.**
+
+  `@mui/x-data-grid-premium` is a superset of `@mui/x-data-grid-pro`, so you can upgrade from the Pro to the Pro Premium like this:.
+
+  ```diff
+  -import { DataGridPro } from '@mui/x-data-grid-pro';
+  +import { DataGridPremium } from '@mui/x-data-grid-premium';
+  ```
+
+  :::info
+  If you are looking for upgrading from Pro to Premium, please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%20discount%20to%20Premium).
+  We'll provide you with a discount to recoup the remaining time of your Pro license.
+  :::
 
 For more details on how to install the packages, please check out our [package installation guide](/x/introduction/installation/).
-
-## Upgrading from Pro to Premium
-
-When upgrading from Pro, you can upgrade the dependency on `@mui/x-data-grid-pro` to `@mui/x-data-grid-premium` and replace all your data grid imports.
-
-```diff
-//diff when upgrading from Pro to Premium
-
--import { DataGridPro } from '@mui/x-data-grid-pro';
-+import { DataGridPremium } from '@mui/x-data-grid-premium';
-```
-
-:::info
-You can use your Pro license as a credit when purchasing MUI X Premium.
-We'll provide you with a discount based on the remaining time that your current license is valid.
-Please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%20discount%20to%20Premium) to upgrade.
-:::
 
 ## Evaluation (trial) licenses
 


### PR DESCRIPTION
An attempt to improve #5683. Here is what I found as opportunities in https://mui.com/x/introduction/licensing/#upgrading-from-community

1. The TOCs, there are harder to scan, using "Upgrading" would be faster to search and scan. We use two different h2, for the same information, It feels more cluttered. 

Before

<img width="203" alt="Screenshot 2022-09-03 at 17 11 20" src="https://user-images.githubusercontent.com/3165635/188276810-04592976-2116-4c34-8c5e-837d80969cc0.png">

After

<img width="213" alt="Screenshot 2022-09-03 at 17 09 26" src="https://user-images.githubusercontent.com/3165635/188276744-351711b9-94ec-4193-9d41-9a12bd2f741d.png">

2. "Superset", this part seems super important, I'm giving it more emphasis and also make it clear that this is a rule we aim to always follow.
3. We break the superset rule in one case, this also feels important to document.
4. We are in the docs for the license, but the docs feels like it's about the data grid. I have turned the phrase so it takes the data grid as an example
5. "MUI X (Pro or Premium)" -> "MUI X Pro or Premium" to lean on the side of MUI X being an open-source product on its own.
6. "Upgrading from Community" -> "Upgrading from Community to Pro" to be clearer.
7. I had to read the "You can use your Pro license as a credit when purchasing MUI X Premium. We'll provide you with a discount based on the remaining time that your current license is valid. Please contact us at [sales@mui.com](mailto:sales@mui.com?subject=My%20upgrade%20discount%20to%20Premium) to upgrade." info twice to understand what we were talking about. I have tried to rephrase it.


https://deploy-preview-6018--material-ui-x.netlify.app/x/introduction/licensing/#upgrading