### PR TITLE
[core] Remove the `test_browsers` CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,23 +181,25 @@ jobs:
       - run:
           name: '`yarn l10n` changes committed?'
           command: git diff --exit-code
-  test_browser:
-    <<: *defaults
-    docker:
-      - image: mcr.microsoft.com/playwright@sha256:c3c8a833254aaad31b2d336e67b0dbb9af744a12ab486e18f230033b99649c4f
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
-    steps:
-      - checkout
-      - install_js:
-          browsers: true
-      - run:
-          name: Tests real browsers
-          command: yarn test:karma
-      - store_artifacts:
-          # hardcoded in karma-webpack
-          path: /tmp/_karma_webpack_
-          destination: artifact-file
+  # Tests run in BrowserStack are flaky and give a missleading information about the state of the code.
+  # Due to this the build on the master branch is aways red.
+  # test_browser:
+  #   <<: *defaults
+  #   docker:
+  #     - image: mcr.microsoft.com/playwright@sha256:c3c8a833254aaad31b2d336e67b0dbb9af744a12ab486e18f230033b99649c4f
+  #       environment:
+  #         NODE_ENV: development # Needed if playwright is in `devDependencies`
+  #   steps:
+  #     - checkout
+  #     - install_js:
+  #         browsers: true
+  #     - run:
+  #         name: Tests real browsers
+  #         command: yarn test:karma
+  #     - store_artifacts:
+  #         # hardcoded in karma-webpack
+  #         path: /tmp/_karma_webpack_
+  #         destination: artifact-file
   test_types:
     <<: *defaults
     steps:

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -142,7 +142,7 @@ module.exports = function setKarmaConfig(config) {
     newConfig = {
       ...baseConfig,
       browserStack,
-      browsers: baseConfig.browsers.concat(['chrome', 'safari', 'edge']),
+      browsers: baseConfig.browsers.concat(['chrome', 'firefox', 'safari', 'edge']),
       plugins: baseConfig.plugins.concat(['karma-browserstack-launcher']),
       customLaunchers: {
         ...baseConfig.customLaunchers,
@@ -156,15 +156,13 @@ module.exports = function setKarmaConfig(config) {
           // TODO: Investigate why.
           browser_version: '87.0',
         },
-        // Firefox tests are flaky and give a missleading information about the state of the code.
-        // Due to this the build on the master branch is aways red.
-        // firefox: {
-        //   base: 'BrowserStack',
-        //   os: 'Windows',
-        //   os_version: '10',
-        //   browser: 'firefox',
-        //   browser_version: '78.0',
-        // },
+        firefox: {
+          base: 'BrowserStack',
+          os: 'Windows',
+          os_version: '10',
+          browser: 'firefox',
+          browser_version: '78.0',
+        },
         safari: {
           base: 'BrowserStack',
           os: 'OS X',


### PR DESCRIPTION
The fix of removing `Firefox` didn't work. I reverted my initial change and opted to comment on the entire step based on our initial discussion. I'm not sure if this is the correct way to do it because that way it won't be run on the PRs as well.