### PR TITLE
[DataGrid] Rename `filterPanelOperators` -> `filterPanelOperator`

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -140,7 +140,7 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
 - The `GridApiRef` type was removed. Use `React.MutableRefObject<GridApi>` instead.
 - The `GridCellValue` type was removed. Use `any` or the `V` generic passed to most interfaces.
 - The `GridRowData` type was removed. Use `GridRowModel` instead.
-- `filterPanelOperators` translation key was renamed to `filterPanelOperator`
+- The `filterPanelOperators` translation key was renamed to `filterPanelOperator`
 
 <!--
 ### CSS classes

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -140,6 +140,7 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
 - The `GridApiRef` type was removed. Use `React.MutableRefObject<GridApi>` instead.
 - The `GridCellValue` type was removed. Use `any` or the `V` generic passed to most interfaces.
 - The `GridRowData` type was removed. Use `GridRowModel` instead.
+- `filterPanelOperators` translation key was renamed to `filterPanelOperator`
 
 <!--
 ### CSS classes

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -469,11 +469,11 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
           )}
         >
           <InputLabel htmlFor={operatorSelectId} id={operatorSelectLabelId}>
-            {apiRef.current.getLocaleText('filterPanelOperators')}
+            {apiRef.current.getLocaleText('filterPanelOperator')}
           </InputLabel>
           <rootProps.components.BaseSelect
             labelId={operatorSelectLabelId}
-            label={apiRef.current.getLocaleText('filterPanelOperators')}
+            label={apiRef.current.getLocaleText('filterPanelOperator')}
             id={operatorSelectId}
             value={item.operator}
             onChange={changeOperator}

--- a/packages/grid/x-data-grid/src/constants/localeTextConstants.ts
+++ b/packages/grid/x-data-grid/src/constants/localeTextConstants.ts
@@ -48,7 +48,7 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
   filterPanelAddFilter: 'Add filter',
   filterPanelDeleteIconLabel: 'Delete',
   filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Operator', // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operator',
   filterPanelOperatorAnd: 'And',
   filterPanelOperatorOr: 'Or',
   filterPanelColumns: 'Columns',

--- a/packages/grid/x-data-grid/src/locales/arSD.ts
+++ b/packages/grid/x-data-grid/src/locales/arSD.ts
@@ -50,9 +50,7 @@ const arSDGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'إضافة مرشِح',
   filterPanelDeleteIconLabel: 'حذف',
   filterPanelLinkOperator: 'عامل منطقي',
-  filterPanelOperators: 'عامل',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'عامل',
   filterPanelOperatorAnd: 'و',
   filterPanelOperatorOr: 'أو',
   filterPanelColumns: 'الأعمدة',

--- a/packages/grid/x-data-grid/src/locales/bgBG.ts
+++ b/packages/grid/x-data-grid/src/locales/bgBG.ts
@@ -49,9 +49,7 @@ const bgBGGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Добави Филтър',
   filterPanelDeleteIconLabel: 'Изтрий',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Оператори',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Оператори',
   filterPanelOperatorAnd: 'И',
   filterPanelOperatorOr: 'Или',
   filterPanelColumns: 'Колони',

--- a/packages/grid/x-data-grid/src/locales/csCZ.ts
+++ b/packages/grid/x-data-grid/src/locales/csCZ.ts
@@ -57,9 +57,7 @@ const csCZGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Přidat filtr',
   filterPanelDeleteIconLabel: 'Odstranit',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Operátory',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operátory',
   filterPanelOperatorAnd: 'A',
   filterPanelOperatorOr: 'Nebo',
   filterPanelColumns: 'Sloupce',

--- a/packages/grid/x-data-grid/src/locales/daDK.ts
+++ b/packages/grid/x-data-grid/src/locales/daDK.ts
@@ -50,9 +50,7 @@ const daDKGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Tilføj filter',
   filterPanelDeleteIconLabel: 'Slet',
   filterPanelLinkOperator: 'Logisk operator',
-  filterPanelOperators: 'Operatorer',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatorer',
   filterPanelOperatorAnd: 'Og',
   filterPanelOperatorOr: 'Eller',
   filterPanelColumns: 'Kolonne',

--- a/packages/grid/x-data-grid/src/locales/deDE.ts
+++ b/packages/grid/x-data-grid/src/locales/deDE.ts
@@ -50,9 +50,7 @@ const deDEGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Filter hinzufügen',
   filterPanelDeleteIconLabel: 'Löschen',
   filterPanelLinkOperator: 'Logische Operatoren',
