### PR TITLE
[docs] Remove broken welcome page

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,4 +1,5 @@
 / /x/introduction/ 301
+/x/ https://mui.com/x/ 302
 # Avoid conflicts with the other Next.js apps hosted under https://mui.com/
 /x/_next/* /_next/:splat
 


### PR DESCRIPTION
The https://next.mui.com/x/ page is broken, because of bad URL addresses for assets

Sounds like a duplicate of https://mui.com/x/ so better to do a redirect.

### Context

found it because it's [reported by ahrefs as orphan page](https://app.ahrefs.com/site-audit/3523498/36/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CcontentType%2Cdepth%2CincomingLinks%2CincomingRedirect%2CincomingCanonical%2CincomingHreflang%2CincomingCss%2CincomingImage%2CincomingJs&filterCollapsed=true&filterId=ec88e618f9ea51131562c23a677ee3f0&issueId=944b9296-00b2-11e8-aeb8-001e67ed4656)