### PR TITLE
[docs] Add missing pickers migration docs

### DIFF
--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -19,6 +19,13 @@ Since v6 is a major release, it contains some changes that affect the public API
 These changes were done for consistency, improve stability and make room for new features.
 Below are described the steps you need to make to migrate from v5 to v6.
 
+### Drop `clock` in desktop mode
+
+We have dropped the clock picker behavior in desktop mode for `DateTimePicker` and `TimePicker` components.
+This is the first step towards moving to a [better implementation](https://github.com/mui/mui-x/issues/4483).
+The behavior on mobile mode is still the same.
+If you were relying on Clock Picker in desktop mode for tests—make sure to check [testing caveats](/x/react-date-pickers/getting-started/#testing-caveats) to choose the best replacement for it.
+
 ### Update the format of the `value` prop
 
 Previously, it was possible to provide any format that your date management library was able to parse.

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -26,6 +26,17 @@ This is the first step towards moving to a [better implementation](https://githu
 The behavior on mobile mode is still the same.
 If you were relying on Clock Picker in desktop mode for tests—make sure to check [testing caveats](/x/react-date-pickers/getting-started/#testing-caveats) to choose the best replacement for it.
 
+### Drop direct `@date-io` adapters support
+
+In order to support new Date and Time pickers with [fields components](/x/react-date-pickers/fields/) we had to augment `@date-io` adapters.
+If you were using adapter from `@date-io`—you will need to update the import.
+If we do not have a specific augmented adapter you were using—there probably was a reason for it, but you can raise an issue expressing interest in it.
+
+```diff
+-import AdapterJalaali from '@date-io/jalaali';
++import { AdapterMomentJalaali } from '@mui/x-date-pickers-pro/AdapterMomentJalaali';
+```
+
 ### Update the format of the `value` prop
 
 Previously, it was possible to provide any format that your date management library was able to parse.

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -304,3 +304,64 @@ Component name changes are also reflected in `themeAugmentation`:
    },
  });
 ```
+
+### Replace `toolbar` props by slot
+
+- The `ToolbarComponent` has been replaced by a `Toolbar` component slot. You can find more information about this pattern in the [MUI Base documentation](https://mui.com/base/getting-started/usage/#shared-props):
+
+  ```diff
+  // Same on all other pickers
+  <DatePicker
+  -  ToolbarComponent: MyToolbar,
+  +  components={{ Toolbar: MyToolbar }}
+  />
+  ```
+
+- The `toolbarPlaceholder` and `toolbarFormat` props have been moved to the `toolbar` component props slot:
+
+  ```diff
+  // Same on all other pickers
+  <DatePicker
+  -  toolbarPlaceholder="__"
+  -  toolbarFormat="DD / MM / YYYY"
+  +  componentsProps={{
+  +    toolbar: {
+  +      toolbarPlaceholder: "__",
+  +      toolbarFormat: "DD / MM / YYYY",
+  +    }
+  +  }}
+  />
+  ```
+
+- The `toolbarTitle` prop has been moved to the localization object:
+
+  ```diff
+  // Same on all other pickers
+  <DatePicker
+  -  toolbarTitle="Title"
+  +  localeText={{ toolbarTitle: "Title" }}
+  />
+  ```
+
+- The toolbar related translation keys have been renamed to better fit their usage:
+
+  ```diff
+  // Same on all other pickers
+  <DatePicker
+    localeText={{
+  -    datePickerDefaultToolbarTitle: 'Date Picker',
+  +    datePickerToolbarTitle: 'Date Picker',
+
+  -    timePickerDefaultToolbarTitle: 'Time Picker',
+  +    timePickerToolbarTitle: 'Time Picker',
+
+  -    dateTimePickerDefaultToolbarTitle: 'Date Time Picker',
+  +    dateTimePickerToolbarTitle: 'Date Time Picker',
+
+  -    dateRangePickerDefaultToolbarTitle: 'Date Range Picker',
+  +    dateRangePickerToolbarTitle: 'Date Range Picker',
+    }}
+  />
+  ```
+
+- The `onChange` / `openView` props on the toolbar have been renamed to `onViewChange` / `view`

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -178,7 +178,7 @@ For instance if you want to replace the `startText` / `endText`
 
 ### Rename the `locale` prop on `LocalizationProvider`
 
-The `locale` prop of the `LocalizationProvider` component have been renamed `adapterLcoale`:
+The `locale` prop of the `LocalizationProvider` component have been renamed `adapterLocale`:
 
 ```diff
  <LocalizationProvider
@@ -238,7 +238,7 @@ Component names in the theme have changed as well:
 
 ### Rename `date` prop to `value` on view components
 
-The `date` prop has been renamed `value` on `MonthCalendar`, `YearCalendar`, `TimeClock` and `DateCalendar` (components renamed in previous section):
+The `date` prop has been renamed `value` on `MonthCalendar`, `YearCalendar`, `TimeClock`, and `DateCalendar` (components renamed in previous section):
 
 ```diff
 -<MonthPicker date={dayjs()} onChange={handleMonthChange} />
@@ -310,18 +310,18 @@ Component name changes are also reflected in `themeAugmentation`:
 - The `ToolbarComponent` has been replaced by a `Toolbar` component slot. You can find more information about this pattern in the [MUI Base documentation](https://mui.com/base/getting-started/usage/#shared-props):
 
   ```diff
-  // Same on all other pickers
-  <DatePicker
+   // Same on all other pickers
+   <DatePicker
   -  ToolbarComponent: MyToolbar,
   +  components={{ Toolbar: MyToolbar }}
-  />
+   />
   ```
 
 - The `toolbarPlaceholder` and `toolbarFormat` props have been moved to the `toolbar` component props slot:
 
   ```diff
-  // Same on all other pickers
-  <DatePicker
+   // Same on all other pickers
+   <DatePicker
   -  toolbarPlaceholder="__"
   -  toolbarFormat="DD / MM / YYYY"
   +  componentsProps={{
@@ -330,24 +330,24 @@ Component name changes are also reflected in `themeAugmentation`:
   +      toolbarFormat: "DD / MM / YYYY",
   +    }
   +  }}
