### PR TITLE
[l10n] Fix translation of `filterOperatorBefore` in Arabic (ar-SD) locale

### DIFF
--- a/packages/grid/x-data-grid/src/locales/arSD.ts
+++ b/packages/grid/x-data-grid/src/locales/arSD.ts
@@ -68,7 +68,7 @@ const arSDGrid: Partial<GridLocaleText> = {
   filterOperatorNot: 'ليس',
   filterOperatorAfter: 'بعد',
   filterOperatorOnOrAfter: 'عند أو بعد',
-  filterOperatorBefore: 'بعد',
+  filterOperatorBefore: 'قبل',
   filterOperatorOnOrBefore: 'عند أو قبل',
   filterOperatorIsEmpty: 'خالي',
   filterOperatorIsNotEmpty: 'غير خالي',


### PR DESCRIPTION
Backports #6884 