### PR TITLE
[DataGrid] Removes <GridCell /> fallback to `valueToRender` on `null` children

### DIFF
--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -293,7 +293,7 @@ const GridRow = React.forwardRef<
       }
 
       const editCellState = editRowsState[rowId] ? editRowsState[rowId][column.field] : null;
-      let content: React.ReactNode = null;
+      let content: React.ReactNode;
 
       if (editCellState == null && column.renderCell) {
         content = column.renderCell({ ...cellParams, api: apiRef.current });

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -236,7 +236,7 @@ function GridCell(props: GridCellProps) {
   const managesOwnFocus = column.type === 'actions';
 
   const renderChildren = () => {
-    if (children == null) {
+    if (children === undefined) {
       return <div className={classes.content}>{valueToRender?.toString()}</div>;
     }
 

--- a/packages/grid/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -133,6 +133,19 @@ describe('<DataGrid /> - Cells', () => {
     expect(getCell(0, 0)).to.have.text('0');
   });
 
+  it('should render nothing in cell when renderCell returns a `null` value', () => {
+    render(
+      <div style={{ width: 300, height: 500 }}>
+        <DataGrid
+          autoHeight={isJSDOM}
+          columns={[{ field: 'brand', renderCell: () => null }]}
+          rows={[{ id: 1, brand: 'Nike' }]}
+        />
+      </div>,
+    );
+    expect(getCell(0, 0)).to.have.text('');
+  });
+
   it('should call the valueFormatter with the correct params', () => {
     const valueFormatter = spy(({ value }) => (value ? 'Yes' : 'No'));
     render(


### PR DESCRIPTION
Closes #5612

- [x] Fix the issue
- [x] Test the fix
- [x] Fix other impacting tests

## Changelog

### Breaking changes

- Passing children as `null` to `<GridCell />` will not render `valueToRender` anymore