### PR TITLE
[docs] Add pro logo in "column ordering" link

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -32,7 +32,7 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-data-grid/column-dimensions' },
           { pathname: '/x/react-data-grid/column-visibility' },
           { pathname: '/x/react-data-grid/column-header' },
-          { pathname: '/x/react-data-grid/column-ordering' },
+          { pathname: '/x/react-data-grid/column-ordering', plan: 'pro' },
           { pathname: '/x/react-data-grid/column-pinning', plan: 'pro' },
           { pathname: '/x/react-data-grid/column-spanning' },
           { pathname: '/x/react-data-grid/column-groups' },


### PR DESCRIPTION
Just notice that "Column ordering" is a pro feature but does not have the logo in the menu.

![image](https://user-images.githubusercontent.com/45398769/189636157-58e4adfd-ac7b-4a4f-8692-c3786baf38b9.png)
