### PR TITLE
[docs] Enable inlined preview for disbled date picker

### DIFF
--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
@@ -18,11 +18,11 @@ export default function FormPropsDatePickers() {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <Stack spacing={3}>
+    <Stack spacing={3}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DatePicker {...defaultProps} label="disabled" disabled />
         <DatePicker {...defaultProps} label="read-only" readOnly />
-      </Stack>
-    </LocalizationProvider>
+      </LocalizationProvider>
+    </Stack>
   );
 }

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
@@ -9,27 +9,19 @@ import Stack from '@mui/material/Stack';
 export default function FormPropsDatePickers() {
   const [value, setValue] = React.useState(null);
 
+  const defaultProps = {
+    value,
+    onChange: (newValue) => {
+      setValue(newValue);
+    },
+    renderInput: (params) => <TextField {...params} />,
+  };
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={3}>
-        <DatePicker
-          label="disabled"
-          disabled
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => <TextField {...params} />}
-        />
-        <DatePicker
-          label="read-only"
-          readOnly
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => <TextField {...params} />}
-        />
+        <DatePicker {...defaultProps} label="disabled" disabled />
+        <DatePicker {...defaultProps} label="read-only" readOnly />
       </Stack>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
@@ -21,7 +21,7 @@ export default function FormPropsDatePickers() {
     <Stack spacing={3}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DatePicker {...defaultProps} label="disabled" disabled />
-        <DatePicker {...defaultProps} label="read-only" readOnly />
+        <DatePicker {...defaultProps} label="readOnly" readOnly />
       </LocalizationProvider>
     </Stack>
   );

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
@@ -18,11 +18,11 @@ export default function FormPropsDatePickers() {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <Stack spacing={3}>
+    <Stack spacing={3}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DatePicker {...defaultProps} label="disabled" disabled />
         <DatePicker {...defaultProps} label="read-only" readOnly />
-      </Stack>
-    </LocalizationProvider>
+      </LocalizationProvider>
+    </Stack>
   );
 }

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
@@ -9,27 +9,19 @@ import Stack from '@mui/material/Stack';
 export default function FormPropsDatePickers() {
   const [value, setValue] = React.useState<Dayjs | null>(null);
 
+  const defaultProps = {
+    value,
+    onChange: (newValue: typeof value) => {
+      setValue(newValue);
+    },
+    renderInput: (params: any) => <TextField {...params} />,
+  };
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={3}>
-        <DatePicker
-          label="disabled"
-          disabled
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => <TextField {...params} />}
-        />
-        <DatePicker
-          label="read-only"
-          readOnly
-          value={value}
-          onChange={(newValue) => {
-            setValue(newValue);
-          }}
-          renderInput={(params) => <TextField {...params} />}
-        />
+        <DatePicker {...defaultProps} label="disabled" disabled />
+        <DatePicker {...defaultProps} label="read-only" readOnly />
       </Stack>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
@@ -21,7 +21,7 @@ export default function FormPropsDatePickers() {
     <Stack spacing={3}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DatePicker {...defaultProps} label="disabled" disabled />
-        <DatePicker {...defaultProps} label="read-only" readOnly />
+        <DatePicker {...defaultProps} label="readOnly" readOnly />
       </LocalizationProvider>
     </Stack>
   );

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
@@ -1,6 +1,4 @@
 <LocalizationProvider dateAdapter={AdapterDayjs}>
-  <Stack spacing={3}>
-    <DatePicker {...defaultProps} label="disabled" disabled />
-    <DatePicker {...defaultProps} label="read-only" readOnly />
-  </Stack>
+  <DatePicker {...defaultProps} label="disabled" disabled />
+  <DatePicker {...defaultProps} label="read-only" readOnly />
 </LocalizationProvider>

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
@@ -1,0 +1,6 @@
+<LocalizationProvider dateAdapter={AdapterDayjs}>
+  <Stack spacing={3}>
+    <DatePicker {...defaultProps} label="disabled" disabled />
+    <DatePicker {...defaultProps} label="read-only" readOnly />
+  </Stack>
+</LocalizationProvider>

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
@@ -1,4 +1,4 @@
 <LocalizationProvider dateAdapter={AdapterDayjs}>
   <DatePicker {...defaultProps} label="disabled" disabled />
-  <DatePicker {...defaultProps} label="read-only" readOnly />
+  <DatePicker {...defaultProps} label="readOnly" readOnly />
 </LocalizationProvider>


### PR DESCRIPTION
I was looking on how to integrate the date picker with a custom component inside Toolpad: https://master--toolpad.mui.com/_toolpad/app/cl4hla83p01949xoizo5uxf2a/pages/cl4hla87800029xoihl7tf4qz. I had to search how to disable the date picker, I found: https://mui.com/x/react-date-pickers/date-picker/#form-props. But I had to open the code sample to find the answer. It was a bit frustrating.

Preview: https://deploy-preview-6477--material-ui-x.netlify.app/x/react-date-pickers/date-picker/#form-props