### PR TITLE
[I10n] Improve Finnish (fi-FI) locale on the data grid (#6859)

### DIFF
--- a/packages/grid/x-data-grid/src/locales/fiFI.ts
+++ b/packages/grid/x-data-grid/src/locales/fiFI.ts
@@ -85,8 +85,8 @@ const fiFIGrid: Partial<GridLocaleText> = {
   columnMenuFilter: 'Suodata',
   columnMenuHideColumn: 'Piilota',
   columnMenuUnsort: 'Poista järjestys',
-  columnMenuSortAsc: 'Järjestä laskevasti',
-  columnMenuSortDesc: 'Järjestä nousevasti',
+  columnMenuSortAsc: 'Järjestä nousevasti',
+  columnMenuSortDesc: 'Järjestä laskevasti',
 
   // Column header text
   columnHeaderFiltersTooltipActive: (count) =>


### PR DESCRIPTION
#6859 on `master`