### PR TITLE
[DataGrid] Avoid future regression with React 19

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -189,10 +189,12 @@ export const useGridCellEditing = (
       const startCellEditModeParams: GridStartCellEditModeParams = { id, field };
 
       if (reason === GridCellEditStartReasons.printableKeyDown) {
-        if (React.version.startsWith('18')) {
-          startCellEditModeParams.initialValue = key; // In React 17, cleaning the input is enough
-        } else {
+        if (React.version.startsWith('17')) {
+          // In React 17, cleaning the input is enough.
+          // The sequence of events makes the key pressed by the end-users update the textbox directly.
           startCellEditModeParams.deleteValue = true;
+        } else {
+          startCellEditModeParams.initialValue = key;
         }
       } else if (reason === GridCellEditStartReasons.deleteKeyDown) {
         startCellEditModeParams.deleteValue = true;

--- a/packages/grid/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -257,10 +257,12 @@ export const useGridRowEditing = (
       const startRowEditModeParams: GridStartRowEditModeParams = { id, fieldToFocus: field };
 
       if (reason === GridRowEditStartReasons.printableKeyDown) {
-        if (React.version.startsWith('18')) {
-          startRowEditModeParams.initialValue = key; // In React 17, cleaning the input is enough
-        } else {
+        if (React.version.startsWith('17')) {
+          // In React 17, cleaning the input is enough.
+          // The sequence of events makes the key pressed by the end-users update the textbox directly.
           startRowEditModeParams.deleteValue = !!field;
+        } else {
+          startRowEditModeParams.initialValue = key;
         }
       } else if (reason === GridRowEditStartReasons.deleteKeyDown) {
         startRowEditModeParams.deleteValue = !!field;


### PR DESCRIPTION
Based on https://github.com/mui/mui-x/pull/6257#discussion_r996500466. It feels a lot more likely that v19 behavior will be v18 rather than v17.