### PR TITLE
[DateRangePicker] Force focus to stay on inputs

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
@@ -180,7 +180,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     validationError: startValidationError !== null,
     TextFieldProps: {
       ...TextFieldProps,
-      ref: startRef,
+      inputRef: startRef,
       focused: open && currentlySelectingRangeEnd === 'start',
     },
     inputProps: {
@@ -199,7 +199,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     validationError: endValidationError !== null,
     TextFieldProps: {
       ...TextFieldProps,
-      ref: endRef,
+      inputRef: endRef,
       focused: open && currentlySelectingRangeEnd === 'end',
     },
     inputProps: {

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -697,10 +697,12 @@ describe('<DesktopDateRangePicker />', () => {
       // Dismiss the picker
       const input = document.getElementById('test-id')!;
 
-      fireEvent.mouseDown(input);
-      input.focus();
-      fireEvent.mouseUp(input);
-      clock.runToLast();
+      act(() => {
+        fireEvent.mouseDown(input);
+        input.focus();
+        fireEvent.mouseUp(input);
+        clock.runToLast();
+      });
 
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -739,9 +739,11 @@ describe('<DesktopDateRangePicker />', () => {
       // Dismiss the picker
       const input = document.getElementById('test-id')!;
 
-      fireEvent.mouseDown(input);
-      input.focus();
-      fireEvent.mouseUp(input);
+      act(() => {
+        fireEvent.mouseDown(input);
+        input.focus();
+        fireEvent.mouseUp(input);
+      });
 
       clock.runToLast();
 
@@ -793,7 +795,9 @@ describe('<DesktopDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
       expect(screen.getByRole('tooltip')).toBeVisible();
 
-      screen.getAllByRole('textbox')[0].blur();
+      act(() => {
+        screen.getAllByRole('textbox')[0].blur();
+      });
       clock.runToLast();
 
       expect(onChange.callCount).to.equal(0);
@@ -826,7 +830,9 @@ describe('<DesktopDateRangePicker />', () => {
       userEvent.mousePress(getPickerDay('3'));
       clock.runToLast();
 
-      screen.getAllByRole('textbox')[1].blur();
+      act(() => {
+        screen.getAllByRole('textbox')[1].blur();
+      });
       clock.runToLast();
 
       expect(onChange.callCount).to.equal(1); // Start date change

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -681,18 +681,25 @@ describe('<DesktopDateRangePicker />', () => {
       const onClose = spy();
 
       render(
-        <WrappedDesktopDateRangePicker
-          onChange={onChange}
-          onAccept={onAccept}
-          onClose={onClose}
-          initialValue={[null, null]}
-        />,
+        <div>
+          <WrappedDesktopDateRangePicker
+            onChange={onChange}
+            onAccept={onAccept}
+            onClose={onClose}
+            initialValue={[null, null]}
+          />
+          <input id="test-id" />
+        </div>,
       );
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
       // Dismiss the picker
-      userEvent.mousePress(document.body);
+      const input = document.getElementById('test-id')!;
+
+      fireEvent.mouseDown(input);
+      input.focus();
+      fireEvent.mouseUp(input);
       clock.runToLast();
 
       expect(onChange.callCount).to.equal(0);
@@ -710,21 +717,30 @@ describe('<DesktopDateRangePicker />', () => {
       ];
 
       render(
-        <WrappedDesktopDateRangePicker
-          onChange={onChange}
-          onAccept={onAccept}
-          onClose={onClose}
-          initialValue={initialValue}
-        />,
+        <div>
+          <WrappedDesktopDateRangePicker
+            onChange={onChange}
+            onAccept={onAccept}
+            onClose={onClose}
+            initialValue={initialValue}
+          />
+          <input id="test-id" />
+        </div>,
       );
 
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
       // Change the start date (already tested)
       userEvent.mousePress(getPickerDay('3'));
+      clock.runToLast();
 
       // Dismiss the picker
-      userEvent.mousePress(document.body);
+      const input = document.getElementById('test-id')!;
+
+      fireEvent.mouseDown(input);
+      input.focus();
+      fireEvent.mouseUp(input);
+
       clock.runToLast();
 
       expect(onChange.callCount).to.equal(1); // Start date change
@@ -775,7 +791,7 @@ describe('<DesktopDateRangePicker />', () => {
       openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
       expect(screen.getByRole('tooltip')).toBeVisible();
 
-      fireEvent.blur(screen.getAllByRole('textbox')[0]);
+      screen.getAllByRole('textbox')[0].blur();
       clock.runToLast();
 
       expect(onChange.callCount).to.equal(0);
@@ -806,8 +822,9 @@ describe('<DesktopDateRangePicker />', () => {
 
       // Change the start date (already tested)
       userEvent.mousePress(getPickerDay('3'));
+      clock.runToLast();
 
-      fireEvent.blur(screen.getAllByRole('textbox')[0]);
+      screen.getAllByRole('textbox')[1].blur();
       clock.runToLast();
 
       expect(onChange.callCount).to.equal(1); // Start date change


### PR DESCRIPTION
Fix #6298

For now, the focus was getting lost somewhere on the Popper without keyboard navigation, and with the text fields that look like they are focused but are not truly.

I replaced the `ref` by `inputRef` such that the focus truly goes onto the input. This means the user can know either use the mouse to continue filling the form, or enter a date with a keyboard