### PR TITLE
[docs] Fix codesandboxes with v4

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -33,7 +33,7 @@ import { ACTION_TYPES, CODE_VARIANTS } from 'docs/src/modules/constants';
 
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
-    return 'latest';
+    return '^4.0.0';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui-org/material-ui-x/commit/${shortSha}/@material-ui/${packageName}`;


### PR DESCRIPTION
To reproduce the issue:

1. Open https://618001407e06010008d74197--material-ui-x.netlify.app/components/data-grid/columns/#resizing (based on the `v4.x` branch
2. Click on the "Edit in CodeSandbox" button
3. It fails:
  <img width="532" alt="Screenshot 2022-10-22 at 00 56 48" src="https://user-images.githubusercontent.com/3165635/197302388-96847f17-e6c1-4cf7-ab93-29f42dc9ffb2.png">

I worked on this because of https://mui.zendesk.com/agent/tickets/5398.

To prove that this fix works, I cherry-picked it to `docs-v4`: https://v4.mui.com/components/data-grid/columns/#resizing.