### PR TITLE
Update DateTimePicker export pattern to match

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -59,7 +59,7 @@ type DateTimePickerComponent = (<TDate>(
  *
  * - [DateTimePicker API](https://mui.com/x/api/date-pickers/date-time-picker/)
  */
-const DateTimePicker = React.forwardRef(function DateTimePicker<TDate>(
+export const DateTimePicker = React.forwardRef(function DateTimePicker<TDate>(
   inProps: DateTimePickerProps<TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
@@ -423,5 +423,3 @@ DateTimePicker.propTypes = {
     PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']).isRequired,
   ),
 } as any;
-
-export { DateTimePicker };


### PR DESCRIPTION
DateTimePickers export pattern doesn't match how all the other components are exported. This fixes that, see [DatePicker for ref](https://github.com/mui/mui-x/blob/next/packages/x-date-pickers/src/DatePicker/DatePicker.tsx#L62). 

This change fixes an issue with [react-docgen-typescript](https://www.npmjs.com/package/react-docgen-typescript) being able to locate the component.

Signed-off-by: Keal Jones <41018730+kealjones-wk@users.noreply.github.com>