### PR TITLE
[docs] Update material.io links to the right version

### DIFF
--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -106,10 +106,12 @@ You can find more details on, the [feature comparison](/x/react-data-grid/gettin
 
 Here are some resources you might be interested in to learn more about the grid:
 
-- The [source on GitHub](https://github.com/mui/mui-x/tree/master/packages/)
-- The [Material Design specification](https://material.io/components/data-tables) specification
+<!-- #default-branch-switch -->
+
+- The [source on GitHub](https://github.com/mui/mui-x/tree/next/packages/)
+- The [Material Design specification](https://m2.material.io/components/data-tables) specification
 - The accessibility [WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)
-- The [Sketch](https://mui.com/store/items/sketch-react/) and [Figma](https://mui.com/store/items/figma-react/) design assets
+- The Figma, Adobe XD, and Sketch [design kits](https://mui.com/design-kits/).
 
 ## API
 

--- a/docs/data/data-grid/row-height/row-height.md
+++ b/docs/data/data-grid/row-height/row-height.md
@@ -9,7 +9,7 @@ title: Data Grid - Row height
 ## Static row height
 
 By default, the rows have a height of 52 pixels.
-This matches the normal height in the [Material Design guidelines](https://material.io/components/data-tables).
+This matches the normal height in the [Material Design guidelines](https://m2.material.io/components/data-tables).
 
 Use the `rowHeight` prop to change this default value, as shown below:
 

--- a/docs/data/date-pickers/date-picker/date-picker-pt.md
+++ b/docs/data/date-pickers/date-picker/date-picker-pt.md
@@ -3,7 +3,7 @@ title: Componente React Seletor de data
 components: DateCalendar, DatePicker, DayCalendarSkeleton, DesktopDatePicker, MobileDatePicker, MonthCalendar, PickersDay, StaticDatePicker, YearCalendar
 githubLabel: 'component: DatePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Seletor de data

--- a/docs/data/date-pickers/date-picker/date-picker-zh.md
+++ b/docs/data/date-pickers/date-picker/date-picker-zh.md
@@ -3,7 +3,7 @@ title: React Date Picker（日期选择器）组件
 components: DateCalendar, DatePicker, DesktopDatePicker, DayCalendarSkeleton, MobileDatePicker, MonthCalendar, PickersDay, StaticDatePicker, YearCalendar
 githubLabel: 'component: DatePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date Picker 日期选择器

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -4,7 +4,7 @@ title: React Date Picker component
 components: DateCalendar, DatePicker, DayCalendarSkeleton, DesktopDatePicker, MobileDatePicker, MonthCalendar, PickersDay, StaticDatePicker, YearCalendar
 githubLabel: 'component: DatePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date picker

--- a/docs/data/date-pickers/date-range-picker/date-range-picker-pt.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker-pt.md
@@ -3,7 +3,7 @@ title: Componente React Seletor intervalo de data
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
 githubLabel: 'component: DateRangePicker'
 packageName: '@mui/x-date-pickers-pro'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Seletor de intervalo de data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)

--- a/docs/data/date-pickers/date-range-picker/date-range-picker-zh.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker-zh.md
@@ -3,7 +3,7 @@ title: React Date Range Picker（日期范围选择器）组件
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
 githubLabel: 'component: DateRangePicker'
 packageName: '@mui/x-date-pickers-pro'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -4,7 +4,7 @@ title: React Date Range Picker component
 components: DateRangePicker, DateRangePickerDay, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
 githubLabel: 'component: DateRangePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date range picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)

--- a/docs/data/date-pickers/date-time-picker/date-time-picker-pt.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker-pt.md
@@ -3,7 +3,7 @@ title: Componente React Seletor de data e hora
 components: DateTimePicker,DesktopDateTimePicker,MobileDateTimePicker,StaticDateTimePicker
 githubLabel: 'component: DateTimePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Seletor de data e hora

--- a/docs/data/date-pickers/date-time-picker/date-time-picker-zh.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker-zh.md
@@ -3,7 +3,7 @@ title: React Date Time Picker（日期时间选择器） 组件
 components: DateTimePicker,DesktopDateTimePicker,MobileDateTimePicker,StaticDateTimePicker
 githubLabel: 'component: DateTimePicker'
 packageName: '@mui/x-date-pickers-pro'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date Time Picker 日期时间选择器

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -4,7 +4,7 @@ title: React Date Time Picker component
 components: DateTimePicker,DesktopDateTimePicker,MobileDateTimePicker,StaticDateTimePicker
 githubLabel: 'component: DateTimePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date time picker

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -3,7 +3,7 @@ product: date-pickers
 title: React Date Time Range Picker component
 githubLabel: 'component: DateTimeRangePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Date time range picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)

--- a/docs/data/date-pickers/getting-started/getting-started-pt.md
+++ b/docs/data/date-pickers/getting-started/getting-started-pt.md
@@ -2,7 +2,7 @@
 title: Componente React para Data e Hora
 components: TextField
 githubLabel: 'component: DatePicker'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html
 packageName: '@mui/x-date-pickers'
 ---

--- a/docs/data/date-pickers/getting-started/getting-started-zh.md
+++ b/docs/data/date-pickers/getting-started/getting-started-zh.md
@@ -2,7 +2,7 @@
 title: React Date Picker（日期选择器）和 Time Picker（时间选择器）组件
 components: TextField
 githubLabel: 'component: DatePicker'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html
 packageName: '@mui/x-date-pickers'
 ---

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -3,7 +3,7 @@ product: date-pickers
 title: Date picker, Time picker React components
 components: DatePicker,DateTimePicker,TimePicker
 githubLabel: 'component: DatePicker'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-dialog.html
 packageName: '@mui/x-date-pickers'
 ---

--- a/docs/data/date-pickers/time-picker/time-picker-pt.md
+++ b/docs/data/date-pickers/time-picker/time-picker-pt.md
@@ -3,7 +3,7 @@ title: Componente React Seletor de hora
 components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
 githubLabel: 'component: TimePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/time-pickers
+materialDesign: https://m2.material.io/components/time-pickers
 ---
 
 # Seletor de hora

--- a/docs/data/date-pickers/time-picker/time-picker-zh.md
+++ b/docs/data/date-pickers/time-picker/time-picker-zh.md
@@ -3,7 +3,7 @@ title: React Time Picker（时间选择器）组件
 components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
 githubLabel: 'component: TimePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/time-pickers
+materialDesign: https://m2.material.io/components/time-pickers
 ---
 
 # Time Picker 时间选择器

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -4,7 +4,7 @@ title: React Time Picker component
 components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
 githubLabel: 'component: TimePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/time-pickers
+materialDesign: https://m2.material.io/components/time-pickers
 ---
 
 # Time picker

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -3,7 +3,7 @@ product: date-pickers
 title: React Time Range Picker component
 githubLabel: 'component: TimeRangePicker'
 packageName: '@mui/x-date-pickers'
-materialDesign: https://material.io/components/date-pickers
+materialDesign: https://m2.material.io/components/date-pickers
 ---
 
 # Time range picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)


### PR DESCRIPTION
Material Design has changed the structure of its docs to have clear versions.