### PR TITLE
[core] Small typescript improvements

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -24,12 +24,12 @@ const SingleInputDateRangeField = React.forwardRef(function SingleInputDateRange
   const ownerState = themeProps;
 
   const Input = components?.Input ?? TextField;
-  const inputProps = useSlotProps({
+  const inputProps: SingleInputDateRangeFieldProps<TDate> = useSlotProps({
     elementType: Input,
     externalSlotProps: componentsProps?.input,
     externalForwardedProps: other,
     ownerState,
-  }) as Omit<SingleInputDateRangeFieldProps<TDate>, 'components' | 'componentsProps'>;
+  });
 
   const {
     ref: inputRef,

--- a/packages/x-date-pickers-pro/src/tests/testValidation/testTextFieldValidation.tsx
+++ b/packages/x-date-pickers-pro/src/tests/testValidation/testTextFieldValidation.tsx
@@ -78,7 +78,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
               [2018, 2, 10],
             ])}
             shouldDisableDate={(date) =>
-              adapterToUse.isAfter(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+              adapterToUse.isAfter(date, adapterToUse.date(new Date(2018, 2, 10)))
             }
           />,
         );
@@ -108,7 +108,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
             [2018, 2, 13],
           ]),
           shouldDisableDate: (date) =>
-            adapterToUse.isBefore(date as any, adapterToUse.date(new Date(2018, 2, 10))),
+            adapterToUse.isBefore(date, adapterToUse.date(new Date(2018, 2, 10))),
         });
         testInvalidStatus([true, false], isSingleInput);
       });
@@ -128,7 +128,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
             ])}
             shouldDisableDate={(date, position) =>
               position === 'end'
-                ? adapterToUse.isAfter(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+                ? adapterToUse.isAfter(date, adapterToUse.date(new Date(2018, 2, 10)))
                 : false
             }
           />,
@@ -159,7 +159,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
           ]),
           shouldDisableDate: (date, position) =>
             position === 'end'
-              ? adapterToUse.isBefore(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+              ? adapterToUse.isBefore(date, adapterToUse.date(new Date(2018, 2, 10)))
               : false,
         });
         testInvalidStatus([false, false], isSingleInput);
@@ -180,7 +180,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
             ])}
             shouldDisableDate={(date, position) =>
               position === 'start'
-                ? adapterToUse.isAfter(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+                ? adapterToUse.isAfter(date, adapterToUse.date(new Date(2018, 2, 10)))
                 : false
             }
           />,
@@ -211,7 +211,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
           ]),
           shouldDisableDate: (date, position) =>
             position === 'start'
-              ? adapterToUse.isBefore(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+              ? adapterToUse.isBefore(date, adapterToUse.date(new Date(2018, 2, 10)))
               : false,
         });
         testInvalidStatus([true, false], isSingleInput);

--- a/packages/x-date-pickers/src/DateField/DateField.tsx
+++ b/packages/x-date-pickers/src/DateField/DateField.tsx
@@ -24,12 +24,12 @@ const DateField = React.forwardRef(function DateField<TDate>(
   const ownerState = themeProps;
 
   const Input = components?.Input ?? TextField;
-  const { inputRef: externalInputRef, ...inputProps } = useSlotProps({
+  const { inputRef: externalInputRef, ...inputProps }: DateFieldProps<TDate> = useSlotProps({
     elementType: Input,
     externalSlotProps: componentsProps?.input,
     externalForwardedProps: other,
     ownerState,
-  }) as Omit<DateFieldProps<TDate>, 'components' | 'componentsProps'>;
+  });
 
   const {
     ref: inputRef,

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
@@ -24,12 +24,12 @@ const DateTimeField = React.forwardRef(function DateTimeField<TDate>(
   const ownerState = themeProps;
 
   const Input = components?.Input ?? TextField;
-  const { inputRef: externalInputRef, ...inputProps } = useSlotProps({
+  const { inputRef: externalInputRef, ...inputProps }: DateTimeFieldProps<TDate> = useSlotProps({
     elementType: Input,
     externalSlotProps: componentsProps?.input,
     externalForwardedProps: other,
     ownerState,
-  }) as Omit<DateTimeFieldProps<TDate>, 'components' | 'componentsProps'>;
+  });
 
   const {
     ref: inputRef,

--- a/packages/x-date-pickers/src/TimeField/TimeField.tsx
+++ b/packages/x-date-pickers/src/TimeField/TimeField.tsx
@@ -24,12 +24,12 @@ const TimeField = React.forwardRef(function TimeField<TDate>(
   const ownerState = themeProps;
 
   const Input = components?.Input ?? TextField;
-  const { inputRef: externalInputRef, ...inputProps } = useSlotProps({
+  const { inputRef: externalInputRef, ...inputProps }: TimeFieldProps<TDate> = useSlotProps({
     elementType: Input,
     externalSlotProps: componentsProps?.input,
     externalForwardedProps: other,
     ownerState,
-  }) as Omit<TimeFieldProps<TDate>, 'components' | 'componentsProps'>;
+  });
 
   const {
     ref: inputRef,

--- a/packages/x-date-pickers/src/tests/testValidation/testDayViewValidation.tsx
+++ b/packages/x-date-pickers/src/tests/testValidation/testDayViewValidation.tsx
@@ -27,7 +27,7 @@ function testDayViewValidation(ElementToTest, propsToTest, getOptions) {
             {...defaultProps}
             value={adapterToUse.date(new Date(2018, 2, 12))}
             shouldDisableDate={(date) =>
-              adapterToUse.isAfter(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+              adapterToUse.isAfter(date, adapterToUse.date(new Date(2018, 2, 10)))
             }
           />,
         );

--- a/packages/x-date-pickers/src/tests/testValidation/testTextFieldValidation.tsx
+++ b/packages/x-date-pickers/src/tests/testValidation/testTextFieldValidation.tsx
@@ -26,7 +26,7 @@ function testTextFieldValidation(ElementToTest, propsToTest, getOptions) {
             {...defaultProps}
             value={adapterToUse.date(new Date(2018, 2, 12))}
             shouldDisableDate={(date) =>
-              adapterToUse.isAfter(date as any, adapterToUse.date(new Date(2018, 2, 10)))
+              adapterToUse.isAfter(date, adapterToUse.date(new Date(2018, 2, 10)))
             }
           />,
         );


### PR DESCRIPTION
- `date` already equals `any` on the tests, the cast does nothing
- the cast was not needed on the slot, we can just define the type in a regular way