### PR TITLE
[docs] Link the OpenSSF Best Practices card

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ They feature advanced functionality for data-rich applications and a wide range 
 MUI X is **open core**—base components are MIT-licensed, while more advanced features require a Pro or Premium commercial license.
 See the [Licensing page](https://mui.com/x/introduction/licensing/) for details.
 
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6293/badge)](https://bestpractices.coreinfrastructure.org/projects/6293)
+
 ## Components
 
 - [Data Grid](https://mui.com/x/react-data-grid/)


### PR DESCRIPTION
This is part of improving our score in https://deps.dev/npm/%40mui%2Fx-date-pickers

<img width="384" alt="Screenshot 2022-09-15 at 19 21 45" src="https://user-images.githubusercontent.com/3165635/190470000-50ace3b9-0dff-42c9-8bcb-2b3838cd7980.png">

See https://bestpractices.coreinfrastructure.org/en for why it matters, it also seems to be confirmed with https://mui.zendesk.com/agent/tickets/4926. An example of a project having this: https://github.com/tensorflow/tensorflow.