### PR TITLE
Fix gridcoltype autocomplete

### DIFF
--- a/packages/grid/x-data-grid/src/models/colDef/gridColType.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColType.ts
@@ -15,7 +15,10 @@ export type GridNativeColTypes =
  */
 type LiteralAnyString = string & Record<never, never>
 
+/**
+ * Immitate typescript's template literal syntax to document in autocomplete that the string type is open for extension.
+ */
 // eslint-disable-next-line no-template-curly-in-string
-type LiteralAnyStringPrompt = '${string}'
+type LiteralAnyStringDocPrompt = '${string}'
 
-export type GridColType = GridNativeColTypes | LiteralAnyStringPrompt | LiteralAnyString;
+export type GridColType = GridNativeColTypes | LiteralAnyStringDocPrompt | LiteralAnyString;

--- a/packages/grid/x-data-grid/src/models/colDef/gridColType.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColType.ts
@@ -7,4 +7,15 @@ export type GridNativeColTypes =
   | 'singleSelect'
   | 'actions';
 
-export type GridColType = GridNativeColTypes | string;
+/**
+ * Workaround for Typescript losing type information when a string literal is opened up to any string
+ * 
+ * Can be removed if this issue is ever resolved:
+ * https://github.com/Microsoft/TypeScript/issues/29729
+ */
+type LiteralAnyString = string & Record<never, never>
+
+// eslint-disable-next-line no-template-curly-in-string
+type LiteralAnyStringPrompt = '${string}'
+
+export type GridColType = GridNativeColTypes | LiteralAnyStringPrompt | LiteralAnyString;


### PR DESCRIPTION
Fixes #7173

This PR enables editor autocomplete for gridColType which should improve the developer experience of defining columns

Just an initial draft for now as there are a few ideas I'm bouncing around, small stuff but will leave some comments with my reasoning