### PR TITLE
[pickers] Fix calendar header switch view button hover circle

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/PickersCalendarHeader.tsx
@@ -111,7 +111,6 @@ const PickersCalendarHeaderLabelContainer = styled('div', {
   ownerState: PickersCalendarHeaderProps<any>;
 }>(({ theme }) => ({
   display: 'flex',
-  maxHeight: 30,
   overflow: 'hidden',
   alignItems: 'center',
   cursor: 'pointer',


### PR DESCRIPTION
Fixed picker selection circle

<img width="337" alt="Screenshot 2022-11-21 at 11 10 12 AM" src="https://user-images.githubusercontent.com/7589596/202974055-4166bbe6-4231-486f-acf9-c9b5a727948f.png">

With removing `maxHeight`:

<img width="325" alt="Screenshot 2022-11-21 at 11 10 44 AM" src="https://user-images.githubusercontent.com/7589596/202974089-4163b780-9dbd-4716-bb58-db728bc3b6f1.png">
