### PR TITLE
[docs] Fix API page ad space regression

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -14,6 +14,7 @@ import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
+import Ad from 'docs/src/modules/components/Ad';
 
 const Asterisk = styled('abbr')(({ theme }) => ({ color: theme.palette.error.main }));
 
@@ -212,8 +213,8 @@ Heading.propTypes = {
   level: PropTypes.string,
 };
 
-function ApiDocs(props) {
-  const { descriptions, pageContent } = props;
+export default function ApiPage(props) {
+  const { descriptions, disableAd = false, pageContent } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
 
@@ -310,7 +311,7 @@ function ApiDocs(props) {
   return (
     <AppLayoutDocs
       description={description}
-      disableAd={false}
+      disableAd={disableAd}
       disableToc={false}
       location={apiSourceLocation}
       title={`${componentName} API`}
@@ -318,8 +319,14 @@ function ApiDocs(props) {
     >
       <MarkdownElement>
         <h1>{componentName} API</h1>
-        <Typography variant="h5" component="p" className="description" gutterBottom>
+        <Typography
+          variant="h5"
+          component="p"
+          className={`description${disableAd ? '' : ' ad'}`}
+          gutterBottom
+        >
           {description}
+          {disableAd ? null : <Ad />}
         </Typography>
         <Heading hash="import" />
         <HighlightedCode code={imports.join(`\n// ${t('or')}\n`)} language="jsx" />
@@ -411,13 +418,12 @@ function ApiDocs(props) {
   );
 }
 
-ApiDocs.propTypes = {
+ApiPage.propTypes = {
   descriptions: PropTypes.object.isRequired,
+  disableAd: PropTypes.bool,
   pageContent: PropTypes.object.isRequired,
 };
 
 if (process.env.NODE_ENV !== 'production') {
-  ApiDocs.propTypes = exactProp(ApiDocs.propTypes);
+  ApiPage.propTypes = exactProp(ApiPage.propTypes);
 }
-
-export default ApiDocs;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,8 +2479,8 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.10.14"
-  resolved "https://github.com/mui/material-ui.git#1b86330da8fff81ce5c28b0c5da0cebeb2be6932"
+  version "5.10.16"
+  resolved "https://github.com/mui/material-ui.git#b8e30a4b7c668ede64d5f1f76c00401590c977c1"
 
 "@mui/private-theming@^5.10.14":
   version "5.10.14"


### PR DESCRIPTION
Apply https://github.com/mui/material-ui/pull/35201 in MUI X.

Before: https://next.mui.com/x/api/data-grid/data-grid/
After: https://deploy-preview-7051--material-ui-x.netlify.app/x/api/data-grid/data-grid/

---

We should be able to remove this duplication of the `ApiPage` component as we move forward. It feels like we introduced debt when we decided to fork the file. The current diff now between the mono repo and MUI X seems to be about:

- Slots, Material UI should have https://mui.com/x/api/data-grid/data-grid/#slots too but doesn't yet
- A different way to display the import path. So this should be outside of the file.
- MUI X has a better way to show the global class name

https://github.com/mui/material-ui/pull/35202 will also need to be applied twice.