### PR TITLE
[pickers] Do not use `Partial` for `components` and `componentsProps` props

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -325,7 +325,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
   const componentsForDayCalendar = {
     Day: DateRangePickerDay,
     ...components,
-  } as Partial<DayCalendarSlotsComponent<TDate>>;
+  } as DayCalendarSlotsComponent<TDate>;
 
   const componentsPropsForDayCalendar = {
     ...componentsProps,
@@ -343,7 +343,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
         ...(resolveComponentProps(componentsProps?.day, dayOwnerState) ?? {}),
       };
     },
-  } as Partial<DayCalendarSlotsComponentsProps<TDate>>;
+  } as DayCalendarSlotsComponentsProps<TDate>;
 
   return (
     <DateRangeCalendarRoot

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
@@ -50,12 +50,12 @@ export interface DateRangeCalendarProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateRangeCalendarSlotsComponent<TDate>>;
+  components?: DateRangeCalendarSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DateRangeCalendarSlotsComponentsProps<TDate>>;
+  componentsProps?: DateRangeCalendarSlotsComponentsProps<TDate>;
   /**
    * If `true`, after selecting `start` date calendar will not automatically switch to the month of `end` date.
    * @default false

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -40,12 +40,12 @@ export interface DateRangePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateRangePickerSlotsComponent<TDate>>;
+  components?: DateRangePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DateRangePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: DateRangePickerSlotsComponentsProps<TDate>;
 }
 
 type DateRangePickerComponent = (<TDate>(

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerView.tsx
@@ -52,12 +52,12 @@ export interface ExportedDateRangePickerViewProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateRangePickerViewSlotsComponent<TDate>>;
+  components?: DateRangePickerViewSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DateRangePickerViewSlotsComponentsProps<TDate>>;
+  componentsProps?: DateRangePickerViewSlotsComponentsProps<TDate>;
   /**
    * If `true`, after selecting `start` date calendar will not automatically switch to the month of `end` date.
    * @default false

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewDesktop.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewDesktop.tsx
@@ -77,12 +77,12 @@ export interface DateRangePickerViewDesktopProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DesktopDateRangeCalendarSlotsComponent<TDate>>;
+  components?: DesktopDateRangeCalendarSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DesktopDateRangeCalendarSlotsComponentsProps<TDate>>;
+  componentsProps?: DesktopDateRangeCalendarSlotsComponentsProps<TDate>;
   calendars: 1 | 2 | 3;
   value: DateRange<TDate>;
   changeMonth: (date: TDate) => void;
@@ -228,7 +228,7 @@ export function DateRangePickerViewDesktop<TDate>(inProps: DateRangePickerViewDe
   const componentsForDayCalendar = {
     Day: DateRangePickerDay,
     ...components,
-  } as Partial<DayCalendarSlotsComponent<TDate>>;
+  } as DayCalendarSlotsComponent<TDate>;
 
   const componentsPropsForDayCalendar = {
     ...componentsProps,
@@ -246,7 +246,7 @@ export function DateRangePickerViewDesktop<TDate>(inProps: DateRangePickerViewDe
         ...(resolveComponentProps(componentsProps?.day, dayOwnerState) ?? {}),
       };
     },
-  } as Partial<DayCalendarSlotsComponentsProps<TDate>>;
+  } as DayCalendarSlotsComponentsProps<TDate>;
 
   return (
     <DateRangePickerViewDesktopRoot className={clsx(className, classes.root)}>

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewMobile.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerViewMobile.tsx
@@ -46,12 +46,12 @@ interface DesktopDateRangeCalendarProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateRangePickerViewMobileSlotsComponent<TDate>>;
+  components?: DateRangePickerViewMobileSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DateRangePickerViewMobileSlotsComponentsProps<TDate>>;
+  componentsProps?: DateRangePickerViewMobileSlotsComponentsProps<TDate>;
   value: DateRange<TDate>;
   changeMonth: (date: TDate) => void;
 }
@@ -90,7 +90,7 @@ export function DateRangePickerViewMobile<TDate>(props: DesktopDateRangeCalendar
   const componentsForDayCalendar = {
     Day: DateRangePickerDay,
     ...components,
-  } as Partial<DayCalendarSlotsComponent<TDate>>;
+  } as DayCalendarSlotsComponent<TDate>;
 
   // Range going for the start of the start day to the end of the end day.
   // This makes sure that `isWithinRange` works with any time in the start and end day.
@@ -117,7 +117,7 @@ export function DateRangePickerViewMobile<TDate>(props: DesktopDateRangeCalendar
         ...(resolveComponentProps(componentsProps?.day, dayOwnerState) ?? {}),
       };
     },
-  } as Partial<DayCalendarSlotsComponentsProps<TDate>>;
+  } as DayCalendarSlotsComponentsProps<TDate>;
 
   return (
     <React.Fragment>

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -44,12 +44,12 @@ export interface DesktopDateRangePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DesktopDateRangePickerSlotsComponent<TDate>>;
+  components?: DesktopDateRangePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DesktopDateRangePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: DesktopDateRangePickerSlotsComponentsProps<TDate>;
 }
 
 type DesktopDateRangePickerComponent = (<TDate>(

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -44,12 +44,12 @@ export interface MobileDateRangePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<MobileDateRangePickerSlotsComponent<TDate>>;
+  components?: MobileDateRangePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<MobileDateRangePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: MobileDateRangePickerSlotsComponentsProps<TDate>;
 }
 
 type MobileDateRangePickerComponent = (<TDate>(

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -39,12 +39,12 @@ export interface StaticDateRangePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<StaticDateRangePickerSlotsComponent<TDate>>;
+  components?: StaticDateRangePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<StaticDateRangePickersSlotsComponentsProps<TDate>>;
+  componentsProps?: StaticDateRangePickersSlotsComponentsProps<TDate>;
 }
 
 type StaticDateRangePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
+++ b/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx
@@ -69,12 +69,12 @@ export interface ClockPickerProps<TDate> extends ExportedClockPickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<ClockPickerSlotsComponent>;
+  components?: ClockPickerSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<ClockPickerSlotsComponentsProps>;
+  componentsProps?: ClockPickerSlotsComponentsProps;
   /**
    * Selected date @DateIOType.
    */

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -63,12 +63,12 @@ export interface DateCalendarProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateCalendarSlotsComponent<TDate>>;
+  components?: DateCalendarSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DateCalendarSlotsComponentsProps<TDate>>;
+  componentsProps?: DateCalendarSlotsComponentsProps<TDate>;
   value: TDate | null;
   /**
    * Default calendar month displayed when `value={null}`.

--- a/packages/x-date-pickers/src/DateCalendar/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/PickersCalendarHeader.tsx
@@ -31,12 +31,12 @@ export interface PickersCalendarHeaderSlotsComponent extends PickersArrowSwitche
    * Button displayed to switch between different calendar views.
    * @default IconButton
    */
-  SwitchViewButton: React.ElementType;
+  SwitchViewButton?: React.ElementType;
   /**
    * Icon displayed in the SwitchViewButton. Rotated by 180° when the open view is 'year'.
    * @default ArrowDropDown
    */
-  SwitchViewIcon: React.ElementType;
+  SwitchViewIcon?: React.ElementType;
 }
 
 // We keep the interface to allow module augmentation
