### PR TITLE
[DataGridPremium] Use separate cache for aggregation columns pre-processor

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
@@ -21,6 +21,7 @@ import { DataGridPremiumProcessedProps } from '../../../models/dataGridPremiumPr
 import { GridAggregationColumnMenuItem } from '../../../components/GridAggregationColumnMenuItem';
 import { gridAggregationModelSelector } from './gridAggregationSelectors';
 import { GridInitialStatePremium } from '../../../models/gridStatePremium';
+import { GridAggregationRules } from './gridAggregationInterfaces';
 
 function Divider() {
   return <MuiDivider onClick={(event) => event.stopPropagation()} />;
@@ -33,10 +34,12 @@ export const useGridAggregationPreProcessors = (
     'aggregationFunctions' | 'disableAggregation' | 'getAggregationPosition'
   >,
 ) => {
+  // apiRef.current.caches.aggregation.rulesOnLastColumnHydration is not used because by the time
+  // that the pre-processor is called it will already have been updated with the current rules.
+  const rulesOnLastColumnHydration = React.useRef<GridAggregationRules>({});
+
   const updateAggregatedColumns = React.useCallback<GridPipeProcessor<'hydrateColumns'>>(
     (columnsState) => {
-      const { rulesOnLastColumnHydration } = apiRef.current.caches.aggregation;
-
       const aggregationRules = props.disableAggregation
         ? {}
         : getAggregationRules({
@@ -47,7 +50,7 @@ export const useGridAggregationPreProcessors = (
 
       columnsState.orderedFields.forEach((field) => {
         const shouldHaveAggregationValue = !!aggregationRules[field];
-        const haveAggregationColumnValue = !!rulesOnLastColumnHydration[field];
+        const haveAggregationColumnValue = !!rulesOnLastColumnHydration.current[field];
 
         let column = columnsState.lookup[field];
 
@@ -67,6 +70,8 @@ export const useGridAggregationPreProcessors = (
 
         columnsState.lookup[field] = column;
       });
+
+      rulesOnLastColumnHydration.current = aggregationRules;
 
       return columnsState;
     },

--- a/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer, screen, userEvent, within, act } from '@mui/monorepo/test/utils';
 import { expect } from 'chai';
-import { getColumnValues } from 'test/utils/helperFn';
+import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
 import { SinonSpy, spy } from 'sinon';
 import {
   DataGridPremium,
@@ -139,6 +139,13 @@ describe('<DataGridPremium /> - Aggregation', () => {
       it('should ignore aggregation rules with invalid aggregation functions', () => {
         render(<Test initialState={{ aggregation: { model: { id: 'mux' } } }} />);
         expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5']);
+      });
+
+      it('should correctly restore the column when changing from aggregated to non-aggregated', () => {
+        const { setProps } = render(<Test aggregationModel={{ id: 'max' }} />);
+        expect(getColumnHeaderCell(0, 0).textContent).to.equal('idmax');
+        setProps({ aggregationModel: {} });
+        expect(getColumnHeaderCell(0, 0).textContent).to.equal('id');
       });
     });
   });


### PR DESCRIPTION
Preview: https://deploy-preview-7142--material-ui-x.netlify.app/x/react-data-grid/aggregation/

Fixes #7138 

In #7043, I changed to update the cache before applying the pre-processors, but this created a problem where `apiRef.current.caches.aggregation.rulesOnLastColumnHydration` inside the pre-processor would always be equal to the current rules. Now I changed so the pre-processor has its own cache.

https://github.com/mui/mui-x/blob/02df3c6da0d82b3b9709c448512bcebbf9176cd0/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts#L120-L121