### PR TITLE
[docs] Update the codesandbox to use next

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -19,7 +19,7 @@ module.exports = withDocsInfra({
     DATA_GRID_VERSION: dataGridPkg.version,
     DATE_PICKERS_VERSION: datePickersPkg.version,
     // #default-branch-switch
-    SOURCE_CODE_ROOT_URL: 'https://github.com/mui/mui-x/blob/master',
+    SOURCE_CODE_ROOT_URL: 'https://github.com/mui/mui-x/blob/next',
     SOURCE_CODE_REPO: 'https://github.com/mui/mui-x',
   },
   webpack: (config, options) => {

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -30,7 +30,8 @@ LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);
 
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
-    return 'latest';
+    // #default-branch-switch
+    return 'next';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui/mui-x/commit/${shortSha}/@mui/${packageName}`;

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -30,7 +30,7 @@ LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);
 
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
-    // #default-branch-switch
+    // #default-branch-switch with latest for the master branch
     return 'next';
   }
   const shortSha = commitRef.slice(0, 8);

--- a/scripts/releaseChangelog.js
+++ b/scripts/releaseChangelog.js
@@ -238,7 +238,7 @@ yargs
         })
         .option('release', {
           // #default-branch-switch
-          default: 'master',
+          default: 'next',
           describe: 'Ref which we want to release',
           type: 'string',
         });


### PR DESCRIPTION
We missed the `#default-branch-switch` flags.

Before: https://next--material-ui-x.netlify.com/x/react-data-grid/
After: https://deploy-preview-6275--material-ui-x.netlify.app/x/react-data-grid/