### PR TITLE
[core] Sync ApiPage.js with monorepo

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -171,12 +171,12 @@ ClassesTable.propTypes = {
 
 function getTranslatedHeader(t, header) {
   const translations = {
+    demos: t('api-docs.demos'),
     import: t('api-docs.import'),
     'component-name': t('api-docs.componentName'),
     props: t('api-docs.props'),
     slots: t('api-docs.slots'),
     inheritance: t('api-docs.inheritance'),
-    demos: t('api-docs.demos'),
     css: 'CSS',
   };
 
@@ -262,13 +262,13 @@ export default function ApiPage(props) {
   }
 
   const toc = [
+    createTocEntry('demos'),
     createTocEntry('import'),
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
     createTocEntry('props'),
     Object.keys(slots).length && createTocEntry('slots'),
     componentStyles.classes.length > 0 && createTocEntry('css'),
-    createTocEntry('demos'),
   ].filter(Boolean);
 
   // The `ref` is forwarded to the root element.
@@ -328,6 +328,16 @@ export default function ApiPage(props) {
           {description}
           {disableAd ? null : <Ad />}
         </Typography>
+        <Heading hash="demos" />
+        <div className="MuiCallout-root MuiCallout-info">
+          <p
+            dangerouslySetInnerHTML={{
+              __html:
+                'For examples and details on the usage of this React component, visit the component demo pages:',
+            }}
+          />
+          <span dangerouslySetInnerHTML={{ __html: demos }} />
+        </div>
         <Heading hash="import" />
         <HighlightedCode code={imports.join(`\n// ${t('or')}\n`)} language="jsx" />
         <span dangerouslySetInnerHTML={{ __html: t('api-docs.importDifference') }} />
@@ -406,8 +416,6 @@ export default function ApiPage(props) {
             />
           </React.Fragment>
         ) : null}
-        <Heading hash="demos" />
-        <span dangerouslySetInnerHTML={{ __html: demos }} />
       </MarkdownElement>
       <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
         <symbol id="anchor-link-icon" viewBox="0 0 16 16">

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -404,11 +404,7 @@ export default function ApiPage(props) {
         {Object.keys(componentStyles.classes).length ? (
           <React.Fragment>
             <Heading hash="css" />
-            <ClassesTable
-              componentName={componentName}
-              componentStyles={componentStyles}
-              classDescriptions={classDescriptions}
-            />
+            <ClassesTable componentStyles={componentStyles} classDescriptions={classDescriptions} />
             <br />
             <span dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />
             <span


### PR DESCRIPTION
I apply https://github.com/mui/material-ui/pull/35202

---

Same comment as with #7051 ("We should be able to remove this duplication of the ApiPage component as we move forward."). The git diff between `ApiPage.js` in the two repositories looks like this:

```diff
diff --git a/docs/src/modules/components/ApiPage.js b/docs/src/modules/components/ApiPage.js
index 112aab9478..77d2978167 100644
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -171,6 +175,7 @@ function getTranslatedHeader(t, header) {
     import: t('api-docs.import'),
     'component-name': t('api-docs.componentName'),
     props: t('api-docs.props'),
+    slots: t('api-docs.slots'),
     inheritance: t('api-docs.inheritance'),
     css: 'CSS',
   };
@@ -222,7 +227,9 @@ export default function ApiPage(props) {
     name: componentName,
     props: componentProps,
     spread,
+    slots,
     styles: componentStyles,
+    packages,
   } = pageContent;

   const {
@@ -230,11 +237,12 @@ export default function ApiPage(props) {
     componentDescriptionToc = [],
     classDescriptions,
     propDescriptions,
+    slotDescriptions,
   } = descriptions[userLanguage];
   const description = t('api-docs.pageDescription').replace(/{{name}}/, componentName);

   const source = filename
-    .replace(/\/packages\/mui(-(.+?))?\/src/, (match, dash, pkg) => `@mui/${pkg}`)
+    .replace(/\/packages\/(grid\/|)(.+?)?\/src/, (match, dash, pkg) => `@mui/${pkg}`)
     // convert things like `/Table/Table.js` to ``
     .replace(/\/([^/]+)\/\1\.(js|tsx)$/, '');

@@ -259,6 +267,7 @@ export default function ApiPage(props) {
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
     createTocEntry('props'),
+    Object.keys(slots).length && createTocEntry('slots'),
     componentStyles.classes.length > 0 && createTocEntry('css'),
   ].filter(Boolean);

@@ -285,6 +294,20 @@ export default function ApiPage(props) {
     inheritanceSuffix = t('api-docs.inheritanceSuffixTransition');
   }

+  const imports = [];
+
+  if (source === '@mui/x-date-pickers' || source === '@mui/x-date-pickers-pro') {
+    packages.forEach((pkg) => {
+      // e.g. import DatePicker from '@mui/x-date-pickers/DatePicker';
+      imports.push(`import { ${pkg.componentName} } from '${pkg.packageName}/${componentName}';`);
+    });
+  }
+
+  packages.forEach((pkg) => {
+    // e.g. import { DatePicker } from '@mui/x-date-pickers';
+    imports.push(`import { ${pkg.componentName} } from '${pkg.packageName}';`);
+  });
+
   return (
     <AppLayoutDocs
       description={description}
@@ -316,13 +339,7 @@ export default function ApiPage(props) {
           <span dangerouslySetInnerHTML={{ __html: demos }} />
         </div>
         <Heading hash="import" />
-        <HighlightedCode
-          code={`
-import ${componentName} from '${source}/${componentName}';
-// ${t('or')}
-import { ${componentName} } from '${source}';`}
-          language="jsx"
-        />
+        <HighlightedCode code={imports.join(`\n// ${t('or')}\n`)} language="jsx" />
         <span dangerouslySetInnerHTML={{ __html: t('api-docs.importDifference') }} />
         {componentDescription ? (
           <React.Fragment>
@@ -352,6 +369,12 @@ import { ${componentName} } from '${source}';`}
         <p dangerouslySetInnerHTML={{ __html: spreadHint }} />
         <PropsTable componentProps={componentProps} propDescriptions={propDescriptions} />
         <br />
+        {Object.keys(slots).length ? (
+          <React.Fragment>
+            <Heading hash="slots" />
+            <PropsTable componentProps={slots} propDescriptions={slotDescriptions} />
+          </React.Fragment>
+        ) : null}
         {cssComponent && (
           <React.Fragment>
             <span
```

It seems that we could easily add the slots logic to Material UI which would benefit them (cc @samuelsycamore). And move the import code generation logic to the `yarn docs:api` script, to keep the UI focused on presenting the information. 