### PR TITLE
[CalendarPicker] Don't move to closest enabled date when `props.date` contains a disabled date

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -158,22 +158,6 @@ describe('<CalendarPicker />', () => {
     });
   });
 
-  it('should select the closest enabled date if the prop.date contains a disabled date', () => {
-    const onChange = spy();
-
-    render(
-      <CalendarPicker
-        date={adapterToUse.date(new Date(2019, 0, 1))}
-        onChange={onChange}
-        maxDate={adapterToUse.date(new Date(2018, 0, 1))}
-      />,
-    );
-
-    // onChange must be dispatched with newly selected date
-    expect(onChange.callCount).to.equal(React.version.startsWith('18') ? 2 : 1); // Strict Effects run mount effects twice
-    expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 1));
-  });
-
   describe('view: day', () => {
     it('renders day calendar standalone', () => {
       render(<CalendarPicker date={adapterToUse.date(new Date(2019, 0, 1))} onChange={() => {}} />);

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -392,24 +392,6 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   );
 
   React.useEffect(() => {
-    if (date && isDateDisabled(date)) {
-      const closestEnabledDate = findClosestEnabledDate({
-        utils,
-        date,
-        minDate,
-        maxDate,
-        disablePast,
-        disableFuture,
-        isDateDisabled,
-      });
-
-      onChange(closestEnabledDate, 'partial');
-    }
-    // This call is too expensive to run it on each prop change.
-    // So just ensure that we are not rendering disabled as selected on mount.
-  }, []); // eslint-disable-line
-
-  React.useEffect(() => {
     if (date) {
       changeMonth(date);
     }


### PR DESCRIPTION
Fixes #5393

Behavior described in the issue.