### PR TITLE
[pickers] Fix pickers toolbar styling

### DIFF
--- a/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
@@ -3,7 +3,6 @@ import Typography from '@mui/material/Typography';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/utils';
 import { PickersToolbar } from '../internals/components/PickersToolbar';
-import { pickersToolbarClasses } from '../internals/components/pickersToolbarClasses';
 import { useLocaleText, useUtils } from '../internals/hooks/useUtils';
 import { BaseToolbarProps, ExportedBaseToolbarProps } from '../internals/models/props/toolbar';
 import { isYearOnlyView, isYearAndMonthViews } from '../internals/utils/views';
@@ -34,12 +33,7 @@ const DatePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiDatePickerToolbar',
   slot: 'Root',
   overridesResolver: (_, styles) => styles.root,
-})<{ ownerState: DatePickerToolbarProps<any> }>({
-  [`& .${pickersToolbarClasses.penIconButton}`]: {
-    position: 'relative',
-    top: 4,
-  },
-});
+})({});
 
 const DatePickerToolbarTitle = styled(Typography, {
   name: 'MuiDatePickerToolbar',
@@ -112,7 +106,6 @@ export const DatePickerToolbar = React.forwardRef(function DatePickerToolbar<TDa
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}
       isLandscape={isLandscape}
-      ownerState={ownerState}
       className={classes.root}
       {...other}
     >

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -47,6 +47,7 @@ const DateTimePickerToolbarRoot = styled(PickersToolbar, {
   paddingLeft: 16,
   paddingRight: 16,
   justifyContent: 'space-around',
+  position: 'relative',
   [`& .${pickersToolbarClasses.penIconButton}`]: {
     position: 'absolute',
     top: 8,

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -43,7 +43,7 @@ const DateTimePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiDateTimePickerToolbar',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: DateTimePickerToolbarProps<any> }>({
+})<{ ownerState: DateTimePickerToolbarProps<any> }>(({ theme }) => ({
   paddingLeft: 16,
   paddingRight: 16,
   justifyContent: 'space-around',
@@ -51,9 +51,9 @@ const DateTimePickerToolbarRoot = styled(PickersToolbar, {
   [`& .${pickersToolbarClasses.penIconButton}`]: {
     position: 'absolute',
     top: 8,
-    right: 8,
+    ...(theme.direction === 'rtl' ? { left: 8 } : { right: 8 }),
   },
-});
+}));
 
 const DateTimePickerToolbarDateContainer = styled('div', {
   name: 'MuiDateTimePickerToolbar',

--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -65,10 +65,12 @@ const PickersToolbarContent = styled(Grid, {
   overridesResolver: (props, styles) => styles.content,
 })<{
   ownerState: PickersToolbarProps<any, any>;
-}>({
+}>(({ ownerState }) => ({
   flex: 1,
-  alignItems: 'center',
-});
+  ...(!ownerState.isLandscape && {
+    alignItems: 'center',
+  }),
+}));
 
 const PickersToolbarPenIconButton = styled(IconButton, {
   name: 'MuiPickersToolbar',

--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -67,6 +67,7 @@ const PickersToolbarContent = styled(Grid, {
   ownerState: PickersToolbarProps<any, any>;
 }>({
   flex: 1,
+  alignItems: 'center',
 });
 
 const PickersToolbarPenIconButton = styled(IconButton, {


### PR DESCRIPTION
- Fix vertical alignment
- Remove redundant style overrides
- Add `position: relative` to fix `penIcon` placement in `DateTimePickerToolbar`

[Before](https://codesandbox.io/s/black-platform-26j6o2?file=/demo.tsx) | [After](https://codesandbox.io/s/festive-tharp-fiihkz?file=/demo.tsx:689-837)

Please also [have a look at argos](https://app.argos-ci.com/mui/mui-x/builds/5620) and decide if you agree on the changes visible there.