### PR TITLE
[test] Run the intergration tests in Firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,7 @@ jobs:
           command: git diff --exit-code
   test_browser:
     <<: *defaults
+    resource_class: 'medium+'
     docker:
       - image: mcr.microsoft.com/playwright@sha256:c3c8a833254aaad31b2d336e67b0dbb9af744a12ab486e18f230033b99649c4f
         environment:

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "^1.6.0",
     "karma-chrome-launcher": "^3.1.1",
+    "karma-firefox-launcher": "^2.1.2",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-webpack": "^5.0.0",

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.test.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.test.tsx
@@ -4,7 +4,7 @@ import { describeConformance } from '@mui/monorepo/test/utils';
 import { fireEvent, screen } from '@mui/monorepo/test/utils/createRenderer';
 import { expect } from 'chai';
 import { createPickerRenderer, stubMatchMedia, wrapPickerMount } from 'test/utils/pickers-utils';
-import { TimePicker } from './TimePicker';
+import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 
 describe('<TimePicker />', () => {
   const ControlledTimePicker = () => {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -30,6 +30,7 @@ const browserStack = {
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();
+process.env.FIREFOX_BIN = playwright.firefox.executablePath();
 
 // BrowserStack rate limit after 1600 calls every 5 minutes.
 // Per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
@@ -44,7 +45,7 @@ const MAX_CIRCLE_CI_CONCURRENCY = 83;
 module.exports = function setKarmaConfig(config) {
   const baseConfig = {
     basePath: '../',
-    browsers: ['chromeHeadless'],
+    browsers: ['chromeHeadless', 'Firefox'],
     browserDisconnectTimeout: 3 * 60 * 1000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 6 * 60 * 1000, // default 10000
@@ -64,7 +65,13 @@ module.exports = function setKarmaConfig(config) {
         included: true,
       },
     ],
-    plugins: ['karma-mocha', 'karma-chrome-launcher', 'karma-sourcemap-loader', 'karma-webpack'],
+    plugins: [
+      'karma-mocha',
+      'karma-chrome-launcher',
+      'karma-sourcemap-loader',
+      'karma-webpack',
+      'karma-firefox-launcher',
+    ],
     /**
      * possible values:
      * - config.LOG_DISABLE

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -45,7 +45,7 @@ const MAX_CIRCLE_CI_CONCURRENCY = 83;
 module.exports = function setKarmaConfig(config) {
   const baseConfig = {
     basePath: '../',
-    browsers: ['chromeHeadless', 'Firefox'],
+    browsers: ['chromeHeadless', 'FirefoxHeadless'],
     browserDisconnectTimeout: 3 * 60 * 1000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 6 * 60 * 1000, // default 10000

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,7 +2520,7 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.10.5"
+  version "5.10.8"
   resolved "https://github.com/mui/material-ui.git#f235e8ee868011f87c073d5cf28b6207168769ed"
 
 "@mui/private-theming@^5.10.6":
@@ -9516,6 +9516,14 @@ karma-chrome-launcher@^3.1.1:
   integrity sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==
   dependencies:
     which "^1.2.1"
+
+karma-firefox-launcher@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-2.1.2.tgz#9a38cc783c579a50f3ed2a82b7386186385cfc2d"
+  integrity sha512-VV9xDQU1QIboTrjtGVD4NCfzIH7n01ZXqy/qpBhnOeGVOkG5JYPEm8kuSd7psHE6WouZaQ9Ool92g8LFweSNMA==
+  dependencies:
+    is-wsl "^2.2.0"
+    which "^2.0.1"
 
 karma-mocha@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
#5874 had removed Firefox because BrowserStack was unreliable. This PR is adding it back this time using CircleCI as the execution environment.

If we want a different version of Firefox, we can use https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install-firefox.