### PR TITLE
[DataGrid] Fix `undefined` value being showed in filter button tooltip text

### DIFF
--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
@@ -85,7 +85,7 @@ const GridToolbarFilterButton = React.forwardRef<HTMLButtonElement, GridToolbarF
                 <li key={index}>
                   {`${lookup[item.columnField!].headerName || item.columnField}
                   ${getOperatorLabel(item)}
-                  ${item.value}`}
+                  ${item.value ?? ''}`}
                 </li>
               )),
             }))}


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/6246

Before:
<img width="422" alt="Screenshot 2022-09-22 at 16 43 22" src="https://user-images.githubusercontent.com/13808724/191778047-41958272-a803-4447-892d-fdf00078cfba.png">

After:
<img width="257" alt="Screenshot 2022-09-22 at 18 21 42" src="https://user-images.githubusercontent.com/13808724/191800645-d714e3f7-4c7a-44c3-bba9-afaecf216eac.png">



Preview: https://deploy-preview-6259--material-ui-x.netlify.app/x/react-data-grid/filtering/

- [ ] backported to `master` branch