### PR TITLE
[data grid] Fix scroll anchoring with master details

### DIFF
--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -90,6 +90,7 @@ export const GridRootStyles = styled('div', {
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
+    overflowAnchor: 'none', // Keep the same scrolling position
     [`&.${gridClasses.autoHeight}`]: {
       height: 'auto',
       [`& .${gridClasses['row--lastVisible']} .${gridClasses.cell}`]: {


### PR DESCRIPTION
I have noticed this bug in #5292. Take the first demo of https://mui.com/x/react-data-grid/master-detail/ and use `autoHeight`. You will get https://codesandbox.io/s/peaceful-ishizaka-lc53sw?file=/demo.tsx:0-5223. Now, try to expand a row, and see how bad it feels with the scroll position that changes:

https://user-images.githubusercontent.com/3165635/188738223-3c1a9a0e-3ef5-49c3-b5c8-83c5a8cc95ca.mov

It drove me crazy, I couldn't help myself not to open this PR 😁. The fix is made after https://github.com/mui/material-ui/pull/22292.

**After**  😌

https://user-images.githubusercontent.com/3165635/188738402-ba2f4a15-38c3-4914-b108-fee45b6f9af6.mov

https://codesandbox.io/s/pensive-voice-1wif1j?file=/demo.tsx