### PR TITLE
[fields] Update sections when the locale changes

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -313,7 +313,7 @@ export const useFieldState = <
       ...prevState,
       sections,
     }));
-  }, [format]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [format, utils.locale]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     state,


### PR DESCRIPTION
Bug found while working on #6625

Without this line, changing the locale does not trigger a recomputation of the sections and thus the format in the input remains the old one.