### PR TITLE
[DataGrid] Simplify `useGridApiContext` and `useGridApiRef` type overrides

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/utils/useGridApiContext.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/utils/useGridApiContext.ts
@@ -1,10 +1,4 @@
-import * as React from 'react';
-import {
-  GridApiCommon,
-  useGridApiContext as useCommunityGridApiContext,
-} from '@mui/x-data-grid-pro';
+import { useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
 import { GridApiPremium } from '../../models/gridApiPremium';
 
-export const useGridApiContext = useCommunityGridApiContext as <
-  GridApi extends GridApiCommon = GridApiPremium,
->() => React.MutableRefObject<GridApi>;
+export const useGridApiContext = useCommunityGridApiContext<GridApiPremium>;

--- a/packages/grid/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
@@ -1,7 +1,4 @@
-import * as React from 'react';
-import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid-pro';
+import { useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPremium } from '../../models/gridApiPremium';
 
-export const useGridApiRef = useCommunityGridApiRef as <
-  Api extends GridApiCommon = GridApiPremium,
->() => React.MutableRefObject<Api>;
+export const useGridApiRef = useCommunityGridApiRef<GridApiPremium>;

--- a/packages/grid/x-data-grid-pro/src/components/GridDetailPanelToggleCell.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/GridDetailPanelToggleCell.tsx
@@ -7,7 +7,6 @@ import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
 import { DataGridProProcessedProps } from '../models/dataGridProProps';
 import { gridDetailPanelExpandedRowsContentCacheSelector } from '../hooks/features/detailPanel/gridDetailPanelSelector';
-import { GridApiPro } from '../models/gridApiPro';
 
 type OwnerState = { classes: DataGridProProcessedProps['classes']; isExpanded: boolean };
 
@@ -25,7 +24,7 @@ const GridDetailPanelToggleCell = (props: GridRenderCellParams) => {
   const { id, value: isExpanded } = props;
 
   const rootProps = useGridRootProps();
-  const apiRef = useGridApiContext<GridApiPro>();
+  const apiRef = useGridApiContext();
   const ownerState: OwnerState = { classes: rootProps.classes, isExpanded };
   const classes = useUtilityClasses(ownerState);
 

--- a/packages/grid/x-data-grid-pro/src/hooks/utils/useGridApiContext.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/utils/useGridApiContext.ts
@@ -1,7 +1,4 @@
-import * as React from 'react';
-import { GridApiCommon, useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
+import { useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
 import { GridApiPro } from '../../models/gridApiPro';
 
-export const useGridApiContext = useCommunityGridApiContext as <
-  GridApi extends GridApiCommon = GridApiPro,
->() => React.MutableRefObject<GridApi>;
+export const useGridApiContext = useCommunityGridApiContext<GridApiPro>;

--- a/packages/grid/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
@@ -1,7 +1,4 @@
-import * as React from 'react';
-import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
+import { useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPro } from '../../models/gridApiPro';
 
-export const useGridApiRef = useCommunityGridApiRef as <
-  Api extends GridApiCommon = GridApiPro,
->() => React.MutableRefObject<Api>;
+export const useGridApiRef = useCommunityGridApiRef<GridApiPro>;


### PR DESCRIPTION
Just an opportunity for simplification I've noticed while working on https://github.com/mui/mui-x/pull/6388