### PR TITLE
[core] Hide the date on the print regression test

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -131,6 +131,12 @@ function TestViewer(props) {
             margin: 0,
             overflowX: 'hidden',
           },
+          '@media print': {
+            '@page': {
+              size: 'auto',
+              margin: 0,
+            },
+          },
         }}
       />
       <MockTime isDataGridTest={isDataGridTest}>

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -132,10 +132,7 @@ function App() {
             return null;
           }
 
-          let isDataGridTest = false;
-          if (path.indexOf('/docs-data-grid') === 0 || path.indexOf('/stories-') === 0) {
-            isDataGridTest = true;
-          }
+          const isDataGridTest = path.indexOf('/docs-data-grid') === 0;
 
           return (
             <Route


### PR DESCRIPTION
When removing the Storybook, I migrated the regression test of the print to a doc example.
But it renders the date on the printed page, leading to Argos errors.

I can't just mock the time because the date is added by the browser outside of the page.
So I'm just removing the margin to hide it (similar to the solution described [on this page](https://www.geeksforgeeks.org/how-to-remove-url-from-printing-the-page/)).

I also removed an useless check on the test name.