### PR TITLE
[pickers] Remove `valueStr` from the field state

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
@@ -90,7 +90,6 @@ export interface FieldValueManager<TValue, TDate, TSection extends FieldSection,
 }
 
 export interface UseFieldState<TValue, TSections> {
-  valueStr: string;
   valueParsed: TValue;
   sections: TSections;
   selectedSectionIndexes: { start: number; end: number } | null;

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -395,7 +395,7 @@ export const useField = <
 
   const valueStr = React.useMemo(
     () => fieldValueManager.getValueStrFromSections(state.sections),
-    [state.sections],
+    [state.sections, fieldValueManager],
   );
 
   return {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -70,7 +70,6 @@ export const useField = <
     return {
       sections,
       valueParsed,
-      valueStr: fieldValueManager.getValueStrFromSections(sections),
       selectedSectionIndexes: null,
     };
   });
@@ -86,7 +85,6 @@ export const useField = <
     setState((prevState) => ({
       ...prevState,
       sections,
-      valueStr: fieldValueManager.getValueStrFromSections(sections),
       valueParsed: newValueParsed,
     }));
 
@@ -374,7 +372,6 @@ export const useField = <
       setState((prevState) => ({
         ...prevState,
         valueParsed,
-        valueStr: fieldValueManager.getValueStrFromSections(sections),
         sections,
       }));
     }
@@ -396,10 +393,15 @@ export const useField = <
     return () => window.clearTimeout(focusTimeoutRef.current);
   }, []);
 
+  const valueStr = React.useMemo(
+    () => fieldValueManager.getValueStrFromSections(state.sections),
+    [state.sections],
+  );
+
   return {
     inputProps: {
       ...otherForwardedProps,
-      value: state.valueStr,
+      value: valueStr,
       onClick: handleInputClick,
       onFocus: handleInputFocus,
       onBlur: handleInputBlur,


### PR DESCRIPTION
We are always generating the date with the exact same function and only with stuff that is also on the state.
So we can just generate it a `useMemo` instead of in the state updaters.