### PR TITLE
[core] Tag release as next in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "release:changelog": "node scripts/releaseChangelog",
     "release:version": "lerna version --exact --no-changelog --no-push --no-git-tag-version",
     "release:build": "lerna run --parallel --scope \"@mui/*\" build",
-    "release:publish": "lerna publish from-package --dist-tag latest --contents build",
-    "release:publish:dry-run": "lerna publish from-package --dist-tag latest --contents build --registry=\"http://localhost:4873/\"",
+    "release:publish": "lerna publish from-package --dist-tag next --contents build",
+    "release:publish:dry-run": "lerna publish from-package --dist-tag next --contents build --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag"
   },
   "devDependencies": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` 
 - [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.
 
 ```sh
-git push upstream master:docs-v5 -f
+git push upstream master:docs-next -f
 ```
 
 You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,7 +46,7 @@ The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` 
 - [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.
 
 ```sh
-git push upstream master:docs-next -f
+git push upstream next:docs-next -f
 ```
 
 You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)


### PR DESCRIPTION
Without this change, the alpha packages will be tagged as `latest`.