### PR TITLE
[core] Remove unused `react-text-mask` package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -73,7 +73,6 @@
     "react-is": "^18.2.0",
     "react-router": "^6.4.1",
     "react-router-dom": "^6.4.1",
-    "react-text-mask": "^5.4.3",
     "recast": "^0.21.2",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,7 +2520,7 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.10.5"
+  version "5.10.8"
   resolved "https://github.com/mui/material-ui.git#f235e8ee868011f87c073d5cf28b6207168769ed"
 
 "@mui/private-theming@^5.10.6":
@@ -11839,7 +11839,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -12127,13 +12127,6 @@ react-test-renderer@^18.0.0:
     react-is "^18.2.0"
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
-
-react-text-mask@^5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.4.3.tgz#991efb4299e30c2e6c2c46d13f617169463e0d2d"
-  integrity sha1-mR77QpnjDC5sLEbRP2FxaUY+DS0=
-  dependencies:
-    prop-types "^15.5.6"
 
 react-transition-group@^4.4.0, react-transition-group@^4.4.1, react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
While looking at https://github.com/mui/mui-x/pull/6357 I discovered that:
- this package does not seem to be used
- this package is no longer maintained
- [material-ui replaced](https://github.com/mui/material-ui/pull/27071) it with a different package quite some time ago