@@ -44,7 +44,7 @@ export interface PickersCalendarHeaderComponentsPropsOverrides {}
 
 export interface PickersCalendarHeaderSlotsComponentsProps
   extends PickersArrowSwitcherSlotsComponentsProps {
-  switchViewButton: React.ComponentPropsWithRef<typeof IconButton> &
+  switchViewButton?: React.ComponentPropsWithRef<typeof IconButton> &
     PickersCalendarHeaderComponentsPropsOverrides;
 }
 
@@ -55,12 +55,12 @@ export interface PickersCalendarHeaderProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<PickersCalendarHeaderSlotsComponent>;
+  components?: PickersCalendarHeaderSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<PickersCalendarHeaderSlotsComponentsProps>;
+  componentsProps?: PickersCalendarHeaderSlotsComponentsProps;
   currentMonth: TDate;
   disabled?: boolean;
   views: readonly CalendarPickerView[];

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -36,12 +36,12 @@ export interface DatePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DatePickerSlotsComponent<TDate>>;
+  components?: DatePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DatePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: DatePickerSlotsComponentsProps<TDate>;
 }
 
 type DatePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -36,12 +36,12 @@ export interface DateTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateTimePickerSlotsComponent<TDate>>;
+  components?: DateTimePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DateTimePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: DateTimePickerSlotsComponentsProps<TDate>;
 }
 
 type DateTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -33,12 +33,12 @@ export interface DesktopDatePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DesktopDatePickerSlotsComponent<TDate>>;
