### PR TITLE
[core] Fix typo in the state updater of useField

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -106,7 +106,7 @@ export const useField = <
   }, [selectedSections, state.sections]);
 
   const updateSections = (sections: TSection[]) => {
-    const { value: newValueParsed, shouldPublish } = fieldValueManager.getValueFromSections(
+    const { value: newValue, shouldPublish } = fieldValueManager.getValueFromSections(
       utils,
       state.sections,
       sections,
@@ -116,11 +116,11 @@ export const useField = <
     setState((prevState) => ({
       ...prevState,
       sections,
-      valueParsed: newValueParsed,
+      value: newValue,
     }));
 
     if (onChange && shouldPublish) {
-      onChange(newValueParsed);
+      onChange(newValue);
     }
   };
 
@@ -403,7 +403,7 @@ export const useField = <
       const sections = fieldValueManager.getSectionsFromValue(utils, state.sections, value, format);
       setState((prevState) => ({
         ...prevState,
-        valueParsed: value,
+        value,
         sections,
       }));
     }


### PR DESCRIPTION
I was still putting `valueParsed` in state instead of `value`, which totally broke the editing.
It is also fixed by #6141 (and tested to avoid future regressions), but I'm doing a standalone quick fix to be able to move forward on other topics.

It has never been released so I'm marking it as `core`.

Will auto-merge