### PR TITLE
[docs] Enforce values for installation options in Date / Time pickers Getting Started page

### DIFF
--- a/docs/data/date-pickers/getting-started/InstructionsNoSnap.js
+++ b/docs/data/date-pickers/getting-started/InstructionsNoSnap.js
@@ -14,11 +14,15 @@ const InstructionsNoSnap = () => {
   const [libraryUsed, setLibraryUsed] = React.useState('moment');
 
   const handlePackageMangerChange = (event, nextPackageManger) => {
-    setPackageManger(nextPackageManger);
+    if (nextPackageManger !== null) {
+      setPackageManger(nextPackageManger);
+    }
   };
 
   const handleLicenceTypeChange = (event, nextLicenceType) => {
-    setLicenceType(nextLicenceType);
+    if (nextLicenceType !== null) {
+      setLicenceType(nextLicenceType);
+    }
   };
 
   const handleLibraryUsedChange = (event) => {


### PR DESCRIPTION
* Enforce a value for package manager and license type options
* It makes sense that at least one of the options is selected at all times
* This will avoid the bug where 'null' ends up getting displayed

Before: 

![image](https://user-images.githubusercontent.com/85733202/202479121-b79036da-18f5-413a-b294-6f3e26b37974.png)

After: 

![image](https://user-images.githubusercontent.com/85733202/202479347-681ca22c-00b7-439c-8ddc-b0f6d864ae98.png)
