### PR TITLE
[DataGrid] Tab should update `state.focus` on edit mode

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.new.ts
@@ -206,6 +206,13 @@ export const useGridRowEditing = (
           if (reason) {
             event.preventDefault(); // Prevent going to the next element in the tab sequence
           }
+
+          if (!reason) {
+            event.preventDefault();
+            const index = columnFields.findIndex((field) => field === params.field);
+            const nextFieldToFocus = columnFields[event.shiftKey ? index - 1 : index + 1];
+            apiRef.current.setCellFocus(params.id, nextFieldToFocus);
+          }
         }
 
         if (reason) {

--- a/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.old.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editRows/useGridRowEditing.old.ts
@@ -259,13 +259,11 @@ export const useGridRowEditing = (
 
           if (reason) {
             event.preventDefault(); // Prevent going to the next element in the tab sequence
-
-            const newParams: GridRowEditStopParams = {
-              ...rowParams,
-              reason,
-              field: params.field,
-            };
-            apiRef.current.publishEvent('rowEditStop', newParams, event);
+            const isValid = await apiRef.current.commitRowChange(params.id);
+            if (!isValid && props.experimentalFeatures?.preventCommitWhileValidating) {
+              return;
+            }
+            apiRef.current.publishEvent('rowEditStop', rowParams as GridRowEditStopParams, event);
           }
 
           if (!reason) {

--- a/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
@@ -331,7 +331,10 @@ export const useGridKeyboardNavigation = (
       // Get the most recent params because the cell mode may have changed by another listener
       const cellParams = apiRef.current.getCellParams(params.id, params.field);
 
-      if (cellParams.cellMode !== GridCellModes.Edit && isNavigationKey(event.key)) {
+      if (
+        (cellParams.cellMode !== GridCellModes.Edit && isNavigationKey(event.key)) ||
+        event.key === 'Tab'
+      ) {
         apiRef.current.publishEvent('cellNavigationKeyDown', cellParams, event);
       }
     },

--- a/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
@@ -333,7 +333,7 @@ export const useGridKeyboardNavigation = (
 
       if (
         (cellParams.cellMode !== GridCellModes.Edit && isNavigationKey(event.key)) ||
-        event.key === 'Tab'
+        (cellParams.cellMode === GridCellModes.Edit && event.key === 'Tab')
       ) {
         apiRef.current.publishEvent('cellNavigationKeyDown', cellParams, event);
       }

--- a/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
@@ -331,10 +331,7 @@ export const useGridKeyboardNavigation = (
       // Get the most recent params because the cell mode may have changed by another listener
       const cellParams = apiRef.current.getCellParams(params.id, params.field);
 
-      if (
-        (cellParams.cellMode !== GridCellModes.Edit && isNavigationKey(event.key)) ||
-        (cellParams.cellMode === GridCellModes.Edit && event.key === 'Tab')
-      ) {
+      if (cellParams.cellMode !== GridCellModes.Edit && isNavigationKey(event.key)) {
         apiRef.current.publishEvent('cellNavigationKeyDown', cellParams, event);
       }
     },


### PR DESCRIPTION
Fixes #5952 

**Before**
on Edit mode `Tab` key was not updating the `state.focus`. even if the focus of the component changes the state is not updating.
Demo: https://codesandbox.io/s/updaterowsapiref-demo-mui-x-forked-buy7rq?file=/demo.tsx

**Now**
https://codesandbox.io/s/updaterowsapiref-demo-mui-x-forked-kcn7ft?file=/demo.tsx