### PR TITLE
[docs] Fixes DataGrid/DataGridPro row styling issue

### DIFF
--- a/docs/data/data-grid/style/StylingRowsGrid.js
+++ b/docs/data/data-grid/style/StylingRowsGrid.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import { DataGrid } from '@mui/x-data-grid';
 import { useDemoData } from '@mui/x-data-grid-generator';
-import { darken, lighten } from '@mui/material/styles';
+import { darken, lighten, styled } from '@mui/material/styles';
 
 const getBgColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.7) : lighten(color, 0.7);
@@ -16,6 +16,69 @@ const getSelectedBgColor = (color, mode) =>
 const getSelectedHoverBgColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.4) : lighten(color, 0.4);
 
+const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
+  '& .super-app-theme--Open': {
+    backgroundColor: getBgColor(theme.palette.info.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.info.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.info.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+  '& .super-app-theme--Filled': {
+    backgroundColor: getBgColor(theme.palette.success.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.success.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.success.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+  '& .super-app-theme--PartiallyFilled': {
+    backgroundColor: getBgColor(theme.palette.warning.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.warning.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+  '& .super-app-theme--Rejected': {
+    backgroundColor: getBgColor(theme.palette.error.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.error.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.error.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+}));
+
 export default function StylingRowsGrid() {
   const { data } = useDemoData({
     dataSet: 'Commodity',
@@ -24,86 +87,8 @@ export default function StylingRowsGrid() {
 
   return (
     <Box sx={{ height: 400, width: '100%' }}>
-      <DataGrid
+      <StyledDataGrid
         {...data}
-        sx={{
-          '& .super-app-theme--Open': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.info.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.info.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.info.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-          '& .super-app-theme--Filled': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.success.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.success.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.success.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-          '& .super-app-theme--PartiallyFilled': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.warning.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.warning.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-          '& .super-app-theme--Rejected': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.error.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.error.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.error.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-        }}
         getRowClassName={(params) => `super-app-theme--${params.row.status}`}
       />
     </Box>

--- a/docs/data/data-grid/style/StylingRowsGrid.js
+++ b/docs/data/data-grid/style/StylingRowsGrid.js
@@ -4,11 +4,17 @@ import { DataGrid } from '@mui/x-data-grid';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import { darken, lighten } from '@mui/material/styles';
 
-const getBackgroundColor = (color, mode) =>
+const getBgColor = (color, mode) =>
+  mode === 'dark' ? darken(color, 0.7) : lighten(color, 0.7);
+
+const getHoverBgColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.6) : lighten(color, 0.6);
 
-const getHoverBackgroundColor = (color, mode) =>
+const getSelectedBgColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.5) : lighten(color, 0.5);
+
+const getSelectedHoverBgColor = (color, mode) =>
+  mode === 'dark' ? darken(color, 0.4) : lighten(color, 0.4);
 
 export default function StylingRowsGrid() {
   const { data } = useDemoData({
@@ -17,52 +23,87 @@ export default function StylingRowsGrid() {
   });
 
   return (
-    <Box
-      sx={{
-        height: 400,
-        width: '100%',
-        '&& .super-app-theme--Open': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.info.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(theme.palette.info.main, theme.palette.mode),
-          },
-        },
-        '&& .super-app-theme--Filled': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.success.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(
-                theme.palette.success.main,
-                theme.palette.mode,
-              ),
-          },
-        },
-        '&& .super-app-theme--PartiallyFilled': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.warning.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(
-                theme.palette.warning.main,
-                theme.palette.mode,
-              ),
-          },
-        },
-        '&& .super-app-theme--Rejected': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.error.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(theme.palette.error.main, theme.palette.mode),
-          },
-        },
-      }}
-    >
+    <Box sx={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
+        sx={{
+          '& .super-app-theme--Open': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.info.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.info.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.info.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+          '& .super-app-theme--Filled': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.success.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.success.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.success.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+          '& .super-app-theme--PartiallyFilled': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.warning.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.warning.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+          '& .super-app-theme--Rejected': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.error.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.error.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.error.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+        }}
         getRowClassName={(params) => `super-app-theme--${params.row.status}`}
       />
     </Box>

--- a/docs/data/data-grid/style/StylingRowsGrid.js
+++ b/docs/data/data-grid/style/StylingRowsGrid.js
@@ -4,31 +4,34 @@ import { DataGrid } from '@mui/x-data-grid';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import { darken, lighten, styled } from '@mui/material/styles';
 
-const getBgColor = (color, mode) =>
+const getBackgroundColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.7) : lighten(color, 0.7);
 
-const getHoverBgColor = (color, mode) =>
+const getHoverBackgroundColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.6) : lighten(color, 0.6);
 
-const getSelectedBgColor = (color, mode) =>
+const getSelectedBackgroundColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.5) : lighten(color, 0.5);
 
-const getSelectedHoverBgColor = (color, mode) =>
+const getSelectedHoverBackgroundColor = (color, mode) =>
   mode === 'dark' ? darken(color, 0.4) : lighten(color, 0.4);
 
 const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   '& .super-app-theme--Open': {
-    backgroundColor: getBgColor(theme.palette.info.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(theme.palette.info.main, theme.palette.mode),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.info.main, theme.palette.mode),
+      backgroundColor: getHoverBackgroundColor(
+        theme.palette.info.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.info.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.info.main,
           theme.palette.mode,
         ),
@@ -36,20 +39,23 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     },
   },
   '& .super-app-theme--Filled': {
-    backgroundColor: getBgColor(theme.palette.success.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(
+      theme.palette.success.main,
+      theme.palette.mode,
+    ),
     '&:hover': {
-      backgroundColor: getHoverBgColor(
+      backgroundColor: getHoverBackgroundColor(
         theme.palette.success.main,
         theme.palette.mode,
       ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.success.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.success.main,
           theme.palette.mode,
         ),
@@ -57,20 +63,23 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     },
   },
   '& .super-app-theme--PartiallyFilled': {
-    backgroundColor: getBgColor(theme.palette.warning.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(
+      theme.palette.warning.main,
+      theme.palette.mode,
+    ),
     '&:hover': {
-      backgroundColor: getHoverBgColor(
+      backgroundColor: getHoverBackgroundColor(
         theme.palette.warning.main,
         theme.palette.mode,
       ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.warning.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.warning.main,
           theme.palette.mode,
         ),
@@ -78,17 +87,23 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     },
   },
   '& .super-app-theme--Rejected': {
-    backgroundColor: getBgColor(theme.palette.error.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(
+      theme.palette.error.main,
+      theme.palette.mode,
+    ),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.error.main, theme.palette.mode),
+      backgroundColor: getHoverBackgroundColor(
+        theme.palette.error.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.error.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.error.main,
           theme.palette.mode,
         ),

--- a/docs/data/data-grid/style/StylingRowsGrid.js
+++ b/docs/data/data-grid/style/StylingRowsGrid.js
@@ -21,7 +21,7 @@ export default function StylingRowsGrid() {
       sx={{
         height: 400,
         width: '100%',
-        '& .super-app-theme--Open': {
+        '&& .super-app-theme--Open': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.info.main, theme.palette.mode),
           '&:hover': {
@@ -29,7 +29,7 @@ export default function StylingRowsGrid() {
               getHoverBackgroundColor(theme.palette.info.main, theme.palette.mode),
           },
         },
-        '& .super-app-theme--Filled': {
+        '&& .super-app-theme--Filled': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.success.main, theme.palette.mode),
           '&:hover': {
@@ -40,7 +40,7 @@ export default function StylingRowsGrid() {
               ),
           },
         },
-        '& .super-app-theme--PartiallyFilled': {
+        '&& .super-app-theme--PartiallyFilled': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.warning.main, theme.palette.mode),
           '&:hover': {
@@ -51,7 +51,7 @@ export default function StylingRowsGrid() {
               ),
           },
         },
-        '& .super-app-theme--Rejected': {
+        '&& .super-app-theme--Rejected': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.error.main, theme.palette.mode),
           '&:hover': {

--- a/docs/data/data-grid/style/StylingRowsGrid.js
+++ b/docs/data/data-grid/style/StylingRowsGrid.js
@@ -23,42 +23,57 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
       backgroundColor: getHoverBgColor(theme.palette.info.main, theme.palette.mode),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.info.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.info.main,
-            theme.palette.mode,
-          ),
+          theme.palette.info.main,
+          theme.palette.mode,
+        ),
       },
     },
   },
   '& .super-app-theme--Filled': {
     backgroundColor: getBgColor(theme.palette.success.main, theme.palette.mode),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.success.main, theme.palette.mode),
+      backgroundColor: getHoverBgColor(
+        theme.palette.success.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.success.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.success.main,
-            theme.palette.mode,
-          ),
+          theme.palette.success.main,
+          theme.palette.mode,
+        ),
       },
     },
   },
   '& .super-app-theme--PartiallyFilled': {
     backgroundColor: getBgColor(theme.palette.warning.main, theme.palette.mode),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
+      backgroundColor: getHoverBgColor(
+        theme.palette.warning.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.warning.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.warning.main,
-            theme.palette.mode,
-          ),
+          theme.palette.warning.main,
+          theme.palette.mode,
+        ),
       },
     },
   },
