### PR TITLE
[DataGridPro] Fix lazy-loaded rows not working with `updateRows` API method

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
@@ -114,7 +114,7 @@ describe('<DataGridPro /> - Lazy loader', () => {
 
   // See https://github.com/mui/mui-x/issues/6857
   it('should update the row when `apiRef.current.updateRows` is called on lazy-loaded rows', () => {
-    render(<TestLazyLoader rowCount={5} />);
+    render(<TestLazyLoader rowCount={5} autoHeight={isJSDOM} />);
 
     const newRows: GridRowModel[] = [
       { id: 4, first: 'John' },

--- a/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, fireEvent, act } from '@mui/monorepo/test/utils';
-import { getColumnHeaderCell, getRow } from 'test/utils/helperFn';
+import { getColumnHeaderCell, getColumnValues, getRow } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import {
   DataGridPro,
@@ -110,6 +110,22 @@ describe('<DataGridPro /> - Lazy loader', () => {
 
     const updatedAllRows = apiRef.current.state.rows.ids;
     expect(updatedAllRows.slice(4, 6)).to.deep.equal([4, 5]);
+  });
+
+  // See https://github.com/mui/mui-x/issues/6857
+  it('should update the row when `apiRef.current.updateRows` is called on lazy-loaded rows', () => {
+    render(<TestLazyLoader rowCount={5} />);
+
+    const newRows: GridRowModel[] = [
+      { id: 4, first: 'John' },
+      { id: 5, first: 'Mac' },
+    ];
+
+    act(() => apiRef.current.unstable_replaceRows(3, newRows));
+    expect(getColumnValues(1)).to.deep.equal(['Mike', 'Jack', 'Jim', 'John', 'Mac']);
+
+    act(() => apiRef.current.updateRows([{ id: 4, first: 'John updated' }]));
+    expect(getColumnValues(1)).to.deep.equal(['Mike', 'Jack', 'Jim', 'John updated', 'Mac']);
   });
 
   it('should update all rows accordingly when `apiRef.current.unstable_replaceRows` is called and props.getRowId is defined', () => {

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -400,6 +400,10 @@ export const useGridRows = (
         updatedTree[row.id] = rowTreeNodeConfig;
       });
 
+      apiRef.current.unstable_caches.rows.idRowsLookup = updatedIdRowsLookup;
+      apiRef.current.unstable_caches.rows.idToIdLookup = updatedIdToIdLookup;
+      apiRef.current.unstable_caches.rows.ids = updatedRows;
+
       apiRef.current.setState((state) => ({
         ...state,
         rows: {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/6857

TODO:
- [ ] Port to the `next` branch

Before: https://codesandbox.io/s/funny-lovelace-4igujv?file=/demo.tsx

https://user-images.githubusercontent.com/13808724/202181987-8aaf7362-03e4-434b-8120-a46f52118d07.mov

After: https://codesandbox.io/s/fragrant-rgb-yivj2n?file=/demo.tsx

https://user-images.githubusercontent.com/13808724/202182581-b0f041e6-c217-4db7-88c3-423dbe59acea.mov


