### PR TITLE
v6.0.0 alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
   They might receive breaking changes on their props to have the best components possible by the time of the stable release.
 
 - 📝 Allow to limit to one filter per column for `DataGridPro` and `DataGridPremium` (#6333) @MBilalShafi
-- 🎁 Support pasting in pickers @flaviendelangle
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
@@ -43,14 +42,14 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
   For users that didn't migrate to the new editing API in v5, additional work may be needed because the new API is not equivalent to the legacy API. Although, some migration steps are available to help in this task.
 
   - The `editCellPropsChange` event was removed. If you still need it please file a new issue so we can propose an alternative.
-  - The `cellEditCommit` event was removed and the `processRowUpdate` prop can be used in place. More information, check the [docs](https://mui.com/x/react-data-grid/editing/#persistence) section about the topic.
-  - The `editRowsModel` and `onEditRowsModelChange` props were removed. The [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props can be used to achieve the same goal.
+  - The `cellEditCommit` event was removed and the `processRowUpdate` prop can be used in place. More information, check the [docs](https://next.mui.com/x/react-data-grid/editing/#persistence) section about the topic.
+  - The `editRowsModel` and `onEditRowsModelChange` props were removed. The [`cellModesModel`](https://next.mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://next.mui.com/x/react-data-grid/editing/#controlled-mode) props can be used to achieve the same goal.
   - The following API methods were removed:
     - Use `apiRef.current.stopCellEditMode` to replace `apiRef.current.commitCellChange`
     - Use `apiRef.current.startCellEditMode` to replace `apiRef.current.setCellMode(id, field, 'edit')`
     - Use `apiRef.current.stopRowEditMode` to replace `apiRef.current.commitRowChange`
     - Use `apiRef.current.startRowMode` to replace `apiRef.current.setRowMode(id, 'edit')`
-    - Use the [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props to replace `apiRef.current.setEditRowsModel`
+    - Use the [`cellModesModel`](https://next.mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://next.mui.com/x/react-data-grid/editing/#controlled-mode) props to replace `apiRef.current.setEditRowsModel`
 #### Changes
 
 - [DataGrid] Fix start edit mode with printable character in React 18 (#6257) @m4theushw
@@ -89,7 +88,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
   />
   ```
 
-  The `PopperProps` prop has been replaced by a `popper` component  props slot on all responsive and desktop pickers:
+  The `PopperProps` prop has been replaced by a `popper` component props slot on all responsive and desktop pickers:
 
   ```diff
   // Same on DesktopDatePicker, DateTimePicker, DesktopDateTimePicker, 
@@ -195,6 +194,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Create first publishable version of the field doc (#6323) @flaviendelangle
 - [docs] Fix trailing spaces in the readme @oliviertassinari
 - [docs] New page for the pickers: Validation (#6064) @flaviendelangle
+- [docs] Organize migration pages (#6480) @flaviendelangle
 
 ### Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,181 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## v6.0.0-alpha.3
+
+_Oct 13, 2022_
+
+We'd like to offer a big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
+
+
+- 📚 Documentation improvements
+
+From https://github.com/mui/mui-x/pull/6381
+
+
+#### Breaking changes
+
+- All the props used by the mobile and desktop wrappers to override components or components props has been replaced by component slots. You can find more information about this pattern in the [MUI Base documentation](https://mui.com/base/getting-started/usage/#shared-props).
+
+  Some of the names have also been prefixed by `desktop` when it was unclear that the behavior was only applied on the desktop version of the pickers (or the responsive version when used on a desktop).
+
+  The `DialogProps` prop has been replaced by a `dialog` component props slot on a responsive an mobile pickers:
+
+  ```diff
+  // Same on MobileDatePicker, DateTimePicker, MobileDateTimePicker, 
+  // TimePicker, MobileTimePicker, DateRangePicker and MobileDateRangePicker.
+  <DatePicker
+  -  DialogProps={{ backgroundColor: 'red' }}
+  +  componentsProps={{ dialog: { backgroundColor: 'red }}}
+  />
+  ```
+
+  The `PaperProps` prop has been replaced by a `desktopPaper` component props slot on all responsive and desktop pickers:
+
+  ```diff
+  // Same on DesktopDatePicker, DateTimePicker, DesktopDateTimePicker, 
+  // TimePicker, DesktopTimePicker, DateRangePicker and DesktopDateRangePicker.
+  <DatePicker
+  -  PaperProps={{ backgroundColor: 'red' }}
+  +  componentsProps={{ desktopPaper: { backgroundColor: 'red }}}
+  />
+  ```
+
+  The `PopperProps` prop has been replaced by a `popper` component  props slot on all responsive and desktop pickers:
+
+  ```diff
+  // Same on DesktopDatePicker, DateTimePicker, DesktopDateTimePicker, 
+  // TimePicker, DesktopTimePicker, DateRangePicker and DesktopDateRangePicker.
+  <DatePicker
+  -  PopperProps={{ onClick: handleClick }}
+  +  componentsProps={{ popper: { onClick: handleClick }}}
+  />
+  ```
+
+  The `TransitionComponent` prop has been replaced by a `DesktopTransition` component slot on all responsive and desktop pickers:
+
+  ```diff
+  // Same on DesktopDatePicker, DateTimePicker, DesktopDateTimePicker, 
+  // TimePicker, DesktopTimePicker, DateRangePicker and DesktopDateRangePicker.
+  <DatePicker
+  -  TransitionComponent={Fade}
+  +  components={{ DesktopTransition: Fade }}
+  />
+  ```
+
+  The `TrapFocusProps` prop has been replaced by a `desktopTrapFocus` component props slot on all responsive and desktop pickers:
+
+  ```diff
+  // Same on DesktopDatePicker, DateTimePicker, DesktopDateTimePicker, 
+  // TimePicker, DesktopTimePicker, DateRangePicker and DesktopDateRangePicker.
+  <DatePicker
+  -  TrapFocusProps={{ isEnabled: () => false }}
+  +  componentsProps={{ desktopTrapFocus: { isEnabled: () => false }}}
+  />
+  ```
+ 
+From https://github.com/mui/mui-x/pull/6389
+
+
+#### Breaking changes
+
+- The view components allowing to pick a date or parts of a date without an input have been renamed to better fit their usage:
+
+  ```diff
+  -<CalendarPicker {...props} />
+  +<DateCalendar  {...props} />
+  ```
+
+  ```diff
+  -<DayPicker {...props} />
+  +<DayCalendar  {...props} />
+  ```
+
+  ```diff
+  -<CalendarPickerSkeleton {...props} />
+  +<DayCalendarSkeleton  {...props} />
+  ```
+
+  ```diff
+  -<MonthPicker {...props} />
+  +<MonthCalendar  {...props} />
+  ```
+
+  ```diff
+  -<YearPicker {...props} />
+  +<YearCalendar  {...props} />
+  ```
+
+- Component names in the theme have changed as well:
+
+  ```diff
+  -MuiCalendarPicker: {
+  +MuiDateCalendar: {
+  ```
+
+  ```diff
+  -MuiDayPicker: {
+  +MuiDayCalendar: {
+  ```
+
+  ```diff
+  -MuiCalendarPickerSkeleton: {
+  +MuiDayCalendarSkeleton: {
+  ```
+
+  ```diff
+  -MuiMonthPicker: {
+  +MuiMonthCalendar: {
+  ```
+
+  ```diff
+  -MuiYearPicker: {
+  +MuiYearCalendar: {
+  ```
+### `@mui/x-data-grid@v__VERSION__` / `@mui/x-data-grid-pro@v__VERSION__` / `@mui/x-data-grid-premium@v__VERSION__`
+
+#### Changes
+
+- [DataGrid] Fix start edit mode with printable character in React 18 (#6257) @m4theushw
+- [DataGrid] Remove legacy editing API (#6016) @m4theushw
+- [DataGrid] Allow to limit to one filter per column (#6333) @MBilalShafi
+- [DataGrid] Simplify `useGridApiContext` and `useGridApiRef` type overrides (#6423) @cherniavskii
+- [DataGrid] Use generics instead of verbose state overrides (#6409) @cherniavskii
+
+### `@mui/x-date-pickers@v__PICKERS_VERSION__` / `@mui/x-date-pickers-pro@v__PICKERS_VERSION__`
+
+#### Changes
+
+- [DatePicker] Allows to fix the number of week displayed (#6299) @alexfauquette
+- [DateRangePicker] Fix calendar day outside of month layout shifting on hover (#6448) @alexfauquette
+- [fields] Prepare the field exports for the public release (#6467) @flaviendelangle
+- [fields] Support paste in single section (#6422) @alexfauquette
+- [pickers] Add field placeholders to the locale (#6337) @flaviendelangle
+- [pickers] Do not use `Partial` for `components` and `componentsProps` props (#6463) @flaviendelangle
+- [pickers] New component: `DateRangeCalendar` (#6416) @flaviendelangle
+- [pickers] Replace the `Picker` prefix in the view component by `Calendar` (eg: `MonthPicker` => `MonthCalendar`) (#6389) @flaviendelangle
+- [pickers] Support pasting on fields (#6364) @flaviendelangle
+- [pickers] Use slots in the mobile and desktop wrappers instead of `XXXComponent` and `XXXProps` (#6381) @flaviendelangle
+
+### Docs
+
+- [docs] Add migration to DataGrid v6 page (#6235) @m4theushw
+- [docs] Create first publishable version of the field doc (#6323) @flaviendelangle
+- [docs] Fix trailing spaces in the readme @oliviertassinari
+- [docs] New page for the pickers: Validation (#6064) @flaviendelangle
+
+### Core
+
+- [core] Add CodeQL workflow (#6387) @DanailH
+- [core] Add missing breaking change to the changelog (#6471) @flaviendelangle
+- [core] Fix playground structure (#6466) @LukasTy
+- [core] Fix tests for pasting on fields (#6465) @flaviendelangle
+- [core] Remove absolute link (#6420) @flaviendelangle
+- [core] Remove unused `react-text-mask` package (#6408) @LukasTy
+- [core] Send explicit warning when dayjs locale is not found (#6424) @alexfauquette
+- [core] Test validation on textfield and date views (#6265) @alexfauquette
+- New components: `MultiInputDateTimeRangePicker` and `MultiInputTimeRangePicker` (#6392) @alexfauquette
+- [test] Sync comment with monorepo @oliviertassinari
 ## v6.0.0-alpha.2
 
 _Oct 7, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ _Oct 13, 2022_
 
 We'd like to offer a big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
-- 🚀 Simplify `useGridApiContext` and `useGridApiRef` type overrides (#6423) @cherniavskii
+- ⌚️ New components to edit date and time with <kbd>keyboard</kbd>—without using any modal or dropdown UI.
+  Please check out our [documentation](https://next.mui.com/x/react-date-pickers/fields/) to discover those new components.
+  - [`DateField`](https://next.mui.com/x/react-date-pickers/date-field/) to edit date
+  - [`TimeField`](https://next.mui.com/x/react-date-pickers/time-field/)  to edit time
+  - [`DateTimeField`](https://next.mui.com/x/react-date-pickers/date-time-field/)  to edit date and time
+  - [`MultiInputDateRangeField` / `SingleInputDateRangeField`](https://next.mui.com/x/react-date-pickers/date-range-field/) to edit date range
+  - [`MultiInputTimeRangeField`](https://next.mui.com/x/react-date-pickers/time-range-field/) to edit time range with two inputs
+  - [`MultiInputDateTimeRangeField`](https://next.mui.com/x/react-date-pickers/date-time-range-field/) to edit date and time range with two inputs
+  
+  ⚠️ These components are unstable.
+  They might receive breaking changes on their props to have the best components possible by the time of the stable release.
+
 - 📝 Allow to limit to one filter per column for `DataGridPro` and `DataGridPremium` (#6333) @MBilalShafi
 - 🎁 Support pasting in pickers @flaviendelangle
 - 📚 Documentation improvements
@@ -17,6 +28,29 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 ### `@mui/x-data-grid@v6.0.0-alpha.3` / `@mui/x-data-grid-pro@v6.0.0-alpha.3` / `@mui/x-data-grid-premium@v6.0.0-alpha.3`
 
+#### Breaking changes
+
+- [DataGrid] Remove legacy editing API
+
+  The editing API that is enabled by default was replaced with a new API that contains better support for server-side persistence, validation and customization. This new editing feature was already available in v5 under the `newEditingApi` experimental flag. In v6, this flag can be removed.
+
+  ```diff
+   <DataGrid
+  -  experimentalFeatures={{ newEditingApi: true }}
+   />
+  ```
+
+  For users that didn't migrate to the new editing API in v5, additional work may be needed because the new API is not equivalent to the legacy API. Although, some migration steps are available to help in this task.
+
+  - The `editCellPropsChange` event was removed. If you still need it please file a new issue so we can propose an alternative.
+  - The `cellEditCommit` event was removed and the `processRowUpdate` prop can be used in place. More information, check the [docs](https://mui.com/x/react-data-grid/editing/#persistence) section about the topic.
+  - The `editRowsModel` and `onEditRowsModelChange` props were removed. The [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props can be used to achieve the same goal.
+  - The following API methods were removed:
+    - Use `apiRef.current.stopCellEditMode` to replace `apiRef.current.commitCellChange`
+    - Use `apiRef.current.startCellEditMode` to replace `apiRef.current.setCellMode(id, field, 'edit')`
+    - Use `apiRef.current.stopRowEditMode` to replace `apiRef.current.commitRowChange`
+    - Use `apiRef.current.startRowMode` to replace `apiRef.current.setRowMode(id, 'edit')`
+    - Use the [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props to replace `apiRef.current.setEditRowsModel`
 #### Changes
 
 - [DataGrid] Fix start edit mode with printable character in React 18 (#6257) @m4theushw
@@ -29,11 +63,11 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 #### Breaking changes
 
-- All the props used by the mobile and desktop wrappers to override components or components props has been replaced by component slots. You can find more information about this pattern in the [MUI Base documentation](https://mui.com/base/getting-started/usage/#shared-props).
+- All the props used by the mobile and desktop wrappers to override components or components' props have been replaced by component slots. You can find more information about this pattern in the [MUI Base documentation](https://mui.com/base/getting-started/usage/#shared-props).
 
   Some of the names have also been prefixed by `desktop` when it was unclear that the behavior was only applied on the desktop version of the pickers (or the responsive version when used on a desktop).
 
-  The `DialogProps` prop has been replaced by a `dialog` component props slot on a responsive an mobile pickers:
+  The `DialogProps` prop has been replaced by a `dialog` component props slot on responsive and mobile pickers:
 
   ```diff
   // Same on MobileDatePicker, DateTimePicker, MobileDateTimePicker, 
@@ -145,6 +179,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 - [DatePicker] Allows to fix the number of week displayed (#6299) @alexfauquette
 - [DateRangePicker] Fix calendar day outside of month layout shifting on hover (#6448) @alexfauquette
+- [fields] New components: `MultiInputDateTimeRangePicker` and `MultiInputTimeRangePicker` (#6392) @alexfauquette
 - [fields] Prepare the field exports for the public release (#6467) @flaviendelangle
 - [fields] Support paste in single section (#6422) @alexfauquette
 - [pickers] Add field placeholders to the locale (#6337) @flaviendelangle
@@ -171,7 +206,6 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [core] Remove unused `react-text-mask` package (#6408) @LukasTy
 - [core] Send explicit warning when dayjs locale is not found (#6424) @alexfauquette
 - [core] Test validation on textfield and date views (#6265) @alexfauquette
-- New components: `MultiInputDateTimeRangePicker` and `MultiInputTimeRangePicker` (#6392) @alexfauquette
 - [test] Sync comment with monorepo @oliviertassinari
 
 ## v6.0.0-alpha.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
   They might receive breaking changes on their props to have the best components possible by the time of the stable release.
 
 - 📝 Allow to limit to one filter per column for `DataGridPro` and `DataGridPremium` (#6333) @MBilalShafi
+- 📚 New [page describing the validation props on each picker](https://next.mui.com/x/react-date-pickers/validation/) (#6064) @flaviendelangle
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
@@ -50,6 +51,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
     - Use `apiRef.current.stopRowEditMode` to replace `apiRef.current.commitRowChange`
     - Use `apiRef.current.startRowMode` to replace `apiRef.current.setRowMode(id, 'edit')`
     - Use the [`cellModesModel`](https://next.mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://next.mui.com/x/react-data-grid/editing/#controlled-mode) props to replace `apiRef.current.setEditRowsModel`
+
 #### Changes
 
 - [DataGrid] Fix start edit mode with printable character in React 18 (#6257) @m4theushw
@@ -120,6 +122,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
   +  componentsProps={{ desktopTrapFocus: { isEnabled: () => false }}}
   />
   ```
+  
 - The view components allowing to pick a date or parts of a date without an input have been renamed to better fit their usage:
 
   ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,23 @@ _Oct 13, 2022_
 
 We'd like to offer a big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
 
-
+- 🚀 Simplify `useGridApiContext` and `useGridApiRef` type overrides (#6423) @cherniavskii
+- 📝 Allow to limit to one filter per column for `DataGridPro` and `DataGridPremium` (#6333) @MBilalShafi
+- 🎁 Support pasting in pickers @flaviendelangle
 - 📚 Documentation improvements
+- 🐞 Bugfixes
 
-From https://github.com/mui/mui-x/pull/6381
+### `@mui/x-data-grid@v6.0.0-alpha.3` / `@mui/x-data-grid-pro@v6.0.0-alpha.3` / `@mui/x-data-grid-premium@v6.0.0-alpha.3`
 
+#### Changes
+
+- [DataGrid] Fix start edit mode with printable character in React 18 (#6257) @m4theushw
+- [DataGrid] Remove legacy editing API (#6016) @m4theushw
+- [DataGrid] Simplify `useGridApiContext` and `useGridApiRef` type overrides (#6423) @cherniavskii
+- [DataGrid] Use generics instead of verbose state overrides (#6409) @cherniavskii
+- [DataGridPro] Allow to limit to one filter per column (#6333) @MBilalShafi
+
+### `@mui/x-date-pickers@v6.0.0-alpha.3` / `@mui/x-date-pickers-pro@v6.0.0-alpha.3`
 
 #### Breaking changes
 
@@ -75,12 +87,6 @@ From https://github.com/mui/mui-x/pull/6381
   +  componentsProps={{ desktopTrapFocus: { isEnabled: () => false }}}
   />
   ```
- 
-From https://github.com/mui/mui-x/pull/6389
-
-
-#### Breaking changes
-
 - The view components allowing to pick a date or parts of a date without an input have been renamed to better fit their usage:
 
   ```diff
@@ -134,17 +140,6 @@ From https://github.com/mui/mui-x/pull/6389
   -MuiYearPicker: {
   +MuiYearCalendar: {
   ```
-### `@mui/x-data-grid@v__VERSION__` / `@mui/x-data-grid-pro@v__VERSION__` / `@mui/x-data-grid-premium@v__VERSION__`
-
-#### Changes
-
-- [DataGrid] Fix start edit mode with printable character in React 18 (#6257) @m4theushw
-- [DataGrid] Remove legacy editing API (#6016) @m4theushw
-- [DataGrid] Allow to limit to one filter per column (#6333) @MBilalShafi
-- [DataGrid] Simplify `useGridApiContext` and `useGridApiRef` type overrides (#6423) @cherniavskii
-- [DataGrid] Use generics instead of verbose state overrides (#6409) @cherniavskii
-
-### `@mui/x-date-pickers@v__PICKERS_VERSION__` / `@mui/x-date-pickers-pro@v__PICKERS_VERSION__`
 
 #### Changes
 
@@ -178,6 +173,7 @@ From https://github.com/mui/mui-x/pull/6389
 - [core] Test validation on textfield and date views (#6265) @alexfauquette
 - New components: `MultiInputDateTimeRangePicker` and `MultiInputTimeRangePicker` (#6392) @alexfauquette
 - [test] Sync comment with monorepo @oliviertassinari
+
 ## v6.0.0-alpha.2
 
 _Oct 7, 2022_

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "private": true,
   "author": "MUI Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "private": true,
   "scripts": {
     "start": "yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@mui/base": "^5.0.0-alpha.101",
-    "@mui/x-data-grid-premium": "6.0.0-alpha.2",
+    "@mui/x-data-grid-premium": "6.0.0-alpha.3",
     "chance": "^1.1.8",
     "clsx": "^1.2.1",
     "lru-cache": "^7.14.0"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,9 +44,9 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@mui/utils": "^5.10.9",
-    "@mui/x-data-grid": "6.0.0-alpha.2",
-    "@mui/x-data-grid-pro": "6.0.0-alpha.2",
-    "@mui/x-license-pro": "6.0.0-alpha.2",
+    "@mui/x-data-grid": "6.0.0-alpha.3",
+    "@mui/x-data-grid-pro": "6.0.0-alpha.3",
+    "@mui/x-license-pro": "6.0.0-alpha.3",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "exceljs": "^4.3.0",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,8 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@mui/utils": "^5.10.9",
-    "@mui/x-data-grid": "6.0.0-alpha.2",
-    "@mui/x-license-pro": "6.0.0-alpha.2",
+    "@mui/x-data-grid": "6.0.0-alpha.3",
+    "@mui/x-license-pro": "6.0.0-alpha.3",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -47,8 +47,8 @@
     "@date-io/luxon": "^2.16.0",
     "@date-io/moment": "^2.16.0",
     "@mui/utils": "^5.10.9",
-    "@mui/x-date-pickers": "6.0.0-alpha.2",
-    "@mui/x-license-pro": "6.0.0-alpha.2",
+    "@mui/x-date-pickers": "6.0.0-alpha.3",
+    "@mui/x-license-pro": "6.0.0-alpha.3",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
     "react-transition-group": "^4.4.5",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license-pro",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-alpha.3",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",


### PR DESCRIPTION
- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [x] Update the root `package.json`'s version
- [x] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
- [x] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
- [x] Open PR with changes and wait for review and green CI.
- [ ] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

```sh
git push upstream next:docs-next -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v5` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)