### PR TITLE
[DateRangePicker] Switch to new month when changing the value from the outside

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
@@ -144,63 +144,56 @@ function DateRangePickerViewRaw<TInputDate, TDate>(
     ((dayToTest: TDate) => shouldDisableDate?.(dayToTest, currentlySelectingRangeEnd));
 
   const [start, end] = parsedValue;
-  const {
-    changeMonth,
-    calendarState,
-    isDateDisabled,
-    onMonthSwitchingAnimationEnd,
-    changeFocusedDay,
-  } = useCalendarState({
-    value: start || end,
-    defaultCalendarMonth,
-    disableFuture,
-    disablePast,
-    disableSwitchToMonthOnDayFocus: true,
-    maxDate,
-    minDate,
-    onMonthChange,
-    reduceAnimations,
-    shouldDisableDate: wrappedShouldDisableDate,
-  });
+  const { changeMonth, calendarState, onMonthSwitchingAnimationEnd, changeFocusedDay } =
+    useCalendarState({
+      value: start || end,
+      defaultCalendarMonth,
+      disableFuture,
+      disablePast,
+      disableSwitchToMonthOnDayFocus: true,
+      maxDate,
+      minDate,
+      onMonthChange,
+      reduceAnimations,
+      shouldDisableDate: wrappedShouldDisableDate,
+    });
 
   const toShowToolbar = showToolbar ?? wrapperVariant !== 'desktop';
 
-  const scrollToDayIfNeeded = (day: TDate | null) => {
-    if (!day || !utils.isValid(day) || isDateDisabled(day)) {
+  const prevValue = React.useRef<DateRange<TDate> | null>(null);
+  React.useEffect(() => {
+    const date = currentlySelectingRangeEnd === 'start' ? start : end;
+    if (!date || !utils.isValid(date)) {
       return;
     }
 
-    const currentlySelectedDate = currentlySelectingRangeEnd === 'start' ? start : end;
-    if (currentlySelectedDate === null) {
-      // do not scroll if one of ages is not selected
+    const prevDate =
+      currentlySelectingRangeEnd === 'start' ? prevValue.current?.[0] : prevValue.current?.[1];
+    prevValue.current = parsedValue;
+
+    // The current date did not change, this call comes either from a `currentlySelectingRangeEnd` change or a change in the other date.
+    // In both cases, we don't want to change the visible month(s).
+    if (disableAutoMonthSwitching && prevDate && utils.isEqual(prevDate, date)) {
       return;
     }
 
     const displayingMonthRange = wrapperVariant === 'mobile' ? 0 : calendars - 1;
     const currentMonthNumber = utils.getMonth(calendarState.currentMonth);
-    const requestedMonthNumber = utils.getMonth(day);
+    const requestedMonthNumber = utils.getMonth(date);
 
     if (
-      !utils.isSameYear(calendarState.currentMonth, day) ||
+      !utils.isSameYear(calendarState.currentMonth, date) ||
       requestedMonthNumber < currentMonthNumber ||
       requestedMonthNumber > currentMonthNumber + displayingMonthRange
     ) {
       const newMonth =
         currentlySelectingRangeEnd === 'start'
-          ? currentlySelectedDate
+          ? date
           : // If need to focus end, scroll to the state when "end" is displaying in the last calendar
-            utils.addMonths(currentlySelectedDate, -displayingMonthRange);
+            utils.addMonths(date, -displayingMonthRange);
 
       changeMonth(newMonth);
     }
-  };
-
-  React.useEffect(() => {
-    if (disableAutoMonthSwitching || !open) {
-      return;
-    }
-
-    scrollToDayIfNeeded(currentlySelectingRangeEnd === 'start' ? start : end);
   }, [currentlySelectingRangeEnd, parsedValue]); // eslint-disable-line
 
   const handleSelectedDayChange = React.useCallback<DayPickerProps<TDate>['onSelectedDaysChange']>(

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -406,6 +406,57 @@ describe('<DesktopDateRangePicker />', () => {
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
+  describe('prop: disableAutoMonthSwitching', () => {
+    it('should go to the month of the end date when changing the start date', () => {
+      render(
+        <WrappedDesktopDateRangePicker
+          initialValue={[
+            adapterToUse.date(new Date(2018, 0, 1)),
+            adapterToUse.date(new Date(2018, 6, 1)),
+          ]}
+        />,
+      );
+
+      openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
+      fireEvent.click(getPickerDay('5', 'January 2018'));
+      clock.runToLast();
+      expect(getPickerDay('1', 'July 2018')).not.to.equal(null);
+    });
+
+    it('should not go to the month of the end date when changing the start date and props.disableAutoMonthSwitching = true', () => {
+      render(
+        <WrappedDesktopDateRangePicker
+          initialValue={[
+            adapterToUse.date(new Date(2018, 0, 1)),
+            adapterToUse.date(new Date(2018, 6, 1)),
+          ]}
+          disableAutoMonthSwitching
+        />,
+      );
+
+      openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
+      fireEvent.click(getPickerDay('5', 'January 2018'));
+      clock.runToLast();
+      expect(getPickerDay('1', 'January 2018')).not.to.equal(null);
+    });
+
+    it('should go to the month of the start date when changing both date from the outside', () => {
+      const { setProps } = render(
+        <WrappedDesktopDateRangePicker
+          value={[adapterToUse.date(new Date(2018, 0, 1)), adapterToUse.date(new Date(2018, 6, 1))]}
+        />,
+      );
+
+      openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
+
+      setProps({
+        value: [adapterToUse.date(new Date(2018, 3, 1)), adapterToUse.date(new Date(2018, 3, 1))],
+      });
+      clock.runToLast();
+      expect(getPickerDay('1', 'April 2018')).not.to.equal(null);
+    });
+  });
+
   describe('prop: PopperProps', () => {
     it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -388,7 +388,7 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
   );
 
   React.useEffect(() => {
-    if (value) {
+    if (value != null && utils.isValid(value)) {
       changeMonth(value);
     }
   }, [value]); // eslint-disable-line

--- a/packages/x-date-pickers/src/CalendarPicker/useCalendarState.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/useCalendarState.tsx
@@ -152,7 +152,7 @@ export const useCalendarState = <TDate extends unknown>({
 
   const changeMonth = React.useCallback(
     (newDate: TDate) => {
-      const newDateRequested = newDate ?? now;
+      const newDateRequested = newDate;
       if (utils.isSameMonth(newDateRequested, calendarState.currentMonth)) {
         return;
       }
@@ -164,7 +164,7 @@ export const useCalendarState = <TDate extends unknown>({
           : 'right',
       });
     },
-    [calendarState.currentMonth, handleChangeMonth, now, utils],
+    [calendarState.currentMonth, handleChangeMonth, utils],
   );
 
   const isDateDisabled = useIsDateDisabled({

--- a/test/utils/pickers-utils.tsx
+++ b/test/utils/pickers-utils.tsx
@@ -8,6 +8,7 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import sinon from 'sinon';
+import { useControlled } from '@mui/material/utils';
 
 const availableAdapters = {
   'date-fns': AdapterDateFns,
@@ -160,20 +161,26 @@ export const withPickerControls =
     return (
       props: Omit<Props, 'value' | 'onChange' | keyof DefaultProps> &
         Partial<DefaultProps> & {
-          initialValue: TValue;
+          initialValue?: TValue;
+          value?: TValue;
           onChange?: any;
         },
     ) => {
-      const { initialValue, onChange, ...other } = props;
+      const { initialValue, value: inValue, onChange, ...other } = props;
 
-      const [value, setValue] = React.useState<TValue>(initialValue);
+      const [value, setValue] = useControlled({
+        controlled: inValue,
+        default: initialValue,
+        name: 'withPickerControls',
+        state: 'value,',
+      });
 
       const handleChange = React.useCallback(
         (newValue: TValue, keyboardInputValue?: string) => {
           setValue(newValue);
           onChange?.(newValue, keyboardInputValue);
         },
-        [onChange],
+        [onChange, setValue],
       );
 
       return (


### PR DESCRIPTION
Closing #5346

## Behavior changes

- Do not check if `open === true` (I don't understand this check, on pickers and it always `true` - otherwise this component is not rendered - and on static pickers it is always `false`, which caused #5346
- When `disableAutoMonthSwitching`, allow to switch month when it is caused by full value change (makez #5346 works even with this prop)
- Do not restrict the month change when the target date is disabled, `CalendarPicker` is not doing it.