### PR TITLE
[docs] Add warning alert for components requiring `WrapperVariantContext`

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -457,5 +457,6 @@
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx",
   "demos": "<ul><li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPremium</a></li></ul>",
-  "packages": [{ "packageName": "@mui/x-data-grid-premium", "componentName": "DataGridPremium" }]
+  "packages": [{ "packageName": "@mui/x-data-grid-premium", "componentName": "DataGridPremium" }],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -435,5 +435,6 @@
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx",
   "demos": "<ul><li><a href=\"/x/react-data-grid/#commercial-version\">DataGridPro</a></li></ul>",
-  "packages": [{ "packageName": "@mui/x-data-grid-pro", "componentName": "DataGridPro" }]
+  "packages": [{ "packageName": "@mui/x-data-grid-pro", "componentName": "DataGridPro" }],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -379,5 +379,6 @@
   "forwardsRefTo": "GridRoot",
   "filename": "/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx",
   "demos": "<ul><li><a href=\"/x/react-data-grid/#mit-version\">DataGrid</a></li></ul>",
-  "packages": [{ "packageName": "@mui/x-data-grid", "componentName": "DataGrid" }]
+  "packages": [{ "packageName": "@mui/x-data-grid", "componentName": "DataGrid" }],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/data-grid/grid-filter-form.json
+++ b/docs/pages/x/api/data-grid/grid-filter-form.json
@@ -39,5 +39,6 @@
     { "packageName": "@mui/x-data-grid-premium", "componentName": "GridFilterForm" },
     { "packageName": "@mui/x-data-grid-pro", "componentName": "GridFilterForm" },
     { "packageName": "@mui/x-data-grid", "componentName": "GridFilterForm" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/data-grid/grid-filter-panel.json
+++ b/docs/pages/x/api/data-grid/grid-filter-panel.json
@@ -29,5 +29,6 @@
     { "packageName": "@mui/x-data-grid-premium", "componentName": "GridFilterPanel" },
     { "packageName": "@mui/x-data-grid-pro", "componentName": "GridFilterPanel" },
     { "packageName": "@mui/x-data-grid", "componentName": "GridFilterPanel" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-calendar.json
@@ -82,5 +82,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateCalendar" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateCalendar" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-field.json
+++ b/docs/pages/x/api/date-pickers/date-field.json
@@ -31,5 +31,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DateField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DateField" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -127,5 +127,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-range-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.json
@@ -61,5 +61,6 @@
   "filename": "/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li></ul>",
-  "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangeCalendar" }]
+  "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangeCalendar" }],
+  "requiresWrapperVariantContext": true
 }

--- a/docs/pages/x/api/date-pickers/date-range-picker-day.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-day.json
@@ -42,5 +42,6 @@
   "filename": "/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li></ul>",
-  "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePickerDay" }]
+  "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePickerDay" }],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -113,5 +113,6 @@
   "filename": "/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
-  "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePicker" }]
+  "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePicker" }],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-time-field.json
+++ b/docs/pages/x/api/date-pickers/date-time-field.json
@@ -39,5 +39,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DateTimeField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DateTimeField" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/date-time-picker-tabs.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker-tabs.json
@@ -24,5 +24,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateTimePickerTabs" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateTimePickerTabs" }
-  ]
+  ],
+  "requiresWrapperVariantContext": true
 }

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -139,5 +139,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/day-calendar-skeleton.json
+++ b/docs/pages/x/api/date-pickers/day-calendar-skeleton.json
@@ -23,5 +23,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DayCalendarSkeleton" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DayCalendarSkeleton" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.json
@@ -120,5 +120,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DesktopDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -108,5 +108,6 @@
   "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDateRangePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -132,5 +132,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DesktopDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-picker.json
@@ -119,5 +119,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DesktopNextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DesktopNextDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-range-picker.json
@@ -102,5 +102,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_DesktopNextDateRangePicker"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-time-picker.json
@@ -132,5 +132,6 @@
       "componentName": "Unstable_DesktopNextDateTimePicker"
     },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DesktopNextDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-time-picker.json
@@ -97,5 +97,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DesktopNextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DesktopNextTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/desktop-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-picker.json
@@ -95,5 +95,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DesktopTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/localization-provider.json
+++ b/docs/pages/x/api/date-pickers/localization-provider.json
@@ -20,5 +20,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "LocalizationProvider" },
     { "packageName": "@mui/x-date-pickers", "componentName": "LocalizationProvider" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.json
@@ -112,5 +112,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MobileDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -100,5 +100,6 @@
   "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDateRangePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
@@ -124,5 +124,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MobileDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-date-picker.json
@@ -108,5 +108,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_MobileNextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_MobileNextDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-date-range-picker.json
@@ -94,5 +94,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_MobileNextDateRangePicker"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-date-time-picker.json
@@ -121,5 +121,6 @@
       "componentName": "Unstable_MobileNextDateTimePicker"
     },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_MobileNextDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-time-picker.json
@@ -87,5 +87,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_MobileNextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_MobileNextTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/mobile-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-picker.json
@@ -87,5 +87,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MobileTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/month-calendar.json
+++ b/docs/pages/x/api/date-pickers/month-calendar.json
@@ -28,5 +28,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MonthCalendar" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MonthCalendar" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
@@ -38,5 +38,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_MultiInputDateRangeField"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
@@ -46,5 +46,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_MultiInputDateTimeRangeField"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
@@ -41,5 +41,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_MultiInputTimeRangeField"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-picker.json
@@ -126,5 +126,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_NextDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-range-picker.json
@@ -106,5 +106,6 @@
   "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextDateRangePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-time-picker.json
