### PR TITLE
[pickers] Fix invalid date error when decreasing `DateField` day 

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -140,9 +140,9 @@ export const adjustInvalidDateSectionValue = <TDate, TSection extends FieldSecti
       let newDate: TDate;
       if (shouldSetAbsolute) {
         if (delta > 0 || isEnd) {
-          newDate = utils.endOfMonth(today);
-        } else {
           newDate = utils.startOfMonth(today);
+        } else {
+          newDate = utils.endOfMonth(today);
         }
       } else {
         newDate = utils.addDays(utils.parse(section.value, section.formatValue)!, delta);

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -146,6 +146,13 @@ export const adjustInvalidDateSectionValue = <TDate, TSection extends FieldSecti
         }
       } else {
         newDate = utils.addDays(utils.parse(section.value, section.formatValue)!, delta);
+        if (!utils.isSameMonth(newDate, today)) {
+          if (delta > 0) {
+            newDate = utils.startOfMonth(today);
+          } else {
+            newDate = utils.endOfMonth(today);
+          }
+        }
       }
 
       return utils.formatByString(newDate, section.formatValue);


### PR DESCRIPTION
## Reproduce the bug

Select day, press ArrowDown down to reach a 31. The next ArrowDown leads to an error

https://user-images.githubusercontent.com/45398769/188917580-7025f1e8-0b03-4d4c-aa09-36bdc65271cf.mp4


[current demo](https://mui.com/x/react-date-pickers/date-field/)
[fixed demo](https://deploy-preview-6071--material-ui-x.netlify.app/x/react-date-pickers/date-field/)

## The reason

The `utils.parse` set the other date parameters to today. So when modifying the day, we set:

|current day value | parsedValue (with dd/mm/yyyy format) | applied diff | newValue | 
|---|---|---|---|
| 1 | 01/09/2022 | -1 | 31/08/2022 |
| 31 | 31/09/2022 (InvalidDate) | crash | crash |

## Solutions

- Force the date to stick into today month (current fix)
- do not pass only the section value but a full date object

I chose the first solution because 
1. it was easier to implement and I was working on something else 👼
2. with the second one (which is more robust) if you loop on day you would be modifying the months so the first month to appear will not be today one