### PR TITLE
[DateTimePicker] Update export pattern

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -59,10 +59,10 @@ type DateTimePickerComponent = (<TInputDate, TDate = TInputDate>(
  *
  * - [DateTimePicker API](https://mui.com/x/api/date-pickers/date-time-picker/)
  */
-export const DateTimePicker = React.forwardRef(function DateTimePicker<TInputDate, TDate = TInputDate>(
-  inProps: DateTimePickerProps<TInputDate, TDate>,
-  ref: React.Ref<HTMLDivElement>,
-) {
+export const DateTimePicker = React.forwardRef(function DateTimePicker<
+  TInputDate,
+  TDate = TInputDate,
+>(inProps: DateTimePickerProps<TInputDate, TDate>, ref: React.Ref<HTMLDivElement>) {
   const props = useThemeProps({ props: inProps, name: 'MuiDateTimePicker' });
   const {
     desktopModeMediaQuery = '@media (pointer: fine)',

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -59,7 +59,7 @@ type DateTimePickerComponent = (<TInputDate, TDate = TInputDate>(
  *
  * - [DateTimePicker API](https://mui.com/x/api/date-pickers/date-time-picker/)
  */
-const DateTimePicker = React.forwardRef(function DateTimePicker<TInputDate, TDate = TInputDate>(
+export const DateTimePicker = React.forwardRef(function DateTimePicker<TInputDate, TDate = TInputDate>(
   inProps: DateTimePickerProps<TInputDate, TDate>,
   ref: React.Ref<HTMLDivElement>,
 ) {
@@ -501,5 +501,3 @@ DateTimePicker.propTypes = {
     PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']).isRequired,
   ),
 } as any;
-
-export { DateTimePicker };


### PR DESCRIPTION
DateTimePickers export pattern doesn't match that of all the other x-date-picker components. 

This change fixes an issue with [react-docgen-typescript](https://www.npmjs.com/package/react-docgen-typescript) being able to locate the component. I am already in the process of looking for a fix in react-docgen-typescript but its not as simple. This change over here seems small enough and has no impact and would improve consistency, so maybe we could get this in in the meantime?

Examples of other component exports:
[ClockPicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/ClockPicker/ClockPicker.tsx#L206)
[CalendarPicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/CalendarPicker/CalendarPicker.tsx#L216)
[DatePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/DatePicker/DatePicker.tsx#L62)
[DesktopDateTimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx#L64)
[DesktopDatePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx#L61)
[DesktopTimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx#L63)
[LocalizationProvider](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx#L55)
[MobileDatePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx#L61)
[MobileTimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx#L62)
[MobileDateTimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx#L63)
[MonthPicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/MonthPicker/MonthPicker.tsx#L105)
[PickersActionBar](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx#L27)
[PickersDay](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/PickersDay/PickersDay.tsx#L403)
[StaticDatePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx#L61)
[StaticDateTimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx#L62)
[StaticTimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx#L61)
[TimePicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/TimePicker/TimePicker.tsx#L62)
[YearPicker](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/YearPicker/YearPicker.tsx#L90)

Signed-off-by: Keal Jones <41018730+kealjones-wk@users.noreply.github.com>