### PR TITLE
[docs] Unify a few of the capitalizations

### DIFF
--- a/docs/data/data-grid/column-definition/column-definition.md
+++ b/docs/data/data-grid/column-definition/column-definition.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Column definition
----
-
-# Data grid - Column definition
+# Data Grid - Column definition
 
 <p class="description">Define your columns.</p>
 

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Column dimensions
----
-
-# Data grid - Column dimensions
+# Data Grid - Column dimensions
 
 <p class="description">Customize the dimensions and resizing behavior of your columns.</p>
 

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Column groups
----
-
-# Data grid - Column groups
+# Data Grid - Column groups
 
 <p class="description">Group your columns.</p>
 

--- a/docs/data/data-grid/column-header/column-header.md
+++ b/docs/data/data-grid/column-header/column-header.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Column header
----
-
-# Data grid - Column header
+# Data Grid - Column header
 
 <p class="description">Customize your columns header.</p>
 

--- a/docs/data/data-grid/column-ordering/column-ordering.md
+++ b/docs/data/data-grid/column-ordering/column-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column ordering
 ---
 
-# Data grid - Column ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Column ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Drag and drop your columns to reorder them.</p>
 

--- a/docs/data/data-grid/column-pinning/column-pinning.md
+++ b/docs/data/data-grid/column-pinning/column-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column pinning
 ---
 
-# Data grid - Column pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Column pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Pin columns to keep them visible at all time.</p>
 

--- a/docs/data/data-grid/column-spanning/column-spanning.md
+++ b/docs/data/data-grid/column-spanning/column-spanning.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Column spanning
----
-
-# Data grid - Column spanning
+# Data Grid - Column spanning
 
 <p class="description">Span cells across several columns.</p>
 

--- a/docs/data/data-grid/column-visibility/column-visibility.md
+++ b/docs/data/data-grid/column-visibility/column-visibility.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Column visibility
----
-
-# Data grid - Column visibility
+# Data Grid - Column visibility
 
 <p class="description">Define which columns are visible.</p>
 

--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Components
----
-
-# Data grid - Components
+# Data Grid - Components
 
 <p class="description">The grid is highly customizable. Override components using the <code>components</code> prop.</p>
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Editing
----
-
-# Data grid - Editing
+# Data Grid - Editing
 
 <p class="description">The data grid has built-in support for cell and row editing.</p>
 

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Export
----
-
-# Data grid - Export
+# Data Grid - Export
 
 <p class="description">Easily export the rows in various file formats such as CSV, Excel, or PDF.</p>
 

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Filtering
----
-
-# Data grid - Filtering
+# Data Grid - Filtering
 
 <p class="description">Easily filter your rows based on one or several criteria.</p>
 

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Getting started
----
-
-# Data grid - Getting started
+# Data Grid - Getting started
 
 <p class="description">Get started with the last React data grid you will need. Install the package, configure the columns, provide rows, and you are set.</p>
 

--- a/docs/data/data-grid/layout/layout.md
+++ b/docs/data/data-grid/layout/layout.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Layout
----
-
-# Data grid - Layout
+# Data Grid - Layout
 
 <p class="description">The data grid offers multiple layout mode.</p>
 

--- a/docs/data/data-grid/localization/localization.md
+++ b/docs/data/data-grid/localization/localization.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Localization
----
-
-# Data grid - Localization
+# Data Grid - Localization
 
 <p class="description">The data grid allows to support users from different locales, with formatting, RTL, and localized strings.</p>
 

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -2,7 +2,7 @@
 title: Data Grid - Master detail
 ---
 
-# Data grid - Master detail [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Master detail [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Expand your rows to display additional information.</p>
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -5,7 +5,7 @@ packageName: '@mui/x-data-grid'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 ---
 
-# Data grid
+# Data Grid
 
 <p class="description">A fast and extendable react data table and react data grid. It's a feature-rich component available in MIT or Commercial versions.</p>
 

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Pagination
----
-
-# Data grid - Pagination
+# Data Grid - Pagination
 
 <p class="description">Easily paginate your rows and only fetch what you need.</p>
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -2,7 +2,7 @@
 title: Data Grid - Pivoting
 ---
 
