### PR TITLE
[DataGrid] Pass generics to the components in the theme augmentation

### DIFF
--- a/packages/grid/x-data-grid-pro/src/themeAugmentation/props.ts
+++ b/packages/grid/x-data-grid-pro/src/themeAugmentation/props.ts
@@ -1,4 +1,4 @@
-import { ComponentsOverrides, ComponentsProps } from '@mui/material/styles';
+import { ComponentsOverrides, ComponentsProps, Theme } from '@mui/material/styles';
 import { DataGridProProps } from '../models/dataGridProProps';
 
 export interface DataGridProComponentsPropsList {
@@ -8,7 +8,7 @@ export interface DataGridProComponentsPropsList {
 export interface DataGridProComponents {
   MuiDataGrid?: {
     defaultProps?: ComponentsProps['MuiDataGrid'];
-    styleOverrides?: ComponentsOverrides['MuiDataGrid'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiDataGrid'];
   };
 }
 

--- a/packages/grid/x-data-grid/src/themeAugmentation/props.ts
+++ b/packages/grid/x-data-grid/src/themeAugmentation/props.ts
@@ -1,4 +1,4 @@
-import { ComponentsOverrides, ComponentsProps } from '@mui/material/styles';
+import { ComponentsOverrides, ComponentsProps, Theme } from '@mui/material/styles';
 import { DataGridProps } from '../models/props/DataGridProps';
 
 export interface DataGridComponentsPropsList {
@@ -8,7 +8,7 @@ export interface DataGridComponentsPropsList {
 export interface DataGridComponents {
   MuiDataGrid?: {
     defaultProps?: ComponentsProps['MuiDataGrid'];
-    styleOverrides?: ComponentsOverrides['MuiDataGrid'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiDataGrid'];
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/6268

Same as https://github.com/mui/mui-x/pull/5199, but for the grid

Before: https://codesandbox.io/s/muidatagrid-theme-override-forked-1czck5?file=/src/theme.ts
After: https://codesandbox.io/s/muidatagrid-theme-override-fgfz36?file=/src/theme.ts

- [ ] backported to `master` branch