-  />
+   />
   ```
 
 - The `toolbarTitle` prop has been moved to the localization object:
 
   ```diff
-  // Same on all other pickers
-  <DatePicker
+   // Same on all other pickers
+   <DatePicker
   -  toolbarTitle="Title"
   +  localeText={{ toolbarTitle: "Title" }}
-  />
+   />
   ```
 
 - The toolbar related translation keys have been renamed to better fit their usage:
 
   ```diff
-  // Same on all other pickers
-  <DatePicker
+   // Same on all other pickers
+   <DatePicker
     localeText={{
   -    datePickerDefaultToolbarTitle: 'Date Picker',
   +    datePickerToolbarTitle: 'Date Picker',
@@ -361,7 +361,36 @@ Component name changes are also reflected in `themeAugmentation`:
   -    dateRangePickerDefaultToolbarTitle: 'Date Range Picker',
   +    dateRangePickerToolbarTitle: 'Date Range Picker',
     }}
-  />
+   />
   ```
 
 - The `onChange` / `openView` props on the toolbar have been renamed to `onViewChange` / `view`
+
+### Replace `tabs` props
+
+- The `hideTabs`, `dateRangeIcon`, and `timeIcon` props have been moved to `tabs` component props:
+
+  ```diff
+   // Same on all other Date Time picker variations
+   <DateTimePicker
+  -  hideTabs={false}
+  -  dateRangeIcon={<LightModeIcon />}
+  -  timeIcon={<AcUnitIcon />}
+  +  componentsProps={{
+  +    tabs: {
+  +      hidden: false,
+  +      dateRangeIcon: <LightModeIcon />,
+  +      timeIcon: <AcUnitIcon />,
+  +    }
+  +  }}
+   />
+  ```
+
+- The `onChange` prop on `DateTimePickerTabs` component has been renamed to `onViewChange` to better fit its usage:
+
+  ```diff
+   <DateTimePickerTabs
+  -  onChange={() => {}}
+  +  onViewChange={() => {}}
+   />
+  ```

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -21,15 +21,16 @@ Below are described the steps you need to make to migrate from v5 to v6.
 
 ### Drop `clock` in desktop mode
 
-We have dropped the clock picker behavior in desktop mode for `DateTimePicker` and `TimePicker` components.
+In desktop mode, the `DateTimePicker` and `TimePicker` components will not display the clock.
 This is the first step towards moving to a [better implementation](https://github.com/mui/mui-x/issues/4483).
 The behavior on mobile mode is still the same.
 If you were relying on Clock Picker in desktop mode for tests—make sure to check [testing caveats](/x/react-date-pickers/getting-started/#testing-caveats) to choose the best replacement for it.
 
 ### Extended `@date-io` adapters
 
-In order to support new Date and Time pickers with [fields components](/x/react-date-pickers/fields/) we had to augment `@date-io` adapters.
-If you were using adapter from `@date-io`—you will need to update the import.
+In v5, it was possible to import adapters either from `@date-io` or `@mui/x-date-pickers` which were the same.
+In v6, the adapters are extended by `@mui/x-date-pickers` to support [fields components](/x/react-date-pickers/fields/). 
+Which means adapters can not be imported from `@date-io` anymore. They need to be imported from `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`. Otherwise, some methods will be missing.
 If you do not find the adapter you were using—there probably was a reason for it, but you can raise an issue expressing interest in it.
 
 ```diff

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -394,3 +394,17 @@ Component name changes are also reflected in `themeAugmentation`:
   +  onViewChange={() => {}}
    />
   ```
+
+  ```diff
+   const CustomTabsComponent = props => (
+     <div>
+  -    <button onClick={() => props.onChange('day')}>Show day view</button>
+  +    <button onClick={() => props.onViewChange('day')}>Show day view</button>
+     </div>
+   )
+   <DateTimePicker
+     components={{
+       tabs: CustomTabsComponent
+     }}
+   />
+  ```

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -26,11 +26,11 @@ This is the first step towards moving to a [better implementation](https://githu
 The behavior on mobile mode is still the same.
 If you were relying on Clock Picker in desktop mode for tests—make sure to check [testing caveats](/x/react-date-pickers/getting-started/#testing-caveats) to choose the best replacement for it.
 
-### Drop direct `@date-io` adapters support
+### Extended `@date-io` adapters
 
 In order to support new Date and Time pickers with [fields components](/x/react-date-pickers/fields/) we had to augment `@date-io` adapters.
 If you were using adapter from `@date-io`—you will need to update the import.
-If we do not have a specific augmented adapter you were using—there probably was a reason for it, but you can raise an issue expressing interest in it.
+If you do not find the adapter you were using—there probably was a reason for it, but you can raise an issue expressing interest in it.
 
 ```diff
 -import AdapterJalaali from '@date-io/jalaali';

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -29,7 +29,7 @@ If you were relying on Clock Picker in desktop mode for tests—make sure to che
 ### Extended `@date-io` adapters
 
 In v5, it was possible to import adapters either from `@date-io` or `@mui/x-date-pickers` which were the same.
-In v6, the adapters are extended by `@mui/x-date-pickers` to support [fields components](/x/react-date-pickers/fields/). 
+In v6, the adapters are extended by `@mui/x-date-pickers` to support [fields components](/x/react-date-pickers/fields/).
 Which means adapters can not be imported from `@date-io` anymore. They need to be imported from `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`. Otherwise, some methods will be missing.
 If you do not find the adapter you were using—there probably was a reason for it, but you can raise an issue expressing interest in it.
 


### PR DESCRIPTION
Add missing breaking changes from #6543 and #6445.

[Docs preview](https://deploy-preview-7000--material-ui-x.netlify.app/x/migration/migration-pickers-v5/#replace-toolbar-props-by-slot)

P.S. I've already updated the GH pre-release with missing info (about tabs)