### PR TITLE
[data grid] Improve print support

### DIFF
--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -203,12 +203,6 @@ By default, the print export display all the DataGrid. It is possible to remove 
 
 For more option to customize the print export, please visit the [`printOptions` api page](/x/api/data-grid/grid-print-export-options/).
 
-:::warning
-Due to the fact that the Print export relies on the usage of an `iframe`, there is a limitation around the usage of `X-Frame-Options`.
-
-In order for the Print export to work as expected set `X-Frame-Options: SAMEORIGIN` or unset the `X-Frame-Options` header.
-:::
-
 ## Custom export format
 
 You can add custom export formats by creating your own export menu.

--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -22,6 +22,14 @@ import {
   GridPrintExportMenuItem,
 } from '../../../components/toolbar/GridToolbarExport';
 
+function raf() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      resolve();
+    });
+  });
+}
+
 type PrintWindowOnLoad = (
   printWindow: HTMLIFrameElement,
   options?: Pick<
@@ -54,6 +62,7 @@ export const useGridPrintExport = (
   const updateGridColumnsForPrint = React.useCallback(
     (fields?: string[], allColumns?: boolean) =>
       new Promise<void>((resolve) => {
+        // TODO remove unused Promise
         if (!fields && !allColumns) {
           resolve();
           return;
@@ -72,18 +81,15 @@ export const useGridPrintExport = (
         });
 
         apiRef.current.setColumnVisibilityModel(newColumnVisibilityModel);
-
         resolve();
       }),
     [apiRef],
   );
 
+  // TODO move outside of this scope and remove React.useCallback
   const buildPrintWindow = React.useCallback((title?: string): HTMLIFrameElement => {
     const iframeEl = document.createElement('iframe');
 
-    iframeEl.id = 'grid-print-window';
-    // Without this 'onload' event won't fire in some browsers
-    iframeEl.src = window.location.href;
     iframeEl.style.position = 'absolute';
     iframeEl.style.width = '0px';
     iframeEl.style.height = '0px';
@@ -101,11 +107,7 @@ export const useGridPrintExport = (
         ...options,
       };
 
-      // Some agents, such as IE11 and Enzyme (as of 2 Jun 2020) continuously call the
-      // `onload` callback. This ensures that it is only called once.
-      printWindow.onload = null;
-
-      const printDoc = printWindow.contentDocument || printWindow.contentWindow?.document;
+      const printDoc = printWindow.contentDocument;
 
       if (!printDoc) {
         return;
@@ -158,9 +160,11 @@ export const useGridPrintExport = (
         gridFooterElementHeight
       }px`;
 
-      // Remove all loaded elements from the current host
-      printDoc.body.innerHTML = '';
-      printDoc.body.appendChild(gridClone);
+      // printDoc.body.appendChild(gridClone); should be enough but a clone isolation bug in Safari
+      // prevents us to do it
+      const container = document.createElement('div');
+      container.appendChild(gridClone);
+      printDoc.body.innerHTML = container.innerHTML;
 
       const defaultPageStyle =
         typeof normalizeOptions.pageStyle === 'function'
@@ -262,15 +266,21 @@ export const useGridPrintExport = (
 
       await updateGridColumnsForPrint(options?.fields, options?.allColumns);
       apiRef.current.unstable_disableVirtualization();
+      await raf(); // wait for the state changes to take action
       const printWindow = buildPrintWindow(options?.fileName);
-      doc.current!.body.appendChild(printWindow);
       if (process.env.NODE_ENV === 'test') {
+        doc.current!.body.appendChild(printWindow);
         // In test env, run the all pipeline without waiting for loading
         handlePrintWindowLoad(printWindow, options);
         handlePrintWindowAfterPrint(printWindow);
       } else {
-        printWindow.onload = () => handlePrintWindowLoad(printWindow, options);
-        printWindow.contentWindow!.onafterprint = () => handlePrintWindowAfterPrint(printWindow);
+        printWindow.onload = () => {
+          handlePrintWindowLoad(printWindow, options);
+          printWindow.contentWindow!.onafterprint = () => {
+            handlePrintWindowAfterPrint(printWindow);
+          };
+        };
+        doc.current!.body.appendChild(printWindow);
       }
     },
     [

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -6,7 +6,9 @@ import GlobalStyles from '@mui/material/GlobalStyles';
 import { useLocation } from 'react-router-dom';
 import { useFakeTimers } from 'sinon';
 
-const StyledBox = styled(Box)(({ theme, isDataGridTest }) => ({
+const StyledBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isDataGridTest',
+})(({ theme, isDataGridTest }) => ({
   backgroundColor: theme.palette.background.default,
   display: 'flex',
   padding: theme.spacing(1),

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -181,10 +181,14 @@ async function main() {
 
       // Click the print export option from the export menu in the toolbar.
       await page.$eval(`li[role="menuitem"]:last-child`, (printButton) => {
-        printButton.click();
+        // Trigger the action async because window.print() is blocking the main thread
+        // like window.alert() is.
+        setTimeout(() => {
+          printButton.click();
+        });
       });
 
-      await sleep(6000);
+      await sleep(4000);
 
       return new Promise((resolve, reject) => {
         // See https://ffmpeg.org/ffmpeg-devices.html#x11grab
@@ -195,7 +199,7 @@ async function main() {
           if (code === 0) {
             resolve();
           } else {
-            reject();
+            reject(code);
           }
         });
       });

--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -23,6 +23,7 @@ const blacklist = ['sessionStorage', 'localStorage'];
 function createDOM() {
   const dom = new JSDOM('', {
     pretendToBeVisual: true,
+    url: 'http://localhost',
   });
   global.window = dom.window;
   // Not yet supported: https://github.com/jsdom/jsdom/issues/2152


### PR DESCRIPTION
This seems to be an opportunity to:

1. Fix #6272
2. Show the print window faster, no need to wait for the page to load
3. Remove the HTTP header iframe limitation
4. Remove the dependency on https://github.com/mui/mui-x/pull/4149#issuecomment-1064109395

Before: https://mui.com/x/react-data-grid/export/#default-toolbar
After: https://deploy-preview-6273--material-ui-x.netlify.app/x/react-data-grid/export/#default-toolbar

Tested in Firefox, Safari, Chrome, latest versions

---

I have left a couple of TODO for a clean-up follow-up. I was also surprised with how we document the print export. If you:
1. open https://mui.com/.
2. search for print export: 
<img width="745" alt="Screenshot 2022-09-24 at 00 55 30" src="https://user-images.githubusercontent.com/3165635/192066959-e1948618-5410-408c-8b3a-01510456513d.png">

3. click on the first link, you will land on https://mui.com/x/react-data-grid/export/#print-export, without a demo. I was disoriented by this, I struggled a bit to find a demo where I could see the feature in action. Would it make sense to add one? 