+  components?: DesktopDatePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DesktopDatePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: DesktopDatePickerSlotsComponentsProps<TDate>;
 }
 
 type DesktopDatePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -39,12 +39,12 @@ export interface DesktopDateTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DesktopDateTimePickerSlotsComponent<TDate>>;
+  components?: DesktopDateTimePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DesktopDateTimePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: DesktopDateTimePickerSlotsComponentsProps<TDate>;
 }
 
 type DesktopDateTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -38,12 +38,12 @@ export interface DesktopTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DesktopTimePickerSlotsComponent>;
+  components?: DesktopTimePickerSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DesktopTimePickerSlotsComponentsProps>;
+  componentsProps?: DesktopTimePickerSlotsComponentsProps;
 }
 
 type DesktopTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -33,12 +33,12 @@ export interface MobileDatePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<MobileDatePickerSlotsComponent<TDate>>;
+  components?: MobileDatePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<MobileDatePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: MobileDatePickerSlotsComponentsProps<TDate>;
 }
 
 type MobileDatePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -38,12 +38,12 @@ export interface MobileDateTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<MobileDateTimePickerSlotsComponent<TDate>>;
+  components?: MobileDateTimePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<MobileDateTimePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: MobileDateTimePickerSlotsComponentsProps<TDate>;
 }
 
 type MobileDateTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -37,12 +37,12 @@ export interface MobileTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<MobileTimePickerSlotsComponent>;
+  components?: MobileTimePickerSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<MobileTimePickerSlotsComponentsProps>;
+  componentsProps?: MobileTimePickerSlotsComponentsProps;
 }
 
 type MobileTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -33,12 +33,12 @@ export interface StaticDatePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<StaticDatePickerSlotsComponent<TDate>>;
+  components?: StaticDatePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<StaticDatePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: StaticDatePickerSlotsComponentsProps<TDate>;
 }
 
 type StaticDatePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -37,12 +37,12 @@ export interface StaticDateTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<StaticDateTimePickerSlotsComponent<TDate>>;
+  components?: StaticDateTimePickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<StaticDateTimePickerSlotsComponentsProps<TDate>>;
+  componentsProps?: StaticDateTimePickerSlotsComponentsProps<TDate>;
 }
 
 type StaticDateTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
@@ -36,12 +36,12 @@ export interface StaticTimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<StaticTimePickerSlotsComponents>;
+  components?: StaticTimePickerSlotsComponents;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<StaticTimePickerSlotsComponentsProps>;
+  componentsProps?: StaticTimePickerSlotsComponentsProps;
 }
 
 type StaticTimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
