### PR TITLE
[pickers] Improve consistency between single and multiple range pickers

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/hooks/validation/useDateRangeValidation.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/validation/useDateRangeValidation.ts
@@ -21,11 +21,6 @@ export const validateDateRange: Validator<
 > = ({ props, value, adapter }) => {
   const [start, end] = value;
 
-  // for partial input
-  if (start === null || end === null) {
-    return [null, null];
-  }
-
   const { shouldDisableDate, ...otherProps } = props;
 
   const dateValidations: [DateRangeValidationErrorValue, DateRangeValidationErrorValue] = [
@@ -49,6 +44,11 @@ export const validateDateRange: Validator<
 
   if (dateValidations[0] || dateValidations[1]) {
     return dateValidations;
+  }
+
+  // for partial input
+  if (start === null || end === null) {
+    return [null, null];
   }
 
   if (!isRangeValid(adapter.utils, value)) {

--- a/packages/x-date-pickers-pro/src/internal/hooks/validation/useDateTimeRangeValidation.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/validation/useDateTimeRangeValidation.ts
@@ -24,11 +24,6 @@ export const validateDateTimeRange: Validator<
 > = ({ props, value, adapter }) => {
   const [start, end] = value;
 
-  // for partial input
-  if (start === null || end === null) {
-    return [null, null];
-  }
-
   const { shouldDisableDate, ...otherProps } = props;
 
   const dateTimeValidations: [
@@ -55,6 +50,11 @@ export const validateDateTimeRange: Validator<
 
   if (dateTimeValidations[0] || dateTimeValidations[1]) {
     return dateTimeValidations;
+  }
+
+  // for partial input
+  if (start === null || end === null) {
+    return [null, null];
   }
 
   if (!isRangeValid(adapter.utils, value)) {

--- a/packages/x-date-pickers-pro/src/internal/hooks/validation/useTimeRangeValidation.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/validation/useTimeRangeValidation.ts
@@ -19,11 +19,6 @@ export const validateTimeRange: Validator<
 > = ({ props, value, adapter }) => {
   const [start, end] = value;
 
-  // for partial input
-  if (start === null || end === null) {
-    return [null, null];
-  }
-
   const dateTimeValidations: [TimeRangeValidationErrorValue, TimeRangeValidationErrorValue] = [
     validateTime({
       adapter,
@@ -39,6 +34,11 @@ export const validateTimeRange: Validator<
 
   if (dateTimeValidations[0] || dateTimeValidations[1]) {
     return dateTimeValidations;
+  }
+
+  // for partial input
+  if (start === null || end === null) {
+    return [null, null];
   }
 
   if (!isRangeValid(adapter.utils, value)) {

--- a/packages/x-date-pickers-pro/src/tests/describeValidation.tsx
+++ b/packages/x-date-pickers-pro/src/tests/describeValidation.tsx
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
-import { BaseDateValidationProps } from '@mui/x-date-pickers/internals';
+import { BaseDateValidationProps, TimeValidationProps } from '@mui/x-date-pickers/internals';
 // import testDayViewValidation from './testValidation/testDayViewValidation';
 import testTextFieldValidation from './testValidation/testTextFieldValidation';
 import { DayRangeValidationProps } from '../internal/models';
 
 type ValidationProps =
-  | keyof (DayRangeValidationProps<any> & BaseDateValidationProps<any>)
+  | keyof (DayRangeValidationProps<any> & BaseDateValidationProps<any> & TimeValidationProps<any>)
   | 'minDateTime'
   | 'maxDateTime';
 
@@ -17,8 +17,8 @@ const defaultAvailableProps: ValidationProps[] = [
   'minDate',
   'maxDate',
   // time range
-  'minDate',
-  'maxDate',
+  'minTime',
+  'maxTime',
   // date time range
   'minDateTime',
   'maxDateTime',

--- a/packages/x-date-pickers-pro/src/tests/testValidation/testTextFieldValidation.tsx
+++ b/packages/x-date-pickers-pro/src/tests/testValidation/testTextFieldValidation.tsx
@@ -325,6 +325,50 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
         });
         testInvalidStatus([false, false], isSingleInput);
       });
+
+      it('should apply minDate when only first field is filled', function test() {
+        const { render, withDate, isSingleInput } = getOptions();
+        if (!withDate) {
+          return;
+        }
+
+        const { setProps } = render(
+          <ElementToTest
+            {...defaultProps}
+            value={dateParser([[2018, 2, 9], null])}
+            minDate={adapterToUse.date(new Date(2018, 2, 11))}
+          />,
+        );
+
+        testInvalidStatus([true, false], isSingleInput);
+
+        setProps({
+          value: dateParser([[2018, 2, 16], null]),
+        });
+        testInvalidStatus([false, false], isSingleInput);
+      });
+
+      it('should apply minDate when only second field is filled', function test() {
+        const { render, withDate, isSingleInput } = getOptions();
+        if (!withDate) {
+          return;
+        }
+
+        const { setProps } = render(
+          <ElementToTest
+            {...defaultProps}
+            value={dateParser([null, [2018, 2, 9]])}
+            minDate={adapterToUse.date(new Date(2018, 2, 15))}
+          />,
+        );
+
+        testInvalidStatus([false, true], isSingleInput);
+
+        setProps({
+          value: dateParser([null, [2018, 2, 16]]),
+        });
+        testInvalidStatus([false, false], isSingleInput);
+      });
     }
 
     if (propsToTest.includes('maxDate')) {
@@ -427,7 +471,52 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
         });
         testInvalidStatus([false, false], isSingleInput);
       });
+
+      it('should apply minTime when only first field is filled', function test() {
+        const { render, withTime, isSingleInput } = getOptions();
+        if (!withTime) {
+          return;
+        }
+
+        const { setProps } = render(
+          <ElementToTest
+            {...defaultProps}
+            value={dateParser([[2018, 1, 1, 15], null])}
+            minTime={adapterToUse.date(new Date(2018, 1, 1, 12))}
+          />,
+        );
+
+        testInvalidStatus([false, false], isSingleInput);
+
+        setProps({
+          value: dateParser([[2018, 1, 1, 5], null]),
+        });
+        testInvalidStatus([true, false], isSingleInput);
+      });
+
+      it('should apply minTime when only second field is filled', function test() {
+        const { render, withTime, isSingleInput } = getOptions();
+        if (!withTime) {
+          return;
+        }
+
+        const { setProps } = render(
+          <ElementToTest
+            {...defaultProps}
+            value={dateParser([null, [2018, 1, 1, 15]])}
+            minTime={adapterToUse.date(new Date(2018, 1, 1, 12))}
+          />,
+        );
+
+        testInvalidStatus([false, false], isSingleInput);
+
+        setProps({
+          value: dateParser([null, [2018, 1, 1, 5]]),
+        });
+        testInvalidStatus([false, true], isSingleInput);
+      });
     }
+
     if (propsToTest.includes('maxTime')) {
       it('should apply maxTime', function test() {
         const { render, withTime, isSingleInput } = getOptions();

--- a/packages/x-date-pickers/src/internals/hooks/validation/useDateValidation.ts
+++ b/packages/x-date-pickers/src/internals/hooks/validation/useDateValidation.ts
@@ -30,13 +30,13 @@ export const validateDate: Validator<
   DateValidationError,
   DateComponentValidationProps<any>
 > = ({ props, value, adapter }): DateValidationError => {
-  const now = adapter.utils.date()!;
-  const minDate = applyDefaultDate(adapter.utils, props.minDate, adapter.defaultDates.minDate);
-  const maxDate = applyDefaultDate(adapter.utils, props.maxDate, adapter.defaultDates.maxDate);
-
   if (value === null) {
     return null;
   }
+
+  const now = adapter.utils.date()!;
+  const minDate = applyDefaultDate(adapter.utils, props.minDate, adapter.defaultDates.minDate);
+  const maxDate = applyDefaultDate(adapter.utils, props.maxDate, adapter.defaultDates.maxDate);
 
   switch (true) {
     case !adapter.utils.isValid(value):


### PR DESCRIPTION
Fix #6404 

Before, we had an early return if one of the fields was incomplete.

Now if one of the fields has an error, it displays the error immediately (even if the second one is not set). 

I had in mind the following use case: If you set the start date to 2021 and `disablePast` is set to `true` you don't need to wait for the second field to be filled to warn the user that the start date is wrong.

If you're ok with the behavior Iw ill add tests