@@ -68,12 +83,15 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
       backgroundColor: getHoverBgColor(theme.palette.error.main, theme.palette.mode),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.error.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.error.main,
-            theme.palette.mode,
-          ),
+          theme.palette.error.main,
+          theme.palette.mode,
+        ),
       },
     },
   },

--- a/docs/data/data-grid/style/StylingRowsGrid.tsx
+++ b/docs/data/data-grid/style/StylingRowsGrid.tsx
@@ -21,7 +21,7 @@ export default function StylingRowsGrid() {
       sx={{
         height: 400,
         width: '100%',
-        '& .super-app-theme--Open': {
+        '&& .super-app-theme--Open': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.info.main, theme.palette.mode),
           '&:hover': {
@@ -29,7 +29,7 @@ export default function StylingRowsGrid() {
               getHoverBackgroundColor(theme.palette.info.main, theme.palette.mode),
           },
         },
-        '& .super-app-theme--Filled': {
+        '&& .super-app-theme--Filled': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.success.main, theme.palette.mode),
           '&:hover': {
@@ -40,7 +40,7 @@ export default function StylingRowsGrid() {
               ),
           },
         },
-        '& .super-app-theme--PartiallyFilled': {
+        '&& .super-app-theme--PartiallyFilled': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.warning.main, theme.palette.mode),
           '&:hover': {
@@ -51,7 +51,7 @@ export default function StylingRowsGrid() {
               ),
           },
         },
-        '& .super-app-theme--Rejected': {
+        '&& .super-app-theme--Rejected': {
           bgcolor: (theme) =>
             getBackgroundColor(theme.palette.error.main, theme.palette.mode),
           '&:hover': {

--- a/docs/data/data-grid/style/StylingRowsGrid.tsx
+++ b/docs/data/data-grid/style/StylingRowsGrid.tsx
@@ -23,42 +23,57 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
       backgroundColor: getHoverBgColor(theme.palette.info.main, theme.palette.mode),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.info.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.info.main,
-            theme.palette.mode,
-          ),
+          theme.palette.info.main,
+          theme.palette.mode,
+        ),
       },
     },
   },
   '& .super-app-theme--Filled': {
     backgroundColor: getBgColor(theme.palette.success.main, theme.palette.mode),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.success.main, theme.palette.mode),