@@ -136,5 +136,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_NextDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/next-time-picker.json
@@ -104,5 +104,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_NextTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/picker-static-wrapper.json
+++ b/docs/pages/x/api/date-pickers/picker-static-wrapper.json
@@ -33,5 +33,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "PickerStaticWrapper" },
     { "packageName": "@mui/x-date-pickers", "componentName": "PickerStaticWrapper" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/pickers-day.json
+++ b/docs/pages/x/api/date-pickers/pickers-day.json
@@ -33,5 +33,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "PickersDay" },
     { "packageName": "@mui/x-date-pickers", "componentName": "PickersDay" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -31,5 +31,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_SingleInputDateRangeField"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-picker.json
@@ -111,5 +111,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "StaticDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -99,5 +99,6 @@
   "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDateRangePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.json
@@ -123,5 +123,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "StaticDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-picker.json
@@ -88,5 +88,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_StaticNextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_StaticNextDatePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-range-picker.json
@@ -76,5 +76,6 @@
       "packageName": "@mui/x-date-pickers-pro",
       "componentName": "Unstable_StaticNextDateRangePicker"
     }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-time-picker.json
@@ -101,5 +101,6 @@
       "componentName": "Unstable_StaticNextDateTimePicker"
     },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_StaticNextDateTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-time-picker.json
@@ -69,5 +69,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_StaticNextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_StaticNextTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/static-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-time-picker.json
@@ -92,5 +92,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "StaticTimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/time-clock.json
+++ b/docs/pages/x/api/date-pickers/time-clock.json
@@ -62,5 +62,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "TimeClock" },
     { "packageName": "@mui/x-date-pickers", "componentName": "TimeClock" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/time-field.json
+++ b/docs/pages/x/api/date-pickers/time-field.json
@@ -32,5 +32,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_TimeField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_TimeField" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/time-picker.json
+++ b/docs/pages/x/api/date-pickers/time-picker.json
@@ -102,5 +102,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "TimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "TimePicker" }
-  ]
+  ],
+  "requiresWrapperVariantContext": false
 }

--- a/docs/pages/x/api/date-pickers/year-calendar.json
+++ b/docs/pages/x/api/date-pickers/year-calendar.json
@@ -28,5 +28,6 @@
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "YearCalendar" },
     { "packageName": "@mui/x-date-pickers", "componentName": "YearCalendar" }
-  ]
+  ],
+  "requiresWrapperVariantContext": true
 }

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -45,6 +45,7 @@ interface ReactApi extends ReactDocgenApi {
   inheritance: { component: string; pathname: string } | null;
   name: string;
   spread: boolean | undefined;
+  requiresWrapperVariantContext: boolean | undefined;
   src: string;
   styles: Styles;
   displayName: string;
@@ -483,6 +484,8 @@ const buildComponentDocumentation = async (options: {
       .map((item) => `<li><a href="${item.demoPathname}">${item.name}</a></li>`)
       .join('\n')}</ul>`,
     packages: reactApi.packages,
+    // Resolve if the component depends on `WrapperVariantContext` existing in the react context
+    requiresWrapperVariantContext: src.includes('React.useContext(WrapperVariantContext)'),
   };
 
   // docs/pages/component-name.json

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -353,16 +353,17 @@ export default function ApiPage(props) {
             />
           </React.Fragment>
         ) : null}
-        {requiresWrapperVariantContext && (<div className="MuiCallout-root MuiCallout-warning">
-          <p
-            dangerouslySetInnerHTML={{
-              __html:
-                `This component expects <code>WrapperVariantContext</code> to exist above in the React component tree.
+        {requiresWrapperVariantContext && (
+          <div className="MuiCallout-root MuiCallout-warning">
+            <p
+              dangerouslySetInnerHTML={{
+                __html: `This component expects <code>WrapperVariantContext</code> to exist above in the React component tree.
                 If this component is used standalone and the context is not provided—the component might have unexpected behavior.<br>
                 Make sure that the component is used inside any of the Date and Time Picker components or provide the context yourself.`,
-            }}
-          />
-        </div>)}
+              }}
+            />
+          </div>
+        )}
         {componentStyles.name && (
           <React.Fragment>
             <Heading hash="component-name" />

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -230,6 +230,7 @@ export default function ApiPage(props) {
     slots,
     styles: componentStyles,
     packages,
+    requiresWrapperVariantContext,
   } = pageContent;
 
   const {
@@ -352,6 +353,16 @@ export default function ApiPage(props) {
             />
           </React.Fragment>
         ) : null}
+        {requiresWrapperVariantContext && (<div className="MuiCallout-root MuiCallout-warning">
+          <p
+            dangerouslySetInnerHTML={{
+              __html:
+                `This component expects <code>WrapperVariantContext</code> to exist above in the React component tree.
+                If this component is used standalone and the context is not provided—the component might have unexpected behavior.<br>
+                Make sure that the component is used inside any of the Date and Time Picker components or provide the context yourself.`,
+            }}
+          />
+        </div>)}
         {componentStyles.name && (
           <React.Fragment>
             <Heading hash="component-name" />


### PR DESCRIPTION
Fixes #7064 

Add a warning alert in component api page to components using `React.useContext(WrapperVariantContext)`.

[Example](https://deploy-preview-7105--material-ui-x.netlify.app/x/api/date-pickers/date-range-calendar/)