### PR TITLE
[DataGridPremium] Remove the aggregation from the experimental features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,314 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.0-alpha.1
+
+_Sep 29, 2022_
+
+We'd like to offer a big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
+
+- 🚀 Better support for custom overlays (#5808) @cherniavskii
+- 🖨️ Improve print export (#6273) @oliviertassinari
+- 🎁 Reduce confusion when initializing pickers with a date value (#6170) @flaviendelangle
+- 📚 Documentation improvements
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v6.0.0-alpha.1` / `@mui/x-data-grid-pro@v6.0.0-alpha.1` / `@mui/x-data-grid-premium@v6.0.0-alpha.1`
+
+#### Breaking changes
+
+- New internal rows structure for v6 (#4927) @flaviendelangle
+
+  Some selectors related to the rows have been renamed to better describe the type of rows they are returning:
+
+  ```diff
+  -const result = gridRowsIdToIdLookupSelector(apiRef);
+  +const result = gridRowsDataRowIdToIdLookupSelector(apiRef);
+  ```
+
+  ```diff
+  -const result = gridRowTreeDepthSelector(apiRef);
+  +const result = gridRowMaximumTreeDepthSelector(apiRef);
+  ```
+
+  The format of the tree nodes (the element accessible in `params.node` or with the `apiRef.current.getRowNode` method) have changed.
+  You have a new `type` property, which can be useful, for example, to apply custom behavior on groups.
+  Here is an example of the old and new approach showing how to apply a custom value formatter in groups for the grouping column:
+
+  ```diff
+   <DataGridPremium 
+     groupingColDef={() => ({
+       valueFormatter: (params) => {
+         if (params.id == null) {
+           return params.value;
+         }
+
+         const rowNode = apiRef.current.getRowNode(params.id!)!;
+  -      if (rowNode.children?.length) {
+  +      if (rowNode.type === 'group') {
+           return `by ${rowNode.groupingKey ?? ''}`;
+         }
+
+         return params.value;
+       }
+     })}
+   />
+  ```
+
+- The `GridFeatureModeConstant` constant no longer exists (#6077) @DanailH
+
+  ```diff
+  -import { GridFeatureModeConstant } from '@mui/x-data-grid';
+  ```
+
+#### Changes
+
+- [DataGrid] Fix `GridPagination` props typing (#6238) @cherniavskii
+- [DataGrid] Fix `GridRow` not forwarding `ref` to the root element (#6274) @cherniavskii
+- [DataGrid] Fix `undefined` value being showed in filter button tooltip text (#6259) @cherniavskii
+- [DataGrid] Fix blank space when changing page with dynamic row height (#6049) @m4theushw
+- [DataGrid] New internal rows structure for v6 (#4927) @flaviendelangle
+- [DataGrid] Revert cell/row mode if `processRowUpdate` fails (#6185) @m4theushw
+- [DataGrid] Rework overlays layout (#5808) @cherniavskii
+- [DataGrid] Improve print support (#6273) @oliviertassinari
+- [DataGridPremium] Add missing `themeAugmentation` module (#6270) @cherniavskii
+
+### `@mui/x-date-pickers@v6.0.0-alpha.1` / `@mui/x-date-pickers-pro@v6.0.0-alpha.1`
+
+#### Breaking changes
+
+- [pickers] Do not support unparsed date formats anymore (#6170) @flaviendelangle
+
+  The `value` prop of the pickers now expects a parsed value.
+  Until now, it was possible to provide any format that your date management library was able to parse.
+  For instance, you could pass `value={new Date()}` when using `AdapterDayjs`.
+
+  This brought a lot of confusion so we decided to remove this behavior.
+  The format expected by the `value` prop is now the same as for any other prop holding a date.
+  Here is the syntax to initialize a date picker at the current date for each adapter:
+
+  ```tsx
+  // Date-fns
+  <DatePicker value={new Date()} />
+
+  // Dayjs
+  import dayjs from 'dayjs'
+  <DatePicker value={dayjs()} />
+
+  // Moment
+  import moment from 'moment'
+  <DatePicker value={moment()} />
+
+  // Luxon
+  import { DateTime } from 'luxon'
+  <DatePicker value={DateTime.now()} />
+  ```
+
+#### Changes
+
+- [DatePicker] Respect `minDate` and `maxDate` when opening a `DatePicker` or `DateTimePicker` (#6309) @alexfauquette
+- [DateTimePicker] Fix validation with `shouldDisableMonth` and `shouldDisableYear` (#6266) @flaviendelangle
+- [TimePicker] Add support for `disablePast` and `disableFuture` validation props (#6226) @LukasTy
+- [CalendarPicker] Prevent getting focus when `autoFocus=false` (#6304) @alexfauquette
+- [DateField] Extend moment adapter to support `expandFormat` and `formatTokenMap` (#6215) @alexfauquette
+- [pickers] Allow to control the selected sections (#6209, #6307) @flaviendelangle
+- [pickers] Do not loose the value of date sections not present in the format in the new field components (#6141) @flaviendelangle
+- [pickers] Do not support unparsed date formats anymore (#6170) @flaviendelangle
+- [pickers] Support slots on the `DateField` component  (#6048) @flaviendelangle
+- [pickers] Support Luxon v3 in `AdapterLuxon` (#6069) @alexfauquette
+- [pickers] New components `TimeField` and `DateTimeField` (#6312) @flaviendelangle
+- [pickers] Support basic mobile edition on new field components (#5958) @flaviendelangle
+
+### Docs
+
+- [docs] Fix issue in DataGrid/DataGridPro row styling demo (#6264) @MBilalShafi
+- [docs] Improve pickers Getting Started examples (#6292) @flaviendelangle
+- [docs] Pass model change callbacks in controlled grid editing demos (#6296) @cherniavskii
+- [docs] Update the CodeSandbox to use the `next` branch (#6275) @oliviertassinari
+
+### Core
+
+- [core] Fix typing error (#6291) @flaviendelangle
+- [core] Fix typo in the state updater of `useField` (#6311) @flaviendelangle
+- [core] Remove `GridFeatureModeConstant` (#6077) @DanailH
+- [core] Simplify testing architecture (#6043) @flaviendelangle
+- [test] Skip test in Chrome non-headless and Edge (#6318) @m4theushw
+
+## 6.0.0-alpha.0
+
+_Sep 22, 2022_
+
+We'd like to offer a big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
+
+- 🌍 Add a `localeText` prop to all pickers to customize the translations (#6212) @flaviendelangle
+- 🌍 Add Finnish (fi-FI) locale to the pickers (#6219) @PetroSilenius
+- 🌍 Add Persian (fa-IR) locale to the pickers (#6181) @fakhamatia
+- 📚 Documentation improvements
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v6.0.0-alpha.0` / `@mui/x-data-grid-pro@v6.0.0-alpha.0` / `@mui/x-data-grid-premium@v6.0.0-alpha.0`
+
+#### Breaking changes
+
+- The deprecated `hide` column property has been removed in favor of the `columnVisibilityModel` prop and initial state.
+
+  ```diff
+  <DataGrid
+    columns={[
+      field: 'id,
+  -   hide: true,
+    ]}
+  +  initialState={{
+  +    columns: {
+  +      columnVisibilityModel: { id: false },
+  +    }
+  +  }}
+  />
+  ```
+
+  You can find more information about this new API on our [documentation](https://next.mui.com/x/react-data-grid/column-visibility/).
+
+- The `GridEvents` enum is now a TypeScript type.
+
+  ```diff
+  - apiRef.current.subscribeEvent(GridEvents.rowClick', handleRowClick)
+  + apiRef.current.subscribeEvent('rowClick', handleRowClick)
+  ```
+
+#### Changes
+
+- [DataGrid] Do not publish `cellFocusOut` event if the row was removed (#6251) @cherniavskii
+- [DataGrid] Fix scroll anchoring with master details (#6054) @oliviertassinari
+- [DataGrid] Improve Polish (pl-PL) locale on the data grid (#6245) @grzegorz-bach
+- [DataGrid] Remove the `GridEvents` enum (#6003) @flaviendelangle
+- [DataGrid] Remove the deprecated `hide` column property (#5999) @flaviendelangle
+
+### `@mui/x-date-pickers@v6.0.0-alpha.0` / `@mui/x-date-pickers-pro@v6.0.0-alpha.0`
+
+#### Breaking changes
+
+- All the deprecated props that allowed you to set the text displayed in the pickers have been removed.
+
+  You can now use the `localText` prop available on all picker components:
+
+  | Removed prop                 | Property in the new `localText` prop                                              |
+  |------------------------------|-----------------------------------------------------------------------------------|
+  | `endText`                    | `end`                                                                             |
+  | `getClockLabelText`          | `clockLabelText`                                                                  |
+  | `getHoursClockNumberText`    | `hoursClockNumberText`                                                            |
+  | `getMinutesClockNumberText`  | `minutesClockNumberText`                                                          |
+  | `getSecondsClockNumberText`  | `secondsClockNumberText`                                                          |
+  | `getViewSwitchingButtonText` | `calendarViewSwitchingButtonAriaLabel`                                            |
+  | `leftArrowButtonText`        | `openPreviousView` (or `previousMonth` when the button changes the visible month) |
+  | `rightArrowButtonText`       | `openNextView` (or `nextMonth` when the button changes the visible month)         |
+  | `startText`                  | `start`                                                                           |
+
+  For instance if you want to replace the `startText` / `endText`
+
+  ```diff
+  <DateRangePicker
+  -  startText="From"
+  -  endText="To"
+  +  localeText={{
+  +    start: 'From',
+  +    end: 'To',
+  +  }}
+  />
+  ```
+
+You can find more information about the new api, including how to set those translations on all your components at once in the [documentation](https://next.mui.com/x/react-date-pickers/localization/)
+
+- The component slots `LeftArrowButton` and `RightArrowButton` have been renamed `PreviousIconButton` and `NextIconButton` to better describe there usage:
+
+  ```diff
+  <DatePicker 
+    components={{
+  -   LeftArrowButton: CustomButton,  
+  +   PreviousIconButton: CustomButton,
+
+  -   RightArrowButton: CustomButton,
+  +   NextIconButton: CustomButton,
+    }}
+
+    componentsProps={{
+  -   leftArrowButton: {},  
+  +   previousIconButton: {},
+
+  -   rightArrowButton: {},
+  +   nextIconButton: {},
+    }}
+  />
+  ```
+
+- The `date` prop has been renamed `value` on  `MonthPicker` / `YearPicker`, `ClockPicker` and `CalendarPicker`.
+
+  ```diff
+  - <MonthPicker date={dayjs()} onChange={handleMonthChange} />
+  + <MonthPicker value={dayjs()} onChange={handleMonthChange} />
+
+  - <YearPicker date={dayjs()} onChange={handleYearChange} />
+  + <YearPicker value={dayjs()} onChange={handleYearChange} />
+
+  - <ClockPicker date={dayjs()} onChange={handleTimeChange} />
+  + <ClockPicker value={dayjs()} onChange={handleTimeChange} />
+
+  - <CalendarPicker date={dayjs()} onChange={handleDateChange} />
+  + <CalendarPicker value={dayjs()} onChange={handleDateChange} />
+  ```
+
+#### Changes
+
+- [CalendarPicker] Don't move to closest enabled date when `props.date` contains a disabled date (#6146) @flaviendelangle
+- [DateRangePicker] Switch to new month when changing the value from the outside (#6166) @flaviendelangle
+- [pickers] Add a `localeText` prop to all pickers to customize the translations (#6212) @flaviendelangle
+- [pickers] Add Finnish (fi-FI) locale to the pickers (#6219) (#6230) @PetroSilenius
+- [pickers] Add Persian (fa-IR) locale to the pickers (#6181) @fakhamatia
+- [pickers] Allow nested `LocalizationProvider` (#6011) @flaviendelangle
+- [pickers] Clean slots on `PickersArrowSwitcher` component (#5890) @flaviendelangle
+- [pickers] Fix invalid date error when decreasing `DateField` day (#6071) @alexfauquette
+- [pickers] Fix mobile section selection (#6207) @oliviertassinari
+- [pickers] Fix usage with Typescript 4.8 (#6229) @flaviendelangle
+- [pickers] Improve error message when no adapter context is found (#6211) @flaviendelangle
+- [pickers] Remove `valueStr` from the field state (#6142) @flaviendelangle
+- [pickers] Remove remaining deprecated locale props (#6233) @flaviendelangle
+- [pickers] Rename the `date` prop `value` on `MonthPicker` / `YearPicker`, `ClockPicker` and `CalendarPicker` (#6128) @flaviendelangle
+- [pickers] Rename the `onClose` prop of  `PickersPopper` `onDismiss` to simplify typing (#6155) @flaviendelangle
+- [pickers] Support the `sx` prop on all public component with a root HTML elements (#5944) @flaviendelangle
+- [pickers] Unify `PickersMonth` and `PickersYear` behaviors (#6034) @flaviendelangle
+- [pickers] Use `shouldDisableMonth` and `shouldDisableYear` for date validation (#6066) @flaviendelangle
+- [YearPicker] Scroll to the current year even with `autoFocus=false` (#6224) @alexfauquette
+
+### Docs
+
+- [docs] Add automatic vale check (#5429) @alexfauquette
+- [docs] Add Pro logo in "column ordering" link (#6127) @alexfauquette
+- [docs] Fix 301 link (#6239) @oliviertassinari
+- [docs] Fix broken link (#6163) @alexfauquette
+- [docs] Fix broken links (#6101) @alexfauquette
+- [docs] Fix demonstration date to avoid hydration errors (#6032) @alexfauquette
+- [docs] Fix hidden popper in restore state example (#6191) @heyfirst
+- [docs] Fix invalid links causing 404 & 301 errors (#6105) @oliviertassinari
+- [docs] Fix npm repository url in the pickers `package.json` (#6172) @oliviertassinari
+- [docs] Fix typo in linked issue (#6162) @flaviendelangle
+- [docs] Import `generateUtilityClass` from `@mui/utils` (#6216) @michaldudak
+- [docs] Improve Upgrade plan docs (#6018) @oliviertassinari
+- [docs] Link the OpenSSF Best Practices card (#6171) @oliviertassinari
+
+### Core
+
+- [core] Add `v5.17.3` changelog to next branch (#6250) @flaviendelangle
+- [core] Add link to the security page on the `README` (#6073) @oliviertassinari
+- [core] Fix scroll restoration in the docs (#5938) @oliviertassinari
+- [core] Remove the Storybook (#6099) @flaviendelangle
+- [core] Tag release as `next` in NPM (#6256) @m4theushw
+- [core] Update monorepo (#6180) @flaviendelangle
+- [core] Use the `next` branch for Prettier (#6097) @flaviendelangle
+- [core] Use the official repository for `@mui/monorepo` instead of a fork (#6189) @oliviertassinari
+- [test] Fix logic to skip column pinning tests (#6133) @m4theushw
+- [test] Hide the date on the print regression test (#6120) @flaviendelangle
+- [test] Skip tests for column pinning and dynamic row height (#5997) @m4theushw
+- [website] Improve security header @oliviertassinari
+
 ## v5.17.4
 
 _Sep 22, 2022_
@@ -135,7 +443,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 
 _Sep 2, 2022_
 
-🎉 We are excited to finally introduce a stable release (v5.0.0) for the `@mui/x-date-pickers` and `@mui/x-date-pickers-pro` packages!
+🎉 We are excited to finally introduce a stable release (v5.0.0) for the `@mui/x-date-pickers` and  `@mui/x-date-pickers-pro` packages!
 
 If you are still using picker components from the `lab`, take a look at the [migration guide](https://mui.com/x/react-date-pickers/migration-lab/).
 
@@ -1440,7 +1748,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [DataGrid] Stop checkbox ripple on blur (#3835) @m4theushw
 - [DataGrid] Stop calling `onRowClick` when clicking in cells with interactive elements (#3929) @m4theushw
 - [DataGrid] Use only `headerName` when available to search column (#3959) @pkratz
-- [DataGrid] Use the bundling scripts as the packages published by the [https://github.com/mui/material-ui](material-ui) repository (#3965) @flaviendelangle
+- [DataGrid] Use the bundling scripts as the packages published by the [material-ui](https://github.com/mui/material-ui) repository (#3965) @flaviendelangle
 - [DataGridPro] Add `unstable_setRowHeight` method to `apiRef` (#3751) @cherniavskii
 - [DataGridPro] Always export the `pageSize` and `page` when it has been initialized or is being controlled (#3908) @flaviendelangle
 - [DataGridPro] Disable export for detail panel column (#4057) @gustavhagland
@@ -4085,7 +4393,7 @@ Big thanks to the 7 contributors who made this release possible. Here are some h
 
 - 💄 Release the cell editing feature (#1287) @dtassone
 
-  This is the first release of the Cell editing feature. You can find the documentation [following this link](https://mui.com/x/react-data-grid/editing/#cell-editing). We have spent the last three months working on it.
+  This is the first release of the Cell editing feature. You can find the documentation [following this link](https://mui.com/x/react-data-grid/editing/). We have spent the last three months working on it.
 
   ![cell edit](https://user-images.githubusercontent.com/3165635/115632215-87994700-a307-11eb-91d9-9f5537df0911.gif)
 
@@ -4695,7 +5003,7 @@ _Dec 9, 2020_
 
 Big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
-- 🔍 Add a new data grid [density selector](https://mui.com/x/react-data-grid/rendering/#density) feature (#606) @DanailH.
+- 🔍 Add a new data grid [density selector](https://mui.com/x/react-data-grid/accessibility/#density) feature (#606) @DanailH.
 - 💄 A first iteration on the data grid's toolbar.
 - 🧪 Continue the iteration on the data grid filtering feature, soon to be released @dtassone.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,314 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 6.0.0-alpha.1
-
-_Sep 29, 2022_
-
-We'd like to offer a big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
-
-- 🚀 Better support for custom overlays (#5808) @cherniavskii
-- 🖨️ Improve print export (#6273) @oliviertassinari
-- 🎁 Reduce confusion when initializing pickers with a date value (#6170) @flaviendelangle
-- 📚 Documentation improvements
-- 🐞 Bugfixes
-
-### `@mui/x-data-grid@v6.0.0-alpha.1` / `@mui/x-data-grid-pro@v6.0.0-alpha.1` / `@mui/x-data-grid-premium@v6.0.0-alpha.1`
-
-#### Breaking changes
-
-- New internal rows structure for v6 (#4927) @flaviendelangle
-
-  Some selectors related to the rows have been renamed to better describe the type of rows they are returning:
-
-  ```diff
-  -const result = gridRowsIdToIdLookupSelector(apiRef);
-  +const result = gridRowsDataRowIdToIdLookupSelector(apiRef);
-  ```
-
-  ```diff
-  -const result = gridRowTreeDepthSelector(apiRef);
-  +const result = gridRowMaximumTreeDepthSelector(apiRef);
-  ```
-
-  The format of the tree nodes (the element accessible in `params.node` or with the `apiRef.current.getRowNode` method) have changed.
-  You have a new `type` property, which can be useful, for example, to apply custom behavior on groups.
-  Here is an example of the old and new approach showing how to apply a custom value formatter in groups for the grouping column:
-
-  ```diff
-   <DataGridPremium 
-     groupingColDef={() => ({
-       valueFormatter: (params) => {
-         if (params.id == null) {
-           return params.value;
-         }
-
-         const rowNode = apiRef.current.getRowNode(params.id!)!;
-  -      if (rowNode.children?.length) {
-  +      if (rowNode.type === 'group') {
-           return `by ${rowNode.groupingKey ?? ''}`;
-         }
-
-         return params.value;
-       }
-     })}
-   />
-  ```
-
-- The `GridFeatureModeConstant` constant no longer exists (#6077) @DanailH
-
-  ```diff
-  -import { GridFeatureModeConstant } from '@mui/x-data-grid';
-  ```
-
-#### Changes
-
-- [DataGrid] Fix `GridPagination` props typing (#6238) @cherniavskii
-- [DataGrid] Fix `GridRow` not forwarding `ref` to the root element (#6274) @cherniavskii
-- [DataGrid] Fix `undefined` value being showed in filter button tooltip text (#6259) @cherniavskii
-- [DataGrid] Fix blank space when changing page with dynamic row height (#6049) @m4theushw
-- [DataGrid] New internal rows structure for v6 (#4927) @flaviendelangle
-- [DataGrid] Revert cell/row mode if `processRowUpdate` fails (#6185) @m4theushw
-- [DataGrid] Rework overlays layout (#5808) @cherniavskii
-- [DataGrid] Improve print support (#6273) @oliviertassinari
-- [DataGridPremium] Add missing `themeAugmentation` module (#6270) @cherniavskii
-
-### `@mui/x-date-pickers@v6.0.0-alpha.1` / `@mui/x-date-pickers-pro@v6.0.0-alpha.1`
-
-#### Breaking changes
-
-- [pickers] Do not support unparsed date formats anymore (#6170) @flaviendelangle
-
-  The `value` prop of the pickers now expects a parsed value.
-  Until now, it was possible to provide any format that your date management library was able to parse.
-  For instance, you could pass `value={new Date()}` when using `AdapterDayjs`.
-
-  This brought a lot of confusion so we decided to remove this behavior.
-  The format expected by the `value` prop is now the same as for any other prop holding a date.
-  Here is the syntax to initialize a date picker at the current date for each adapter:
-
-  ```tsx
-  // Date-fns
-  <DatePicker value={new Date()} />
-
-  // Dayjs
-  import dayjs from 'dayjs'
-  <DatePicker value={dayjs()} />
-
-  // Moment
-  import moment from 'moment'
-  <DatePicker value={moment()} />
-
-  // Luxon
-  import { DateTime } from 'luxon'
-  <DatePicker value={DateTime.now()} />
-  ```
-
-#### Changes
-
-- [DatePicker] Respect `minDate` and `maxDate` when opening a `DatePicker` or `DateTimePicker` (#6309) @alexfauquette
-- [DateTimePicker] Fix validation with `shouldDisableMonth` and `shouldDisableYear` (#6266) @flaviendelangle
-- [TimePicker] Add support for `disablePast` and `disableFuture` validation props (#6226) @LukasTy
-- [CalendarPicker] Prevent getting focus when `autoFocus=false` (#6304) @alexfauquette
-- [DateField] Extend moment adapter to support `expandFormat` and `formatTokenMap` (#6215) @alexfauquette
-- [pickers] Allow to control the selected sections (#6209, #6307) @flaviendelangle
-- [pickers] Do not loose the value of date sections not present in the format in the new field components (#6141) @flaviendelangle
-- [pickers] Do not support unparsed date formats anymore (#6170) @flaviendelangle
-- [pickers] Support slots on the `DateField` component  (#6048) @flaviendelangle
-- [pickers] Support Luxon v3 in `AdapterLuxon` (#6069) @alexfauquette
-- [pickers] New components `TimeField` and `DateTimeField` (#6312) @flaviendelangle
-- [pickers] Support basic mobile edition on new field components (#5958) @flaviendelangle
-
-### Docs
-
-- [docs] Fix issue in DataGrid/DataGridPro row styling demo (#6264) @MBilalShafi
-- [docs] Improve pickers Getting Started examples (#6292) @flaviendelangle
-- [docs] Pass model change callbacks in controlled grid editing demos (#6296) @cherniavskii
-- [docs] Update the CodeSandbox to use the `next` branch (#6275) @oliviertassinari
-
-### Core
-
-- [core] Fix typing error (#6291) @flaviendelangle
-- [core] Fix typo in the state updater of `useField` (#6311) @flaviendelangle
-- [core] Remove `GridFeatureModeConstant` (#6077) @DanailH
-- [core] Simplify testing architecture (#6043) @flaviendelangle
-- [test] Skip test in Chrome non-headless and Edge (#6318) @m4theushw
-
-## 6.0.0-alpha.0
-
-_Sep 22, 2022_
-
-We'd like to offer a big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
-
-- 🌍 Add a `localeText` prop to all pickers to customize the translations (#6212) @flaviendelangle
-- 🌍 Add Finnish (fi-FI) locale to the pickers (#6219) @PetroSilenius
-- 🌍 Add Persian (fa-IR) locale to the pickers (#6181) @fakhamatia
-- 📚 Documentation improvements
-- 🐞 Bugfixes
-
-### `@mui/x-data-grid@v6.0.0-alpha.0` / `@mui/x-data-grid-pro@v6.0.0-alpha.0` / `@mui/x-data-grid-premium@v6.0.0-alpha.0`
-
-#### Breaking changes
-
-- The deprecated `hide` column property has been removed in favor of the `columnVisibilityModel` prop and initial state.
-
-  ```diff
-  <DataGrid
-    columns={[
-      field: 'id,
-  -   hide: true,
-    ]}
-  +  initialState={{
-  +    columns: {
-  +      columnVisibilityModel: { id: false },
-  +    }
-  +  }}
-  />
-  ```
-
-  You can find more information about this new API on our [documentation](https://next.mui.com/x/react-data-grid/column-visibility/).
-
-- The `GridEvents` enum is now a TypeScript type.
-
-  ```diff
-  - apiRef.current.subscribeEvent(GridEvents.rowClick', handleRowClick)
-  + apiRef.current.subscribeEvent('rowClick', handleRowClick)
-  ```
-
-#### Changes
-
-- [DataGrid] Do not publish `cellFocusOut` event if the row was removed (#6251) @cherniavskii
-- [DataGrid] Fix scroll anchoring with master details (#6054) @oliviertassinari
-- [DataGrid] Improve Polish (pl-PL) locale on the data grid (#6245) @grzegorz-bach
-- [DataGrid] Remove the `GridEvents` enum (#6003) @flaviendelangle
-- [DataGrid] Remove the deprecated `hide` column property (#5999) @flaviendelangle
-
-### `@mui/x-date-pickers@v6.0.0-alpha.0` / `@mui/x-date-pickers-pro@v6.0.0-alpha.0`
-
-#### Breaking changes
-
-- All the deprecated props that allowed you to set the text displayed in the pickers have been removed.
-
-  You can now use the `localText` prop available on all picker components:
-
-  | Removed prop                 | Property in the new `localText` prop                                              |
-  |------------------------------|-----------------------------------------------------------------------------------|
-  | `endText`                    | `end`                                                                             |
-  | `getClockLabelText`          | `clockLabelText`                                                                  |
-  | `getHoursClockNumberText`    | `hoursClockNumberText`                                                            |
-  | `getMinutesClockNumberText`  | `minutesClockNumberText`                                                          |
-  | `getSecondsClockNumberText`  | `secondsClockNumberText`                                                          |
-  | `getViewSwitchingButtonText` | `calendarViewSwitchingButtonAriaLabel`                                            |
-  | `leftArrowButtonText`        | `openPreviousView` (or `previousMonth` when the button changes the visible month) |
-  | `rightArrowButtonText`       | `openNextView` (or `nextMonth` when the button changes the visible month)         |
-  | `startText`                  | `start`                                                                           |
-
-  For instance if you want to replace the `startText` / `endText`
-
-  ```diff
-  <DateRangePicker
-  -  startText="From"
-  -  endText="To"
-  +  localeText={{
-  +    start: 'From',
-  +    end: 'To',
-  +  }}
-  />
-  ```
-
-You can find more information about the new api, including how to set those translations on all your components at once in the [documentation](https://next.mui.com/x/react-date-pickers/localization/)
-
-- The component slots `LeftArrowButton` and `RightArrowButton` have been renamed `PreviousIconButton` and `NextIconButton` to better describe there usage:
-
-  ```diff
-  <DatePicker 
-    components={{
-  -   LeftArrowButton: CustomButton,  
-  +   PreviousIconButton: CustomButton,
-
-  -   RightArrowButton: CustomButton,
-  +   NextIconButton: CustomButton,
-    }}
-
-    componentsProps={{
-  -   leftArrowButton: {},  
-  +   previousIconButton: {},
-
-  -   rightArrowButton: {},
-  +   nextIconButton: {},
-    }}
-  />
-  ```
-
-- The `date` prop has been renamed `value` on  `MonthPicker` / `YearPicker`, `ClockPicker` and `CalendarPicker`.
-
-  ```diff
-  - <MonthPicker date={dayjs()} onChange={handleMonthChange} />
-  + <MonthPicker value={dayjs()} onChange={handleMonthChange} />
-
-  - <YearPicker date={dayjs()} onChange={handleYearChange} />
-  + <YearPicker value={dayjs()} onChange={handleYearChange} />
-
-  - <ClockPicker date={dayjs()} onChange={handleTimeChange} />
-  + <ClockPicker value={dayjs()} onChange={handleTimeChange} />
-
-  - <CalendarPicker date={dayjs()} onChange={handleDateChange} />
-  + <CalendarPicker value={dayjs()} onChange={handleDateChange} />
-  ```
-
-#### Changes
-
-- [CalendarPicker] Don't move to closest enabled date when `props.date` contains a disabled date (#6146) @flaviendelangle
-- [DateRangePicker] Switch to new month when changing the value from the outside (#6166) @flaviendelangle
-- [pickers] Add a `localeText` prop to all pickers to customize the translations (#6212) @flaviendelangle
-- [pickers] Add Finnish (fi-FI) locale to the pickers (#6219) (#6230) @PetroSilenius
-- [pickers] Add Persian (fa-IR) locale to the pickers (#6181) @fakhamatia
-- [pickers] Allow nested `LocalizationProvider` (#6011) @flaviendelangle
-- [pickers] Clean slots on `PickersArrowSwitcher` component (#5890) @flaviendelangle
-- [pickers] Fix invalid date error when decreasing `DateField` day (#6071) @alexfauquette
-- [pickers] Fix mobile section selection (#6207) @oliviertassinari
-- [pickers] Fix usage with Typescript 4.8 (#6229) @flaviendelangle
-- [pickers] Improve error message when no adapter context is found (#6211) @flaviendelangle
-- [pickers] Remove `valueStr` from the field state (#6142) @flaviendelangle
-- [pickers] Remove remaining deprecated locale props (#6233) @flaviendelangle
-- [pickers] Rename the `date` prop `value` on `MonthPicker` / `YearPicker`, `ClockPicker` and `CalendarPicker` (#6128) @flaviendelangle
-- [pickers] Rename the `onClose` prop of  `PickersPopper` `onDismiss` to simplify typing (#6155) @flaviendelangle
-- [pickers] Support the `sx` prop on all public component with a root HTML elements (#5944) @flaviendelangle
-- [pickers] Unify `PickersMonth` and `PickersYear` behaviors (#6034) @flaviendelangle
-- [pickers] Use `shouldDisableMonth` and `shouldDisableYear` for date validation (#6066) @flaviendelangle
-- [YearPicker] Scroll to the current year even with `autoFocus=false` (#6224) @alexfauquette
-
-### Docs
-
-- [docs] Add automatic vale check (#5429) @alexfauquette
-- [docs] Add Pro logo in "column ordering" link (#6127) @alexfauquette
-- [docs] Fix 301 link (#6239) @oliviertassinari
-- [docs] Fix broken link (#6163) @alexfauquette
-- [docs] Fix broken links (#6101) @alexfauquette
-- [docs] Fix demonstration date to avoid hydration errors (#6032) @alexfauquette
-- [docs] Fix hidden popper in restore state example (#6191) @heyfirst
-- [docs] Fix invalid links causing 404 & 301 errors (#6105) @oliviertassinari
-- [docs] Fix npm repository url in the pickers `package.json` (#6172) @oliviertassinari
-- [docs] Fix typo in linked issue (#6162) @flaviendelangle
-- [docs] Import `generateUtilityClass` from `@mui/utils` (#6216) @michaldudak
-- [docs] Improve Upgrade plan docs (#6018) @oliviertassinari
-- [docs] Link the OpenSSF Best Practices card (#6171) @oliviertassinari
-
-### Core
-
-- [core] Add `v5.17.3` changelog to next branch (#6250) @flaviendelangle
-- [core] Add link to the security page on the `README` (#6073) @oliviertassinari
-- [core] Fix scroll restoration in the docs (#5938) @oliviertassinari
-- [core] Remove the Storybook (#6099) @flaviendelangle
-- [core] Tag release as `next` in NPM (#6256) @m4theushw
-- [core] Update monorepo (#6180) @flaviendelangle
-- [core] Use the `next` branch for Prettier (#6097) @flaviendelangle
-- [core] Use the official repository for `@mui/monorepo` instead of a fork (#6189) @oliviertassinari
-- [test] Fix logic to skip column pinning tests (#6133) @m4theushw
-- [test] Hide the date on the print regression test (#6120) @flaviendelangle
-- [test] Skip tests for column pinning and dynamic row height (#5997) @m4theushw
-- [website] Improve security header @oliviertassinari
-
 ## v5.17.4
 
 _Sep 22, 2022_
@@ -443,7 +135,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 
 _Sep 2, 2022_
 
-🎉 We are excited to finally introduce a stable release (v5.0.0) for the `@mui/x-date-pickers` and  `@mui/x-date-pickers-pro` packages!
+🎉 We are excited to finally introduce a stable release (v5.0.0) for the `@mui/x-date-pickers` and `@mui/x-date-pickers-pro` packages!
 
 If you are still using picker components from the `lab`, take a look at the [migration guide](https://mui.com/x/react-date-pickers/migration-lab/).
 
@@ -712,7 +404,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
   https://user-images.githubusercontent.com/45398769/181581503-77cc412e-9d9e-4de1-8bc3-c3bccc54cdaa.mp4
 
-  To enable this feature, add ``.
+  To enable this feature, add `experimentalFeatures={{ aggregation: true }}`.
   Aggregation functions are customizable and they combine well with row grouping.
   See the [documentation](https://mui.com/x/react-data-grid/aggregation/) to explore everything it has to offer.
 
@@ -1748,7 +1440,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [DataGrid] Stop checkbox ripple on blur (#3835) @m4theushw
 - [DataGrid] Stop calling `onRowClick` when clicking in cells with interactive elements (#3929) @m4theushw
 - [DataGrid] Use only `headerName` when available to search column (#3959) @pkratz
-- [DataGrid] Use the bundling scripts as the packages published by the [material-ui](https://github.com/mui/material-ui) repository (#3965) @flaviendelangle
+- [DataGrid] Use the bundling scripts as the packages published by the [https://github.com/mui/material-ui](material-ui) repository (#3965) @flaviendelangle
 - [DataGridPro] Add `unstable_setRowHeight` method to `apiRef` (#3751) @cherniavskii
 - [DataGridPro] Always export the `pageSize` and `page` when it has been initialized or is being controlled (#3908) @flaviendelangle
 - [DataGridPro] Disable export for detail panel column (#4057) @gustavhagland
@@ -4393,7 +4085,7 @@ Big thanks to the 7 contributors who made this release possible. Here are some h
 
 - 💄 Release the cell editing feature (#1287) @dtassone
 
-  This is the first release of the Cell editing feature. You can find the documentation [following this link](https://mui.com/x/react-data-grid/editing/). We have spent the last three months working on it.
+  This is the first release of the Cell editing feature. You can find the documentation [following this link](https://mui.com/x/react-data-grid/editing/#cell-editing). We have spent the last three months working on it.
 
   ![cell edit](https://user-images.githubusercontent.com/3165635/115632215-87994700-a307-11eb-91d9-9f5537df0911.gif)
 
@@ -5003,7 +4695,7 @@ _Dec 9, 2020_
 
 Big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
 
-- 🔍 Add a new data grid [density selector](https://mui.com/x/react-data-grid/accessibility/#density) feature (#606) @DanailH.
+- 🔍 Add a new data grid [density selector](https://mui.com/x/react-data-grid/rendering/#density) feature (#606) @DanailH.
 - 💄 A first iteration on the data grid's toolbar.
 - 🧪 Continue the iteration on the data grid filtering feature, soon to be released @dtassone.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -712,7 +712,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
   https://user-images.githubusercontent.com/45398769/181581503-77cc412e-9d9e-4de1-8bc3-c3bccc54cdaa.mp4
 
-  To enable this feature, add `experimentalFeatures={{ aggregation: true }}`.
+  To enable this feature, add ``.
   Aggregation functions are customizable and they combine well with row grouping.
   See the [documentation](https://mui.com/x/react-data-grid/aggregation/) to explore everything it has to offer.
 

--- a/docs/data/data-grid/aggregation/AggregationColDefAggregable.js
+++ b/docs/data/data-grid/aggregation/AggregationColDefAggregable.js
@@ -54,7 +54,6 @@ export default function AggregationColDefAggregable() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationColDefAggregable.tsx
+++ b/docs/data/data-grid/aggregation/AggregationColDefAggregable.tsx
@@ -54,7 +54,6 @@ export default function AggregationColDefAggregable() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationColDefAggregable.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationColDefAggregable.tsx.preview
@@ -9,5 +9,4 @@
       },
     },
   }}
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationControlled.js
+++ b/docs/data/data-grid/aggregation/AggregationControlled.js
@@ -40,7 +40,6 @@ export default function AggregationControlled() {
         columns={COLUMNS}
         aggregationModel={aggregationModel}
         onAggregationModelChange={(newModel) => setAggregationModel(newModel)}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationControlled.tsx
+++ b/docs/data/data-grid/aggregation/AggregationControlled.tsx
@@ -45,7 +45,6 @@ export default function AggregationControlled() {
         columns={COLUMNS}
         aggregationModel={aggregationModel}
         onAggregationModelChange={(newModel) => setAggregationModel(newModel)}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationControlled.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationControlled.tsx.preview
@@ -3,5 +3,4 @@
   columns={COLUMNS}
   aggregationModel={aggregationModel}
   onAggregationModelChange={(newModel) => setAggregationModel(newModel)}
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationCustomFunction.js
+++ b/docs/data/data-grid/aggregation/AggregationCustomFunction.js
@@ -88,7 +88,6 @@ export default function AggregationCustomFunction() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationCustomFunction.tsx
+++ b/docs/data/data-grid/aggregation/AggregationCustomFunction.tsx
@@ -91,7 +91,6 @@ export default function AggregationCustomFunction() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationCustomFunction.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationCustomFunction.tsx.preview
@@ -4,6 +4,7 @@
   aggregationFunctions={{
     ...GRID_AGGREGATION_FUNCTIONS,
     firstAlphabetical: firstAlphabeticalAggregation,
+    lastAlphabetical: lastAlphabeticalAggregation,
   }}
   initialState={{
     aggregation: {

--- a/docs/data/data-grid/aggregation/AggregationDisabled.js
+++ b/docs/data/data-grid/aggregation/AggregationDisabled.js
@@ -11,7 +11,6 @@ export default function AggregationDisabled() {
         {...data}
         disableAggregation
         initialState={{ aggregation: { model: { gross: 'sum' } } }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationDisabled.tsx
+++ b/docs/data/data-grid/aggregation/AggregationDisabled.tsx
@@ -11,7 +11,6 @@ export default function AggregationDisabled() {
         {...data}
         disableAggregation
         initialState={{ aggregation: { model: { gross: 'sum' } } }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationDisabled.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationDisabled.tsx.preview
@@ -2,5 +2,4 @@
   {...data}
   disableAggregation
   initialState={{ aggregation: { model: { gross: 'sum' } } }}
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationFiltering.js
+++ b/docs/data/data-grid/aggregation/AggregationFiltering.js
@@ -49,9 +49,6 @@ export default function AggregationFiltering() {
           },
         }}
         aggregationRowsScope="all"
-        experimentalFeatures={{
-          aggregation: true,
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationFiltering.tsx
+++ b/docs/data/data-grid/aggregation/AggregationFiltering.tsx
@@ -49,9 +49,6 @@ export default function AggregationFiltering() {
           },
         }}
         aggregationRowsScope="all"
-        experimentalFeatures={{
-          aggregation: true,
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationGetAggregationPosition.js
+++ b/docs/data/data-grid/aggregation/AggregationGetAggregationPosition.js
@@ -69,7 +69,6 @@ export default function AggregationGetAggregationPosition() {
         getAggregationPosition={(groupNode) =>
           groupNode.depth === -1 ? null : 'footer'
         }
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationGetAggregationPosition.tsx
+++ b/docs/data/data-grid/aggregation/AggregationGetAggregationPosition.tsx
@@ -70,7 +70,6 @@ export default function AggregationGetAggregationPosition() {
         getAggregationPosition={(groupNode) =>
           groupNode.depth === -1 ? null : 'footer'
         }
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationGetAggregationPosition.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationGetAggregationPosition.tsx.preview
@@ -7,5 +7,4 @@
   getAggregationPosition={(groupNode) =>
     groupNode.depth === -1 ? null : 'footer'
   }
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationInitialState.js
+++ b/docs/data/data-grid/aggregation/AggregationInitialState.js
@@ -41,7 +41,6 @@ export default function AggregationInitialState() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationInitialState.tsx
+++ b/docs/data/data-grid/aggregation/AggregationInitialState.tsx
@@ -41,7 +41,6 @@ export default function AggregationInitialState() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationInitialState.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationInitialState.tsx.preview
@@ -8,5 +8,4 @@
       },
     },
   }}
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationRemoveFunctionAllColumns.js
+++ b/docs/data/data-grid/aggregation/AggregationRemoveFunctionAllColumns.js
@@ -49,7 +49,6 @@ export default function AggregationRemoveFunctionAllColumns() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRemoveFunctionAllColumns.tsx
+++ b/docs/data/data-grid/aggregation/AggregationRemoveFunctionAllColumns.tsx
@@ -50,7 +50,6 @@ export default function AggregationRemoveFunctionAllColumns() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRemoveFunctionAllColumns.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationRemoveFunctionAllColumns.tsx.preview
@@ -1,10 +1,14 @@
 <DataGridPremium
   rows={data.rows}
   columns={COLUMNS}
+  aggregationFunctions={Object.fromEntries(
+    Object.entries(GRID_AGGREGATION_FUNCTIONS).filter(
+      ([name]) => name !== 'sum',
+    ),
+  )}
   initialState={{
     aggregation: {
       model: {
-        year: 'max',
         gross: 'max',
       },
     },

--- a/docs/data/data-grid/aggregation/AggregationRemoveFunctionOneColumn.js
+++ b/docs/data/data-grid/aggregation/AggregationRemoveFunctionOneColumn.js
@@ -48,7 +48,6 @@ export default function AggregationRemoveFunctionOneColumn() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRemoveFunctionOneColumn.tsx
+++ b/docs/data/data-grid/aggregation/AggregationRemoveFunctionOneColumn.tsx
@@ -48,7 +48,6 @@ export default function AggregationRemoveFunctionOneColumn() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRenderCell.js
+++ b/docs/data/data-grid/aggregation/AggregationRenderCell.js
@@ -49,7 +49,6 @@ export default function AggregationRenderCell() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRenderCell.tsx
+++ b/docs/data/data-grid/aggregation/AggregationRenderCell.tsx
@@ -49,7 +49,6 @@ export default function AggregationRenderCell() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRenderCell.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationRenderCell.tsx.preview
@@ -8,5 +8,4 @@
       },
     },
   }}
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationRowGrouping.js
+++ b/docs/data/data-grid/aggregation/AggregationRowGrouping.js
@@ -61,7 +61,6 @@ export default function AggregationRowGrouping() {
         columns={COLUMNS}
         disableSelectionOnClick
         initialState={initialState}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRowGrouping.tsx
+++ b/docs/data/data-grid/aggregation/AggregationRowGrouping.tsx
@@ -62,7 +62,6 @@ export default function AggregationRowGrouping() {
         columns={COLUMNS}
         disableSelectionOnClick
         initialState={initialState}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationRowGrouping.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationRowGrouping.tsx.preview
@@ -4,5 +4,4 @@
   columns={COLUMNS}
   disableSelectionOnClick
   initialState={initialState}
-  experimentalFeatures={{ aggregation: true }}
 />

--- a/docs/data/data-grid/aggregation/AggregationTreeData.js
+++ b/docs/data/data-grid/aggregation/AggregationTreeData.js
@@ -145,9 +145,6 @@ export default function AggregationTreeData() {
             },
           },
         }}
-        experimentalFeatures={{
-          aggregation: true,
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationTreeData.tsx
+++ b/docs/data/data-grid/aggregation/AggregationTreeData.tsx
@@ -158,9 +158,6 @@ export default function AggregationTreeData() {
             },
           },
         }}
-        experimentalFeatures={{
-          aggregation: true,
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationTreeData.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationTreeData.tsx.preview
@@ -1,0 +1,16 @@
+<DataGridPremium
+  treeData
+  rows={rows}
+  columns={columns}
+  getTreeDataPath={getTreeDataPath}
+  getRowId={getRowId}
+  groupingColDef={{ headerName: 'Files', width: 350 }}
+  initialState={{
+    aggregation: {
+      model: {
+        size: 'sum',
+        updatedAt: 'max',
+      },
+    },
+  }}
+/>

--- a/docs/data/data-grid/aggregation/AggregationValueFormatter.js
+++ b/docs/data/data-grid/aggregation/AggregationValueFormatter.js
@@ -68,7 +68,6 @@ export default function AggregationValueFormatter() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/AggregationValueFormatter.tsx
+++ b/docs/data/data-grid/aggregation/AggregationValueFormatter.tsx
@@ -71,7 +71,6 @@ export default function AggregationValueFormatter() {
             },
           },
         }}
-        experimentalFeatures={{ aggregation: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/aggregation/aggregation.md
+++ b/docs/data/data-grid/aggregation/aggregation.md
@@ -10,15 +10,6 @@ You can aggregate rows through the grid interface by opening the column menu and
 
 The aggregated values will be rendered in a footer row at the bottom of the grid.
 
-:::warning
-This feature is experimental, it needs to be explicitly activated using the `aggregation` experimental feature flag.
-
-```tsx
-<DataGridPremium experimentalFeatures={{ aggregation: true }} {...otherProps} />
-```
-
-:::
-
 {{"demo": "AggregationInitialState.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Pass aggregation to the grid

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -73,7 +73,7 @@
     "experimentalFeatures": {
       "type": {
         "name": "shape",
-        "description": "{ aggregation?: bool, columnGrouping?: bool, lazyLoading?: bool, newEditingApi?: bool, preventCommitWhileValidating?: bool, rowPinning?: bool, warnIfFocusStateIsNotSynced?: bool }"
+        "description": "{ columnGrouping?: bool, lazyLoading?: bool, newEditingApi?: bool, preventCommitWhileValidating?: bool, rowPinning?: bool, warnIfFocusStateIsNotSynced?: bool }"
       }
     },
     "filterMode": {

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -286,7 +286,6 @@ DataGridPremiumRaw.propTypes = {
    * For each feature, if the flag is not explicitly set to `true`, the feature will be fully disabled and any property / method call will not have any effect.
    */
   experimentalFeatures: PropTypes.shape({
-    aggregation: PropTypes.bool,
     columnGrouping: PropTypes.bool,
     lazyLoading: PropTypes.bool,
     newEditingApi: PropTypes.bool,

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
@@ -56,8 +56,6 @@ export const useDataGridPremiumProps = (inProps: DataGridPremiumProps) => {
     () => ({
       ...DATA_GRID_PREMIUM_PROPS_DEFAULT_VALUES,
       ...themedProps,
-      disableAggregation:
-        themedProps.disableAggregation || !themedProps.experimentalFeatures?.aggregation,
       localeText,
       components,
       signature: 'DataGridPremium',

--- a/packages/grid/x-data-grid-premium/src/models/dataGridPremiumProps.ts
+++ b/packages/grid/x-data-grid-premium/src/models/dataGridPremiumProps.ts
@@ -16,12 +16,7 @@ import type {
 import { GridInitialStatePremium } from './gridStatePremium';
 import { GridApiPremium } from './gridApiPremium';
 
-export interface GridExperimentalPremiumFeatures extends GridExperimentalProFeatures {
-  /**
-   * Enables the aggregation feature.
-   */
-  aggregation: boolean;
-}
+export interface GridExperimentalPremiumFeatures extends GridExperimentalProFeatures {}
 
 /**
  * The props users can give to the `DataGridProProps` component.

--- a/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -52,14 +52,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
 
     return (
       <div style={{ width: 300, height: 300 }}>
-        <DataGridPremium
-          {...baselineProps}
-          apiRef={apiRef}
-          {...props}
-          experimentalFeatures={{
-            aggregation: true,
-          }}
-        />
+        <DataGridPremium {...baselineProps} apiRef={apiRef} {...props} />
       </div>
     );
   };

--- a/packages/grid/x-data-grid-premium/src/tests/statePersistence.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/statePersistence.DataGridPremium.test.tsx
@@ -68,9 +68,6 @@ describe('<DataGridPremium /> - State Persistence', () => {
           {...props}
           defaultGroupingExpansionDepth={-1}
           groupingColDef={{ headerName: 'Group' }}
-          experimentalFeatures={{
-            aggregation: true,
-          }}
         />
       </div>
     );

--- a/packages/grid/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/grid/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -30,7 +30,7 @@ export interface GridExperimentalProFeatures extends GridExperimentalFeatures {
    */
   lazyLoading: boolean;
   /**
-   * Enables the the ability for rows to be pinned in data grid.
+   * Enables the ability for rows to be pinned in data grid.
    */
   rowPinning: boolean;
 }


### PR DESCRIPTION
## Changelog

### Highlight

- 🎁 The aggregation is no longer experimental.

  You can now use the aggregation without the `experimentalFeatures.aggregation` flag enabled. 

  ```diff
  <DataGridPremium 
  -  experimentalFeatures={{ aggregation: true }}
  />
  ```

  The aggregation of the columns through the column menu is now enabled by default on `DataGridPremium`. You can set `disableAggregation={true}` to disable it.