### PR TITLE
[fields] Distinguish start and end input error on multi input fields

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/hooks/useMultiInputRangeField/useMultiInputDateRangeField.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMultiInputRangeField/useMultiInputDateRangeField.ts
@@ -14,7 +14,6 @@ import {
   validateDateRange,
 } from '../validation/useDateRangeValidation';
 import { dateRangePickerValueManager } from '../../../DateRangePicker/shared';
-import { dateRangeFieldValueManager } from '../valueManager/dateRangeValueManager';
 
 export const useMultiInputDateRangeField = <TDate, TChildProps extends {}>({
   sharedProps: inSharedProps,
@@ -81,19 +80,15 @@ export const useMultiInputDateRangeField = <TDate, TChildProps extends {}>({
     DateRangeValidationError,
     DateRangeComponentValidationProps<TDate>
   >({ ...sharedProps, value }, validateDateRange, () => true);
-  const inputError = React.useMemo(
-    () => dateRangeFieldValueManager.hasError(validationError),
-    [validationError],
-  );
 
   const startDateResponse = {
     ...rawStartDateResponse,
-    error: inputError,
+    error: !!validationError[0],
   };
 
   const endDateResponse = {
     ...rawEndDateResponse,
-    error: inputError,
+    error: !!validationError[1],
   };
 
   return { startDate: startDateResponse, endDate: endDateResponse };

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMultiInputRangeField/useMultiInputDateTimeRangeField.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMultiInputRangeField/useMultiInputDateTimeRangeField.ts
@@ -22,7 +22,6 @@ import {
   validateDateTimeRange,
 } from '../validation/useDateTimeRangeValidation';
 import { dateRangePickerValueManager } from '../../../DateRangePicker/shared';
-import { dateTimeRangeFieldValueManager } from '../valueManager/dateTimeRangeValueManager';
 
 export const useDefaultizedDateTimeRangeFieldProps = <TDate, AdditionalProps extends {}>(
   props: UseMultiInputDateTimeRangeFieldProps<TDate>,
@@ -113,19 +112,15 @@ export const useMultiInputDateTimeRangeField = <TDate, TChildProps extends {}>({
     DateTimeRangeValidationError,
     DateTimeRangeComponentValidationProps<TDate>
   >({ ...sharedProps, value }, validateDateTimeRange, () => true);
-  const inputError = React.useMemo(
-    () => dateTimeRangeFieldValueManager.hasError(validationError),
-    [validationError],
-  );
 
   const startDateResponse = {
     ...rawStartDateResponse,
-    error: inputError,
+    error: !!validationError[0],
   };
 
   const endDateResponse = {
     ...rawEndDateResponse,
-    error: inputError,
+    error: !!validationError[1],
   };
 
   return { startDate: startDateResponse, endDate: endDateResponse };

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMultiInputRangeField/useMultiInputTimeRangeField.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMultiInputRangeField/useMultiInputTimeRangeField.ts
@@ -17,7 +17,6 @@ import {
   UseMultiInputTimeRangeFieldProps,
 } from '../../../MultiInputTimeRangeField/MultiInputTimeRangeField.types';
 import { dateRangePickerValueManager } from '../../../DateRangePicker/shared';
-import { timeRangeFieldValueManager } from '../valueManager/timeRangeValueManager';
 
 export const useDefaultizedTimeRangeFieldProps = <TDate, AdditionalProps extends {}>(
   props: UseMultiInputTimeRangeFieldProps<TDate>,
@@ -102,19 +101,15 @@ export const useMultiInputTimeRangeField = <TDate, TChildProps extends {}>({
     TimeRangeValidationError,
     TimeRangeComponentValidationProps
   >({ ...sharedProps, value }, validateTimeRange, () => true);
-  const inputError = React.useMemo(
-    () => timeRangeFieldValueManager.hasError(validationError),
-    [validationError],
-  );
 
   const startDateResponse = {
     ...rawStartDateResponse,
-    error: inputError,
+    error: !!validationError[0],
   };
 
   const endDateResponse = {
     ...rawEndDateResponse,
-    error: inputError,
+    error: !!validationError[1],
   };
 
   return { startDate: startDateResponse, endDate: endDateResponse };


### PR DESCRIPTION
### Goal

When only one of the two date does not pass the validation, we should only mark its input as invalid.
That is the behavior on the current `DateRangePicker` component.

For the single input range fields, we have to set the whole input as invalid of course.

### Reproduction case

On both examples below, only the start date is invalid (it is before the `minDate` prop)

[Before](https://codesandbox.io/s/date-and-time-pickers-forked-9pqyfg?file=/src/App.tsx)
[After](https://codesandbox.io/s/date-and-time-pickers-forked-czkwue?file=/src/App.tsx)