### PR TITLE
[data grid] Remove `React.memo` from `GridCellCheckboxRenderer`

### DIFF
--- a/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -195,4 +195,4 @@ GridCellCheckboxForwardRef.propTypes = {
 
 export { GridCellCheckboxForwardRef };
 
-export const GridCellCheckboxRenderer = React.memo(GridCellCheckboxForwardRef);
+export const GridCellCheckboxRenderer = GridCellCheckboxForwardRef;


### PR DESCRIPTION
Closes #6646

Tested with the demo provided on the ticket and confirmed that it resolves the issue.