### PR TITLE
[DataGrid] Support `Date` objects in filter model

### DIFF
--- a/docs/data/data-grid/custom-columns/EditingWithDatePickers.js
+++ b/docs/data/data-grid/custom-columns/EditingWithDatePickers.js
@@ -87,7 +87,7 @@ function GridFilterDateInput(props) {
 
   return (
     <Component
-      value={item.value || null}
+      value={item.value ? new Date(item.value) : null}
       autoFocus
       label={apiRef.current.getLocaleText('filterPanelInputLabel')}
       slotProps={{

--- a/docs/data/data-grid/custom-columns/EditingWithDatePickers.js
+++ b/docs/data/data-grid/custom-columns/EditingWithDatePickers.js
@@ -4,6 +4,7 @@ import {
   useGridApiContext,
   GRID_DATE_COL_DEF,
   GRID_DATETIME_COL_DEF,
+  getGridDateOperators,
 } from '@mui/x-data-grid';
 import {
   randomCreatedDate,
@@ -18,131 +19,6 @@ import InputBase from '@mui/material/InputBase';
 import locale from 'date-fns/locale/en-US';
 import { styled } from '@mui/material/styles';
 
-function buildApplyDateFilterFn(filterItem, compareFn, showTime = false) {
-  if (!filterItem.value) {
-    return null;
-  }
-
-  // Make a copy of the date to not reset the hours in the original object
-  const filterValueCopy = new Date(filterItem.value);
-  filterValueCopy.setHours(0, 0, 0, 0);
-
-  const filterValueMs = filterValueCopy.getTime();
-
-  return (value) => {
-    if (!value) {
-      return false;
-    }
-
-    // Make a copy of the date to not reset the hours in the original object
-    const dateCopy = new Date(value);
-    dateCopy.setHours(
-      showTime ? value.getHours() : 0,
-      showTime ? value.getMinutes() : 0,
-      0,
-      0,
-    );
-    const cellValueMs = dateCopy.getTime();
-
-    return compareFn(cellValueMs, filterValueMs);
-  };
-}
-
-function getDateFilterOperators(showTime = false) {
-  return [
-    {
-      value: 'is',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 === value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'not',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 !== value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'after',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 > value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'onOrAfter',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 >= value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'before',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 < value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'onOrBefore',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 <= value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'isEmpty',
-      getApplyFilterFn: () => {
-        return (value) => {
-          return value == null;
-        };
-      },
-      requiresFilterValue: false,
-    },
-    {
-      value: 'isNotEmpty',
-      getApplyFilterFn: () => {
-        return (value) => {
-          return value != null;
-        };
-      },
-      requiresFilterValue: false,
-    },
-  ];
-}
-
 const dateAdapter = new AdapterDateFns({ locale });
 
 /**
@@ -155,7 +31,11 @@ const dateColumnType = {
   renderEditCell: (params) => {
     return <GridEditDateCell {...params} />;
   },
-  filterOperators: getDateFilterOperators(),
+  filterOperators: getGridDateOperators(false).map((item) => ({
+    ...item,
+    InputComponent: GridFilterDateInput,
+    InputComponentProps: { showTime: false },
+  })),
   valueFormatter: (params) => {
     if (typeof params.value === 'string') {
       return params.value;
@@ -237,7 +117,11 @@ const dateTimeColumnType = {
   renderEditCell: (params) => {
     return <GridEditDateCell {...params} />;
   },
-  filterOperators: getDateFilterOperators(true),
+  filterOperators: getGridDateOperators(true).map((item) => ({
+    ...item,
+    InputComponent: GridFilterDateInput,
+    InputComponentProps: { showTime: true },
+  })),
   valueFormatter: (params) => {
     if (typeof params.value === 'string') {
       return params.value;

--- a/docs/data/data-grid/custom-columns/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/custom-columns/EditingWithDatePickers.tsx
@@ -7,11 +7,9 @@ import {
   GridRenderEditCellParams,
   GRID_DATE_COL_DEF,
   GRID_DATETIME_COL_DEF,
-  GridFilterItem,
   GridColTypeDef,
   GridFilterInputValueProps,
-  GetApplyFilterFn,
-  GridFilterOperator,
+  getGridDateOperators,
 } from '@mui/x-data-grid';
 import {
   randomCreatedDate,
@@ -27,137 +25,6 @@ import locale from 'date-fns/locale/en-US';
 import { styled } from '@mui/material/styles';
 import { TextFieldProps } from '@mui/material/TextField';
 
-function buildApplyDateFilterFn(
-  filterItem: GridFilterItem,
-  compareFn: (value1: number, value2: number) => boolean,
-  showTime: boolean = false,
-): ReturnType<GetApplyFilterFn<any, Date, string>> {
-  if (!filterItem.value) {
-    return null;
-  }
-
-  // Make a copy of the date to not reset the hours in the original object
-  const filterValueCopy = new Date(filterItem.value);
-  filterValueCopy.setHours(0, 0, 0, 0);
-
-  const filterValueMs = filterValueCopy.getTime();
-
-  return (value) => {
-    if (!value) {
-      return false;
-    }
-
-    // Make a copy of the date to not reset the hours in the original object
-    const dateCopy = new Date(value);
-    dateCopy.setHours(
-      showTime ? value.getHours() : 0,
-      showTime ? value.getMinutes() : 0,
-      0,
-      0,
-    );
-    const cellValueMs = dateCopy.getTime();
-
-    return compareFn(cellValueMs, filterValueMs);
-  };
-}
-
-function getDateFilterOperators(
-  showTime: boolean = false,
-): GridFilterOperator<any, Date, string>[] {
-  return [
-    {
-      value: 'is',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 === value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'not',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 !== value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'after',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 > value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'onOrAfter',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 >= value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'before',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 < value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'onOrBefore',
-      getApplyFilterFn: (filterItem) => {
-        return buildApplyDateFilterFn(
-          filterItem,
-          (value1, value2) => value1 <= value2,
-          showTime,
-        );
-      },
-      InputComponent: GridFilterDateInput,
-      InputComponentProps: { showTime },
-    },
-    {
-      value: 'isEmpty',
-      getApplyFilterFn: () => {
-        return (value): boolean => {
-          return value == null;
-        };
-      },
-      requiresFilterValue: false,
-    },
-    {
-      value: 'isNotEmpty',
-      getApplyFilterFn: () => {
-        return (value): boolean => {
-          return value != null;
-        };
-      },
-      requiresFilterValue: false,
-    },
-  ];
-}
-
 const dateAdapter = new AdapterDateFns({ locale });
 
 /**
@@ -170,7 +37,11 @@ const dateColumnType: GridColTypeDef<Date, string> = {
   renderEditCell: (params) => {
     return <GridEditDateCell {...params} />;
   },
-  filterOperators: getDateFilterOperators(),
+  filterOperators: getGridDateOperators(false).map((item) => ({
+    ...item,
+    InputComponent: GridFilterDateInput,
+    InputComponentProps: { showTime: false },
+  })),
   valueFormatter: (params) => {
     if (typeof params.value === 'string') {
       return params.value;
@@ -261,7 +132,11 @@ const dateTimeColumnType: GridColTypeDef<Date, string> = {
   renderEditCell: (params) => {
     return <GridEditDateCell {...params} />;
   },
-  filterOperators: getDateFilterOperators(true),
+  filterOperators: getGridDateOperators(true).map((item) => ({
+    ...item,
+    InputComponent: GridFilterDateInput,
+    InputComponentProps: { showTime: true },
+  })),
   valueFormatter: (params) => {
     if (typeof params.value === 'string') {
       return params.value;

--- a/docs/data/data-grid/custom-columns/EditingWithDatePickers.tsx
+++ b/docs/data/data-grid/custom-columns/EditingWithDatePickers.tsx
@@ -102,7 +102,7 @@ function GridFilterDateInput(
 
   return (
     <Component
-      value={item.value || null}
+      value={item.value ? new Date(item.value) : null}
       autoFocus
       label={apiRef.current.getLocaleText('filterPanelInputLabel')}
       slotProps={{

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -229,6 +229,9 @@ Below are described the steps you need to make to migrate from v6 to v7.
   | `unstable_gridTabIndexColumnHeaderFilterSelector` | `gridTabIndexColumnHeaderFilterSelector` |
 
 - The filter panel no longer uses the native version of the [`Select`](https://mui.com/material-ui/react-select/) component for all components.
+- The `filterModel` now supports `Date` objects as values for `date` and `dateTime` column types.
+  The `filterModel` still accepts strings as values for `date` and `dateTime` column types,
+  but all updates to the `filterModel` coming from the UI (e.g. filter panel) will set the value as a `Date` object.
 
 <!-- ### Editing
 

--- a/packages/grid/x-data-grid/src/colDef/gridDateOperators.ts
+++ b/packages/grid/x-data-grid/src/colDef/gridDateOperators.ts
@@ -2,9 +2,6 @@ import { GridFilterInputDate } from '../components/panel/filterPanel/GridFilterI
 import { GridFilterItem } from '../models/gridFilterItem';
 import { GridFilterOperator, GetApplyFilterFn } from '../models/gridFilterOperator';
 
-const dateRegex = /(\d+)-(\d+)-(\d+)/;
-const dateTimeRegex = /(\d+)-(\d+)-(\d+)T(\d+):(\d+)/;
-
 function buildApplyFilterFn(
   filterItem: GridFilterItem,
   compareFn: (value1: number, value2: number) => boolean,
@@ -15,14 +12,15 @@ function buildApplyFilterFn(
     return null;
   }
 
-  const [year, month, day, hour, minute] = filterItem.value
-    .match(showTime ? dateTimeRegex : dateRegex)!
-    .slice(1)
-    .map(Number);
+  const date = new Date(filterItem.value);
+  if (showTime) {
+    date.setSeconds(0, 0);
+  } else {
+    date.setHours(0, 0, 0, 0);
+  }
+  const time = date.getTime();
 
-  const time = new Date(year, month - 1, day, hour || 0, minute || 0).getTime();
-
-  return (value): boolean => {
+  return (value: Date): boolean => {
     if (!value) {
       return false;
     }
@@ -33,13 +31,12 @@ function buildApplyFilterFn(
 
     // Make a copy of the date to not reset the hours in the original object
     const dateCopy = new Date(value);
-    const timeToCompare = dateCopy.setHours(
-      showTime ? value.getHours() : 0,
-      showTime ? value.getMinutes() : 0,
-      0,
-      0,
-    );
-    return compareFn(timeToCompare, time);
+    if (showTime) {
+      dateCopy.setSeconds(0, 0);
+    } else {
+      dateCopy.setHours(0, 0, 0, 0);
+    }
+    return compareFn(dateCopy.getTime(), time);
   };
 }
 

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -66,7 +66,7 @@ function GridFilterInputDate(props: GridFilterInputDateProps) {
 
       setIsApplying(true);
       filterTimeout.start(rootProps.filterDebounceMs, () => {
-        applyValue({ ...item, value: new Date(value) });
+        applyValue({ ...item, value });
         setIsApplying(false);
       });
     },

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -22,20 +22,18 @@ function convertFilterItemValueToInputValue(
   itemValue: GridFilterItem['value'],
   inputType: GridFilterInputDateProps['type'],
 ) {
-  let value = itemValue ?? '';
-  if (itemValue instanceof Date) {
-    const dateCopy = new Date(itemValue);
-    // The date picker expects the date to be in the local timezone.
-    // But .toISOString() converts it to UTC with zero offset.
-    // So we need to subtract the timezone offset.
-    dateCopy.setMinutes(dateCopy.getMinutes() - dateCopy.getTimezoneOffset());
-    if (inputType === 'date') {
-      value = dateCopy.toISOString().substring(0, 10);
-    } else if (inputType === 'datetime-local') {
-      value = dateCopy.toISOString().substring(0, 19);
-    }
+  const dateCopy = new Date(itemValue ?? '');
+  // The date picker expects the date to be in the local timezone.
+  // But .toISOString() converts it to UTC with zero offset.
+  // So we need to subtract the timezone offset.
+  dateCopy.setMinutes(dateCopy.getMinutes() - dateCopy.getTimezoneOffset());
+  if (inputType === 'date') {
+    return dateCopy.toISOString().substring(0, 10);
   }
-  return value;
+  if (inputType === 'datetime-local') {
+    return dateCopy.toISOString().substring(0, 19);
+  }
+  return dateCopy.toISOString().substring(0, 10);
 }
 
 function GridFilterInputDate(props: GridFilterInputDateProps) {

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -22,7 +22,10 @@ function convertFilterItemValueToInputValue(
   itemValue: GridFilterItem['value'],
   inputType: GridFilterInputDateProps['type'],
 ) {
-  const dateCopy = new Date(itemValue ?? '');
+  if (itemValue == null) {
+    return '';
+  }
+  const dateCopy = new Date(itemValue);
   // The date picker expects the date to be in the local timezone.
   // But .toISOString() converts it to UTC with zero offset.
   // So we need to subtract the timezone offset.

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -66,7 +66,7 @@ function GridFilterInputDate(props: GridFilterInputDateProps) {
 
       setIsApplying(true);
       filterTimeout.start(rootProps.filterDebounceMs, () => {
-        applyValue({ ...item, value });
+        applyValue({ ...item, value: new Date(value) });
         setIsApplying(false);
       });
     },

--- a/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -651,6 +651,10 @@ describe('<DataGrid /> - Filter', () => {
         '1/1/2001, 12:00:00 AM',
         '1/1/2001, 8:30:00 AM',
       ]);
+      expect(getRows({ operator: 'is', value: new Date('2001-01-01') })).to.deep.equal([
+        '1/1/2001, 12:00:00 AM',
+        '1/1/2001, 8:30:00 AM',
+      ]);
       expect(getRows({ operator: 'is', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'is', value: '' })).to.deep.equal(ALL_ROWS);
     });
@@ -661,12 +665,19 @@ describe('<DataGrid /> - Filter', () => {
         '1/1/2000, 12:00:00 AM',
         '1/1/2002, 12:00:00 AM',
       ]);
+      expect(getRows({ operator: 'not', value: new Date('2001-01-01') })).to.deep.equal([
+        '1/1/2000, 12:00:00 AM',
+        '1/1/2002, 12:00:00 AM',
+      ]);
       expect(getRows({ operator: 'not', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'not', value: '' })).to.deep.equal(ALL_ROWS);
     });
 
     it('should filter with operator "before"', () => {
       expect(getRows({ operator: 'before', value: '2001-01-01' })).to.deep.equal([
+        '1/1/2000, 12:00:00 AM',
+      ]);
+      expect(getRows({ operator: 'before', value: new Date('2001-01-01') })).to.deep.equal([
         '1/1/2000, 12:00:00 AM',
       ]);
       expect(getRows({ operator: 'before', value: undefined })).to.deep.equal(ALL_ROWS);
@@ -679,6 +690,11 @@ describe('<DataGrid /> - Filter', () => {
         '1/1/2001, 12:00:00 AM',
         '1/1/2001, 8:30:00 AM',
       ]);
+      expect(getRows({ operator: 'onOrBefore', value: new Date('2001-01-01') })).to.deep.equal([
+        '1/1/2000, 12:00:00 AM',
+        '1/1/2001, 12:00:00 AM',
+        '1/1/2001, 8:30:00 AM',
+      ]);
       expect(getRows({ operator: 'onOrBefore', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'onOrBefore', value: '' })).to.deep.equal(ALL_ROWS);
     });
@@ -687,12 +703,20 @@ describe('<DataGrid /> - Filter', () => {
       expect(getRows({ operator: 'after', value: '2001-01-01' })).to.deep.equal([
         '1/1/2002, 12:00:00 AM',
       ]);
+      expect(getRows({ operator: 'after', value: new Date('2001-01-01') })).to.deep.equal([
+        '1/1/2002, 12:00:00 AM',
+      ]);
       expect(getRows({ operator: 'after', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'after', value: '' })).to.deep.equal(ALL_ROWS);
     });
 
     it('should filter with operator "onOrAfter"', () => {
       expect(getRows({ operator: 'onOrAfter', value: '2001-01-01' })).to.deep.equal([
+        '1/1/2001, 12:00:00 AM',
+        '1/1/2001, 8:30:00 AM',
+        '1/1/2002, 12:00:00 AM',
+      ]);
+      expect(getRows({ operator: 'onOrAfter', value: new Date('2001-01-01') })).to.deep.equal([
         '1/1/2001, 12:00:00 AM',
         '1/1/2001, 8:30:00 AM',
         '1/1/2002, 12:00:00 AM',
@@ -792,6 +816,9 @@ describe('<DataGrid /> - Filter', () => {
       expect(getRows({ operator: 'is', value: '2001-01-01T07:30' })).to.deep.equal([
         '1/1/2001, 7:30:00 AM',
       ]);
+      expect(getRows({ operator: 'is', value: new Date('2001-01-01T07:30') })).to.deep.equal([
+        '1/1/2001, 7:30:00 AM',
+      ]);
       expect(getRows({ operator: 'is', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'is', value: '' })).to.deep.equal(ALL_ROWS);
     });
@@ -799,6 +826,10 @@ describe('<DataGrid /> - Filter', () => {
     it('should filter with operator "not"', () => {
       // TODO: Should this filter return the invalid dates like for the numeric filters ?
       expect(getRows({ operator: 'not', value: '2001-01-01T07:30' })).to.deep.equal([
+        '1/1/2001, 6:30:00 AM',
+        '1/1/2001, 8:30:00 AM',
+      ]);
+      expect(getRows({ operator: 'not', value: new Date('2001-01-01T07:30') })).to.deep.equal([
         '1/1/2001, 6:30:00 AM',
         '1/1/2001, 8:30:00 AM',
       ]);
@@ -810,6 +841,9 @@ describe('<DataGrid /> - Filter', () => {
       expect(getRows({ operator: 'before', value: '2001-01-01T07:30' })).to.deep.equal([
         '1/1/2001, 6:30:00 AM',
       ]);
+      expect(getRows({ operator: 'before', value: new Date('2001-01-01T07:30') })).to.deep.equal([
+        '1/1/2001, 6:30:00 AM',
+      ]);
       expect(getRows({ operator: 'before', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'before', value: '' })).to.deep.equal(ALL_ROWS);
     });
@@ -819,12 +853,18 @@ describe('<DataGrid /> - Filter', () => {
         '1/1/2001, 6:30:00 AM',
         '1/1/2001, 7:30:00 AM',
       ]);
+      expect(
+        getRows({ operator: 'onOrBefore', value: new Date('2001-01-01T07:30') }),
+      ).to.deep.equal(['1/1/2001, 6:30:00 AM', '1/1/2001, 7:30:00 AM']);
       expect(getRows({ operator: 'onOrBefore', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'onOrBefore', value: '' })).to.deep.equal(ALL_ROWS);
     });
 
     it('should filter with operator "after"', () => {
       expect(getRows({ operator: 'after', value: '2001-01-01T07:30' })).to.deep.equal([
+        '1/1/2001, 8:30:00 AM',
+      ]);
+      expect(getRows({ operator: 'after', value: new Date('2001-01-01T07:30') })).to.deep.equal([
         '1/1/2001, 8:30:00 AM',
       ]);
       expect(getRows({ operator: 'after', value: undefined })).to.deep.equal(ALL_ROWS);
@@ -836,6 +876,9 @@ describe('<DataGrid /> - Filter', () => {
         '1/1/2001, 7:30:00 AM',
         '1/1/2001, 8:30:00 AM',
       ]);
+      expect(getRows({ operator: 'onOrAfter', value: new Date('2001-01-01T07:30') })).to.deep.equal(
+        ['1/1/2001, 7:30:00 AM', '1/1/2001, 8:30:00 AM'],
+      );
       expect(getRows({ operator: 'onOrAfter', value: undefined })).to.deep.equal(ALL_ROWS);
       expect(getRows({ operator: 'onOrAfter', value: '' })).to.deep.equal(ALL_ROWS);
     });


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/6564

TODO:
- [x] add unit tests

# Changelog

### Breaking changes

- The `filterModel` now supports `Date` objects as values for `date` and `dateTime` column types.
  The `filterModel` still accepts strings as values for `date` and `dateTime` column types,
  but all updates to the `filterModel` coming from the UI (e.g. filter panel) will set the value as a `Date` object.