### PR TITLE
feat: add type safety to field property of GridColDef

### DIFF
--- a/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
@@ -40,7 +40,7 @@ export interface GridColDef<R extends GridValidRowModel = any, V = any, F = V> {
   /**
    * The column identifier. It's used to map with [[GridRowModel]] values.
    */
-  field: string;
+  field: keyof R;
   /**
    * The title of the column rendered in the column header cell.
    */


### PR DESCRIPTION
In current implementation of GridColDef you can secify any `field` value regardless of whether the key exists in `R`

Consider an example 
```javascript
type PosReports = {
  serialNumber: string;
  status: string;
}

type Column<T extends GridValidRowModel> = {
  title: string;
  columns: GridColDef<T>[];
};

type Columns = {
  [Key in Report]: Column<Key extends Report.POS ? PosReports : TagReports>;
};

const columns: Columns = {
    [Report.POS]: {
      title: "POS reports",
      columns: [ // columns: GridColDef<PosReports, any, any>[]
        {
          field: "serialNumber", // "serialNumber" is in "PosReports" - OK
          headerName: "S/N",
          disableColumnMenu: true,
        },
        {
          field: "favoriteFoods", // "favoriteFoods" is NOT in "PosReports" still OK but should be an error
          headerName: "Favorite dishes",
          disableColumnMenu: true,
        },
    ],
};
```

This PR fixes it. But it breaks a lot of existing tests. If this feature is desired I can continue on working on this PR. 