### PR TITLE
[test] Sync test:unit with monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/**/*.test.{js,ts,tsx}' --exclude '**/node_modules/**' && nyc report -r lcovonly",
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/**/*.test.{js,ts,tsx}' --exclude '**/node_modules/**' && nyc report --reporter=html",
     "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js",
-    "test:unit": "cross-env NODE_ENV=test node --expose_gc ./node_modules/.bin/mocha 'packages/**/*.test.{js,ts,tsx}' --exclude '**/node_modules/**' --timeout 3000",
+    "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' -n expose_gc",
     "test:e2e": "cross-env NODE_ENV=production yarn test:e2e:build && concurrently --success first --kill-others \"yarn test:e2e:run\" \"yarn test:e2e:server\"",
     "test:e2e:build": "webpack --config test/e2e/webpack.config.js",
     "test:e2e:dev": "concurrently \"yarn test:e2e:build --watch\" \"yarn test:e2e:server\"",


### PR DESCRIPTION
A different take on #5564, this time only copy & pasting what's done in the main repo.

`global.gc` is still available and I removed options of the CLI that override

https://github.com/mui/mui-x/blob/4e5023840793242198772743bc7d968a507db1d6/.mocharc.js#L2-L24

https://github.com/mui/mui-x/pull/5458#issuecomment-1180517434 @mnajdova does it work now on Windows? 