### PR TITLE
[pickers] Clean `autoFocus` behavior on fields and new pickers

### DIFF
--- a/docs/pages/x/api/date-pickers/desktop-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-picker.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/desktop-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-time-picker.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/desktop-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-time-picker.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-picker.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-time-picker.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/next-time-picker.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },

--- a/docs/pages/x/api/date-pickers/static-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-picker.json
@@ -1,5 +1,6 @@
 {
   "props": {
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "components": { "type": { "name": "object" }, "default": "{}" },
     "componentsProps": { "type": { "name": "object" }, "default": "{}" },

--- a/docs/pages/x/api/date-pickers/static-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-time-picker.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "components": { "type": { "name": "object" }, "default": "{}" },
     "componentsProps": { "type": { "name": "object" }, "default": "{}" },

--- a/docs/pages/x/api/date-pickers/static-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-time-picker.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "components": { "type": { "name": "object" }, "default": "{}" },
     "componentsProps": { "type": { "name": "object" }, "default": "{}" },

--- a/docs/translations/api-docs/date-pickers/desktop-next-date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-date-picker-pt.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-date-picker-zh.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-date-picker.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-date-time-picker-pt.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-date-time-picker-zh.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-date-time-picker.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-time-picker-pt.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-time-picker-zh.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/desktop-next-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-next-time-picker.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/next-date-picker-pt.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/next-date-picker-zh.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/next-date-picker.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/next-date-time-picker-pt.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/next-date-time-picker-zh.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/next-date-time-picker.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/next-time-picker-pt.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/next-time-picker-zh.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/next-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/next-time-picker.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the <code>input</code> element is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "closeOnSelect": "If <code>true</code> the popup or dialog will close after submitting full date.",
     "components": "Overrideable components.",

--- a/docs/translations/api-docs/date-pickers/static-next-date-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/static-next-date-picker-pt.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-date-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/static-next-date-picker-zh.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-next-date-picker.json
@@ -1,6 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-date-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/static-next-date-time-picker-pt.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-date-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/static-next-date-time-picker-zh.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-next-date-time-picker.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-time-picker-pt.json
+++ b/docs/translations/api-docs/date-pickers/static-next-time-picker-pt.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-time-picker-zh.json
+++ b/docs/translations/api-docs/date-pickers/static-next-time-picker-zh.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/docs/translations/api-docs/date-pickers/static-next-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-next-time-picker.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
+    "autoFocus": "If <code>true</code>, the view is focused during the first mount.",
     "className": "Class name applied to the root element.",
     "components": "Overrideable components.",
     "componentsProps": "The props used for each component slot.",

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -521,7 +521,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
             renderLoading={renderLoading}
             components={componentsForDayCalendar}
             componentsProps={componentsPropsForDayCalendar}
-            autoFocus={autoFocus}
+            autoFocus={autoFocus && (value[0] == null || utils.isSameMonth(value[0], month))}
             fixedWeekNumber={fixedWeekNumber}
             displayWeekNumber={displayWeekNumber}
           />

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -25,6 +25,7 @@ import {
   useUtils,
   WrapperVariantContext,
   PickerSelectionState,
+  useNow,
 } from '@mui/x-date-pickers/internals';
 import { getReleaseInfo } from '../internal/utils/releaseInfo';
 import {
@@ -149,6 +150,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
 ) {
   const utils = useUtils<TDate>();
   const localeText = useLocaleText<TDate>();
+  const now = useNow<TDate>();
 
   const props = useDateRangeCalendarDefaultizedProps(inProps, 'MuiDateRangeCalendar');
   const isMobile = React.useContext(WrapperVariantContext) === 'mobile';
@@ -456,6 +458,28 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
     [utils, calendarState.currentMonth, calendars],
   );
 
+  const focusedMonth = React.useMemo(() => {
+    if (!autoFocus) {
+      return null;
+    }
+
+    // The focus priority of the "day" view is as follows:
+    // 1. Month of the `start` date
+    // 2. Month of the `end` date
+    // 3. Month of the current date
+    // 4. First visible month
+
+    if (value[0] != null) {
+      return visibleMonths.find((month) => utils.isSameMonth(month, value[0]!));
+    }
+
+    if (value[1] != null) {
+      return visibleMonths.find((month) => utils.isSameMonth(month, value[1]!));
+    }
+
+    return visibleMonths.find((month) => utils.isSameMonth(month, now)) ?? visibleMonths[0];
+  }, [utils, value, visibleMonths, autoFocus, now]);
+
   return (
     <DateRangeCalendarRoot
       ref={ref}
@@ -521,7 +545,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
             renderLoading={renderLoading}
             components={componentsForDayCalendar}
             componentsProps={componentsPropsForDayCalendar}
-            autoFocus={autoFocus && (value[0] == null || utils.isSameMonth(value[0], month))}
+            autoFocus={month === focusedMonth}
             fixedWeekNumber={fixedWeekNumber}
             displayWeekNumber={displayWeekNumber}
           />

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -91,7 +91,6 @@ DateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.
    * @default 2

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -126,7 +126,6 @@ DesktopDateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.
    * @default 2

--- a/packages/x-date-pickers-pro/src/DesktopNextDateRangePicker/DesktopNextDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopNextDateRangePicker/DesktopNextDateRangePicker.tsx
@@ -34,7 +34,6 @@ const DesktopNextDateRangePicker = React.forwardRef(function DesktopNextDateRang
     views: ['day'] as const,
     openTo: 'day' as const,
     showToolbar: defaultizedProps.showToolbar ?? false,
-    autoFocus: true,
     components: {
       Field: MultiInputDateRangeField,
       ...defaultizedProps.components,

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -139,7 +139,6 @@ MobileDateRangePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  autoFocus: PropTypes.bool,
   /**
    * The number of calendars that render on **desktop**.
    * @default 2

--- a/packages/x-date-pickers-pro/src/MobileNextDateRangePicker/MobileNextDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileNextDateRangePicker/MobileNextDateRangePicker.tsx
@@ -34,7 +34,6 @@ const MobileNextDateRangePicker = React.forwardRef(function MobileNextDateRangeP
     views: ['day'] as const,
     openTo: 'day' as const,
     showToolbar: defaultizedProps.showToolbar ?? true,
-    autoFocus: true,
     components: {
       Field: MultiInputDateRangeField,
       ...defaultizedProps.components,

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
@@ -59,6 +59,7 @@ const MultiInputDateRangeField = React.forwardRef(function MultiInputDateRangeFi
     disablePast,
     selectedSections,
     onSelectedSectionsChange,
+    autoFocus,
     ...other
   } = themeProps;
 
@@ -79,6 +80,7 @@ const MultiInputDateRangeField = React.forwardRef(function MultiInputDateRangeFi
   const startInputProps: TextFieldProps = useSlotProps({
     elementType: Input,
     externalSlotProps: componentsProps?.input,
+    additionalProps: { autoFocus },
     ownerState: { ...ownerState, position: 'start' },
   });
 
@@ -148,6 +150,7 @@ MultiInputDateRangeField.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  autoFocus: PropTypes.bool,
   /**
    * Overrideable components.
    * @default {}

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.types.ts
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.types.ts
@@ -24,7 +24,7 @@ export type UseMultiInputDateRangeFieldComponentProps<TDate, TChildProps extends
   UseMultiInputDateRangeFieldProps<TDate>;
 
 export interface MultiInputDateRangeFieldProps<TDate>
-  extends UseMultiInputDateRangeFieldComponentProps<TDate, {}> {
+  extends UseMultiInputDateRangeFieldComponentProps<TDate, { autoFocus?: boolean }> {
   /**
    * Overrideable components.
    * @default {}

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -44,6 +44,7 @@ export const useDesktopRangePicker = <
     format,
     readOnly,
     disabled,
+    autoFocus,
     disableOpenPicker,
     localeText,
   } = props;
@@ -109,6 +110,7 @@ export const useDesktopRangePicker = <
       disabled,
       className,
       format,
+      autoFocus,
       ref: fieldRef,
     },
     ownerState: props,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -44,6 +44,7 @@ export const useDesktopRangePicker = <
     format,
     readOnly,
     disabled,
+    autoFocus,
     disableOpenPicker,
     localeText,
   } = props;
@@ -110,9 +111,7 @@ export const useDesktopRangePicker = <
       disabled,
       className,
       format,
-      // If we stop opening the view when `autoFocus = true` on the picker,
-      // The add back the `autoFocus` here to forward it to the field.
-      // autoFocus,
+      autoFocus: autoFocus && !props.open,
       ref: fieldRef,
     },
     ownerState: props,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -65,6 +65,7 @@ export const useDesktopRangePicker = <
     wrapperVariant: 'desktop',
     viewLookup,
     validator,
+    autoFocusView: true,
     additionalViewProps: {
       rangePosition,
       onRangePositionChange: setRangePosition,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -44,7 +44,6 @@ export const useDesktopRangePicker = <
     format,
     readOnly,
     disabled,
-    autoFocus,
     disableOpenPicker,
     localeText,
   } = props;
@@ -110,7 +109,9 @@ export const useDesktopRangePicker = <
       disabled,
       className,
       format,
-      autoFocus,
+      // If we stop opening the view when `autoFocus = true` on the picker,
+      // The add back the `autoFocus` here to forward it to the field.
+      // autoFocus,
       ref: fieldRef,
     },
     ownerState: props,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -61,6 +61,7 @@ export const useMobileRangePicker = <
     wrapperVariant: 'mobile',
     viewLookup,
     validator,
+    autoFocusView: true,
     additionalViewProps: {
       rangePosition,
       onRangePositionChange: setRangePosition,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useRangePickerInputProps.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useRangePickerInputProps.ts
@@ -48,9 +48,9 @@ export const useRangePickerInputProps = <TDate, TView extends DateOrTimeView>({
   }, [rangePosition, open]);
 
   const openRangeStartSelection = (
-    event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ) => {
-    event?.stopPropagation();
+    event.stopPropagation();
     onRangePositionChange('start');
     if (!readOnly && !disableOpenPicker) {
       actions.onOpen();
@@ -58,24 +58,14 @@ export const useRangePickerInputProps = <TDate, TView extends DateOrTimeView>({
   };
 
   const openRangeEndSelection = (
-    event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ) => {
-    event?.stopPropagation();
+    event.stopPropagation();
     onRangePositionChange('end');
     if (!readOnly && !disableOpenPicker) {
       actions.onOpen();
     }
   };
-
-  React.useEffect(() => {
-    if (startRef.current && startRef.current === document.activeElement) {
-      openRangeStartSelection();
-      return;
-    }
-    if (endRef.current && endRef.current === document.activeElement) {
-      openRangeEndSelection();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const focusOnRangeStart = () => {
     if (open) {

--- a/packages/x-date-pickers-pro/src/internal/hooks/useRangePickerInputProps.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useRangePickerInputProps.ts
@@ -48,7 +48,7 @@ export const useRangePickerInputProps = <TDate, TView extends DateOrTimeView>({
   }, [rangePosition, open]);
 
   const openRangeStartSelection = (
-    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ) => {
     event?.stopPropagation();
     onRangePositionChange('start');
@@ -58,7 +58,7 @@ export const useRangePickerInputProps = <TDate, TView extends DateOrTimeView>({
   };
 
   const openRangeEndSelection = (
-    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    event?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
   ) => {
     event?.stopPropagation();
     onRangePositionChange('end');
@@ -66,6 +66,16 @@ export const useRangePickerInputProps = <TDate, TView extends DateOrTimeView>({
       actions.onOpen();
     }
   };
+
+  React.useEffect(() => {
+    if (startRef.current && startRef.current === document.activeElement) {
+      openRangeStartSelection();
+      return;
+    }
+    if (endRef.current && endRef.current === document.activeElement) {
+      openRangeEndSelection();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const focusOnRangeStart = () => {
     if (open) {

--- a/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.tsx
@@ -37,7 +37,7 @@ export const useStaticRangePicker = <
   validator,
   ref,
 }: UseStaticRangePickerParams<TDate, TView, TExternalProps>) => {
-  const { localeText, components, componentsProps, displayStaticWrapperAs } = props;
+  const { localeText, components, componentsProps, displayStaticWrapperAs, autoFocus } = props;
 
   const [rangePosition, setRangePosition] = React.useState<RangePosition>('start');
 
@@ -46,6 +46,7 @@ export const useStaticRangePicker = <
     viewLookup,
     valueManager,
     validator,
+    autoFocusView: autoFocus ?? false,
     additionalViewProps: {},
     wrapperVariant: displayStaticWrapperAs,
   });

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -168,6 +168,7 @@ export type ExportedDateCalendarProps<TDate> = Omit<
   | 'componentsProps'
   | 'onFocusedViewChange'
   | 'focusedView'
+  | 'autoFocus'
 >;
 
 export type DateCalendarDefaultizedProps<TDate> = DefaultizedProps<

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -499,7 +499,6 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
             <YearCalendar<TDate>
               {...baseDateValidationProps}
               {...commonViewProps}
-              autoFocus={autoFocus}
               value={value}
               onChange={handleDateYearChange}
               shouldDisableYear={shouldDisableYear}
@@ -512,7 +511,6 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
             <MonthCalendar<TDate>
               {...baseDateValidationProps}
               {...commonViewProps}
-              autoFocus={autoFocus}
               hasFocus={hasFocus}
               className={className}
               value={value}
@@ -527,7 +525,6 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
               {...calendarState}
               {...baseDateValidationProps}
               {...commonViewProps}
-              autoFocus={autoFocus}
               onMonthSwitchingAnimationEnd={onMonthSwitchingAnimationEnd}
               onFocusedDayChange={changeFocusedDay}
               reduceAnimations={reduceAnimations}

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -25,6 +25,15 @@ describe('<DateField /> - Selection', () => {
   };
 
   describe('Focus', () => {
+    it('should select all on mount focus (`autoFocus = true`)', () => {
+      render(<DateField autoFocus />);
+      const input = screen.getByRole('textbox');
+
+      expect(input.value).to.equal('MM / DD / YYYY');
+      expect(input.selectionStart).to.equal(0);
+      expect(input.selectionEnd).to.equal(input.value.length);
+    });
+
     it('should select all on <Tab> focus', () => {
       render(<DateField />);
       const input = screen.getByRole('textbox');

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -86,7 +86,6 @@ DatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -96,7 +96,6 @@ DateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -109,7 +109,6 @@ DesktopDatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -122,7 +122,6 @@ DesktopDateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/DesktopNextDatePicker/DesktopNextDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopNextDatePicker/DesktopNextDatePicker.tsx
@@ -42,7 +42,6 @@ const DesktopNextDatePicker = React.forwardRef(function DesktopNextDatePicker<TD
     ...defaultizedProps,
     format: getDatePickerFieldFormat(utils, defaultizedProps),
     showToolbar: defaultizedProps.showToolbar ?? false,
-    autoFocus: true,
     components: {
       OpenPickerIcon: Calendar,
       Field: DateField,
@@ -78,6 +77,9 @@ DesktopNextDatePicker.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
   autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.

--- a/packages/x-date-pickers/src/DesktopNextDateTimePicker/DesktopNextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopNextDateTimePicker/DesktopNextDateTimePicker.tsx
@@ -40,7 +40,6 @@ const DesktopNextDateTimePicker = React.forwardRef(function DesktopNextDateTimeP
   const props = {
     ...defaultizedProps,
     showToolbar: defaultizedProps.showToolbar ?? false,
-    autoFocus: true,
     components: {
       Field: DateTimeField,
       OpenPickerIcon: Calendar,
@@ -87,6 +86,9 @@ DesktopNextDateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
   autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.

--- a/packages/x-date-pickers/src/DesktopNextTimePicker/DesktopNextTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopNextTimePicker/DesktopNextTimePicker.tsx
@@ -36,7 +36,6 @@ const DesktopNextTimePicker = React.forwardRef(function DesktopNextTimePicker<TD
   const props = {
     ...defaultizedProps,
     showToolbar: defaultizedProps.showToolbar ?? false,
-    autoFocus: true,
     components: {
       Field: TimeField,
       OpenPickerIcon: Clock,
@@ -83,6 +82,9 @@ DesktopNextTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
   autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -112,7 +112,6 @@ MobileDatePicker.propTypes = {
    * @default /\dap/gi
    */
   acceptRegex: PropTypes.instanceOf(RegExp),
-  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -123,7 +123,6 @@ MobileDateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   /**
    * className applied to the root component.

--- a/packages/x-date-pickers/src/MobileNextDatePicker/MobileNextDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileNextDatePicker/MobileNextDatePicker.tsx
@@ -41,7 +41,6 @@ const MobileNextDatePicker = React.forwardRef(function MobileNextDatePicker<TDat
     ...defaultizedProps,
     format: getDatePickerFieldFormat(utils, defaultizedProps),
     showToolbar: defaultizedProps.showToolbar ?? true,
-    autoFocus: true,
     components: {
       Field: DateField,
       ...defaultizedProps.components,
@@ -76,7 +75,6 @@ MobileNextDatePicker.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
-  autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.
    */

--- a/packages/x-date-pickers/src/MobileNextDateTimePicker/MobileNextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileNextDateTimePicker/MobileNextDateTimePicker.tsx
@@ -39,7 +39,6 @@ const MobileNextDateTimePicker = React.forwardRef(function MobileNextDateTimePic
   const props = {
     ...defaultizedProps,
     showToolbar: defaultizedProps.showToolbar ?? true,
-    autoFocus: true,
     components: {
       Field: DateTimeField,
       ...defaultizedProps.components,
@@ -85,7 +84,6 @@ MobileNextDateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.
    */

--- a/packages/x-date-pickers/src/MobileNextTimePicker/MobileNextTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileNextTimePicker/MobileNextTimePicker.tsx
@@ -36,7 +36,6 @@ const MobileNextTimePicker = React.forwardRef(function MobileNextTimePicker<TDat
   const props = {
     ...defaultizedProps,
     showToolbar: defaultizedProps.showToolbar ?? true,
-    autoFocus: true,
     components: {
       Field: TimeField,
       ...defaultizedProps.components,
@@ -82,7 +81,6 @@ MobileNextTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.
    */

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -173,11 +173,11 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
   }, [now, value, utils, disableHighlightToday]);
   const [focusedMonth, setFocusedMonth] = React.useState(() => selectedMonth || todayMonth);
 
-  const [internalHasFocus, setInternalHasFocus] = useControlled<boolean>({
+  const [internalHasFocus, setInternalHasFocus] = useControlled({
     name: 'MonthCalendar',
     state: 'hasFocus',
     controlled: hasFocus,
-    default: autoFocus,
+    default: autoFocus ?? false,
   });
 
   const changeHasFocus = useEventCallback((newHasFocus: boolean) => {

--- a/packages/x-date-pickers/src/NextDatePicker/NextDatePicker.tsx
+++ b/packages/x-date-pickers/src/NextDatePicker/NextDatePicker.tsx
@@ -33,6 +33,9 @@ NextDatePicker.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
   autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.

--- a/packages/x-date-pickers/src/NextDateTimePicker/NextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/NextDateTimePicker/NextDateTimePicker.tsx
@@ -43,6 +43,9 @@ NextDateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
   autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.

--- a/packages/x-date-pickers/src/NextTimePicker/NextTimePicker.tsx
+++ b/packages/x-date-pickers/src/NextTimePicker/NextTimePicker.tsx
@@ -43,6 +43,9 @@ NextTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
   autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.

--- a/packages/x-date-pickers/src/StaticNextDatePicker/StaticNextDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticNextDatePicker/StaticNextDatePicker.tsx
@@ -51,7 +51,6 @@ StaticNextDatePicker.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
-  autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.
    */

--- a/packages/x-date-pickers/src/StaticNextDatePicker/StaticNextDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticNextDatePicker/StaticNextDatePicker.tsx
@@ -52,6 +52,10 @@ StaticNextDatePicker.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
+   * If `true`, the view is focused during the first mount.
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Class name applied to the root element.
    */
   className: PropTypes.string,

--- a/packages/x-date-pickers/src/StaticNextDateTimePicker/StaticNextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticNextDateTimePicker/StaticNextDateTimePicker.tsx
@@ -72,7 +72,6 @@ StaticNextDateTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.
    */

--- a/packages/x-date-pickers/src/StaticNextDateTimePicker/StaticNextDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticNextDateTimePicker/StaticNextDateTimePicker.tsx
@@ -73,6 +73,10 @@ StaticNextDateTimePicker.propTypes = {
    */
   ampmInClock: PropTypes.bool,
   /**
+   * If `true`, the view is focused during the first mount.
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Class name applied to the root element.
    */
   className: PropTypes.string,

--- a/packages/x-date-pickers/src/StaticNextTimePicker/StaticNextTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticNextTimePicker/StaticNextTimePicker.tsx
@@ -62,7 +62,6 @@ StaticNextTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
-  autoFocus: PropTypes.bool,
   /**
    * Class name applied to the root element.
    */

--- a/packages/x-date-pickers/src/StaticNextTimePicker/StaticNextTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticNextTimePicker/StaticNextTimePicker.tsx
@@ -63,6 +63,10 @@ StaticNextTimePicker.propTypes = {
    */
   ampmInClock: PropTypes.bool,
   /**
+   * If `true`, the view is focused during the first mount.
+   */
+  autoFocus: PropTypes.bool,
+  /**
    * Class name applied to the root element.
    */
   className: PropTypes.string,

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
@@ -129,6 +129,7 @@ StaticTimePicker.propTypes = {
    * @default false
    */
   ampmInClock: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   /**
    * className applied to the root component.
    */

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -173,11 +173,11 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
   }, [now, value, utils, disableHighlightToday]);
   const [focusedYear, setFocusedYear] = React.useState(() => selectedYear || todayYear);
 
-  const [internalHasFocus, setInternalHasFocus] = useControlled<boolean>({
+  const [internalHasFocus, setInternalHasFocus] = useControlled({
     name: 'YearCalendar',
     state: 'hasFocus',
     controlled: hasFocus,
-    default: autoFocus,
+    default: autoFocus ?? false,
   });
 
   const changeHasFocus = useEventCallback((newHasFocus: boolean) => {

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -74,7 +74,7 @@ export const useDesktopPicker = <
       disabled,
       className,
       format,
-      autoFocus,
+      autoFocus: autoFocus && !props.open,
     },
     ownerState: props,
   });

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -77,7 +77,7 @@ export const useDesktopPicker = <
     },
     ownerState: props,
   });
-
+  
   const InputAdornment = components.InputAdornment ?? MuiInputAdornment;
   const inputAdornmentProps = useSlotProps({
     elementType: InputAdornment,

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -31,7 +31,16 @@ export const useDesktopPicker = <
   viewLookup,
   validator,
 }: UseDesktopPickerParams<TDate, TView, TExternalProps>) => {
-  const { components, componentsProps, className, format, readOnly, disabled, localeText } = props;
+  const {
+    components,
+    componentsProps,
+    className,
+    format,
+    readOnly,
+    disabled,
+    autoFocus,
+    localeText,
+  } = props;
 
   const utils = useUtils<TDate>();
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -64,6 +73,7 @@ export const useDesktopPicker = <
       disabled,
       className,
       format,
+      autoFocus,
     },
     ownerState: props,
   });

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -59,6 +59,7 @@ export const useDesktopPicker = <
     viewLookup,
     valueManager,
     validator,
+    autoFocusView: true,
     additionalViewProps: {},
     wrapperVariant: 'desktop',
   });

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -77,7 +77,7 @@ export const useDesktopPicker = <
     },
     ownerState: props,
   });
-  
+
   const InputAdornment = components.InputAdornment ?? MuiInputAdornment;
   const inputAdornmentProps = useSlotProps({
     elementType: InputAdornment,

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
@@ -74,7 +74,12 @@ export interface UseDesktopPickerSlotsComponentsProps<TDate, TView extends DateO
 export interface DesktopOnlyPickerProps<TDate>
   extends BaseNextNonStaticPickerProps,
     UsePickerValueNonStaticProps<TDate | null>,
-    UsePickerViewsNonStaticProps {}
+    UsePickerViewsNonStaticProps {
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   */
+  autoFocus?: boolean;
+}
 
 export interface UseDesktopPickerProps<TDate, TView extends DateOrTimeView, TError>
   extends BaseNextPickerProps<TDate | null, TDate, TView, TError>,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -90,12 +90,12 @@ export const useField = <
   const handleInputFocus = useEventCallback((...args) => {
     onFocus?.(...(args as []));
     // The ref is guaranteed to be resolved that this point.
-    const input = inputRef.current as HTMLInputElement;
+    const input = inputRef.current;
 
     clearTimeout(focusTimeoutRef.current);
     focusTimeoutRef.current = setTimeout(() => {
       // The ref changed, the component got remounted, the focus event is no longer relevant.
-      if (input !== inputRef.current) {
+      if (!input || input !== inputRef.current) {
         return;
       }
 
@@ -464,8 +464,13 @@ export const useField = <
   );
 
   React.useEffect(() => {
+    // Select the right section when focused on mount (`autoFocus = true` on the input)
+    if (inputRef.current && inputRef.current === document.activeElement) {
+      setSelectedSections({ startIndex: 0, endIndex: state.sections.length - 1 });
+    }
+
     return () => window.clearTimeout(focusTimeoutRef.current);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const valueStr = React.useMemo(
     () => state.tempValueStrAndroid ?? fieldValueManager.getValueStrFromSections(state.sections),

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -47,6 +47,7 @@ export const useMobilePicker = <
     viewLookup,
     valueManager,
     validator,
+    autoFocusView: true,
     additionalViewProps: {},
     wrapperVariant: 'mobile',
   });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
@@ -19,6 +19,7 @@ export const usePicker = <
   inputRef,
   additionalViewProps,
   validator,
+  autoFocusView,
 }: UsePickerParams<TValue, TDate, TView, TExternalProps, TAdditionalProps>): UsePickerResponse<
   TValue,
   TView,
@@ -37,6 +38,7 @@ export const usePicker = <
     viewLookup,
     wrapperVariant,
     additionalViewProps,
+    autoFocusView,
     propsFromPickerValue: pickerValueResponse.viewProps,
   });
 

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
@@ -38,7 +38,7 @@ export interface UsePickerParams<
     >,
     Pick<
       UsePickerViewParams<TValue, TView, TExternalProps, TAdditionalProps>,
-      'viewLookup' | 'additionalViewProps' | 'inputRef'
+      'viewLookup' | 'additionalViewProps' | 'inputRef' | 'autoFocusView'
     > {
   props: TExternalProps;
 }

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
@@ -29,7 +29,6 @@ export type PickerViewRendererLookup<
  * Props used to handle the views that are common to all pickers.
  */
 export interface UsePickerViewsBaseProps<TView extends DateOrTimeView> {
-  autoFocus?: boolean;
   /**
    * If `true`, the picker and text field are disabled.
    * @default false
@@ -146,7 +145,7 @@ export const usePickerViews = <
   TAdditionalProps
 >): UsePickerViewsResponse<TView> => {
   const { onChange, open, onSelectedSectionsChange, onClose } = propsFromPickerValue;
-  const { views, openTo, onViewChange, disableOpenPicker, autoFocus } = props;
+  const { views, openTo, onViewChange, disableOpenPicker } = props;
 
   if (process.env.NODE_ENV !== 'production') {
     if (!warnedOnceNotValidOpenTo && !views.includes(openTo)) {
@@ -167,7 +166,7 @@ export const usePickerViews = <
   });
 
   // TODO v6: Move `useFocusManagement` here
-  const { focusedView, setFocusedView } = useFocusManagement<TView>({ autoFocus, openView });
+  const { focusedView, setFocusedView } = useFocusManagement<TView>({ autoFocus: true, openView });
 
   const { hasUIView, viewModeLookup } = React.useMemo(
     () =>

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
@@ -84,6 +84,7 @@ export interface UsePickerViewParams<
   additionalViewProps: TAdditionalProps;
   inputRef?: React.RefObject<HTMLInputElement>;
   wrapperVariant: WrapperVariant;
+  autoFocusView: boolean;
 }
 
 export interface UsePickerViewsResponse<TView extends DateOrTimeView> {
@@ -138,6 +139,7 @@ export const usePickerViews = <
   additionalViewProps,
   inputRef,
   wrapperVariant,
+  autoFocusView,
 }: UsePickerViewParams<
   TValue,
   TView,
@@ -166,7 +168,10 @@ export const usePickerViews = <
   });
 
   // TODO v6: Move `useFocusManagement` here
-  const { focusedView, setFocusedView } = useFocusManagement<TView>({ autoFocus: true, openView });
+  const { focusedView, setFocusedView } = useFocusManagement<TView>({
+    autoFocus: autoFocusView,
+    openView,
+  });
 
   const { hasUIView, viewModeLookup } = React.useMemo(
     () =>

--- a/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
@@ -31,13 +31,14 @@ export const useStaticPicker = <
   validator,
   ref,
 }: UseStaticPickerParams<TDate, TView, TExternalProps>) => {
-  const { localeText, components, componentsProps, displayStaticWrapperAs } = props;
+  const { localeText, components, componentsProps, displayStaticWrapperAs, autoFocus } = props;
 
   const { layoutProps, renderCurrentView } = usePicker({
     props,
     viewLookup,
     valueManager,
     validator,
+    autoFocusView: autoFocus ?? false,
     additionalViewProps: {},
     wrapperVariant: displayStaticWrapperAs,
   });

--- a/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.types.ts
@@ -18,6 +18,10 @@ export interface StaticOnlyPickerProps {
    * @default "mobile"
    */
   displayStaticWrapperAs: 'desktop' | 'mobile';
+  /**
+   * If `true`, the view is focused during the first mount.
+   */
+  autoFocus?: boolean;
 }
 
 export interface UseStaticPickerProps<TDate, TView extends DateOrTimeView, TError>

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -131,7 +131,13 @@ export type {
   UseStaticPickerSlotsComponent,
   UseStaticPickerSlotsComponentsProps,
 } from './hooks/useStaticPicker';
-export { useLocalizationContext, useDefaultDates, useUtils, useLocaleText } from './hooks/useUtils';
+export {
+  useLocalizationContext,
+  useDefaultDates,
+  useUtils,
+  useLocaleText,
+  useNow,
+} from './hooks/useUtils';
 export type {
   BaseDateValidationProps,
   BaseTimeValidationProps,

--- a/packages/x-date-pickers/src/internals/models/props/staticPickerProps.ts
+++ b/packages/x-date-pickers/src/internals/models/props/staticPickerProps.ts
@@ -6,4 +6,6 @@ export type StaticPickerProps<TDate, BaseProps extends BasePickerProps<any, TDat
   BaseProps,
   'open' | 'onOpen' | 'onClose'
 > &
-  ExportedPickerStaticWrapperProps;
+  ExportedPickerStaticWrapperProps & {
+    autoFocus?: boolean;
+  };

--- a/packages/x-date-pickers/src/internals/utils/viewRenderers.tsx
+++ b/packages/x-date-pickers/src/internals/utils/viewRenderers.tsx
@@ -41,5 +41,7 @@ export const renderTimeView = <TDate extends unknown>(props: TimeViewRendererPro
     view={props.view as TimeView}
     // We don't want to pass this prop to the views because it can cause proptypes warnings
     openTo={undefined}
+    // TODO: Remove when `TimeClock` will support `focusedView`
+    autoFocus
   />
 );


### PR DESCRIPTION
A lot of small big / small fixes when our components receive `autoFocus: true`.
I tried to clarify the when the field / view should be focused.
I hope I did not introduce any regression.

## Expected behavior

### Single Input Field

- `autoFocus: true` => focus the input and select all sections
- `autoFocus: false` => don't focus the input

### Multi Input Field

- `autoFocus: true` => focus the first input and select all of its sections
- `autoFocus: false` => don't focus any input

### Desktop Single Item Pickers

If `props.open === false` on mount

- `autoFocus: true` => focus the input and select all sections
- `autoFocus: false` => don't focus the input

If `props.open === true` on mount

- `autoFocus: true` => focus the visible view
- `autoFocus: false` => focus the visible view
(the `autoFocus` has no effect)

### Desktop Range Pickers

If `props.open === false` on mount

- `autoFocus: true` => focus the first input and select all of its sections
- `autoFocus: false` => don't focus any input

If `props.open === true` on mount

- `autoFocus: true` => focus the visible view
- `autoFocus: false` => focus the visible view
(the `autoFocus` has no effect)

### Mobile Pickers

No `autoFocus` prop

### Static Pickers

- `autoFocus: true` => focus the visible view
- `autoFocus: false` => don't focus anything inside the component

