### PR TITLE
[DataGridPro] Fix lazy-loaded rows not working with `updateRows` API method

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, fireEvent, act } from '@mui/monorepo/test/utils';
-import { getColumnHeaderCell, getRow } from 'test/utils/helperFn';
+import { getColumnHeaderCell, getColumnValues, getRow } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import {
   DataGridPro,
@@ -112,6 +112,22 @@ describe('<DataGridPro /> - Lazy loader', () => {
 
     const updatedAllRows = apiRef.current.getRowNode<GridGroupNode>(GRID_ROOT_GROUP_ID)!.children;
     expect(updatedAllRows.slice(4, 6)).to.deep.equal([4, 5]);
+  });
+
+  // See https://github.com/mui/mui-x/issues/6857
+  it('should update the row when `apiRef.current.updateRows` is called on lazy-loaded rows', () => {
+    render(<TestLazyLoader rowCount={5} autoHeight={isJSDOM} />);
+
+    const newRows: GridRowModel[] = [
+      { id: 4, first: 'John' },
+      { id: 5, first: 'Mac' },
+    ];
+
+    act(() => apiRef.current.unstable_replaceRows(3, newRows));
+    expect(getColumnValues(1)).to.deep.equal(['Mike', 'Jack', 'Jim', 'John', 'Mac']);
+
+    act(() => apiRef.current.updateRows([{ id: 4, first: 'John updated' }]));
+    expect(getColumnValues(1)).to.deep.equal(['Mike', 'Jack', 'Jim', 'John updated', 'Mac']);
   });
 
   it('should update all rows accordingly when `apiRef.current.unstable_replaceRows` is called and props.getRowId is defined', () => {

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -402,6 +402,9 @@ export const useGridRows = (
       // Removes potential remaining skeleton rows from the dataRowIds.
       const dataRowIds = rootGroupChildren.filter((childId) => tree[childId].type === 'leaf');
 
+      apiRef.current.caches.rows.dataRowIdToModelLookup = dataRowIdToModelLookup;
+      apiRef.current.caches.rows.dataRowIdToIdLookup = dataRowIdToIdLookup;
+
       apiRef.current.setState((state) => ({
         ...state,
         rows: {


### PR DESCRIPTION
Port of https://github.com/mui/mui-x/pull/6875 to the `next` branch