### PR TITLE
[docs] Add missing Pro header suffix

### DIFF
--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -32,7 +32,7 @@ Support for the Jalali and Hijri adapters will come in the future.
 
 {{"demo": "SingleDateFieldExamples.js", "defaultCodeOpen": false}}
 
-### Fields to edit a range
+### Fields to edit a range [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 All fields to edit a range are available in a single input version and in a multi input version.
 


### PR DESCRIPTION
The demo imports from a `-pro` npm package. https://deploy-preview-6775--material-ui-x.netlify.app/x/react-date-pickers/fields/#fields-to-edit-a-range

I was looking at something unrelated, I was curious about how the range is implemented, I got confused about the docs.