### PR TITLE
v5.17.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 5.17.7
+
+_Oct 13, 2022_
+
+We'd like to offer a big thanks to the 2 contributors who made this release possible. Here are some highlights ✨:
+
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@5.17.7` / `@mui/x-data-grid-pro@5.17.7` / `@mui/x-data-grid-premium@5.17.7`
+
+#### Changes
+
+- [DataGrid] Fix error when using columnGrouping with all columns hidden (#6425) @alexfauquette
+- [DataGrid] Fix start edit mode with printable character in React 18 (#6478) @m4theushw
+
 ## 5.17.6
 
 _Oct 6, 2022_


### PR DESCRIPTION

- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [ ] Update the root `package.json`'s version
- [ ] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
- [ ] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
- [ ] Open PR with changes and wait for review and green CI.
- [ ] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

```sh
git push upstream next:docs-next -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v5` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)