### PR TITLE
[DateRangePicker] Fix input focused style and mobile behaviour

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
@@ -144,7 +144,10 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     lazyHandleChangeCallback([start, date], inputString);
   };
 
-  const openRangeStartSelection = () => {
+  const openRangeStartSelection = (
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+  ) => {
+    event.stopPropagation();
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('start');
     }
@@ -153,7 +156,10 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     }
   };
 
-  const openRangeEndSelection = () => {
+  const openRangeEndSelection = (
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+  ) => {
+    event.stopPropagation();
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('end');
     }
@@ -184,6 +190,9 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
       ...TextFieldProps,
       inputRef: startRef,
       focused: open ? currentlySelectingRangeEnd === 'start' : undefined,
+      // registering `onClick` listener on the root element as well to correctly handle cases where user is clicking on `label`
+      // which has `pointer-events: none` and due to DOM structure the `input` does not catch the click event
+      ...(!readOnly && !other.disabled && { onClick: openRangeStartSelection }),
     },
     inputProps: {
       onClick: openRangeStartSelection,
@@ -204,6 +213,9 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
       ...TextFieldProps,
       inputRef: endRef,
       focused: open ? currentlySelectingRangeEnd === 'end' : undefined,
+      // registering `onClick` listener on the root element as well to correctly handle cases where user is clicking on `label`
+      // which has `pointer-events: none` and due to DOM structure the `input` does not catch the click event
+      ...(!readOnly && !other.disabled && { onClick: openRangeEndSelection }),
     },
     inputProps: {
       onClick: openRangeEndSelection,

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
@@ -181,7 +181,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     TextFieldProps: {
       ...TextFieldProps,
       inputRef: startRef,
-      focused: open && currentlySelectingRangeEnd === 'start',
+      focused: open ? currentlySelectingRangeEnd === 'start' : undefined,
     },
     inputProps: {
       onClick: openRangeStartSelection,
@@ -200,7 +200,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     TextFieldProps: {
       ...TextFieldProps,
       inputRef: endRef,
-      focused: open && currentlySelectingRangeEnd === 'end',
+      focused: open ? currentlySelectingRangeEnd === 'end' : undefined,
     },
     inputProps: {
       onClick: openRangeEndSelection,

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerInput.tsx
@@ -77,6 +77,7 @@ export interface DateRangePickerInputProps<TDate>
   validationError: DateRangeValidationError;
   value: DateRange<TDate>;
   classes?: Partial<DateRangePickerInputClasses>;
+  mobile?: boolean;
 }
 
 type DatePickerInputComponent = <TDate>(
@@ -106,6 +107,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
     TextFieldProps,
     validationError: [startValidationError, endValidationError],
     className,
+    mobile,
     ...other
   } = props;
 
@@ -187,6 +189,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
       onClick: openRangeStartSelection,
       onKeyDown: onSpaceOrEnter(openRangeStartSelection),
       onFocus: focusOnRangeStart,
+      readOnly: mobile,
     },
   });
 
@@ -206,6 +209,7 @@ export const DateRangePickerInput = React.forwardRef(function DateRangePickerInp
       onClick: openRangeEndSelection,
       onKeyDown: onSpaceOrEnter(openRangeEndSelection),
       onFocus: focusOnRangeEnd,
+      readOnly: mobile,
     },
   });
 

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
@@ -311,6 +311,14 @@ describe('<MobileDateRangePicker />', () => {
 
       expect(screen.getByText('Start', { selector: 'label' })).to.have.class('Mui-focused');
     });
+
+    it('should render "readonly" input elements', () => {
+      render(<WrappedMobileDateRangePicker initialValue={[null, null]} />);
+
+      screen.getAllByRole('textbox').forEach((input) => {
+        expect(input).to.have.attribute('readonly');
+      });
+    });
   });
 
   // TODO: Write test

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 import TextField from '@mui/material/TextField';
-import { describeConformance, screen, userEvent } from '@mui/monorepo/test/utils';
+import { describeConformance, screen, userEvent, fireEvent } from '@mui/monorepo/test/utils';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import describeValidation from '@mui/x-date-pickers-pro/tests/describeValidation';
 import {
@@ -301,6 +301,15 @@ describe('<MobileDateRangePicker />', () => {
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(1);
+    });
+
+    it('should correctly set focused styles when input is focused', () => {
+      render(<WrappedMobileDateRangePicker initialValue={[null, null]} />);
+
+      const firstInput = screen.getAllByRole('textbox')[0];
+      fireEvent.focus(firstInput);
+
+      expect(screen.getByText('Start', { selector: 'label' })).to.have.class('Mui-focused');
     });
   });
 

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -103,6 +103,7 @@ export const MobileDateRangePicker = React.forwardRef(function MobileDateRangePi
     setCurrentlySelectingRangeEnd,
     validationError,
     ref,
+    mobile: true,
   };
 
   return (

--- a/packages/x-date-pickers/src/internals/utils/utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/utils.ts
@@ -10,10 +10,13 @@ export function arrayIncludes<T>(array: T[] | readonly T[], itemOrItems: T | T[]
 }
 
 export const onSpaceOrEnter =
-  (innerFn: () => void, onFocus?: (event: React.KeyboardEvent<any>) => void) =>
+  (
+    innerFn: (ev: React.MouseEvent<any> | React.KeyboardEvent<any>) => void,
+    onFocus?: (event: React.KeyboardEvent<any>) => void,
+  ) =>
   (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' || event.key === ' ') {
-      innerFn();
+      innerFn(event);
 
       // prevent any side effects
       event.preventDefault();


### PR DESCRIPTION
Fixes #6627 

- fix `focused` prop declaration to allow for `focused` styles application both on tab-focus and when picker is open
- add `readonly` prop to `inputProps`  in mobile date range picker to align the behaviour with regular Date Picker and avoiding opening keyboard on mobile when value is selected