### PR TITLE
[DataGrid] Row ordering fix for virtualization

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
@@ -52,7 +52,7 @@ export const useGridRowReorder = (
     };
   }, []);
 
-  // In case React event failed to trigger "rowDragEnd", this function will trigger it.
+  // In case React event failed to trigger "rowDragEnd".This function will make sure it's triggered..
   const publishRowDragEnd = React.useCallback(
     (event: any) => {
       event.preventDefault();


### PR DESCRIPTION
Fixes #6165

**Problem**

Row ordering sometimes won't work with virtualization enabled. if the row that's being dragged unmounted `onDragEnd` event won't be triggered.

https://user-images.githubusercontent.com/34584266/205438411-51948e57-e738-4d0d-aadc-3383bcbb8d96.mov

**Solution**

I looked at how other people approach this problem (AG-Grid, react-beautiful-dnd). When you drag an element, you drag the element or a copy of the element, which will always be in the DOM. but in MUI-DataGrid, when you drag a `row` you are dragging the ghost of the `row` so the element might get unmounted while dragging when virtualization is enabled. This causes `onDragEnd` not to be triggered. This can be solved by adding `dragend` listener with `addEventListener`  to the row because DOM event listeners persist longer than component life cycles.
 