### PR TITLE
v6.0.0-alpha.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [DataGrid] Provide a clear error message when upgrading (#6685) @oliviertassinari
 - [DataGridPremium] Allow to customize the indent of group expansion toggle (#6837) @MBilalShafi
 - [DataGridPremium] Support aggregating data from multiple row fields (#6656) @cherniavskii
-- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @gavbrennan
-- [DataGridPro] Opt-out for column jump back on re-order (#6733) @m4theushw
+- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @cherniavskii
+- [DataGridPro] Opt-out for column jump back on re-order (#6733) @gavbrennan
 - [l10n] Improve Finnish (fi-FI) locale (#6859) @RainoPikkarainen
 
 ### `@mui/x-date-pickers@v6.0.0-alpha.8` / `@mui/x-date-pickers-pro@v6.0.0-alpha.8`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 _Nov 17, 2022_
 
-We'd like to offer a big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
+We'd like to offer a big thanks to the 12 contributors who made this release possible. Here are some highlights ✨:
 
 - 🎁 Support aggregating data from multiple row fields (#6656) @cherniavskii
 - 📚 Documentation improvements
@@ -18,12 +18,12 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 #### Changes
 
 - [DataGrid] Fix `ErrorOverlay` not receiving defined input props (#6819) @banoth-ravinder
-- [DataGrid] Fix conflict with `onResize` added to `React.HTMLAttributes` (#6797) @vizv
+- [DataGrid] Fix conflict with the latest version of `@types/react` (#6797) @vizv
 - [DataGrid] Make more `apiRef` methods private (#6700) @cherniavskii
 - [DataGrid] Provide a clear error message when upgrading (#6685) @oliviertassinari
 - [DataGridPremium] Allow to customize the indent of group expansion toggle (#6837) @MBilalShafi
 - [DataGridPremium] Support aggregating data from multiple row fields (#6656) @cherniavskii
-- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @cherniavskii
+- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @gavbrennan
 - [DataGridPro] Opt-out for column jump back on re-order (#6733) @m4theushw
 - [l10n] Improve Finnish (fi-FI) locale (#6859) @RainoPikkarainen
 
@@ -31,7 +31,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
 #### Breaking changes
 
-The `ClockPicker` view component has been renamed  `TimeClock` to better fit its usage:
+- The `ClockPicker` view component has been renamed to `TimeClock` to better fit its usage:
 
 ```diff
 -<ClockPicker {...props} />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1018,6 +1018,35 @@ You can find more information about the new api, including how to set those tran
 - [test] Skip tests for column pinning and dynamic row height (#5997) @m4theushw
 - [website] Improve security header @oliviertassinari
 
+## 5.17.11
+
+_Nov 10, 2022_
+
+We'd like to offer a big thanks to the 5 contributors who made this release possible. Here are some highlights ✨:
+
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v5.17.11` / `@mui/x-data-grid-pro@v5.17.11` / `@mui/x-data-grid-premium@v5.17.11`
+
+#### Changes
+
+- [DataGrid] Fix for cell focus preventing scroll when virtualization enabled (#6622) @yaredtsy
+- [DataGridPro] Opt-out for column jump back on re-order (#6697) @gavbrennan
+
+### `@mui/x-date-pickers@v5.0.8` / `@mui/x-date-pickers-pro@v5.0.8`
+
+#### Changes
+
+- [pickers] Fix pickers toolbar styling (#6793) @LukasTy
+
+### Docs
+
+- [docs] Fix link to localization page (#6766) @alexfauquette
+
+### Core
+
+- [license] Add new license status 'Out of scope' (#6774) @oliviertassinari
+
 ## 5.17.10
 
 _Nov 4, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,17 +33,17 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 
 - The `ClockPicker` view component has been renamed to `TimeClock` to better fit its usage:
 
-```diff
--<ClockPicker {...props} />
-+<TimeClock {...props} />
-```
+  ```diff
+  -<ClockPicker {...props} />
+  +<TimeClock {...props} />
+  ```
 
-Component name in the theme has changed as well:
+  Component name in the theme has changed as well:
 
-```diff
--MuiClockPicker: {
-+MuiTimeClock: {
-```
+  ```diff
+  -MuiClockPicker: {
+  +MuiTimeClock: {
+  ```
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,75 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.0-alpha.8
+
+_Nov 17, 2022_
+
+We'd like to offer a big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
+
+- 🎁 Support aggregating data from multiple row fields (#6656) @cherniavskii
+- 📚 Documentation improvements
+- 🐞 Bugfixes
+
+#### Breaking changes
+
+The `ClockPicker` view component has been renamed  `TimeClock` to better fit its usage:
+
+```diff
+-<ClockPicker {...props} />
++<TimeClock {...props} />
+```
+
+Component name in the theme has changed as well:
+
+```diff
+-MuiClockPicker: {
++MuiTimeClock: {
+```
+### `@mui/x-data-grid@v6.0.0-alpha.8` / `@mui/x-data-grid-pro@v6.0.0-alpha.8` / `@mui/x-data-grid-premium@v6.0.0-alpha.8`
+
+#### Changes
+
+- [DataGrid] Fix ErrorOverlay not receiving defined input props (#6819) @banoth-ravinder
+- [DataGrid] Fix conflict with `onResize` added to `React.HTMLAttributes` (#6797) @vizv
+- [DataGrid] Make more `apiRef` methods private (#6700) @cherniavskii
+- [DataGrid] Provide a clear error message when upgrading (#6685) @oliviertassinari
+- [DataGridPremium] Allow to customize the indent of group expansion toggle (#6837) @MBilalShafi
+- [DataGridPremium] Support aggregating data from multiple row fields (#6656) @cherniavskii
+- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @cherniavskii
+- [DataGridPro] Opt-out for column jump back on re-order (#6733) @m4theushw
+
+### `@mui/x-date-pickers@v6.0.0-alpha.8` / `@mui/x-date-pickers-pro@v6.0.0-alpha.8`
+
+#### Changes
+
+- [pickers] Fix typing and prop drilling on `DateRangeCalendar` and multi input range fields (#6852) @flaviendelangle
+- [pickers] Pass the ampm prop from the new pickers to their field (#6868) @flaviendelangle
+- [pickers] Rename `CalendarPickerView`, `ClockPickerView` and `CalendarOrClockPickerView` (#6855) @flaviendelangle
+- [pickers] Rename `ClockPicker` into `TimeClock` (#6851) @flaviendelangle
+
+### Docs
+
+- [docs] Add dayjs to the dependencies (#6862) @m4theushw
+- [docs] Clarify DataGrid Row Pinning docs (#6853) @cherniavskii
+- [docs] Fix typo in Export page (#6848) @m4theushw
+- [docs] Group picker pages (#6369) @flaviendelangle
+- [docs] Remove default prop and improve format (#6781) @oliviertassinari
+- [docs] Sync prism-okaidia.css with source (#6820) @oliviertassinari
+
+### Core
+
+- [core] Convert scripts to ESM (#6789) @LukasTy
+- [core] Feedback on branch protection @oliviertassinari
+- [core] Fix `test-types` out of memory error (#6850) @LukasTy
+- [core] Import from `@mui/utils` instead of `@mui/material/utils` (#6816) @cherniavskii
+- [core] Show the whole version to make blame easier @oliviertassinari
+- [core] Small changes on new pickers internals (#6840) @flaviendelangle
+- [core] Remove prettier scripts (#6815) @Janpot
+- [I10n] Improve Finnish (fi-FI) locale on the data grid (#6859) @RainoPikkarainen
+- [license] Polish error messages (#6881) @oliviertassinari
+- [test] Verify `onError` call (#6771) @alexfauquette
+
 ## 6.0.0-alpha.7
 
 _Nov 10, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1019,6 +1019,33 @@ You can find more information about the new api, including how to set those tran
 - [test] Skip tests for column pinning and dynamic row height (#5997) @m4theushw
 - [website] Improve security header @oliviertassinari
 
+## 5.17.12
+
+_Nov 17, 2022_
+
+We'd like to offer a big thanks to the 5 contributors who made this release possible. Here are some highlights ✨:
+
+- 🌍 Improve Finnish (fi-FI) locale (#6859) @RainoPikkarainen
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v5.17.12` / `@mui/x-data-grid-pro@v5.17.12` / `@mui/x-data-grid-premium@v5.17.12`
+
+#### Changes
+
+- [DataGrid] Fix conflict with the latest version of `@types/react` (#6883) @vizv
+- [DataGridPremium] Support aggregating data from multiple row fields (#6844) @cherniavskii
+- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6858) @cherniavskii
+- [l10n] Improve Finnish (fi-FI) locale (#6859) @RainoPikkarainen
+
+### Docs
+
+- [docs] Clarify DataGrid Row Pinning docs (#6891) @cherniavskii
+
+### Core
+
+- [core] Upgrade monorepo (#6864) @m4theushw
+- [license] Polish error messages (#6881) @oliviertassinari
+
 ## 5.17.11
 
 _Nov 10, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
+### `@mui/x-data-grid@v6.0.0-alpha.8` / `@mui/x-data-grid-pro@v6.0.0-alpha.8` / `@mui/x-data-grid-premium@v6.0.0-alpha.8`
+
+#### Changes
+
+- [DataGrid] Fix `ErrorOverlay` not receiving defined input props (#6819) @banoth-ravinder
+- [DataGrid] Fix conflict with `onResize` added to `React.HTMLAttributes` (#6797) @vizv
+- [DataGrid] Make more `apiRef` methods private (#6700) @cherniavskii
+- [DataGrid] Provide a clear error message when upgrading (#6685) @oliviertassinari
+- [DataGridPremium] Allow to customize the indent of group expansion toggle (#6837) @MBilalShafi
+- [DataGridPremium] Support aggregating data from multiple row fields (#6656) @cherniavskii
+- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @cherniavskii
+- [DataGridPro] Opt-out for column jump back on re-order (#6733) @m4theushw
+- [l10n] Improve Finnish (fi-FI) locale (#6859) @RainoPikkarainen
+
+### `@mui/x-date-pickers@v6.0.0-alpha.8` / `@mui/x-date-pickers-pro@v6.0.0-alpha.8`
+
 #### Breaking changes
 
 The `ClockPicker` view component has been renamed  `TimeClock` to better fit its usage:
@@ -28,32 +44,18 @@ Component name in the theme has changed as well:
 -MuiClockPicker: {
 +MuiTimeClock: {
 ```
-### `@mui/x-data-grid@v6.0.0-alpha.8` / `@mui/x-data-grid-pro@v6.0.0-alpha.8` / `@mui/x-data-grid-premium@v6.0.0-alpha.8`
-
-#### Changes
-
-- [DataGrid] Fix ErrorOverlay not receiving defined input props (#6819) @banoth-ravinder
-- [DataGrid] Fix conflict with `onResize` added to `React.HTMLAttributes` (#6797) @vizv
-- [DataGrid] Make more `apiRef` methods private (#6700) @cherniavskii
-- [DataGrid] Provide a clear error message when upgrading (#6685) @oliviertassinari
-- [DataGridPremium] Allow to customize the indent of group expansion toggle (#6837) @MBilalShafi
-- [DataGridPremium] Support aggregating data from multiple row fields (#6656) @cherniavskii
-- [DataGridPro] Fix detail panel not working with `getRowSpacing` prop (#6707) @cherniavskii
-- [DataGridPro] Opt-out for column jump back on re-order (#6733) @m4theushw
-
-### `@mui/x-date-pickers@v6.0.0-alpha.8` / `@mui/x-date-pickers-pro@v6.0.0-alpha.8`
 
 #### Changes
 
 - [pickers] Fix typing and prop drilling on `DateRangeCalendar` and multi input range fields (#6852) @flaviendelangle
-- [pickers] Pass the ampm prop from the new pickers to their field (#6868) @flaviendelangle
+- [pickers] Pass the `ampm` prop from the new pickers to their field (#6868) @flaviendelangle
 - [pickers] Rename `CalendarPickerView`, `ClockPickerView` and `CalendarOrClockPickerView` (#6855) @flaviendelangle
 - [pickers] Rename `ClockPicker` into `TimeClock` (#6851) @flaviendelangle
 
 ### Docs
 
-- [docs] Add dayjs to the dependencies (#6862) @m4theushw
-- [docs] Clarify DataGrid Row Pinning docs (#6853) @cherniavskii
+- [docs] Add `dayjs` to the dependencies (#6862) @m4theushw
+- [docs] Clarify how the Row Pinning works with other features of the DataGrid (#6853) @cherniavskii
 - [docs] Fix typo in Export page (#6848) @m4theushw
 - [docs] Group picker pages (#6369) @flaviendelangle
 - [docs] Remove default prop and improve format (#6781) @oliviertassinari
@@ -68,9 +70,8 @@ Component name in the theme has changed as well:
 - [core] Show the whole version to make blame easier @oliviertassinari
 - [core] Small changes on new pickers internals (#6840) @flaviendelangle
 - [core] Remove prettier scripts (#6815) @Janpot
-- [I10n] Improve Finnish (fi-FI) locale on the data grid (#6859) @RainoPikkarainen
 - [license] Polish error messages (#6881) @oliviertassinari
-- [test] Verify `onError` call (#6771) @alexfauquette
+- [test] Verify `onError` call on the pickers (#6771) @alexfauquette
 
 ## 6.0.0-alpha.7
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "private": true,
   "author": "MUI Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "private": true,
   "scripts": {
     "start": "yarn && yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@mui/base": "^5.0.0-alpha.106",
-    "@mui/x-data-grid-premium": "6.0.0-alpha.7",
+    "@mui/x-data-grid-premium": "6.0.0-alpha.8",
     "chance": "^1.1.9",
     "clsx": "^1.2.1",
     "lru-cache": "^7.14.1"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,9 +44,9 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@mui/utils": "^5.10.14",
-    "@mui/x-data-grid": "6.0.0-alpha.7",
-    "@mui/x-data-grid-pro": "6.0.0-alpha.7",
-    "@mui/x-license-pro": "6.0.0-alpha.5",
+    "@mui/x-data-grid": "6.0.0-alpha.8",
+    "@mui/x-data-grid-pro": "6.0.0-alpha.8",
+    "@mui/x-license-pro": "6.0.0-alpha.8",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "exceljs": "^4.3.0",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,8 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.19.0",
     "@mui/utils": "^5.10.14",
-    "@mui/x-data-grid": "6.0.0-alpha.7",
-    "@mui/x-license-pro": "6.0.0-alpha.5",
+    "@mui/x-data-grid": "6.0.0-alpha.8",
+    "@mui/x-license-pro": "6.0.0-alpha.8",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -47,8 +47,8 @@
     "@date-io/luxon": "^2.16.1",
     "@date-io/moment": "^2.16.1",
     "@mui/utils": "^5.10.14",
-    "@mui/x-date-pickers": "6.0.0-alpha.7",
-    "@mui/x-license-pro": "6.0.0-alpha.5",
+    "@mui/x-date-pickers": "6.0.0-alpha.8",
+    "@mui/x-license-pro": "6.0.0-alpha.8",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
     "react-transition-group": "^4.4.5",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -48,9 +48,9 @@
     "@date-io/core": "^2.16.0",
     "@date-io/date-fns": "^2.16.0",
     "@date-io/date-fns-jalali": "^2.16.0",
-    "@date-io/jalaali": "^2.16.1",
-    "@date-io/hijri": "^2.16.1",
     "@date-io/dayjs": "^2.16.0",
+    "@date-io/hijri": "^2.16.1",
+    "@date-io/jalaali": "^2.16.1",
     "@date-io/luxon": "^2.16.1",
     "@date-io/moment": "^2.16.1",
     "@mui/utils": "^5.10.14",
@@ -66,12 +66,12 @@
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
     "date-fns": "^2.25.0",
+    "date-fns-jalali": "^2.13.0-0",
     "dayjs": "^1.10.7",
     "luxon": "^1.28.0 || ^2.0.0 || ^3.0.2",
     "moment": "^2.29.1",
     "moment-hijri": "^2.1.2",
     "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0",
-    "date-fns-jalali": "^2.13.0-0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"
   },
@@ -107,12 +107,12 @@
   "devDependencies": {
     "@types/luxon": "^3.1.0",
     "date-fns": "^2.29.3",
+    "date-fns-jalali": "^2.13.0-0",
     "dayjs": "^1.11.6",
     "luxon": "^3.1.0",
     "moment": "^2.29.4",
     "moment-hijri": "^2.1.2",
-    "moment-jalaali": "^0.9.6",
-    "date-fns-jalali": "^2.13.0-0"
+    "moment-jalaali": "^0.9.6"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license-pro",
-  "version": "6.0.0-alpha.5",
+  "version": "6.0.0-alpha.8",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",


### PR DESCRIPTION
- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [x] Update the root `package.json`'s version
- [x] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
- [x] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
- [x] Open PR with changes and wait for review and green CI.
- [ ] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

```sh
git push upstream next:docs-next -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v5` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)