### PR TITLE
[docs] Update localization doc to use existing locale

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -30,9 +30,9 @@ you just have to import the locale from `@mui/x-date-pikers` (see the [list of s
 
 ```jsx
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { DateCalendar, LocalizationProvider, bgBG } from '@mui/x-date-pickers';
+import { DateCalendar, LocalizationProvider, deDE } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import bgLocale from 'date-fns/locale/bg';
+import 'date-fns/locale/de';
 
 const theme = createTheme(
   {
@@ -40,7 +40,7 @@ const theme = createTheme(
       primary: { main: '#1976d2' },
     },
   },
-  bgBG, // use 'bg' locale for UI texts (start, next month, ...)
+  deDE, // use 'de' locale for UI texts (start, next month, ...)
 );
 
 function App({ children }) {
@@ -49,14 +49,14 @@ function App({ children }) {
 ```
 
 Note that `createTheme` accepts any number of arguments.
-If you are already using the [translations of the core components](/material-ui/guides/localization/#locale-text) or the [translations of the data grid](/x/react-data-grid/localization/#locale-text), you can add `bgBG` as a new argument.
+If you are already using the [translations of the core components](/material-ui/guides/localization/#locale-text) or the [translations of the data grid](/x/react-data-grid/localization/#locale-text), you can add `deDE` as a new argument.
 
 ```jsx
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { DataGrid, bgBG as dataGridBgBG } from '@mui/x-data-grid';
-import { bgBG as coreBgBG } from '@mui/material/locale';
-import bgLocale from 'date-fns/locale/bg';
-import { DateCalendar, LocalizationProvider, bgBG } from '@mui/x-date-pickers';
+import { DataGrid, deDE as dataGridDeDE } from '@mui/x-data-grid';
+import { deDE as coreDeDE } from '@mui/material/locale';
+import 'date-fns/locale/de';
+import { DateCalendar, LocalizationProvider, deDE } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 
 const theme = createTheme(
@@ -65,9 +65,9 @@ const theme = createTheme(
       primary: { main: '#1976d2' },
     },
   },
-  bgBG, // x-date-pickers translations
-  dataGridBgBG, // x-data-grid translations
-  coreBgBG, // core translations
+  deDE, // x-date-pickers translations
+  dataGridDeDE, // x-data-grid translations
+  coreDeDE, // core translations
 );
 
 function App({ children }) {
@@ -82,11 +82,11 @@ you can directly load the language translations from the `@mui/x-date-pickers` o
 
 ```jsx
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DateCalendar, LocalizationProvider, bgBG } from '@mui/x-date-pickers';
-import bgLocale from 'date-fns/locale/bg';
+import { DateCalendar, LocalizationProvider, deDE } from '@mui/x-date-pickers';
+import 'date-fns/locale/de';
 
 <LocalizationProvider
-  localeText={bgBG.components.MuiLocalizationProvider.defaultProps.localeText}
+  localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
 >
   <DatePicker />
 </LocalizationProvider>;
@@ -108,7 +108,9 @@ This method can be combined with the ones shown above.
 If you pass a locale through `LocalizationProvider` or the theme, and you provide translation keys through the `localeText` prop of a picker at the same time, then only the latter translation keys will be overridden.
 
 ```tsx
-<LocalizationProvider localeText={frFR}>
+<LocalizationProvider
+  localeText={frFR.components.MuiLocalizationProvider.defaultProps.localeText}
+>
   <DatePicker
     // ...other props
     localeText={{

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -30,9 +30,7 @@ you just have to import the locale from `@mui/x-date-pikers` (see the [list of s
 
 ```jsx
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { DateCalendar, LocalizationProvider, deDE } from '@mui/x-date-pickers';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import 'date-fns/locale/de';
+import { deDE } from '@mui/x-date-pickers';
 
 const theme = createTheme(
   {
@@ -53,11 +51,9 @@ If you are already using the [translations of the core components](/material-ui/
 
 ```jsx
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { DataGrid, deDE as dataGridDeDE } from '@mui/x-data-grid';
+import { deDE as dataGridDeDE } from '@mui/x-data-grid';
 import { deDE as coreDeDE } from '@mui/material/locale';
-import 'date-fns/locale/de';
-import { DateCalendar, LocalizationProvider, deDE } from '@mui/x-date-pickers';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { deDE } from '@mui/x-date-pickers';
 
 const theme = createTheme(
   {
@@ -81,9 +77,7 @@ If you want to pass language translations without using `createTheme` and `Theme
 you can directly load the language translations from the `@mui/x-date-pickers` or `@mui/x-date-pickers-pro` package and pass them to the `LocalizationProvider`.
 
 ```jsx
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DateCalendar, LocalizationProvider, deDE } from '@mui/x-date-pickers';
-import 'date-fns/locale/de';
+import { LocalizationProvider, deDE } from '@mui/x-date-pickers';
 
 <LocalizationProvider
   localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -77,7 +77,7 @@ If you want to pass language translations without using `createTheme` and `Theme
 you can directly load the language translations from the `@mui/x-date-pickers` or `@mui/x-date-pickers-pro` package and pass them to the `LocalizationProvider`.
 
 ```jsx
-import { LocalizationProvider, deDE } from '@mui/x-date-pickers';
+import { LocalizationProvider, deDE, DatePicker } from '@mui/x-date-pickers';
 
 <LocalizationProvider
   localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -99,11 +99,11 @@ If you want to customize some translations on specific component, you can use th
 :::info
 This method can be combined with the ones shown above.
 
-If you pass a locale through `LocalizationProvider` or the theme, and you provide translation keys through the `localeText` prop of a picker at the same time, then only the latter translation keys will be overridden.
+If you pass a localization through `LocalizationProvider` or the theme, and you provide translation keys through the `localeText` prop of a picker at the same time, then only the latter translation keys will be overridden.
 
 ```tsx
 <LocalizationProvider
-  localeText={frFR.components.MuiLocalizationProvider.defaultProps.localeText}
+  localeText={{ clearButtonLabel: 'Empty', todayButtonLabel: 'Now' }}
 >
   <DatePicker
     // ...other props
@@ -113,6 +113,11 @@ If you pass a locale through `LocalizationProvider` or the theme, and you provid
   />
 </LocalizationProvider>
 ```
+
+This will produce the following result:
+
+- "Today" button with text **Now** taken from the Localization Provider's `localeText` prop
+- "Clear" button with text **Vider** overridden by the Date Picker's `localeText` prop
 
 :::
 


### PR DESCRIPTION
Part of #7096 

Update documentation to use a locale, which exists among all the products (data grid, material ui, pickers).
I've chosen `deDE` as we have already used it in other demos.
Feel free to suggest a better alternative. 🙈 

[Preview](https://deploy-preview-7102--material-ui-x.netlify.app/x/react-date-pickers/localization/)