### PR TITLE
[CalendarPicker] Prevent getting focus when `autoFocus=false`

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -437,8 +437,13 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
     },
   );
 
+  const prevOpenViewRef = React.useRef(openView);
   React.useEffect(() => {
     // Set focus to the button when switching from a view to another
+    if (prevOpenViewRef.current === openView) {
+      return;
+    }
+    prevOpenViewRef.current = openView;
     handleFocusedViewChange(openView)(true);
   }, [openView, handleFocusedViewChange]);
 


### PR DESCRIPTION
In [DatePicker doc page](https://mui.com/x/react-date-pickers/date-picker/) the focus is caught by the year picker.

This PR should fix this bug
