### PR TITLE
[DataGridPremium] Add missing `themeAugmentation` module

### DIFF
--- a/packages/grid/x-data-grid-premium/src/themeAugmentation/index.js
+++ b/packages/grid/x-data-grid-premium/src/themeAugmentation/index.js
@@ -1,0 +1,1 @@
+// Prefer to use `import type {} from '@mui/x-data-grid-premium/themeAugmentation';` instead to avoid importing an empty file.

--- a/packages/grid/x-data-grid-premium/src/themeAugmentation/index.ts
+++ b/packages/grid/x-data-grid-premium/src/themeAugmentation/index.ts
@@ -1,0 +1,4 @@
+export * from './overrides';
+export * from './props';
+// TODO v5
+// export * from './components';

--- a/packages/grid/x-data-grid-premium/src/themeAugmentation/overrides.ts
+++ b/packages/grid/x-data-grid-premium/src/themeAugmentation/overrides.ts
@@ -1,0 +1,9 @@
+import { GridClassKey } from '@mui/x-data-grid';
+
+export interface DataGridPremiumComponentNameToClassKey {
+  MuiDataGrid: GridClassKey;
+}
+
+declare module '@mui/material/styles/overrides' {
+  interface ComponentNameToClassKey extends DataGridPremiumComponentNameToClassKey {}
+}

--- a/packages/grid/x-data-grid-premium/src/themeAugmentation/props.ts
+++ b/packages/grid/x-data-grid-premium/src/themeAugmentation/props.ts
@@ -1,0 +1,21 @@
+import { ComponentsOverrides, ComponentsProps, Theme } from '@mui/material/styles';
+import { DataGridPremiumProps } from '../models/dataGridPremiumProps';
+
+export interface DataGridPremiumComponentsPropsList {
+  MuiDataGrid: DataGridPremiumProps;
+}
+
+export interface DataGridPremiumComponents {
+  MuiDataGrid?: {
+    defaultProps?: ComponentsProps['MuiDataGrid'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiDataGrid'];
+  };
+}
+
+declare module '@mui/material/styles' {
+  interface ComponentsPropsList extends DataGridPremiumComponentsPropsList {}
+}
+
+declare module '@mui/material/styles/components' {
+  interface Components extends DataGridPremiumComponents {}
+}


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/pull/6269#issuecomment-1256512798

Before: https://codesandbox.io/s/muidatagrid-theme-override-forked-23ofno?file=/src/theme.ts
After: https://codesandbox.io/s/muidatagrid-theme-override-forked-exig8p?file=/src/theme.ts

- [ ] backported to `master` branch