### PR TITLE
[core] Organize tests for pickers slots

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -97,8 +97,8 @@ describe('<DateRangeCalendar />', () => {
     });
   });
 
-  describe('Component slots', () => {
-    it('slot: `Day` - renders custom day', () => {
+  describe('Component slots: Day', () => {
+    it('should render custom day component', () => {
       render(
         <DateRangeCalendar
           components={{

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -361,8 +361,8 @@ describe('<DesktopDateRangePicker />', () => {
   });
 
   // TODO: Remove on new pickers, has been moved to `DateRangeCalendar` tests
-  describe('Component slots', () => {
-    it('slot: `Day` - renders custom day', () => {
+  describe('Component slots: Day', () => {
+    it('should render custom day component', () => {
       render(
         <WrappedDesktopDateRangePicker
           components={{
@@ -385,32 +385,6 @@ describe('<DesktopDateRangePicker />', () => {
     openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
 
     expect(screen.getAllByMuiTest('pickers-calendar')).to.have.length(3);
-  });
-
-  it('componentsProps `actionBar` - allows to renders clear button in Desktop mode', () => {
-    function DesktopDateRangePickerClearable() {
-      return (
-        <WrappedDesktopDateRangePicker
-          initialValue={[
-            adapterToUse.date(new Date(2018, 0, 1)),
-            adapterToUse.date(new Date(2018, 0, 31)),
-          ]}
-          componentsProps={{ actionBar: { actions: ['clear'] } }}
-        />
-      );
-    }
-    render(<DesktopDateRangePickerClearable />);
-
-    openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
-
-    expect(screen.getAllByRole('textbox')[0]).to.have.value('01/01/2018');
-    expect(screen.getAllByRole('textbox')[1]).to.have.value('01/31/2018');
-
-    fireEvent.click(screen.getByText('Clear'));
-
-    expect(screen.getAllByRole('textbox')[0]).to.have.value('');
-    expect(screen.getAllByRole('textbox')[1]).to.have.value('');
-    expect(screen.queryByRole('dialog')).to.equal(null);
   });
 
   // TODO: Remove on new pickers, has been moved to `DateRangeCalendar` tests
@@ -465,7 +439,35 @@ describe('<DesktopDateRangePicker />', () => {
     });
   });
 
-  describe('componentsProps: popper', () => {
+  describe('Component slots: ActionBar', () => {
+    it('should render custom actions', () => {
+      function DesktopDateRangePickerClearable() {
+        return (
+          <WrappedDesktopDateRangePicker
+            initialValue={[
+              adapterToUse.date(new Date(2018, 0, 1)),
+              adapterToUse.date(new Date(2018, 0, 31)),
+            ]}
+            componentsProps={{ actionBar: { actions: ['clear'] } }}
+          />
+        );
+      }
+      render(<DesktopDateRangePickerClearable />);
+
+      openPicker({ type: 'date-range', variant: 'desktop', initialFocus: 'start' });
+
+      expect(screen.getAllByRole('textbox')[0]).to.have.value('01/01/2018');
+      expect(screen.getAllByRole('textbox')[1]).to.have.value('01/31/2018');
+
+      fireEvent.click(screen.getByText('Clear'));
+
+      expect(screen.getAllByRole('textbox')[0]).to.have.value('');
+      expect(screen.getAllByRole('textbox')[1]).to.have.value('');
+      expect(screen.queryByRole('dialog')).to.equal(null);
+    });
+  });
+
+  describe('Component slots: Popper', () => {
     it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -186,8 +186,8 @@ describe('<DesktopDatePicker />', () => {
     expect(screen.getByLabelText('year view is open, switch to calendar view')).toBeVisible();
   });
 
-  describe('componentsProps: popper', () => {
-    it('forwards onClick and onTouchStart', () => {
+  describe('Component slots: Popper', () => {
+    it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();
       render(
@@ -214,7 +214,7 @@ describe('<DesktopDatePicker />', () => {
     });
   });
 
-  describe('componentsProps: desktopPaper', () => {
+  describe('Component slots: DesktopPaper', () => {
     it('forwards onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -244,8 +244,8 @@ describe('<DesktopDateTimePicker />', () => {
     expect(onChange.lastCall.args[0]).toEqualDateTime(new Date('2018-01-01T10:53:00.000'));
   });
 
-  describe('componentsProps: popper', () => {
-    it('forwards onClick and onTouchStart', () => {
+  describe('Component slots: Popper', () => {
+    it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();
       render(
@@ -272,8 +272,8 @@ describe('<DesktopDateTimePicker />', () => {
     });
   });
 
-  describe('componentsProps: desktopPaper', () => {
-    it('forwards onClick and onTouchStart', () => {
+  describe('Component slots: DesktopPaper', () => {
+    it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();
       render(

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -265,8 +265,8 @@ describe('<DesktopTimePicker />', () => {
     });
   });
 
-  describe('componentsProps: popper', () => {
-    it('forwards onClick and onTouchStart', () => {
+  describe('Component slots: Popper', () => {
+    it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();
       render(
@@ -293,8 +293,8 @@ describe('<DesktopTimePicker />', () => {
     });
   });
 
-  describe('componentsProps: desktopPaper', () => {
-    it('forwards onClick and onTouchStart', () => {
+  describe('Component slots: DesktopPaper', () => {
+    it('should forward onClick and onTouchStart', () => {
       const handleClick = spy();
       const handleTouchStart = spy();
       render(

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.test.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.test.tsx
@@ -21,7 +21,7 @@ const ContextListener = ({
   return null;
 };
 
-describe('component <LocalizationProvider />', () => {
+describe('<LocalizationProvider />', () => {
   const { render } = createRenderer();
 
   it('should respect localeText from the theme', () => {


### PR DESCRIPTION
On my previous PRs to migrate to slots, I did not follow a consistent nomenclature for the tests.
This PR is here to clean that a bit.


I propose to always apply the following pattern for component slots tests:

```ts
describe('Component slots: Popper', () => {});
```

It allows to easily look for all the tests related to one slot across components.

It would also probably be nice to create conformance tests like `describeValidation` for the various slots to test it more in depth.