### PR TITLE
[DataGrid] focused cell should be in the DOM

### DIFF
--- a/docs/data/data-grid/events/events.json
+++ b/docs/data/data-grid/events/events.json
@@ -55,6 +55,13 @@
   },
   {
     "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
+    "name": "cellFocusUnmount",
+    "description": "Fired when a focused cell unmount.",
+    "params": "React.ReactElement",
+    "event": "MuiEvent<{}>"
+  },
+  {
+    "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
     "name": "cellKeyDown",
     "description": "Fired when a <code>keydown</code> event happens in a cell.",
     "params": "GridCellParams",

--- a/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
@@ -10,6 +10,7 @@ import {
   useGridApiEventHandler,
   GridRowId,
   GridOverlays,
+  GridTempContainers,
 } from '@mui/x-data-grid';
 import {
   GridVirtualScroller,
@@ -364,6 +365,7 @@ const DataGridProVirtualScroller = React.forwardRef<
   return (
     <GridVirtualScroller {...getRootProps(other)}>
       <GridOverlays />
+      <GridTempContainers />
       {topPinnedRowsData.length > 0 ? (
         <VirtualScrollerPinnedRows
           className={classes.topPinnedRows}

--- a/packages/grid/x-data-grid/src/components/DataGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/components/DataGridVirtualScroller.tsx
@@ -4,6 +4,7 @@ import { GridVirtualScrollerContent } from './virtualization/GridVirtualScroller
 import { GridVirtualScrollerRenderZone } from './virtualization/GridVirtualScrollerRenderZone';
 import { useGridVirtualScroller } from '../hooks/features/virtualization/useGridVirtualScroller';
 import { GridOverlays } from './base/GridOverlays';
+import { GridTempContainers } from './base/GridTempContainers';
 
 interface DataGridVirtualScrollerProps extends React.HTMLAttributes<HTMLDivElement> {
   disableVirtualization?: boolean;
@@ -21,6 +22,7 @@ const DataGridVirtualScroller = React.forwardRef<HTMLDivElement, DataGridVirtual
     return (
       <GridVirtualScroller className={className} {...getRootProps(other)}>
         <GridOverlays />
+        <GridTempContainers />
         <GridVirtualScrollerContent {...getContentProps()}>
           <GridVirtualScrollerRenderZone {...getRenderZoneProps()}>
             {getRows()}

--- a/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
@@ -15,12 +15,20 @@ export function GridTempContainers() {
 
   const handelcellFocusUnmount = React.useCallback<GridEventListener<'cellFocusUnmount'>>(
     (params) => {
-      const { cell } = apiRef.current.state.focus;
+      const { cell, columnHeader } = apiRef.current.state.focus;
       if (cell) {
         const cellElement = apiRef.current.getCellElement(cell.id, cell.field);
         if (cellElement && focusedCellElement !== null) {
           setFocusedCellElement(null);
         } else if (focusedCellElement === null && cellElement === null) {
+          setFocusedCellElement(params);
+        }
+      }
+      if (columnHeader) {
+        const columnElement = apiRef.current.getColumnHeaderElement(columnHeader.field);
+        if (columnElement && focusedCellElement !== null) {
+          setFocusedCellElement(null);
+        } else if (focusedCellElement === null && columnElement === null) {
           setFocusedCellElement(params);
         }
       }
@@ -33,6 +41,7 @@ export function GridTempContainers() {
 
   useGridApiEventHandler(apiRef, 'cellFocusUnmount', handelcellFocusUnmount);
   useGridApiEventHandler(apiRef, 'cellFocusOut', handleCellFocusOut);
+  useGridApiEventHandler(apiRef, 'columnHeaderBlur', handleCellFocusOut);
 
   return (
     <Box sx={{ height: 0, width: 0, opacity: 0 }}>{focusedCellElement && focusedCellElement}</Box>

--- a/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+
+import { GridEventListener } from '../../models/events';
+import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiContext';
+import { useGridApiEventHandler } from '../../hooks/utils/useGridApiEventHandler';
+
+// This container helps cell elements stay in the DOM if they are the active elements and
+// are not in the view range when virtualization is enabled.
+
+export function GridTempContainers() {
+  const apiRef = useGridPrivateApiContext();
+  const [focusedCellElement, setFocusedCellElement] = React.useState<React.ReactElement | null>(
+    null,
+  );
+
+  const handelcellFocusUnmount = React.useCallback<GridEventListener<'cellFocusUnmount'>>(
+    (params) => {
+      const { cell } = apiRef.current.state.focus;
+      if (cell) {
+        const cellElement = apiRef.current.getCellElement(cell.id, cell.field);
+        if (cellElement) {
+          setFocusedCellElement(null);
+        } else {
+          setFocusedCellElement(params);
+        }
+      }
+    },
+    [apiRef],
+  );
+  const handleCellFocusOut = React.useCallback<GridEventListener<'cellFocusOut'>>(() => {
+    setFocusedCellElement(null);
+  }, []);
+
+  useGridApiEventHandler(apiRef, 'cellFocusUnmount', handelcellFocusUnmount);
+  useGridApiEventHandler(apiRef, 'cellFocusOut', handleCellFocusOut);
+
+  return (
+    <Box sx={{ height: 0, width: 0, opacity: 0 }}>{focusedCellElement && focusedCellElement}</Box>
+  );
+}

--- a/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
@@ -21,12 +21,12 @@ export function GridTempContainers() {
         const cellElement = apiRef.current.getCellElement(cell.id, cell.field);
         if (cellElement) {
           setFocusedCellElement(null);
-        } else {
+        } else if (focusedCellElement === null) {
           setFocusedCellElement(params);
         }
       }
     },
-    [apiRef],
+    [apiRef, focusedCellElement],
   );
   const handleCellFocusOut = React.useCallback<GridEventListener<'cellFocusOut'>>(() => {
     setFocusedCellElement(null);

--- a/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridTempContainers.tsx
@@ -6,8 +6,7 @@ import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiCon
 import { useGridApiEventHandler } from '../../hooks/utils/useGridApiEventHandler';
 
 // This container helps cell elements stay in the DOM if they are the active elements and
-// are not in the view range when virtualization is enabled.
-
+// If they have an event attached to them, that should be active even if using virtualization.
 export function GridTempContainers() {
   const apiRef = useGridPrivateApiContext();
   const [focusedCellElement, setFocusedCellElement] = React.useState<React.ReactElement | null>(
@@ -19,9 +18,9 @@ export function GridTempContainers() {
       const { cell } = apiRef.current.state.focus;
       if (cell) {
         const cellElement = apiRef.current.getCellElement(cell.id, cell.field);
-        if (cellElement) {
+        if (cellElement && focusedCellElement !== null) {
           setFocusedCellElement(null);
-        } else if (focusedCellElement === null) {
+        } else if (focusedCellElement === null && cellElement === null) {
           setFocusedCellElement(params);
         }
       }

--- a/packages/grid/x-data-grid/src/components/base/index.ts
+++ b/packages/grid/x-data-grid/src/components/base/index.ts
@@ -3,3 +3,4 @@ export * from './GridErrorHandler';
 export * from './GridFooterPlaceholder';
 export * from './GridHeaderPlaceholder';
 export * from './GridOverlays';
+export * from './GridTempContainers';

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -211,8 +211,8 @@ function GridCell(props: GridCellProps) {
       if (isNotInRow) {
         return;
       }
-      const type = current.getRowNode(rowId)!.type;
-      if (hasFocus && type !== 'pinnedRow') {
+      const rowNode = current.getRowNode(rowId);
+      if (hasFocus && rowNode && rowNode.type !== 'pinnedRow') {
         current.publishEvent('cellFocusUnmount', <GridCell {...props} isNotInRow />);
       }
     };

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -202,6 +202,15 @@ function GridCell(props: GridCellProps) {
     }
   }, [hasFocus, cellMode, apiRef]);
 
+  React.useEffect(() => {
+    const current = apiRef.current;
+    return () => {
+      if (hasFocus) {
+        current.publishEvent('cellFocusUnmount', <GridCell {...props} />);
+      }
+    };
+  }, [hasFocus, props, apiRef]);
+
   let handleFocus: any = other.onFocus;
 
   if (

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -40,6 +40,7 @@ export interface GridCellProps<V = any, F = V> {
   tabIndex: 0 | -1;
   colSpan?: number;
   disableDragEvents?: boolean;
+  isNotInRow?: boolean;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
   onDoubleClick?: React.MouseEventHandler<HTMLDivElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
@@ -108,6 +109,7 @@ function GridCell(props: GridCellProps) {
     row,
     colSpan,
     disableDragEvents,
+    isNotInRow,
     onClick,
     onDoubleClick,
     onMouseDown,
@@ -204,12 +206,16 @@ function GridCell(props: GridCellProps) {
 
   React.useEffect(() => {
     const current = apiRef.current;
+
     return () => {
+      if (isNotInRow) {
+        return;
+      }
       if (hasFocus) {
-        current.publishEvent('cellFocusUnmount', <GridCell {...props} />);
+        current.publishEvent('cellFocusUnmount', <GridCell {...props} isNotInRow />);
       }
     };
-  }, [hasFocus, props, apiRef]);
+  }, [hasFocus, props, apiRef, rowId, isNotInRow]);
 
   let handleFocus: any = other.onFocus;
 

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -211,7 +211,8 @@ function GridCell(props: GridCellProps) {
       if (isNotInRow) {
         return;
       }
-      if (hasFocus) {
+      const type = current.getRowNode(rowId)!.type;
+      if (hasFocus && type !== 'pinnedRow') {
         current.publishEvent('cellFocusUnmount', <GridCell {...props} isNotInRow />);
       }
     };
@@ -311,6 +312,7 @@ GridCell.propTypes = {
   hasFocus: PropTypes.bool,
   height: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.number]).isRequired,
   isEditable: PropTypes.bool,
+  isNotInRow: PropTypes.bool,
   onClick: PropTypes.func,
   onDoubleClick: PropTypes.func,
   onDragEnter: PropTypes.func,

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -30,6 +30,7 @@ interface GridColumnHeaderItemProps {
   tabIndex: 0 | -1;
   disableReorder?: boolean;
   separatorSide?: GridColumnHeaderSeparatorProps['side'];
+  isNotInRow?: boolean;
 }
 
 type OwnerState = GridColumnHeaderItemProps & {
@@ -83,6 +84,7 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
     extendRowFullWidth,
     disableReorder,
     separatorSide,
+    isNotInRow,
   } = props;
   const apiRef = useGridApiContext();
   const rootProps = useGridRootProps();
@@ -231,7 +233,20 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
       elementToFocus?.focus();
       apiRef.current.columnHeadersContainerElementRef!.current!.scrollLeft = 0;
     }
-  }, [apiRef, hasFocus]);
+  }, [apiRef, hasFocus, isNotInRow]);
+
+  React.useEffect(() => {
+    const current = apiRef.current;
+
+    return () => {
+      if (isNotInRow) {
+        return;
+      }
+      if (hasFocus) {
+        current.publishEvent('cellFocusUnmount', <GridColumnHeaderItem {...props} isNotInRow />);
+      }
+    };
+  }, [hasFocus, props, apiRef, isNotInRow]);
 
   const headerClassName =
     typeof column.headerClassName === 'function'

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -242,11 +242,12 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
       if (isNotInRow) {
         return;
       }
-      if (hasFocus) {
+      const isvisible = current.getVisibleColumns().some((col) => col.field === column.field);
+      if (hasFocus && isvisible) {
         current.publishEvent('cellFocusUnmount', <GridColumnHeaderItem {...props} isNotInRow />);
       }
     };
-  }, [hasFocus, props, apiRef, isNotInRow]);
+  }, [hasFocus, props, apiRef, isNotInRow, column]);
 
   const headerClassName =
     typeof column.headerClassName === 'function'
@@ -301,6 +302,7 @@ GridColumnHeaderItem.propTypes = {
   headerHeight: PropTypes.number.isRequired,
   isDragging: PropTypes.bool.isRequired,
   isLastColumn: PropTypes.bool.isRequired,
+  isNotInRow: PropTypes.bool,
   isResizing: PropTypes.bool.isRequired,
   separatorSide: PropTypes.oneOf(['left', 'right']),
   sortDirection: PropTypes.oneOf(['asc', 'desc']),

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
@@ -40,6 +40,7 @@ interface GridGenericColumnHeaderItemProps
   draggableContainerProps?: Partial<React.HTMLProps<HTMLDivElement>>;
   columnHeaderSeparatorProps?: Partial<GridColumnHeaderSeparatorProps>;
   disableHeaderSeparator?: boolean;
+  isNotInRow?: boolean;
 }
 
 const GridGenericColumnHeaderItem = React.forwardRef(function GridGenericColumnHeaderItem(
@@ -96,7 +97,7 @@ const GridGenericColumnHeaderItem = React.forwardRef(function GridGenericColumnH
     if (hasFocus && !columnMenuState.open) {
       const focusableElement = headerCellRef.current!.querySelector<HTMLElement>('[tabindex="0"]');
       const elementToFocus = focusableElement || headerCellRef.current;
-      elementToFocus?.focus();
+      elementToFocus?.focus({ preventScroll: true });
       apiRef.current.columnHeadersContainerElementRef!.current!.scrollLeft = 0;
     }
   }, [apiRef, hasFocus]);

--- a/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
@@ -459,7 +459,10 @@ export interface GridEventLookup
    * Fired when a cell loses focus.
    */
   cellFocusOut: { params: GridCellParams; event: MuiBaseEvent };
-
+  /**
+   * Fired when a focused cell unmount.
+   */
+  cellFocusUnmount: { params: React.ReactElement };
   // Scroll
   /**
    * Fired during the scroll of the grid viewport.

--- a/packages/grid/x-data-grid/src/utils/domUtils.ts
+++ b/packages/grid/x-data-grid/src/utils/domUtils.ts
@@ -34,19 +34,18 @@ export function getGridColumnHeaderElement(root: Element, field: string) {
     `[role="columnheader"][data-field="${escapeOperandAttributeSelector(field)}"]`,
   );
 }
+function getGridRowElementSelector(id: GridRowId): string {
+  return `.${gridClasses.row}[data-id="${escapeOperandAttributeSelector(String(id))}"]`;
+}
 
 export function getGridRowElement(root: Element, id: GridRowId) {
-  return root.querySelector<HTMLDivElement>(
-    `.${gridClasses.row}[data-id="${escapeOperandAttributeSelector(String(id))}"]`,
-  );
+  return root.querySelector<HTMLDivElement>(getGridRowElementSelector(id));
 }
 
 export function getGridCellElement(root: Element, { id, field }: { id: GridRowId; field: string }) {
-  const row = getGridRowElement(root, id);
-  if (!row) {
-    return null;
-  }
-  return row.querySelector<HTMLDivElement>(
-    `.${gridClasses.cell}[data-field="${escapeOperandAttributeSelector(field)}"]`,
-  );
+  const rowSelector = getGridRowElementSelector(id);
+  const cellSelector = `.${gridClasses.cell}[data-field="${escapeOperandAttributeSelector(
+    field,
+  )}"]`;
+  return root.querySelector<HTMLDivElement>(`${rowSelector} ${cellSelector}`);
 }

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -492,6 +492,7 @@
   { "name": "GridTabIndexState", "kind": "Interface" },
   { "name": "gridTabIndexStateSelector", "kind": "Variable" },
   { "name": "GridTableRowsIcon", "kind": "Variable" },
+  { "name": "GridTempContainers", "kind": "Function" },
   { "name": "GridToolbar", "kind": "Variable" },
   { "name": "GridToolbarColumnsButton", "kind": "Variable" },
   { "name": "GridToolbarContainer", "kind": "Variable" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -455,6 +455,7 @@
   { "name": "GridTabIndexState", "kind": "Interface" },
   { "name": "gridTabIndexStateSelector", "kind": "Variable" },
   { "name": "GridTableRowsIcon", "kind": "Variable" },
+  { "name": "GridTempContainers", "kind": "Function" },
   { "name": "GridToolbar", "kind": "Variable" },
   { "name": "GridToolbarColumnsButton", "kind": "Variable" },
   { "name": "GridToolbarContainer", "kind": "Variable" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -419,6 +419,7 @@
   { "name": "GridTabIndexState", "kind": "Interface" },
   { "name": "gridTabIndexStateSelector", "kind": "Variable" },
   { "name": "GridTableRowsIcon", "kind": "Variable" },
+  { "name": "GridTempContainers", "kind": "Function" },
   { "name": "GridToolbar", "kind": "Variable" },
   { "name": "GridToolbarColumnsButton", "kind": "Variable" },
   { "name": "GridToolbarContainer", "kind": "Variable" },


### PR DESCRIPTION
Fixes #5750 

this is an alternative, in case #5911 has been abandoned.

**#Problem**

when virtualization is enabled, focused cells might get unmounted when it's out of view range, this causes keyboard navigation not to work as intended.

**#Method** 

This solution is derivative of #5911. but instead of keeping the whole row in DOM, I keep the active cell. 
When the focused cell is unmounted, it publishes the event `cellFocusUnmount`. I have created a container called `GridTempContainers`, which listens for the event `cellFocusUnmount`, and renders the copy element when the event triggers and the cell component stays in the DOM as long as it is the active element and the main cell is not mounted.

**#Todos**
- [ ] improve variable and function names
- [ ] Write test