+      backgroundColor: getHoverBgColor(
+        theme.palette.success.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.success.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.success.main,
-            theme.palette.mode,
-          ),
+          theme.palette.success.main,
+          theme.palette.mode,
+        ),
       },
     },
   },
   '& .super-app-theme--PartiallyFilled': {
     backgroundColor: getBgColor(theme.palette.warning.main, theme.palette.mode),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
+      backgroundColor: getHoverBgColor(
+        theme.palette.warning.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.warning.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.warning.main,
-            theme.palette.mode,
-          ),
+          theme.palette.warning.main,
+          theme.palette.mode,
+        ),
       },
     },
   },
@@ -68,12 +83,15 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
       backgroundColor: getHoverBgColor(theme.palette.error.main, theme.palette.mode),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
+      backgroundColor: getSelectedBgColor(
+        theme.palette.error.main,
+        theme.palette.mode,
+      ),
       '&:hover': {
         backgroundColor: getSelectedHoverBgColor(
-            theme.palette.error.main,
-            theme.palette.mode,
-          ),
+          theme.palette.error.main,
+          theme.palette.mode,
+        ),
       },
     },
   },

--- a/docs/data/data-grid/style/StylingRowsGrid.tsx
+++ b/docs/data/data-grid/style/StylingRowsGrid.tsx
@@ -4,31 +4,34 @@ import { DataGrid } from '@mui/x-data-grid';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import { darken, lighten, styled } from '@mui/material/styles';
 
