### PR TITLE
[DataGrid] Fix conflict with `onResize` added to `React.HTMLAttributes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.11.9",
     "@types/prettier": "^2.7.1",
-    "@types/react": "^18.0.24",
+    "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "@types/requestidlecallback": "^0.3.5",
     "@types/sinon": "^10.0.13",

--- a/packages/grid/x-data-grid/src/components/GridAutoSizer.tsx
+++ b/packages/grid/x-data-grid/src/components/GridAutoSizer.tsx
@@ -17,7 +17,8 @@ export interface AutoSizerSize {
 // Credit to https://github.com/bvaughn/react-virtualized/blob/master/source/AutoSizer/AutoSizer.js
 // for the sources.
 
-export interface AutoSizerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+export interface AutoSizerProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children' | 'onResize'> {
   /**
    * Function responsible for rendering children.
    * @param {AutoSizerSize} size The grid's size.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,10 +3501,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.24":
-  version "18.0.24"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.24.tgz#2f79ed5b27f08d05107aab45c17919754cc44c20"
-  integrity sha512-wRJWT6ouziGUy+9uX0aW4YOJxAY0bG6/AOk5AW5QSvZqI7dk6VBIbXvcVgIw/W5Jrl24f77df98GEKTJGOLx7Q==
+"@types/react@*", "@types/react@^18.0.25":
+  version "18.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
+  integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
I got the following error when build my TypeScript project with `@mui/x-data-grid@5.17.10`:

```
node_modules/@mui/x-data-grid/components/GridAutoSizer.d.ts:6:18 - error TS2430: Interface 'AutoSizerProps' incorrectly extends interface 'Omit<HTMLAttributes<HTMLDivElement>, "children">'.
  Types of property 'onResize' are incompatible.
    Type '((size: AutoSizerSize) => void) | undefined' is not assignable to type 'ReactEventHandler<HTMLDivElement> | undefined'.
      Type '(size: AutoSizerSize) => void' is not assignable to type 'ReactEventHandler<HTMLDivElement>'.
        Types of parameters 'size' and 'event' are incompatible.
          Type 'SyntheticEvent<HTMLDivElement, Event>' is missing the following properties from type 'AutoSizerSize': height, width

6 export interface AutoSizerProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
                   ~~~~~~~~~~~~~~


Found 1 error in node_modules/@mui/x-data-grid/components/GridAutoSizer.d.ts:6
```

After investigation, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63076 adds `onResize` event to video elements for `@types/react@18.0.25` due to https://github.com/facebook/react/pull/21973, which causes the issue.

To fix this error, I omitted property `onResize` when extending `AutoSizerProps` from `HTMLDivElement` attributes.

Note this PR might also need to backport to `master` branch for v5