### PR TITLE
[docs] Fix hidden popper in restore state example

### DIFF
--- a/docs/data/data-grid/state/RestoreStateApiRef.js
+++ b/docs/data/data-grid/state/RestoreStateApiRef.js
@@ -307,7 +307,7 @@ function CustomToolbar() {
           role={undefined}
           transition
           placement="bottom-start"
-          sx={{ zIndex: 1 }}
+          sx={{ zIndex: 'modal' }}
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>

--- a/docs/data/data-grid/state/RestoreStateApiRef.js
+++ b/docs/data/data-grid/state/RestoreStateApiRef.js
@@ -307,7 +307,7 @@ function CustomToolbar() {
           role={undefined}
           transition
           placement="bottom-start"
-          style={{ zIndex: 1 }}
+          sx={{ zIndex: 1 }}
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>

--- a/docs/data/data-grid/state/RestoreStateApiRef.js
+++ b/docs/data/data-grid/state/RestoreStateApiRef.js
@@ -307,6 +307,7 @@ function CustomToolbar() {
           role={undefined}
           transition
           placement="bottom-start"
+          style={{ zIndex: 1 }}
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>

--- a/docs/data/data-grid/state/RestoreStateApiRef.tsx
+++ b/docs/data/data-grid/state/RestoreStateApiRef.tsx
@@ -291,6 +291,7 @@ function CustomToolbar() {
           role={undefined}
           transition
           placement="bottom-start"
+          style={{ zIndex: 1 }}
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>

--- a/docs/data/data-grid/state/RestoreStateApiRef.tsx
+++ b/docs/data/data-grid/state/RestoreStateApiRef.tsx
@@ -291,7 +291,7 @@ function CustomToolbar() {
           role={undefined}
           transition
           placement="bottom-start"
-          sx={{ zIndex: 1 }}
+          sx={{ zIndex: 'modal' }}
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>

--- a/docs/data/data-grid/state/RestoreStateApiRef.tsx
+++ b/docs/data/data-grid/state/RestoreStateApiRef.tsx
@@ -291,7 +291,7 @@ function CustomToolbar() {
           role={undefined}
           transition
           placement="bottom-start"
-          style={{ zIndex: 1 }}
+          sx={{ zIndex: 1 }}
         >
           {({ TransitionProps }) => (
             <Fade {...TransitionProps} timeout={350}>


### PR DESCRIPTION
Closes #6190 

By fixing the Popper, I explicitly add `sx={{ zIndex: 'modal' }}` to Popper which will apply this z-index on to `MuiPopperUnstyled-root` class directly as `style` attribute does not work with Popper component.

Expected behavior you can see this screen record below. More information provided on [the issue](#6190)

![expected-data-grid](https://user-images.githubusercontent.com/4945174/190876511-cdb6bb68-4c94-42a9-91f6-6aa8b10a039c.gif)
