### PR TITLE
[CalendarPicker] Prevent getting focus when `autoFocus=false` (#6304)

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx
@@ -445,8 +445,13 @@ export const CalendarPicker = React.forwardRef(function CalendarPicker<TDate>(
     },
   );
 
+  const prevOpenViewRef = React.useRef(openView);
   React.useEffect(() => {
     // Set focus to the button when switching from a view to another
+    if (prevOpenViewRef.current === openView) {
+      return;
+    }
+    prevOpenViewRef.current = openView;
     handleFocusedViewChange(openView)(true);
   }, [openView, handleFocusedViewChange]);
 


### PR DESCRIPTION
Cherry picking from #6304

Fix #6343