### PR TITLE
[docs] Fix 301 link

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -460,6 +460,6 @@
   },
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx",
-  "demos": "<ul><li><a href=\"/x/react-data-grid#commercial-version\">DataGridPremium</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPremium</a></li></ul>",
   "packages": ["@mui/x-data-grid-premium"]
 }

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -438,6 +438,6 @@
   },
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx",
-  "demos": "<ul><li><a href=\"/x/react-data-grid#commercial-version\">DataGridPro</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPro</a></li></ul>",
   "packages": ["@mui/x-data-grid-pro"]
 }

--- a/docs/pages/x/api/data-grid/grid-filter-form.json
+++ b/docs/pages/x/api/data-grid/grid-filter-form.json
@@ -33,6 +33,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDataGrid" },
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx",
-  "demos": "<ul><li><a href=\"/x/react-data-grid/#mit-version\">DataGrid</a></li>\n<li><a href=\"/x/react-data-grid#commercial-version\">DataGridPro</a></li>\n<li><a href=\"/x/react-data-grid#commercial-version\">DataGridPremium</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-data-grid/#mit-version\">DataGrid</a></li>\n<li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPro</a></li>\n<li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPremium</a></li></ul>",
   "packages": ["@mui/x-data-grid-premium", "@mui/x-data-grid-pro", "@mui/x-data-grid"]
 }

--- a/docs/pages/x/api/data-grid/grid-filter-panel.json
+++ b/docs/pages/x/api/data-grid/grid-filter-panel.json
@@ -23,6 +23,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDataGrid" },
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx",
-  "demos": "<ul><li><a href=\"/x/react-data-grid/#mit-version\">DataGrid</a></li>\n<li><a href=\"/x/react-data-grid#commercial-version\">DataGridPro</a></li>\n<li><a href=\"/x/react-data-grid#commercial-version\">DataGridPremium</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-data-grid/#mit-version\">DataGrid</a></li>\n<li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPro</a></li>\n<li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPremium</a></li></ul>",
   "packages": ["@mui/x-data-grid-premium", "@mui/x-data-grid-pro", "@mui/x-data-grid"]
 }

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -217,20 +217,20 @@ const buildComponentDocumentation = async (options: {
       demos.push(['/x/react-data-grid/#mit-version', 'DataGrid']);
     }
     if (reactApi.name === 'DataGridPro' || reactApi.name.startsWith('Grid')) {
-      demos.push(['/x/react-data-grid#commercial-version', 'DataGridPro']);
+      demos.push(['/x/react-data-grid/#commercial-version', 'DataGridPro']);
     }
     if (reactApi.name === 'DataGridPremium' || reactApi.name.startsWith('Grid')) {
-      demos.push(['/x/react-data-grid#commercial-version', 'DataGridPremium']);
+      demos.push(['/x/react-data-grid/#commercial-version', 'DataGridPremium']);
     }
   } else {
     if (reactApi.name === 'DataGrid' || reactApi.name.startsWith('Grid')) {
-      demos.push(['/components/data-grid#mit-version', 'DataGrid']);
+      demos.push(['/components/data-grid/#mit-version', 'DataGrid']);
     }
     if (reactApi.name === 'DataGridPro' || reactApi.name.startsWith('Grid')) {
-      demos.push(['/components/data-grid#commercial-version', 'DataGridPro']);
+      demos.push(['/components/data-grid/#commercial-version', 'DataGridPro']);
     }
     if (reactApi.name === 'DataGridPremium' || reactApi.name.startsWith('Grid')) {
-      demos.push(['/components/data-grid#commercial-version', 'DataGridPremium']);
+      demos.push(['/components/data-grid/#commercial-version', 'DataGridPremium']);
     }
   }
   reactApi.demos = demos;
@@ -479,7 +479,7 @@ export default function Page(props) {
 
 Page.getInitialProps = () => {
   const req = require.context(
-    'docsx/translations/api-docs/${project.documentationFolderName}', 
+    'docsx/translations/api-docs/${project.documentationFolderName}',
     false,
     /\\/${kebabCase(reactApi.name)}(-[a-z]{2})?\\.json$/,
   );


### PR DESCRIPTION
I found this in the Algolia crawl results (I was looking a bit at how we can improve the Algolia UX)

<img width="1121" alt="Screenshot 2022-09-21 at 18 15 13" src="https://user-images.githubusercontent.com/3165635/191556989-7191896a-4042-455b-a271-441c5d8c18fc.png">

https://crawler.algolia.com/admin/crawlers/739c29c8-99ea-4945-bd27-17a1df391902/inspector?search=&page=1&status=SKIPPED