### PR TITLE
[docs] Import generateUtilityClass from @mui/utils

### DIFF
--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -21,7 +21,7 @@ import {
   getHeaders,
 } from '@mui/monorepo/docs/packages/markdown';
 import { getLineFeed } from '@mui/monorepo/docs/scripts/helpers';
-import generateUtilityClass from '@mui/base/generateUtilityClass';
+import { unstable_generateUtilityClass as generateUtilityClass } from '@mui/utils';
 import { DocumentedInterfaces, getJsdocDefaultValue, linkify, writePrettifiedFile } from './utils';
 import { Project, Projects } from '../getTypeScriptProjects';
 


### PR DESCRIPTION
The `generateUtilityClass` from @mui/base is going to have a Base-specific implementation (see https://github.com/mui/material-ui/pull/33411). The "bare" version of this function will remain in the @mui/utils package.