### PR TITLE
Mention the use of Support key as an alternative to the OrderID

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -64,6 +64,6 @@ body:
   - type: input
     id: contact
     attributes:
-      label: Order ID 💳 (optional)
-      description: The [Pro plan](https://mui.com/pricing/) comes with priority over the Community plan. Providing your order ID might give your problem more attention.
+      label: Order ID or Support key 💳 (optional)
+      description: The [Pro plan](https://mui.com/pricing/) comes with priority over the Community plan. Providing your order ID (or support key) gives your problem more attention.
       placeholder: 'e.g. 11111'

--- a/.github/ISSUE_TEMPLATE/3.pro-support.yml
+++ b/.github/ISSUE_TEMPLATE/3.pro-support.yml
@@ -12,7 +12,7 @@ body:
   - type: input
     id: contact
     attributes:
-      label: Order ID 💳
+      label: Order ID or Support key 💳 (optional)
       description: The order ID of the purchased Pro plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
       placeholder: 'e.g. 11111'
     validations:

--- a/.github/ISSUE_TEMPLATE/4.premium-support.yml
+++ b/.github/ISSUE_TEMPLATE/4.premium-support.yml
@@ -12,7 +12,7 @@ body:
   - type: input
     id: contact
     attributes:
-      label: Order ID 💳
+      label: Order ID or Support key 💳 (optional)
       description: The order ID of the purchased Premium plan. Community users can [learn more about support](https://mui.com/getting-started/support/) in the documentation.
       placeholder: 'e.g. 11111'
     validations:

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -28,7 +28,7 @@ Support is available on multiple channels, but the recommended channels are:
 - GitHub: You can [open a new issue](https://github.com/mui/mui-x/issues/new/choose) and leave your Order ID (or Support key), so we can prioritize accordingly.
 - Email: If you need to share **private information** you can [submit a request](https://support.mui.com/hc/en-us/requests/new?tf_360023797420=mui_x) or send an email to [x@mui.com](mailto:x@mui.com).
 
-Including your Order ID in the issue helps us prioritize the issues based on the following support levels:
+Including your Order ID (or Support key) in the issue helps us prioritize the issues based on the following support levels:
 
 1. MUI X Pro: maintainers give these issues more attention than the ones from the community.
 2. MUI X Premium: The same as MUI X Pro, but with higher priority.

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -25,7 +25,7 @@ The technical support covers only MUI X components.
 When purchasing a MUI X Pro or Premium license you get access to technical support until the end of your subscription.
 Support is available on multiple channels, but the recommended channels are:
 
-- GitHub: You can [open a new issue](https://github.com/mui/mui-x/issues/new/choose) and leave your Order ID, so we can prioritize accordingly.
+- GitHub: You can [open a new issue](https://github.com/mui/mui-x/issues/new/choose) and leave your Order ID (or Support key), so we can prioritize accordingly.
 - Email: If you need to share **private information** you can [submit a request](https://support.mui.com/hc/en-us/requests/new?tf_360023797420=mui_x) or send an email to [x@mui.com](mailto:x@mui.com).
 
 Including your Order ID in the issue helps us prioritize the issues based on the following support levels:


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/6899

### Summary 

Users purchasing a license through a procurement service sometimes don't get access to the original order ID. We'll ship the order ID as a Support key together with the license key, to make sure the number reaches the developers that will be using the license and technical support.

This PR goes together with https://github.com/mui/mui-store/pull/230, which adds the order Id as a support key to the order note, as we do with the license key.