-  filterPanelOperators: 'Operatoren',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatoren',
   filterPanelOperatorAnd: 'Und',
   filterPanelOperatorOr: 'Oder',
   filterPanelColumns: 'Spalten',

--- a/packages/grid/x-data-grid/src/locales/elGR.ts
+++ b/packages/grid/x-data-grid/src/locales/elGR.ts
@@ -49,9 +49,7 @@ const elGRGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Προσθήκη φίλτρου',
   filterPanelDeleteIconLabel: 'Διαγραφή',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Τελεστές',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Τελεστές',
   filterPanelOperatorAnd: 'Καί',
   filterPanelOperatorOr: 'Ή',
   filterPanelColumns: 'Στήλες',

--- a/packages/grid/x-data-grid/src/locales/esES.ts
+++ b/packages/grid/x-data-grid/src/locales/esES.ts
@@ -50,9 +50,7 @@ const esESGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Agregar filtro',
   filterPanelDeleteIconLabel: 'Borrar',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Operadores',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operadores',
   filterPanelOperatorAnd: 'Y',
   filterPanelOperatorOr: 'O',
   filterPanelColumns: 'Columnas',

--- a/packages/grid/x-data-grid/src/locales/faIR.ts
+++ b/packages/grid/x-data-grid/src/locales/faIR.ts
@@ -50,9 +50,7 @@ const faIRGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'افزودن فیلتر',
   filterPanelDeleteIconLabel: 'حذف',
   filterPanelLinkOperator: 'عملگر منطقی',
-  filterPanelOperators: 'عملگرها',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'عملگرها',
   filterPanelOperatorAnd: 'و',
   filterPanelOperatorOr: 'یا',
   filterPanelColumns: 'ستون‌ها',

--- a/packages/grid/x-data-grid/src/locales/fiFI.ts
+++ b/packages/grid/x-data-grid/src/locales/fiFI.ts
@@ -50,9 +50,7 @@ const fiFIGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Lisää suodatin',
   filterPanelDeleteIconLabel: 'Poista',
   filterPanelLinkOperator: 'Logiikkaoperaattori',
-  filterPanelOperators: 'Operaattorit',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operaattorit',
   filterPanelOperatorAnd: 'Ja',
   filterPanelOperatorOr: 'Tai',
   filterPanelColumns: 'Sarakkeet',

--- a/packages/grid/x-data-grid/src/locales/frFR.ts
+++ b/packages/grid/x-data-grid/src/locales/frFR.ts
@@ -50,9 +50,7 @@ const frFRGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Ajouter un filtre',
   filterPanelDeleteIconLabel: 'Supprimer',
   filterPanelLinkOperator: 'Opérateur logique',
-  filterPanelOperators: 'Opérateur',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Opérateur',
   filterPanelOperatorAnd: 'Et',
   filterPanelOperatorOr: 'Ou',
   filterPanelColumns: 'Colonnes',

--- a/packages/grid/x-data-grid/src/locales/heIL.ts
+++ b/packages/grid/x-data-grid/src/locales/heIL.ts
@@ -50,9 +50,7 @@ const heILGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'הוסף מסנן',
   filterPanelDeleteIconLabel: 'מחק',
   filterPanelLinkOperator: 'אופרטור לוגי',
-  filterPanelOperators: 'אופרטור',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'אופרטור',
   filterPanelOperatorAnd: 'וגם',
   filterPanelOperatorOr: 'או',
   filterPanelColumns: 'עמודות',

--- a/packages/grid/x-data-grid/src/locales/huHU.ts
+++ b/packages/grid/x-data-grid/src/locales/huHU.ts
@@ -49,9 +49,7 @@ const huHUGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Szűrő hozzáadása',
   filterPanelDeleteIconLabel: 'Törlés',
   filterPanelLinkOperator: 'Logikai operátor',
-  filterPanelOperators: 'Operátorok',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operátorok',
   filterPanelOperatorAnd: 'És',
   filterPanelOperatorOr: 'Vagy',
   filterPanelColumns: 'Oszlopok',

--- a/packages/grid/x-data-grid/src/locales/itIT.ts
+++ b/packages/grid/x-data-grid/src/locales/itIT.ts
@@ -50,9 +50,7 @@ const itITGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Aggiungi un filtro',
   filterPanelDeleteIconLabel: 'Rimuovi',
   filterPanelLinkOperator: 'Operatore logico',
-  filterPanelOperators: 'Operatori',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatori',
   filterPanelOperatorAnd: 'E (and)',
   filterPanelOperatorOr: 'O (or)',
   filterPanelColumns: 'Colonne',