-const getBgColor = (color: string, mode: string) =>
+const getBackgroundColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.7) : lighten(color, 0.7);
 
-const getHoverBgColor = (color: string, mode: string) =>
+const getHoverBackgroundColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.6) : lighten(color, 0.6);
 
-const getSelectedBgColor = (color: string, mode: string) =>
+const getSelectedBackgroundColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.5) : lighten(color, 0.5);
 
-const getSelectedHoverBgColor = (color: string, mode: string) =>
+const getSelectedHoverBackgroundColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.4) : lighten(color, 0.4);
 
 const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   '& .super-app-theme--Open': {
-    backgroundColor: getBgColor(theme.palette.info.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(theme.palette.info.main, theme.palette.mode),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.info.main, theme.palette.mode),
+      backgroundColor: getHoverBackgroundColor(
+        theme.palette.info.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.info.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.info.main,
           theme.palette.mode,
         ),
@@ -36,20 +39,23 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     },
   },
   '& .super-app-theme--Filled': {
-    backgroundColor: getBgColor(theme.palette.success.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(
+      theme.palette.success.main,
+      theme.palette.mode,
+    ),
     '&:hover': {
-      backgroundColor: getHoverBgColor(
+      backgroundColor: getHoverBackgroundColor(
         theme.palette.success.main,
         theme.palette.mode,
       ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.success.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.success.main,
           theme.palette.mode,
         ),
@@ -57,20 +63,23 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     },
   },
   '& .super-app-theme--PartiallyFilled': {
-    backgroundColor: getBgColor(theme.palette.warning.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(
+      theme.palette.warning.main,
+      theme.palette.mode,
+    ),
     '&:hover': {
-      backgroundColor: getHoverBgColor(
+      backgroundColor: getHoverBackgroundColor(
         theme.palette.warning.main,
         theme.palette.mode,
       ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.warning.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.warning.main,
           theme.palette.mode,
         ),
@@ -78,17 +87,23 @@ const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
     },
   },
   '& .super-app-theme--Rejected': {
-    backgroundColor: getBgColor(theme.palette.error.main, theme.palette.mode),
+    backgroundColor: getBackgroundColor(
+      theme.palette.error.main,
+      theme.palette.mode,
+    ),
     '&:hover': {
-      backgroundColor: getHoverBgColor(theme.palette.error.main, theme.palette.mode),
+      backgroundColor: getHoverBackgroundColor(
+        theme.palette.error.main,
+        theme.palette.mode,
+      ),
     },
     '&.Mui-selected': {
-      backgroundColor: getSelectedBgColor(
+      backgroundColor: getSelectedBackgroundColor(
         theme.palette.error.main,
         theme.palette.mode,
       ),
       '&:hover': {
-        backgroundColor: getSelectedHoverBgColor(
+        backgroundColor: getSelectedHoverBackgroundColor(
           theme.palette.error.main,
           theme.palette.mode,
         ),

--- a/docs/data/data-grid/style/StylingRowsGrid.tsx
+++ b/docs/data/data-grid/style/StylingRowsGrid.tsx
@@ -4,11 +4,17 @@ import { DataGrid } from '@mui/x-data-grid';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import { darken, lighten } from '@mui/material/styles';
 
-const getBackgroundColor = (color: string, mode: string) =>
+const getBgColor = (color: string, mode: string) =>
+  mode === 'dark' ? darken(color, 0.7) : lighten(color, 0.7);
+
+const getHoverBgColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.6) : lighten(color, 0.6);
 
-const getHoverBackgroundColor = (color: string, mode: string) =>
+const getSelectedBgColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.5) : lighten(color, 0.5);
+
+const getSelectedHoverBgColor = (color: string, mode: string) =>
+  mode === 'dark' ? darken(color, 0.4) : lighten(color, 0.4);
 
 export default function StylingRowsGrid() {
   const { data } = useDemoData({
@@ -17,52 +23,87 @@ export default function StylingRowsGrid() {
   });
 
   return (
-    <Box
-      sx={{
-        height: 400,
-        width: '100%',
-        '&& .super-app-theme--Open': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.info.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(theme.palette.info.main, theme.palette.mode),
-          },
-        },
-        '&& .super-app-theme--Filled': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.success.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(
-                theme.palette.success.main,
-                theme.palette.mode,
-              ),
-          },
-        },
-        '&& .super-app-theme--PartiallyFilled': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.warning.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(
-                theme.palette.warning.main,
-                theme.palette.mode,
-              ),
-          },
-        },
-        '&& .super-app-theme--Rejected': {
-          bgcolor: (theme) =>
-            getBackgroundColor(theme.palette.error.main, theme.palette.mode),
-          '&:hover': {
-            bgcolor: (theme) =>
-              getHoverBackgroundColor(theme.palette.error.main, theme.palette.mode),
-          },
-        },
-      }}
-    >
+    <Box sx={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
+        sx={{
+          '& .super-app-theme--Open': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.info.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.info.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.info.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+          '& .super-app-theme--Filled': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.success.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.success.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.success.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+          '& .super-app-theme--PartiallyFilled': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.warning.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.warning.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+          '& .super-app-theme--Rejected': {
+            bgcolor: (theme) =>
+              getBgColor(theme.palette.error.main, theme.palette.mode),
+            '&:hover': {
+              bgcolor: (theme) =>
+                getHoverBgColor(theme.palette.error.main, theme.palette.mode),
+            },
+            '&.Mui-selected': {
+              bgcolor: (theme) =>
+                getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
+              '&:hover': {
+                bgcolor: (theme) =>
+                  getSelectedHoverBgColor(
+                    theme.palette.error.main,
+                    theme.palette.mode,
+                  ),
+              },
+            },
+          },
+        }}
         getRowClassName={(params) => `super-app-theme--${params.row.status}`}
       />
     </Box>

--- a/docs/data/data-grid/style/StylingRowsGrid.tsx
+++ b/docs/data/data-grid/style/StylingRowsGrid.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import { DataGrid } from '@mui/x-data-grid';
 import { useDemoData } from '@mui/x-data-grid-generator';
-import { darken, lighten } from '@mui/material/styles';
+import { darken, lighten, styled } from '@mui/material/styles';
 
 const getBgColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.7) : lighten(color, 0.7);
@@ -16,6 +16,69 @@ const getSelectedBgColor = (color: string, mode: string) =>
 const getSelectedHoverBgColor = (color: string, mode: string) =>
   mode === 'dark' ? darken(color, 0.4) : lighten(color, 0.4);
 
+const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
+  '& .super-app-theme--Open': {
+    backgroundColor: getBgColor(theme.palette.info.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.info.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.info.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+  '& .super-app-theme--Filled': {
+    backgroundColor: getBgColor(theme.palette.success.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.success.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.success.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+  '& .super-app-theme--PartiallyFilled': {
+    backgroundColor: getBgColor(theme.palette.warning.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.warning.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+  '& .super-app-theme--Rejected': {
+    backgroundColor: getBgColor(theme.palette.error.main, theme.palette.mode),
+    '&:hover': {
+      backgroundColor: getHoverBgColor(theme.palette.error.main, theme.palette.mode),
+    },
+    '&.Mui-selected': {
+      backgroundColor: getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
+      '&:hover': {
+        backgroundColor: getSelectedHoverBgColor(
+            theme.palette.error.main,
+            theme.palette.mode,
+          ),
+      },
+    },
+  },
+}));
+
 export default function StylingRowsGrid() {
   const { data } = useDemoData({
     dataSet: 'Commodity',
@@ -24,86 +87,8 @@ export default function StylingRowsGrid() {
 
   return (
     <Box sx={{ height: 400, width: '100%' }}>
-      <DataGrid
+      <StyledDataGrid
         {...data}
-        sx={{
-          '& .super-app-theme--Open': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.info.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.info.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.info.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.info.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-          '& .super-app-theme--Filled': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.success.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.success.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.success.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.success.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-          '& .super-app-theme--PartiallyFilled': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.warning.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.warning.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.warning.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.warning.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-          '& .super-app-theme--Rejected': {
-            bgcolor: (theme) =>
-              getBgColor(theme.palette.error.main, theme.palette.mode),
-            '&:hover': {
-              bgcolor: (theme) =>
-                getHoverBgColor(theme.palette.error.main, theme.palette.mode),
-            },
-            '&.Mui-selected': {
-              bgcolor: (theme) =>
-                getSelectedBgColor(theme.palette.error.main, theme.palette.mode),
-              '&:hover': {
-                bgcolor: (theme) =>
-                  getSelectedHoverBgColor(
-                    theme.palette.error.main,
-                    theme.palette.mode,
-                  ),
-              },
-            },
-          },
-        }}
         getRowClassName={(params) => `super-app-theme--${params.row.status}`}
       />
     </Box>

--- a/docs/data/data-grid/style/StylingRowsGrid.tsx.preview
+++ b/docs/data/data-grid/style/StylingRowsGrid.tsx.preview
@@ -1,4 +1,4 @@
-<DataGrid
+<StyledDataGrid
   {...data}
   getRowClassName={(params) => `super-app-theme--${params.row.status}`}
 />

--- a/docs/data/data-grid/style/style.md
+++ b/docs/data/data-grid/style/style.md
@@ -45,7 +45,7 @@ const columns: GridColumns = [
 
 ## Styling rows
 
-The `getRowClassName` prop can be used to apply a custom CSS class on each row. It's called with a `GridRowParams` object and must return a string.
+The `getRowClassName` prop can be used to apply a custom CSS class on each row. It's called with a `GridRowParams` object and must return a string. Sometimes it might be needed to override the existing rules using higher specificity CSS selectors.
 
 ```tsx
 interface GridRowParams<R extends GridRowModel = GridRowModel> {


### PR DESCRIPTION
Preview: https://deploy-preview-6264--material-ui-x.netlify.app/x/react-data-grid/style/#styling-rows

Issue: #6065 

Tried to see if we can do some fix by changing the order of how the classes are being used inside DataGrid, it didn't work probably due to how emotion bundles css assets. Solution proposed by @m4theushw seemed most appropriate.

**Update:** The catch to fix specificity was to use sx on Grid itself rather than Box wrapping the Grid.