@@ -36,12 +36,12 @@ export interface TimePickerProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<TimePickerSlotsComponent>;
+  components?: TimePickerSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<TimePickerSlotsComponentsProps>;
+  componentsProps?: TimePickerSlotsComponentsProps;
 }
 
 type TimePickerComponent = (<TDate>(

--- a/packages/x-date-pickers/src/internals/components/CalendarOrClockPicker/CalendarOrClockPicker.tsx
+++ b/packages/x-date-pickers/src/internals/components/CalendarOrClockPicker/CalendarOrClockPicker.tsx
@@ -31,12 +31,12 @@ export interface CalendarOrClockPickerSlotsComponent<TDate>
    * Tabs enabling toggling between date and time pickers.
    * @default DateTimePickerTabs
    */
-  Tabs: React.ElementType<DateTimePickerTabsProps>;
+  Tabs?: React.ElementType<DateTimePickerTabsProps>;
 }
 
 export interface CalendarOrClockPickerSlotsComponentsProps<TDate>
   extends DateCalendarSlotsComponentsProps<TDate> {
-  tabs: Omit<DateTimePickerTabsProps, 'onChange' | 'view'>;
+  tabs?: Omit<DateTimePickerTabsProps, 'onChange' | 'view'>;
 }
 
 export interface ExportedCalendarOrClockPickerProps<TDate, View extends CalendarOrClockPickerView>
@@ -63,12 +63,12 @@ export interface ExportedCalendarOrClockPickerProps<TDate, View extends Calendar
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<CalendarOrClockPickerSlotsComponent<TDate>>;
+  components?: CalendarOrClockPickerSlotsComponent<TDate>;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<CalendarOrClockPickerSlotsComponentsProps<TDate>>;
+  componentsProps?: CalendarOrClockPickerSlotsComponentsProps<TDate>;
   toolbarFormat?: string;
   toolbarPlaceholder?: React.ReactNode;
   toolbarTitle?: React.ReactNode;

--- a/packages/x-date-pickers/src/internals/components/PickerStaticWrapper/PickerStaticWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerStaticWrapper/PickerStaticWrapper.tsx
@@ -61,12 +61,12 @@ export interface PickerStaticWrapperProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<PickersStaticWrapperSlotsComponent>;
+  components?: PickersStaticWrapperSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<PickersStaticWrapperSlotsComponentsProps>;
+  componentsProps?: PickersStaticWrapperSlotsComponentsProps;
 }
 
 const PickerStaticWrapperRoot = styled('div', {

--- a/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.types.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.types.tsx
@@ -9,12 +9,12 @@ export interface ExportedPickersArrowSwitcherProps {
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<PickersArrowSwitcherSlotsComponent>;
+  components?: PickersArrowSwitcherSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<PickersArrowSwitcherSlotsComponentsProps>;
+  componentsProps?: PickersArrowSwitcherSlotsComponentsProps;
   classes?: Partial<PickersArrowSwitcherClasses>;
 }
 
@@ -41,22 +41,22 @@ export interface PickersArrowSwitcherSlotsComponent {
    * Button allowing to switch to the left view.
    * @default IconButton
    */
-  PreviousIconButton: React.ElementType;
+  PreviousIconButton?: React.ElementType;
   /**
    * Button allowing to switch to the right view.
    * @default IconButton
    */
-  NextIconButton: React.ElementType;
+  NextIconButton?: React.ElementType;
   /**
    * Icon displayed in the left view switch button.
    * @default ArrowLeft
    */
-  LeftArrowIcon: React.ElementType;
+  LeftArrowIcon?: React.ElementType;
   /**
    * Icon displayed in the right view switch button.
    * @default ArrowRight
    */
-  RightArrowIcon: React.ElementType;
+  RightArrowIcon?: React.ElementType;
 }
 
 export interface PickersArrowSwitcherButtonSlotOwnerState extends PickersArrowSwitcherOwnerState {
@@ -64,22 +64,22 @@ export interface PickersArrowSwitcherButtonSlotOwnerState extends PickersArrowSw
 }
 
 export interface PickersArrowSwitcherSlotsComponentsProps {
-  previousIconButton: SlotComponentProps<
+  previousIconButton?: SlotComponentProps<
     typeof IconButton,
     PickersArrowSwitcherComponentsPropsOverrides,
     PickersArrowSwitcherButtonSlotOwnerState
   >;
-  nextIconButton: SlotComponentProps<
+  nextIconButton?: SlotComponentProps<
     typeof IconButton,
     PickersArrowSwitcherComponentsPropsOverrides,
     PickersArrowSwitcherButtonSlotOwnerState
   >;
-  leftArrowIcon: SlotComponentProps<
+  leftArrowIcon?: SlotComponentProps<
     typeof SvgIcon,
     PickersArrowSwitcherComponentsPropsOverrides,
     undefined
   >;
-  rightArrowIcon: SlotComponentProps<
+  rightArrowIcon?: SlotComponentProps<
     typeof SvgIcon,
     PickersArrowSwitcherComponentsPropsOverrides,
     undefined

--- a/packages/x-date-pickers/src/internals/components/PickersModalDialog.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersModalDialog.tsx
@@ -49,12 +49,12 @@ export interface PickersModalDialogProps extends PickerStateWrapperProps {
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<PickersModalDialogSlotsComponent>;
+  components?: PickersModalDialogSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<PickersModalDialogSlotsComponentsProps>;
+  componentsProps?: PickersModalDialogSlotsComponentsProps;
 }
 
 const PickersModalDialogRoot = styled(MuiDialog)({

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -73,8 +73,8 @@ export interface PickerPopperProps extends PickerStateWrapperProps {
   containerRef?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
   onBlur?: () => void;
-  components?: Partial<PickersPopperSlotsComponent>;
-  componentsProps?: Partial<PickersPopperSlotsComponentsProps>;
+  components?: PickersPopperSlotsComponent;
+  componentsProps?: PickersPopperSlotsComponentsProps;
   classes?: Partial<PickersPopperClasses>;
 }
 

--- a/packages/x-date-pickers/src/internals/components/PureDateInput.tsx
+++ b/packages/x-date-pickers/src/internals/components/PureDateInput.tsx
@@ -16,7 +16,7 @@ export interface DateInputSlotsComponent {
    * Icon displayed in the open picker button.
    * @default Calendar or Clock
    */
-  OpenPickerIcon: React.ElementType;
+  OpenPickerIcon?: React.ElementType;
 }
 
 export interface DateInputProps<TDate> {
@@ -30,7 +30,7 @@ export interface DateInputProps<TDate> {
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DateInputSlotsComponent>;
+  components?: DateInputSlotsComponent;
   disabled?: boolean;
   /**
    * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.

--- a/packages/x-date-pickers/src/internals/components/wrappers/DesktopWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/DesktopWrapper.tsx
@@ -37,12 +37,12 @@ export interface InternalDesktopWrapperProps<TDate>
    * Overrideable components.
    * @default {}
    */
-  components?: Partial<DesktopWrapperSlotsComponent>;
+  components?: DesktopWrapperSlotsComponent;
   /**
    * The props used for each component slot.
    * @default {}
    */
-  componentsProps?: Partial<DesktopWrapperSlotsComponentsProps>;
+  componentsProps?: DesktopWrapperSlotsComponentsProps;
 }
 
 export function DesktopWrapper<TDate>(props: InternalDesktopWrapperProps<TDate>) {

--- a/packages/x-date-pickers/src/internals/components/wrappers/MobileWrapper.tsx
+++ b/packages/x-date-pickers/src/internals/components/wrappers/MobileWrapper.tsx
@@ -30,8 +30,8 @@ export interface InternalMobileWrapperProps<TDate>
     PickerStateWrapperProps {
   DateInputProps: DateInputPropsLike & { ref?: React.Ref<HTMLDivElement> };
   PureDateInputComponent: React.JSXElementConstructor<DateInputPropsLike>;
-  components?: Partial<MobileWrapperSlotsComponent>;
-  componentsProps?: Partial<MobileWrapperSlotsComponentsProps>;
+  components?: MobileWrapperSlotsComponent;
+  componentsProps?: MobileWrapperSlotsComponentsProps;
 }
 
 export function MobileWrapper<TDate>(props: InternalMobileWrapperProps<TDate>) {


### PR DESCRIPTION
## Why ?

On the new pickers, some internal components have mandatory slots (`components.Field` for the mobile and desktop wrappers).
Which is not compatible with a `Partial` that makes every slot optional.

This PR replaces all `Partial` with an `?` on each of its slots.