### PR TITLE
[DataGrid] Stop exporting `gridColumnsSelector`

### DIFF
--- a/docs/pages/x/api/data-grid/selectors.json
+++ b/docs/pages/x/api/data-grid/selectors.json
@@ -12,20 +12,6 @@
     "supportsApiRef": true
   },
   {
-    "name": "gridColumnDefinitionsSelector",
-    "returnType": "GridStateColDef<any, any, any>[]",
-    "category": "Columns",
-    "description": "Get the columns as an array.",
-    "supportsApiRef": true
-  },
-  {
-    "name": "gridColumnFieldsSelector",
-    "returnType": "string[]",
-    "category": "Columns",
-    "description": "Get the field of each column.",
-    "supportsApiRef": true
-  },
-  {
     "name": "gridColumnGroupsHeaderMaxDepthSelector",
     "returnType": "number",
     "description": "",
@@ -50,24 +36,10 @@
     "supportsApiRef": true
   },
   {
-    "name": "gridColumnLookupSelector",
-    "returnType": "GridColumnLookup",
-    "category": "Columns",
-    "description": "Get the columns as a lookup (an object containing the field for keys and the definition for values).",
-    "supportsApiRef": true
-  },
-  {
     "name": "gridColumnMenuSelector",
     "returnType": "GridColumnMenuState",
     "description": "",
     "supportsApiRef": false
-  },
-  {
-    "name": "gridColumnPositionsSelector",
-    "returnType": "number[]",
-    "category": "Visible Columns",
-    "description": "Get the left position in pixel of each visible columns relative to the left of the first column.",
-    "supportsApiRef": true
   },
   {
     "name": "gridColumnReorderDragColSelector",
@@ -86,20 +58,6 @@
     "returnType": "GridColumnResizeState",
     "description": "",
     "supportsApiRef": false
-  },
-  {
-    "name": "gridColumnVisibilityModelSelector",
-    "returnType": "GridColumnVisibilityModel",
-    "category": "Visible Columns",
-    "description": "Get the column visibility model, containing the visibility status of each column.\nIf a column is not registered in the model, it is visible.",
-    "supportsApiRef": true
-  },
-  {
-    "name": "gridColumnsTotalWidthSelector",
-    "returnType": "number",
-    "category": "Visible Columns",
-    "description": "Get the summed width of all the visible columns.",
-    "supportsApiRef": true
   },
   {
     "name": "gridDensityFactorSelector",
@@ -150,20 +108,6 @@
     "category": "Filtering",
     "description": "",
     "supportsApiRef": false
-  },
-  {
-    "name": "gridFilterableColumnDefinitionsSelector",
-    "returnType": "GridStateColDef<any, any, any>[]",
-    "category": "Columns",
-    "description": "Get the filterable columns as an array.",
-    "supportsApiRef": true
-  },
-  {
-    "name": "gridFilterableColumnLookupSelector",
-    "returnType": "GridColumnLookup",
-    "category": "Columns",
-    "description": "Get the filterable columns as a lookup (an object containing the field for keys and the definition for values).",
-    "supportsApiRef": true
   },
   {
     "name": "gridFilteredSortedRowEntriesSelector",
@@ -331,20 +275,6 @@
     "name": "gridTotalHeaderHeightSelector",
     "returnType": "number",
     "description": "",
-    "supportsApiRef": true
-  },
-  {
-    "name": "gridVisibleColumnDefinitionsSelector",
-    "returnType": "GridStateColDef<any, any, any>[]",
-    "category": "Visible Columns",
-    "description": "Get the visible columns as a lookup (an object containing the field for keys and the definition for values).",
-    "supportsApiRef": true
-  },
-  {
-    "name": "gridVisibleColumnFieldsSelector",
-    "returnType": "string[]",
-    "category": "Visible Columns",
-    "description": "Get the field of each visible column.",
     "supportsApiRef": true
   },
   {

--- a/packages/grid/x-data-grid/src/hooks/features/columns/index.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/index.ts
@@ -1,4 +1,22 @@
-export * from './gridColumnsSelector';
+export {
+  gridColumnFieldsSelector,
+  gridColumnLookupSelector,
+  gridColumnDefinitionsSelector,
+  gridColumnVisibilityModelSelector,
+  gridVisibleColumnDefinitionsSelector,
+  gridVisibleColumnFieldsSelector,
+  gridColumnPositionsSelector,
+  gridColumnsTotalWidthSelector,
+  gridFilterableColumnDefinitionsSelector,
+  gridFilterableColumnLookupSelector,
+  allGridColumnsFieldsSelector,
+  allGridColumnsSelector,
+  visibleGridColumnsSelector,
+  filterableGridColumnsSelector,
+  filterableGridColumnsIdsSelector,
+  visibleGridColumnsLengthSelector,
+  gridColumnsMetaSelector,
+} from './gridColumnsSelector';
 export type {
   GridColumnLookup,
   GridColumnsState,

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -191,7 +191,6 @@
   { "name": "gridColumnsMetaSelector", "kind": "Variable" },
   { "name": "GridColumnsPanel", "kind": "Function" },
   { "name": "GridColumnsPanelProps", "kind": "Interface" },
-  { "name": "gridColumnsSelector", "kind": "Variable" },
   { "name": "GridColumnsState", "kind": "Interface" },
   { "name": "gridColumnsTotalWidthSelector", "kind": "Variable" },
   { "name": "GridColumnTypesRecord", "kind": "TypeAlias" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -170,7 +170,6 @@
   { "name": "gridColumnsMetaSelector", "kind": "Variable" },
   { "name": "GridColumnsPanel", "kind": "Function" },
   { "name": "GridColumnsPanelProps", "kind": "Interface" },
-  { "name": "gridColumnsSelector", "kind": "Variable" },
   { "name": "GridColumnsState", "kind": "Interface" },
   { "name": "gridColumnsTotalWidthSelector", "kind": "Variable" },
   { "name": "GridColumnTypesRecord", "kind": "TypeAlias" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -156,7 +156,6 @@
   { "name": "gridColumnsMetaSelector", "kind": "Variable" },
   { "name": "GridColumnsPanel", "kind": "Function" },
   { "name": "GridColumnsPanelProps", "kind": "Interface" },
-  { "name": "gridColumnsSelector", "kind": "Variable" },
   { "name": "GridColumnsState", "kind": "Interface" },
   { "name": "gridColumnsTotalWidthSelector", "kind": "Variable" },
   { "name": "GridColumnTypesRecord", "kind": "TypeAlias" },


### PR DESCRIPTION
Solves the discussion in https://github.com/mui/mui-x/pull/6647#discussion_r1006932943

## Changelog

### Breaking changes

- The `gridColumnsSelector` selector is not exported anymore. Use the following selectors to access the same parts of the state that were returned by the removed selector: `gridColumnFieldsSelector`, to obtain the column fields in the order they appear in the screen; `gridColumnLookupSelector`, to access column definitions by field; and `gridColumnVisibilityModelSelector`, for the visibility state of each column.