### PR TITLE
[core] Change reproduction position

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -24,22 +24,11 @@ body:
           required: true
   - type: textarea
     attributes:
-      label: Current behavior 😯
-      description: Describe what happens instead of the expected behavior.
-  - type: textarea
-    attributes:
-      label: Expected behavior 🤔
-      description: Describe what should happen.
-  - type: textarea
-    attributes:
       label: Steps to reproduce 🕹
       description: |
-        Please provide a link to a live example and an unambiguous set of steps to reproduce this bug.
+        **⚠️ Issues that we can't reproduce will be closed.**
 
-        As a starting point, we recommend you [browse the documentation](https://mui.com/x/introduction/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case.
-        Or you can use a [basic template](https://mui.com/r/x-issue-template) to build your reproduction case.
-
-        Issues that we can't reproduce will be closed.
+        Please provide a link to a live example and an unambiguous set of steps to reproduce this bug. As a starting point, we recommend you [browse the documentation](https://mui.com/x/introduction/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case. Or you can use a [basic template](https://mui.com/r/x-issue-template) to build your reproduction case.
       value: |
         Link to live example:
 
@@ -47,7 +36,14 @@ body:
         1.
         2.
         3.
-        4.
+  - type: textarea
+    attributes:
+      label: Current behavior 😯
+      description: Describe what happens instead of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Expected behavior 🤔
+      description: Describe what should happen.
   - type: textarea
     attributes:
       label: Context 🔦


### PR DESCRIPTION
We have tried the change https://github.com/mui/material-ui/pull/34279 in core and toolpad, it seems to be a step forward, a proposal to do the same here.