### PR TITLE
[DateTimePicker] Fix toolbar time order when `theme.rtl=true`

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled, useThemeProps } from '@mui/material/styles';
+import { styled, useThemeProps, useTheme, Theme } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/utils';
 import { PickersToolbarText } from '../internals/components/PickersToolbarText';
 import { PickersToolbar } from '../internals/components/PickersToolbar';
@@ -26,12 +26,12 @@ export interface DateTimePickerToolbarProps<TDate>
   classes?: Partial<DateTimePickerToolbarClasses>;
 }
 
-const useUtilityClasses = (ownerState: DateTimePickerToolbarProps<any>) => {
-  const { classes } = ownerState;
+const useUtilityClasses = (ownerState: DateTimePickerToolbarProps<any> & { theme: Theme }) => {
+  const { classes, theme } = ownerState;
   const slots = {
     root: ['root'],
     dateContainer: ['dateContainer'],
-    timeContainer: ['timeContainer'],
+    timeContainer: ['timeContainer', theme.direction === 'rtl' && 'timeLabelReverse'],
     separator: ['separator'],
   };
 
@@ -67,9 +67,12 @@ const DateTimePickerToolbarTimeContainer = styled('div', {
   name: 'MuiDateTimePickerToolbar',
   slot: 'TimeContainer',
   overridesResolver: (props, styles) => styles.timeContainer,
-})<{ ownerState: DateTimePickerToolbarProps<any> }>({
+})<{ ownerState: DateTimePickerToolbarProps<any> }>(({ theme }) => ({
   display: 'flex',
-});
+  ...(theme.direction === 'rtl' && {
+    flexDirection: 'row-reverse',
+  }),
+}));
 
 const DateTimePickerToolbarSeparator = styled(PickersToolbarText, {
   name: 'MuiDateTimePickerToolbar',
@@ -104,8 +107,9 @@ export function DateTimePickerToolbar<TDate extends unknown>(
   } = props;
   const ownerState = props;
   const utils = useUtils<TDate>();
+  const theme = useTheme();
   const localeText = useLocaleText();
-  const classes = useUtilityClasses(ownerState);
+  const classes = useUtilityClasses({ ...ownerState, theme });
 
   const formatHours = (time: TDate) =>
     ampm ? utils.format(time, 'hours12h') : utils.format(time, 'hours24h');

--- a/packages/x-date-pickers/src/DateTimePicker/dateTimePickerToolbarClasses.ts
+++ b/packages/x-date-pickers/src/DateTimePicker/dateTimePickerToolbarClasses.ts
@@ -10,6 +10,8 @@ export interface DateTimePickerToolbarClasses {
   dateContainer: string;
   /** Styles applied to the time container element. */
   timeContainer: string;
+  /** Styles applied to the time container if rtl. */
+  timeLabelReverse: string;
   /** Styles applied to the separator element. */
   separator: string;
 }
@@ -22,5 +24,5 @@ export function getDateTimePickerToolbarUtilityClass(slot: string) {
 
 export const dateTimePickerToolbarClasses: DateTimePickerToolbarClasses = generateUtilityClasses(
   'MuiDateTimePickerToolbar',
-  ['root', 'dateContainer', 'timeContainer', 'separator'],
+  ['root', 'dateContainer', 'timeContainer', 'separator', 'timeLabelReverse'],
 );


### PR DESCRIPTION
Fix #5561