### PR TITLE
[core] Freeze vale action to a specific release

### DIFF
--- a/.github/workflows/vale-action.yml
+++ b/.github/workflows/vale-action.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
-      - uses: errata-ai/vale-action@reviewdog
+      - uses: errata-ai/vale-action@c4213d4de3d5f718b8497bd86161531c78992084 # tag=v2.0.1
         with:
           reporter: github-pr-review
           files: docs/data


### PR DESCRIPTION
Fix https://github.com/mui/mui-x/security/code-scanning/9 to help a bit with https://mui.zendesk.com/agent/tickets/5635. We are currently using HEAD https://github.com/errata-ai/vale-action.