### PR TITLE
[DataGridPremium] Update cache before hydrating columns

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts
@@ -117,6 +117,7 @@ export const useGridAggregation = (
 
     // Re-apply the column hydration to wrap / unwrap the aggregated columns
     if (!areAggregationRulesEqual(rulesOnLastColumnHydration, aggregationRules)) {
+      apiRef.current.caches.aggregation.rulesOnLastColumnHydration = aggregationRules;
       apiRef.current.requestPipeProcessorsApplication('hydrateColumns');
     }
   }, [apiRef, applyAggregation, props.aggregationFunctions, props.disableAggregation]);

--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
@@ -68,8 +68,6 @@ export const useGridAggregationPreProcessors = (
         columnsState.lookup[field] = column;
       });
 
-      apiRef.current.caches.aggregation.rulesOnLastColumnHydration = aggregationRules;
-
       return columnsState;
     },
     [apiRef, props.aggregationFunctions, props.disableAggregation],


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/7005

Before: https://codesandbox.io/s/xenodochial-borg-4ydhmm?file=/demo.tsx
After: https://codesandbox.io/s/boring-david-8ilxtj?file=/demo.tsx

If the aggregation functions change between renders, an infinite loop is caused due to the fact that we only save the rules inside the `hydrateColumns` pre-processor, but this pre-processor never runs because it gets removed before since the props it has as dependencies change. It begins with:

1. The application of the `hydrateColums` pre-processors is requested because `aggregationFunctions` has changed.
https://github.com/mui/mui-x/blob/2933784402996df5e4d3ee5a8f786bc482e1789a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts#L119-L122

2. Since `aggregationFunctions` is a dependency of the pre-processor below, when it changes the cleanup of the pre-processor is invoked.
https://github.com/mui/mui-x/blob/2933784402996df5e4d3ee5a8f786bc482e1789a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx#L36
https://github.com/mui/mui-x/blob/2933784402996df5e4d3ee5a8f786bc482e1789a/packages/grid/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts#L80-L82

3. Invoking the cleanup means that the pre-processor won't be called, consequentially `apiRef.current.caches.aggregation.rulesOnLastColumnHydration` will not be updated.

4. After hydrating the columns, `columnsChange` is published.
https://github.com/mui/mui-x/blob/2933784402996df5e4d3ee5a8f786bc482e1789a/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx#L103

5. Whenever there's a `columnsChange` event, the columns are hydrated if the aggregation rules are not the same from last time. But, since the cache was not updated earlier, they are not the same now and it returns to 2.
https://github.com/mui/mui-x/blob/2933784402996df5e4d3ee5a8f786bc482e1789a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts#L119-L125

My fix is quite simple. It only saves the cache immediately before calling the pre-processor to avoid the opportunity of creating an infinite loop. This could also happen with `hydrateRows` if we had an event published after hydrating the rows which `checkAggregationRulesDiff` listens to. Suggesting to memoize the aggregation function only solves the problem if they don't have any dependency, but having a single dependency already triggers the loop.