### PR TITLE
[core] Replace `useOpenState` with `useControlled` in `usePickerValue`

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useOpenState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useOpenState.ts
@@ -1,11 +1,14 @@
 import * as React from 'react';
 
-export interface OpenStateProps {
+interface OpenStateProps {
   open?: boolean;
   onOpen?: () => void;
   onClose?: () => void;
 }
 
+/**
+ * TODO v6: Remove
+ */
 export const useOpenState = ({ open, onOpen, onClose }: OpenStateProps) => {
   const isControllingOpenProp = React.useRef(typeof open === 'boolean').current;
   const [openState, setIsOpenState] = React.useState(false);


### PR DESCRIPTION
Simplifies the understanding of the codebase by using a common pattern instead of re-implementing it inside a custom hook.