### PR TITLE
[DataGridPremium] Add support for lazy-loading

### DIFF
--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
@@ -58,6 +58,8 @@ import {
   rowPinningStateInitializer,
   useGridColumnGrouping,
   columnGroupsStateInitializer,
+  useGridLazyLoader,
+  useGridLazyLoaderPreProcessors,
 } from '@mui/x-data-grid-pro/internals';
 import { GridApiPremium, GridPrivateApiPremium } from '../models/gridApiPremium';
 import { DataGridPremiumProcessedProps } from '../models/dataGridPremiumProps';
@@ -90,6 +92,7 @@ export const useDataGridPremiumComponent = (
   useGridRowReorderPreProcessors(privateApiRef, props);
   useGridRowGroupingPreProcessors(privateApiRef, props);
   useGridTreeDataPreProcessors(privateApiRef, props);
+  useGridLazyLoaderPreProcessors(privateApiRef, props);
   useGridRowPinningPreProcessors(privateApiRef);
   useGridAggregationPreProcessors(privateApiRef, props);
   useGridDetailPanelPreProcessors(privateApiRef, props);
@@ -148,6 +151,7 @@ export const useDataGridPremiumComponent = (
   useGridRowReorder(privateApiRef, props);
   useGridScroll(privateApiRef, props);
   useGridInfiniteLoader(privateApiRef, props);
+  useGridLazyLoader(privateApiRef, props);
   useGridColumnMenu(privateApiRef);
   useGridCsvExport(privateApiRef);
   useGridPrintExport(privateApiRef, props);

--- a/packages/grid/x-data-grid-pro/src/internals/index.ts
+++ b/packages/grid/x-data-grid-pro/src/internals/index.ts
@@ -35,6 +35,8 @@ export {
   useGridRowPinningPreProcessors,
   addPinnedRow,
 } from '../hooks/features/rowPinning/useGridRowPinningPreProcessors';
+export { useGridLazyLoader } from '../hooks/features/lazyLoader/useGridLazyLoader';
+export { useGridLazyLoaderPreProcessors } from '../hooks/features/lazyLoader/useGridLazyLoaderPreProcessors';
 
 export type {
   GridExperimentalProFeatures,


### PR DESCRIPTION
Fixes #7112 

https://github.com/mui/mui-x/pull/5214 didn't include the lazy-loading hook in DataGridPremium.