### PR TITLE
[fields] Add a `validationError` property to the `onChange` callback

### DIFF
--- a/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.js
+++ b/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.js
@@ -19,8 +19,8 @@ export default function LifeCycleIgnoreInvalidValue() {
               setValue(newValue);
             }
           }}
-          minDate={dayjs('2022-04-01')}
-          maxDate={dayjs('2022-04-30')}
+          minDate={dayjs('2022-01-01')}
+          maxDate={dayjs('2022-12-31')}
         />
       </LocalizationProvider>
       <Typography>Value: {value == null ? 'null' : value.format('L')}</Typography>

--- a/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.js
+++ b/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
+
+export default function LifeCycleIgnoreInvalidValue() {
+  const [value, setValue] = React.useState(null);
+
+  return (
+    <Stack spacing={2}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <DateField
+          value={value}
+          onChange={(newValue, context) => {
+            if (context.validationError == null) {
+              setValue(newValue);
+            }
+          }}
+          minDate={dayjs('2022-04-01')}
+          maxDate={dayjs('2022-04-30')}
+        />
+      </LocalizationProvider>
+      <Typography>Value: {value == null ? 'null' : value.format('L')}</Typography>
+    </Stack>
+  );
+}

--- a/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx
+++ b/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx
@@ -19,8 +19,8 @@ export default function LifeCycleIgnoreInvalidValue() {
               setValue(newValue);
             }
           }}
-          minDate={dayjs('2022-04-01')}
-          maxDate={dayjs('2022-04-30')}
+          minDate={dayjs('2022-01-01')}
+          maxDate={dayjs('2022-12-31')}
         />
       </LocalizationProvider>
       <Typography>Value: {value == null ? 'null' : value.format('L')}</Typography>

--- a/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx
+++ b/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
+
+export default function LifeCycleIgnoreInvalidValue() {
+  const [value, setValue] = React.useState<Dayjs | null>(null);
+
+  return (
+    <Stack spacing={2}>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <DateField
+          value={value}
+          onChange={(newValue, context) => {
+            if (context.validationError == null) {
+              setValue(newValue);
+            }
+          }}
+          minDate={dayjs('2022-04-01')}
+          maxDate={dayjs('2022-04-30')}
+        />
+      </LocalizationProvider>
+      <Typography>Value: {value == null ? 'null' : value.format('L')}</Typography>
+    </Stack>
+  );
+}

--- a/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx.preview
+++ b/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx.preview
@@ -6,8 +6,8 @@
         setValue(newValue);
       }
     }}
-    minDate={dayjs('2022-04-01')}
-    maxDate={dayjs('2022-04-30')}
+    minDate={dayjs('2022-01-01')}
+    maxDate={dayjs('2022-12-31')}
   />
 </LocalizationProvider>
 <Typography>Value: {value == null ? 'null' : value.format('L')}</Typography>

--- a/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx.preview
+++ b/docs/data/date-pickers/fields/LifeCycleIgnoreInvalidValue.tsx.preview
@@ -1,0 +1,13 @@
+<LocalizationProvider dateAdapter={AdapterDayjs}>
+  <DateField
+    value={value}
+    onChange={(newValue, context) => {
+      if (context.validationError == null) {
+        setValue(newValue);
+      }
+    }}
+    minDate={dayjs('2022-04-01')}
+    maxDate={dayjs('2022-04-30')}
+  />
+</LocalizationProvider>
+<Typography>Value: {value == null ? 'null' : value.format('L')}</Typography>

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -87,7 +87,7 @@ But changing the value of an end date section will not fire `onChange` until the
 The `onChange` callback received a 2nd parameter containing the validation error associated to the current value.
 If you only want to update your state when the value is valid, you can ignore any `onChange` call with a non-null `validationError`.
 
-In the example below, `onChange` will only be fired if the date is valid and in April 2022:
+In the example below, `onChange` will only be fired if the date is valid and its year is 2022:
 
 {{"demo": "LifeCycleIgnoreInvalidValue.js"}}
 

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -82,6 +82,15 @@ But changing the value of an end date section will not fire `onChange` until the
 
 {{"demo": "LifeCycleDateRangeField.js", "defaultCodeOpen": false}}
 
