### PR TITLE
[core] Fix `test-types` out of memory error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ jobs:
           destination: artifact-file
   test_types:
     <<: *defaults
+    resource_class: 'medium+'
     steps:
       - checkout
       - install_js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,6 @@ jobs:
           destination: artifact-file
   test_types:
     <<: *defaults
-    resource_class: 'medium+'
     steps:
       - checkout
       - install_js

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 5 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 6 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 4 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 5 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 6 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 4 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 6 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 5 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",


### PR DESCRIPTION
Try tackling the [same yarn error code 137 appearing](https://mui-org.slack.com/archives/G011VC970AW/p1668416304708469) when `typescript:ci` is being run.
This error is thrown when the system runs out of physical memory (RAM).

Done some testing using a few different configurations:
- [concurrency 4](https://app.circleci.com/pipelines/github/mui/mui-x/27811/workflows/7d2df8c8-9aba-4522-8c67-960ca7a54680/jobs/159852/resources) -> 72.68s
- [concurrency 5](https://app.circleci.com/pipelines/github/mui/mui-x/27820/workflows/4a246363-93d6-43da-a042-5feb62a37fa9/jobs/159891/resources) -> 69.43s
- [concurrency 7 + medium+*](https://app.circleci.com/pipelines/github/mui/mui-x/27822/workflows/a0a15bd1-4d31-40e0-9509-87dd6a005f36/jobs/159898/steps) -> 76.88s
- [concurrency 6 + medium+*](https://app.circleci.com/pipelines/github/mui/mui-x/27824/workflows/fb8eb19d-dadd-4f68-abb5-52a269a26aa0/jobs/159910/resources) -> 57.07s

* `medium+` is a one step bigger container: **6GB** RAM & **3-core** CPU instead of **4GB** RAM & **2-core** CPU.

Based on the above experiments it seems that firstly going with a simple approach of reducing the concurrency is perfectly viable. Upsizing the container does yield a bit better performance, but if it costs more to us—it does not seem like it is worth the trade-off. At least at the moment, because we are not able to consume >75% of RAM.
Besides, lower concurrency does not necessarily mean longer task runtime as seen by examples and local experiments.

In any case we have somewhat low amount of cores and spawning a lot of processes requires a lot of task switching to happen when executing tasks. In our case—each of the task runtime is quite small and can benefit from lower concurrency and less CPU scheduler priority switching needed.