### PR TITLE
[pickers] Fix usage with Typescript 4.8

### DIFF
--- a/packages/x-date-pickers/src/internals/models/muiPickersAdapter.d.ts
+++ b/packages/x-date-pickers/src/internals/models/muiPickersAdapter.d.ts
@@ -1,7 +1,7 @@
 import { IUtils } from '@date-io/core/IUtils';
 
-// @ts-ignore TDate in our codebase does not have the `ExtendableDateType` constraint.
 // TODO: Maybe we should add the same constraint.
+// @ts-expect-error TDate in our codebase does not have the `ExtendableDateType` constraint.
 export type MuiPickersAdapter<TDate> = IUtils<TDate>;
 
 export type MuiDateSectionName = 'day' | 'month' | 'year' | 'hour' | 'minute' | 'second' | 'am-pm';


### PR DESCRIPTION
Fixes #6134

- [x] Use `@ts-expect-error` to be aware if the error goes away in the future
- [x] Change the file extension to `.d.ts` to avoid having the `@ts-expect-error` comment removed during the build