### PR TITLE
[core] Send explicit warning when dayjs locale is not found

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/index.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/index.ts
@@ -5,7 +5,7 @@ import { buildWarning } from '../internals/utils/warning';
 
 const localeNotFoundWarning = buildWarning([
   'Your locale has not been found.',
-  'Either the locale key is nt a support one. Locales supported by dayjs are available here: https://github.com/iamkun/dayjs/tree/dev/src/locale',
+  'Either the locale key is not a supported one. Locales supported by dayjs are available here: https://github.com/iamkun/dayjs/tree/dev/src/locale',
   "Or you forget to import the locale with `require('dayjs/locale/{localeUsed}')`",
   'fallback on English locale',
 ]);

--- a/packages/x-date-pickers/src/AdapterDayjs/index.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/index.ts
@@ -1,6 +1,14 @@
 import { Dayjs } from 'dayjs';
 import BaseAdapterDayjs from '@date-io/dayjs';
 import { MuiFormatTokenMap, MuiPickerFieldAdapter } from '../internals/models';
+import { buildWarning } from '../internals/utils/warning';
+
+const localeNotFoundWarning = buildWarning([
+  'Your locale has not been found.',
+  'Either the locale key is nt a support one. Locales supported by dayjs are available here: https://github.com/iamkun/dayjs/tree/dev/src/locale',
+  "Or you forget to import the locale with `require('dayjs/locale/{localeUsed}')`",
+  'fallback on English locale',
+]);
 
 const formatTokenMap: MuiFormatTokenMap = {
   YY: 'year',
@@ -31,7 +39,13 @@ export class AdapterDayjs extends BaseAdapterDayjs implements MuiPickerFieldAdap
    * We should use this one in the future to support all localized formats.
    */
   public expandFormat = (format: string) => {
-    const localeFormats = this.rawDayJsInstance.Ls[this.locale || 'en']?.formats;
+    const localeObject = this.rawDayJsInstance.Ls[this.locale || 'en'];
+
+    if (localeObject === undefined) {
+      localeNotFoundWarning();
+    }
+    const localeFormats =
+      localeObject === undefined ? this.rawDayJsInstance.Ls.en.formats : localeObject.formats;
 
     // @see https://github.com/iamkun/dayjs/blob/dev/src/plugin/localizedFormat/index.js
     const t = (formatBis: string) =>


### PR DESCRIPTION
I was playing with #6337 codesanbox when I tried to use `fr` locale, if failed saying that `"L"` was not a valid token. It took me some time to realize `dayjs` needs to have `'fr'` and not `'frFR'`. And the I have to import `'dayjs/locale/fr'` to let it work.

This PR add a warning and a fallback on `en`