### PR TITLE
[license] Polish error messages

### DIFF
--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -216,7 +216,7 @@ however you'll be required to renew your license if you need to continue develop
 #### License key plan mismatch
 
 This error indicates that the component you are trying to use is not included in the plan of your license key.
-For example, this happen if you try to use `DataGridPremium` with a license key for the Pro plan.
+This happens if you try to use `DataGridPremium` with a license key for the Pro plan.
 
 #### Invalid license key
 

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -213,14 +213,15 @@ For example, if you purchase a one-year license today, you will be able to updat
 Those versions will always be available for use in a deployed application,
 however you'll be required to renew your license if you need to continue development with a version released after twelve months.
 
-#### Out of scope license key
+#### License key plan mismatch
 
-This error indicates that the component you are trying to use is not included in your license.
-This can happen if you try to use `DataGridPremium` with a Pro license.
+This error indicates that the component you are trying to use is not included in the plan of your license key.
+For example, this happen if you try to use `DataGridPremium` with a license key for the Pro plan.
 
 #### Invalid license key
 
-This error indicates that your license key doesn't match what is expected. This is likely a typo.
+This error indicates that your license key doesn't match what is expected.
+It could be because the license key is missing a character or has a typo.
 
 #### Invalid license key (TypeError: extracting license expiry timestamp)
 

--- a/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
@@ -18,7 +18,7 @@ describe('<DataGridPremium /> - License', () => {
       }),
     );
     expect(() => render(<DataGridPremium columns={[]} rows={[]} autoHeight />)).toErrorDev([
-      'Your MUI X license key isn\'t valid. You are rendering a DataGridPremium component that requires a license key with the "premium" feature scope but your license key has the "pro" feature scope',
+      'MUI: License key plan mismatch',
     ]);
   });
 });

--- a/packages/x-license-pro/src/Watermark/Watermark.tsx
+++ b/packages/x-license-pro/src/Watermark/Watermark.tsx
@@ -9,7 +9,7 @@ function getLicenseErrorMessage(licenseStatus: LicenseStatus) {
     case LicenseStatus.Invalid:
       return 'MUI X: Invalid license key';
     case LicenseStatus.OutOfScope:
-      return 'MUI X: Out of scope license key';
+      return 'MUI X: License key plan mismatch';
     case LicenseStatus.NotFound:
       return 'MUI X: Missing license key';
     default:

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -22,12 +22,13 @@ export function showInvalidLicenseError() {
 
 export function showOutOfScopeLicenseError() {
   showError([
-    'MUI: Out of scope license key.',
+    'MUI: License key plan mismatch.',
     '',
-    'Your MUI X license key isn\'t valid. You are rendering a DataGridPremium component that requires a license key with the "premium" feature scope but your license key has the "pro" feature scope.',
+    'Your use of MUI X is not compatible with the plan of your license key.',
+    'You are rendering a `DataGridPremium` component that requires a license key for the Premium plan but your license key is for the Pro plan.',
     '',
-    'You can solve the issue by purchasing a Premium license at https://mui.com/r/x-get-license?scope=premium',
-    'Alternatively, you can replace the import on DataGridPremium with DataGridPro.',
+    'You can solve the issue by upgrading to Premium at https://mui.com/r/x-get-license?scope=premium',
+    'Alternatively, you can replace the import of `DataGridPremium` with `DataGridPro`.',
   ]);
 }
 


### PR DESCRIPTION
- We mention "scope" in the docs but I believe that we only used this terminology in the code to be more flexible in the future. As of now, I believe that it would be clearer to reference a "plan".
- I have used "license key" over "license" to reinforce "Please note that the license key does not cover every scenario, so possession of a valid license key does not by itself confer the right to use the Software." [source](https://mui.com/legal/mui-x-eula/#license-key).

It's a side fix while I was looking at how to fix the root problem of https://mail.google.com/mail/u/0/#inbox/FMfcgzGqRZhTNhvHTVzRCHKXcnSDlnfm. I think that #1364 could be it, point 5. and 7.