### PR TITLE
[DataGrid] Prevents master detail panel toggle with Ctrl+Enter

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
@@ -117,12 +117,6 @@ export const useGridDetailPanel = (
         return;
       }
 
-      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
-        // TODO v6: only support Space on the detail toggle
-        apiRef.current.toggleDetailPanel(params.id);
-        return;
-      }
-
       if (params.field === GRID_DETAIL_PANEL_TOGGLE_FIELD && event.key === ' ') {
         apiRef.current.toggleDetailPanel(params.id);
       }

--- a/packages/grid/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
@@ -292,17 +292,6 @@ describe('<DataGridPro /> - Detail panel', () => {
     expect(virtualScroller.scrollTop).to.equal(0);
   });
 
-  it('should toggle the detail panel when pressing Ctrl/Cmd+Enter', () => {
-    render(<TestCase getDetailPanelContent={() => <div>Detail</div>} />);
-    expect(screen.queryByText('Detail')).to.equal(null);
-    const cell = getCell(1, 1);
-    userEvent.mousePress(cell);
-    fireEvent.keyDown(cell, { ctrlKey: true, key: 'Enter' });
-    expect(screen.queryByText('Detail')).not.to.equal(null);
-    fireEvent.keyDown(cell, { metaKey: true, key: 'Enter' });
-    expect(screen.queryByText('Detail')).to.equal(null);
-  });
-
   it('should toggle the detail panel when pressing Space on detail toggle cell', () => {
     render(<TestCase getDetailPanelContent={() => <div>Detail</div>} />);
     expect(screen.queryByText('Detail')).to.equal(null);
@@ -514,7 +503,7 @@ describe('<DataGridPro /> - Detail panel', () => {
   });
 
   describe('prop: onDetailPanelsExpandedRowIds', () => {
-    it('shoull call when a row is expanded or closed', () => {
+    it('should call when a row is expanded or closed', () => {
       const handleDetailPanelsExpandedRowIdsChange = spy();
       render(
         <TestCase
@@ -532,7 +521,7 @@ describe('<DataGridPro /> - Detail panel', () => {
       expect(handleDetailPanelsExpandedRowIdsChange.lastCall.args[0]).to.deep.equal([]);
     });
 
-    it('shoull not change the open detail panels when called while detailPanelsExpandedRowIds is the same', () => {
+    it('should not change the open detail panels when called while detailPanelsExpandedRowIds is the same', () => {
       const handleDetailPanelsExpandedRowIdsChange = spy();
       render(
         <TestCase
@@ -561,7 +550,7 @@ describe('<DataGridPro /> - Detail panel', () => {
       expect(screen.queryByText('Row 2')).to.equal(null);
     });
 
-    it("should not change the open detail panels if the prop  didn't change", () => {
+    it("should not change the open detail panels if the prop didn't change", () => {
       render(
         <TestCase
           getDetailPanelContent={({ id }) => <div>Row {id}</div>}


### PR DESCRIPTION
Closes #5613 

## Changelog

### Breaking changes

- `Ctrl/Cmd + Enter` will no longer toggle the master detail panel