### PR TITLE
[pickers] Pass the ampm prop from the new pickers to their field

### DIFF
--- a/packages/x-date-pickers/src/DesktopNextDateTimePicker/DesktopNextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopNextDateTimePicker/DesktopNextDateTimePicker.tsx
@@ -56,6 +56,7 @@ const DesktopNextDateTimePicker = React.forwardRef(function DesktopNextDateTimeP
         sx,
         inputRef: defaultizedProps.inputRef,
         label: defaultizedProps.label,
+        ampm: defaultizedProps.ampm,
       }),
     },
   };

--- a/packages/x-date-pickers/src/DesktopNextDateTimePicker/tests/field.DesktopNextDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopNextDateTimePicker/tests/field.DesktopNextDateTimePicker.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { screen } from '@mui/monorepo/test/utils';
+import { createPickerRenderer, expectInputValue } from 'test/utils/pickers-utils';
+import { Unstable_DesktopNextDateTimePicker as DesktopNextDateTimePicker } from '@mui/x-date-pickers/DesktopNextDateTimePicker';
+
+describe('<DesktopNextDateTimePicker /> - Field', () => {
+  const { render } = createPickerRenderer();
+
+  it('should pass the ampm prop to the field', () => {
+    const { setProps } = render(<DesktopNextDateTimePicker ampm />);
+
+    const input = screen.getByRole('textbox');
+    expectInputValue(input, 'MM / DD / YYYY hh:mm aa');
+
+    setProps({ ampm: false });
+    expectInputValue(input, 'MM / DD / YYYY hh:mm');
+  });
+});

--- a/packages/x-date-pickers/src/DesktopNextTimePicker/DesktopNextTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopNextTimePicker/DesktopNextTimePicker.tsx
@@ -52,6 +52,7 @@ const DesktopNextTimePicker = React.forwardRef(function DesktopNextTimePicker<TD
         sx,
         inputRef: defaultizedProps.inputRef,
         label: defaultizedProps.label,
+        ampm: defaultizedProps.ampm,
       }),
     },
   };

--- a/packages/x-date-pickers/src/DesktopNextTimePicker/tests/field.DesktopNextTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopNextTimePicker/tests/field.DesktopNextTimePicker.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { screen } from '@mui/monorepo/test/utils';
+import { createPickerRenderer, expectInputValue } from 'test/utils/pickers-utils';
+import { Unstable_DesktopNextTimePicker as DesktopNextTimePicker } from '@mui/x-date-pickers/DesktopNextTimePicker';
+
+describe('<DesktopNextTimePicker /> - Field', () => {
+  const { render } = createPickerRenderer();
+
+  it('should pass the ampm prop to the field', () => {
+    const { setProps } = render(<DesktopNextTimePicker ampm />);
+
+    const input = screen.getByRole('textbox');
+    expectInputValue(input, 'hh:mm aa');
+
+    setProps({ ampm: false });
+    expectInputValue(input, 'hh:mm');
+  });
+});

--- a/packages/x-date-pickers/src/MobileNextDateTimePicker/MobileNextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileNextDateTimePicker/MobileNextDateTimePicker.tsx
@@ -54,6 +54,7 @@ const MobileNextDateTimePicker = React.forwardRef(function MobileNextDateTimePic
         sx,
         inputRef: defaultizedProps.inputRef,
         label: defaultizedProps.label,
+        ampm: defaultizedProps.ampm,
       }),
     },
   };

--- a/packages/x-date-pickers/src/MobileNextDateTimePicker/tests/field.MobileNextDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileNextDateTimePicker/tests/field.MobileNextDateTimePicker.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { screen } from '@mui/monorepo/test/utils';
+import { createPickerRenderer, expectInputValue } from 'test/utils/pickers-utils';
+import { Unstable_MobileNextDateTimePicker as MobileNextDateTimePicker } from '@mui/x-date-pickers/MobileNextDateTimePicker';
+
+describe('<MobileNextDateTimePicker /> - Field', () => {
+  const { render } = createPickerRenderer();
+
+  it('should pass the ampm prop to the field', () => {
+    const { setProps } = render(<MobileNextDateTimePicker ampm />);
+
+    const input = screen.getByRole('textbox');
+    expectInputValue(input, 'MM / DD / YYYY hh:mm aa');
+
+    setProps({ ampm: false });
+    expectInputValue(input, 'MM / DD / YYYY hh:mm');
+  });
+});

--- a/packages/x-date-pickers/src/MobileNextTimePicker/MobileNextTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileNextTimePicker/MobileNextTimePicker.tsx
@@ -51,6 +51,7 @@ const MobileNextTimePicker = React.forwardRef(function MobileNextTimePicker<TDat
         sx,
         inputRef: defaultizedProps.inputRef,
         label: defaultizedProps.label,
+        ampm: defaultizedProps.ampm,
       }),
     },
   };

--- a/packages/x-date-pickers/src/MobileNextTimePicker/tests/field.MobileNextTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileNextTimePicker/tests/field.MobileNextTimePicker.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { screen } from '@mui/monorepo/test/utils';
+import { createPickerRenderer, expectInputValue } from 'test/utils/pickers-utils';
+import { Unstable_MobileNextTimePicker as MobileNextTimePicker } from '@mui/x-date-pickers/MobileNextTimePicker';
+
+describe('<MobileNextTimePicker /> - Field', () => {
+  const { render } = createPickerRenderer();
+
+  it('should pass the ampm prop to the field', () => {
+    const { setProps } = render(<MobileNextTimePicker ampm />);
+
+    const input = screen.getByRole('textbox');
+    expectInputValue(input, 'hh:mm aa');
+
+    setProps({ ampm: false });
+    expectInputValue(input, 'hh:mm');
+  });
+});


### PR DESCRIPTION
Currently, the format in the field does not react to the `ampm` props when used inside a picker.