### PR TITLE
[pickers] Initialize date without time when selecting year or month

### DIFF
--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -159,6 +159,7 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
     () => value ?? utils.startOfMonth(now),
     [now, utils, value],
   );
+
   const selectedMonth = React.useMemo(() => {
     if (value != null) {
       return utils.getMonth(value);

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -155,7 +155,10 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
 
   const todayMonth = React.useMemo(() => utils.getMonth(now), [utils, now]);
 
-  const selectedDateOrToday = value ?? now;
+  const selectedDateOrStartOfMonth = React.useMemo(
+    () => value ?? utils.startOfMonth(now),
+    [now, utils, value],
+  );
   const selectedMonth = React.useMemo(() => {
     if (value != null) {
       return utils.getMonth(value);
@@ -213,13 +216,13 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
       return;
     }
 
-    const newDate = utils.setMonth(selectedDateOrToday, month);
+    const newDate = utils.setMonth(selectedDateOrStartOfMonth, month);
     setValue(newDate);
     onChange?.(newDate);
   });
 
   const focusMonth = useEventCallback((month: number) => {
-    if (!isMonthDisabled(utils.setMonth(selectedDateOrToday, month))) {
+    if (!isMonthDisabled(utils.setMonth(selectedDateOrStartOfMonth, month))) {
       setFocusedMonth(month);
       changeHasFocus(true);
       if (onMonthFocus) {
@@ -281,7 +284,7 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
       ownerState={ownerState}
       {...other}
     >
-      {utils.getMonthArray(selectedDateOrToday).map((month) => {
+      {utils.getMonthArray(selectedDateOrStartOfMonth).map((month) => {
         const monthNumber = utils.getMonth(month);
         const monthText = utils.format(month, 'monthShort');
         const isSelected = monthNumber === selectedMonth;

--- a/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
@@ -6,7 +6,7 @@ import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
 import { adapterToUse, createPickerRenderer } from 'test/utils/pickers-utils';
 
 describe('<MonthCalendar />', () => {
-  const { render } = createPickerRenderer();
+  const { render } = createPickerRenderer({ clock: 'fake', clockConfig: new Date(2019, 0, 1) });
 
   it('allows to pick month standalone by click, `Enter` and `Space`', () => {
     const onChange = spy();
@@ -24,6 +24,16 @@ describe('<MonthCalendar />', () => {
 
     expect(onChange.callCount).to.equal(1);
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2019, 1, 2));
+  });
+
+  it('should select start of month without time when no initial value is present', () => {
+    const onChange = spy();
+    render(<MonthCalendar onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Feb' }));
+
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.args[0][0]).toEqualDateTime(new Date(2019, 1, 1, 0, 0, 0));
   });
 
   it('does not allow to pick months if readOnly prop is passed', () => {

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -158,6 +158,7 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
     () => value ?? utils.startOfYear(now),
     [now, utils, value],
   );
+
   const todayYear = React.useMemo(() => utils.getYear(now), [utils, now]);
   const selectedYear = React.useMemo(() => {
     if (value != null) {

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -154,7 +154,10 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
     default: defaultValue ?? null,
   });
 
-  const selectedDateOrToday = value ?? now;
+  const selectedDateOrStartOfYear = React.useMemo(
+    () => value ?? utils.startOfYear(now),
+    [now, utils, value],
+  );
   const todayYear = React.useMemo(() => utils.getYear(now), [utils, now]);
   const selectedYear = React.useMemo(() => {
     if (value != null) {
@@ -208,13 +211,13 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
       return;
     }
 
-    const newDate = utils.setYear(selectedDateOrToday, year);
+    const newDate = utils.setYear(selectedDateOrStartOfYear, year);
     setValue(newDate);
     onChange?.(newDate);
   });
 
   const focusYear = useEventCallback((year: number) => {
-    if (!isYearDisabled(utils.setYear(selectedDateOrToday, year))) {
+    if (!isYearDisabled(utils.setYear(selectedDateOrStartOfYear, year))) {
       setFocusedYear(year);
       changeHasFocus(true);
       onYearFocus?.(year);

--- a/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
@@ -26,6 +26,16 @@ describe('<YearCalendar />', () => {
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2025, 1, 2));
   });
 
+  it('should select start of year without time when no initial value is present', () => {
+    const onChange = spy();
+    render(<YearCalendar onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '2025' }));
+
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.args[0][0]).toEqualDateTime(new Date(2025, 0, 1, 0, 0, 0, 0));
+  });
+
   it('does not allow to pick year if readOnly prop is passed', () => {
     const onChangeMock = spy();
     render(


### PR DESCRIPTION
Fixes #7114 

Instead of current approach, when `now` is used and has a side-effect of initialising date with current time, change to:
- Fix to init date to `startOfYear` when selecting a year
- Fix to init date to `startOfMonth` when selecting a month