### PR TITLE
[docs] Use new pickers on the validation page

### DIFF
--- a/docs/data/date-pickers/validation/DateRangeValidationShouldDisableDate.js
+++ b/docs/data/date-pickers/validation/DateRangeValidationShouldDisableDate.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
-import Box from '@mui/material/Box';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const lastSunday = dayjs().startOf('week').subtract(1, 'day');
 const nextSunday = dayjs().endOf('week').startOf('day');
@@ -16,11 +14,10 @@ const isWeekend = (date) => {
 };
 
 export default function DateRangeValidationShouldDisableDate() {
-  const [value, setValue] = React.useState([lastSunday, nextSunday]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DateRangePicker
+      <NextDateRangePicker
+        defaultValue={[lastSunday, nextSunday]}
         shouldDisableDate={(date, position) => {
           if (position === 'end') {
             return false;
@@ -28,15 +25,6 @@ export default function DateRangeValidationShouldDisableDate() {
 
           return isWeekend(date);
         }}
-        value={value}
-        onChange={(newValue) => setValue(newValue)}
-        renderInput={(startProps, endProps) => (
-          <React.Fragment>
-            <TextField {...startProps} />
-            <Box sx={{ mx: 2 }}> to </Box>
-            <TextField {...endProps} />
-          </React.Fragment>
-        )}
       />
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/validation/DateRangeValidationShouldDisableDate.tsx
+++ b/docs/data/date-pickers/validation/DateRangeValidationShouldDisableDate.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
-import Box from '@mui/material/Box';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const lastSunday = dayjs().startOf('week').subtract(1, 'day');
 const nextSunday = dayjs().endOf('week').startOf('day');
@@ -16,14 +14,10 @@ const isWeekend = (date: Dayjs) => {
 };
 
 export default function DateRangeValidationShouldDisableDate() {
-  const [value, setValue] = React.useState<DateRange<Dayjs>>([
-    lastSunday,
-    nextSunday,
-  ]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DateRangePicker
+      <NextDateRangePicker
+        defaultValue={[lastSunday, nextSunday]}
         shouldDisableDate={(date, position) => {
           if (position === 'end') {
             return false;
@@ -31,15 +25,6 @@ export default function DateRangeValidationShouldDisableDate() {
 
           return isWeekend(date);
         }}
-        value={value}
-        onChange={(newValue) => setValue(newValue)}
-        renderInput={(startProps, endProps) => (
-          <React.Fragment>
-            <TextField {...startProps} />
-            <Box sx={{ mx: 2 }}> to </Box>
-            <TextField {...endProps} />
-          </React.Fragment>
-        )}
       />
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/validation/DateRangeValidationShouldDisableDate.tsx.preview
+++ b/docs/data/date-pickers/validation/DateRangeValidationShouldDisableDate.tsx.preview
@@ -1,0 +1,10 @@
+<NextDateRangePicker
+  defaultValue={[lastSunday, nextSunday]}
+  shouldDisableDate={(date, position) => {
+    if (position === 'end') {
+      return false;
+    }
+
+    return isWeekend(date);
+  }}
+/>

--- a/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.js
+++ b/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const todayAtNoon = dayjs().set('hour', 12).startOf('hour');
 const todayAt9AM = dayjs().set('hour', 9).startOf('hour');
@@ -29,17 +28,10 @@ GridItem.propTypes = {
 };
 
 export default function DateTimeValidationMaxDateTime() {
-  const [value, setValue] = React.useState(todayAtNoon);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <GridItem label="DateTimePicker">
-        <DateTimePicker
-          maxDateTime={todayAt9AM}
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
-          renderInput={(params) => <TextField {...params} />}
-        />
+        <NextDateTimePicker defaultValue={todayAtNoon} maxDateTime={todayAt9AM} />
       </GridItem>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx
+++ b/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import dayjs from 'dayjs';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const todayAtNoon = dayjs().set('hour', 12).startOf('hour');
 const todayAt9AM = dayjs().set('hour', 9).startOf('hour');
@@ -30,17 +29,10 @@ function GridItem({
 }
 
 export default function DateTimeValidationMaxDateTime() {
-  const [value, setValue] = React.useState<Dayjs | null>(todayAtNoon);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <GridItem label="DateTimePicker">
-        <DateTimePicker
-          maxDateTime={todayAt9AM}
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
-          renderInput={(params) => <TextField {...params} />}
-        />
+        <NextDateTimePicker defaultValue={todayAtNoon} maxDateTime={todayAt9AM} />
       </GridItem>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx.preview
+++ b/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx.preview
@@ -1,8 +1,3 @@
 <GridItem label="DateTimePicker">
-  <DateTimePicker
-    maxDateTime={todayAt9AM}
-    value={value}
-    onChange={(newValue) => setValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextDateTimePicker defaultValue={todayAtNoon} maxDateTime={todayAt9AM} />
 </GridItem>

--- a/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.js
+++ b/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const todayAtNoon = dayjs().set('hour', 12).startOf('hour');
 const todayAt3PM = dayjs().set('hour', 15).startOf('hour');
@@ -29,17 +28,10 @@ GridItem.propTypes = {
 };
 
 export default function DateTimeValidationMinDateTime() {
-  const [value, setValue] = React.useState(todayAtNoon);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <GridItem label="DateTimePicker">
-        <DateTimePicker
-          minDateTime={todayAt3PM}
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
-          renderInput={(params) => <TextField {...params} />}
-        />
+        <NextDateTimePicker defaultValue={todayAtNoon} minDateTime={todayAt3PM} />
       </GridItem>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx
+++ b/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import dayjs from 'dayjs';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const todayAtNoon = dayjs().set('hour', 12).startOf('hour');
 const todayAt3PM = dayjs().set('hour', 15).startOf('hour');
@@ -30,17 +29,10 @@ function GridItem({
 }
 
 export default function DateTimeValidationMinDateTime() {
-  const [value, setValue] = React.useState<Dayjs | null>(todayAtNoon);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <GridItem label="DateTimePicker">
-        <DateTimePicker
-          minDateTime={todayAt3PM}
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
-          renderInput={(params) => <TextField {...params} />}
-        />
+        <NextDateTimePicker defaultValue={todayAtNoon} minDateTime={todayAt3PM} />
       </GridItem>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx.preview
+++ b/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx.preview
@@ -1,8 +1,3 @@
 <GridItem label="DateTimePicker">
-  <DateTimePicker
-    minDateTime={todayAt3PM}
-    value={value}
-    onChange={(newValue) => setValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextDateTimePicker defaultValue={todayAtNoon} minDateTime={todayAt3PM} />
 </GridItem>

--- a/docs/data/date-pickers/validation/DateValidationDisableFuture.js
+++ b/docs/data/date-pickers/validation/DateValidationDisableFuture.js
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { TimePicker } from '@mui/x-date-pickers';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const tomorrow = dayjs().add(1, 'day');
@@ -34,59 +33,28 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationDisableFuture() {
-  const [datePickerValue, setDatePickerValue] = React.useState(tomorrow);
-
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(tomorrow);
-
-  const [timePickerValue, setTimePickerValue] = React.useState(todayEndOfTheDay);
-
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState([
-    today,
-    tomorrow,
-  ]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={tomorrow}
             disableFuture
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
+        <GridItem label="TimePicker">
+          <NextTimePicker defaultValue={todayEndOfTheDay} disableFuture />
+        </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={tomorrow}
             disableFuture
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
-        <GridItem label="TimePicker">
-          <TimePicker
-            disableFuture
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
-        </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
-            disableFuture
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
-          />
+          <NextDateRangePicker defaultValue={[today, tomorrow]} disableFuture />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/DateValidationDisableFuture.tsx
+++ b/docs/data/date-pickers/validation/DateValidationDisableFuture.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { TimePicker } from '@mui/x-date-pickers';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const tomorrow = dayjs().add(1, 'day');
@@ -35,61 +34,28 @@ function GridItem({
 }
 
 export default function DateValidationDisableFuture() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(
-    tomorrow,
-  );
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    tomorrow,
-  );
-  const [timePickerValue, setTimePickerValue] = React.useState<Dayjs | null>(
-    todayEndOfTheDay,
-  );
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState<
-    DateRange<Dayjs>
-  >([today, tomorrow]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={tomorrow}
             disableFuture
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
+        <GridItem label="TimePicker">
+          <NextTimePicker defaultValue={todayEndOfTheDay} disableFuture />
+        </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={tomorrow}
             disableFuture
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
-        <GridItem label="TimePicker">
-          <TimePicker
-            disableFuture
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
-        </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
-            disableFuture
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
-          />
+          <NextDateRangePicker defaultValue={[today, tomorrow]} disableFuture />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/DateValidationDisablePast.js
+++ b/docs/data/date-pickers/validation/DateValidationDisablePast.js
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const yesterday = dayjs().subtract(1, 'day');
@@ -34,59 +33,28 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationDisablePast() {
-  const [datePickerValue, setDatePickerValue] = React.useState(yesterday);
-
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(yesterday);
-
-  const [timePickerValue, setTimePickerValue] = React.useState(todayStartOfTheDay);
-
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState([
-    yesterday,
-    today,
-  ]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={yesterday}
             disablePast
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
+        <GridItem label="TimePicker">
+          <NextTimePicker defaultValue={todayStartOfTheDay} disablePast />
+        </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={yesterday}
             disablePast
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
-        <GridItem label="TimePicker">
-          <TimePicker
-            disablePast
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
-        </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
-            disablePast
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
-          />
+          <NextDateRangePicker defaultValue={[yesterday, today]} disablePast />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/DateValidationDisablePast.tsx
+++ b/docs/data/date-pickers/validation/DateValidationDisablePast.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const yesterday = dayjs().subtract(1, 'day');
@@ -35,61 +34,28 @@ function GridItem({
 }
 
 export default function DateValidationDisablePast() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(
-    yesterday,
-  );
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    yesterday,
-  );
-  const [timePickerValue, setTimePickerValue] = React.useState<Dayjs | null>(
-    todayStartOfTheDay,
-  );
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState<
-    DateRange<Dayjs>
-  >([yesterday, today]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={yesterday}
             disablePast
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
+        <GridItem label="TimePicker">
+          <NextTimePicker defaultValue={todayStartOfTheDay} disablePast />
+        </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={yesterday}
             disablePast
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
-        <GridItem label="TimePicker">
-          <TimePicker
-            disablePast
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
-        </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
-            disablePast
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
-          />
+          <NextDateRangePicker defaultValue={[yesterday, today]} disablePast />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/DateValidationMaxDate.js
+++ b/docs/data/date-pickers/validation/DateValidationMaxDate.js
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const yesterday = dayjs().subtract(1, 'day');
@@ -32,47 +31,27 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationMaxDate() {
-  const [datePickerValue, setDatePickerValue] = React.useState(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(today);
-
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState([
-    yesterday,
-    today,
-  ]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={today}
             maxDate={yesterday}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             maxDate={yesterday}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
+          <NextDateRangePicker
+            defaultValue={[yesterday, today]}
             maxDate={yesterday}
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/DateValidationMaxDate.tsx
+++ b/docs/data/date-pickers/validation/DateValidationMaxDate.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const yesterday = dayjs().subtract(1, 'day');
@@ -33,47 +32,27 @@ function GridItem({
 }
 
 export default function DateValidationMaxDate() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    today,
-  );
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState<
-    DateRange<Dayjs>
-  >([yesterday, today]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={today}
             maxDate={yesterday}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             maxDate={yesterday}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
+          <NextDateRangePicker
+            defaultValue={[yesterday, today]}
             maxDate={yesterday}
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/DateValidationMinDate.js
+++ b/docs/data/date-pickers/validation/DateValidationMinDate.js
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const tomorrow = dayjs().add(1, 'day');
@@ -32,48 +31,25 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationMinDate() {
-  const [datePickerValue, setDatePickerValue] = React.useState(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(today);
-
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState([
-    today,
-    tomorrow,
-  ]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={today}
             minDate={tomorrow}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             minDate={tomorrow}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
-            minDate={tomorrow}
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
-          />
+          <NextDateRangePicker defaultValue={[today, tomorrow]} minDate={tomorrow} />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/DateValidationMinDate.tsx
+++ b/docs/data/date-pickers/validation/DateValidationMinDate.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const today = dayjs();
 const tomorrow = dayjs().add(1, 'day');
@@ -33,48 +32,25 @@ function GridItem({
 }
 
 export default function DateValidationMinDate() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    today,
-  );
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState<
-    DateRange<Dayjs>
-  >([today, tomorrow]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={today}
             minDate={tomorrow}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             minDate={tomorrow}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
-            minDate={tomorrow}
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
-          />
+          <NextDateRangePicker defaultValue={[today, tomorrow]} minDate={tomorrow} />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableDate.js
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableDate.js
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const lastMonday = dayjs().startOf('week');
 const nextSunday = dayjs().endOf('week').startOf('day');
@@ -38,48 +37,27 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationShouldDisableDate() {
-  const [datePickerValue, setDatePickerValue] = React.useState(nextSunday);
-
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(nextSunday);
-
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState([
-    lastMonday,
-    nextSunday,
-  ]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={nextSunday}
             shouldDisableDate={isWeekend}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={nextSunday}
             shouldDisableDate={isWeekend}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
+          <NextDateRangePicker
+            defaultValue={[lastMonday, nextSunday]}
             shouldDisableDate={isWeekend}
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableDate.tsx
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableDate.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { DateRange, DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
+import { Unstable_NextDateRangePicker as NextDateRangePicker } from '@mui/x-date-pickers-pro/NextDateRangePicker';
 
 const lastMonday = dayjs().startOf('week');
 const nextSunday = dayjs().endOf('week').startOf('day');
@@ -39,49 +38,27 @@ function GridItem({
 }
 
 export default function DateValidationShouldDisableDate() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(
-    nextSunday,
-  );
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    nextSunday,
-  );
-  const [dateRangePickerValue, setDateRangePickerValue] = React.useState<
-    DateRange<Dayjs>
-  >([lastMonday, nextSunday]);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={nextSunday}
             shouldDisableDate={isWeekend}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={nextSunday}
             shouldDisableDate={isWeekend}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>
         <GridItem label="DateRangePicker" spacing={2}>
-          <DateRangePicker
+          <NextDateRangePicker
+            defaultValue={[lastMonday, nextSunday]}
             shouldDisableDate={isWeekend}
-            value={dateRangePickerValue}
-            onChange={(newValue) => setDateRangePickerValue(newValue)}
-            renderInput={(startProps, endProps) => (
-              <React.Fragment>
-                <TextField {...startProps} />
-                <Box sx={{ mx: 2 }}> to </Box>
-                <TextField {...endProps} />
-              </React.Fragment>
-            )}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableMonth.js
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableMonth.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const today = dayjs();
 
@@ -32,27 +31,20 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationShouldDisableMonth() {
-  const [datePickerValue, setDatePickerValue] = React.useState(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(today);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={today}
             shouldDisableMonth={isInCurrentMonth}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             shouldDisableMonth={isInCurrentMonth}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableMonth.tsx
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableMonth.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const today = dayjs();
 
@@ -33,29 +32,20 @@ function GridItem({
 }
 
 export default function DateValidationShouldDisableMonth() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    today,
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
+          <NextDatePicker
+            defaultValue={today}
             shouldDisableMonth={isInCurrentMonth}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day']}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             shouldDisableMonth={isInCurrentMonth}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
             views={['year', 'month', 'day', 'hours', 'minutes']}
           />
         </GridItem>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableMonth.tsx.preview
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableMonth.tsx.preview
@@ -1,0 +1,14 @@
+<GridItem label="DatePicker">
+  <NextDatePicker
+    defaultValue={today}
+    shouldDisableMonth={isInCurrentMonth}
+    views={['year', 'month', 'day']}
+  />
+</GridItem>
+<GridItem label="DateTimePicker">
+  <NextDateTimePicker
+    defaultValue={today}
+    shouldDisableMonth={isInCurrentMonth}
+    views={['year', 'month', 'day', 'hours', 'minutes']}
+  />
+</GridItem>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableYear.js
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableYear.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const today = dayjs();
 
@@ -32,26 +31,16 @@ GridItem.propTypes = {
 };
 
 export default function DateValidationShouldDisableYear() {
-  const [datePickerValue, setDatePickerValue] = React.useState(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(today);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
-            shouldDisableYear={isInCurrentYear}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextDatePicker defaultValue={today} shouldDisableYear={isInCurrentYear} />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             shouldDisableYear={isInCurrentYear}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableYear.tsx
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableYear.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const today = dayjs();
 
@@ -33,28 +32,16 @@ function GridItem({
 }
 
 export default function DateValidationShouldDisableYear() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(today);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    today,
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="DatePicker">
-          <DatePicker
-            shouldDisableYear={isInCurrentYear}
-            value={datePickerValue}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextDatePicker defaultValue={today} shouldDisableYear={isInCurrentYear} />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={today}
             shouldDisableYear={isInCurrentYear}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/DateValidationShouldDisableYear.tsx.preview
+++ b/docs/data/date-pickers/validation/DateValidationShouldDisableYear.tsx.preview
@@ -1,16 +1,9 @@
 <GridItem label="DatePicker">
-  <DatePicker
-    shouldDisableYear={isInCurrentYear}
-    value={datePickerValue}
-    onChange={(newValue) => setDatePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextDatePicker defaultValue={today} shouldDisableYear={isInCurrentYear} />
 </GridItem>
 <GridItem label="DateTimePicker">
-  <DateTimePicker
+  <NextDateTimePicker
+    defaultValue={today}
     shouldDisableYear={isInCurrentYear}
-    value={dateTimePickerValue}
-    onChange={(newValue) => setDateTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
   />
 </GridItem>

--- a/docs/data/date-pickers/validation/RenderErrorUnderField.js
+++ b/docs/data/date-pickers/validation/RenderErrorUnderField.js
@@ -1,17 +1,14 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 
 const startOfQ12022 = dayjs('2022-01-01T00:00:00.000');
 const endOfQ12022 = dayjs('2022-03-31T23:59:59.999');
 
 export default function RenderErrorUnderField() {
-  const [value, setValue] = React.useState(() => dayjs('2022-07-12T00:00:00.000'));
-
   const [error, setError] = React.useState(null);
 
   const errorMessage = React.useMemo(() => {
@@ -34,13 +31,14 @@ export default function RenderErrorUnderField() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box width={300}>
-        <DatePicker
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+        <NextDatePicker
+          defaultValue={dayjs('2022-07-12T00:00:00.000')}
           onError={(newError) => setError(newError)}
-          renderInput={(params) => (
-            <TextField {...params} helperText={errorMessage} fullWidth />
-          )}
+          componentsProps={{
+            input: {
+              helperText: errorMessage,
+            },
+          }}
           minDate={startOfQ12022}
           maxDate={endOfQ12022}
         />

--- a/docs/data/date-pickers/validation/RenderErrorUnderField.tsx
+++ b/docs/data/date-pickers/validation/RenderErrorUnderField.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Box from '@mui/material/Box';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { Unstable_NextDatePicker as NextDatePicker } from '@mui/x-date-pickers/NextDatePicker';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import type { DateValidationError } from '@mui/x-date-pickers';
 
@@ -11,9 +10,6 @@ const startOfQ12022 = dayjs('2022-01-01T00:00:00.000');
 const endOfQ12022 = dayjs('2022-03-31T23:59:59.999');
 
 export default function RenderErrorUnderField() {
-  const [value, setValue] = React.useState<Dayjs | null>(() =>
-    dayjs('2022-07-12T00:00:00.000'),
-  );
   const [error, setError] = React.useState<DateValidationError | null>(null);
 
   const errorMessage = React.useMemo(() => {
@@ -36,13 +32,14 @@ export default function RenderErrorUnderField() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box width={300}>
-        <DatePicker
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+        <NextDatePicker
+          defaultValue={dayjs('2022-07-12T00:00:00.000')}
           onError={(newError) => setError(newError)}
-          renderInput={(params) => (
-            <TextField {...params} helperText={errorMessage} fullWidth />
-          )}
+          componentsProps={{
+            input: {
+              helperText: errorMessage,
+            },
+          }}
           minDate={startOfQ12022}
           maxDate={endOfQ12022}
         />

--- a/docs/data/date-pickers/validation/RenderErrorUnderField.tsx.preview
+++ b/docs/data/date-pickers/validation/RenderErrorUnderField.tsx.preview
@@ -1,10 +1,11 @@
-<DatePicker
-  value={value}
-  onChange={(newValue) => setValue(newValue)}
+<NextDatePicker
+  defaultValue={dayjs('2022-07-12T00:00:00.000')}
   onError={(newError) => setError(newError)}
-  renderInput={(params) => (
-    <TextField {...params} helperText={errorMessage} fullWidth />
-  )}
+  componentsProps={{
+    input: {
+      helperText: errorMessage,
+    },
+  }}
   minDate={startOfQ12022}
   maxDate={endOfQ12022}
 />

--- a/docs/data/date-pickers/validation/TimeValidationMaxTime.js
+++ b/docs/data/date-pickers/validation/TimeValidationMaxTime.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const fiveAM = dayjs().set('hour', 5).startOf('hour');
 const nineAM = dayjs().set('hour', 9).startOf('hour');
@@ -31,27 +30,14 @@ GridItem.propTypes = {
 };
 
 export default function TimeValidationMaxTime() {
-  const [timePickerValue, setTimePickerValue] = React.useState(nineAM);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(nineAM);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="TimePicker">
-          <TimePicker
-            maxTime={fiveAM}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextTimePicker defaultValue={nineAM} maxTime={fiveAM} />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
-            maxTime={fiveAM}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextDateTimePicker defaultValue={nineAM} maxTime={fiveAM} />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx
+++ b/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const fiveAM = dayjs().set('hour', 5).startOf('hour');
 const nineAM = dayjs().set('hour', 9).startOf('hour');
@@ -32,29 +31,14 @@ function GridItem({
 }
 
 export default function TimeValidationMaxTime() {
-  const [timePickerValue, setTimePickerValue] = React.useState<Dayjs | null>(nineAM);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    nineAM,
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="TimePicker">
-          <TimePicker
-            maxTime={fiveAM}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextTimePicker defaultValue={nineAM} maxTime={fiveAM} />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
-            maxTime={fiveAM}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextDateTimePicker defaultValue={nineAM} maxTime={fiveAM} />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx.preview
+++ b/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx.preview
@@ -1,16 +1,6 @@
 <GridItem label="TimePicker">
-  <TimePicker
-    maxTime={fiveAM}
-    value={timePickerValue}
-    onChange={(newValue) => setTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextTimePicker defaultValue={nineAM} maxTime={fiveAM} />
 </GridItem>
 <GridItem label="DateTimePicker">
-  <DateTimePicker
-    maxTime={fiveAM}
-    value={dateTimePickerValue}
-    onChange={(newValue) => setDateTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextDateTimePicker defaultValue={nineAM} maxTime={fiveAM} />
 </GridItem>

--- a/docs/data/date-pickers/validation/TimeValidationMinTime.js
+++ b/docs/data/date-pickers/validation/TimeValidationMinTime.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const fiveAM = dayjs().set('hour', 5).startOf('hour');
 const nineAM = dayjs().set('hour', 9).startOf('hour');
@@ -31,27 +30,14 @@ GridItem.propTypes = {
 };
 
 export default function TimeValidationMinTime() {
-  const [timePickerValue, setTimePickerValue] = React.useState(fiveAM);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(fiveAM);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="TimePicker">
-          <TimePicker
-            minTime={nineAM}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextTimePicker defaultValue={fiveAM} minTime={nineAM} />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
-            minTime={nineAM}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextDateTimePicker defaultValue={fiveAM} minTime={nineAM} />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/TimeValidationMinTime.tsx
+++ b/docs/data/date-pickers/validation/TimeValidationMinTime.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const fiveAM = dayjs().set('hour', 5).startOf('hour');
 const nineAM = dayjs().set('hour', 9).startOf('hour');
@@ -32,29 +31,14 @@ function GridItem({
 }
 
 export default function TimeValidationMinTime() {
-  const [timePickerValue, setTimePickerValue] = React.useState<Dayjs | null>(fiveAM);
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    fiveAM,
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="TimePicker">
-          <TimePicker
-            minTime={nineAM}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextTimePicker defaultValue={fiveAM} minTime={nineAM} />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
-            minTime={nineAM}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-          />
+          <NextDateTimePicker defaultValue={fiveAM} minTime={nineAM} />
         </GridItem>
       </Stack>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/TimeValidationMinTime.tsx.preview
+++ b/docs/data/date-pickers/validation/TimeValidationMinTime.tsx.preview
@@ -1,16 +1,6 @@
 <GridItem label="TimePicker">
-  <TimePicker
-    minTime={nineAM}
-    value={timePickerValue}
-    onChange={(newValue) => setTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextTimePicker defaultValue={fiveAM} minTime={nineAM} />
 </GridItem>
 <GridItem label="DateTimePicker">
-  <DateTimePicker
-    minTime={nineAM}
-    value={dateTimePickerValue}
-    onChange={(newValue) => setDateTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
-  />
+  <NextDateTimePicker defaultValue={fiveAM} minTime={nineAM} />
 </GridItem>

--- a/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.js
+++ b/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { Unstable_NextTimePicker as NextTimePicker } from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
 const shouldDisableTime = (timeValue, view) => view === 'minutes' && timeValue >= 45;
 
@@ -32,27 +31,19 @@ GridItem.propTypes = {
 };
 
 export default function TimeValidationShouldDisableTime() {
-  const [timePickerValue, setTimePickerValue] = React.useState(defaultValue);
-
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState(defaultValue);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="TimePicker">
-          <TimePicker
+          <NextTimePicker
+            defaultValue={defaultValue}
             shouldDisableTime={shouldDisableTime}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={defaultValue}
             shouldDisableTime={shouldDisableTime}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.tsx
+++ b/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { TimePicker, TimePickerProps } from '@mui/x-date-pickers/TimePicker';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import {
+  Unstable_NextTimePicker as NextTimePicker,
+  NextTimePickerProps,
+} from '@mui/x-date-pickers/NextTimePicker';
+import { Unstable_NextDateTimePicker as NextDateTimePicker } from '@mui/x-date-pickers/NextDateTimePicker';
 
-const shouldDisableTime: TimePickerProps<Dayjs>['shouldDisableTime'] = (
+const shouldDisableTime: NextTimePickerProps<Dayjs>['shouldDisableTime'] = (
   timeValue,
   view,
 ) => view === 'minutes' && timeValue >= 45;
@@ -36,30 +38,19 @@ function GridItem({
 }
 
 export default function TimeValidationShouldDisableTime() {
-  const [timePickerValue, setTimePickerValue] = React.useState<Dayjs | null>(
-    defaultValue,
-  );
-  const [dateTimePickerValue, setDateTimePickerValue] = React.useState<Dayjs | null>(
-    defaultValue,
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Stack spacing={4}>
         <GridItem label="TimePicker">
-          <TimePicker
+          <NextTimePicker
+            defaultValue={defaultValue}
             shouldDisableTime={shouldDisableTime}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
           />
         </GridItem>
         <GridItem label="DateTimePicker">
-          <DateTimePicker
+          <NextDateTimePicker
+            defaultValue={defaultValue}
             shouldDisableTime={shouldDisableTime}
-            value={dateTimePickerValue}
-            onChange={(newValue) => setDateTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
           />
         </GridItem>
       </Stack>

--- a/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.tsx.preview
+++ b/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.tsx.preview
@@ -1,16 +1,12 @@
 <GridItem label="TimePicker">
-  <TimePicker
+  <NextTimePicker
+    defaultValue={defaultValue}
     shouldDisableTime={shouldDisableTime}
-    value={timePickerValue}
-    onChange={(newValue) => setTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
   />
 </GridItem>
 <GridItem label="DateTimePicker">
-  <DateTimePicker
+  <NextDateTimePicker
+    defaultValue={defaultValue}
     shouldDisableTime={shouldDisableTime}
-    value={dateTimePickerValue}
-    onChange={(newValue) => setDateTimePickerValue(newValue)}
-    renderInput={(params) => <TextField {...params} />}
   />
 </GridItem>

--- a/docs/data/date-pickers/validation/ValidationBehaviorInput.js
+++ b/docs/data/date-pickers/validation/ValidationBehaviorInput.js
@@ -1,24 +1,15 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 
 const tomorrow = dayjs().add(1, 'day');
 
 export default function ValidationBehaviorInput() {
-  const [value, setValue] = React.useState(tomorrow);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DesktopDatePicker
-        disableFuture
-        disableOpenPicker
-        value={value}
-        onChange={(newValue) => setValue(newValue)}
-        renderInput={(params) => <TextField {...params} />}
-      />
+      <DateField defaultValue={tomorrow} disableFuture />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/validation/ValidationBehaviorInput.tsx
+++ b/docs/data/date-pickers/validation/ValidationBehaviorInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';

--- a/docs/data/date-pickers/validation/ValidationBehaviorInput.tsx
+++ b/docs/data/date-pickers/validation/ValidationBehaviorInput.tsx
@@ -1,24 +1,15 @@
 import * as React from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
 
 const tomorrow = dayjs().add(1, 'day');
 
 export default function ValidationBehaviorInput() {
-  const [value, setValue] = React.useState<Dayjs | null>(tomorrow);
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DesktopDatePicker
-        disableFuture
-        disableOpenPicker
-        value={value}
-        onChange={(newValue) => setValue(newValue)}
-        renderInput={(params) => <TextField {...params} />}
-      />
+      <DateField defaultValue={tomorrow} disableFuture />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/validation/ValidationBehaviorInput.tsx.preview
+++ b/docs/data/date-pickers/validation/ValidationBehaviorInput.tsx.preview
@@ -1,7 +1,1 @@
-<DesktopDatePicker
-  disableFuture
-  disableOpenPicker
-  value={value}
-  onChange={(newValue) => setValue(newValue)}
-  renderInput={(params) => <TextField {...params} />}
-/>
+<DateField defaultValue={tomorrow} disableFuture />

--- a/docs/data/date-pickers/validation/ValidationBehaviorView.js
+++ b/docs/data/date-pickers/validation/ValidationBehaviorView.js
@@ -6,6 +6,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { TimeClock } from '@mui/x-date-pickers/TimeClock';
 
+const today = dayjs();
 const twoPM = dayjs().set('hour', 14).startOf('hour');
 const threePM = dayjs().set('hour', 15).startOf('hour');
 
@@ -20,7 +21,7 @@ export default function ValidationBehaviorView() {
         justifyContent="center"
       >
         <Grid item>
-          <DateCalendar defaultValue={null} disableFuture />
+          <DateCalendar defaultValue={today} disableFuture />
         </Grid>
         <Grid item>
           <TimeClock defaultValue={twoPM} maxTime={threePM} />

--- a/docs/data/date-pickers/validation/ValidationBehaviorView.js
+++ b/docs/data/date-pickers/validation/ValidationBehaviorView.js
@@ -1,18 +1,15 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import TextField from '@mui/material/TextField';
 import Grid from '@mui/material/Grid';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
-import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { TimeClock } from '@mui/x-date-pickers/TimeClock';
+
+const twoPM = dayjs().set('hour', 14).startOf('hour');
+const threePM = dayjs().set('hour', 15).startOf('hour');
 
 export default function ValidationBehaviorView() {
-  const [datePickerValue, setDatePickerValue] = React.useState(null);
-  const [timePickerValue, setTimePickerValue] = React.useState(
-    dayjs().set('hour', 14).startOf('hour'),
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid
@@ -23,25 +20,10 @@ export default function ValidationBehaviorView() {
         justifyContent="center"
       >
         <Grid item>
-          <StaticDatePicker
-            disableFuture
-            value={datePickerValue}
-            views={['day']}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-            showToolbar={false}
-            components={{ ActionBar: () => null }}
-          />
+          <DateCalendar defaultValue={null} disableFuture />
         </Grid>
         <Grid item>
-          <StaticTimePicker
-            maxTime={dayjs().set('hour', 15).startOf('hour')}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-            showToolbar={false}
-            components={{ ActionBar: () => null }}
-          />
+          <TimeClock defaultValue={twoPM} maxTime={threePM} />
         </Grid>
       </Grid>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/ValidationBehaviorView.tsx
+++ b/docs/data/date-pickers/validation/ValidationBehaviorView.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
-import TextField from '@mui/material/TextField';
+import dayjs from 'dayjs';
 import Grid from '@mui/material/Grid';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
-import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { TimeClock } from '@mui/x-date-pickers/TimeClock';
+
+const today = dayjs();
+const twoPM = dayjs().set('hour', 14).startOf('hour');
+const threePM = dayjs().set('hour', 15).startOf('hour');
 
 export default function ValidationBehaviorView() {
-  const [datePickerValue, setDatePickerValue] = React.useState<Dayjs | null>(null);
-  const [timePickerValue, setTimePickerValue] = React.useState<Dayjs | null>(
-    dayjs().set('hour', 14).startOf('hour'),
-  );
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Grid
@@ -23,25 +21,10 @@ export default function ValidationBehaviorView() {
         justifyContent="center"
       >
         <Grid item>
-          <StaticDatePicker
-            disableFuture
-            value={datePickerValue}
-            views={['day']}
-            onChange={(newValue) => setDatePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-            showToolbar={false}
-            components={{ ActionBar: () => null }}
-          />
+          <DateCalendar defaultValue={today} disableFuture />
         </Grid>
         <Grid item>
-          <StaticTimePicker
-            maxTime={dayjs().set('hour', 15).startOf('hour')}
-            value={timePickerValue}
-            onChange={(newValue) => setTimePickerValue(newValue)}
-            renderInput={(params) => <TextField {...params} />}
-            showToolbar={false}
-            components={{ ActionBar: () => null }}
-          />
+          <TimeClock defaultValue={twoPM} maxTime={threePM} />
         </Grid>
       </Grid>
     </LocalizationProvider>

--- a/docs/data/date-pickers/validation/ValidationBehaviorView.tsx.preview
+++ b/docs/data/date-pickers/validation/ValidationBehaviorView.tsx.preview
@@ -6,7 +6,7 @@
   justifyContent="center"
 >
   <Grid item>
-    <DateCalendar defaultValue={null} disableFuture />
+    <DateCalendar defaultValue={today} disableFuture />
   </Grid>
   <Grid item>
     <TimeClock defaultValue={twoPM} maxTime={threePM} />

--- a/docs/data/date-pickers/validation/ValidationBehaviorView.tsx.preview
+++ b/docs/data/date-pickers/validation/ValidationBehaviorView.tsx.preview
@@ -1,0 +1,14 @@
+<Grid
+  container
+  columns={{ xs: 1, lg: 2 }}
+  spacing={4}
+  alignItems="center"
+  justifyContent="center"
+>
+  <Grid item>
+    <DateCalendar defaultValue={null} disableFuture />
+  </Grid>
+  <Grid item>
+    <TimeClock defaultValue={twoPM} maxTime={threePM} />
+  </Grid>
+</Grid>

--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -7,23 +7,39 @@ title: Date and Time pickers - Validation
 <p class="description">Add custom validation to user inputs.</p>
 
 All the date and time pickers have an API for adding validation constraints.
-By default they provide visual feedback if the component value doesn't meet the validation criteria.
+By default, they provide visual feedback if the component value doesn't meet the validation criteria.
 
 :::info
-The validation props are showcased for each type of picker component (`TimePicker`, `DatePicker`, `DateRangePicker`, etc).
-But the same props are available on all component variants.
+The validation props are showcased for each type of picker component using the new responsive pickers (`NextTimePicker`, `NextDatePicker`, `NextDateRangePicker`, etc)
 
-For example—the validation props available on the `DatePicker` component are also available on:
+But the same props are available on:
 
-- `DesktopDatePicker`
-- `MobileDatePicker`
-- `StaticDatePicker`
+- all the other variants of this picker
+
+  For example—the validation props showcased with `NextDatePicker` are also available on:
+
+  - `DesktopNextDatePicker`
+  - `MobileNextDatePicker`
+  - `StaticNextDatePicker`
+
+- the field used by this picker
+
+  For example—the validation props showcased with `NextDatePicker` are also available on `DateField`.
+
+- all the variants of the legacy picker,
+
+  For example—the validation props showcased with `NextDatePicker` are also available on:
+
+  - `DatePicker`
+  - `DesktopDatePicker`
+  - `MobileDatePicker`
+  - `StaticDatePicker`
 
 :::
 
 ## Invalid values feedback
 
-On the input—it enables its error state.
+On the field—it enables its error state.
 
 {{"demo": "ValidationBehaviorInput.js", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
[Doc preview](https://deploy-preview-7047--material-ui-x.netlify.app/x/react-date-pickers/validation/)

- [x] Use new pickers in the demos
- [x] Improve the note at the top of the page to say that the validation also works on the legacy pickers
- [x] Use field and clock on the `Invalid values feedback` section
