### PR TITLE
[DataGridPremium] Improve typing for theme in `styleOverrides`

### DIFF
--- a/packages/grid/x-data-grid-premium/src/themeAugmentation/props.ts
+++ b/packages/grid/x-data-grid-premium/src/themeAugmentation/props.ts
@@ -1,11 +1,11 @@
-import { ComponentsOverrides, ComponentsProps, Theme } from '@mui/material/styles';
+import { ComponentsOverrides, ComponentsProps } from '@mui/material/styles';
 import { DataGridPremiumProps } from '../models/dataGridPremiumProps';
 
 export interface DataGridPremiumComponentsPropsList {
   MuiDataGrid: DataGridPremiumProps;
 }
 
-export interface DataGridPremiumComponents {
+export interface DataGridPremiumComponents<Theme = unknown> {
   MuiDataGrid?: {
     defaultProps?: ComponentsProps['MuiDataGrid'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDataGrid'];
@@ -14,8 +14,5 @@ export interface DataGridPremiumComponents {
 
 declare module '@mui/material/styles' {
   interface ComponentsPropsList extends DataGridPremiumComponentsPropsList {}
-}
-
-declare module '@mui/material/styles/components' {
-  interface Components extends DataGridPremiumComponents {}
+  interface Components<Theme = unknown> extends DataGridPremiumComponents<Theme> {}
 }


### PR DESCRIPTION
#5818 missed `DataGridPremium`.

Before: https://codesandbox.io/s/datagridpro-styleoverrides-issue-forked-l2di20?file=/src/App.tsx
After: https://codesandbox.io/s/datagridpro-styleoverrides-issue-forked-2s6x1g?file=/src/App.tsx