### PR TITLE
[core] Start enforcing consistency in documentation vocabulary

### DIFF
--- a/.github/styles/Blog/NamingConventions.yml
+++ b/.github/styles/Blog/NamingConventions.yml
@@ -1,0 +1,11 @@
+extends: substitution
+message: Consider using '%s' instead of '%s'
+level: warning
+ignorecase: false
+# swap maps tokens in form of bad: good
+# for more information: https://vale.sh/docs/topics/styles/#substitution
+swap:
+  '[A|a]pi': API
+  typescript: Typescript
+  ts: Typescript
+  TS: Typescript

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,11 +2,14 @@
 StylesPath = .github/styles
 MinAlertLevel = suggestion
 
-Packages = Google
+Packages = Google, Blog
 
 [*.md]
 # Ignore code injection which start with {{...
 BlockIgnores = {{.*
+
+# Custom syle
+Blog.NamingConventions = YES
 
 # Google:
 Google.FirstPerson = YES # Avoid first-person pronouns such as I, me, ...'.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1035,7 +1035,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [CalendarPicker] Don't move to closest enabled date when `props.date` contains a disabled date (#6537) @flaviendelangle
 - [DateRangePicker] Fix calendar day outside of month layout shifting on hover (pick #6448) (#6538) @alexfauquette
-- [pickers] Fix typescript issues (#6510) @flaviendelangle
+- [pickers] Fix Typescript issues (#6510) @flaviendelangle
 
 ### Docs
 
@@ -1181,7 +1181,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 ### Core
 
-- [core] Update to typescript 4.8.3 (#6136) @flaviendelangle
+- [core] Update to Typescript 4.8.3 (#6136) @flaviendelangle
 - [core] Update RFC template (#6100) @bytasv
 
 ## 5.17.2

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -135,7 +135,7 @@ You can provide a [`valueFormatter`](/x/react-data-grid/column-definition/#value
 ### File encoding
 
 You can use `csvOptions` to specify the format of the export, such as the `delimiter` character used to separate fields, the `fileName`, or `utf8WithBom` to prefix the exported file with UTF-8 Byte Order Mark (BOM).
-For more details on these options, please visit the [`csvOptions` api page](/x/api/data-grid/grid-csv-export-options/).
+For more details on these options, please visit the [`csvOptions` API page](/x/api/data-grid/grid-csv-export-options/).
 
 ```jsx
 <GridToolbarExport
@@ -197,7 +197,7 @@ By default, the print export display all the DataGrid. It is possible to remove 
 />
 ```
 
-For more option to customize the print export, please visit the [`printOptions` api page](/x/api/data-grid/grid-print-export-options/).
+For more option to customize the print export, please visit the [`printOptions` API page](/x/api/data-grid/grid-print-export-options/).
 
 ## Custom export format
 

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -29,7 +29,7 @@ You need to install 3 different types of package to make the pickers work:
 
 1. **The component** (`@mui/x-date-pickers` or `@mui/x-date-pickers-pro`) manages the rendering.
 2. **The date-library** ([`moment`](https://momentjs.com/), [`dayjs`](https://day.js.org/), ...) manages the date manipulation.
-3. **The adapter** ([`@date-io`](https://github.com/dmtrKovalenko/date-io#projects)) exposes your favorite **date-library** under a unified api used by **component**.
+3. **The adapter** ([`@date-io`](https://github.com/dmtrKovalenko/date-io#projects)) exposes your favorite **date-library** under a unified API used by **component**.
 
 First you have to install the date-library you want to use to manage dates, and the component package:
 


### PR DESCRIPTION
Inspired from #6848

- enforce `API` and `Typescript`