### PR TITLE
[pickers] Ignore milliseconds in mask logic

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useMaskedInput.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMaskedInput.tsx
@@ -95,7 +95,13 @@ export const useMaskedInput = <TInputDate, TDate>({
     const newParsedValue = rawValue === null ? null : utils.date(rawValue);
     const isAcceptedValue = rawValue === null || utils.isValid(newParsedValue);
 
-    if (!localeHasChanged && (!isAcceptedValue || utils.isEqual(innerInputValue, newParsedValue))) {
+    const innerEqualsParsed =
+      innerInputValue === null
+        ? newParsedValue === null
+        : newParsedValue !== null &&
+          Math.abs(utils.getDiff(innerInputValue, newParsedValue, 'seconds')) === 0;
+
+    if (!localeHasChanged && (!isAcceptedValue || innerEqualsParsed)) {
       return;
     }
 


### PR DESCRIPTION
Fix #6587

Maybe a better approach would be that date parsing ignore the milliseconds such that we can always use `isEqual` without having to worry about those miliseconds