### PR TITLE
[docs] Fix link to localization page

### DIFF
--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -51,7 +51,7 @@ The date picker component can be disabled or read-only.
 ## Localization
 
 Use `LocalizationProvider` to change the date-library locale that is used to render the date picker.
-See the documentation page [about localization](/x/react-date-pickers/date-picker/#localization) for more details.
+See the documentation page [about localization](/x/react-date-pickers/localization/) for more details.
 
 ## Jalali calendar system
 


### PR DESCRIPTION
Fix #6758

@flaviendelangle For `next` branch I'm thinking about deleting the section, since all the other pages do not have any localization section:
 
https://next.mui.com/x/react-date-pickers/date-picker/#localization