### PR TITLE
[core] Parse markdown to detect broken links

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "build": "cross-env NODE_ENV=production next build --profile",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
+    "check-links": "node ./scripts/checkLinks.js",
     "dev": "rimraf ./node_modules/.cache/babel-loader && next dev --port 3001",
     "deploy": "git push upstream master:docs-v5",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",

--- a/docs/scripts/checkLinks.js
+++ b/docs/scripts/checkLinks.js
@@ -1,0 +1,146 @@
+/* eslint-disable no-console */
+const path = require('path');
+const fse = require('fs-extra');
+const { createRender } = require('@mui/monorepo/docs/packages/markdown');
+const { marked } = require('marked');
+
+// Use renderer to extract all links into a markdown document
+const getPageLinks = (markdown) => {
+  const hrefs = [];
+
+  const renderer = new marked.Renderer();
+  renderer.link = (href) => {
+    if (href[0] === '/') {
+      hrefs.push(href);
+    }
+  };
+  marked(markdown, { renderer });
+  return hrefs;
+};
+
+// List all .js files in a folder
+const getJsFilesInFolder = (folderPath) => {
+  const files = fse.readdirSync(folderPath, { withFileTypes: true });
+  return files.reduce((acc, file) => {
+    if (file.isDirectory()) {
+      const filesInFolder = getJsFilesInFolder(path.join(folderPath, file.name));
+      return [...acc, ...filesInFolder];
+    }
+    if (file.name.endsWith('.js')) {
+      return [...acc, path.join(folderPath, file.name)];
+    }
+    return acc;
+  }, []);
+};
+
+// Returns url assuming it's "./docs/pages/x/..." becomes  "mui.com/x/..."
+const jsFilePathToUrl = (jsFilePath) => {
+  const folder = path.dirname(jsFilePath);
+  const file = path.basename(jsFilePath);
+
+  const root = folder.slice(jsFilePath.indexOf('/pages') + '/pages'.length);
+  let page = `/${file.slice(0, file.length - '.js'.length)}`;
+
+  if (page === '/index') {
+    page = '';
+  }
+
+  return `${root}${page}`;
+};
+
+function getLinksAndAnchors(fileName) {
+  const toc = [];
+  const headingHashes = {};
+  const userLanguage = 'en';
+  const render = createRender({ headingHashes, toc, userLanguage });
+
+  const data = fse.readFileSync(fileName, { encoding: 'utf-8' });
+  render(data);
+
+  const links = getPageLinks(data);
+
+  return {
+    hashes: Object.keys(headingHashes),
+    links,
+  };
+}
+
+// {[url with hash]: true}
+const availableLinks = {};
+
+// {[url with hash]: list of files using this link}
+const usedLinks = {};
+
+const jsPageFiles = getJsFilesInFolder(path.join(__dirname, '../pages/x'));
+
+const mdFiles = jsPageFiles.flatMap((jsPageFile) => {
+  // For each JS file extract the markdown rendered if it exists
+  const fileContent = fse.readFileSync(jsPageFile, 'utf8');
+  /**
+   * Content files can be represented by either:
+   * - 'docsx/data/advanced-components/overview.md?@mui/markdown';
+   * - './index.md?@mui/markdown';
+   */
+  const importPaths = fileContent.match(/'.*\?@mui\/markdown'/g);
+
+  return importPaths === null
+    ? []
+    : importPaths.map((importPath) => {
+        let cleanImportPath = importPath.slice(1, importPath.length - "?@mui/markdown'".length);
+        if (cleanImportPath.startsWith('docsx/data/')) {
+          cleanImportPath = path.join(__dirname, `../${cleanImportPath.slice('docsx/'.length)}`);
+        } else {
+          cleanImportPath = path.join(path.dirname(jsPageFile), cleanImportPath);
+        }
+        const url = jsFilePathToUrl(jsPageFile);
+
+        return { fileName: cleanImportPath, url };
+      });
+});
+
+// Mark all the existing page as available
+jsPageFiles.forEach((jsFilePath) => {
+  const url = jsFilePathToUrl(jsFilePath);
+  availableLinks[url] = true;
+});
+
+// For each markdown file, extract links
+mdFiles.forEach(({ fileName, url }) => {
+  const { hashes, links } = getLinksAndAnchors(fileName);
+
+  links
+    .map((link) => (link[link.length - 1] === '/' ? link.slice(0, link.length - 1) : link))
+    .forEach((link) => {
+      if (usedLinks[link] === undefined) {
+        usedLinks[link] = [fileName];
+      } else {
+        usedLinks[link].push(fileName);
+      }
+    });
+
+  hashes.forEach((hash) => {
+    availableLinks[`${url}/#${hash}`] = true;
+  });
+});
+
+function getPageUrlFromLink(link) {
+  const [rep] = link.split('/#');
+  return rep;
+}
+
+Object.keys(usedLinks)
+  .filter((link) => link.startsWith('/x'))
+  .filter((link) => !availableLinks[link])
+  .sort()
+  .forEach((linkKey) => {
+    console.log(`not found: https://mui.com${linkKey}`);
+    console.log(`used in`);
+    usedLinks[linkKey].forEach((f) => console.log(`- ${f}`));
+    console.log('available on the same page:');
+    console.log(
+      Object.keys(availableLinks)
+        .filter((link) => getPageUrlFromLink(link) === getPageUrlFromLink(linkKey))
+        .sort(),
+    );
+    console.log('\n\n');
+  });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "node ./scripts/prettier.js --branch master",
     "prettier:all": "node ./scripts/prettier.js write",
     "proptypes": "cross-env BABEL_ENV=development babel-node -i \"/node_modules/(?!@mui)/\" -x .ts,.tsx,.js ./docs/scripts/generateProptypes.ts",
+    "check-links": "node ./docs/scripts/checkLinks.js",
     "size:snapshot": "node --max-old-space-size=2048 ./scripts/sizeSnapshot/create",
     "size:why": "yarn size:snapshot --analyze --accurateBundles",
     "test": "lerna run test --parallel",


### PR DESCRIPTION
Sometimes, we change header names or the entire structure of a doc page. But we do not realize it's breaking all the external anchor links.

I propose a script that checks all the `.md` files and verifies that internal links are ok. Used to create #6101

It’s not perfect because it has:

1. false positives, the #slot because API page structure are made with `json` and not `md`
2. does not support links across projects
3. only about internal links

Linked to: https://www.notion.so/mui-org/Detect-301-404-in-the-CI-a8a2404d62a24fccb0f10b8318150ca3