### PR TITLE
[core] Upgrade monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "format-util": "^1.0.5",
     "glob-gitignore": "^1.0.14",
+    "globby": "^13.1.2",
+    "html-webpack-plugin": "^5.5.0",
     "jsdom": "^20.0.0",
     "jss": "^10.9.2",
     "jss-plugin-template": "^10.9.2",
@@ -178,10 +180,7 @@
       "**/@mui/monorepo"
     ]
   },
-  "dependencies": {
-    "globby": "^13.1.2",
-    "html-webpack-plugin": "^5.5.0"
-  },
+  "dependencies": {},
   "resolutions": {
     "**/react-is": "^18.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2527,7 +2527,7 @@
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
   version "5.10.14"
-  resolved "https://github.com/mui/material-ui.git#30e42b8991e3c42790d99f1ede8310a20c956837"
+  resolved "https://github.com/mui/material-ui.git#2f27c2eafdf04f278c94a483b76ca6ec925903e9"
 
 "@mui/private-theming@^5.10.3":
   version "5.10.3"


### PR DESCRIPTION
Same as https://github.com/mui/mui-x/pull/6905, but for `master` branch

Preview: https://deploy-preview-6906--material-ui-x.netlify.app/x/api/data-grid/data-grid/

I will cherry-pick the merge commit on `docs-v5` branch after merging this PR and deploy it to production.