### PR TITLE
[README] Add link to the security page

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ The [changelog](https://github.com/mui/mui-x/releases) is regularly updated to r
 ## Roadmap
 
 Future plans and high-priority features and enhancements can be found in our [roadmap](https://mui.com/x/introduction/roadmap/).
+
+## Security
+
+For details of supported versions and contact details for reporting security issues, please refer to the [security policy](https://github.com/mui/mui-x/security/policy).


### PR DESCRIPTION
It reproduces https://github.com/mui/material-ui#security. My assumption is that there isn't any real reason for having a different tradeoff on how we structure the main Readme, so using the same strategy would be simpler.

I noticed the opportunity while working on https://github.com/mui/material-ui/pull/34219.