-# Data grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
 
 <p class="description">Turn a column values into columns.</p>
 

--- a/docs/data/data-grid/recipes-editing/recipes-editing.md
+++ b/docs/data/data-grid/recipes-editing/recipes-editing.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Editing recipes
----
-
-# Data grid - Editing recipes
+# Data Grid - Editing recipes
 
 <p class="description">Advanced grid customization recipes.</p>
 

--- a/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
+++ b/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Row grouping recipes
----
-
-# Data grid - Row grouping recipes
+# Data Grid - Row grouping recipes
 
 <p class="description">Advanced grid customization recipes.</p>
 

--- a/docs/data/data-grid/row-definition/row-definition.md
+++ b/docs/data/data-grid/row-definition/row-definition.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row definition
 ---
 
-# Data grid - Row definition
+# Data Grid - Row definition
 
 <p class="description">Define your rows.</p>
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row grouping
 ---
 
-# Data grid - Row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
 
 <p class="description">Group your rows according to some column values.</p>
 

--- a/docs/data/data-grid/row-height/row-height.md
+++ b/docs/data/data-grid/row-height/row-height.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Row height
----
-
-# Data grid - Row height
+# Data Grid - Row height
 
 <p class="description">Customize the height of your rows.</p>
 

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row ordering
 ---
 
-# Data grid - Row ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Row ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Drag and drop your rows to reorder them.</p>
 

--- a/docs/data/data-grid/row-pinning/row-pinning.md
+++ b/docs/data/data-grid/row-pinning/row-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row pinning
 ---
 
-# Data grid - Row pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Row pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Pin rows to keep them visible at all times.</p>
 

--- a/docs/data/data-grid/row-spanning/row-spanning.md
+++ b/docs/data/data-grid/row-spanning/row-spanning.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Row spanning
----
-
-# Data grid - Row spanning
+# Data Grid - Row spanning
 
 <p class="description">Span cells across several columns.</p>
 

--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Row updates
----
-
-# Data grid - Row updates
+# Data Grid - Row updates
 
 <p class="description">Always keep your rows up to date.</p>
 

--- a/docs/data/data-grid/scrolling/scrolling.md
+++ b/docs/data/data-grid/scrolling/scrolling.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Scrolling
----
-
-# Data grid - Scrolling
+# Data Grid - Scrolling
 
 <p class="description">This section presents how to programmatically control the scroll.</p>
 

--- a/docs/data/data-grid/selection/selection.md
+++ b/docs/data/data-grid/selection/selection.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Selection
----
-
-# Data grid - Selection
+# Data Grid - Selection
 
 <p class="description">Selection allows the user to select and highlight a number of rows that they can then take action on.</p>
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Sorting
----
-
-# Data grid - Sorting
+# Data Grid - Sorting
 
 <p class="description">Easily sort your rows based on one or several criteria.</p>
 

--- a/docs/data/data-grid/style/style.md
+++ b/docs/data/data-grid/style/style.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Styling
----
-
-# Data grid - Styling
+# Data Grid - Styling
 
 <p class="description">The grid CSS can be easily overwritten.</p>
 

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -2,7 +2,7 @@
 title: Data Grid - Tree data
 ---
 
-# Data grid - Tree data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Tree data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Use Tree data to handle rows with parent / child relationship.</p>
 

--- a/docs/data/data-grid/virtualization/virtualization.md
+++ b/docs/data/data-grid/virtualization/virtualization.md
@@ -1,8 +1,4 @@
----
-title: Data Grid - Virtualization
----
-
-# Data grid - Virtualization
+# Data Grid - Virtualization
 
 <p class="description">The grid is high performing thanks to its rows and columns virtualization engine.</p>
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers
 ---
 
-# Date picker
+# Date Picker
 
 <p class="description">The date picker let the user select a date.</p>
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers
 ---
 