+#### Only update when the value is valid
+
+The `onChange` callback received a 2nd parameter containing the validation error associated to the current value.
+If you only want to update your state when the value is valid, you can ignore any `onChange` call with a non-null `validationError`.
+
+In the example below, `onChange` will only be fired if the date is valid and in April 2022:
+
+{{"demo": "LifeCycleIgnoreInvalidValue.js"}}
+
 ### Control the selected sections
 
 Use the `selectedSections` and `onSelectedSectionsChange` props to control which sections are currently being selected.

--- a/packages/x-date-pickers/src/internals-fields/index.ts
+++ b/packages/x-date-pickers/src/internals-fields/index.ts
@@ -12,4 +12,6 @@ export type {
   UseFieldResponse,
   FieldValueManager,
   FieldSection,
+  FieldChangeHandler,
+  FieldChangeHandlerContext,
 } from '../internals/hooks/useField';

--- a/packages/x-date-pickers/src/internals/hooks/useField/index.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/index.ts
@@ -7,6 +7,8 @@ export type {
   UseFieldParams,
   UseFieldResponse,
   FieldSelectedSections,
+  FieldChangeHandler,
+  FieldChangeHandlerContext,
 } from './useField.interfaces';
 export {
   splitFormatIntoSections,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
@@ -27,7 +27,7 @@ export interface UseFieldParams<
 
 export interface UseFieldInternalProps<TValue, TError> {
   value?: TValue;
-  onChange?: (value: TValue) => void;
+  onChange?: (value: TValue, context: FieldChangeHandlerContext<TError>) => void;
   onError?: (error: TError, value: TValue) => void;
   /**
    * The default value. Use when the component is not controlled.
@@ -104,6 +104,10 @@ export type FieldBoundaries<TDate, TSection extends FieldSection> = Record<
   MuiDateSectionName,
   (currentDate: TDate | null, section: TSection) => { minimum: number; maximum: number }
 >;
+
+export interface FieldChangeHandlerContext<TError> {
+  validationError: TError | null;
+}
 
 /**
  * Object used to access and update the active value.

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
@@ -27,7 +27,7 @@ export interface UseFieldParams<
 
 export interface UseFieldInternalProps<TValue, TError> {
   value?: TValue;
-  onChange?: (value: TValue, context: FieldChangeHandlerContext<TError>) => void;
+  onChange?: FieldChangeHandler<TValue, TError>;
   onError?: (error: TError, value: TValue) => void;
   /**
    * The default value. Use when the component is not controlled.
@@ -104,6 +104,11 @@ export type FieldBoundaries<TDate, TSection extends FieldSection> = Record<
   MuiDateSectionName,
   (currentDate: TDate | null, section: TSection) => { minimum: number; maximum: number }
 >;
+
+export type FieldChangeHandler<TValue, TError> = (
+  value: TValue,
+  context: FieldChangeHandlerContext<TError>,
+) => void;
 
 export interface FieldChangeHandlerContext<TError> {
   validationError: TError;

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.interfaces.ts
@@ -106,7 +106,7 @@ export type FieldBoundaries<TDate, TSection extends FieldSection> = Record<
 >;
 
 export interface FieldChangeHandlerContext<TError> {
-  validationError: TError | null;
+  validationError: TError;
 }
 
 /**

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -55,6 +55,7 @@ export const useField = <
 
   const {
     inputRef: inputRefProp,
+    internalProps,
     internalProps: { readOnly = false },
     forwardedProps: { onClick, onKeyDown, onFocus, onBlur, onMouseUp, ...otherForwardedProps },
     fieldValueManager,
@@ -446,7 +447,7 @@ export const useField = <
   });
 
   const validationError = useValidation(
-    { ...params.internalProps, value: state.value },
+    { ...internalProps, value: state.value },
     validator,
     fieldValueManager.isSameError,
   );

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import useControlled from '@mui/utils/useControlled';
 import { MuiPickerFieldAdapter } from '../../models/muiPickersAdapter';
-import { useUtils, useLocaleText } from '../useUtils';
+import { useUtils, useLocaleText, useLocalizationContext } from '../useUtils';
 import {
   FieldSection,
   UseFieldForwardedProps,
@@ -11,6 +11,7 @@ import {
   FieldSelectedSectionsIndexes,
   FieldSelectedSections,
   FieldBoundaries,
+  FieldChangeHandlerContext,
 } from './useField.interfaces';
 import {
   addPositionPropertiesToSections,
@@ -28,6 +29,9 @@ interface UpdateSectionValueParams<TDate, TSection extends FieldSection> {
   setSectionValueOnSections: (boundaries: FieldBoundaries<TDate, TSection>) => string;
 }
 
+type InferError<TInternalProps extends UseFieldInternalProps<any, any>> =
+  TInternalProps extends UseFieldInternalProps<any, infer TError> ? TError : never;
+
 export const useFieldState = <
   TValue,
   TDate,
@@ -38,12 +42,15 @@ export const useFieldState = <
   params: UseFieldParams<TValue, TDate, TSection, TForwardedProps, TInternalProps>,
 ) => {
   const utils = useUtils<TDate>() as MuiPickerFieldAdapter<TDate>;
-  const localeText = useLocaleText();
+  const localeText = useLocaleText<TDate>();
+  const adapter = useLocalizationContext<TDate>();
 
   const {
     valueManager,
     fieldValueManager,
     supportedDateSections,
+    validator,
+    internalProps,
     internalProps: {
       value: valueProp,
       defaultValue,
@@ -137,7 +144,13 @@ export const useFieldState = <
       tempValueStrAndroid: null,
     }));
 
-    onChange?.(value);
+    if (onChange) {
+      const context: FieldChangeHandlerContext<InferError<TInternalProps>> = {
+        validationError: validator({ adapter, value, props: { ...internalProps, value } }),
+      };
+
+      onChange(value, context);
+    }
   };
 
   const setSectionValue = (sectionIndex: number, newSectionValue: string) => {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -23,14 +23,14 @@ import {
   validateSections,
 } from './useField.utils';
 
+type InferErrorFromInternalProps<TInternalProps extends UseFieldInternalProps<any, any>> =
+  TInternalProps extends UseFieldInternalProps<any, infer TError> ? TError : never;
+
 interface UpdateSectionValueParams<TDate, TSection extends FieldSection> {
   activeSection: TSection;
   setSectionValueOnDate: (activeDate: TDate, boundaries: FieldBoundaries<TDate, TSection>) => TDate;
   setSectionValueOnSections: (boundaries: FieldBoundaries<TDate, TSection>) => string;
 }
-
-type InferError<TInternalProps extends UseFieldInternalProps<any, any>> =
-  TInternalProps extends UseFieldInternalProps<any, infer TError> ? TError : never;
 
 export const useFieldState = <
   TValue,
@@ -145,7 +145,7 @@ export const useFieldState = <
     }));
 
     if (onChange) {
-      const context: FieldChangeHandlerContext<InferError<TInternalProps>> = {
+      const context: FieldChangeHandlerContext<InferErrorFromInternalProps<TInternalProps>> = {
         validationError: validator({ adapter, value, props: { ...internalProps, value } }),
       };
 


### PR DESCRIPTION
Fixes #6421

- [x] Pass the validation error in the `onChange` callback

I went for an object instead of just passing the validation error as the 2nd parameter to be future proof.
I think that the validation is light enough to compute it on every call but we could change for a lazy approach:


```tsx
interface FieldChangeHandlerContext<TError> {
  validationError: TError;
}

onChange: (value: TValue,  getContext: () => FieldChangeHandlerContext<TError>) => void;
```

Or 


```tsx
interface FieldChangeHandlerContext<TError> {
  getValidationError: () => TError;
}

onChange: (value: TValue,  context: FieldChangeHandlerContext<TError>) => void;
```