### PR TITLE
[YearPicker] Scroll to the current year even with `autoFocus=false`

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -419,7 +419,7 @@ describe('<CalendarPicker />', () => {
       }
       render(
         <CalendarPicker
-          value={adapterToUse.date(new Date(2019, 3, 29))}
+          date={adapterToUse.date(new Date(2019, 3, 29))}
           onChange={() => {}}
           views={['year']}
           openTo="year"

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.test.tsx
@@ -14,6 +14,8 @@ import {
   createPickerRenderer,
 } from '../../../../test/utils/pickers-utils';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<CalendarPicker />', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });
 
@@ -409,6 +411,34 @@ describe('<CalendarPicker />', () => {
 
       expect(onChange.callCount).to.equal(0);
       expect(screen.getByMuiTest('calendar-month-and-year-text')).to.have.text('January 2022');
+    });
+
+    it('should scroll to show the selected year', function test() {
+      if (isJSDOM) {
+        this.skip(); // Needs layout
+      }
+      render(
+        <CalendarPicker
+          value={adapterToUse.date(new Date(2019, 3, 29))}
+          onChange={() => {}}
+          views={['year']}
+          openTo="year"
+        />,
+      );
+
+      // const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
+      //
+      const rootElement = document.querySelector('.MuiCalendarPicker-root')!;
+      const selectedButton = document.querySelector('.Mui-selected')!;
+
+      expect(rootElement).not.to.equal(null);
+      expect(selectedButton).not.to.equal(null);
+
+      const parentBoundingBox = rootElement.getBoundingClientRect();
+      const buttonBoundingBox = selectedButton.getBoundingClientRect();
+
+      expect(parentBoundingBox.top).not.to.greaterThan(buttonBoundingBox.top);
+      expect(parentBoundingBox.bottom).not.to.lessThan(buttonBoundingBox.bottom);
     });
   });
 });

--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -197,9 +197,7 @@ const CalendarPickerViewTransitionContainer = styled(PickersFadeTransitionGroup,
   name: 'MuiCalendarPicker',
   slot: 'ViewTransitionContainer',
   overridesResolver: (props, styles) => styles.viewTransitionContainer,
-})<{ ownerState: CalendarPickerProps<any> }>({
-  overflowY: 'auto',
-});
+})<{ ownerState: CalendarPickerProps<any> }>({});
 
 type CalendarPickerComponent = (<TDate>(
   props: CalendarPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
@@ -446,6 +444,11 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
       }
     },
   );
+
+  React.useEffect(() => {
+    // Set focus to the button when switching from a view to another
+    handleFocusedViewChange(openView)(true);
+  }, [openView, handleFocusedViewChange]);
 
   return (
     <CalendarPickerRoot ref={ref} className={clsx(classes.root, className)} ownerState={ownerState}>

--- a/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
+++ b/packages/x-date-pickers/src/YearPicker/PickersYear.tsx
@@ -126,10 +126,10 @@ export const PickersYear = React.forwardRef<HTMLButtonElement, PickersYearProps>
 
     const classes = useUtilityClasses(ownerState);
 
-    // TODO: Can we just forward this to the button?
+    // We can't forward the `autoFocus` to the button because it is a native button, not a MUI Button
     React.useEffect(() => {
       if (autoFocus) {
-        // `ref.current` being `null` would be a bug in MUIu
+        // `ref.current` being `null` would be a bug in MUI.
         ref.current!.focus();
       }
     }, [autoFocus]);


### PR DESCRIPTION
Fix #6187

Cherry picking from #6089