### PR TITLE
[DataGrid] Remove column separator to match table styles

### DIFF
--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
@@ -191,7 +191,6 @@ function GridColumnGroupHeader(props: GridColumnGroupHeaderProps) {
       aria-colspan={fields.length}
       // The fields are wrapped between |-...-| to avoid confusion between fields "id" and "id2" when using selector data-fields~=
       data-fields={`|-${fields.join('-|-')}-|`}
-      disableHeaderSeparator
       {...mouseEventsHandlers}
     />
   );

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
@@ -39,7 +39,6 @@ interface GridGenericColumnHeaderItemProps
   label: string;
   draggableContainerProps?: Partial<React.HTMLProps<HTMLDivElement>>;
   columnHeaderSeparatorProps?: Partial<GridColumnHeaderSeparatorProps>;
-  disableHeaderSeparator?: boolean;
 }
 
 const GridGenericColumnHeaderItem = React.forwardRef(function GridGenericColumnHeaderItem(
@@ -69,7 +68,6 @@ const GridGenericColumnHeaderItem = React.forwardRef(function GridGenericColumnH
     resizable,
     draggableContainerProps,
     columnHeaderSeparatorProps,
-    disableHeaderSeparator,
     ...other
   } = props;
 
@@ -135,15 +133,13 @@ const GridGenericColumnHeaderItem = React.forwardRef(function GridGenericColumnH
         </div>
         {columnMenuIconButton}
       </div>
-      {!disableHeaderSeparator && (
-        <GridColumnHeaderSeparator
-          resizable={!rootProps.disableColumnResize && !!resizable}
-          resizing={isResizing}
-          height={height}
-          side={separatorSide}
-          {...columnHeaderSeparatorProps}
-        />
-      )}
+      <GridColumnHeaderSeparator
+        resizable={!rootProps.disableColumnResize && !!resizable}
+        resizing={isResizing}
+        height={height}
+        side={separatorSide}
+        {...columnHeaderSeparatorProps}
+      />
       {columnMenu}
     </div>
   );

--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -217,6 +217,7 @@ export const GridRootStyles = styled('div', {
       backgroundColor: (theme.vars || theme).palette.action.hover,
     },
     [`& .${gridClasses.columnSeparator}`]: {
+      visibility: 'hidden',
       position: 'absolute',
       zIndex: 100,
       display: 'flex',
@@ -224,6 +225,11 @@ export const GridRootStyles = styled('div', {
       justifyContent: 'center',
       color: borderColor,
     },
+    [`& .${gridClasses.columnHeaders}:hover .${gridClasses.columnSeparator}, .${gridClasses['columnSeparator--resizing']}`]:
+      {
+        visibility: 'visible',
+        width: 'auto',
+      },
     [`& .${gridClasses['columnSeparator--sideLeft']}`]: {
       left: -12,
     },


### PR DESCRIPTION
Fixes #1623

Removed column separator, it will only be shown when there's resize support available.

## Changelog

- [x] Remove column separator
- [x] Remove unused `disableHeaderSeparator`

## Design
- [Figma Process](https://www.figma.com/file/W6TItYkiGJZjL5zLnfeSjy/Data-grid?node-id=1227%3A62449&t=MAO4kO2qvUssZFTG-0) 
- Figma Final