### PR TITLE
[DatePicker] Allow keyboard navigation to ignore disabled date for left/right arrow

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPickerKeyboard.test.tsx
@@ -97,5 +97,46 @@ describe('<CalendarPicker /> keyboard interactions', () => {
         expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);
       });
     });
+
+    describe('navigation with disabled dates', () => {
+      const disabledDates = [
+        adapterToUse.date(new Date(2020, 0, 10)),
+        // month extremities
+        adapterToUse.date(new Date(2019, 11, 31)),
+        adapterToUse.date(new Date(2020, 0, 1)),
+        adapterToUse.date(new Date(2020, 0, 2)),
+        adapterToUse.date(new Date(2020, 0, 31)),
+        adapterToUse.date(new Date(2020, 1, 1)),
+      ];
+      [
+        { initialDay: 11, key: 'ArrowLeft', expectFocusedDay: '9' },
+        { initialDay: 9, key: 'ArrowRight', expectFocusedDay: '11' },
+        // Switch between months
+        { initialDay: 3, key: 'ArrowLeft', expectFocusedDay: '30' },
+        { initialDay: 30, key: 'ArrowRight', expectFocusedDay: '2' },
+      ].forEach(({ initialDay, key, expectFocusedDay }) => {
+        it(key, () => {
+          render(
+            <CalendarPicker
+              date={adapterToUse.date(new Date(2020, 0, initialDay))}
+              onChange={() => {}}
+              shouldDisableDate={(date) =>
+                disabledDates.some((disabled) => adapterToUse.isSameDay(date, disabled))
+              }
+            />,
+          );
+
+          act(() => screen.getByText(`${initialDay}`).focus());
+          // Don't care about what's focused.
+          // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
+          fireEvent.keyDown(document.activeElement!, { key });
+
+          clock.runToLast();
+          // Based on column header, screen reader should pronounce <Day Number> <Week Day>
+          // But `toHaveAccessibleName` does not do the link between column header and cell value, so we only get <day number> in test
+          expect(document.activeElement).toHaveAccessibleName(expectFocusedDay);
+        });
+      });
+    });
   });
 });

--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -205,14 +205,46 @@ export function DayPicker<TDate>(props: DayPickerProps<TDate>) {
         focusDay(utils.addDays(day, 7));
         event.preventDefault();
         break;
-      case 'ArrowLeft':
-        focusDay(utils.addDays(day, theme.direction === 'ltr' ? -1 : 1));
+      case 'ArrowLeft': {
+        const newFocusedDayDefault = utils.addDays(day, theme.direction === 'ltr' ? -1 : 1);
+        const nextAvailableMonth =
+          theme.direction === 'ltr' ? utils.getPreviousMonth(day) : utils.getNextMonth(day);
+
+        const closestDayToFocus = findClosestEnabledDate({
+          utils,
+          date: newFocusedDayDefault,
+          minDate:
+            theme.direction === 'ltr'
+              ? utils.startOfMonth(nextAvailableMonth)
+              : newFocusedDayDefault,
+          maxDate:
+            theme.direction === 'ltr' ? newFocusedDayDefault : utils.endOfMonth(nextAvailableMonth),
+          isDateDisabled,
+        });
+        focusDay(closestDayToFocus || newFocusedDayDefault);
         event.preventDefault();
         break;
-      case 'ArrowRight':
-        focusDay(utils.addDays(day, theme.direction === 'ltr' ? 1 : -1));
+      }
+      case 'ArrowRight': {
+        const newFocusedDayDefault = utils.addDays(day, theme.direction === 'ltr' ? 1 : -1);
+        const nextAvailableMonth =
+          theme.direction === 'ltr' ? utils.getNextMonth(day) : utils.getPreviousMonth(day);
+
+        const closestDayToFocus = findClosestEnabledDate({
+          utils,
+          date: newFocusedDayDefault,
+          minDate:
+            theme.direction === 'ltr'
+              ? newFocusedDayDefault
+              : utils.startOfMonth(nextAvailableMonth),
+          maxDate:
+            theme.direction === 'ltr' ? utils.endOfMonth(nextAvailableMonth) : newFocusedDayDefault,
+          isDateDisabled,
+        });
+        focusDay(closestDayToFocus || newFocusedDayDefault);
         event.preventDefault();
         break;
+      }
       case 'Home':
         focusDay(utils.startOfWeek(day));
         event.preventDefault();


### PR DESCRIPTION
Fix #6076

If the next date to focus is disabled, it looks in the current month, and the next one if there is an available date to focus.