### PR TITLE
[DataGrid] Rename `components` and `componentsProps` props

### DIFF
--- a/docs/data/data-grid/accessibility/DensitySelectorGrid.js
+++ b/docs/data/data-grid/accessibility/DensitySelectorGrid.js
@@ -25,7 +25,7 @@ export default function DensitySelectorGrid() {
     <div style={{ height: 300, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/accessibility/DensitySelectorGrid.tsx
+++ b/docs/data/data-grid/accessibility/DensitySelectorGrid.tsx
@@ -25,7 +25,7 @@ export default function DensitySelectorGrid() {
     <div style={{ height: 300, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/accessibility/DensitySelectorGrid.tsx.preview
+++ b/docs/data/data-grid/accessibility/DensitySelectorGrid.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/accessibility/DensitySelectorSmallGrid.js
+++ b/docs/data/data-grid/accessibility/DensitySelectorSmallGrid.js
@@ -26,7 +26,7 @@ export default function DensitySelectorSmallGrid() {
       <DataGrid
         {...data}
         density="compact"
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/accessibility/DensitySelectorSmallGrid.tsx
+++ b/docs/data/data-grid/accessibility/DensitySelectorSmallGrid.tsx
@@ -26,7 +26,7 @@ export default function DensitySelectorSmallGrid() {
       <DataGrid
         {...data}
         density="compact"
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/accessibility/DensitySelectorSmallGrid.tsx.preview
+++ b/docs/data/data-grid/accessibility/DensitySelectorSmallGrid.tsx.preview
@@ -1,7 +1,7 @@
 <DataGrid
   {...data}
   density="compact"
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/api-object/UseGridApiContext.js
+++ b/docs/data/data-grid/api-object/UseGridApiContext.js
@@ -27,7 +27,7 @@ export default function UseGridApiContext() {
     <Box sx={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
         pageSize={10}

--- a/docs/data/data-grid/api-object/UseGridApiContext.tsx
+++ b/docs/data/data-grid/api-object/UseGridApiContext.tsx
@@ -27,7 +27,7 @@ export default function UseGridApiContext() {
     <Box sx={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
         pageSize={10}

--- a/docs/data/data-grid/api-object/UseGridApiContext.tsx.preview
+++ b/docs/data/data-grid/api-object/UseGridApiContext.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
   pageSize={10}

--- a/docs/data/data-grid/column-pinning/DisableColumnPinningButtons.js
+++ b/docs/data/data-grid/column-pinning/DisableColumnPinningButtons.js
@@ -46,7 +46,7 @@ export default function DisableColumnPinningButtons() {
       <DataGridPro
         rows={rows}
         columns={columns}
-        components={{ ColumnMenu: CustomColumnMenu }}
+        slots={{ ColumnMenu: CustomColumnMenu }}
         initialState={{ pinnedColumns: { left: ['name'], right: ['actions'] } }}
       />
     </div>

--- a/docs/data/data-grid/column-pinning/DisableColumnPinningButtons.tsx
+++ b/docs/data/data-grid/column-pinning/DisableColumnPinningButtons.tsx
@@ -40,7 +40,7 @@ export default function DisableColumnPinningButtons() {
       <DataGridPro
         rows={rows}
         columns={columns}
-        components={{ ColumnMenu: CustomColumnMenu }}
+        slots={{ ColumnMenu: CustomColumnMenu }}
         initialState={{ pinnedColumns: { left: ['name'], right: ['actions'] } }}
       />
     </div>

--- a/docs/data/data-grid/column-pinning/DisableColumnPinningButtons.tsx.preview
+++ b/docs/data/data-grid/column-pinning/DisableColumnPinningButtons.tsx.preview
@@ -1,6 +1,6 @@
 <DataGridPro
   rows={rows}
   columns={columns}
-  components={{ ColumnMenu: CustomColumnMenu }}
+  slots={{ ColumnMenu: CustomColumnMenu }}
   initialState={{ pinnedColumns: { left: ['name'], right: ['actions'] } }}
 />

--- a/docs/data/data-grid/column-visibility/ColumnSelectorGrid.js
+++ b/docs/data/data-grid/column-visibility/ColumnSelectorGrid.js
@@ -13,7 +13,7 @@ export default function ColumnSelectorGrid() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/column-visibility/ColumnSelectorGrid.tsx
+++ b/docs/data/data-grid/column-visibility/ColumnSelectorGrid.tsx
@@ -13,7 +13,7 @@ export default function ColumnSelectorGrid() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/column-visibility/ColumnSelectorGrid.tsx.preview
+++ b/docs/data/data-grid/column-visibility/ColumnSelectorGrid.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: GridToolbar,
   }}
 />

--- a/docs/data/data-grid/column-visibility/VisibleColumnsBasicExample.js
+++ b/docs/data/data-grid/column-visibility/VisibleColumnsBasicExample.js
@@ -26,7 +26,7 @@ export default function VisibleColumnsBasicExample() {
           { field: 'desk' },
         ]}
         rows={rows}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/column-visibility/VisibleColumnsBasicExample.tsx
+++ b/docs/data/data-grid/column-visibility/VisibleColumnsBasicExample.tsx
@@ -26,7 +26,7 @@ export default function VisibleColumnsBasicExample() {
           { field: 'desk' },
         ]}
         rows={rows}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/column-visibility/VisibleColumnsBasicExample.tsx.preview
+++ b/docs/data/data-grid/column-visibility/VisibleColumnsBasicExample.tsx.preview
@@ -5,7 +5,7 @@
     { field: 'desk' },
   ]}
   rows={rows}
-  components={{
+  slots={{
     Toolbar: GridToolbar,
   }}
 />

--- a/docs/data/data-grid/components/CellWithPopover.js
+++ b/docs/data/data-grid/components/CellWithPopover.js
@@ -31,7 +31,7 @@ export default function CellWithPopover() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        componentsProps={{
+        slotsProps={{
           cell: {
             onMouseEnter: handlePopoverOpen,
             onMouseLeave: handlePopoverClose,

--- a/docs/data/data-grid/components/CellWithPopover.tsx
+++ b/docs/data/data-grid/components/CellWithPopover.tsx
@@ -31,7 +31,7 @@ export default function CellWithPopover() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        componentsProps={{
+        slotsProps={{
           cell: {
             onMouseEnter: handlePopoverOpen,
             onMouseLeave: handlePopoverClose,

--- a/docs/data/data-grid/components/CustomColumnMenu.js
+++ b/docs/data/data-grid/components/CustomColumnMenu.js
@@ -121,10 +121,10 @@ export default function CustomColumnMenu() {
               default: 'Enterprise',
             },
           ]}
-          components={{
+          slots={{
             ColumnMenu: CustomColumnMenuComponent,
           }}
-          componentsProps={{
+          slotsProps={{
             columnMenu: { color },
           }}
         />

--- a/docs/data/data-grid/components/CustomColumnMenu.tsx
+++ b/docs/data/data-grid/components/CustomColumnMenu.tsx
@@ -120,10 +120,10 @@ export default function CustomColumnMenu() {
               default: 'Enterprise',
             },
           ]}
-          components={{
+          slots={{
             ColumnMenu: CustomColumnMenuComponent,
           }}
-          componentsProps={{
+          slotsProps={{
             columnMenu: { color },
           }}
         />

--- a/docs/data/data-grid/components/CustomEmptyOverlayGrid.js
+++ b/docs/data/data-grid/components/CustomEmptyOverlayGrid.js
@@ -85,7 +85,7 @@ export default function CustomEmptyOverlayGrid() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
-        components={{
+        slots={{
           NoRowsOverlay: CustomNoRowsOverlay,
         }}
         {...data}

--- a/docs/data/data-grid/components/CustomEmptyOverlayGrid.tsx
+++ b/docs/data/data-grid/components/CustomEmptyOverlayGrid.tsx
@@ -85,7 +85,7 @@ export default function CustomEmptyOverlayGrid() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
-        components={{
+        slots={{
           NoRowsOverlay: CustomNoRowsOverlay,
         }}
         {...data}

--- a/docs/data/data-grid/components/CustomEmptyOverlayGrid.tsx.preview
+++ b/docs/data/data-grid/components/CustomEmptyOverlayGrid.tsx.preview
@@ -1,5 +1,5 @@
 <DataGrid
-  components={{
+  slots={{
     NoRowsOverlay: CustomNoRowsOverlay,
   }}
   {...data}

--- a/docs/data/data-grid/components/CustomFooter.js
+++ b/docs/data/data-grid/components/CustomFooter.js
@@ -39,10 +39,10 @@ export default function CustomFooter() {
       <Box sx={{ height: 350, width: '100%', mb: 1 }}>
         <DataGrid
           {...data}
-          components={{
+          slots={{
             Footer: CustomFooterStatusComponent,
           }}
-          componentsProps={{
+          slotsProps={{
             footer: { status },
           }}
         />

--- a/docs/data/data-grid/components/CustomFooter.tsx
+++ b/docs/data/data-grid/components/CustomFooter.tsx
@@ -34,10 +34,10 @@ export default function CustomFooter() {
       <Box sx={{ height: 350, width: '100%', mb: 1 }}>
         <DataGrid
           {...data}
-          components={{
+          slots={{
             Footer: CustomFooterStatusComponent,
           }}
-          componentsProps={{
+          slotsProps={{
             footer: { status },
           }}
         />

--- a/docs/data/data-grid/components/CustomLoadingOverlayGrid.js
+++ b/docs/data/data-grid/components/CustomLoadingOverlayGrid.js
@@ -13,7 +13,7 @@ export default function CustomLoadingOverlayGrid() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
-        components={{
+        slots={{
           LoadingOverlay: LinearProgress,
         }}
         loading

--- a/docs/data/data-grid/components/CustomLoadingOverlayGrid.tsx
+++ b/docs/data/data-grid/components/CustomLoadingOverlayGrid.tsx
@@ -13,7 +13,7 @@ export default function CustomLoadingOverlayGrid() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
-        components={{
+        slots={{
           LoadingOverlay: LinearProgress,
         }}
         loading

--- a/docs/data/data-grid/components/CustomLoadingOverlayGrid.tsx.preview
+++ b/docs/data/data-grid/components/CustomLoadingOverlayGrid.tsx.preview
@@ -1,5 +1,5 @@
 <DataGrid
-  components={{
+  slots={{
     LoadingOverlay: LinearProgress,
   }}
   loading

--- a/docs/data/data-grid/components/CustomPaginationGrid.js
+++ b/docs/data/data-grid/components/CustomPaginationGrid.js
@@ -58,7 +58,7 @@ export default function CustomPaginationGrid() {
     <Box sx={{ height: 400, width: '100%' }}>
       <DataGrid
         pagination
-        components={{
+        slots={{
           Pagination: CustomPagination,
         }}
         {...data}

--- a/docs/data/data-grid/components/CustomPaginationGrid.tsx
+++ b/docs/data/data-grid/components/CustomPaginationGrid.tsx
@@ -47,7 +47,7 @@ export default function CustomPaginationGrid() {
     <Box sx={{ height: 400, width: '100%' }}>
       <DataGrid
         pagination
-        components={{
+        slots={{
           Pagination: CustomPagination,
         }}
         {...data}

--- a/docs/data/data-grid/components/CustomPaginationGrid.tsx.preview
+++ b/docs/data/data-grid/components/CustomPaginationGrid.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   pagination
-  components={{
+  slots={{
     Pagination: CustomPagination,
   }}
   {...data}

--- a/docs/data/data-grid/components/CustomSortIcons.js
+++ b/docs/data/data-grid/components/CustomSortIcons.js
@@ -36,7 +36,7 @@ export default function CustomSortIcons() {
         columns={columns}
         rows={rows}
         sortModel={[{ field: 'name', sort: 'asc' }]}
-        components={{
+        slots={{
           ColumnSortedDescendingIcon: SortedDescendingIcon,
           ColumnSortedAscendingIcon: SortedAscendingIcon,
         }}

--- a/docs/data/data-grid/components/CustomSortIcons.tsx
+++ b/docs/data/data-grid/components/CustomSortIcons.tsx
@@ -36,7 +36,7 @@ export default function CustomSortIcons() {
         columns={columns}
         rows={rows}
         sortModel={[{ field: 'name', sort: 'asc' }]}
-        components={{
+        slots={{
           ColumnSortedDescendingIcon: SortedDescendingIcon,
           ColumnSortedAscendingIcon: SortedAscendingIcon,
         }}

--- a/docs/data/data-grid/components/CustomSortIcons.tsx.preview
+++ b/docs/data/data-grid/components/CustomSortIcons.tsx.preview
@@ -2,7 +2,7 @@
   columns={columns}
   rows={rows}
   sortModel={[{ field: 'name', sort: 'asc' }]}
-  components={{
+  slots={{
     ColumnSortedDescendingIcon: SortedDescendingIcon,
     ColumnSortedAscendingIcon: SortedAscendingIcon,
   }}

--- a/docs/data/data-grid/components/CustomToolbarGrid.js
+++ b/docs/data/data-grid/components/CustomToolbarGrid.js
@@ -31,7 +31,7 @@ export default function CustomToolbarGrid() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/components/CustomToolbarGrid.tsx
+++ b/docs/data/data-grid/components/CustomToolbarGrid.tsx
@@ -31,7 +31,7 @@ export default function CustomToolbarGrid() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/components/CustomToolbarGrid.tsx.preview
+++ b/docs/data/data-grid/components/CustomToolbarGrid.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/components/RowContextMenu.js
+++ b/docs/data/data-grid/components/RowContextMenu.js
@@ -89,7 +89,7 @@ export default function RowContextMenu() {
       <DataGrid
         columns={columns}
         rows={rows}
-        componentsProps={{
+        slotsProps={{
           row: {
             onContextMenu: handleContextMenu,
             style: { cursor: 'context-menu' },

--- a/docs/data/data-grid/components/RowContextMenu.tsx
+++ b/docs/data/data-grid/components/RowContextMenu.tsx
@@ -92,7 +92,7 @@ export default function RowContextMenu() {
       <DataGrid
         columns={columns}
         rows={rows}
-        componentsProps={{
+        slotsProps={{
           row: {
             onContextMenu: handleContextMenu,
             style: { cursor: 'context-menu' },

--- a/docs/data/data-grid/components/ToolbarGrid.js
+++ b/docs/data/data-grid/components/ToolbarGrid.js
@@ -13,7 +13,7 @@ export default function ToolbarGrid() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/components/ToolbarGrid.tsx
+++ b/docs/data/data-grid/components/ToolbarGrid.tsx
@@ -13,7 +13,7 @@ export default function ToolbarGrid() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/components/ToolbarGrid.tsx.preview
+++ b/docs/data/data-grid/components/ToolbarGrid.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: GridToolbar,
   }}
 />

--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -1,13 +1,13 @@
-# Data Grid - Components
+# Data Grid - Slots
 
-<p class="description">The grid is highly customizable. Override components using the <code>components</code> prop.</p>
+<p class="description">The grid is highly customizable. Override components using the <code>slots</code> prop.</p>
 
 ## Overriding components
 
-As part of the customization API, the grid allows you to override internal components with the `components` prop.
+As part of the customization API, the grid allows you to override internal components with the `slots` prop.
 The prop accepts an object of type [`GridSlotsComponent`](/x/api/data-grid/data-grid/#slots).
 
-If you wish to pass additional props in a component slot, you can do it using the `componentsProps` prop.
+If you wish to pass additional props in a component slot, you can do it using the `slotsProps` prop.
 This prop is of type `GridSlotsComponentsProps`.
 
 As an example, you could override the column menu and pass additional props as below.
@@ -16,17 +16,17 @@ As an example, you could override the column menu and pass additional props as b
 <DataGrid
   rows={rows}
   columns={columns}
-  components={{
+  slots={{
     ColumnMenu: MyCustomColumnMenu,
   }}
-  componentsProps={{
+  slotsProps={{
     columnMenu: { background: 'red', counter: rows.length },
   }}
 />
 ```
 
 :::info
-The casing is different between the `components` (ColumnMenu) and `componentsProps` (columnMenu) props.
+The casing is different between the `slots` (ColumnMenu) and `slotsProps` (columnMenu) props.
 :::
 
 ### Interacting with the grid
@@ -148,7 +148,7 @@ As the no rows overlay, the grid allows to override the no results overlay with 
 
 ### Row
 
-The `componentsProps.row` prop can be used to pass additional props to the row component.
+The `slotsProps.row` prop can be used to pass additional props to the row component.
 One common use case might be to listen for events not exposed by [default](/x/react-data-grid/events/#catalog-of-events).
 The demo below shows a context menu when a row is right-clicked.
 
@@ -156,14 +156,14 @@ The demo below shows a context menu when a row is right-clicked.
 
 ### Cell
 
-The following demo uses the `componentsProps.cell` prop to listen for specific events emitted by the cells.
+The following demo uses the `slotsProps.cell` prop to listen for specific events emitted by the cells.
 Try it by hovering a cell with the mouse and it should display the number of characters each cell has.
 
 {{"demo": "CellWithPopover.js", "bg": "inline"}}
 
 ### Icons
 
-As any component slot, every icon can be customized. However, it is not yet possible to use the `componentsProps` with icons.
+As any component slot, every icon can be customized. However, it is not yet possible to use the `slotsProps` with icons.
 
 {{"demo": "CustomSortIcons.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/demo/FullFeaturedDemo.js
+++ b/docs/data/data-grid/demo/FullFeaturedDemo.js
@@ -301,10 +301,10 @@ export default function FullFeaturedDemo() {
       />
       <DataGridComponent
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: { showQuickFilter: true },
         }}
         loading={loading}

--- a/docs/data/data-grid/demo/FullFeaturedDemo.tsx
+++ b/docs/data/data-grid/demo/FullFeaturedDemo.tsx
@@ -333,10 +333,10 @@ export default function FullFeaturedDemo() {
       />
       <DataGridComponent
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: { showQuickFilter: true },
         }}
         loading={loading}

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.js
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.js
@@ -356,12 +356,12 @@ export default function PopularFeaturesDemo() {
         autoHeight
         disableRowSelectionOnClick
         onRowClick={onRowClick}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
           DetailPanelExpandIcon: ArrowDown,
           DetailPanelCollapseIcon: ArrowUp,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: { showQuickFilter: true, quickFilterProps: { debounceMs: 500 } },
         }}
         getDetailPanelContent={getDetailPanelContent}

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
@@ -367,12 +367,12 @@ export default function PopularFeaturesDemo() {
         autoHeight
         disableRowSelectionOnClick
         onRowClick={onRowClick}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
           DetailPanelExpandIcon: ArrowDown,
           DetailPanelCollapseIcon: ArrowUp,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: { showQuickFilter: true, quickFilterProps: { debounceMs: 500 } },
         }}
         getDetailPanelContent={getDetailPanelContent}

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
@@ -214,10 +214,10 @@ export default function FullFeaturedCrudGrid() {
         onRowEditStart={handleRowEditStart}
         onRowEditStop={handleRowEditStop}
         processRowUpdate={processRowUpdate}
-        components={{
+        slots={{
           Toolbar: EditToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: { setRows, setRowModesModel },
         }}
       />

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -226,10 +226,10 @@ export default function FullFeaturedCrudGrid() {
         onRowEditStart={handleRowEditStart}
         onRowEditStop={handleRowEditStop}
         processRowUpdate={processRowUpdate}
-        components={{
+        slots={{
           Toolbar: EditToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: { setRows, setRowModesModel },
         }}
       />

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
@@ -7,10 +7,10 @@
   onRowEditStart={handleRowEditStart}
   onRowEditStop={handleRowEditStop}
   processRowUpdate={processRowUpdate}
-  components={{
+  slots={{
     Toolbar: EditToolbar,
   }}
-  componentsProps={{
+  slotsProps={{
     toolbar: { setRows, setRowModesModel },
   }}
 />

--- a/docs/data/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/data/data-grid/editing/StartEditButtonGrid.js
@@ -125,10 +125,10 @@ export default function StartEditButtonGrid() {
         onCellKeyDown={handleCellKeyDown}
         cellModesModel={cellModesModel}
         onCellModesModelChange={(model) => setCellModesModel(model)}
-        components={{
+        slots={{
           Toolbar: EditToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: {
             cellMode,
             selectedCellParams,

--- a/docs/data/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/data/data-grid/editing/StartEditButtonGrid.tsx
@@ -138,10 +138,10 @@ export default function StartEditButtonGrid() {
         onCellKeyDown={handleCellKeyDown}
         cellModesModel={cellModesModel}
         onCellModesModelChange={(model) => setCellModesModel(model)}
-        components={{
+        slots={{
           Toolbar: EditToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           toolbar: {
             cellMode,
             selectedCellParams,

--- a/docs/data/data-grid/events/CatalogOfEventsNoSnap.js
+++ b/docs/data/data-grid/events/CatalogOfEventsNoSnap.js
@@ -141,7 +141,7 @@ export default function CatalogOfEventsNoSnap() {
       getRowHeight={() => 'auto'}
       disableRowSelection
       hideFooter
-      components={{
+      slots={{
         Toolbar,
       }}
       sx={{

--- a/docs/data/data-grid/events/SubscribeToEventsHook.js
+++ b/docs/data/data-grid/events/SubscribeToEventsHook.js
@@ -34,7 +34,7 @@ export default function SubscribeToEventsHook() {
   return (
     <Stack spacing={2} sx={{ width: '100%' }}>
       <Box sx={{ height: 350, width: '100%' }}>
-        <DataGrid {...data} components={{ Footer }} />
+        <DataGrid {...data} slots={{ Footer }} />
       </Box>
     </Stack>
   );

--- a/docs/data/data-grid/events/SubscribeToEventsHook.tsx
+++ b/docs/data/data-grid/events/SubscribeToEventsHook.tsx
@@ -35,7 +35,7 @@ export default function SubscribeToEventsHook() {
   return (
     <Stack spacing={2} sx={{ width: '100%' }}>
       <Box sx={{ height: 350, width: '100%' }}>
-        <DataGrid {...data} components={{ Footer }} />
+        <DataGrid {...data} slots={{ Footer }} />
       </Box>
     </Stack>
   );

--- a/docs/data/data-grid/events/SubscribeToEventsHook.tsx.preview
+++ b/docs/data/data-grid/events/SubscribeToEventsHook.tsx.preview
@@ -1,3 +1,3 @@
 <Box sx={{ height: 350, width: '100%' }}>
-  <DataGrid {...data} components={{ Footer }} />
+  <DataGrid {...data} slots={{ Footer }} />
 </Box>

--- a/docs/data/data-grid/export/CsvGetRowsToExport.js
+++ b/docs/data/data-grid/export/CsvGetRowsToExport.js
@@ -70,7 +70,7 @@ export default function CsvGetRowsToExport() {
       <DataGrid
         {...data}
         loading={loading}
-        components={{ Toolbar: CustomToolbar }}
+        slots={{ Toolbar: CustomToolbar }}
         pageSize={10}
         rowsPerPageOptions={[10]}
         initialState={{

--- a/docs/data/data-grid/export/CsvGetRowsToExport.tsx
+++ b/docs/data/data-grid/export/CsvGetRowsToExport.tsx
@@ -75,7 +75,7 @@ export default function CsvGetRowsToExport() {
       <DataGrid
         {...data}
         loading={loading}
-        components={{ Toolbar: CustomToolbar }}
+        slots={{ Toolbar: CustomToolbar }}
         pageSize={10}
         rowsPerPageOptions={[10]}
         initialState={{

--- a/docs/data/data-grid/export/CsvGetRowsToExport.tsx.preview
+++ b/docs/data/data-grid/export/CsvGetRowsToExport.tsx.preview
@@ -1,7 +1,7 @@
 <DataGrid
   {...data}
   loading={loading}
-  components={{ Toolbar: CustomToolbar }}
+  slots={{ Toolbar: CustomToolbar }}
   pageSize={10}
   rowsPerPageOptions={[10]}
   initialState={{

--- a/docs/data/data-grid/export/CsvGetRowsToExportRowGrouping.js
+++ b/docs/data/data-grid/export/CsvGetRowsToExportRowGrouping.js
@@ -65,7 +65,7 @@ export default function CsvGetRowsToExportRowGrouping() {
       <DataGridPremium
         {...data}
         loading={loading}
-        components={{ Toolbar: CustomToolbar }}
+        slots={{ Toolbar: CustomToolbar }}
         initialState={{
           ...data.initialState,
           rowGrouping: {

--- a/docs/data/data-grid/export/CsvGetRowsToExportRowGrouping.tsx
+++ b/docs/data/data-grid/export/CsvGetRowsToExportRowGrouping.tsx
@@ -69,7 +69,7 @@ export default function CsvGetRowsToExportRowGrouping() {
       <DataGridPremium
         {...data}
         loading={loading}
-        components={{ Toolbar: CustomToolbar }}
+        slots={{ Toolbar: CustomToolbar }}
         initialState={{
           ...data.initialState,
           rowGrouping: {

--- a/docs/data/data-grid/export/CsvGetRowsToExportRowGrouping.tsx.preview
+++ b/docs/data/data-grid/export/CsvGetRowsToExportRowGrouping.tsx.preview
@@ -1,7 +1,7 @@
 <DataGridPremium
   {...data}
   loading={loading}
-  components={{ Toolbar: CustomToolbar }}
+  slots={{ Toolbar: CustomToolbar }}
   initialState={{
     ...data.initialState,
     rowGrouping: {

--- a/docs/data/data-grid/export/CustomExport.js
+++ b/docs/data/data-grid/export/CustomExport.js
@@ -100,11 +100,7 @@ export default function CustomExport() {
 
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGrid
-        {...data}
-        loading={loading}
-        components={{ Toolbar: CustomToolbar }}
-      />
+      <DataGrid {...data} loading={loading} slots={{ Toolbar: CustomToolbar }} />
     </div>
   );
 }

--- a/docs/data/data-grid/export/CustomExport.tsx
+++ b/docs/data/data-grid/export/CustomExport.tsx
@@ -100,11 +100,7 @@ export default function CustomExport() {
 
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGrid
-        {...data}
-        loading={loading}
-        components={{ Toolbar: CustomToolbar }}
-      />
+      <DataGrid {...data} loading={loading} slots={{ Toolbar: CustomToolbar }} />
     </div>
   );
 }

--- a/docs/data/data-grid/export/CustomExport.tsx.preview
+++ b/docs/data/data-grid/export/CustomExport.tsx.preview
@@ -1,5 +1,5 @@
 <DataGrid
   {...data}
   loading={loading}
-  components={{ Toolbar: CustomToolbar }}
+  slots={{ Toolbar: CustomToolbar }}
 />

--- a/docs/data/data-grid/export/ExcelCustomExport.js
+++ b/docs/data/data-grid/export/ExcelCustomExport.js
@@ -283,8 +283,8 @@ export default function ExcelCustomExport() {
         columns={columns}
         groupingColDef={groupingColDef}
         defaultGroupingExpansionDepth={-1}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{ toolbar: { excelOptions } }}
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{ toolbar: { excelOptions } }}
       />
     </div>
   );

--- a/docs/data/data-grid/export/ExcelCustomExport.tsx
+++ b/docs/data/data-grid/export/ExcelCustomExport.tsx
@@ -288,8 +288,8 @@ export default function ExcelCustomExport() {
         columns={columns}
         groupingColDef={groupingColDef}
         defaultGroupingExpansionDepth={-1}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{ toolbar: { excelOptions } }}
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{ toolbar: { excelOptions } }}
       />
     </div>
   );

--- a/docs/data/data-grid/export/ExcelCustomExport.tsx.preview
+++ b/docs/data/data-grid/export/ExcelCustomExport.tsx.preview
@@ -5,6 +5,6 @@
   columns={columns}
   groupingColDef={groupingColDef}
   defaultGroupingExpansionDepth={-1}
-  components={{ Toolbar: GridToolbar }}
-  componentsProps={{ toolbar: { excelOptions } }}
+  slots={{ Toolbar: GridToolbar }}
+  slotsProps={{ toolbar: { excelOptions } }}
 />

--- a/docs/data/data-grid/export/ExcelExport.js
+++ b/docs/data/data-grid/export/ExcelExport.js
@@ -129,7 +129,7 @@ export default function ExcelExport() {
       <DataGridPremium
         rows={rows}
         columns={columns}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/export/ExcelExport.tsx
+++ b/docs/data/data-grid/export/ExcelExport.tsx
@@ -131,7 +131,7 @@ export default function ExcelExport() {
       <DataGridPremium
         rows={rows}
         columns={columns}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/export/ExcelExport.tsx.preview
+++ b/docs/data/data-grid/export/ExcelExport.tsx.preview
@@ -1,7 +1,7 @@
 <DataGridPremium
   rows={rows}
   columns={columns}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/export/ExportCustomToolbar.js
+++ b/docs/data/data-grid/export/ExportCustomToolbar.js
@@ -22,7 +22,7 @@ export default function ExportCustomToolbar() {
       <DataGrid
         {...data}
         loading={loading}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/export/ExportCustomToolbar.tsx
+++ b/docs/data/data-grid/export/ExportCustomToolbar.tsx
@@ -22,7 +22,7 @@ export default function ExportCustomToolbar() {
       <DataGrid
         {...data}
         loading={loading}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/export/ExportCustomToolbar.tsx.preview
+++ b/docs/data/data-grid/export/ExportCustomToolbar.tsx.preview
@@ -1,7 +1,7 @@
 <DataGrid
   {...data}
   loading={loading}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/export/ExportDefaultToolbar.js
+++ b/docs/data/data-grid/export/ExportDefaultToolbar.js
@@ -11,7 +11,7 @@ export default function ExportDefaultToolbar() {
 
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGrid {...data} loading={loading} components={{ Toolbar: GridToolbar }} />
+      <DataGrid {...data} loading={loading} slots={{ Toolbar: GridToolbar }} />
     </div>
   );
 }

--- a/docs/data/data-grid/export/ExportDefaultToolbar.tsx
+++ b/docs/data/data-grid/export/ExportDefaultToolbar.tsx
@@ -11,7 +11,7 @@ export default function ExportDefaultToolbar() {
 
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGrid {...data} loading={loading} components={{ Toolbar: GridToolbar }} />
+      <DataGrid {...data} loading={loading} slots={{ Toolbar: GridToolbar }} />
     </div>
   );
 }

--- a/docs/data/data-grid/export/ExportDefaultToolbar.tsx.preview
+++ b/docs/data/data-grid/export/ExportDefaultToolbar.tsx.preview
@@ -1,1 +1,1 @@
-<DataGrid {...data} loading={loading} components={{ Toolbar: GridToolbar }} />
+<DataGrid {...data} loading={loading} slots={{ Toolbar: GridToolbar }} />

--- a/docs/data/data-grid/export/RemovePrintExport.js
+++ b/docs/data/data-grid/export/RemovePrintExport.js
@@ -21,7 +21,7 @@ export default function RemovePrintExport() {
       <DataGrid
         {...data}
         loading={loading}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/export/RemovePrintExport.tsx
+++ b/docs/data/data-grid/export/RemovePrintExport.tsx
@@ -21,7 +21,7 @@ export default function RemovePrintExport() {
       <DataGrid
         {...data}
         loading={loading}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/export/RemovePrintExport.tsx.preview
+++ b/docs/data/data-grid/export/RemovePrintExport.tsx.preview
@@ -1,7 +1,7 @@
 <DataGrid
   {...data}
   loading={loading}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -6,7 +6,7 @@
 
 ### Default Toolbar
 
-To enable the export menu, pass the `GridToolbar` component in the `Toolbar` [component slot](/x/react-data-grid/components/#toolbar).
+To enable the export menu, pass the `GridToolbar` component in the `Toolbar` [component slot](/x/react-data-grid/slots/#toolbar).
 
 {{"demo": "ExportDefaultToolbar.js", "bg": "inline"}}
 
@@ -38,7 +38,7 @@ By default, the export menu displays all the available export formats, according
 You can customize their respective behavior by passing an options object either to the `GridToolbar` or to the `GridToolbarExport` as a prop.
 
 ```tsx
-<DataGrid componentsProps={{ toolbar: { csvOptions } }} />
+<DataGrid slotsProps={{ toolbar: { csvOptions } }} />
 
 // same as
 
@@ -57,7 +57,7 @@ In the following example, the print export is disabled.
 
 ```jsx
 <DataGrid
-  componentsProps={{ toolbar: { printOptions: { disableToolbarButton: true } } }}
+  slotsProps={{ toolbar: { printOptions: { disableToolbarButton: true } } }}
 />
 ```
 
@@ -77,15 +77,13 @@ There are a few ways to include or hide other columns.
 - Set `allColumns` in export option to `true` to also include hidden columns. Those with `disableExport=true` will not be exported.
 
 ```jsx
-<DataGrid componentsProps={{ toolbar: { csvOptions: { allColumns: true } } }} />
+<DataGrid slotsProps={{ toolbar: { csvOptions: { allColumns: true } } }} />
 ```
 
 - Set the exact columns to be exported in the export option. Setting `fields` overrides the other properties. Such that the exported columns are exactly those in `fields` in the same order.
 
 ```jsx
-<DataGrid
-  componentsProps={{ toolbar: { csvOptions: { fields: ['name', 'brand'] } } }}
-/>
+<DataGrid slotsProps={{ toolbar: { csvOptions: { fields: ['name', 'brand'] } } }} />
 ```
 
 ## Exported rows
@@ -175,7 +173,7 @@ With `pageStyle` option, you can override the main content color with a [more sp
 
 ```jsx
 <DataGrid
-  componentsProps={{
+  slotsProps={{
     toolbar: {
       printOptions:{
         pageStyle: '.MuiDataGrid-root .MuiDataGrid-main { color: rgba(0, 0, 0, 0.87); }',

--- a/docs/data/data-grid/filtering/BasicExampleDataGrid.js
+++ b/docs/data/data-grid/filtering/BasicExampleDataGrid.js
@@ -13,7 +13,7 @@ export default function BasicExampleDataGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid {...data} components={{ Toolbar: GridToolbar }} />
+      <DataGrid {...data} slots={{ Toolbar: GridToolbar }} />
     </div>
   );
 }

--- a/docs/data/data-grid/filtering/BasicExampleDataGrid.tsx
+++ b/docs/data/data-grid/filtering/BasicExampleDataGrid.tsx
@@ -13,7 +13,7 @@ export default function BasicExampleDataGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid {...data} components={{ Toolbar: GridToolbar }} />
+      <DataGrid {...data} slots={{ Toolbar: GridToolbar }} />
     </div>
   );
 }

--- a/docs/data/data-grid/filtering/BasicExampleDataGrid.tsx.preview
+++ b/docs/data/data-grid/filtering/BasicExampleDataGrid.tsx.preview
@@ -1,1 +1,1 @@
-<DataGrid {...data} components={{ Toolbar: GridToolbar }} />
+<DataGrid {...data} slots={{ Toolbar: GridToolbar }} />

--- a/docs/data/data-grid/filtering/ControlledFilters.js
+++ b/docs/data/data-grid/filtering/ControlledFilters.js
@@ -25,7 +25,7 @@ export default function ControlledFilters() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
         filterModel={filterModel}

--- a/docs/data/data-grid/filtering/ControlledFilters.tsx
+++ b/docs/data/data-grid/filtering/ControlledFilters.tsx
@@ -25,7 +25,7 @@ export default function ControlledFilters() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
         filterModel={filterModel}

--- a/docs/data/data-grid/filtering/ControlledFilters.tsx.preview
+++ b/docs/data/data-grid/filtering/ControlledFilters.tsx.preview
@@ -1,6 +1,6 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: GridToolbar,
   }}
   filterModel={filterModel}

--- a/docs/data/data-grid/filtering/CustomFilterPanelContent.js
+++ b/docs/data/data-grid/filtering/CustomFilterPanelContent.js
@@ -15,12 +15,12 @@ export default function CustomFilterPanelContent() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGridPro
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
           // Use custom FilterPanel only for deep modification
           // FilterPanel: MyCustomFilterPanel,
         }}
-        componentsProps={{
+        slotsProps={{
           filterPanel: {
             // Force usage of "And" operator
             linkOperators: [GridLinkOperator.And],

--- a/docs/data/data-grid/filtering/CustomFilterPanelContent.tsx
+++ b/docs/data/data-grid/filtering/CustomFilterPanelContent.tsx
@@ -16,12 +16,12 @@ export default function CustomFilterPanelContent() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGridPro
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
           // Use custom FilterPanel only for deep modification
           // FilterPanel: MyCustomFilterPanel,
         }}
-        componentsProps={{
+        slotsProps={{
           filterPanel: {
             // Force usage of "And" operator
             linkOperators: [GridLinkOperator.And],

--- a/docs/data/data-grid/filtering/CustomFilterPanelPosition.js
+++ b/docs/data/data-grid/filtering/CustomFilterPanelPosition.js
@@ -34,10 +34,10 @@ export default function CustomFilterPanelPosition() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           panel: {
             anchorEl: filterButtonEl,
           },

--- a/docs/data/data-grid/filtering/CustomFilterPanelPosition.tsx
+++ b/docs/data/data-grid/filtering/CustomFilterPanelPosition.tsx
@@ -34,10 +34,10 @@ export default function CustomFilterPanelPosition() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           panel: {
             anchorEl: filterButtonEl,
           },

--- a/docs/data/data-grid/filtering/CustomFilterPanelPosition.tsx.preview
+++ b/docs/data/data-grid/filtering/CustomFilterPanelPosition.tsx.preview
@@ -1,9 +1,9 @@
 <DataGrid
   {...data}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
-  componentsProps={{
+  slotsProps={{
     panel: {
       anchorEl: filterButtonEl,
     },

--- a/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.js
+++ b/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.js
@@ -37,8 +37,8 @@ export default function DisableMultiFiltersDataGridPro() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGridPro
         {...data}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           filterPanel: {
             filterFormProps: {
               filterColumns,

--- a/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.tsx
+++ b/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.tsx
@@ -45,8 +45,8 @@ export default function DisableMultiFiltersDataGridPro() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGridPro
         {...data}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           filterPanel: {
             filterFormProps: {
               filterColumns,

--- a/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.tsx.preview
+++ b/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.tsx.preview
@@ -1,7 +1,7 @@
 <DataGridPro
   {...data}
-  components={{ Toolbar: GridToolbar }}
-  componentsProps={{
+  slots={{ Toolbar: GridToolbar }}
+  slotsProps={{
     filterPanel: {
       filterFormProps: {
         filterColumns,

--- a/docs/data/data-grid/filtering/InitialFilters.js
+++ b/docs/data/data-grid/filtering/InitialFilters.js
@@ -15,7 +15,7 @@ export default function InitialFilters() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
         initialState={{

--- a/docs/data/data-grid/filtering/InitialFilters.tsx
+++ b/docs/data/data-grid/filtering/InitialFilters.tsx
@@ -15,7 +15,7 @@ export default function InitialFilters() {
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid
         {...data}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
         initialState={{

--- a/docs/data/data-grid/filtering/QuickFilteringCustomLogic.js
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomLogic.js
@@ -63,7 +63,7 @@ export default function QuickFilteringCustomLogic() {
       <DataGrid
         {...data}
         columns={columns}
-        components={{ Toolbar: QuickSearchToolbar }}
+        slots={{ Toolbar: QuickSearchToolbar }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringCustomLogic.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomLogic.tsx
@@ -63,7 +63,7 @@ export default function QuickFilteringCustomLogic() {
       <DataGrid
         {...data}
         columns={columns}
-        components={{ Toolbar: QuickSearchToolbar }}
+        slots={{ Toolbar: QuickSearchToolbar }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringCustomLogic.tsx.preview
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomLogic.tsx.preview
@@ -1,5 +1,5 @@
 <DataGrid
   {...data}
   columns={columns}
-  components={{ Toolbar: QuickSearchToolbar }}
+  slots={{ Toolbar: QuickSearchToolbar }}
 />

--- a/docs/data/data-grid/filtering/QuickFilteringCustomizedGrid.js
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomizedGrid.js
@@ -57,7 +57,7 @@ export default function QuickFilteringCustomizedGrid() {
             },
           },
         }}
-        components={{ Toolbar: QuickSearchToolbar }}
+        slots={{ Toolbar: QuickSearchToolbar }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringCustomizedGrid.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomizedGrid.tsx
@@ -57,7 +57,7 @@ export default function QuickFilteringCustomizedGrid() {
             },
           },
         }}
-        components={{ Toolbar: QuickSearchToolbar }}
+        slots={{ Toolbar: QuickSearchToolbar }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringCustomizedGrid.tsx.preview
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomizedGrid.tsx.preview
@@ -11,5 +11,5 @@
       },
     },
   }}
-  components={{ Toolbar: QuickSearchToolbar }}
+  slots={{ Toolbar: QuickSearchToolbar }}
 />

--- a/docs/data/data-grid/filtering/QuickFilteringGrid.js
+++ b/docs/data/data-grid/filtering/QuickFilteringGrid.js
@@ -26,8 +26,8 @@ export default function QuickFilteringGrid() {
         disableColumnSelector
         disableDensitySelector
         columns={columns}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           toolbar: {
             showQuickFilter: true,
             quickFilterProps: { debounceMs: 500 },

--- a/docs/data/data-grid/filtering/QuickFilteringGrid.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringGrid.tsx
@@ -26,8 +26,8 @@ export default function QuickFilteringGrid() {
         disableColumnSelector
         disableDensitySelector
         columns={columns}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           toolbar: {
             showQuickFilter: true,
             quickFilterProps: { debounceMs: 500 },

--- a/docs/data/data-grid/filtering/QuickFilteringGrid.tsx.preview
+++ b/docs/data/data-grid/filtering/QuickFilteringGrid.tsx.preview
@@ -4,8 +4,8 @@
   disableColumnSelector
   disableDensitySelector
   columns={columns}
-  components={{ Toolbar: GridToolbar }}
-  componentsProps={{
+  slots={{ Toolbar: GridToolbar }}
+  slotsProps={{
     toolbar: {
       showQuickFilter: true,
       quickFilterProps: { debounceMs: 500 },

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -30,7 +30,7 @@ The following demo lets you filter the rows according to several criteria at the
 
 ### One filter per column [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
-You can also limit to only one filter per column while still allowing to filter other columns. For this, use the [`filterColumns`](/x/api/data-grid/grid-filter-form/) and [`getColumnForNewFilter`](/x/api/data-grid/grid-filter-panel/) props available in `componentsProps.filterPanel`.
+You can also limit to only one filter per column while still allowing to filter other columns. For this, use the [`filterColumns`](/x/api/data-grid/grid-filter-form/) and [`getColumnForNewFilter`](/x/api/data-grid/grid-filter-panel/) props available in `slotsProps.filterPanel`.
 
 #### Use cases
 

--- a/docs/data/data-grid/localization/CustomLocaleTextGrid.js
+++ b/docs/data/data-grid/localization/CustomLocaleTextGrid.js
@@ -20,7 +20,7 @@ export default function CustomLocaleTextGrid() {
           toolbarDensityStandard: 'Medium',
           toolbarDensityComfortable: 'Large',
         }}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/localization/CustomLocaleTextGrid.tsx
+++ b/docs/data/data-grid/localization/CustomLocaleTextGrid.tsx
@@ -20,7 +20,7 @@ export default function CustomLocaleTextGrid() {
           toolbarDensityStandard: 'Medium',
           toolbarDensityComfortable: 'Large',
         }}
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
       />

--- a/docs/data/data-grid/localization/CustomLocaleTextGrid.tsx.preview
+++ b/docs/data/data-grid/localization/CustomLocaleTextGrid.tsx.preview
@@ -7,7 +7,7 @@
     toolbarDensityStandard: 'Medium',
     toolbarDensityComfortable: 'Large',
   }}
-  components={{
+  slots={{
     Toolbar: GridToolbar,
   }}
 />

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -100,7 +100,7 @@ To change the icon used for the toggle, you can provide a different component fo
 
 ```tsx
 <DataGridPro
-  components={{
+  slots={{
     DetailPanelExpandIcon: CustomExpandIcon,
     DetailPanelCollapseIcon: CustomCollapseIcon,
   }}

--- a/docs/data/data-grid/overview/DataGridPremiumDemo.js
+++ b/docs/data/data-grid/overview/DataGridPremiumDemo.js
@@ -51,7 +51,7 @@ export default function DataGridPremiumDemo() {
         loading={loading}
         disableRowSelectionOnClick
         initialState={initialState}
-        components={{ Toolbar: GridToolbar }}
+        slots={{ Toolbar: GridToolbar }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridPremiumDemo.tsx
+++ b/docs/data/data-grid/overview/DataGridPremiumDemo.tsx
@@ -51,7 +51,7 @@ export default function DataGridPremiumDemo() {
         loading={loading}
         disableRowSelectionOnClick
         initialState={initialState}
-        components={{ Toolbar: GridToolbar }}
+        slots={{ Toolbar: GridToolbar }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overview/DataGridPremiumDemo.tsx.preview
+++ b/docs/data/data-grid/overview/DataGridPremiumDemo.tsx.preview
@@ -4,5 +4,5 @@
   loading={loading}
   disableRowSelectionOnClick
   initialState={initialState}
-  components={{ Toolbar: GridToolbar }}
+  slots={{ Toolbar: GridToolbar }}
 />

--- a/docs/data/data-grid/row-height/ExpandableCells.js
+++ b/docs/data/data-grid/row-height/ExpandableCells.js
@@ -90,7 +90,7 @@ export default function ExpandableCells() {
         columns={columns}
         getEstimatedRowHeight={() => 100}
         getRowHeight={() => 'auto'}
-        components={{ Toolbar: GridToolbar }}
+        slots={{ Toolbar: GridToolbar }}
         sx={{
           '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {
             py: 1,

--- a/docs/data/data-grid/row-height/ExpandableCells.tsx
+++ b/docs/data/data-grid/row-height/ExpandableCells.tsx
@@ -81,7 +81,7 @@ export default function ExpandableCells() {
         columns={columns}
         getEstimatedRowHeight={() => 100}
         getRowHeight={() => 'auto'}
-        components={{ Toolbar: GridToolbar }}
+        slots={{ Toolbar: GridToolbar }}
         sx={{
           '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {
             py: 1,

--- a/docs/data/data-grid/row-height/VariableRowHeightGrid.js
+++ b/docs/data/data-grid/row-height/VariableRowHeightGrid.js
@@ -47,7 +47,7 @@ export default function VariableRowHeightGrid() {
 
           return null;
         }}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/row-height/VariableRowHeightGrid.tsx
+++ b/docs/data/data-grid/row-height/VariableRowHeightGrid.tsx
@@ -48,7 +48,7 @@ export default function VariableRowHeightGrid() {
 
           return null;
         }}
-        components={{
+        slots={{
           Toolbar: CustomToolbar,
         }}
       />

--- a/docs/data/data-grid/row-height/VariableRowHeightGrid.tsx.preview
+++ b/docs/data/data-grid/row-height/VariableRowHeightGrid.tsx.preview
@@ -8,7 +8,7 @@
 
     return null;
   }}
-  components={{
+  slots={{
     Toolbar: CustomToolbar,
   }}
 />

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -48,7 +48,7 @@ To change the icon used for the row reordering, you can provide a different comp
 
 ```tsx
 <DataGridPro
-  components={{
+  slots={{
     RowReorderIcon: CustomMoveIcon,
   }}
 />

--- a/docs/data/data-grid/row-updates/InfiniteLoadingGrid.js
+++ b/docs/data/data-grid/row-updates/InfiniteLoadingGrid.js
@@ -59,7 +59,7 @@ export default function InfiniteLoadingGrid() {
         loading={loading}
         hideFooterPagination
         onRowsScrollEnd={handleOnRowsScrollEnd}
-        components={{
+        slots={{
           LoadingOverlay: LinearProgress,
         }}
       />

--- a/docs/data/data-grid/row-updates/InfiniteLoadingGrid.tsx
+++ b/docs/data/data-grid/row-updates/InfiniteLoadingGrid.tsx
@@ -59,7 +59,7 @@ export default function InfiniteLoadingGrid() {
         loading={loading}
         hideFooterPagination
         onRowsScrollEnd={handleOnRowsScrollEnd}
-        components={{
+        slots={{
           LoadingOverlay: LinearProgress,
         }}
       />

--- a/docs/data/data-grid/row-updates/InfiniteLoadingGrid.tsx.preview
+++ b/docs/data/data-grid/row-updates/InfiniteLoadingGrid.tsx.preview
@@ -4,7 +4,7 @@
   loading={loading}
   hideFooterPagination
   onRowsScrollEnd={handleOnRowsScrollEnd}
-  components={{
+  slots={{
     LoadingOverlay: LinearProgress,
   }}
 />

--- a/docs/data/data-grid/state/RestoreStateApiRef.js
+++ b/docs/data/data-grid/state/RestoreStateApiRef.js
@@ -354,7 +354,7 @@ export default function RestoreStateApiRef() {
   return (
     <Box sx={{ width: '100%', height: 400 }}>
       <DataGridPro
-        components={{ Toolbar: CustomToolbar }}
+        slots={{ Toolbar: CustomToolbar }}
         loading={loading}
         apiRef={apiRef}
         pagination

--- a/docs/data/data-grid/state/RestoreStateApiRef.tsx
+++ b/docs/data/data-grid/state/RestoreStateApiRef.tsx
@@ -338,7 +338,7 @@ export default function RestoreStateApiRef() {
   return (
     <Box sx={{ width: '100%', height: 400 }}>
       <DataGridPro
-        components={{ Toolbar: CustomToolbar }}
+        slots={{ Toolbar: CustomToolbar }}
         loading={loading}
         apiRef={apiRef}
         pagination

--- a/docs/data/data-grid/state/RestoreStateApiRef.tsx.preview
+++ b/docs/data/data-grid/state/RestoreStateApiRef.tsx.preview
@@ -1,5 +1,5 @@
 <DataGridPro
-  components={{ Toolbar: CustomToolbar }}
+  slots={{ Toolbar: CustomToolbar }}
   loading={loading}
   apiRef={apiRef}
   pagination

--- a/docs/data/data-grid/state/RestoreStateInitialState.js
+++ b/docs/data/data-grid/state/RestoreStateInitialState.js
@@ -23,9 +23,9 @@ function GridCustomToolbar({ syncState }) {
       <GridToolbarDensitySelector />
       <Button
         size="small"
-        startIcon={<rootProps.components.ColumnSelectorIcon />}
+        startIcon={<rootProps.slots.ColumnSelectorIcon />}
         onClick={() => syncState(apiRef.current.exportState())}
-        {...rootProps.componentsProps?.baseButton}
+        {...rootProps.slotsProps?.baseButton}
       >
         Recreate the 2nd grid
       </Button>
@@ -63,8 +63,8 @@ export default function RestoreStateInitialState() {
         <DataGridPro
           {...data}
           loading={loading}
-          components={{ Toolbar: GridCustomToolbar }}
-          componentsProps={{ toolbar: { syncState } }}
+          slots={{ Toolbar: GridCustomToolbar }}
+          slotsProps={{ toolbar: { syncState } }}
         />
       </Box>
       <Box sx={{ height: 300 }}>

--- a/docs/data/data-grid/state/RestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/RestoreStateInitialState.tsx
@@ -27,9 +27,9 @@ function GridCustomToolbar({
       <GridToolbarDensitySelector />
       <Button
         size="small"
-        startIcon={<rootProps.components.ColumnSelectorIcon />}
+        startIcon={<rootProps.slots.ColumnSelectorIcon />}
         onClick={() => syncState(apiRef.current.exportState())}
-        {...rootProps.componentsProps?.baseButton}
+        {...rootProps.slotsProps?.baseButton}
       >
         Recreate the 2nd grid
       </Button>
@@ -63,8 +63,8 @@ export default function RestoreStateInitialState() {
         <DataGridPro
           {...data}
           loading={loading}
-          components={{ Toolbar: GridCustomToolbar }}
-          componentsProps={{ toolbar: { syncState } }}
+          slots={{ Toolbar: GridCustomToolbar }}
+          slotsProps={{ toolbar: { syncState } }}
         />
       </Box>
       <Box sx={{ height: 300 }}>

--- a/docs/data/data-grid/state/RestoreStateInitialState.tsx.preview
+++ b/docs/data/data-grid/state/RestoreStateInitialState.tsx.preview
@@ -2,8 +2,8 @@
   <DataGridPro
     {...data}
     loading={loading}
-    components={{ Toolbar: GridCustomToolbar }}
-    componentsProps={{ toolbar: { syncState } }}
+    slots={{ Toolbar: GridCustomToolbar }}
+    slotsProps={{ toolbar: { syncState } }}
   />
 </Box>
 <Box sx={{ height: 300 }}>

--- a/docs/data/data-grid/state/UseGridSelector.js
+++ b/docs/data/data-grid/state/UseGridSelector.js
@@ -40,7 +40,7 @@ export default function UseGridSelector() {
         pagination
         pageSize={10}
         hideFooter
-        components={{
+        slots={{
           Toolbar,
         }}
       />

--- a/docs/data/data-grid/state/UseGridSelector.tsx
+++ b/docs/data/data-grid/state/UseGridSelector.tsx
@@ -40,7 +40,7 @@ export default function UseGridSelector() {
         pagination
         pageSize={10}
         hideFooter
-        components={{
+        slots={{
           Toolbar,
         }}
       />

--- a/docs/data/data-grid/state/UseGridSelector.tsx.preview
+++ b/docs/data/data-grid/state/UseGridSelector.tsx.preview
@@ -4,7 +4,7 @@
   pagination
   pageSize={10}
   hideFooter
-  components={{
+  slots={{
     Toolbar,
   }}
 />

--- a/docs/data/data-grid/style/AntDesignGrid.js
+++ b/docs/data/data-grid/style/AntDesignGrid.js
@@ -130,7 +130,7 @@ export default function AntDesignGrid() {
         checkboxSelection
         pageSize={5}
         rowsPerPageOptions={[5]}
-        components={{
+        slots={{
           Pagination: CustomPagination,
         }}
         {...data}

--- a/docs/data/data-grid/style/AntDesignGrid.tsx
+++ b/docs/data/data-grid/style/AntDesignGrid.tsx
@@ -132,7 +132,7 @@ export default function AntDesignGrid() {
         checkboxSelection
         pageSize={5}
         rowsPerPageOptions={[5]}
-        components={{
+        slots={{
           Pagination: CustomPagination,
         }}
         {...data}

--- a/docs/data/data-grid/style/AntDesignGrid.tsx.preview
+++ b/docs/data/data-grid/style/AntDesignGrid.tsx.preview
@@ -2,7 +2,7 @@
   checkboxSelection
   pageSize={5}
   rowsPerPageOptions={[5]}
-  components={{
+  slots={{
     Pagination: CustomPagination,
   }}
   {...data}

--- a/docs/data/data-grid/tree-data/TreeDataLazyLoading.js
+++ b/docs/data/data-grid/tree-data/TreeDataLazyLoading.js
@@ -169,8 +169,8 @@ function GroupingCellWithLazyLoading(props) {
   const classes = useUtilityClasses({ classes: rootProps.classes });
 
   const Icon = rowNode.childrenExpanded
-    ? rootProps.components.TreeDataCollapseIcon
-    : rootProps.components.TreeDataExpandIcon;
+    ? rootProps.slots.TreeDataCollapseIcon
+    : rootProps.slots.TreeDataExpandIcon;
 
   const handleClick = (event) => {
     apiRef.current.setRowChildrenExpansion(id, !rowNode.childrenExpanded);

--- a/docs/data/data-grid/tree-data/TreeDataLazyLoading.tsx
+++ b/docs/data/data-grid/tree-data/TreeDataLazyLoading.tsx
@@ -190,8 +190,8 @@ function GroupingCellWithLazyLoading(props: GroupingCellWithLazyLoadingProps) {
   const classes = useUtilityClasses({ classes: rootProps.classes });
 
   const Icon = rowNode.childrenExpanded
-    ? rootProps.components.TreeDataCollapseIcon
-    : rootProps.components.TreeDataExpandIcon;
+    ? rootProps.slots.TreeDataCollapseIcon
+    : rootProps.slots.TreeDataExpandIcon;
 
   const handleClick: IconButtonProps['onClick'] = (event) => {
     apiRef.current.setRowChildrenExpansion(id, !rowNode.childrenExpanded);

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -33,6 +33,8 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
   | `onSelectionModelChange`   | `onRowSelectionModelChange`   |
   | `disableSelectionOnClick`  | `disableRowSelectionOnClick`  |
   | `disableMultipleSelection` | `disableMultipleRowSelection` |
+  | `components`               | `slots`                       |
+  | `componentsProps`          | `slotsProps`                  |
 
 ### Removed props
 

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -154,14 +154,6 @@ DataGridPremiumRaw.propTypes = {
    */
   columnVisibilityModel: PropTypes.object,
   /**
-   * Overrideable components.
-   */
-  components: PropTypes.object,
-  /**
-   * Overrideable components props dynamically passed to the component at rendering.
-   */
-  componentsProps: PropTypes.object,
-  /**
    * If above 0, the row children will be expanded up to this depth.
    * If equal to -1, all the row children will be expanded.
    * @default 0
@@ -910,6 +902,90 @@ DataGridPremiumRaw.propTypes = {
    * @default false
    */
   showColumnRightBorder: PropTypes.bool,
+  /**
+   * Overrideable components.
+   */
+  slots: PropTypes.shape({
+    BaseButton: PropTypes.elementType.isRequired,
+    BaseCheckbox: PropTypes.elementType.isRequired,
+    BaseFormControl: PropTypes.elementType.isRequired,
+    BasePopper: PropTypes.elementType.isRequired,
+    BaseSelect: PropTypes.elementType.isRequired,
+    BaseSwitch: PropTypes.elementType.isRequired,
+    BaseTextField: PropTypes.elementType.isRequired,
+    BaseTooltip: PropTypes.elementType.isRequired,
+    BooleanCellFalseIcon: PropTypes.elementType.isRequired,
+    BooleanCellTrueIcon: PropTypes.elementType.isRequired,
+    Cell: PropTypes.elementType.isRequired,
+    ColumnFilteredIcon: PropTypes.elementType.isRequired,
+    ColumnHeaderFilterIconButton: PropTypes.elementType.isRequired,
+    ColumnMenu: PropTypes.elementType.isRequired,
+    ColumnMenuIcon: PropTypes.elementType.isRequired,
+    ColumnResizeIcon: PropTypes.elementType.isRequired,
+    ColumnSelectorIcon: PropTypes.elementType.isRequired,
+    ColumnSortedAscendingIcon: PropTypes.func,
+    ColumnSortedDescendingIcon: PropTypes.func,
+    ColumnsPanel: PropTypes.elementType.isRequired,
+    ColumnUnsortedIcon: PropTypes.func,
+    DensityComfortableIcon: PropTypes.elementType.isRequired,
+    DensityCompactIcon: PropTypes.elementType.isRequired,
+    DensityStandardIcon: PropTypes.elementType.isRequired,
+    DetailPanelCollapseIcon: PropTypes.elementType.isRequired,
+    DetailPanelExpandIcon: PropTypes.elementType.isRequired,
+    ErrorOverlay: PropTypes.elementType.isRequired,
+    ExportIcon: PropTypes.elementType.isRequired,
+    FilterPanel: PropTypes.elementType.isRequired,
+    FilterPanelDeleteIcon: PropTypes.elementType.isRequired,
+    Footer: PropTypes.elementType.isRequired,
+    GroupingCriteriaCollapseIcon: PropTypes.elementType.isRequired,
+    GroupingCriteriaExpandIcon: PropTypes.elementType.isRequired,
+    Header: PropTypes.elementType.isRequired,
+    LoadingOverlay: PropTypes.elementType.isRequired,
+    MoreActionsIcon: PropTypes.elementType.isRequired,
+    NoResultsOverlay: PropTypes.elementType.isRequired,
+    NoRowsOverlay: PropTypes.elementType.isRequired,
+    OpenFilterButtonIcon: PropTypes.elementType.isRequired,
+    Pagination: PropTypes.func,
+    Panel: PropTypes.elementType.isRequired,
+    PreferencesPanel: PropTypes.elementType.isRequired,
+    QuickFilterClearIcon: PropTypes.elementType.isRequired,
+    QuickFilterIcon: PropTypes.elementType.isRequired,
+    Row: PropTypes.elementType.isRequired,
+    RowReorderIcon: PropTypes.elementType.isRequired,
+    SkeletonCell: PropTypes.elementType.isRequired,
+    Toolbar: PropTypes.func,
+    TreeDataCollapseIcon: PropTypes.elementType.isRequired,
+    TreeDataExpandIcon: PropTypes.elementType.isRequired,
+  }),
+  /**
+   * Overrideable components props dynamically passed to the component at rendering.
+   */
+  slotsProps: PropTypes.shape({
+    baseButton: PropTypes.any,
+    baseCheckbox: PropTypes.any,
+    baseFormControl: PropTypes.any,
+    basePopper: PropTypes.any,
+    baseSelect: PropTypes.any,
+    baseSwitch: PropTypes.any,
+    baseTextField: PropTypes.any,
+    baseTooltip: PropTypes.any,
+    cell: PropTypes.any,
+    columnHeaderFilterIconButton: PropTypes.any,
+    columnMenu: PropTypes.any,
+    columnsPanel: PropTypes.any,
+    errorOverlay: PropTypes.any,
+    filterPanel: PropTypes.any,
+    footer: PropTypes.any,
+    header: PropTypes.any,
+    loadingOverlay: PropTypes.any,
+    noResultsOverlay: PropTypes.any,
+    noRowsOverlay: PropTypes.any,
+    pagination: PropTypes.any,
+    panel: PropTypes.any,
+    preferencesPanel: PropTypes.any,
+    row: PropTypes.any,
+    toolbar: PropTypes.any,
+  }),
   /**
    * Sorting can be processed on the server or client-side.
    * Set it to 'client' if you would like to handle sorting on the client-side.

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
@@ -34,8 +34,8 @@ export const useDataGridPremiumProps = (inProps: DataGridPremiumProps) => {
     [themedProps.localeText],
   );
 
-  const components = React.useMemo<GridSlotsComponent>(() => {
-    const overrides = themedProps.components;
+  const slots = React.useMemo<GridSlotsComponent>(() => {
+    const overrides = themedProps.slots;
 
     if (!overrides) {
       return { ...DATA_GRID_DEFAULT_SLOTS_COMPONENTS };
@@ -50,16 +50,16 @@ export const useDataGridPremiumProps = (inProps: DataGridPremiumProps) => {
     });
 
     return mergedComponents;
-  }, [themedProps.components]);
+  }, [themedProps.slots]);
 
   return React.useMemo<DataGridPremiumProcessedProps>(
     () => ({
       ...DATA_GRID_PREMIUM_PROPS_DEFAULT_VALUES,
       ...themedProps,
       localeText,
-      components,
+      slots,
       signature: 'DataGridPremium',
     }),
-    [themedProps, localeText, components],
+    [themedProps, localeText, slots],
   );
 };

--- a/packages/grid/x-data-grid-premium/src/components/GridGroupingCriteriaCell.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridGroupingCriteriaCell.tsx
@@ -44,8 +44,8 @@ export function GridGroupingCriteriaCell(props: GridGroupingCriteriaCellProps) {
   const filteredDescendantCount = filteredDescendantCountLookup[rowNode.id] ?? 0;
 
   const Icon = rowNode.childrenExpanded
-    ? rootProps.components.GroupingCriteriaCollapseIcon
-    : rootProps.components.GroupingCriteriaExpandIcon;
+    ? rootProps.slots.GroupingCriteriaCollapseIcon
+    : rootProps.slots.GroupingCriteriaExpandIcon;
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === ' ') {

--- a/packages/grid/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
@@ -57,7 +57,7 @@ describe('<DataGridPremium /> - Export Excel', () => {
     });
 
     it('should display export option', () => {
-      render(<TestCaseExcelExport components={{ Toolbar: GridToolbar }} />);
+      render(<TestCaseExcelExport slots={{ Toolbar: GridToolbar }} />);
 
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
       expect(screen.queryByRole('menu')).not.to.equal(null);

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -135,14 +135,6 @@ DataGridProRaw.propTypes = {
    */
   columnVisibilityModel: PropTypes.object,
   /**
-   * Overrideable components.
-   */
-  components: PropTypes.object,
-  /**
-   * Overrideable components props dynamically passed to the component at rendering.
-   */
-  componentsProps: PropTypes.object,
-  /**
    * If above 0, the row children will be expanded up to this depth.
    * If equal to -1, all the row children will be expanded.
    * @default 0
@@ -852,6 +844,90 @@ DataGridProRaw.propTypes = {
    * @default false
    */
   showColumnRightBorder: PropTypes.bool,
+  /**
+   * Overrideable components.
+   */
+  slots: PropTypes.shape({
+    BaseButton: PropTypes.elementType.isRequired,
+    BaseCheckbox: PropTypes.elementType.isRequired,
+    BaseFormControl: PropTypes.elementType.isRequired,
+    BasePopper: PropTypes.elementType.isRequired,
+    BaseSelect: PropTypes.elementType.isRequired,
+    BaseSwitch: PropTypes.elementType.isRequired,
+    BaseTextField: PropTypes.elementType.isRequired,
+    BaseTooltip: PropTypes.elementType.isRequired,
+    BooleanCellFalseIcon: PropTypes.elementType.isRequired,
+    BooleanCellTrueIcon: PropTypes.elementType.isRequired,
+    Cell: PropTypes.elementType.isRequired,
+    ColumnFilteredIcon: PropTypes.elementType.isRequired,
+    ColumnHeaderFilterIconButton: PropTypes.elementType.isRequired,
+    ColumnMenu: PropTypes.elementType.isRequired,
+    ColumnMenuIcon: PropTypes.elementType.isRequired,
+    ColumnResizeIcon: PropTypes.elementType.isRequired,
+    ColumnSelectorIcon: PropTypes.elementType.isRequired,
+    ColumnSortedAscendingIcon: PropTypes.func,
+    ColumnSortedDescendingIcon: PropTypes.func,
+    ColumnsPanel: PropTypes.elementType.isRequired,
+    ColumnUnsortedIcon: PropTypes.func,
+    DensityComfortableIcon: PropTypes.elementType.isRequired,
+    DensityCompactIcon: PropTypes.elementType.isRequired,
+    DensityStandardIcon: PropTypes.elementType.isRequired,
+    DetailPanelCollapseIcon: PropTypes.elementType.isRequired,
+    DetailPanelExpandIcon: PropTypes.elementType.isRequired,
+    ErrorOverlay: PropTypes.elementType.isRequired,
+    ExportIcon: PropTypes.elementType.isRequired,
+    FilterPanel: PropTypes.elementType.isRequired,
+    FilterPanelDeleteIcon: PropTypes.elementType.isRequired,
+    Footer: PropTypes.elementType.isRequired,
+    GroupingCriteriaCollapseIcon: PropTypes.elementType.isRequired,
+    GroupingCriteriaExpandIcon: PropTypes.elementType.isRequired,
+    Header: PropTypes.elementType.isRequired,
+    LoadingOverlay: PropTypes.elementType.isRequired,
+    MoreActionsIcon: PropTypes.elementType.isRequired,
+    NoResultsOverlay: PropTypes.elementType.isRequired,
+    NoRowsOverlay: PropTypes.elementType.isRequired,
+    OpenFilterButtonIcon: PropTypes.elementType.isRequired,
+    Pagination: PropTypes.func,
+    Panel: PropTypes.elementType.isRequired,
+    PreferencesPanel: PropTypes.elementType.isRequired,
+    QuickFilterClearIcon: PropTypes.elementType.isRequired,
+    QuickFilterIcon: PropTypes.elementType.isRequired,
+    Row: PropTypes.elementType.isRequired,
+    RowReorderIcon: PropTypes.elementType.isRequired,
+    SkeletonCell: PropTypes.elementType.isRequired,
+    Toolbar: PropTypes.func,
+    TreeDataCollapseIcon: PropTypes.elementType.isRequired,
+    TreeDataExpandIcon: PropTypes.elementType.isRequired,
+  }),
+  /**
+   * Overrideable components props dynamically passed to the component at rendering.
+   */
+  slotsProps: PropTypes.shape({
+    baseButton: PropTypes.any,
+    baseCheckbox: PropTypes.any,
+    baseFormControl: PropTypes.any,
+    basePopper: PropTypes.any,
+    baseSelect: PropTypes.any,
+    baseSwitch: PropTypes.any,
+    baseTextField: PropTypes.any,
+    baseTooltip: PropTypes.any,
+    cell: PropTypes.any,
+    columnHeaderFilterIconButton: PropTypes.any,
+    columnMenu: PropTypes.any,
+    columnsPanel: PropTypes.any,
+    errorOverlay: PropTypes.any,
+    filterPanel: PropTypes.any,
+    footer: PropTypes.any,
+    header: PropTypes.any,
+    loadingOverlay: PropTypes.any,
+    noResultsOverlay: PropTypes.any,
+    noRowsOverlay: PropTypes.any,
+    pagination: PropTypes.any,
+    panel: PropTypes.any,
+    preferencesPanel: PropTypes.any,
+    row: PropTypes.any,
+    toolbar: PropTypes.any,
+  }),
   /**
    * Sorting can be processed on the server or client-side.
    * Set it to 'client' if you would like to handle sorting on the client-side.

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
@@ -38,8 +38,8 @@ export const useDataGridProProps = <R extends GridValidRowModel>(inProps: DataGr
     [themedProps.localeText],
   );
 
-  const components = React.useMemo<GridSlotsComponent>(() => {
-    const overrides = themedProps.components;
+  const slots = React.useMemo<GridSlotsComponent>(() => {
+    const overrides = themedProps.slots;
 
     if (!overrides) {
       return { ...DATA_GRID_DEFAULT_SLOTS_COMPONENTS };
@@ -54,16 +54,16 @@ export const useDataGridProProps = <R extends GridValidRowModel>(inProps: DataGr
     });
 
     return mergedComponents;
-  }, [themedProps.components]);
+  }, [themedProps.slots]);
 
   return React.useMemo<DataGridProProcessedProps<R>>(
     () => ({
       ...DATA_GRID_PRO_PROPS_DEFAULT_VALUES,
       ...themedProps,
       localeText,
-      components,
+      slots,
       signature: 'DataGridPro',
     }),
-    [themedProps, localeText, components],
+    [themedProps, localeText, slots],
   );
 };

--- a/packages/grid/x-data-grid-pro/src/components/GridDetailPanelToggleCell.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/GridDetailPanelToggleCell.tsx
@@ -32,8 +32,8 @@ function GridDetailPanelToggleCell(props: GridRenderCellParams) {
   const hasContent = React.isValidElement(contentCache[id]);
 
   const Icon = isExpanded
-    ? rootProps.components.DetailPanelCollapseIcon
-    : rootProps.components.DetailPanelExpandIcon;
+    ? rootProps.slots.DetailPanelCollapseIcon
+    : rootProps.slots.DetailPanelExpandIcon;
 
   return (
     <IconButton

--- a/packages/grid/x-data-grid-pro/src/components/GridRowReorderCell.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/GridRowReorderCell.tsx
@@ -95,7 +95,7 @@ function GridRowReorderCell(params: GridRenderCellParams) {
 
   return (
     <div className={classes.root} draggable={isDraggable} {...draggableEventHandlers}>
-      <rootProps.components.RowReorderIcon />
+      <rootProps.slots.RowReorderIcon />
       <div className={classes.placeholder}>{cellValue}</div>
     </div>
   );

--- a/packages/grid/x-data-grid-pro/src/components/GridTreeDataGroupingCell.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/GridTreeDataGroupingCell.tsx
@@ -51,8 +51,8 @@ function GridTreeDataGroupingCell(props: GridTreeDataGroupingCellProps) {
   const filteredDescendantCount = filteredDescendantCountLookup[rowNode.id] ?? 0;
 
   const Icon = rowNode.childrenExpanded
-    ? rootProps.components.TreeDataCollapseIcon
-    : rootProps.components.TreeDataExpandIcon;
+    ? rootProps.slots.TreeDataCollapseIcon
+    : rootProps.slots.TreeDataExpandIcon;
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     apiRef.current.setRowChildrenExpansion(id, !rowNode.childrenExpanded);

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -355,7 +355,7 @@ describe('<DataGridPro /> - Columns', () => {
         privateApi = useGridPrivateApiContext();
         return null;
       }
-      render(<Test checkboxSelection components={{ Footer }} />);
+      render(<Test checkboxSelection slots={{ Footer }} />);
 
       act(() => apiRef.current.setColumnWidth('brand', 300));
       expect(gridColumnLookupSelector(apiRef).brand.computedWidth).to.equal(300);
@@ -373,7 +373,7 @@ describe('<DataGridPro /> - Columns', () => {
         <Test
           checkboxSelection
           columns={[{ field: 'id' }, { field: 'brand' }]}
-          components={{ Footer }}
+          slots={{ Footer }}
         />,
       );
 
@@ -390,7 +390,7 @@ describe('<DataGridPro /> - Columns', () => {
         privateApi = useGridPrivateApiContext();
         return null;
       }
-      render(<Test checkboxSelection components={{ Footer }} />);
+      render(<Test checkboxSelection slots={{ Footer }} />);
 
       act(() => apiRef.current.updateColumns([{ field: 'id' }]));
       expect(gridColumnFieldsSelector(apiRef)).to.deep.equal(['__check__', 'brand', 'id']);

--- a/packages/grid/x-data-grid-pro/src/tests/components.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/components.DataGridPro.test.tsx
@@ -13,7 +13,7 @@ import {
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
 import { getCell, getRow } from 'test/utils/helperFn';
 
-describe('<DataGridPro/> - Components', () => {
+describe('<DataGridPro/> - slots', () => {
   const { render } = createRenderer();
 
   let apiRef: React.MutableRefObject<GridApi>;
@@ -41,7 +41,7 @@ describe('<DataGridPro/> - Components', () => {
     });
   });
 
-  describe('components', () => {
+  describe('slots', () => {
     (
       [
         ['onClick', 'cellClick'],
@@ -52,10 +52,10 @@ describe('<DataGridPro/> - Components', () => {
         ['onDragOver', 'cellDragOver'],
       ] as const
     ).forEach(([prop, event]) => {
-      it(`should still publish the '${event}' event when overriding the '${prop}' prop in components.cell`, () => {
+      it(`should still publish the '${event}' event when overriding the '${prop}' prop in slots.cell`, () => {
         const propHandler = spy();
         const eventHandler = spy();
-        render(<TestCase componentsProps={{ cell: { [prop]: propHandler } }} />);
+        render(<TestCase slotsProps={{ cell: { [prop]: propHandler } }} />);
         apiRef!.current.subscribeEvent(event, eventHandler);
 
         expect(propHandler.callCount).to.equal(0);
@@ -76,10 +76,10 @@ describe('<DataGridPro/> - Components', () => {
       });
     });
 
-    it(`should still publish the 'cellKeyDown' event when overriding the 'onKeyDown' prop in components.cell`, () => {
+    it(`should still publish the 'cellKeyDown' event when overriding the 'onKeyDown' prop in slots.cell`, () => {
       const propHandler = spy();
       const eventHandler = spy();
-      render(<TestCase componentsProps={{ cell: { onKeyDown: propHandler } }} />);
+      render(<TestCase slotsProps={{ cell: { onKeyDown: propHandler } }} />);
       apiRef!.current.subscribeEvent('cellKeyDown', eventHandler);
 
       expect(propHandler.callCount).to.equal(0);
@@ -99,10 +99,10 @@ describe('<DataGridPro/> - Components', () => {
         ['onDoubleClick', 'rowDoubleClick'],
       ] as const
     ).forEach(([prop, event]) => {
-      it(`should still publish the '${event}' event when overriding the '${prop}' prop in components.row`, () => {
+      it(`should still publish the '${event}' event when overriding the '${prop}' prop in slots.row`, () => {
         const propHandler = spy();
         const eventHandler = spy();
-        render(<TestCase componentsProps={{ row: { [prop]: propHandler } }} />);
+        render(<TestCase slotsProps={{ row: { [prop]: propHandler } }} />);
         apiRef!.current.subscribeEvent(event, eventHandler);
 
         expect(propHandler.callCount).to.equal(0);

--- a/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
@@ -72,7 +72,7 @@ describe('<DataGridPro /> - Filter', () => {
     ],
   };
 
-  it('componentsProps `filterColumns` and `getColumnForNewFilter` should allow custom filtering', () => {
+  it('slotsProps `filterColumns` and `getColumnForNewFilter` should allow custom filtering', () => {
     const filterColumns = ({ field, columns, currentFilters }: FilterColumnsArgs) => {
       // remove already filtered fields from list of columns
       const filteredFields = currentFilters?.map((item) => item.field);
@@ -100,8 +100,8 @@ describe('<DataGridPro /> - Filter', () => {
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           filterPanel: {
             filterFormProps: {
               filterColumns,
@@ -129,8 +129,8 @@ describe('<DataGridPro /> - Filter', () => {
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           filterPanel: {
             getColumnForNewFilter,
           },
@@ -156,8 +156,8 @@ describe('<DataGridPro /> - Filter', () => {
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}
-        components={{ Toolbar: GridToolbar }}
-        componentsProps={{
+        slots={{ Toolbar: GridToolbar }}
+        slotsProps={{
           filterPanel: {
             filterFormProps: {
               filterColumns,

--- a/packages/grid/x-data-grid-pro/src/tests/printExport.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/printExport.DataGrid.test.tsx
@@ -58,7 +58,7 @@ describe('<DataGridPro /> - Print export', () => {
     clock.withFakeTimers();
 
     it('should display print button by default', () => {
-      render(<Test components={{ Toolbar: GridToolbar }} />);
+      render(<Test slots={{ Toolbar: GridToolbar }} />);
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
       expect(screen.queryByRole('menu')).not.to.equal(null);
       expect(screen.queryByRole('menuitem', { name: 'Print' })).not.to.equal(null);
@@ -67,8 +67,8 @@ describe('<DataGridPro /> - Print export', () => {
     it('should disable print export when passing `printOptions.disableToolbarButton`', () => {
       render(
         <Test
-          components={{ Toolbar: GridToolbar }}
-          componentsProps={{ toolbar: { printOptions: { disableToolbarButton: true } } }}
+          slots={{ Toolbar: GridToolbar }}
+          slotsProps={{ toolbar: { printOptions: { disableToolbarButton: true } } }}
         />,
       );
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -122,14 +122,6 @@ DataGridRaw.propTypes = {
    */
   columnVisibilityModel: PropTypes.object,
   /**
-   * Overrideable components.
-   */
-  components: PropTypes.object,
-  /**
-   * Overrideable components props dynamically passed to the component at rendering.
-   */
-  componentsProps: PropTypes.object,
-  /**
    * Set the density of the grid.
    * @default "standard"
    */
@@ -691,6 +683,90 @@ DataGridRaw.propTypes = {
    * @default false
    */
   showColumnRightBorder: PropTypes.bool,
+  /**
+   * Overrideable components.
+   */
+  slots: PropTypes.shape({
+    BaseButton: PropTypes.elementType.isRequired,
+    BaseCheckbox: PropTypes.elementType.isRequired,
+    BaseFormControl: PropTypes.elementType.isRequired,
+    BasePopper: PropTypes.elementType.isRequired,
+    BaseSelect: PropTypes.elementType.isRequired,
+    BaseSwitch: PropTypes.elementType.isRequired,
+    BaseTextField: PropTypes.elementType.isRequired,
+    BaseTooltip: PropTypes.elementType.isRequired,
+    BooleanCellFalseIcon: PropTypes.elementType.isRequired,
+    BooleanCellTrueIcon: PropTypes.elementType.isRequired,
+    Cell: PropTypes.elementType.isRequired,
+    ColumnFilteredIcon: PropTypes.elementType.isRequired,
+    ColumnHeaderFilterIconButton: PropTypes.elementType.isRequired,
+    ColumnMenu: PropTypes.elementType.isRequired,
+    ColumnMenuIcon: PropTypes.elementType.isRequired,
+    ColumnResizeIcon: PropTypes.elementType.isRequired,
+    ColumnSelectorIcon: PropTypes.elementType.isRequired,
+    ColumnSortedAscendingIcon: PropTypes.func,
+    ColumnSortedDescendingIcon: PropTypes.func,
+    ColumnsPanel: PropTypes.elementType.isRequired,
+    ColumnUnsortedIcon: PropTypes.func,
+    DensityComfortableIcon: PropTypes.elementType.isRequired,
+    DensityCompactIcon: PropTypes.elementType.isRequired,
+    DensityStandardIcon: PropTypes.elementType.isRequired,
+    DetailPanelCollapseIcon: PropTypes.elementType.isRequired,
+    DetailPanelExpandIcon: PropTypes.elementType.isRequired,
+    ErrorOverlay: PropTypes.elementType.isRequired,
+    ExportIcon: PropTypes.elementType.isRequired,
+    FilterPanel: PropTypes.elementType.isRequired,
+    FilterPanelDeleteIcon: PropTypes.elementType.isRequired,
+    Footer: PropTypes.elementType.isRequired,
+    GroupingCriteriaCollapseIcon: PropTypes.elementType.isRequired,
+    GroupingCriteriaExpandIcon: PropTypes.elementType.isRequired,
+    Header: PropTypes.elementType.isRequired,
+    LoadingOverlay: PropTypes.elementType.isRequired,
+    MoreActionsIcon: PropTypes.elementType.isRequired,
+    NoResultsOverlay: PropTypes.elementType.isRequired,
+    NoRowsOverlay: PropTypes.elementType.isRequired,
+    OpenFilterButtonIcon: PropTypes.elementType.isRequired,
+    Pagination: PropTypes.func,
+    Panel: PropTypes.elementType.isRequired,
+    PreferencesPanel: PropTypes.elementType.isRequired,
+    QuickFilterClearIcon: PropTypes.elementType.isRequired,
+    QuickFilterIcon: PropTypes.elementType.isRequired,
+    Row: PropTypes.elementType.isRequired,
+    RowReorderIcon: PropTypes.elementType.isRequired,
+    SkeletonCell: PropTypes.elementType.isRequired,
+    Toolbar: PropTypes.func,
+    TreeDataCollapseIcon: PropTypes.elementType.isRequired,
+    TreeDataExpandIcon: PropTypes.elementType.isRequired,
+  }),
+  /**
+   * Overrideable components props dynamically passed to the component at rendering.
+   */
+  slotsProps: PropTypes.shape({
+    baseButton: PropTypes.any,
+    baseCheckbox: PropTypes.any,
+    baseFormControl: PropTypes.any,
+    basePopper: PropTypes.any,
+    baseSelect: PropTypes.any,
+    baseSwitch: PropTypes.any,
+    baseTextField: PropTypes.any,
+    baseTooltip: PropTypes.any,
+    cell: PropTypes.any,
+    columnHeaderFilterIconButton: PropTypes.any,
+    columnMenu: PropTypes.any,
+    columnsPanel: PropTypes.any,
+    errorOverlay: PropTypes.any,
+    filterPanel: PropTypes.any,
+    footer: PropTypes.any,
+    header: PropTypes.any,
+    loadingOverlay: PropTypes.any,
+    noResultsOverlay: PropTypes.any,
+    noRowsOverlay: PropTypes.any,
+    pagination: PropTypes.any,
+    panel: PropTypes.any,
+    preferencesPanel: PropTypes.any,
+    row: PropTypes.any,
+    toolbar: PropTypes.any,
+  }),
   /**
    * Sorting can be processed on the server or client-side.
    * Set it to 'client' if you would like to handle sorting on the client-side.

--- a/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -87,8 +87,8 @@ export const useDataGridProps = <R extends GridValidRowModel>(inProps: DataGridP
     [themedProps.localeText],
   );
 
-  const components = React.useMemo<GridSlotsComponent>(() => {
-    const overrides = themedProps.components;
+  const slots = React.useMemo<GridSlotsComponent>(() => {
+    const overrides = themedProps.slots;
 
     if (!overrides) {
       return { ...DATA_GRID_DEFAULT_SLOTS_COMPONENTS };
@@ -103,16 +103,16 @@ export const useDataGridProps = <R extends GridValidRowModel>(inProps: DataGridP
     });
 
     return mergedComponents;
-  }, [themedProps.components]);
+  }, [themedProps.slots]);
 
   return React.useMemo<DataGridProcessedProps<R>>(
     () => ({
       ...DATA_GRID_PROPS_DEFAULT_VALUES,
       ...themedProps,
       localeText,
-      components,
+      slots,
       ...DATA_GRID_FORCED_PROPS,
     }),
-    [themedProps, localeText, components],
+    [themedProps, localeText, slots],
   );
 };

--- a/packages/grid/x-data-grid/src/components/GridFooter.tsx
+++ b/packages/grid/x-data-grid/src/components/GridFooter.tsx
@@ -34,8 +34,8 @@ const GridFooter = React.forwardRef<HTMLDivElement, GridFooterContainerProps>(fu
 
   const paginationElement = rootProps.pagination &&
     !rootProps.hideFooterPagination &&
-    rootProps.components.Pagination && (
-      <rootProps.components.Pagination {...rootProps.componentsProps?.pagination} />
+    rootProps.slots.Pagination && (
+      <rootProps.slots.Pagination {...rootProps.slotsProps?.pagination} />
     );
 
   return (

--- a/packages/grid/x-data-grid/src/components/GridHeader.tsx
+++ b/packages/grid/x-data-grid/src/components/GridHeader.tsx
@@ -7,10 +7,8 @@ export const GridHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<
 
     return (
       <div ref={ref} {...props}>
-        <rootProps.components.PreferencesPanel {...rootProps.componentsProps?.preferencesPanel} />
-        {rootProps.components.Toolbar && (
-          <rootProps.components.Toolbar {...rootProps.componentsProps?.toolbar} />
-        )}
+        <rootProps.slots.PreferencesPanel {...rootProps.slotsProps?.preferencesPanel} />
+        {rootProps.slots.Toolbar && <rootProps.slots.Toolbar {...rootProps.slotsProps?.toolbar} />}
       </div>
     );
   },

--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -341,7 +341,7 @@ const GridRow = React.forwardRef<
           : -1;
 
       return (
-        <rootProps.components.Cell
+        <rootProps.slots.Cell
           key={column.field}
           value={cellParams.value}
           field={column.field}
@@ -359,10 +359,10 @@ const GridRow = React.forwardRef<
           className={clsx(classNames)}
           colSpan={cellProps.colSpan}
           disableDragEvents={disableDragEvents}
-          {...rootProps.componentsProps?.cell}
+          {...rootProps.slotsProps?.cell}
         >
           {content}
-        </rootProps.components.Cell>
+        </rootProps.slots.Cell>
       );
     },
     [
@@ -466,7 +466,7 @@ const GridRow = React.forwardRef<
         const contentWidth = Math.round(randomNumber());
 
         cells.push(
-          <rootProps.components.SkeletonCell
+          <rootProps.slots.SkeletonCell
             key={column.field}
             width={width}
             contentWidth={contentWidth}

--- a/packages/grid/x-data-grid/src/components/base/GridErrorHandler.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridErrorHandler.tsx
@@ -20,10 +20,10 @@ function GridErrorHandler(props: { children: React.ReactNode }) {
       logger={logger}
       render={(errorProps) => (
         <GridMainContainer>
-          <rootProps.components.ErrorOverlay
+          <rootProps.slots.ErrorOverlay
             {...errorProps}
             {...errorState}
-            {...rootProps.componentsProps?.errorOverlay}
+            {...rootProps.slotsProps?.errorOverlay}
           />
         </GridMainContainer>
       )}

--- a/packages/grid/x-data-grid/src/components/base/GridFooterPlaceholder.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridFooterPlaceholder.tsx
@@ -14,7 +14,7 @@ export function GridFooterPlaceholder() {
 
   return (
     <div ref={footerRef}>
-      <rootProps.components.Footer {...rootProps.componentsProps?.footer} />
+      <rootProps.slots.Footer {...rootProps.slotsProps?.footer} />
     </div>
   );
 }

--- a/packages/grid/x-data-grid/src/components/base/GridHeaderPlaceholder.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridHeaderPlaceholder.tsx
@@ -10,7 +10,7 @@ export function GridHeaderPlaceholder() {
 
   return (
     <div ref={headerRef}>
-      <rootProps.components.Header {...rootProps.componentsProps?.header} />
+      <rootProps.slots.Header {...rootProps.slotsProps?.header} />
     </div>
   );
 }

--- a/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridOverlays.tsx
@@ -104,19 +104,15 @@ export function GridOverlays() {
   let overlay: JSX.Element | null = null;
 
   if (showNoRowsOverlay) {
-    overlay = <rootProps.components.NoRowsOverlay {...rootProps.componentsProps?.noRowsOverlay} />;
+    overlay = <rootProps.slots.NoRowsOverlay {...rootProps.slotsProps?.noRowsOverlay} />;
   }
 
   if (showNoResultsOverlay) {
-    overlay = (
-      <rootProps.components.NoResultsOverlay {...rootProps.componentsProps?.noResultsOverlay} />
-    );
+    overlay = <rootProps.slots.NoResultsOverlay {...rootProps.slotsProps?.noResultsOverlay} />;
   }
 
   if (loading) {
-    overlay = (
-      <rootProps.components.LoadingOverlay {...rootProps.componentsProps?.loadingOverlay} />
-    );
+    overlay = <rootProps.slots.LoadingOverlay {...rootProps.slotsProps?.loadingOverlay} />;
   }
 
   if (overlay === null) {

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -200,7 +200,7 @@ function GridActionsCell(props: GridActionsCellProps) {
           touchRippleRef={handleTouchRippleRef(buttonId)}
           tabIndex={focusedButtonIndex === iconButtons.length ? tabIndex : -1}
         >
-          <rootProps.components.MoreActionsIcon fontSize="small" />
+          <rootProps.slots.MoreActionsIcon fontSize="small" />
         </IconButton>
       )}
 

--- a/packages/grid/x-data-grid/src/components/cell/GridBooleanCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridBooleanCell.tsx
@@ -49,9 +49,8 @@ function GridBooleanCellRaw(props: GridBooleanCellProps) {
   const classes = useUtilityClasses(ownerState);
 
   const Icon = React.useMemo(
-    () =>
-      value ? rootProps.components.BooleanCellTrueIcon : rootProps.components.BooleanCellFalseIcon,
-    [rootProps.components.BooleanCellFalseIcon, rootProps.components.BooleanCellTrueIcon, value],
+    () => (value ? rootProps.slots.BooleanCellTrueIcon : rootProps.slots.BooleanCellFalseIcon),
+    [rootProps.slots.BooleanCellFalseIcon, rootProps.slots.BooleanCellTrueIcon, value],
   );
 
   return (

--- a/packages/grid/x-data-grid/src/components/cell/GridEditBooleanCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditBooleanCell.tsx
@@ -98,13 +98,13 @@ function GridEditBooleanCell(props: GridEditBooleanCellProps) {
 
   return (
     <label htmlFor={id} className={clsx(classes.root, className)} {...other}>
-      <rootProps.components.BaseCheckbox
+      <rootProps.slots.BaseCheckbox
         id={id}
         inputRef={inputRef}
         checked={Boolean(valueState)}
         onChange={handleChange}
         size="small"
-        {...rootProps.componentsProps?.baseCheckbox}
+        {...rootProps.slotsProps?.baseCheckbox}
       />
     </label>
   );

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -77,7 +77,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
   const inputRef = React.useRef<any>();
   const [open, setOpen] = React.useState(initialOpen);
 
-  const baseSelectProps = rootProps.componentsProps?.baseSelect || {};
+  const baseSelectProps = rootProps.slotsProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? false;
 
   let valueOptionsFormatted: Array<ValueOptions>;
@@ -138,7 +138,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
   }, [hasFocus]);
 
   return (
-    <rootProps.components.BaseSelect
+    <rootProps.slots.BaseSelect
       ref={ref}
       inputRef={inputRef}
       value={value}
@@ -152,12 +152,12 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
       native={isSelectNative}
       fullWidth
       {...other}
-      {...rootProps.componentsProps?.baseSelect}
+      {...rootProps.slotsProps?.baseSelect}
     >
       {valueOptionsFormatted.map((valueOptions) =>
         renderSingleSelectOptions(valueOptions, isSelectNative ? 'option' : MenuItem),
       )}
-    </rootProps.components.BaseSelect>
+    </rootProps.slots.BaseSelect>
   );
 }
 

--- a/packages/grid/x-data-grid/src/components/columnHeaders/ColumnHeaderMenuIcon.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/ColumnHeaderMenuIcon.tsx
@@ -61,7 +61,7 @@ export const ColumnHeaderMenuIcon = React.memo((props: ColumnHeaderMenuIconProps
         aria-controls={columnMenuId}
         id={columnMenuButtonId}
       >
-        <rootProps.components.ColumnMenuIcon fontSize="small" />
+        <rootProps.slots.ColumnMenuIcon fontSize="small" />
       </IconButton>
     </div>
   );

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderFilterIconButton.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderFilterIconButton.tsx
@@ -71,19 +71,19 @@ function GridColumnHeaderFilterIconButton(props: ColumnHeaderFilterIconButtonPro
       size="small"
       tabIndex={-1}
     >
-      <rootProps.components.ColumnFilteredIcon className={classes.icon} fontSize="small" />
+      <rootProps.slots.ColumnFilteredIcon className={classes.icon} fontSize="small" />
     </IconButton>
   );
 
   return (
-    <rootProps.components.BaseTooltip
+    <rootProps.slots.BaseTooltip
       title={
         apiRef.current.getLocaleText('columnHeaderFiltersTooltipActive')(
           counter,
         ) as React.ReactElement
       }
       enterDelay={1000}
-      {...rootProps.componentsProps?.baseTooltip}
+      {...rootProps.slotsProps?.baseTooltip}
     >
       <GridIconButtonContainer>
         {counter > 1 && (
@@ -94,7 +94,7 @@ function GridColumnHeaderFilterIconButton(props: ColumnHeaderFilterIconButtonPro
 
         {counter === 1 && iconButton}
       </GridIconButtonContainer>
-    </rootProps.components.BaseTooltip>
+    </rootProps.slots.BaseTooltip>
   );
 }
 

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -195,8 +195,8 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
       field={column.field}
       open={columnMenuOpen}
       target={iconButtonRef.current}
-      ContentComponent={rootProps.components.ColumnMenu}
-      contentComponentProps={rootProps.componentsProps?.columnMenu}
+      ContentComponent={rootProps.slots.ColumnMenu}
+      contentComponentProps={rootProps.slotsProps?.columnMenu}
       onExited={handleExited}
     />
   );
@@ -206,10 +206,10 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
   const columnTitleIconButtons = (
     <React.Fragment>
       {!rootProps.disableColumnFilter && (
-        <rootProps.components.ColumnHeaderFilterIconButton
+        <rootProps.slots.ColumnHeaderFilterIconButton
           field={column.field}
           counter={filterItemsCounter}
-          {...rootProps.componentsProps?.columnHeaderFilterIconButton}
+          {...rootProps.slotsProps?.columnHeaderFilterIconButton}
         />
       )}
 

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSeparator.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSeparator.tsx
@@ -65,7 +65,7 @@ function GridColumnHeaderSeparatorRaw(props: GridColumnHeaderSeparatorProps) {
       {...other}
       onClick={stopClick}
     >
-      <rootProps.components.ColumnResizeIcon className={classes.icon} />
+      <rootProps.slots.ColumnResizeIcon className={classes.icon} />
     </div>
   );
 }

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
@@ -57,7 +57,7 @@ function GridColumnHeaderSortIconRaw(props: GridColumnHeaderSortIconProps) {
   const ownerState = { ...props, classes: rootProps.classes };
   const classes = useUtilityClasses(ownerState);
 
-  const iconElement = getIcon(rootProps.components, direction, classes.icon, sortingOrder);
+  const iconElement = getIcon(rootProps.slots, direction, classes.icon, sortingOrder);
   if (!iconElement) {
     return null;
   }

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -70,12 +70,12 @@ function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
   }, [titleRef, columnWidth, description, label]);
 
   return (
-    <rootProps.components.BaseTooltip
+    <rootProps.slots.BaseTooltip
       title={description || tooltip}
-      {...rootProps.componentsProps?.baseTooltip}
+      {...rootProps.slotsProps?.baseTooltip}
     >
       <ColumnHeaderInnerTitle ref={titleRef}>{label}</ColumnHeaderInnerTitle>
-    </rootProps.components.BaseTooltip>
+    </rootProps.slots.BaseTooltip>
   );
 }
 

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnUnsortedIcon.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnUnsortedIcon.tsx
@@ -16,8 +16,8 @@ export const GridColumnUnsortedIcon = React.memo(function GridColumnHeaderSortIc
 
   const Icon =
     nextSortDirection === 'asc'
-      ? rootProps.components.ColumnSortedAscendingIcon
-      : rootProps.components.ColumnSortedDescendingIcon;
+      ? rootProps.slots.ColumnSortedAscendingIcon
+      : rootProps.slots.ColumnSortedDescendingIcon;
 
   return Icon ? <Icon {...other} /> : null;
 });

--- a/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -95,7 +95,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
     );
 
     return (
-      <rootProps.components.BaseCheckbox
+      <rootProps.slots.BaseCheckbox
         ref={handleRef}
         tabIndex={tabIndex}
         checked={isChecked}
@@ -105,7 +105,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
         onKeyDown={handleKeyDown}
         disabled={!isSelectable}
         touchRippleRef={rippleRef}
-        {...rootProps.componentsProps?.baseCheckbox}
+        {...rootProps.slotsProps?.baseCheckbox}
         {...other}
       />
     );

--- a/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -129,7 +129,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
     );
 
     return (
-      <rootProps.components.BaseCheckbox
+      <rootProps.slots.BaseCheckbox
         ref={ref}
         indeterminate={isIndeterminate}
         checked={isChecked}
@@ -138,7 +138,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
         inputProps={{ 'aria-label': label }}
         tabIndex={tabIndex}
         onKeyDown={handleKeyDown}
-        {...rootProps.componentsProps?.baseCheckbox}
+        {...rootProps.slotsProps?.baseCheckbox}
         {...other}
       />
     );

--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -98,14 +98,14 @@ function GridMenu(props: GridMenuProps) {
 
   return (
     <GridMenuRoot
-      as={rootProps.components.BasePopper}
+      as={rootProps.slots.BasePopper}
       className={clsx(className, classes.root)}
       open={open}
       anchorEl={target as any}
       transition
       placement={position}
       {...other}
-      {...rootProps.componentsProps?.basePopper}
+      {...rootProps.slotsProps?.basePopper}
     >
       {({ TransitionProps, placement }) => (
         <ClickAwayListener onClickAway={onClickAway} mouseEvent="onMouseDown">

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -176,7 +176,7 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
   return (
     <GridPanelWrapper {...other}>
       <GridPanelHeader>
-        <rootProps.components.BaseTextField
+        <rootProps.slots.BaseTextField
           label={apiRef.current.getLocaleText('columnsPanelTextFieldLabel')}
           placeholder={apiRef.current.getLocaleText('columnsPanelTextFieldPlaceholder')}
           inputRef={searchInputRef}
@@ -184,7 +184,7 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
           onChange={handleSearchValueChange}
           variant="standard"
           fullWidth
-          {...rootProps.componentsProps?.baseTextField}
+          {...rootProps.slotsProps?.baseTextField}
         />
       </GridPanelHeader>
       <GridPanelContent>
@@ -193,14 +193,14 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
             <GridColumnsPanelRowRoot className={classes.columnsPanelRow} key={column.field}>
               <FormControlLabel
                 control={
-                  <rootProps.components.BaseSwitch
+                  <rootProps.slots.BaseSwitch
                     disabled={column.hideable === false}
                     checked={columnVisibilityModel[column.field] !== false}
                     onClick={toggleColumn}
                     name={column.field}
                     size="small"
                     inputRef={isFirstHideableColumn(column) ? firstSwitchRef : undefined}
-                    {...rootProps.componentsProps?.baseSwitch}
+                    {...rootProps.slotsProps?.baseSwitch}
                   />
                 }
                 label={column.headerName || column.field}
@@ -221,18 +221,18 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
         </GridColumnsPanelRoot>
       </GridPanelContent>
       <GridPanelFooter>
-        <rootProps.components.BaseButton
+        <rootProps.slots.BaseButton
           onClick={() => toggleAllColumns(false)}
-          {...rootProps.componentsProps?.baseButton}
+          {...rootProps.slotsProps?.baseButton}
         >
           {apiRef.current.getLocaleText('columnsPanelHideAllButton')}
-        </rootProps.components.BaseButton>
-        <rootProps.components.BaseButton
+        </rootProps.slots.BaseButton>
+        <rootProps.slots.BaseButton
           onClick={() => toggleAllColumns(true)}
-          {...rootProps.componentsProps?.baseButton}
+          {...rootProps.slotsProps?.baseButton}
         >
           {apiRef.current.getLocaleText('columnsPanelShowAllButton')}
-        </rootProps.components.BaseButton>
+        </rootProps.slots.BaseButton>
       </GridPanelFooter>
     </GridPanelWrapper>
   );

--- a/packages/grid/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
@@ -22,15 +22,15 @@ export const GridPreferencesPanel = React.forwardRef<
   );
 
   return (
-    <rootProps.components.Panel
+    <rootProps.slots.Panel
       ref={ref}
-      as={rootProps.components.BasePopper}
+      as={rootProps.slots.BasePopper}
       open={columns.length > 0 && preferencePanelState.open}
-      {...rootProps.componentsProps?.panel}
+      {...rootProps.slotsProps?.panel}
       {...props}
-      {...rootProps.componentsProps?.basePopper}
+      {...rootProps.slotsProps?.basePopper}
     >
       {panelContent}
-    </rootProps.components.Panel>
+    </rootProps.slots.Panel>
   );
 });

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -235,9 +235,9 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
 
     const hasLinkOperatorColumn: boolean = hasMultipleFilters && linkOperators.length > 0;
 
-    const baseFormControlProps = rootProps.componentsProps?.baseFormControl || {};
+    const baseFormControlProps = rootProps.slotsProps?.baseFormControl || {};
 
-    const baseSelectProps = rootProps.componentsProps?.baseSelect || {};
+    const baseSelectProps = rootProps.slotsProps?.baseSelect || {};
     const isBaseSelectNative = baseSelectProps.native ?? true;
     const OptionComponent = isBaseSelectNative ? 'option' : MenuItem;
 
@@ -375,7 +375,7 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
       <GridFilterFormRoot ref={ref} className={classes.root} data-id={item.id} {...other}>
         <FilterFormDeleteIcon
           variant="standard"
-          as={rootProps.components.BaseFormControl}
+          as={rootProps.slots.BaseFormControl}
           {...baseFormControlProps}
           {...deleteIconProps}
           className={clsx(
@@ -390,12 +390,12 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
             onClick={handleDeleteFilter}
             size="small"
           >
-            <rootProps.components.FilterPanelDeleteIcon fontSize="small" />
+            <rootProps.slots.FilterPanelDeleteIcon fontSize="small" />
           </IconButton>
         </FilterFormDeleteIcon>
         <FilterFormLinkOperatorInput
           variant="standard"
-          as={rootProps.components.BaseFormControl}
+          as={rootProps.slots.BaseFormControl}
           {...baseFormControlProps}
           {...linkOperatorInputProps}
           sx={{
@@ -410,7 +410,7 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
             linkOperatorInputProps.className,
           )}
         >
-          <rootProps.components.BaseSelect
+          <rootProps.slots.BaseSelect
             inputProps={{
               'aria-label': apiRef.current.getLocaleText('filterPanelLinkOperator'),
             }}
@@ -418,18 +418,18 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
             onChange={changeLinkOperator}
             disabled={!!disableMultiFilterOperator || linkOperators.length === 1}
             native={isBaseSelectNative}
-            {...rootProps.componentsProps?.baseSelect}
+            {...rootProps.slotsProps?.baseSelect}
           >
             {linkOperators.map((linkOperator) => (
               <OptionComponent key={linkOperator.toString()} value={linkOperator.toString()}>
                 {apiRef.current.getLocaleText(getLinkOperatorLocaleKey(linkOperator))}
               </OptionComponent>
             ))}
-          </rootProps.components.BaseSelect>
+          </rootProps.slots.BaseSelect>
         </FilterFormLinkOperatorInput>
         <FilterFormColumnInput
           variant="standard"
-          as={rootProps.components.BaseFormControl}
+          as={rootProps.slots.BaseFormControl}
           {...baseFormControlProps}
           {...columnInputProps}
           className={clsx(
@@ -441,25 +441,25 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
           <InputLabel htmlFor={columnSelectId} id={columnSelectLabelId}>
             {apiRef.current.getLocaleText('filterPanelColumns')}
           </InputLabel>
-          <rootProps.components.BaseSelect
+          <rootProps.slots.BaseSelect
             labelId={columnSelectLabelId}
             id={columnSelectId}
             label={apiRef.current.getLocaleText('filterPanelColumns')}
             value={item.field || ''}
             onChange={changeColumn}
             native={isBaseSelectNative}
-            {...rootProps.componentsProps?.baseSelect}
+            {...rootProps.slotsProps?.baseSelect}
           >
             {sortedFilteredColumns.map((col) => (
               <OptionComponent key={col.field} value={col.field}>
                 {getColumnLabel(col)}
               </OptionComponent>
             ))}
-          </rootProps.components.BaseSelect>
+          </rootProps.slots.BaseSelect>
         </FilterFormColumnInput>
         <FilterFormOperatorInput
           variant="standard"
-          as={rootProps.components.BaseFormControl}
+          as={rootProps.slots.BaseFormControl}
           {...baseFormControlProps}
           {...operatorInputProps}
           className={clsx(
@@ -471,7 +471,7 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
           <InputLabel htmlFor={operatorSelectId} id={operatorSelectLabelId}>
             {apiRef.current.getLocaleText('filterPanelOperators')}
           </InputLabel>
-          <rootProps.components.BaseSelect
+          <rootProps.slots.BaseSelect
             labelId={operatorSelectLabelId}
             label={apiRef.current.getLocaleText('filterPanelOperators')}
             id={operatorSelectId}
@@ -479,7 +479,7 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
             onChange={changeOperator}
             native={isBaseSelectNative}
             inputRef={filterSelectorRef}
-            {...rootProps.componentsProps?.baseSelect}
+            {...rootProps.slotsProps?.baseSelect}
           >
             {currentColumn?.filterOperators?.map((operator) => (
               <OptionComponent key={operator.value} value={operator.value}>
@@ -489,11 +489,11 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
                   )}
               </OptionComponent>
             ))}
-          </rootProps.components.BaseSelect>
+          </rootProps.slots.BaseSelect>
         </FilterFormOperatorInput>
         <FilterFormValueInput
           variant="standard"
-          as={rootProps.components.BaseFormControl}
+          as={rootProps.slots.BaseFormControl}
           {...baseFormControlProps}
           {...valueInputPropsOther}
           className={clsx(

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
@@ -9,7 +9,7 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
   const [filterValueState, setFilterValueState] = React.useState(item.value || '');
   const rootProps = useGridRootProps();
 
-  const baseSelectProps = rootProps.componentsProps?.baseSelect || {};
+  const baseSelectProps = rootProps.slotsProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? true;
   const OptionComponent = isSelectNative ? 'option' : MenuItem;
 
@@ -27,7 +27,7 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
   }, [item.value]);
 
   return (
-    <rootProps.components.BaseTextField
+    <rootProps.slots.BaseTextField
       label={apiRef.current.getLocaleText('filterPanelInputLabel')}
       value={filterValueState}
       onChange={onFilterChange}
@@ -36,14 +36,14 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
       SelectProps={{
         native: isSelectNative,
         displayEmpty: true,
-        ...rootProps.componentsProps?.baseSelect,
+        ...rootProps.slotsProps?.baseSelect,
       }}
       InputLabelProps={{
         shrink: true,
       }}
       inputRef={focusElementRef}
       {...others}
-      {...rootProps.componentsProps?.baseTextField}
+      {...rootProps.slotsProps?.baseTextField}
     >
       <OptionComponent value="">{apiRef.current.getLocaleText('filterValueAny')}</OptionComponent>
       <OptionComponent value="true">
@@ -52,6 +52,6 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
       <OptionComponent value="false">
         {apiRef.current.getLocaleText('filterValueFalse')}
       </OptionComponent>
-    </rootProps.components.BaseTextField>
+    </rootProps.slots.BaseTextField>
   );
 }

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -47,7 +47,7 @@ function GridFilterInputDate(props: GridFilterInputDateProps) {
   }, [item.value]);
 
   return (
-    <rootProps.components.BaseTextField
+    <rootProps.slots.BaseTextField
       id={id}
       label={apiRef.current.getLocaleText('filterPanelInputLabel')}
       placeholder={apiRef.current.getLocaleText('filterPanelInputPlaceholder')}
@@ -68,7 +68,7 @@ function GridFilterInputDate(props: GridFilterInputDateProps) {
         },
       }}
       {...other}
-      {...rootProps.componentsProps?.baseTextField}
+      {...rootProps.slotsProps?.baseTextField}
     />
   );
 }

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleSingleSelect.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleSingleSelect.tsx
@@ -150,7 +150,7 @@ function GridFilterInputMultipleSingleSelect(props: GridFilterInputMultipleSingl
         ))
       }
       renderInput={(params) => (
-        <rootProps.components.BaseTextField
+        <rootProps.slots.BaseTextField
           {...params}
           label={apiRef.current.getLocaleText('filterPanelInputLabel')}
           placeholder={apiRef.current.getLocaleText('filterPanelInputPlaceholder')}
@@ -161,7 +161,7 @@ function GridFilterInputMultipleSingleSelect(props: GridFilterInputMultipleSingl
           inputRef={focusElementRef}
           type="singleSelect"
           {...TextFieldProps}
-          {...rootProps.componentsProps?.baseTextField}
+          {...rootProps.slotsProps?.baseTextField}
         />
       )}
       {...other}

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -72,7 +72,7 @@ function GridFilterInputMultipleValue(props: GridFilterInputMultipleValueProps) 
         ))
       }
       renderInput={(params) => (
-        <rootProps.components.BaseTextField
+        <rootProps.slots.BaseTextField
           {...params}
           label={apiRef.current.getLocaleText('filterPanelInputLabel')}
           placeholder={apiRef.current.getLocaleText('filterPanelInputPlaceholder')}
@@ -83,7 +83,7 @@ function GridFilterInputMultipleValue(props: GridFilterInputMultipleValueProps) 
           inputRef={focusElementRef}
           type={type || 'text'}
           {...TextFieldProps}
-          {...rootProps.componentsProps?.baseTextField}
+          {...rootProps.slotsProps?.baseTextField}
         />
       )}
       {...other}

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
@@ -46,7 +46,7 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
   const id = useId();
   const rootProps = useGridRootProps();
 
-  const baseSelectProps = rootProps.componentsProps?.baseSelect || {};
+  const baseSelectProps = rootProps.slotsProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? true;
 
   const currentColumn = item.field ? apiRef.current.getColumn(item.field) : null;
@@ -93,7 +93,7 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
   }, [item, currentValueOptions, applyValue]);
 
   return (
-    <rootProps.components.BaseTextField
+    <rootProps.slots.BaseTextField
       id={id}
       label={apiRef.current.getLocaleText('filterPanelInputLabel')}
       placeholder={apiRef.current.getLocaleText('filterPanelInputPlaceholder')}
@@ -108,17 +108,17 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
       select
       SelectProps={{
         native: isSelectNative,
-        ...rootProps.componentsProps?.baseSelect,
+        ...rootProps.slotsProps?.baseSelect,
       }}
       {...others}
-      {...rootProps.componentsProps?.baseTextField}
+      {...rootProps.slotsProps?.baseTextField}
     >
       {renderSingleSelectOptions(
         apiRef.current.getColumn(item.field),
         apiRef.current,
         isSelectNative ? 'option' : MenuItem,
       )}
-    </rootProps.components.BaseTextField>
+    </rootProps.slots.BaseTextField>
   );
 }
 

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
@@ -71,7 +71,7 @@ function GridFilterInputValue(props: GridTypeFilterInputValueProps & TextFieldPr
   const id = useId();
   const rootProps = useGridRootProps();
 
-  const baseSelectProps = rootProps.componentsProps?.baseSelect || {};
+  const baseSelectProps = rootProps.slotsProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? true;
 
   const singleSelectProps: TextFieldProps =
@@ -80,7 +80,7 @@ function GridFilterInputValue(props: GridTypeFilterInputValueProps & TextFieldPr
           select: true,
           SelectProps: {
             native: isSelectNative,
-            ...rootProps.componentsProps?.baseSelect,
+            ...rootProps.slotsProps?.baseSelect,
           },
           children: renderSingleSelectOptions(
             apiRef.current.getColumn(item.field),
@@ -130,7 +130,7 @@ function GridFilterInputValue(props: GridTypeFilterInputValueProps & TextFieldPr
   const InputProps = applying ? { endAdornment: <GridLoadIcon /> } : others.InputProps;
 
   return (
-    <rootProps.components.BaseTextField
+    <rootProps.slots.BaseTextField
       id={id}
       label={apiRef.current.getLocaleText('filterPanelInputLabel')}
       placeholder={apiRef.current.getLocaleText('filterPanelInputPlaceholder')}
@@ -145,7 +145,7 @@ function GridFilterInputValue(props: GridTypeFilterInputValueProps & TextFieldPr
       inputRef={focusElementRef}
       {...singleSelectProps}
       {...others}
-      {...rootProps.componentsProps?.baseTextField}
+      {...rootProps.slotsProps?.baseTextField}
     />
   );
 }

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
@@ -204,13 +204,13 @@ const GridFilterPanel = React.forwardRef<HTMLDivElement, GridFilterPanelProps>(
         </GridPanelContent>
         {!rootProps.disableMultipleColumnsFiltering && (
           <GridPanelFooter>
-            <rootProps.components.BaseButton
+            <rootProps.slots.BaseButton
               onClick={addNewFilter}
               startIcon={<GridAddIcon />}
-              {...rootProps.componentsProps?.baseButton}
+              {...rootProps.slotsProps?.baseButton}
             >
               {apiRef.current.getLocaleText('filterPanelAddFilter')}
-            </rootProps.components.BaseButton>
+            </rootProps.slots.BaseButton>
           </GridPanelFooter>
         )}
       </GridPanelWrapper>

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarColumnsButton.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarColumnsButton.tsx
@@ -29,17 +29,17 @@ export const GridToolbarColumnsButton = React.forwardRef<HTMLButtonElement, Butt
     }
 
     return (
-      <rootProps.components.BaseButton
+      <rootProps.slots.BaseButton
         ref={ref}
         size="small"
         aria-label={apiRef.current.getLocaleText('toolbarColumnsLabel')}
-        startIcon={<rootProps.components.ColumnSelectorIcon />}
+        startIcon={<rootProps.slots.ColumnSelectorIcon />}
         {...other}
         onClick={showColumns}
-        {...rootProps.componentsProps?.baseButton}
+        {...rootProps.slotsProps?.baseButton}
       >
         {apiRef.current.getLocaleText('toolbarColumns')}
-      </rootProps.components.BaseButton>
+      </rootProps.slots.BaseButton>
     );
   },
 );

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
@@ -29,17 +29,17 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
 
     const densityOptions: GridDensityOption[] = [
       {
-        icon: <rootProps.components.DensityCompactIcon />,
+        icon: <rootProps.slots.DensityCompactIcon />,
         label: apiRef.current.getLocaleText('toolbarDensityCompact'),
         value: GridDensityTypes.Compact,
       },
       {
-        icon: <rootProps.components.DensityStandardIcon />,
+        icon: <rootProps.slots.DensityStandardIcon />,
         label: apiRef.current.getLocaleText('toolbarDensityStandard'),
         value: GridDensityTypes.Standard,
       },
       {
-        icon: <rootProps.components.DensityComfortableIcon />,
+        icon: <rootProps.slots.DensityComfortableIcon />,
         label: apiRef.current.getLocaleText('toolbarDensityComfortable'),
         value: GridDensityTypes.Comfortable,
       },
@@ -48,11 +48,11 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
     const startIcon = React.useMemo<React.ReactElement>(() => {
       switch (densityValue) {
         case GridDensityTypes.Compact:
-          return <rootProps.components.DensityCompactIcon />;
+          return <rootProps.slots.DensityCompactIcon />;
         case GridDensityTypes.Comfortable:
-          return <rootProps.components.DensityComfortableIcon />;
+          return <rootProps.slots.DensityComfortableIcon />;
         default:
-          return <rootProps.components.DensityStandardIcon />;
+          return <rootProps.slots.DensityStandardIcon />;
       }
     }, [densityValue, rootProps]);
 
@@ -102,7 +102,7 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
 
     return (
       <React.Fragment>
-        <rootProps.components.BaseButton
+        <rootProps.slots.BaseButton
           ref={handleRef}
           size="small"
           startIcon={startIcon}
@@ -113,10 +113,10 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
           id={densityButtonId}
           {...other}
           onClick={handleDensitySelectorOpen}
-          {...rootProps.componentsProps?.baseButton}
+          {...rootProps.slotsProps?.baseButton}
         >
           {apiRef.current.getLocaleText('toolbarDensity')}
-        </rootProps.components.BaseButton>
+        </rootProps.slots.BaseButton>
         <GridMenu
           open={open}
           target={buttonRef.current}

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -54,10 +54,10 @@ export const GridToolbarExportContainer = React.forwardRef<HTMLButtonElement, Bu
 
     return (
       <React.Fragment>
-        <rootProps.components.BaseButton
+        <rootProps.slots.BaseButton
           ref={handleRef}
           size="small"
-          startIcon={<rootProps.components.ExportIcon />}
+          startIcon={<rootProps.slots.ExportIcon />}
           aria-expanded={open ? 'true' : undefined}
           aria-label={apiRef.current.getLocaleText('toolbarExportLabel')}
           aria-haspopup="menu"
@@ -65,10 +65,10 @@ export const GridToolbarExportContainer = React.forwardRef<HTMLButtonElement, Bu
           id={buttonId}
           {...other}
           onClick={handleMenuOpen}
-          {...rootProps.componentsProps?.baseButton}
+          {...rootProps.slotsProps?.baseButton}
         >
           {apiRef.current.getLocaleText('toolbarExport')}
-        </rootProps.components.BaseButton>
+        </rootProps.slots.BaseButton>
         <GridMenu
           open={open}
           target={buttonRef.current}

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
@@ -42,18 +42,18 @@ const GridToolbarFilterListRoot = styled('ul', {
 }));
 
 export interface GridToolbarFilterButtonProps
-  extends Omit<TooltipProps, 'title' | 'children' | 'componentsProps'> {
+  extends Omit<TooltipProps, 'title' | 'children' | 'slotsProps'> {
   /**
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps?: { button?: ButtonProps };
+  slotsProps?: { button?: ButtonProps };
 }
 
 const GridToolbarFilterButton = React.forwardRef<HTMLButtonElement, GridToolbarFilterButtonProps>(
   function GridToolbarFilterButton(props, ref) {
-    const { componentsProps = {}, ...other } = props;
-    const buttonProps = componentsProps.button || {};
+    const { slotsProps = {}, ...other } = props;
+    const buttonProps = slotsProps.button || {};
     const apiRef = useGridApiContext();
     const rootProps = useGridRootProps();
     const activeFilters = useGridSelector(apiRef, gridFilterActiveItemsSelector);
@@ -111,28 +111,28 @@ const GridToolbarFilterButton = React.forwardRef<HTMLButtonElement, GridToolbarF
     }
 
     return (
-      <rootProps.components.BaseTooltip
+      <rootProps.slots.BaseTooltip
         title={tooltipContentNode}
         enterDelay={1000}
         {...other}
-        {...rootProps.componentsProps?.baseTooltip}
+        {...rootProps.slotsProps?.baseTooltip}
       >
-        <rootProps.components.BaseButton
+        <rootProps.slots.BaseButton
           ref={ref}
           size="small"
           aria-label={apiRef.current.getLocaleText('toolbarFiltersLabel')}
           startIcon={
             <Badge badgeContent={activeFilters.length} color="primary">
-              <rootProps.components.OpenFilterButtonIcon />
+              <rootProps.slots.OpenFilterButtonIcon />
             </Badge>
           }
           {...buttonProps}
           onClick={toggleFilter}
-          {...rootProps.componentsProps?.baseButton}
+          {...rootProps.slotsProps?.baseButton}
         >
           {apiRef.current.getLocaleText('toolbarFilters')}
-        </rootProps.components.BaseButton>
-      </rootProps.components.BaseTooltip>
+        </rootProps.slots.BaseButton>
+      </rootProps.slots.BaseTooltip>
     );
   },
 );
@@ -146,7 +146,9 @@ GridToolbarFilterButton.propTypes = {
    * The props used for each slot inside.
    * @default {}
    */
-  componentsProps: PropTypes.object,
+  slotsProps: PropTypes.shape({
+    button: PropTypes.object,
+  }),
 } as any;
 
 export { GridToolbarFilterButton };

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -125,7 +125,7 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
 
   return (
     <GridToolbarQuickFilterRoot
-      as={rootProps.components.BaseTextField}
+      as={rootProps.slots.BaseTextField}
       variant="standard"
       value={searchValue}
       onChange={handleSearchValueChange}
@@ -133,7 +133,7 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
       aria-label={apiRef.current.getLocaleText('toolbarQuickFilterLabel')}
       type="search"
       InputProps={{
-        startAdornment: <rootProps.components.QuickFilterIcon fontSize="small" />,
+        startAdornment: <rootProps.slots.QuickFilterIcon fontSize="small" />,
         endAdornment: (
           <IconButton
             aria-label={apiRef.current.getLocaleText('toolbarQuickFilterDeleteIconLabel')}
@@ -141,12 +141,12 @@ function GridToolbarQuickFilter(props: GridToolbarQuickFilterProps) {
             sx={{ visibility: searchValue ? 'visible' : 'hidden' }}
             onClick={handleSearchReset}
           >
-            <rootProps.components.QuickFilterClearIcon fontSize="small" />
+            <rootProps.slots.QuickFilterClearIcon fontSize="small" />
           </IconButton>
         ),
       }}
       {...other}
-      {...rootProps.componentsProps?.baseTextField}
+      {...rootProps.slotsProps?.baseTextField}
     />
   );
 }

--- a/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
@@ -72,8 +72,8 @@ export function useGridColumns(
     | 'columnVisibilityModel'
     | 'onColumnVisibilityModelChange'
     | 'columnTypes'
-    | 'components'
-    | 'componentsProps'
+    | 'slots'
+    | 'slotsProps'
   >,
 ): void {
   const logger = useGridLogger(apiRef, 'useGridColumns');
@@ -338,13 +338,13 @@ export function useGridColumns(
   const preferencePanelPreProcessing = React.useCallback<GridPipeProcessor<'preferencePanel'>>(
     (initialValue, value) => {
       if (value === GridPreferencePanelsValue.columns) {
-        const ColumnsPanel = props.components.ColumnsPanel;
-        return <ColumnsPanel {...props.componentsProps?.columnsPanel} />;
+        const ColumnsPanel = props.slots.ColumnsPanel;
+        return <ColumnsPanel {...props.slotsProps?.columnsPanel} />;
       }
 
       return initialValue;
     },
-    [props.components.ColumnsPanel, props.componentsProps?.columnsPanel],
+    [props.slots.ColumnsPanel, props.slotsProps?.columnsPanel],
   );
 
   useGridRegisterPipeProcessor(apiRef, 'exportState', stateExportPreProcessing);

--- a/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
@@ -60,8 +60,8 @@ export const useGridFilter = (
     | 'onFilterModelChange'
     | 'filterMode'
     | 'disableMultipleColumnsFiltering'
-    | 'components'
-    | 'componentsProps'
+    | 'slots'
+    | 'slotsProps'
   >,
 ): void => {
   const logger = useGridLogger(apiRef, 'useGridFilter');
@@ -340,13 +340,13 @@ export const useGridFilter = (
   const preferencePanelPreProcessing = React.useCallback<GridPipeProcessor<'preferencePanel'>>(
     (initialValue, value) => {
       if (value === GridPreferencePanelsValue.filters) {
-        const FilterPanel = props.components.FilterPanel;
-        return <FilterPanel {...props.componentsProps?.filterPanel} />;
+        const FilterPanel = props.slots.FilterPanel;
+        return <FilterPanel {...props.slotsProps?.filterPanel} />;
       }
 
       return initialValue;
     },
-    [props.components.FilterPanel, props.componentsProps?.filterPanel],
+    [props.slots.FilterPanel, props.slotsProps?.filterPanel],
   );
 
   const flatFilteringMethod = React.useCallback<GridStrategyProcessor<'filtering'>>(

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -473,7 +473,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
       }
 
       rows.push(
-        <rootProps.components.Row
+        <rootProps.slots.Row
           key={id}
           row={model}
           rowId={id}
@@ -491,7 +491,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
           isLastVisible={lastVisibleRowIndex}
           position={position}
           {...(typeof getRowProps === 'function' ? getRowProps(id, model) : {})}
-          {...rootProps.componentsProps?.row}
+          {...rootProps.slotsProps?.row}
         />,
       );
     }

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -86,7 +86,7 @@ export type DataGridForcedPropsKey =
  * The `DataGrid` options with a default value that must be merged with the value given through props.
  */
 export interface DataGridPropsWithComplexDefaultValueAfterProcessing {
-  components: GridSlotsComponent;
+  slots: GridSlotsComponent;
   localeText: GridLocaleText;
 }
 
@@ -97,7 +97,7 @@ export interface DataGridPropsWithComplexDefaultValueBeforeProcessing {
   /**
    * Overrideable components.
    */
-  components?: Partial<GridSlotsComponent>;
+  slots?: Partial<GridSlotsComponent>;
   /**
    * Set the locale text of the grid.
    * You can find all the translation keys supported in [the source](https://github.com/mui/mui-x/blob/HEAD/packages/grid/x-data-grid/src/constants/localeTextConstants.ts) in the GitHub repository.
@@ -740,7 +740,7 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
   /**
    * Overrideable components props dynamically passed to the component at rendering.
    */
-  componentsProps?: GridSlotsComponentsProps;
+  slotsProps?: GridSlotsComponentsProps;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
@@ -47,7 +47,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
     it('should update the visible columns when props.onColumnVisibilityModelChange and props.columnVisibilityModel are not defined', () => {
       render(
         <TestDataGrid
-          components={{
+          slots={{
             Toolbar: GridToolbar,
           }}
         />,
@@ -63,7 +63,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
       const onColumnVisibilityModelChange = spy();
       render(
         <TestDataGrid
-          components={{
+          slots={{
             Toolbar: GridToolbar,
           }}
           onColumnVisibilityModelChange={onColumnVisibilityModelChange}
@@ -84,7 +84,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
       const onColumnVisibilityModelChange = spy();
       render(
         <TestDataGrid
-          components={{
+          slots={{
             Toolbar: GridToolbar,
           }}
           columnVisibilityModel={{ idBis: false }}
@@ -107,7 +107,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
       const onColumnVisibilityModelChange = spy();
       render(
         <TestDataGrid
-          components={{
+          slots={{
             Toolbar: GridToolbar,
           }}
           columnVisibilityModel={{ idBis: false }}
@@ -133,7 +133,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
     it('should not hide non hideable columns when toggling all columns', () => {
       render(
         <TestDataGrid
-          components={{
+          slots={{
             Toolbar: GridToolbar,
           }}
           columns={[{ field: 'id' }, { field: 'idBis', hideable: false }]}
@@ -206,7 +206,7 @@ describe('<DataGridPro /> - Columns Visibility', () => {
               columnVisibilityModel: { idBis: false },
             },
           }}
-          components={{
+          slots={{
             Toolbar: GridToolbar,
           }}
         />,
@@ -222,10 +222,10 @@ describe('<DataGridPro /> - Columns Visibility', () => {
   it('should autofocus the first switch element in columns panel when `autoFocusSearchField` disabled', () => {
     render(
       <TestDataGrid
-        components={{
+        slots={{
           Toolbar: GridToolbar,
         }}
-        componentsProps={{
+        slotsProps={{
           columnsPanel: {
             autoFocusSearchField: false,
           },

--- a/packages/grid/x-data-grid/src/tests/components.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/components.DataGrid.test.tsx
@@ -11,7 +11,7 @@ import { spy } from 'sinon';
 import { DataGrid, GridOverlay } from '@mui/x-data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 
-describe('<DataGrid /> - Components', () => {
+describe('<DataGrid /> - slots', () => {
   const { render } = createRenderer();
 
   const baselineProps = {
@@ -48,43 +48,43 @@ describe('<DataGrid /> - Components', () => {
       }
       render(
         <div style={{ width: 300, height: 500 }}>
-          <DataGrid {...baselineProps} hideFooter components={{ Footer: CustomFooter }} />
+          <DataGrid {...baselineProps} hideFooter slots={{ Footer: CustomFooter }} />
         </div>,
       );
       expect(document.querySelectorAll('.customFooter').length).to.equal(0);
     });
   });
 
-  describe('componentsProps', () => {
-    it('should pass the props from componentsProps.cell to the cell', () => {
+  describe('slotsProps', () => {
+    it('should pass the props from slotsProps.cell to the cell', () => {
       render(
         <div style={{ width: 300, height: 500 }}>
           <DataGrid
             {...baselineProps}
             hideFooter
             disableVirtualization
-            componentsProps={{ cell: { 'data-name': 'foobar' } }}
+            slotsProps={{ cell: { 'data-name': 'foobar' } }}
           />
         </div>,
       );
       expect(getCell(0, 0)).to.have.attr('data-name', 'foobar');
     });
 
-    it('should pass the props from componentsProps.row to the row', () => {
+    it('should pass the props from slotsProps.row to the row', () => {
       render(
         <div style={{ width: 300, height: 500 }}>
           <DataGrid
             {...baselineProps}
             hideFooter
             disableVirtualization
-            componentsProps={{ row: { 'data-name': 'foobar' } }}
+            slotsProps={{ row: { 'data-name': 'foobar' } }}
           />
         </div>,
       );
       expect(getRow(0)).to.have.attr('data-name', 'foobar');
     });
 
-    it('should pass the props from componentsProps.columnHeaderFilterIconButton to the column header filter icon', () => {
+    it('should pass the props from slotsProps.columnHeaderFilterIconButton to the column header filter icon', () => {
       const onClick = spy();
       render(
         <div style={{ width: 300, height: 500 }}>
@@ -95,7 +95,7 @@ describe('<DataGrid /> - Components', () => {
               items: [{ field: 'brand', operator: 'contains', value: 'a' }],
             }}
             disableVirtualization
-            componentsProps={{ columnHeaderFilterIconButton: { onClick } }}
+            slotsProps={{ columnHeaderFilterIconButton: { onClick } }}
           />
         </div>,
       );
@@ -107,15 +107,15 @@ describe('<DataGrid /> - Components', () => {
     });
   });
 
-  describe('components', () => {
-    it('should render the cell with the component given in components.Cell', () => {
+  describe('slots', () => {
+    it('should render the cell with the component given in slots.Cell', () => {
       render(
         <div style={{ width: 300, height: 500 }}>
           <DataGrid
             {...baselineProps}
             hideFooter
             disableVirtualization
-            components={{
+            slots={{
               Cell: ({ rowIndex, colIndex }) => (
                 <span role="cell" data-rowindex={rowIndex} data-colindex={colIndex} />
               ),
@@ -126,14 +126,14 @@ describe('<DataGrid /> - Components', () => {
       expect(getCell(0, 0).tagName).to.equal('SPAN');
     });
 
-    it('should render the row with the component given in components.Row', () => {
+    it('should render the row with the component given in slots.Row', () => {
       render(
         <div style={{ width: 300, height: 500 }}>
           <DataGrid
             {...baselineProps}
             hideFooter
             disableVirtualization
-            components={{ Row: ({ index }) => <span role="row" data-rowindex={index} /> }}
+            slots={{ Row: ({ index }) => <span role="row" data-rowindex={index} /> }}
           />
         </div>,
       );

--- a/packages/grid/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -38,7 +38,7 @@ describe('<DataGrid /> - Export', () => {
 
   describe('component: GridToolbar', () => {
     it('should export with the default csvOptions', async () => {
-      render(<TestCase components={{ Toolbar: GridToolbar }} />);
+      render(<TestCase slots={{ Toolbar: GridToolbar }} />);
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
       clock.runToLast();
       expect(screen.queryByRole('menu')).not.to.equal(null);
@@ -51,8 +51,8 @@ describe('<DataGrid /> - Export', () => {
     it('should apply custom csvOptions', async () => {
       render(
         <TestCase
-          components={{ Toolbar: GridToolbar }}
-          componentsProps={{ toolbar: { csvOptions: { delimiter: ';' } } }}
+          slots={{ Toolbar: GridToolbar }}
+          slotsProps={{ toolbar: { csvOptions: { delimiter: ';' } } }}
         />,
       );
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
@@ -67,8 +67,8 @@ describe('<DataGrid /> - Export', () => {
     it('should disable csv export when passing `csvOptions.disableToolbarButton`', () => {
       render(
         <TestCase
-          components={{ Toolbar: GridToolbar }}
-          componentsProps={{ toolbar: { csvOptions: { disableToolbarButton: true } } }}
+          slots={{ Toolbar: GridToolbar }}
+          slotsProps={{ toolbar: { csvOptions: { disableToolbarButton: true } } }}
         />,
       );
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
@@ -80,7 +80,7 @@ describe('<DataGrid /> - Export', () => {
 
   describe('component: GridToolbarExport', () => {
     it('should export with the default csvOptions', async () => {
-      render(<TestCase components={{ Toolbar: () => <GridToolbarExport /> }} />);
+      render(<TestCase slots={{ Toolbar: () => <GridToolbarExport /> }} />);
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
       clock.runToLast();
       expect(screen.queryByRole('menu')).not.to.equal(null);
@@ -93,7 +93,7 @@ describe('<DataGrid /> - Export', () => {
     it('should apply custom csvOptions', async () => {
       render(
         <TestCase
-          components={{ Toolbar: () => <GridToolbarExport csvOptions={{ delimiter: ';' }} /> }}
+          slots={{ Toolbar: () => <GridToolbarExport csvOptions={{ delimiter: ';' }} /> }}
         />,
       );
       fireEvent.click(screen.queryByRole('button', { name: 'Export' }));
@@ -108,7 +108,7 @@ describe('<DataGrid /> - Export', () => {
     it('should disable csv export when passing `csvOptions.disableToolbarButton`', async () => {
       render(
         <TestCase
-          components={{
+          slots={{
             Toolbar: () => <GridToolbarExport csvOptions={{ disableToolbarButton: true }} />,
           }}
         />,

--- a/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -1142,7 +1142,7 @@ describe('<DataGrid /> - Filter', () => {
                 },
               ],
             }}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
           />

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -908,7 +908,7 @@ describe('<DataGrid /> - Layout & Warnings', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
             localeText={{ toolbarDensity: 'Size' }}
@@ -1020,7 +1020,7 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     function TestCase(props: Partial<DataGridProps>) {
       return (
         <div style={{ width: 300, height: 500 }}>
-          <DataGrid {...baselineProps} components={{ NoRowsOverlay }} {...props} />
+          <DataGrid {...baselineProps} slots={{ NoRowsOverlay }} {...props} />
         </div>
       );
     }
@@ -1035,7 +1035,7 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     function TestCase(props: Partial<DataGridProps>) {
       return (
         <div style={{ width: 300, height: 500 }}>
-          <DataGrid {...baselineProps} components={{ NoRowsOverlay }} {...props} />
+          <DataGrid {...baselineProps} slots={{ NoRowsOverlay }} {...props} />
         </div>
       );
     }

--- a/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -40,7 +40,7 @@ describe('<DataGrid /> - Quick Filter', () => {
   function TestCase(props: Partial<DataGridProps>) {
     return (
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid {...baselineProps} components={{ Toolbar: GridToolbarQuickFilter }} {...props} />
+        <DataGrid {...baselineProps} slots={{ Toolbar: GridToolbarQuickFilter }} {...props} />
       </div>
     );
   }
@@ -64,7 +64,7 @@ describe('<DataGrid /> - Quick Filter', () => {
       render(
         <TestCase
           onFilterModelChange={onFilterModelChange}
-          componentsProps={{
+          slotsProps={{
             toolbar: {
               quickFilterParser: (searchInput: string) =>
                 searchInput.split(',').map((value) => value.trim()),
@@ -123,7 +123,7 @@ describe('<DataGrid /> - Quick Filter', () => {
     it('should allow to customize input formatting', () => {
       const { setProps } = render(
         <TestCase
-          componentsProps={{
+          slotsProps={{
             toolbar: {
               quickFilterFormatter: (quickFilterValues: string[]) => quickFilterValues.join(', '),
             },

--- a/packages/grid/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -53,7 +53,7 @@ describe('<DataGrid /> - Toolbar', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
             rowHeight={rowHeight}
@@ -80,7 +80,7 @@ describe('<DataGrid /> - Toolbar', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
             rowHeight={rowHeight}
@@ -157,7 +157,7 @@ describe('<DataGrid /> - Toolbar', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
           />
@@ -177,7 +177,7 @@ describe('<DataGrid /> - Toolbar', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
           />
@@ -207,7 +207,7 @@ describe('<DataGrid /> - Toolbar', () => {
           <DataGrid
             {...baselineProps}
             columns={customColumns}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
             initialState={{
@@ -230,7 +230,7 @@ describe('<DataGrid /> - Toolbar', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
           />
@@ -271,10 +271,10 @@ describe('<DataGrid /> - Toolbar', () => {
           <DataGrid
             {...baselineProps}
             columns={customColumns}
-            components={{
+            slots={{
               Toolbar: GridToolbar,
             }}
-            componentsProps={{
+            slotsProps={{
               columnsPanel: {
                 searchPredicate: columnSearchPredicate,
               },


### PR DESCRIPTION
Fixes #6986

## Breaking change
```diff
-<DataGrid components={} componentsProps={}>
+<DataGrid slots={} slotsProps={}>
```

PS: @flaviendelangle it probably makes sense to do the same change for the pickers