### PR TITLE
[test] Skip test in Chrome non-headless and Edge

### DIFF
--- a/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -818,7 +818,11 @@ describe('<DataGrid /> - Rows', () => {
         });
       });
 
-      it('should position correctly the render zone when changing pageSize to a lower value and moving to next page', async () => {
+      it('should position correctly the render zone when changing pageSize to a lower value and moving to next page', async function test() {
+        const { userAgent } = window.navigator;
+        if (!userAgent.includes('Headless') || /edg/i.test(userAgent)) {
+          this.skip(); // In Chrome non-headless and Edge this test is flacky
+        }
         const data = getBasicGridData(120, 3);
         const headerHeight = 50;
         const measuredRowHeight = 100;


### PR DESCRIPTION
I forgot to skip the test added in #6049. It's the same fix from #6133.