### PR TITLE
[pickers] Re-fix mobile picker not opening on label click

### DIFF
--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePickerLocalization.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePickerLocalization.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import fr from 'date-fns/locale/fr';
 import TextField from '@mui/material/TextField';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
-import { fireEvent, screen } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui/monorepo/test/utils';
 import { adapterToUse, createPickerRenderer } from '../../../../test/utils/pickers-utils';
 
 describe('<MobileDatePicker /> localization', () => {
@@ -22,7 +22,7 @@ describe('<MobileDatePicker /> localization', () => {
 
     expect(screen.getByRole('textbox')).to.have.value('2018');
 
-    fireEvent.mouseDown(screen.getByLabelText(/Choose date/));
+    userEvent.mousePress(screen.getByLabelText(/Choose date/));
     expect(screen.getByMuiTest('datepicker-toolbar-date').textContent).to.equal('2018');
   });
 
@@ -40,7 +40,7 @@ describe('<MobileDatePicker /> localization', () => {
 
     expect(screen.getByRole('textbox')).to.have.value('janvier 2018');
 
-    fireEvent.mouseDown(screen.getByLabelText(/Choose date/));
+    userEvent.mousePress(screen.getByLabelText(/Choose date/));
     expect(screen.getByMuiTest('datepicker-toolbar-date').textContent).to.equal('janvier');
   });
 
@@ -56,7 +56,7 @@ describe('<MobileDatePicker /> localization', () => {
 
     expect(screen.getByRole('textbox')).to.have.value('01/01/2018');
 
-    fireEvent.mouseDown(screen.getByLabelText(/Choose date/));
+    userEvent.mousePress(screen.getByLabelText(/Choose date/));
     expect(screen.getByMuiTest('datepicker-toolbar-date').textContent).to.equal('1 janvier');
   });
 });

--- a/packages/x-date-pickers/src/internals/components/PureDateInput.tsx
+++ b/packages/x-date-pickers/src/internals/components/PureDateInput.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TextFieldProps as MuiTextFieldPropsType } from '@mui/material/TextField';
 import { IconButtonProps } from '@mui/material/IconButton';
 import { InputAdornmentProps } from '@mui/material/InputAdornment';
+import { useEventCallback } from '@mui/material/utils';
 import { onSpaceOrEnter } from '../utils/utils';
 import { useLocaleText, useUtils } from '../hooks/useUtils';
 import { getDisplayDate } from '../utils/text-field-helper';
@@ -151,6 +152,11 @@ export const PureDateInput = React.forwardRef(function PureDateInput<TInputDate,
 
   const inputValue = getDisplayDate(utils, rawValue, inputFormat);
 
+  const handleOnClick = useEventCallback((event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    onOpen();
+  });
+
   return renderInput({
     label,
     disabled,
@@ -159,13 +165,16 @@ export const PureDateInput = React.forwardRef(function PureDateInput<TInputDate,
     error: validationError,
     InputProps: PureDateInputProps,
     className,
+    // registering `onClick` listener on the root element as well to correctly handle cases where user is clicking on `label`
+    // which has `pointer-events: none` and due to DOM structure the `input` does not catch the click event
+    ...(!props.readOnly && !props.disabled && { onClick: handleOnClick }),
     inputProps: {
       disabled,
       readOnly: true,
       'aria-readonly': true,
       'aria-label': getOpenDialogAriaText(rawValue, utils),
       value: inputValue,
-      ...(!props.readOnly && { onMouseDown: onOpen }),
+      ...(!props.readOnly && { onClick: handleOnClick }),
       onKeyDown: onSpaceOrEnter(onOpen),
     },
     ...TextFieldProps,


### PR DESCRIPTION
Fixes #6063 

Revert the change introduced in #5651 as it introduced a regression due to `onMouseUp` event registered on `Clock` component.

With this change we introduce an additional `onClick` listener on the root element to overcome the issue of `click` event not being registered when clicking on `label` element due to DOM structure and the fact, that `TextField` has a `label` with `pointer-events: none`