### PR TITLE
[DataGridPro] Fix row order being reset after updating the row

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -332,6 +332,7 @@ export const useGridRows = (
           ids: updatedRows,
         },
       }));
+      apiRef.current.unstable_caches.rows.ids = updatedRows;
       apiRef.current.publishEvent('rowsSet');
     },
     [apiRef, logger],


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/6520

Before: https://codesandbox.io/s/focused-butterfly-mun6yt?file=/demo.tsx
After: https://codesandbox.io/s/white-firefly-u5tlib?file=/demo.tsx