### PR TITLE
Loading overlay fix and add class support to overlay wrapper

### DIFF
--- a/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/material/utils';
+import { unstable_composeClasses } from '@mui/utils';
+import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { useGridSelector } from '../../hooks/utils/useGridSelector';
 import { gridVisibleRowCountSelector } from '../../hooks/features/filter/gridFilterSelector';
 import {
@@ -9,10 +11,23 @@ import {
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { gridDensityTotalHeaderHeightSelector } from '../../hooks/features/density/densitySelector';
+import { getDataGridUtilityClass } from '../../constants/gridClasses';
+
+const useUtilityClasses = (ownerState: { classes: DataGridProcessedProps['classes'] }) => {
+  const { classes } = ownerState;
+
+  const slots = {
+    root: ['overlayWrapper'],
+  };
+
+  return unstable_composeClasses(slots, getDataGridUtilityClass, classes);
+};
 
 function GridOverlayWrapper(props: React.PropsWithChildren<{}>) {
   const apiRef = useGridApiContext();
   const rootProps = useGridRootProps();
+  const classes = useUtilityClasses({ classes: rootProps.classes });
+
   const totalHeaderHeight = useGridSelector(apiRef, gridDensityTotalHeaderHeightSelector);
 
   const [viewportInnerSize, setViewportInnerSize] = React.useState(
@@ -38,12 +53,14 @@ function GridOverlayWrapper(props: React.PropsWithChildren<{}>) {
 
   return (
     <div
+      className={classes.root}
       style={{
         height,
         width: viewportInnerSize?.width ?? 0,
         position: 'absolute',
         top: totalHeaderHeight,
         bottom: height === 'auto' ? 0 : undefined,
+        zIndex: 1,
       }}
       {...props}
     />

--- a/packages/grid/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/grid/x-data-grid/src/constants/gridClasses.ts
@@ -318,6 +318,10 @@ export interface GridClasses {
    */
   menuList: string;
   /**
+   * Styles applied to the overlay wrapper element.
+   */
+  overlayWrapper: string;
+  /**
    * Styles applied to the overlay element.
    */
   overlay: string;
@@ -572,6 +576,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'menuIconButton',
   'menuOpen',
   'menuList',
+  'overlayWrapper',
   'overlay',
   'root',
   'root--densityStandard',


### PR DESCRIPTION

_Hi, I am a programmer using this library for many projects and I have noticed a problem with the table loading overlay._ 

### The problem
When a background is set for the table and / or the rows and / or the cells, the overlay is no longer visible as it is covered by it.

The **solution** is very simple: just set a zIndex = 1 for the container component.

The only problem is that the container component is hard coded and has no classes applied, so it is not even possible to customize it (except through unorthodox and not very recommended solutions).

So I propose this change that should solve the problem and add a greater possibility of customization (By inserting a customizable class)

### A simple example is: 
```js
  <Box sx={{height: 300, bgcolor: 'common.white'}}>
    <DataGrid
      columns={[]}
      rows={[]}
      loading={true}
    />
  </Box>
```