--- a/packages/grid/x-data-grid/src/locales/jaJP.ts
+++ b/packages/grid/x-data-grid/src/locales/jaJP.ts
@@ -49,9 +49,7 @@ const jaJPGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'フィルター追加',
   filterPanelDeleteIconLabel: '削除',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'オペレータ',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'オペレータ',
   filterPanelOperatorAnd: 'And',
   filterPanelOperatorOr: 'Or',
   filterPanelColumns: '列',

--- a/packages/grid/x-data-grid/src/locales/koKR.ts
+++ b/packages/grid/x-data-grid/src/locales/koKR.ts
@@ -49,9 +49,7 @@ const koKRGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: '필터 추가',
   filterPanelDeleteIconLabel: '삭제',
   filterPanelLinkOperator: '논리 연산자',
-  filterPanelOperators: '연산자',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: '연산자',
   filterPanelOperatorAnd: '그리고',
   filterPanelOperatorOr: '또는',
   filterPanelColumns: '목록',

--- a/packages/grid/x-data-grid/src/locales/nbNO.ts
+++ b/packages/grid/x-data-grid/src/locales/nbNO.ts
@@ -50,9 +50,7 @@ const nbNOGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Legg til filter',
   filterPanelDeleteIconLabel: 'Slett',
   filterPanelLinkOperator: 'Logisk operator',
-  filterPanelOperators: 'Operatører',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatører',
   filterPanelOperatorAnd: 'Og',
   filterPanelOperatorOr: 'Eller',
   filterPanelColumns: 'Kolonner',

--- a/packages/grid/x-data-grid/src/locales/nlNL.ts
+++ b/packages/grid/x-data-grid/src/locales/nlNL.ts
@@ -50,9 +50,7 @@ const nlNLGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Filter toevoegen',
   filterPanelDeleteIconLabel: 'Verwijderen',
   filterPanelLinkOperator: 'Logische operator',
-  filterPanelOperators: 'Operatoren',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatoren',
   filterPanelOperatorAnd: 'En',
   filterPanelOperatorOr: 'Of',
   filterPanelColumns: 'Kolommen',

--- a/packages/grid/x-data-grid/src/locales/plPL.ts
+++ b/packages/grid/x-data-grid/src/locales/plPL.ts
@@ -49,9 +49,7 @@ const plPLGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Dodaj filtr',
   filterPanelDeleteIconLabel: 'Usuń',
   filterPanelLinkOperator: 'Operator logiczny',
-  filterPanelOperators: 'Operator',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operator',
   filterPanelOperatorAnd: 'I',
   filterPanelOperatorOr: 'Lub',
   filterPanelColumns: 'Kolumny',

--- a/packages/grid/x-data-grid/src/locales/ptBR.ts
+++ b/packages/grid/x-data-grid/src/locales/ptBR.ts
@@ -50,9 +50,7 @@ const ptBRGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Adicionar filtro',
   filterPanelDeleteIconLabel: 'Excluir',
   filterPanelLinkOperator: 'Operador lógico',
-  filterPanelOperators: 'Operador',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operador',
   filterPanelOperatorAnd: 'E',
   filterPanelOperatorOr: 'Ou',
   filterPanelColumns: 'Colunas',

--- a/packages/grid/x-data-grid/src/locales/roRO.ts
+++ b/packages/grid/x-data-grid/src/locales/roRO.ts
@@ -50,9 +50,7 @@ const roROGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Adăugare filtru',
   filterPanelDeleteIconLabel: 'Ștergere',
   filterPanelLinkOperator: 'Operatori logici',
-  filterPanelOperators: 'Operatori',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatori',
   filterPanelOperatorAnd: 'Și',
   filterPanelOperatorOr: 'Sau',
   filterPanelColumns: 'Coloane',

--- a/packages/grid/x-data-grid/src/locales/ruRU.ts
+++ b/packages/grid/x-data-grid/src/locales/ruRU.ts
@@ -58,9 +58,7 @@ const ruRUGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Добавить фильтр',
   filterPanelDeleteIconLabel: 'Удалить',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Операторы',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Операторы',
   filterPanelOperatorAnd: 'И',
   filterPanelOperatorOr: 'Или',
   filterPanelColumns: 'Столбцы',

--- a/packages/grid/x-data-grid/src/locales/skSK.ts
+++ b/packages/grid/x-data-grid/src/locales/skSK.ts
@@ -57,9 +57,7 @@ const skSKGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Pridať filter',
   filterPanelDeleteIconLabel: 'Odstrániť',
   filterPanelLinkOperator: 'Logický operátor',
