### PR TITLE
[docs] Setup GitHub issue template for feedbacks about docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/6.docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/6.docs-feedback.yml
@@ -1,0 +1,52 @@
+name: Docs feedback
+description: Improve documentation about MUI Core.
+labels: ['status: needs triage', 'support: docs-feedback']
+title: '[docs] '
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/mui/material-ui/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Related page
+      description: Which page of the documentation is this about?
+      placeholder: https://mui.com/material-ui/react-badge/
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Kind of issue
+      description: What kind of problem are you facing?
+      options:
+        - Unclear explanations
+        - Missing information
+        - Broken demonstration
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: |
+        Let us know what went wrong when you were using this documentation and what we could do to improve it.
+      value: |
+        I was looking for ... and it appears that ...
+
+  - type: textarea
+    attributes:
+      label: Context 🔦
+      description: What are you trying to accomplish? What brought you to this page? Your context can help us to come up with solutions that benefit the community as a whole.

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -23,6 +23,7 @@ module.exports = withDocsInfra({
     // #default-branch-switch
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui/mui-x/blob/next',
     SOURCE_CODE_REPO: 'https://github.com/mui/mui-x',
+    GITHUB_TEMPLATE_DOCS_FEEDBACK: '6.docs-feedback.yml',
   },
   webpack: (config, options) => {
     const plugins = config.plugins.slice();


### PR DESCRIPTION
Follow up of https://github.com/mui/material-ui/pull/34641

Configure docs and create the template for the link "open an issue" in the new documentation feedbacks

![image](https://user-images.githubusercontent.com/45398769/204244801-e8e6659d-baa0-48fb-945d-0b868075cd95.png)