-# Date range picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Date Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">The date range picker let the user select a range of dates.</p>
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/date-pickers
 ---
 
-# Date time picker
+# Date Time Picker
 
 <p class="description">This component combines the date & time pickers.</p>
 

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -1,6 +1,6 @@
 ---
 product: date-pickers
-title: Date picker, Time picker React components
+title: Date Picker, Time Picker React components
 components: DatePicker,DateTimePicker,TimePicker
 githubLabel: 'component: DatePicker'
 materialDesign: https://material.io/components/date-pickers
@@ -8,7 +8,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/datepicker-d
 packageName: '@mui/x-date-pickers'
 ---
 
-# Date / Time pickers
+# Date / Time Pickers
 
 <p class="description">Date pickers and Time pickers allow selecting a single value from a pre-determined set.</p>
 

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 materialDesign: https://material.io/components/time-pickers
 ---
 
-# Time picker
+# Time Picker
 
 <p class="description">Time pickers allow the user to select a single time.</p>
 

--- a/docs/data/introduction/installation/installation.md
+++ b/docs/data/introduction/installation/installation.md
@@ -13,10 +13,10 @@ MUI X components have a peer dependency on `@mui/material`: the installation [in
 
 Note that you only need to install the packages corresponding to the components you're using—e.g. data grid users don't need to install date and time pickers.
 
-### Data grid
+### Data Grid
 
 The installation [instructions](/x/react-data-grid/getting-started/#installation).
 
-### Date and Time pickers
+### Date and Time Pickers
 
 The installation [instructions](/x/react-date-pickers/getting-started/#setup).

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -16,7 +16,7 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-data-grid',
     scopePathnames: ['/x/api/data-grid'],
-    title: 'Data grid',
+    title: 'Data Grid',
     icon: 'TableViewIcon',
     children: [
       { pathname: '/x/react-data-grid', title: 'Overview' },
@@ -144,28 +144,29 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-date-pickers',
     scopePathnames: ['/x/api/date-pickers'],
-    title: 'Date and Time pickers',
+    title: 'Date and Time Pickers',
     icon: 'DatePickerIcon',
     children: [
       { pathname: '/x/react-date-pickers/getting-started' },
-      { pathname: '/x/react-date-pickers/date-picker' },
+      { pathname: '/x/react-date-pickers/date-picker', title: 'Date Picker' },
       {
         pathname: '/x/react-date-pickers/date-range-picker',
+        title: 'Date Range Picker',
         plan: 'pro',
       },
-      { pathname: '/x/react-date-pickers/date-time-picker' },
-      { pathname: '/x/react-date-pickers/time-picker' },
+      { pathname: '/x/react-date-pickers/date-time-picker', title: 'Date Time Picker' },
+      { pathname: '/x/react-date-pickers/time-picker', title: 'Time Picker' },
       { pathname: '/x/react-date-pickers/validation' },
       { pathname: '/x/react-date-pickers/localization' },
       { pathname: '/x/react-date-pickers/custom-components' },
       {
         pathname: '/x/react-date-pickers/date-time-range-picker',
-        title: 'Date time range picker 🚧',
+        title: 'Date Time Range Picker 🚧',
         plan: 'pro',
       },
       {
         pathname: '/x/react-date-pickers/time-range-picker',
-        title: 'Time range picker 🚧',
+        title: 'Time Range Picker 🚧',
         plan: 'pro',
       },
       {

--- a/docs/pages/x/api/data-grid/index.md
+++ b/docs/pages/x/api/data-grid/index.md
@@ -1,4 +1,4 @@
-# Data grid - API Reference
+# Data Grid - API Reference
 
 <p class="description">This page contains an index to the most important APIs of the data grid.</p>
 


### PR DESCRIPTION
I was browsing the docs for something else and saw it wasn't matching https://www.notion.so/mui-org/Style-conventions-for-MUI-components-and-products-dff7d2d7d1ba4a4abd47f48cf345b800 (in place since about a month ago) so I did a PR to fix a few of the instances. I didn't try to cover everything.