### PR TITLE
[docs] Update API links from clock-picker to time-clock

### DIFF
--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -1,7 +1,7 @@
 ---
 product: date-pickers
 title: React Time Picker component
-components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, ClockPicker
+components: DesktopTimePicker, MobileTimePicker, StaticTimePicker, TimePicker, TimeClock
 githubLabel: 'component: TimePicker'
 packageName: '@mui/x-date-pickers'
 materialDesign: https://m2.material.io/components/time-pickers

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -39,6 +39,8 @@
 /x/react-date-pickers/migration-lab/ /x/migration/migration-pickers-lab/ 301
 /:lang/x/react-date-pickers/migration-lab/ /:lang/x/migration/migration-pickers-lab/ 301
 
+/x/api/date-pickers/clock-picker/ /x/api/date-pickers/time-clock/ 301
+/:lang/x/api/date-pickers/clock-picker/ /:lang/x/api/date-pickers/time-clock/ 301
 
 # 2023
 


### PR DESCRIPTION
ahrefs notified a 404 links in https://next.mui.com/x/react-date-pickers/time-picker/ in the API section