### PR TITLE
[docs] Fix npm repository link to date picker

### DIFF
--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui-x.git",
+    "url": "https://github.com/mui/mui-x.git",
     "directory": "packages/x-date-pickers-pro"
   },
   "dependencies": {

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -40,7 +40,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui-x.git",
+    "url": "https://github.com/mui/mui-x.git",
     "directory": "packages/x-date-pickers"
   },
   "dependencies": {


### PR DESCRIPTION
<img width="399" alt="Screenshot 2022-09-15 at 19 28 05" src="https://user-images.githubusercontent.com/3165635/190471209-c88729c2-a43e-4671-8c03-5ab252038474.png">

https://www.npmjs.com/package/@mui/x-date-pickers