### PR TITLE
[pickers] Rename the `date` prop `value` on `MonthPicker` / `YearPicker`, `ClockPicker` and `CalendarPicker`

### DIFF
--- a/docs/data/date-pickers/date-picker/SubComponentsPickers.js
+++ b/docs/data/date-pickers/date-picker/SubComponentsPickers.js
@@ -17,11 +17,11 @@ export default function SubComponentsPickers() {
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid container spacing={3}>
         <Grid item xs={12} md={6}>
-          <CalendarPicker date={date} onChange={(newDate) => setDate(newDate)} />
+          <CalendarPicker value={date} onChange={(newDate) => setDate(newDate)} />
         </Grid>
         <Grid item xs={12} md={6}>
           <MonthPicker
-            date={date}
+            value={date}
             minDate={minDate}
             maxDate={maxDate}
             onChange={(newDate) => setDate(newDate)}
@@ -29,7 +29,7 @@ export default function SubComponentsPickers() {
         </Grid>
         <Grid item xs={12} md={6}>
           <YearPicker
-            date={date}
+            value={date}
             minDate={minDate}
             maxDate={maxDate}
             onChange={(newDate) => setDate(newDate)}

--- a/docs/data/date-pickers/date-picker/SubComponentsPickers.js
+++ b/docs/data/date-pickers/date-picker/SubComponentsPickers.js
@@ -11,28 +11,31 @@ const minDate = dayjs('2020-01-01T00:00:00.000');
 const maxDate = dayjs('2034-01-01T00:00:00.000');
 
 export default function SubComponentsPickers() {
-  const [date, setDate] = React.useState(dayjs());
+  const [value, setValue] = React.useState(dayjs());
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid container spacing={3}>
         <Grid item xs={12} md={6}>
-          <CalendarPicker value={date} onChange={(newDate) => setDate(newDate)} />
+          <CalendarPicker
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <MonthPicker
-            value={date}
+            value={value}
             minDate={minDate}
             maxDate={maxDate}
-            onChange={(newDate) => setDate(newDate)}
+            onChange={(newValue) => setValue(newValue)}
           />
         </Grid>
         <Grid item xs={12} md={6}>
           <YearPicker
-            value={date}
+            value={value}
             minDate={minDate}
             maxDate={maxDate}
-            onChange={(newDate) => setDate(newDate)}
+            onChange={(newValue) => setValue(newValue)}
           />
         </Grid>
       </Grid>

--- a/docs/data/date-pickers/date-picker/SubComponentsPickers.tsx
+++ b/docs/data/date-pickers/date-picker/SubComponentsPickers.tsx
@@ -17,11 +17,11 @@ export default function SubComponentsPickers() {
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid container spacing={3}>
         <Grid item xs={12} md={6}>
-          <CalendarPicker date={date} onChange={(newDate) => setDate(newDate)} />
+          <CalendarPicker value={date} onChange={(newDate) => setDate(newDate)} />
         </Grid>
         <Grid item xs={12} md={6}>
           <MonthPicker
-            date={date}
+            value={date}
             minDate={minDate}
             maxDate={maxDate}
             onChange={(newDate) => setDate(newDate)}
@@ -29,7 +29,7 @@ export default function SubComponentsPickers() {
         </Grid>
         <Grid item xs={12} md={6}>
           <YearPicker
-            date={date}
+            value={date}
             minDate={minDate}
             maxDate={maxDate}
             onChange={(newDate) => setDate(newDate)}

--- a/docs/data/date-pickers/date-picker/SubComponentsPickers.tsx
+++ b/docs/data/date-pickers/date-picker/SubComponentsPickers.tsx
@@ -11,28 +11,31 @@ const minDate = dayjs('2020-01-01T00:00:00.000');
 const maxDate = dayjs('2034-01-01T00:00:00.000');
 
 export default function SubComponentsPickers() {
-  const [date, setDate] = React.useState<Dayjs | null>(dayjs());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid container spacing={3}>
         <Grid item xs={12} md={6}>
-          <CalendarPicker value={date} onChange={(newDate) => setDate(newDate)} />
+          <CalendarPicker
+            value={value}
+            onChange={(newValue) => setValue(newValue)}
+          />
         </Grid>
         <Grid item xs={12} md={6}>
           <MonthPicker
-            value={date}
+            value={value}
             minDate={minDate}
             maxDate={maxDate}
-            onChange={(newDate) => setDate(newDate)}
+            onChange={(newValue) => setValue(newValue)}
           />
         </Grid>
         <Grid item xs={12} md={6}>
           <YearPicker
-            value={date}
+            value={value}
             minDate={minDate}
             maxDate={maxDate}
-            onChange={(newDate) => setDate(newDate)}
+            onChange={(newValue) => setValue(newValue)}
           />
         </Grid>
       </Grid>

--- a/docs/data/date-pickers/time-picker/SubComponentsTimePickers.js
+++ b/docs/data/date-pickers/time-picker/SubComponentsTimePickers.js
@@ -9,7 +9,7 @@ export default function SubComponentsTimePickers() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <ClockPicker date={date} onChange={(newDate) => setDate(newDate)} />
+      <ClockPicker value={date} onChange={(newDate) => setDate(newDate)} />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/time-picker/SubComponentsTimePickers.js
+++ b/docs/data/date-pickers/time-picker/SubComponentsTimePickers.js
@@ -5,11 +5,11 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { ClockPicker } from '@mui/x-date-pickers/ClockPicker';
 
 export default function SubComponentsTimePickers() {
-  const [date, setDate] = React.useState(dayjs());
+  const [value, setValue] = React.useState(dayjs());
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <ClockPicker value={date} onChange={(newDate) => setDate(newDate)} />
+      <ClockPicker value={value} onChange={(newValue) => setValue(newValue)} />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx
+++ b/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx
@@ -5,11 +5,11 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { ClockPicker } from '@mui/x-date-pickers/ClockPicker';
 
 export default function SubComponentsTimePickers() {
-  const [date, setDate] = React.useState<Dayjs | null>(dayjs());
+  const [value, setValue] = React.useState<Dayjs | null>(dayjs());
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <ClockPicker value={date} onChange={(newDate) => setDate(newDate)} />
+      <ClockPicker value={value} onChange={(newValue) => setValue(newValue)} />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx
+++ b/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx
@@ -9,7 +9,7 @@ export default function SubComponentsTimePickers() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <ClockPicker date={date} onChange={(newDate) => setDate(newDate)} />
+      <ClockPicker value={date} onChange={(newDate) => setDate(newDate)} />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx.preview
+++ b/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx.preview
@@ -1,3 +1,3 @@
 <LocalizationProvider dateAdapter={AdapterDayjs}>
-  <ClockPicker date={date} onChange={(newDate) => setDate(newDate)} />
+  <ClockPicker value={date} onChange={(newDate) => setDate(newDate)} />
 </LocalizationProvider>

--- a/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx.preview
+++ b/docs/data/date-pickers/time-picker/SubComponentsTimePickers.tsx.preview
@@ -1,3 +1,3 @@
 <LocalizationProvider dateAdapter={AdapterDayjs}>
-  <ClockPicker value={date} onChange={(newDate) => setDate(newDate)} />
+  <ClockPicker value={value} onChange={(newValue) => setValue(newValue)} />
 </LocalizationProvider>

--- a/docs/pages/x/api/date-pickers/clock-picker.json
+++ b/docs/pages/x/api/date-pickers/clock-picker.json
@@ -1,7 +1,7 @@
 {
   "props": {
-    "date": { "type": { "name": "any" }, "required": true },
     "onChange": { "type": { "name": "func" }, "required": true },
+    "value": { "type": { "name": "any" }, "required": true },
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "autoFocus": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/date-pickers/month-picker.json
+++ b/docs/pages/x/api/date-pickers/month-picker.json
@@ -1,7 +1,7 @@
 {
   "props": {
-    "date": { "type": { "name": "any" }, "required": true },
     "onChange": { "type": { "name": "func" }, "required": true },
+    "value": { "type": { "name": "any" }, "required": true },
     "classes": { "type": { "name": "object" } },
     "className": { "type": { "name": "string" } },
     "disabled": { "type": { "name": "bool" } },

--- a/docs/translations/api-docs/date-pickers/clock-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/clock-picker-pt.json
@@ -7,7 +7,6 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",
-    "date": "Selected date @DateIOType.",
     "disabled": "If <code>true</code>, the picker and text field are disabled.",
     "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
     "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.<br><br><strong>Signature:</strong><br><code>function(view: ClockPickerView, time: TDate | null, adapter: MuiPickersAdapter&lt;TDate&gt;) =&gt; string</code><br><em>view:</em> The current view rendered.<br><em>time:</em> The current time.<br><em>adapter:</em> The current date adapter.<br> <em>returns</em> (string): The clock label.",
@@ -25,6 +24,7 @@
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable.<br><br><strong>Signature:</strong><br><code>function(timeValue: number, clockType: ClockPickerView) =&gt; boolean</code><br><em>timeValue:</em> The value to check.<br><em>clockType:</em> The clock type of the timeValue.<br> <em>returns</em> (boolean): Returns <code>true</code> if the time should be disabled",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "Selected date @DateIOType.",
     "view": "Controlled open view.",
     "views": "Views for calendar picker."
   },

--- a/docs/translations/api-docs/date-pickers/clock-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/clock-picker-zh.json
@@ -7,7 +7,6 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",
-    "date": "Selected date @DateIOType.",
     "disabled": "If <code>true</code>, the picker and text field are disabled.",
     "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
     "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.<br><br><strong>Signature:</strong><br><code>function(view: ClockPickerView, time: TDate | null, adapter: MuiPickersAdapter&lt;TDate&gt;) =&gt; string</code><br><em>view:</em> The current view rendered.<br><em>time:</em> The current time.<br><em>adapter:</em> The current date adapter.<br> <em>returns</em> (string): The clock label.",
@@ -25,6 +24,7 @@
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable.<br><br><strong>Signature:</strong><br><code>function(timeValue: number, clockType: ClockPickerView) =&gt; boolean</code><br><em>timeValue:</em> The value to check.<br><em>clockType:</em> The clock type of the timeValue.<br> <em>returns</em> (boolean): Returns <code>true</code> if the time should be disabled",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "Selected date @DateIOType.",
     "view": "Controlled open view.",
     "views": "Views for calendar picker."
   },

--- a/docs/translations/api-docs/date-pickers/clock-picker.json
+++ b/docs/translations/api-docs/date-pickers/clock-picker.json
@@ -7,7 +7,6 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",
-    "date": "Selected date @DateIOType.",
     "disabled": "If <code>true</code>, the picker and text field are disabled.",
     "disableIgnoringDatePartForTimeValidation": "Do not ignore date part when validating min/max time.",
     "getClockLabelText": "Accessible text that helps user to understand which time and view is selected.<br><br><strong>Signature:</strong><br><code>function(view: ClockPickerView, time: TDate | null, adapter: MuiPickersAdapter&lt;TDate&gt;) =&gt; string</code><br><em>view:</em> The current view rendered.<br><em>time:</em> The current time.<br><em>adapter:</em> The current date adapter.<br> <em>returns</em> (string): The clock label.",
@@ -25,6 +24,7 @@
     "rightArrowButtonText": "Right arrow icon aria-label text.",
     "shouldDisableTime": "Dynamically check if time is disabled or not. If returns <code>false</code> appropriate time point will ot be acceptable.<br><br><strong>Signature:</strong><br><code>function(timeValue: number, clockType: ClockPickerView) =&gt; boolean</code><br><em>timeValue:</em> The value to check.<br><em>clockType:</em> The clock type of the timeValue.<br> <em>returns</em> (boolean): Returns <code>true</code> if the time should be disabled",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "Selected date @DateIOType.",
     "view": "Controlled open view.",
     "views": "Views for calendar picker."
   },

--- a/docs/translations/api-docs/date-pickers/month-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/month-picker-pt.json
@@ -3,7 +3,6 @@
   "propDescriptions": {
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "className": "className applied to the root element.",
-    "date": "Date value for the MonthPicker",
     "disabled": "If <code>true</code> picker is disabled",
     "disableFuture": "If <code>true</code> future days are disabled.",
     "disableHighlightToday": "If <code>true</code>, today&#39;s date is rendering without highlighting with circle.",
@@ -13,7 +12,8 @@
     "onChange": "Callback fired on date change.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableMonth": "Disable specific months dynamically. Works like <code>shouldDisableDate</code> but for month selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(month: TDate) =&gt; boolean</code><br><em>month:</em> The month to check.<br> <em>returns</em> (boolean): If <code>true</code> the month will be disabled.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "Date value for the MonthPicker"
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } },
   "slotDescriptions": {}

--- a/docs/translations/api-docs/date-pickers/month-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/month-picker-pt.json
@@ -9,7 +9,7 @@
     "disablePast": "If <code>true</code> past days are disabled.",
     "maxDate": "Maximal selectable date. @DateIOType",
     "minDate": "Minimal selectable date. @DateIOType",
-    "onChange": "Callback fired on date change.",
+    "onChange": "Callback fired when the value (the selected month) changes.<br><br><strong>Signature:</strong><br><code>function(value: TValue) =&gt; void</code><br><em>value:</em> The new parsed value.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableMonth": "Disable specific months dynamically. Works like <code>shouldDisableDate</code> but for month selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(month: TDate) =&gt; boolean</code><br><em>month:</em> The month to check.<br> <em>returns</em> (boolean): If <code>true</code> the month will be disabled.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",

--- a/docs/translations/api-docs/date-pickers/month-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/month-picker-zh.json
@@ -3,7 +3,6 @@
   "propDescriptions": {
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "className": "className applied to the root element.",
-    "date": "Date value for the MonthPicker",
     "disabled": "If <code>true</code> picker is disabled",
     "disableFuture": "If <code>true</code> future days are disabled.",
     "disableHighlightToday": "If <code>true</code>, today&#39;s date is rendering without highlighting with circle.",
@@ -13,7 +12,8 @@
     "onChange": "Callback fired on date change.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableMonth": "Disable specific months dynamically. Works like <code>shouldDisableDate</code> but for month selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(month: TDate) =&gt; boolean</code><br><em>month:</em> The month to check.<br> <em>returns</em> (boolean): If <code>true</code> the month will be disabled.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "Date value for the MonthPicker"
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } },
   "slotDescriptions": {}

--- a/docs/translations/api-docs/date-pickers/month-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/month-picker-zh.json
@@ -9,7 +9,7 @@
     "disablePast": "If <code>true</code> past days are disabled.",
     "maxDate": "Maximal selectable date. @DateIOType",
     "minDate": "Minimal selectable date. @DateIOType",
-    "onChange": "Callback fired on date change.",
+    "onChange": "Callback fired when the value (the selected month) changes.<br><br><strong>Signature:</strong><br><code>function(value: TValue) =&gt; void</code><br><em>value:</em> The new parsed value.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableMonth": "Disable specific months dynamically. Works like <code>shouldDisableDate</code> but for month selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(month: TDate) =&gt; boolean</code><br><em>month:</em> The month to check.<br> <em>returns</em> (boolean): If <code>true</code> the month will be disabled.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",

--- a/docs/translations/api-docs/date-pickers/month-picker.json
+++ b/docs/translations/api-docs/date-pickers/month-picker.json
@@ -3,7 +3,6 @@
   "propDescriptions": {
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "className": "className applied to the root element.",
-    "date": "Date value for the MonthPicker",
     "disabled": "If <code>true</code> picker is disabled",
     "disableFuture": "If <code>true</code> future days are disabled.",
     "disableHighlightToday": "If <code>true</code>, today&#39;s date is rendering without highlighting with circle.",
@@ -13,7 +12,8 @@
     "onChange": "Callback fired on date change.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableMonth": "Disable specific months dynamically. Works like <code>shouldDisableDate</code> but for month selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(month: TDate) =&gt; boolean</code><br><em>month:</em> The month to check.<br> <em>returns</em> (boolean): If <code>true</code> the month will be disabled.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
+    "value": "Date value for the MonthPicker"
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } },
   "slotDescriptions": {}

--- a/docs/translations/api-docs/date-pickers/month-picker.json
+++ b/docs/translations/api-docs/date-pickers/month-picker.json
@@ -9,7 +9,7 @@
     "disablePast": "If <code>true</code> past days are disabled.",
     "maxDate": "Maximal selectable date. @DateIOType",
     "minDate": "Minimal selectable date. @DateIOType",
-    "onChange": "Callback fired on date change.",
+    "onChange": "Callback fired when the value (the selected month) changes.<br><br><strong>Signature:</strong><br><code>function(value: TValue) =&gt; void</code><br><em>value:</em> The new parsed value.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableMonth": "Disable specific months dynamically. Works like <code>shouldDisableDate</code> but for month selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(month: TDate) =&gt; boolean</code><br><em>month:</em> The month to check.<br> <em>returns</em> (boolean): If <code>true</code> the month will be disabled.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",

--- a/docs/translations/api-docs/date-pickers/year-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/year-picker-pt.json
@@ -9,7 +9,7 @@
     "disablePast": "If <code>true</code> past days are disabled.",
     "maxDate": "Maximal selectable date. @DateIOType",
     "minDate": "Minimal selectable date. @DateIOType",
-    "onChange": "Callback fired on date change.",
+    "onChange": "Callback fired when the value (the selected year) changes.<br><br><strong>Signature:</strong><br><code>function(value: TValue) =&gt; void</code><br><em>value:</em> The new parsed value.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableYear": "Disable specific years dynamically. Works like <code>shouldDisableDate</code> but for year selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(year: TDate) =&gt; boolean</code><br><em>year:</em> The year to test.<br> <em>returns</em> (boolean): Returns <code>true</code> if the year should be disabled.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."

--- a/docs/translations/api-docs/date-pickers/year-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/year-picker-zh.json
@@ -9,7 +9,7 @@
     "disablePast": "If <code>true</code> past days are disabled.",
     "maxDate": "Maximal selectable date. @DateIOType",
     "minDate": "Minimal selectable date. @DateIOType",
-    "onChange": "Callback fired on date change.",
+    "onChange": "Callback fired when the value (the selected year) changes.<br><br><strong>Signature:</strong><br><code>function(value: TValue) =&gt; void</code><br><em>value:</em> The new parsed value.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableYear": "Disable specific years dynamically. Works like <code>shouldDisableDate</code> but for year selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(year: TDate) =&gt; boolean</code><br><em>year:</em> The year to test.<br> <em>returns</em> (boolean): Returns <code>true</code> if the year should be disabled.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."

--- a/docs/translations/api-docs/date-pickers/year-picker.json
+++ b/docs/translations/api-docs/date-pickers/year-picker.json
@@ -9,7 +9,7 @@
     "disablePast": "If <code>true</code> past days are disabled.",
     "maxDate": "Maximal selectable date. @DateIOType",
     "minDate": "Minimal selectable date. @DateIOType",
-    "onChange": "Callback fired on date change.",
+    "onChange": "Callback fired when the value (the selected year) changes.<br><br><strong>Signature:</strong><br><code>function(value: TValue) =&gt; void</code><br><em>value:</em> The new parsed value.",
     "readOnly": "If <code>true</code> picker is readonly",
     "shouldDisableYear": "Disable specific years dynamically. Works like <code>shouldDisableDate</code> but for year selection view @DateIOType.<br><br><strong>Signature:</strong><br><code>function(year: TDate) =&gt; boolean</code><br><em>year:</em> The year to test.<br> <em>returns</em> (boolean): Returns <code>true</code> if the year should be disabled.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
@@ -151,7 +151,7 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
     onMonthSwitchingAnimationEnd,
     changeFocusedDay,
   } = useCalendarState({
-    date: start || end,
+    value: start || end,
     defaultCalendarMonth,
     disableFuture,
     disablePast,

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.spec.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.spec.tsx
@@ -6,7 +6,7 @@ import { CalendarPicker } from '@mui/x-date-pickers/CalendarPicker';
 <CalendarPicker<Moment>
   view="day"
   views={['day']}
-  date={moment()}
+  value={moment()}
   minDate={moment()}
   maxDate={moment()}
   onChange={(date) => date?.format()}

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -17,7 +17,7 @@ import {
 describe('<CalendarPicker />', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });
 
-  describeConformance(<CalendarPicker date={adapterToUse.date()} onChange={() => {}} />, () => ({
+  describeConformance(<CalendarPicker value={adapterToUse.date()} onChange={() => {}} />, () => ({
     classes,
     inheritComponent: 'div',
     render,
@@ -40,7 +40,7 @@ describe('<CalendarPicker />', () => {
     const handleViewChange = spy();
     render(
       <CalendarPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={() => {}}
         onViewChange={handleViewChange}
       />,
@@ -58,7 +58,7 @@ describe('<CalendarPicker />', () => {
     const onMonthChangeMock = spy();
     render(
       <CalendarPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={onChangeMock}
         onMonthChange={onMonthChangeMock}
         readOnly
@@ -85,7 +85,7 @@ describe('<CalendarPicker />', () => {
     const onMonthChangeMock = spy();
     render(
       <CalendarPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={onChangeMock}
         onMonthChange={onMonthChangeMock}
         disabled
@@ -111,7 +111,7 @@ describe('<CalendarPicker />', () => {
     const onMonthChangeMock = spy();
     render(
       <CalendarPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={onChangeMock}
         onMonthChange={onMonthChangeMock}
         disabled
@@ -134,7 +134,7 @@ describe('<CalendarPicker />', () => {
         dateAdapter={AdapterClassToUse}
         dateFormats={{ monthAndYear: 'yyyy/MM' }}
       >
-        <CalendarPicker date={adapterToUse.date(new Date(2019, 0, 1))} onChange={() => {}} />,
+        <CalendarPicker value={adapterToUse.date(new Date(2019, 0, 1))} onChange={() => {}} />,
       </LocalizationProvider>,
     );
 
@@ -145,7 +145,7 @@ describe('<CalendarPicker />', () => {
     render(
       <LocalizationProvider dateAdapter={AdapterClassToUse}>
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 0, 1))}
+          value={adapterToUse.date(new Date(2019, 0, 1))}
           onChange={() => {}}
           dayOfWeekFormatter={(day) => `${day}.`}
         />
@@ -163,7 +163,7 @@ describe('<CalendarPicker />', () => {
 
     render(
       <CalendarPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={onChange}
         maxDate={adapterToUse.date(new Date(2018, 0, 1))}
       />,
@@ -176,7 +176,9 @@ describe('<CalendarPicker />', () => {
 
   describe('view: day', () => {
     it('renders day calendar standalone', () => {
-      render(<CalendarPicker date={adapterToUse.date(new Date(2019, 0, 1))} onChange={() => {}} />);
+      render(
+        <CalendarPicker value={adapterToUse.date(new Date(2019, 0, 1))} onChange={() => {}} />,
+      );
 
       expect(screen.getByText('January 2019')).toBeVisible();
       expect(screen.getAllByMuiTest('day')).to.have.length(31);
@@ -193,7 +195,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={null}
+          value={null}
           onChange={onChange}
           defaultCalendarMonth={adapterToUse.date(new Date(2018, 0, 1))}
           view="day"
@@ -210,7 +212,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2018, 0, 3, 11, 11, 11, 111))}
+          value={adapterToUse.date(new Date(2018, 0, 3, 11, 11, 11, 111))}
           onChange={onChange}
           defaultCalendarMonth={adapterToUse.date(new Date(2018, 0, 1))}
           view="day"
@@ -231,7 +233,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 0, 1))}
+          value={adapterToUse.date(new Date(2019, 0, 1))}
           onChange={onChange}
           shouldDisableDate={(date) => {
             // Missing `getDate` in adapters
@@ -258,7 +260,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 5, 1))}
+          value={adapterToUse.date(new Date(2019, 5, 1))}
           minDate={adapterToUse.date(new Date(2019, 3, 7))}
           onChange={onChange}
           views={['month', 'day']}
@@ -278,7 +280,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 0, 29))}
+          value={adapterToUse.date(new Date(2019, 0, 29))}
           maxDate={adapterToUse.date(new Date(2019, 3, 22))}
           onChange={onChange}
           views={['month', 'day']}
@@ -298,7 +300,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 0, 29))}
+          value={adapterToUse.date(new Date(2019, 0, 29))}
           onChange={onChange}
           shouldDisableDate={(date) => adapterToUse.getMonth(date) === 3}
           views={['month', 'day']}
@@ -319,7 +321,7 @@ describe('<CalendarPicker />', () => {
     it('renders year selection standalone', () => {
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 0, 1))}
+          value={adapterToUse.date(new Date(2019, 0, 1))}
           openTo="year"
           onChange={() => {}}
         />,
@@ -333,7 +335,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 3, 29))}
+          value={adapterToUse.date(new Date(2019, 3, 29))}
           onChange={onChange}
           shouldDisableDate={(date) =>
             adapterToUse.getYear(date) === 2022 && adapterToUse.getMonth(date) === 3
@@ -355,7 +357,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 3, 29))}
+          value={adapterToUse.date(new Date(2019, 3, 29))}
           minDate={adapterToUse.date(new Date(2017, 4, 12))}
           onChange={onChange}
           views={['year', 'day']}
@@ -375,7 +377,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 3, 29))}
+          value={adapterToUse.date(new Date(2019, 3, 29))}
           maxDate={adapterToUse.date(new Date(2022, 2, 31))}
           onChange={onChange}
           views={['year', 'day']}
@@ -395,7 +397,7 @@ describe('<CalendarPicker />', () => {
 
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2019, 3, 29))}
+          value={adapterToUse.date(new Date(2019, 3, 29))}
           onChange={onChange}
           shouldDisableDate={(date) => adapterToUse.getYear(date) === 2022}
           views={['year', 'day']}

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -60,7 +60,7 @@ export interface CalendarPickerProps<TDate>
    * @default {}
    */
   componentsProps?: Partial<CalendarPickerSlotsComponentsProps>;
-  date: TDate | null;
+  value: TDate | null;
   /**
    * Default calendar month displayed when `value={null}`.
    */
@@ -128,7 +128,7 @@ export interface CalendarPickerProps<TDate>
 
 export type ExportedCalendarPickerProps<TDate> = Omit<
   CalendarPickerProps<TDate>,
-  | 'date'
+  | 'value'
   | 'view'
   | 'views'
   | 'openTo'
@@ -233,7 +233,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   const {
     autoFocus,
     onViewChange,
-    date,
+    value,
     disableFuture,
     disablePast,
     defaultCalendarMonth,
@@ -284,7 +284,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
     isDateDisabled,
     onMonthSwitchingAnimationEnd,
   } = useCalendarState({
-    date,
+    value,
     defaultCalendarMonth,
     reduceAnimations,
     onMonthChange,
@@ -296,7 +296,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   });
 
   const handleDateMonthChange = React.useCallback<MonthPickerProps<TDate>['onChange']>(
-    (newDate, selectionState) => {
+    (newDate) => {
       const startOfMonth = utils.startOfMonth(newDate);
       const endOfMonth = utils.endOfMonth(newDate);
 
@@ -313,7 +313,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
         : newDate;
 
       if (closestEnabledDate) {
-        onChange(closestEnabledDate, selectionState);
+        onChange(closestEnabledDate, 'finish');
         onMonthChange?.(startOfMonth);
       } else {
         openNext();
@@ -338,7 +338,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   );
 
   const handleDateYearChange = React.useCallback<YearPickerProps<TDate>['onChange']>(
-    (newDate, selectionState) => {
+    (newDate) => {
       const startOfYear = utils.startOfYear(newDate);
       const endOfYear = utils.endOfYear(newDate);
 
@@ -355,7 +355,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
         : newDate;
 
       if (closestEnabledDate) {
-        onChange(closestEnabledDate, selectionState);
+        onChange(closestEnabledDate, 'finish');
         onYearChange?.(closestEnabledDate);
       } else {
         openNext();
@@ -381,21 +381,21 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
 
   const onSelectedDayChange = React.useCallback<DayPickerProps<TDate>['onSelectedDaysChange']>(
     (day, isFinish) => {
-      if (date && day) {
+      if (value && day) {
         // If there is a date already selected, then we want to keep its time
-        return onChange(utils.mergeDateAndTime(day, date), isFinish);
+        return onChange(utils.mergeDateAndTime(day, value), isFinish);
       }
 
       return onChange(day, isFinish);
     },
-    [utils, date, onChange],
+    [utils, value, onChange],
   );
 
   React.useEffect(() => {
-    if (date && isDateDisabled(date)) {
+    if (value && isDateDisabled(value)) {
       const closestEnabledDate = findClosestEnabledDate({
         utils,
-        date,
+        date: value,
         minDate,
         maxDate,
         disablePast,
@@ -410,10 +410,10 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   }, []); // eslint-disable-line
 
   React.useEffect(() => {
-    if (date) {
-      changeMonth(date);
+    if (value) {
+      changeMonth(value);
     }
-  }, [date]); // eslint-disable-line
+  }, [value]); // eslint-disable-line
 
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
@@ -426,8 +426,8 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   };
 
   // When disabled, limit the view to the selected date
-  const minDateWithDisabled = (disabled && date) || minDate;
-  const maxDateWithDisabled = (disabled && date) || maxDate;
+  const minDateWithDisabled = (disabled && value) || minDate;
+  const maxDateWithDisabled = (disabled && value) || maxDate;
 
   const commonViewProps = {
     disableHighlightToday,
@@ -496,11 +496,11 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
       >
         <div>
           {openView === 'year' && (
-            <YearPicker
+            <YearPicker<TDate>
               {...baseDateValidationProps}
               {...commonViewProps}
               autoFocus={autoFocus}
-              date={date}
+              value={value}
               onChange={handleDateYearChange}
               shouldDisableYear={shouldDisableYear}
               hasFocus={hasFocus}
@@ -509,13 +509,13 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
           )}
 
           {openView === 'month' && (
-            <MonthPicker
+            <MonthPicker<TDate>
               {...baseDateValidationProps}
               {...commonViewProps}
               autoFocus={autoFocus}
               hasFocus={hasFocus}
               className={className}
-              date={date}
+              value={value}
               onChange={handleDateMonthChange}
               shouldDisableMonth={shouldDisableMonth}
               onFocusedViewChange={handleFocusedViewChange('month')}
@@ -531,7 +531,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
               onMonthSwitchingAnimationEnd={onMonthSwitchingAnimationEnd}
               onFocusedDayChange={changeFocusedDay}
               reduceAnimations={reduceAnimations}
-              selectedDays={[date]}
+              selectedDays={[value]}
               onSelectedDaysChange={onSelectedDayChange}
               shouldDisableDate={shouldDisableDate}
               shouldDisableMonth={shouldDisableMonth}
@@ -570,7 +570,6 @@ CalendarPicker.propTypes = {
    * @default {}
    */
   componentsProps: PropTypes.object,
-  date: PropTypes.any,
   /**
    * Formats the day of week displayed in the calendar header.
    * @param {string} day The day of week provided by the adapter's method `getWeekdays`.
@@ -723,6 +722,7 @@ CalendarPicker.propTypes = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  value: PropTypes.any,
   /**
    * Controlled open view.
    */

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPickerKeyboard.test.tsx
@@ -11,7 +11,7 @@ describe('<CalendarPicker /> keyboard interactions', () => {
     it('can autofocus selected day on mount', () => {
       render(
         <CalendarPicker
-          date={adapterToUse.date(new Date(2020, 7, 13))}
+          value={adapterToUse.date(new Date(2020, 7, 13))}
           autoFocus
           onChange={() => {}}
         />,
@@ -30,7 +30,7 @@ describe('<CalendarPicker /> keyboard interactions', () => {
     ].forEach(({ key, expectFocusedDay }) => {
       it(key, () => {
         render(
-          <CalendarPicker date={adapterToUse.date(new Date(2020, 7, 13))} onChange={() => {}} />,
+          <CalendarPicker value={adapterToUse.date(new Date(2020, 7, 13))} onChange={() => {}} />,
         );
 
         act(() => screen.getByText('13').focus());
@@ -46,7 +46,7 @@ describe('<CalendarPicker /> keyboard interactions', () => {
 
     it('should manage a sequence of keyboard interactions', () => {
       render(
-        <CalendarPicker date={adapterToUse.date(new Date(2020, 7, 13))} onChange={() => {}} />,
+        <CalendarPicker value={adapterToUse.date(new Date(2020, 7, 13))} onChange={() => {}} />,
       );
 
       act(() => screen.getByText('13').focus());
@@ -81,7 +81,7 @@ describe('<CalendarPicker /> keyboard interactions', () => {
       it(key, () => {
         render(
           <CalendarPicker
-            date={adapterToUse.date(new Date(2020, 7, initialDay))}
+            value={adapterToUse.date(new Date(2020, 7, initialDay))}
             onChange={() => {}}
           />,
         );
@@ -118,7 +118,7 @@ describe('<CalendarPicker /> keyboard interactions', () => {
         it(key, () => {
           render(
             <CalendarPicker
-              date={adapterToUse.date(new Date(2020, 0, initialDay))}
+              value={adapterToUse.date(new Date(2020, 0, initialDay))}
               onChange={() => {}}
               shouldDisableDate={(date) =>
                 disabledDates.some((disabled) => adapterToUse.isSameDay(date, disabled))

--- a/packages/x-date-pickers/src/CalendarPicker/tests/validation.CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/tests/validation.CalendarPicker.test.tsx
@@ -5,7 +5,7 @@ import { CalendarPicker, CalendarPickerProps } from '@mui/x-date-pickers/Calenda
 import { createPickerRenderer, adapterToUse } from '../../../../../test/utils/pickers-utils';
 
 const WrappedCalendarPicker = <TDate extends any>(
-  props: Omit<CalendarPickerProps<TDate>, 'date' | 'onChange'> & { initialValue: TDate },
+  props: Omit<CalendarPickerProps<TDate>, 'value' | 'onChange'> & { initialValue: TDate },
 ) => {
   const { initialValue, ...other } = props;
 
@@ -15,7 +15,7 @@ const WrappedCalendarPicker = <TDate extends any>(
     setValue(newValue);
   }, []);
 
-  return <CalendarPicker {...other} date={value} onChange={handleChange} />;
+  return <CalendarPicker {...other} value={value} onChange={handleChange} />;
 };
 
 describe('<CalendarPicker /> - Validation', () => {

--- a/packages/x-date-pickers/src/CalendarPicker/useCalendarState.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/useCalendarState.tsx
@@ -93,7 +93,7 @@ export const createCalendarStateReducer =
 interface CalendarStateInput<TDate>
   extends Pick<
     CalendarPickerDefaultizedProps<TDate>,
-    | 'date'
+    | 'value'
     | 'defaultCalendarMonth'
     | 'disableFuture'
     | 'disablePast'
@@ -107,7 +107,7 @@ interface CalendarStateInput<TDate>
 }
 
 export const useCalendarState = <TDate extends unknown>({
-  date,
+  value,
   defaultCalendarMonth,
   disableFuture,
   disablePast,
@@ -131,8 +131,8 @@ export const useCalendarState = <TDate extends unknown>({
 
   const [calendarState, dispatch] = React.useReducer(reducerFn, {
     isMonthSwitchingAnimating: false,
-    focusedDay: date || now,
-    currentMonth: utils.startOfMonth(date ?? defaultCalendarMonth ?? now),
+    focusedDay: value || now,
+    currentMonth: utils.startOfMonth(value ?? defaultCalendarMonth ?? now),
     slideDirection: 'left',
   });
 

--- a/packages/x-date-pickers/src/ClockPicker/Clock.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/Clock.tsx
@@ -16,7 +16,6 @@ export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
   ampmInClock: boolean;
   autoFocus?: boolean;
   children: readonly React.ReactNode[];
-  date: TDate | null;
   getClockLabelText: (
     view: ClockPickerView,
     time: TDate | null,
@@ -31,7 +30,14 @@ export interface ClockProps<TDate> extends ReturnType<typeof useMeridiemMode> {
    */
   selectedId: string | undefined;
   type: ClockPickerView;
-  value: number;
+  /**
+   * The numeric value of the current view.
+   */
+  viewValue: number;
+  /**
+   * The current full date value.
+   */
+  value: TDate | null;
   disabled?: boolean;
   readOnly?: boolean;
 }
@@ -139,7 +145,7 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
     ampmInClock,
     autoFocus,
     children,
-    date,
+    value,
     getClockLabelText,
     handleMeridiemChange,
     isTimeDisabled,
@@ -148,7 +154,7 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
     onChange,
     selectedId,
     type,
-    value,
+    viewValue,
     disabled,
     readOnly,
   } = props;
@@ -159,8 +165,8 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
   const wrapperVariant = React.useContext(WrapperVariantContext);
   const isMoving = React.useRef(false);
 
-  const isSelectedTimeDisabled = isTimeDisabled(value, type);
-  const isPointerInner = !ampm && type === 'hours' && (value < 1 || value > 12);
+  const isSelectedTimeDisabled = isTimeDisabled(viewValue, type);
+  const isPointerInner = !ampm && type === 'hours' && (viewValue < 1 || viewValue > 12);
 
   const handleValueChange = (newValue: number, isFinish: PickerSelectionState) => {
     if (disabled || readOnly) {
@@ -223,8 +229,8 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
       return true;
     }
 
-    return value % 5 === 0;
-  }, [type, value]);
+    return viewValue % 5 === 0;
+  }, [type, viewValue]);
 
   const keyboardControlStep = type === 'minutes' ? minutesStep : 1;
 
@@ -255,11 +261,11 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
         event.preventDefault();
         break;
       case 'ArrowUp':
-        handleValueChange(value + keyboardControlStep, 'partial');
+        handleValueChange(viewValue + keyboardControlStep, 'partial');
         event.preventDefault();
         break;
       case 'ArrowDown':
-        handleValueChange(value - keyboardControlStep, 'partial');
+        handleValueChange(viewValue - keyboardControlStep, 'partial');
         event.preventDefault();
         break;
       default:
@@ -281,10 +287,10 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
         {!isSelectedTimeDisabled && (
           <React.Fragment>
             <ClockPin />
-            {date && (
+            {value != null && (
               <ClockPointer
                 type={type}
-                value={value}
+                viewValue={viewValue}
                 isInner={isPointerInner}
                 hasSelected={hasSelected}
               />
@@ -293,7 +299,7 @@ export function Clock<TDate>(props: ClockProps<TDate>) {
         )}
         <ClockWrapper
           aria-activedescendant={selectedId}
-          aria-label={getClockLabelText(type, date, utils)}
+          aria-label={getClockLabelText(type, value, utils)}
           ref={listboxRef}
           role="listbox"
           onKeyDown={handleKeyDown}

--- a/packages/x-date-pickers/src/ClockPicker/ClockNumbers.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockNumbers.tsx
@@ -5,7 +5,7 @@ import { PickerSelectionState } from '../internals/hooks/usePickerState';
 
 interface GetHourNumbersOptions<TDate> {
   ampm: boolean;
-  date: TDate;
+  value: TDate | null;
   getClockNumberText: (hour: string) => string;
   isDisabled: (value: number) => boolean;
   onChange: (value: number, isFinish?: PickerSelectionState) => void;
@@ -22,13 +22,13 @@ interface GetHourNumbersOptions<TDate> {
  */
 export const getHourNumbers = <TDate extends unknown>({
   ampm,
-  date,
+  value,
   getClockNumberText,
   isDisabled,
   selectedId,
   utils,
 }: GetHourNumbersOptions<TDate>) => {
-  const currentHours = date ? utils.getHours(date) : null;
+  const currentHours = value ? utils.getHours(value) : null;
 
   const hourNumbers: JSX.Element[] = [];
   const startHour = ampm ? 1 : 0;
@@ -85,7 +85,7 @@ export const getMinutesNumbers = <TDate extends unknown>({
   isDisabled,
   getClockNumberText,
   selectedId,
-}: Omit<GetHourNumbersOptions<TDate>, 'ampm' | 'date'> & { value: number }) => {
+}: Omit<GetHourNumbersOptions<TDate>, 'ampm' | 'value'> & { value: number }) => {
   const f = utils.formatNumber;
 
   return (

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.spec.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.spec.tsx
@@ -2,4 +2,4 @@ import * as React from 'react';
 import { ClockPicker } from '@mui/x-date-pickers/ClockPicker';
 
 // External components are generic
-<ClockPicker<Date> view="hours" date={null} onChange={(date) => date?.getDate()} />;
+<ClockPicker<Date> view="hours" value={null} onChange={(date) => date?.getDate()} />;

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.test.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.test.tsx
@@ -20,7 +20,7 @@ describe('<ClockPicker />', () => {
   const { render } = createPickerRenderer();
 
   describeConformance(
-    <ClockPicker date={adapterToUse.date()} showViewSwitcher onChange={() => {}} />,
+    <ClockPicker value={adapterToUse.date()} showViewSwitcher onChange={() => {}} />,
     () => ({
       classes,
       inheritComponent: 'div',
@@ -41,7 +41,7 @@ describe('<ClockPicker />', () => {
   );
 
   it('renders a listbox with a name', () => {
-    render(<ClockPicker date={null} onChange={() => {}} />);
+    render(<ClockPicker value={null} onChange={() => {}} />);
 
     const listbox = screen.getByRole('listbox');
     expect(listbox).toHaveAccessibleName('Select hours. No time selected');
@@ -49,7 +49,7 @@ describe('<ClockPicker />', () => {
 
   it('has a name depending on the `date`', () => {
     render(
-      <ClockPicker date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))} onChange={() => {}} />,
+      <ClockPicker value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))} onChange={() => {}} />,
     );
 
     const listbox = screen.getByRole('listbox');
@@ -58,7 +58,7 @@ describe('<ClockPicker />', () => {
 
   it('renders the current value as an accessible option', () => {
     render(
-      <ClockPicker date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))} onChange={() => {}} />,
+      <ClockPicker value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))} onChange={() => {}} />,
     );
 
     const listbox = screen.getByRole('listbox');
@@ -68,7 +68,7 @@ describe('<ClockPicker />', () => {
   });
 
   it('can be autofocused on mount', () => {
-    render(<ClockPicker autoFocus date={null} onChange={() => {}} />);
+    render(<ClockPicker autoFocus value={null} onChange={() => {}} />);
 
     const listbox = screen.getByRole('listbox');
     expect(listbox).toHaveFocus();
@@ -76,7 +76,7 @@ describe('<ClockPicker />', () => {
 
   it('stays focused when the view changes', () => {
     const { setProps } = render(
-      <ClockPicker autoFocus date={null} onChange={() => {}} view="hours" />,
+      <ClockPicker autoFocus value={null} onChange={() => {}} view="hours" />,
     );
 
     setProps({ view: 'minutes' });
@@ -87,7 +87,7 @@ describe('<ClockPicker />', () => {
 
   it('selects the current date on mount', () => {
     render(
-      <ClockPicker date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))} onChange={() => {}} />,
+      <ClockPicker value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))} onChange={() => {}} />,
     );
 
     const selectedOption = screen.getByRole('option', { selected: true });
@@ -99,7 +99,7 @@ describe('<ClockPicker />', () => {
     render(
       <ClockPicker
         autoFocus
-        date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
+        value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
         onChange={handleChange}
       />,
     );
@@ -122,7 +122,7 @@ describe('<ClockPicker />', () => {
     render(
       <ClockPicker
         autoFocus
-        date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
+        value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
         onChange={handleChange}
       />,
     );
@@ -142,7 +142,7 @@ describe('<ClockPicker />', () => {
     render(
       <ClockPicker
         autoFocus
-        date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
+        value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
         onChange={handleChange}
       />,
     );
@@ -162,7 +162,7 @@ describe('<ClockPicker />', () => {
     render(
       <ClockPicker
         autoFocus
-        date={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
+        value={adapterToUse.date(new Date(2019, 0, 1, 4, 20))}
         onChange={handleChange}
       />,
     );
@@ -183,7 +183,7 @@ describe('<ClockPicker />', () => {
     render(
       <ClockPicker
         autoFocus
-        date={adapterToUse.date(new Date(2019, 0, 1, 18, 20))}
+        value={adapterToUse.date(new Date(2019, 0, 1, 18, 20))}
         onChange={() => {}}
         shouldDisableTime={shouldDisableTime}
         ampm
@@ -216,7 +216,7 @@ describe('<ClockPicker />', () => {
     const onChangeMock = spy();
     render(
       <ClockPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={onChangeMock}
         readOnly
       />,
@@ -250,7 +250,7 @@ describe('<ClockPicker />', () => {
     const onChangeMock = spy();
     render(
       <ClockPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
+        value={adapterToUse.date(new Date(2019, 0, 1))}
         onChange={onChangeMock}
         disabled
       />,
@@ -316,7 +316,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1))}
+          value={adapterToUse.date(new Date(2018, 0, 1))}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -339,7 +339,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1, 13))}
+          value={adapterToUse.date(new Date(2018, 0, 1, 13))}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -362,7 +362,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1, 20))}
+          value={adapterToUse.date(new Date(2018, 0, 1, 20))}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -380,7 +380,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={null}
+          value={null}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -398,7 +398,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1, 13))}
+          value={adapterToUse.date(new Date(2018, 0, 1, 13))}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -416,7 +416,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={null}
+          value={null}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -433,7 +433,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1, 13, 20))}
+          value={adapterToUse.date(new Date(2018, 0, 1, 13, 20))}
           minutesStep={15}
           onChange={() => {}}
           view="minutes"
@@ -450,7 +450,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1, 13, 20))}
+          value={adapterToUse.date(new Date(2018, 0, 1, 13, 20))}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -473,7 +473,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={adapterToUse.date(new Date(2018, 0, 1))}
+          value={adapterToUse.date(new Date(2018, 0, 1))}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -491,7 +491,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           ampm={false}
-          date={null}
+          value={null}
           minTime={adapterToUse.date(new Date(2018, 0, 1, 12, 15))}
           maxTime={adapterToUse.date(new Date(2018, 0, 1, 15, 45, 30))}
           onChange={handleChange}
@@ -511,7 +511,7 @@ describe('<ClockPicker />', () => {
       render(
         <ClockPicker
           autoFocus
-          date={adapterToUse.date(new Date(2019, 0, 1, 4, 19, 47))}
+          value={adapterToUse.date(new Date(2019, 0, 1, 4, 19, 47))}
           onChange={handleChange}
         />,
       );
@@ -528,7 +528,7 @@ describe('<ClockPicker />', () => {
 
     it('if value is not provided, uses zero as default for minutes and seconds when selecting hour', () => {
       const handleChange = spy();
-      render(<ClockPicker autoFocus date={null} onChange={handleChange} />);
+      render(<ClockPicker autoFocus value={null} onChange={handleChange} />);
       const listbox = screen.getByRole('listbox');
 
       fireEvent.keyDown(listbox, { key: 'ArrowUp' });

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -5,7 +5,7 @@ import { unstable_useId as useId } from '@mui/material/utils';
 import { styled, Theme, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/material';
 import { SxProps } from '@mui/system';
-import { Clock } from './Clock';
+import { Clock, ClockProps } from './Clock';
 import { useUtils, useNow, useLocaleText } from '../internals/hooks/useUtils';
 import { buildDeprecatedPropsWarning } from '../internals/utils/warning';
 import { getHourNumbers, getMinutesNumbers } from './ClockNumbers';
@@ -102,7 +102,7 @@ export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate>
   /**
    * Selected date @DateIOType.
    */
-  date: TDate | null;
+  value: TDate | null;
   /**
    * Get clock number aria-text for hours.
    * @param {string} hours The hours to format.
@@ -223,7 +223,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
     autoFocus,
     components,
     componentsProps,
-    date,
+    value,
     disableIgnoringDatePartForTimeValidation,
     getClockLabelText: getClockLabelTextProp,
     getHoursClockNumberText: getHoursClockNumberTextProp,
@@ -278,13 +278,13 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
   const now = useNow<TDate>();
   const utils = useUtils<TDate>();
 
-  const dateOrMidnight = React.useMemo(
-    () => date || utils.setSeconds(utils.setMinutes(utils.setHours(now, 0), 0), 0),
-    [date, now, utils],
+  const selectedTimeOrMidnight = React.useMemo(
+    () => value || utils.setSeconds(utils.setMinutes(utils.setHours(now, 0), 0), 0),
+    [value, now, utils],
   );
 
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode<TDate>(
-    dateOrMidnight,
+    selectedTimeOrMidnight,
     ampm,
     handleChangeAndOpenNext,
   );
@@ -305,13 +305,13 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
         return true;
       };
 
-      const isValidValue = (value: number, step = 1) => {
-        if (value % step !== 0) {
+      const isValidValue = (timeValue: number, step = 1) => {
+        if (timeValue % step !== 0) {
           return false;
         }
 
         if (shouldDisableTime) {
-          return !shouldDisableTime(value, viewType);
+          return !shouldDisableTime(timeValue, viewType);
         }
 
         return true;
@@ -319,16 +319,16 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
 
       switch (viewType) {
         case 'hours': {
-          const value = convertValueToMeridiem(rawValue, meridiemMode, ampm);
-          const dateWithNewHours = utils.setHours(dateOrMidnight, value);
+          const valueWithMeridiem = convertValueToMeridiem(rawValue, meridiemMode, ampm);
+          const dateWithNewHours = utils.setHours(selectedTimeOrMidnight, valueWithMeridiem);
           const start = utils.setSeconds(utils.setMinutes(dateWithNewHours, 0), 0);
           const end = utils.setSeconds(utils.setMinutes(dateWithNewHours, 59), 59);
 
-          return !containsValidTime({ start, end }) || !isValidValue(value);
+          return !containsValidTime({ start, end }) || !isValidValue(valueWithMeridiem);
         }
 
         case 'minutes': {
-          const dateWithNewMinutes = utils.setMinutes(dateOrMidnight, rawValue);
+          const dateWithNewMinutes = utils.setMinutes(selectedTimeOrMidnight, rawValue);
           const start = utils.setSeconds(dateWithNewMinutes, 0);
           const end = utils.setSeconds(dateWithNewMinutes, 59);
 
@@ -336,7 +336,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
         }
 
         case 'seconds': {
-          const dateWithNewSeconds = utils.setSeconds(dateOrMidnight, rawValue);
+          const dateWithNewSeconds = utils.setSeconds(selectedTimeOrMidnight, rawValue);
           const start = dateWithNewSeconds;
           const end = dateWithNewSeconds;
 
@@ -349,7 +349,7 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
     },
     [
       ampm,
-      dateOrMidnight,
+      selectedTimeOrMidnight,
       disableIgnoringDatePartForTimeValidation,
       maxTime,
       meridiemMode,
@@ -362,64 +362,69 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
 
   const selectedId = useId();
 
-  const viewProps = React.useMemo(() => {
+  const viewProps = React.useMemo<
+    Pick<ClockProps<TDate>, 'onChange' | 'viewValue' | 'children'>
+  >(() => {
     switch (openView) {
       case 'hours': {
-        const handleHoursChange = (value: number, isFinish?: PickerSelectionState) => {
-          const valueWithMeridiem = convertValueToMeridiem(value, meridiemMode, ampm);
-          handleChangeAndOpenNext(utils.setHours(dateOrMidnight, valueWithMeridiem), isFinish);
+        const handleHoursChange = (hourValue: number, isFinish?: PickerSelectionState) => {
+          const valueWithMeridiem = convertValueToMeridiem(hourValue, meridiemMode, ampm);
+          handleChangeAndOpenNext(
+            utils.setHours(selectedTimeOrMidnight, valueWithMeridiem),
+            isFinish,
+          );
         };
 
         return {
           onChange: handleHoursChange,
-          value: utils.getHours(dateOrMidnight),
+          viewValue: utils.getHours(selectedTimeOrMidnight),
           children: getHourNumbers({
-            date,
+            value,
             utils,
             ampm,
             onChange: handleHoursChange,
             getClockNumberText: getHoursClockNumberText,
-            isDisabled: (value) => disabled || isTimeDisabled(value, 'hours'),
+            isDisabled: (hourValue) => disabled || isTimeDisabled(hourValue, 'hours'),
             selectedId,
           }),
         };
       }
 
       case 'minutes': {
-        const minutesValue = utils.getMinutes(dateOrMidnight);
-        const handleMinutesChange = (value: number, isFinish?: PickerSelectionState) => {
-          handleChangeAndOpenNext(utils.setMinutes(dateOrMidnight, value), isFinish);
+        const minutesValue = utils.getMinutes(selectedTimeOrMidnight);
+        const handleMinutesChange = (minuteValue: number, isFinish?: PickerSelectionState) => {
+          handleChangeAndOpenNext(utils.setMinutes(selectedTimeOrMidnight, minuteValue), isFinish);
         };
 
         return {
-          value: minutesValue,
+          viewValue: minutesValue,
           onChange: handleMinutesChange,
-          children: getMinutesNumbers({
+          children: getMinutesNumbers<TDate>({
             utils,
             value: minutesValue,
             onChange: handleMinutesChange,
             getClockNumberText: getMinutesClockNumberText,
-            isDisabled: (value) => disabled || isTimeDisabled(value, 'minutes'),
+            isDisabled: (minuteValue) => disabled || isTimeDisabled(minuteValue, 'minutes'),
             selectedId,
           }),
         };
       }
 
       case 'seconds': {
-        const secondsValue = utils.getSeconds(dateOrMidnight);
-        const handleSecondsChange = (value: number, isFinish?: PickerSelectionState) => {
-          handleChangeAndOpenNext(utils.setSeconds(dateOrMidnight, value), isFinish);
+        const secondsValue = utils.getSeconds(selectedTimeOrMidnight);
+        const handleSecondsChange = (secondValue: number, isFinish?: PickerSelectionState) => {
+          handleChangeAndOpenNext(utils.setSeconds(selectedTimeOrMidnight, secondValue), isFinish);
         };
 
         return {
-          value: secondsValue,
+          viewValue: secondsValue,
           onChange: handleSecondsChange,
           children: getMinutesNumbers({
             utils,
             value: secondsValue,
             onChange: handleSecondsChange,
             getClockNumberText: getSecondsClockNumberText,
-            isDisabled: (value) => disabled || isTimeDisabled(value, 'seconds'),
+            isDisabled: (secondValue) => disabled || isTimeDisabled(secondValue, 'seconds'),
             selectedId,
           }),
         };
@@ -431,14 +436,14 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
   }, [
     openView,
     utils,
-    date,
+    value,
     ampm,
     getHoursClockNumberText,
     getMinutesClockNumberText,
     getSecondsClockNumberText,
     meridiemMode,
     handleChangeAndOpenNext,
-    dateOrMidnight,
+    selectedTimeOrMidnight,
     isTimeDisabled,
     selectedId,
     disabled,
@@ -471,8 +476,8 @@ export const ClockPicker = React.forwardRef(function ClockPicker<TDate extends u
 
       <Clock<TDate>
         autoFocus={autoFocus}
-        date={date}
         ampmInClock={ampmInClock}
+        value={value}
         type={openView}
         ampm={ampm}
         getClockLabelText={getClockLabelText}
@@ -523,10 +528,6 @@ ClockPicker.propTypes = {
    * @default {}
    */
   componentsProps: PropTypes.object,
-  /**
-   * Selected date @DateIOType.
-   */
-  date: PropTypes.any,
   /**
    * If `true`, the picker and text field are disabled.
    * @default false
@@ -642,6 +643,10 @@ ClockPicker.propTypes = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  /**
+   * Selected date @DateIOType.
+   */
+  value: PropTypes.any,
   /**
    * Controlled open view.
    */

--- a/packages/x-date-pickers/src/ClockPicker/ClockPointer.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPointer.tsx
@@ -7,7 +7,7 @@ export interface ClockPointerProps extends React.HTMLAttributes<HTMLDivElement> 
   hasSelected: boolean;
   isInner: boolean;
   type: ClockPickerView;
-  value: number;
+  viewValue: number;
 }
 
 const ClockPointerRoot = styled('div')<{
@@ -69,15 +69,15 @@ export class ClockPointer extends React.Component<ClockPointerProps> {
   };
 
   render() {
-    const { className, hasSelected, isInner, type, value, ...other } = this.props;
+    const { className, hasSelected, isInner, type, viewValue, ...other } = this.props;
 
     const ownerState = { ...this.props, ...this.state };
 
     const getAngleStyle = () => {
       const max = type === 'hours' ? 12 : 60;
-      let angle = (360 / max) * value;
+      let angle = (360 / max) * viewValue;
 
-      if (type === 'hours' && value > 12) {
+      if (type === 'hours' && viewValue > 12) {
         angle -= 360; // round up angle to max 360 degrees
       }
 

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.spec.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.spec.tsx
@@ -20,12 +20,12 @@ import { expectType } from '@mui/types';
 
 // Inference from the state
 const InferTest = () => {
-  const [date, setDate] = React.useState<Moment | null>(moment());
+  const [value, setValue] = React.useState<Moment | null>(moment());
 
   return (
     <DatePicker
-      value={date}
-      onChange={(newDate) => setDate(newDate)}
+      value={value}
+      onChange={(newValue) => setValue(newValue)}
       renderInput={() => <input />}
     />
   );

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePickerKeyboard.test.tsx
@@ -174,13 +174,13 @@ describe('<DesktopDatePicker /> keyboard interactions', () => {
         const onErrorMock = spy();
         // we are running validation on value change
         function DatePickerInput() {
-          const [date, setDate] = React.useState<number | Date | null>(null);
+          const [value, setValue] = React.useState<number | Date | null>(null);
 
           return (
             <DesktopDatePicker
-              value={date}
+              value={value}
               onError={onErrorMock}
-              onChange={(newDate) => setDate(newDate)}
+              onChange={(newDate) => setValue(newDate)}
               renderInput={(inputProps) => <TextField {...inputProps} />}
               {...props}
             />

--- a/packages/x-date-pickers/src/MonthPicker/MonthPicker.test.tsx
+++ b/packages/x-date-pickers/src/MonthPicker/MonthPicker.test.tsx
@@ -16,7 +16,7 @@ describe('<MonthPicker />', () => {
     <MonthPicker
       minDate={adapterToUse.date(new Date(2019, 0, 1))}
       maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-      date={adapterToUse.date()}
+      value={adapterToUse.date()}
       onChange={() => {}}
     />,
     () => ({
@@ -37,7 +37,7 @@ describe('<MonthPicker />', () => {
       <MonthPicker
         minDate={adapterToUse.date(new Date(2019, 0, 1))}
         maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-        date={adapterToUse.date(new Date(2019, 1, 2))}
+        value={adapterToUse.date(new Date(2019, 1, 2))}
         onChange={onChangeMock}
       />,
     );
@@ -52,7 +52,7 @@ describe('<MonthPicker />', () => {
       <MonthPicker
         minDate={adapterToUse.date(new Date(2019, 0, 1))}
         maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-        date={adapterToUse.date(new Date(2019, 1, 2))}
+        value={adapterToUse.date(new Date(2019, 1, 2))}
         onChange={onChangeMock}
         readOnly
       />,
@@ -75,7 +75,7 @@ describe('<MonthPicker />', () => {
         <MonthPicker
           minDate={adapterToUse.date(new Date(2019, 0, 1))}
           maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-          date={adapterToUse.date(new Date(2019, 1, 2))}
+          value={adapterToUse.date(new Date(2019, 1, 2))}
           onChange={() => {}}
         />
       </form>,
@@ -90,7 +90,7 @@ describe('<MonthPicker />', () => {
       const onChange = spy();
       render(
         <MonthPicker
-          date={adapterToUse.date(new Date(2019, 1, 15))}
+          value={adapterToUse.date(new Date(2019, 1, 15))}
           onChange={onChange}
           disabled
         />,
@@ -107,7 +107,7 @@ describe('<MonthPicker />', () => {
       const onChange = spy();
       render(
         <MonthPicker
-          date={adapterToUse.date(new Date(2019, 1, 15))}
+          value={adapterToUse.date(new Date(2019, 1, 15))}
           onChange={onChange}
           minDate={adapterToUse.date(new Date(2019, 1, 12))}
         />,
@@ -130,7 +130,7 @@ describe('<MonthPicker />', () => {
       const onChange = spy();
       render(
         <MonthPicker
-          date={adapterToUse.date(new Date(2019, 1, 15))}
+          value={adapterToUse.date(new Date(2019, 1, 15))}
           onChange={onChange}
           maxDate={adapterToUse.date(new Date(2019, 3, 12))}
         />,
@@ -153,7 +153,7 @@ describe('<MonthPicker />', () => {
       const onChange = spy();
       render(
         <MonthPicker
-          date={adapterToUse.date(new Date(2019, 1, 2))}
+          value={adapterToUse.date(new Date(2019, 1, 2))}
           onChange={onChange}
           shouldDisableMonth={(month) => adapterToUse.getMonth(month) === 3}
         />,

--- a/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx
+++ b/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx
@@ -36,11 +36,11 @@ export interface MonthPickerProps<TDate>
    */
   sx?: SxProps<Theme>;
   /** Date value for the MonthPicker */
-  date: TDate | null;
+  value: TDate | null;
   /** If `true` picker is disabled */
   disabled?: boolean;
   /** Callback fired on date change. */
-  onChange: NonNullablePickerChangeHandler<TDate>;
+  onChange: (value: TDate) => void;
   /** If `true` picker is readonly */
   readOnly?: boolean;
   /**
@@ -114,7 +114,7 @@ export const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
 
   const {
     className,
-    date,
+    value,
     disabled,
     disableFuture,
     disablePast,
@@ -136,10 +136,10 @@ export const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
 
   const todayMonth = React.useMemo(() => utils.getMonth(now), [utils, now]);
 
-  const selectedDateOrToday = date ?? now;
+  const selectedDateOrToday = value ?? now;
   const selectedMonth = React.useMemo(() => {
-    if (date != null) {
-      return utils.getMonth(date);
+    if (value != null) {
+      return utils.getMonth(value);
     }
 
     if (disableHighlightToday) {
@@ -147,7 +147,7 @@ export const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
     }
 
     return utils.getMonth(now);
-  }, [now, date, utils, disableHighlightToday]);
+  }, [now, value, utils, disableHighlightToday]);
   const [focusedMonth, setFocusedMonth] = React.useState(() => selectedMonth || todayMonth);
 
   const [internalHasFocus, setInternalHasFocus] = useControlled<boolean>({
@@ -195,7 +195,7 @@ export const MonthPicker = React.forwardRef(function MonthPicker<TDate>(
     }
 
     const newDate = utils.setMonth(selectedDateOrToday, month);
-    onChange(newDate, 'finish');
+    onChange(newDate);
   });
 
   const focusMonth = useEventCallback((month: number) => {
@@ -304,10 +304,6 @@ MonthPicker.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Date value for the MonthPicker
-   */
-  date: PropTypes.any,
-  /**
    * If `true` picker is disabled
    */
   disabled: PropTypes.bool,
@@ -361,4 +357,8 @@ MonthPicker.propTypes = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  /**
+   * Date value for the MonthPicker
+   */
+  value: PropTypes.any,
 } as any;

--- a/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx
+++ b/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx
@@ -10,7 +10,6 @@ import {
 } from '@mui/utils';
 import { PickersMonth } from './PickersMonth';
 import { useUtils, useNow, useDefaultDates } from '../internals/hooks/useUtils';
-import { NonNullablePickerChangeHandler } from '../internals/hooks/useViews';
 import { MonthPickerClasses, getMonthPickerUtilityClass } from './monthPickerClasses';
 import {
   BaseDateValidationProps,
@@ -39,7 +38,11 @@ export interface MonthPickerProps<TDate>
   value: TDate | null;
   /** If `true` picker is disabled */
   disabled?: boolean;
-  /** Callback fired on date change. */
+  /**
+   * Callback fired when the value (the selected month) changes.
+   * @template TValue
+   * @param {TValue} value The new parsed value.
+   */
   onChange: (value: TDate) => void;
   /** If `true` picker is readonly */
   readOnly?: boolean;
@@ -332,7 +335,9 @@ MonthPicker.propTypes = {
    */
   minDate: PropTypes.any,
   /**
-   * Callback fired on date change.
+   * Callback fired when the value (the selected month) changes.
+   * @template TValue
+   * @param {TValue} value The new parsed value.
    */
   onChange: PropTypes.func.isRequired,
   onFocusedViewChange: PropTypes.func,

--- a/packages/x-date-pickers/src/YearPicker/YearPicker.test.tsx
+++ b/packages/x-date-pickers/src/YearPicker/YearPicker.test.tsx
@@ -16,7 +16,7 @@ describe('<YearPicker />', () => {
     <YearPicker
       minDate={adapterToUse.date(new Date(2019, 0, 1))}
       maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-      date={adapterToUse.date()}
+      value={adapterToUse.date()}
       onChange={() => {}}
     />,
     () => ({
@@ -37,7 +37,7 @@ describe('<YearPicker />', () => {
       <YearPicker
         minDate={adapterToUse.date(new Date(2019, 0, 1))}
         maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-        date={adapterToUse.date(new Date(2019, 1, 2))}
+        value={adapterToUse.date(new Date(2019, 1, 2))}
         onChange={onChangeMock}
       />,
     );
@@ -62,7 +62,7 @@ describe('<YearPicker />', () => {
       <YearPicker
         minDate={adapterToUse.date(new Date(2019, 0, 1))}
         maxDate={adapterToUse.date(new Date(2029, 0, 1))}
-        date={adapterToUse.date(new Date(2019, 1, 2))}
+        value={adapterToUse.date(new Date(2019, 1, 2))}
         onChange={onChangeMock}
         readOnly
       />,
@@ -79,7 +79,11 @@ describe('<YearPicker />', () => {
     it('should disable all years if props.disabled = true', () => {
       const onChange = spy();
       render(
-        <YearPicker date={adapterToUse.date(new Date(2017, 1, 15))} onChange={onChange} disabled />,
+        <YearPicker
+          value={adapterToUse.date(new Date(2017, 1, 15))}
+          onChange={onChange}
+          disabled
+        />,
       );
 
       screen.getAllByRole('button').forEach((monthButton) => {
@@ -93,7 +97,7 @@ describe('<YearPicker />', () => {
       const onChange = spy();
       render(
         <YearPicker
-          date={adapterToUse.date(new Date(2017, 1, 15))}
+          value={adapterToUse.date(new Date(2017, 1, 15))}
           onChange={onChange}
           minDate={adapterToUse.date(new Date(2018, 1, 12))}
         />,
@@ -113,7 +117,7 @@ describe('<YearPicker />', () => {
       const onChange = spy();
       render(
         <YearPicker
-          date={adapterToUse.date(new Date(2019, 1, 15))}
+          value={adapterToUse.date(new Date(2019, 1, 15))}
           onChange={onChange}
           maxDate={adapterToUse.date(new Date(2025, 3, 12))}
         />,
@@ -133,7 +137,7 @@ describe('<YearPicker />', () => {
       const onChange = spy();
       render(
         <YearPicker
-          date={adapterToUse.date(new Date(2019, 0, 2))}
+          value={adapterToUse.date(new Date(2019, 0, 2))}
           onChange={onChange}
           shouldDisableYear={(month) => adapterToUse.getYear(month) === 2024}
         />,
@@ -159,7 +163,7 @@ describe('<YearPicker />', () => {
         minDate={adapterToUse.date(new Date(2018, 10, 1))}
         maxDate={adapterToUse.date(new Date(2020, 3, 1))}
         // date is chose such as replacing year by 2018 or 2020 makes it out of valid range
-        date={adapterToUse.date(new Date(2019, 7, 1))}
+        value={adapterToUse.date(new Date(2019, 7, 1))}
         onChange={() => {}}
         autoFocus // needed to allow keyboard navigation
       />,

--- a/packages/x-date-pickers/src/YearPicker/YearPicker.tsx
+++ b/packages/x-date-pickers/src/YearPicker/YearPicker.tsx
@@ -80,11 +80,11 @@ export interface YearPickerProps<TDate>
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx?: SxProps<Theme>;
-  date: TDate | null;
+  value: TDate | null;
   /** If `true` picker is disabled */
   disabled?: boolean;
   /** Callback fired on date change. */
-  onChange: NonNullablePickerChangeHandler<TDate>;
+  onChange: (value: TDate) => void;
   /** If `true` picker is readonly */
   readOnly?: boolean;
   /**
@@ -114,7 +114,7 @@ export const YearPicker = React.forwardRef(function YearPicker<TDate>(
   const {
     autoFocus,
     className,
-    date,
+    value,
     disabled,
     disableFuture,
     disablePast,
@@ -133,11 +133,11 @@ export const YearPicker = React.forwardRef(function YearPicker<TDate>(
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
 
-  const selectedDateOrToday = date ?? now;
+  const selectedDateOrToday = value ?? now;
   const todayYear = React.useMemo(() => utils.getYear(now), [utils, now]);
   const selectedYear = React.useMemo(() => {
-    if (date != null) {
-      return utils.getYear(date);
+    if (value != null) {
+      return utils.getYear(value);
     }
 
     if (disableHighlightToday) {
@@ -145,7 +145,7 @@ export const YearPicker = React.forwardRef(function YearPicker<TDate>(
     }
 
     return utils.getYear(now);
-  }, [now, date, utils, disableHighlightToday]);
+  }, [now, value, utils, disableHighlightToday]);
   const [focusedYear, setFocusedYear] = React.useState(() => selectedYear || todayYear);
 
   const [internalHasFocus, setInternalHasFocus] = useControlled<boolean>({
@@ -188,7 +188,7 @@ export const YearPicker = React.forwardRef(function YearPicker<TDate>(
     }
 
     const newDate = utils.setYear(selectedDateOrToday, year);
-    onChange(newDate, 'finish');
+    onChange(newDate);
   });
 
   const focusYear = useEventCallback((year: number) => {
@@ -288,7 +288,6 @@ YearPicker.propTypes = {
    * className applied to the root element.
    */
   className: PropTypes.string,
-  date: PropTypes.any,
   /**
    * If `true` picker is disabled
    */
@@ -343,4 +342,5 @@ YearPicker.propTypes = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  value: PropTypes.any,
 } as any;

--- a/packages/x-date-pickers/src/YearPicker/YearPicker.tsx
+++ b/packages/x-date-pickers/src/YearPicker/YearPicker.tsx
@@ -11,7 +11,6 @@ import {
 } from '@mui/utils';
 import { PickersYear } from './PickersYear';
 import { useUtils, useNow, useDefaultDates } from '../internals/hooks/useUtils';
-import { NonNullablePickerChangeHandler } from '../internals/hooks/useViews';
 import { WrapperVariantContext } from '../internals/components/wrappers/WrapperVariantContext';
 import { YearPickerClasses, getYearPickerUtilityClass } from './yearPickerClasses';
 import { BaseDateValidationProps, YearValidationProps } from '../internals/hooks/validation/models';
@@ -83,7 +82,11 @@ export interface YearPickerProps<TDate>
   value: TDate | null;
   /** If `true` picker is disabled */
   disabled?: boolean;
-  /** Callback fired on date change. */
+  /**
+   * Callback fired when the value (the selected year) changes.
+   * @template TValue
+   * @param {TValue} value The new parsed value.
+   */
   onChange: (value: TDate) => void;
   /** If `true` picker is readonly */
   readOnly?: boolean;
@@ -317,7 +320,9 @@ YearPicker.propTypes = {
    */
   minDate: PropTypes.any,
   /**
-   * Callback fired on date change.
+   * Callback fired when the value (the selected year) changes.
+   * @template TValue
+   * @param {TValue} value The new parsed value.
    */
   onChange: PropTypes.func.isRequired,
   onFocusedViewChange: PropTypes.func,

--- a/packages/x-date-pickers/src/internals/components/CalendarOrClockPicker/CalendarOrClockPicker.tsx
+++ b/packages/x-date-pickers/src/internals/components/CalendarOrClockPicker/CalendarOrClockPicker.tsx
@@ -213,7 +213,7 @@ export function CalendarOrClockPicker<TDate, View extends CalendarOrClockPickerV
             {isDatePickerView(openView) && (
               <CalendarPicker
                 autoFocus={autoFocus}
-                date={parsedValue}
+                value={parsedValue}
                 onViewChange={setOpenView as (view: CalendarPickerView) => void}
                 onChange={handleChangeAndOpenNext}
                 view={openView}
@@ -229,7 +229,7 @@ export function CalendarOrClockPicker<TDate, View extends CalendarOrClockPickerV
               <ClockPicker
                 {...other}
                 autoFocus={autoFocus}
-                date={parsedValue}
+                value={parsedValue}
                 view={openView}
                 // Unclear why the predicate `isDatePickerView` does not imply the casted type
                 views={views.filter(isTimePickerView) as ClockPickerView[]}

--- a/test/regressions/pickers/CalendarPickerYearOnly.tsx
+++ b/test/regressions/pickers/CalendarPickerYearOnly.tsx
@@ -10,7 +10,7 @@ export default function CalendarPickerYearOnly() {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <CalendarPicker
         views={['year']}
-        date={adapterToUse.date('2019-01-01T00:00:00.000')}
+        value={adapterToUse.date('2019-01-01T00:00:00.000')}
         onChange={() => {}}
       />
     </LocalizationProvider>


### PR DESCRIPTION
Closes #6104

# Changelog

## Breaking change

The `date` prop has been renamed `value` on  `MonthPicker` / `YearPicker`, `ClockPicker` and `CalendarPicker`.

```diff
- <MonthPicker date={dayjs()} onChange={handleMonthChange} />
+ <MonthPicker value={dayjs()} onChange={handleMonthChange} />

- <YearPicker date={dayjs()} onChange={handleYearChange} />
+ <YearPicker value={dayjs()} onChange={handleYearChange} />

- <ClockPicker date={dayjs()} onChange={handleTimeChange} />
+ <ClockPicker value={dayjs()} onChange={handleTimeChange} />

- <CalendarPicker date={dayjs()} onChange={handleDateChange} />
+ <CalendarPicker value={dayjs()} onChange={handleDateChange} />
```


For `CalendarOrClockPicker`, I'm in favor of removing it for #5687 so I kept the `parsedValue` prop (yet another naming :laughing:)