-  filterPanelOperators: 'Operátory',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operátory',
   filterPanelOperatorAnd: 'A',
   filterPanelOperatorOr: 'Alebo',
   filterPanelColumns: 'Stĺpce',

--- a/packages/grid/x-data-grid/src/locales/svSE.ts
+++ b/packages/grid/x-data-grid/src/locales/svSE.ts
@@ -50,9 +50,7 @@ const svSEGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Lägg till filter',
   filterPanelDeleteIconLabel: 'Ta bort',
   filterPanelLinkOperator: 'Logisk operatör',
-  filterPanelOperators: 'Operatör',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatör',
   filterPanelOperatorAnd: 'Och',
   filterPanelOperatorOr: 'Eller',
   filterPanelColumns: 'Kolumner',

--- a/packages/grid/x-data-grid/src/locales/trTR.ts
+++ b/packages/grid/x-data-grid/src/locales/trTR.ts
@@ -49,9 +49,7 @@ const trTRGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Filtre Ekle',
   filterPanelDeleteIconLabel: 'Kaldır',
   filterPanelLinkOperator: 'Mantıksal operatörler',
-  filterPanelOperators: 'Operatör',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Operatör',
   filterPanelOperatorAnd: 'Ve',
   filterPanelOperatorOr: 'Veya',
   filterPanelColumns: 'Sütunlar',

--- a/packages/grid/x-data-grid/src/locales/ukUA.ts
+++ b/packages/grid/x-data-grid/src/locales/ukUA.ts
@@ -73,9 +73,7 @@ const ukUAGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Додати фільтр',
   filterPanelDeleteIconLabel: 'Видалити',
   filterPanelLinkOperator: 'Логічна функція',
-  filterPanelOperators: 'Оператори',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Оператори',
   filterPanelOperatorAnd: 'І',
   filterPanelOperatorOr: 'Або',
   filterPanelColumns: 'Стовпці',

--- a/packages/grid/x-data-grid/src/locales/viVN.ts
+++ b/packages/grid/x-data-grid/src/locales/viVN.ts
@@ -50,9 +50,7 @@ const viVNGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: 'Thêm bộ lọc',
   filterPanelDeleteIconLabel: 'Xóa',
   // filterPanelLinkOperator: 'Logic operator',
-  filterPanelOperators: 'Toán tử',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: 'Toán tử',
   filterPanelOperatorAnd: 'Và',
   filterPanelOperatorOr: 'Hoặc',
   filterPanelColumns: 'Cột',

--- a/packages/grid/x-data-grid/src/locales/zhCN.ts
+++ b/packages/grid/x-data-grid/src/locales/zhCN.ts
@@ -49,9 +49,7 @@ const zhCNGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: '添加筛选器',
   filterPanelDeleteIconLabel: '删除',
   filterPanelLinkOperator: '逻辑操作器',
-  filterPanelOperators: '操作器',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: '操作器',
   filterPanelOperatorAnd: '与',
   filterPanelOperatorOr: '或',
   filterPanelColumns: '列',

--- a/packages/grid/x-data-grid/src/locales/zhTW.ts
+++ b/packages/grid/x-data-grid/src/locales/zhTW.ts
@@ -49,9 +49,7 @@ const zhTWGrid: Partial<GridLocaleText> = {
   filterPanelAddFilter: '增加篩選器',
   filterPanelDeleteIconLabel: '刪除',
   filterPanelLinkOperator: '邏輯運算子',
-  filterPanelOperators: '運算子',
-
-  // TODO v6: rename to filterPanelOperator
+  filterPanelOperator: '運算子',
   filterPanelOperatorAnd: '且',
   filterPanelOperatorOr: '或',
   filterPanelColumns: '欄位',

--- a/packages/grid/x-data-grid/src/models/api/gridLocaleTextApi.ts
+++ b/packages/grid/x-data-grid/src/models/api/gridLocaleTextApi.ts
@@ -51,7 +51,7 @@ export interface GridLocaleText {
   filterPanelAddFilter: React.ReactNode;
   filterPanelDeleteIconLabel: string;
   filterPanelLinkOperator: string;
-  filterPanelOperators: React.ReactNode;
+  filterPanelOperator: React.ReactNode;
   filterPanelOperatorAnd: React.ReactNode;
   filterPanelOperatorOr: React.ReactNode;
   filterPanelColumns: React.ReactNode;


### PR DESCRIPTION
Fixes #6963 

## Changelog

### Breaking changes

- `filterPanelOperators` translation key was renamed to `filterPanelOperator`