### PR TITLE
v6.0.0-alpha.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,117 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.0-alpha.11
+
+_Dec 8, 2022_
+
+We'd like to offer a big thanks to the 7 contributors who made this release possible. Here are some highlights ✨:
+
+- 🚀 Add dragging support for `DateRangePicker` (#6763) @LukasTy
+- ✨ Add missing lazy-loading feature to `DataGridPremium` (#7124) @m4theushw
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v6.0.0-alpha.11` / `@mui/x-data-grid-pro@v6.0.0-alpha.11` / `@mui/x-data-grid-premium@v6.0.0-alpha.11`
+
+#### Breaking changes
+
+- `filterPanelOperators` translation key was renamed to `filterPanelOperator` (#7062) @MBilalShafi
+
+#### Changes
+
+- [DataGrid] Add `GridCell` change in migration guide (#7087) @MBilalShafi
+- [DataGrid] Fixes rows not rendering properly after height change (#6892) @MBilalShafi
+- [DataGrid] Remove `Header` slot (#6999) @cherniavskii
+- [DataGrid] Rename `filterPanelOperators` -> `filterPanelOperator` (#7062) @MBilalShafi
+- [DataGridPremium] Add support for lazy-loading (#7124) @m4theushw
+- [DataGridPremium] Pass `groupId` to aggregation function (#7003) @m4theushw
+
+### `@mui/x-date-pickers@v6.0.0-alpha.11` / `@mui/x-date-pickers-pro@v6.0.0-alpha.11`
+
+#### Breaking changes
+
+- Remove the callback version of the `action` prop on the `actionBar` slot (#7038) @flaviendelangle
+
+  The `action` prop of the `actionBar` slot is no longer supporting a callback.
+  Instead, you can pass a callback at the slot level
+
+  ```diff
+   <DatePicker
+     componentsProps={{
+  -     actionBar: {
+  -       actions: (variant) => (variant === 'desktop' ? [] : ['clear']),
+  -     },
+  +     actionBar: ({ wrapperVariant }) => ({
+  +       actions: wrapperVariant === 'desktop' ? [] : ['clear'],
+  +     }),
+     }}
+   />
+  ```
+
+- The `selectedDays` prop has been removed from the `Day` component (#7066) @flaviendelangle
+  If you need to access it, you can control the value and pass it to the slot using `componentsProps`:
+
+  ```tsx
+  function CustomDay({ selectedDay, ...other }) {
+    // do something with 'selectedDay'
+    return <PickersDay {...other} />;
+  }
+  function App() {
+    const [value, setValue] = React.useState(null);
+    return (
+      <DatePicker
+        value={value}
+        onChange={(newValue) => setValue(newValue)}
+        components={{ Day: CustomDay }}
+        componentsProps={{
+          day: { selectedDay: value },
+        }}
+      />
+    );
+  }
+  ```
+
+- The `currentlySelectingRangeEnd` / `setCurrentlySelectingRangeEnd` props on the Date Range Picker toolbar have been renamed to `rangePosition` / `onRangePositionChange` (#6989) @flaviendelangle
+
+  ```diff
+   const CustomToolbarComponent = props => (
+     <div>
+  -    <button onChange={() => props.setCurrentlySelectingRangeEnd('end')}>Edit end date</button>
+  +    <button onClick={() => props.onRangePositionChange('end')}>Edit end date</button>
+  -    <div>Is editing end date: {props.currentlySelectingRangeEnd === 'end'}</div>
+  +    <div>Is editing end date: {props.rangePosition === 'end'}</div>
+     </div>
+   )
+   <DateRangePicker
+     components={{
+       Toolbar: CustomToolbarComponent
+     }}
+   />
+  ```
+
+#### Changes
+
+- [DateRangePicker] Add dragging support to edit range (#6763) @LukasTy
+- [pickers] Fix lost props on Date Range Pickers (#7092) @flaviendelangle
+- [pickers] Fix toolbar on the new range pickers (#6989) @flaviendelangle
+- [pickers] Improve performance of `DayCalendar` (#7066) @flaviendelangle
+- [pickers] Initialize date without time when selecting year or month (#7120) @LukasTy
+- [pickers] Remove the callback version of the `action` prop in the `actionBar` component slot (#7038) @flaviendelangle
+
+### Docs
+
+- [docs] Fix API page ad space regression (#7051) @oliviertassinari
+- [docs] Update localization doc to use existing locale (#7102) @LukasTy
+
+### Core
+
+- [core] Add codemod to move l10n translation (#7027) @alexfauquette
+- [core] Add notes to remove the legacy pickers internals (#7133) @flaviendelangle
+- [core] Remove internals-fields imports (#7119) @flaviendelangle
+- [core] Remove unused code (#7094) @flaviendelangle
+- [core] Sync `ApiPage.js` with monorepo (#7073) @oliviertassinari
+- [test] Fix karma-mocha assertion error messages (#7054) @cherniavskii
+
 ## 6.0.0-alpha.10
 
 _Dec 1, 2022_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _Dec 8, 2022_
 We'd like to offer a big thanks to the 7 contributors who made this release possible. Here are some highlights ✨:
 
 - 🚀 Add dragging support for the new Date Range Picker (`NextDateRangePicker`) (#6763) @LukasTy
-- ⚡️ Improve performance of `DayCalendar` (#7066) @flaviendelangle
+- ⚡️ Improve performance of the `day` view (#7066) @flaviendelangle
 - ✨ Fix lazy-loading feature not working in `DataGridPremium` (#7124) @m4theushw
 - 🐞 Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,21 @@ _Dec 8, 2022_
 
 We'd like to offer a big thanks to the 7 contributors who made this release possible. Here are some highlights ✨:
 
-- 🚀 Add dragging support for `DateRangePicker` (#6763) @LukasTy
-- ✨ Add missing lazy-loading feature to `DataGridPremium` (#7124) @m4theushw
+- 🚀 Add dragging support for the new Date Range Picker (`NextDateRangePicker`) (#6763) @LukasTy
+- ⚡️ Improve performance of `DayCalendar` (#7066) @flaviendelangle
+- ✨ Fix lazy-loading feature not working in `DataGridPremium` (#7124) @m4theushw
 - 🐞 Bugfixes
 
 ### `@mui/x-data-grid@v6.0.0-alpha.11` / `@mui/x-data-grid-pro@v6.0.0-alpha.11` / `@mui/x-data-grid-premium@v6.0.0-alpha.11`
 
 #### Breaking changes
 
-- `filterPanelOperators` translation key was renamed to `filterPanelOperator` (#7062) @MBilalShafi
+- The `filterPanelOperators` translation key was renamed to `filterPanelOperator` (#7062) @MBilalShafi
+- The `components.Header` slot was removed. Use `components.Toolbar` slot instead (#6999) @cherniavskii
 
 #### Changes
 
-- [DataGrid] Add `GridCell` change in migration guide (#7087) @MBilalShafi
-- [DataGrid] Fixes rows not rendering properly after height change (#6892) @MBilalShafi
+- [DataGrid] Fix rows not rendering properly after height change (#6892) @MBilalShafi
 - [DataGrid] Remove `Header` slot (#6999) @cherniavskii
 - [DataGrid] Rename `filterPanelOperators` -> `filterPanelOperator` (#7062) @MBilalShafi
 - [DataGridPremium] Add support for lazy-loading (#7124) @m4theushw
@@ -35,7 +36,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - Remove the callback version of the `action` prop on the `actionBar` slot (#7038) @flaviendelangle
 
   The `action` prop of the `actionBar` slot is no longer supporting a callback.
-  Instead, you can pass a callback at the slot level
+  Instead, you can pass a callback at the slot level:
 
   ```diff
    <DatePicker
@@ -102,6 +103,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 
 ### Docs
 
+- [docs] Add `GridCell` change in migration guide (#7087) @MBilalShafi
 - [docs] Fix API page ad space regression (#7051) @oliviertassinari
 - [docs] Update localization doc to use existing locale (#7102) @LukasTy
 
@@ -109,7 +111,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 
 - [core] Add codemod to move l10n translation (#7027) @alexfauquette
 - [core] Add notes to remove the legacy pickers internals (#7133) @flaviendelangle
-- [core] Remove internals-fields imports (#7119) @flaviendelangle
+- [core] Remove `internals-fields` imports (#7119) @flaviendelangle
 - [core] Remove unused code (#7094) @flaviendelangle
 - [core] Sync `ApiPage.js` with monorepo (#7073) @oliviertassinari
 - [test] Fix karma-mocha assertion error messages (#7054) @cherniavskii

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "private": true,
   "author": "MUI Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "private": true,
   "scripts": {
     "start": "yarn && yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.1",
     "@mui/base": "^5.0.0-alpha.109",
-    "@mui/x-data-grid-premium": "6.0.0-alpha.10",
+    "@mui/x-data-grid-premium": "6.0.0-alpha.11",
     "chance": "^1.1.9",
     "clsx": "^1.2.1",
     "lru-cache": "^7.14.1"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,9 +44,9 @@
   "dependencies": {
     "@babel/runtime": "^7.20.1",
     "@mui/utils": "^5.10.16",
-    "@mui/x-data-grid": "6.0.0-alpha.10",
-    "@mui/x-data-grid-pro": "6.0.0-alpha.10",
-    "@mui/x-license-pro": "6.0.0-alpha.9",
+    "@mui/x-data-grid": "6.0.0-alpha.11",
+    "@mui/x-data-grid-pro": "6.0.0-alpha.11",
+    "@mui/x-license-pro": "6.0.0-alpha.11",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "exceljs": "^4.3.0",

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -46,7 +46,7 @@
     "@mui/utils": "^5.10.16",
     "@mui/x-data-grid": "6.0.0-alpha.11",
     "@mui/x-data-grid-pro": "6.0.0-alpha.11",
-    "@mui/x-license-pro": "6.0.0-alpha.11",
+    "@mui/x-license-pro": "6.0.0-alpha.10",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "exceljs": "^4.3.0",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -45,7 +45,7 @@
     "@babel/runtime": "^7.20.1",
     "@mui/utils": "^5.10.16",
     "@mui/x-data-grid": "6.0.0-alpha.11",
-    "@mui/x-license-pro": "6.0.0-alpha.11",
+    "@mui/x-license-pro": "6.0.0-alpha.10",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,8 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.20.1",
     "@mui/utils": "^5.10.16",
-    "@mui/x-data-grid": "6.0.0-alpha.10",
-    "@mui/x-license-pro": "6.0.0-alpha.9",
+    "@mui/x-data-grid": "6.0.0-alpha.11",
+    "@mui/x-license-pro": "6.0.0-alpha.11",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-codemod",
-  "version": "6.0.0-alpha.9",
+  "version": "6.0.0-alpha.11",
   "bin": "./codemod.js",
   "private": false,
   "author": "MUI Team",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -48,7 +48,7 @@
     "@date-io/moment": "^2.16.1",
     "@mui/utils": "^5.10.16",
     "@mui/x-date-pickers": "6.0.0-alpha.11",
-    "@mui/x-license-pro": "6.0.0-alpha.11",
+    "@mui/x-license-pro": "6.0.0-alpha.10",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
     "react-transition-group": "^4.4.5",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -47,8 +47,8 @@
     "@date-io/luxon": "^2.16.1",
     "@date-io/moment": "^2.16.1",
     "@mui/utils": "^5.10.16",
-    "@mui/x-date-pickers": "6.0.0-alpha.10",
-    "@mui/x-license-pro": "6.0.0-alpha.9",
+    "@mui/x-date-pickers": "6.0.0-alpha.11",
+    "@mui/x-license-pro": "6.0.0-alpha.11",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
     "react-transition-group": "^4.4.5",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "6.0.0-alpha.10",
+  "version": "6.0.0-alpha.11",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license-pro",
-  "version": "6.0.0-alpha.9",
+  "version": "6.0.0-alpha.11",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license-pro",
-  "version": "6.0.0-alpha.11",
+  "version": "6.0.0-alpha.10",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",


### PR DESCRIPTION
- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [x] Update the root `package.json`'s version
- [x] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
- [x] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
- [x] Open PR with changes and wait for review and green CI.
- [ ] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

```sh
git push upstream next:docs-next -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v5` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)

### Announce

- [ ] Follow the instructions in https://mui-org.notion.site/Releases-7490ef9581b4447ebdbf86b13164272d.