### PR TITLE
[docs] Fix 301 links to demo pages in API pages

### DIFF
--- a/docs/pages/x/api/date-pickers/date-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-calendar.json
@@ -78,7 +78,7 @@
     "name": "MuiDateCalendar"
   },
   "filename": "/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateCalendar" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateCalendar" }

--- a/docs/pages/x/api/date-pickers/date-field.json
+++ b/docs/pages/x/api/date-pickers/date-field.json
@@ -27,7 +27,7 @@
   "name": "DateField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDateField" },
   "filename": "/packages/x-date-pickers/src/DateField/DateField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-field\">Date Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-field/\">Date Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DateField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DateField" }

--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -123,7 +123,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDatePicker" },
   "filename": "/packages/x-date-pickers/src/DatePicker/DatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DatePicker" }

--- a/docs/pages/x/api/date-pickers/date-range-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.json
@@ -60,6 +60,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li></ul>",
   "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangeCalendar" }]
 }

--- a/docs/pages/x/api/date-pickers/date-range-picker-day.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-day.json
@@ -41,6 +41,6 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li></ul>",
   "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePickerDay" }]
 }

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -112,6 +112,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker/\">Date Range Picker </a></li></ul>",
   "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePicker" }]
 }

--- a/docs/pages/x/api/date-pickers/date-time-field.json
+++ b/docs/pages/x/api/date-pickers/date-time-field.json
@@ -35,7 +35,7 @@
   "name": "DateTimeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDateTimeField" },
   "filename": "/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-field\">Date Time Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-field/\">Date Time Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DateTimeField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DateTimeField" }

--- a/docs/pages/x/api/date-pickers/date-time-picker-tabs.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker-tabs.json
@@ -20,7 +20,7 @@
   "name": "DateTimePickerTabs",
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiDateTimePickerTabs" },
   "filename": "/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/custom-components\">Custom components</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/custom-components/\">Custom components</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateTimePickerTabs" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateTimePickerTabs" }

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -135,7 +135,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker\">Date Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker/\">Date Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateTimePicker" }

--- a/docs/pages/x/api/date-pickers/day-calendar-skeleton.json
+++ b/docs/pages/x/api/date-pickers/day-calendar-skeleton.json
@@ -19,7 +19,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DayCalendarSkeleton" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DayCalendarSkeleton" }

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.json
@@ -116,7 +116,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDesktopDatePicker" },
   "filename": "/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DesktopDatePicker" }

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -105,7 +105,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker/\">Date Range Picker </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDateRangePicker" }
   ]

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -128,7 +128,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDesktopDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker\">Date Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker/\">Date Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DesktopDateTimePicker" }

--- a/docs/pages/x/api/date-pickers/desktop-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-picker.json
@@ -116,7 +116,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDesktopNextDatePicker" },
   "filename": "/packages/x-date-pickers/src/DesktopNextDatePicker/DesktopNextDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DesktopNextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DesktopNextDatePicker" }

--- a/docs/pages/x/api/date-pickers/desktop-next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-range-picker.json
@@ -96,7 +96,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DesktopNextDateRangePicker/DesktopNextDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/desktop-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-date-time-picker.json
@@ -126,7 +126,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDesktopNextDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/DesktopNextDateTimePicker/DesktopNextDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker/\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/desktop-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-next-time-picker.json
@@ -94,7 +94,7 @@
   "name": "DesktopNextTimePicker",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiDesktopNextTimePicker" },
   "filename": "/packages/x-date-pickers/src/DesktopNextTimePicker/DesktopNextTimePicker.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker/\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_DesktopNextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_DesktopNextTimePicker" }

--- a/docs/pages/x/api/date-pickers/desktop-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-picker.json
@@ -91,7 +91,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker\">Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker/\">Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DesktopTimePicker" }

--- a/docs/pages/x/api/date-pickers/localization-provider.json
+++ b/docs/pages/x/api/date-pickers/localization-provider.json
@@ -16,7 +16,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiLocalizationProvider" },
   "filename": "/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/adapters-locale\">Localized dates</a></li>\n<li><a href=\"/x/react-date-pickers/calendar-systems\">Support for other calendar systems</a></li>\n<li><a href=\"/x/react-date-pickers/localization\">Localization</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/adapters-locale/\">Localized dates</a></li>\n<li><a href=\"/x/react-date-pickers/calendar-systems/\">Support for other calendar systems</a></li>\n<li><a href=\"/x/react-date-pickers/localization/\">Localization</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "LocalizationProvider" },
     { "packageName": "@mui/x-date-pickers", "componentName": "LocalizationProvider" }

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.json
@@ -108,7 +108,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMobileDatePicker" },
   "filename": "/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MobileDatePicker" }

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -97,7 +97,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker/\">Date Range Picker </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDateRangePicker" }
   ]

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
@@ -120,7 +120,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMobileDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker\">Date Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker/\">Date Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MobileDateTimePicker" }

--- a/docs/pages/x/api/date-pickers/mobile-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-date-picker.json
@@ -104,7 +104,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMobileNextDatePicker" },
   "filename": "/packages/x-date-pickers/src/MobileNextDatePicker/MobileNextDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_MobileNextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_MobileNextDatePicker" }

--- a/docs/pages/x/api/date-pickers/mobile-next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-date-range-picker.json
@@ -88,7 +88,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/MobileNextDateRangePicker/MobileNextDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/mobile-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-date-time-picker.json
@@ -114,7 +114,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMobileNextDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/MobileNextDateTimePicker/MobileNextDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker/\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/mobile-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-next-time-picker.json
@@ -83,7 +83,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMobileNextTimePicker" },
   "filename": "/packages/x-date-pickers/src/MobileNextTimePicker/MobileNextTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker/\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_MobileNextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_MobileNextTimePicker" }

--- a/docs/pages/x/api/date-pickers/mobile-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-picker.json
@@ -83,7 +83,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker\">Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker/\">Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MobileTimePicker" }

--- a/docs/pages/x/api/date-pickers/month-calendar.json
+++ b/docs/pages/x/api/date-pickers/month-calendar.json
@@ -24,7 +24,7 @@
   "name": "MonthCalendar",
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiMonthCalendar" },
   "filename": "/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MonthCalendar" },
     { "packageName": "@mui/x-date-pickers", "componentName": "MonthCalendar" }

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
@@ -32,7 +32,7 @@
   "name": "MultiInputDateRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMultiInputDateRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
@@ -40,7 +40,7 @@
   "name": "MultiInputDateTimeRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMultiInputDateTimeRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
@@ -35,7 +35,7 @@
   "name": "MultiInputTimeRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMultiInputTimeRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field\">Time Range Field </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-picker.json
@@ -123,7 +123,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiNextDatePicker" },
   "filename": "/packages/x-date-pickers/src/NextDatePicker/NextDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_NextDatePicker" }

--- a/docs/pages/x/api/date-pickers/next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-range-picker.json
@@ -103,7 +103,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/NextDateRangePicker/NextDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextDateRangePicker" }
   ]

--- a/docs/pages/x/api/date-pickers/next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/next-date-time-picker.json
@@ -133,7 +133,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiNextDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/NextDateTimePicker/NextDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker/\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_NextDateTimePicker" }

--- a/docs/pages/x/api/date-pickers/next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/next-time-picker.json
@@ -101,7 +101,7 @@
   "name": "NextTimePicker",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiNextTimePicker" },
   "filename": "/packages/x-date-pickers/src/NextTimePicker/NextTimePicker.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker/\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_NextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_NextTimePicker" }

--- a/docs/pages/x/api/date-pickers/pickers-day.json
+++ b/docs/pages/x/api/date-pickers/pickers-day.json
@@ -29,7 +29,7 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/x-date-pickers/src/PickersDay/PickersDay.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "PickersDay" },
     { "packageName": "@mui/x-date-pickers", "componentName": "PickersDay" }

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -25,7 +25,7 @@
   "name": "SingleInputDateRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiSingleInputDateRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/static-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-picker.json
@@ -107,7 +107,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiStaticDatePicker" },
   "filename": "/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "StaticDatePicker" }

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -96,7 +96,7 @@
   "forwardsRefTo": "undefined",
   "filename": "/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-range-picker/\">Date Range Picker </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDateRangePicker" }
   ]

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.json
@@ -119,7 +119,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiStaticDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker\">Date Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-date-time-picker/\">Date Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDateTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "StaticDateTimePicker" }

--- a/docs/pages/x/api/date-pickers/static-next-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-picker.json
@@ -84,7 +84,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiStaticNextDatePicker" },
   "filename": "/packages/x-date-pickers/src/StaticNextDatePicker/StaticNextDatePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_StaticNextDatePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_StaticNextDatePicker" }

--- a/docs/pages/x/api/date-pickers/static-next-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-range-picker.json
@@ -69,7 +69,7 @@
   "forwardsRefTo": "undefined",
   "filename": "/packages/x-date-pickers-pro/src/StaticNextDateRangePicker/StaticNextDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/static-next-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-date-time-picker.json
@@ -94,7 +94,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiStaticNextDateTimePicker" },
   "filename": "/packages/x-date-pickers/src/StaticNextDateTimePicker/StaticNextDateTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-picker/\">Date Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     {
       "packageName": "@mui/x-date-pickers-pro",

--- a/docs/pages/x/api/date-pickers/static-next-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-next-time-picker.json
@@ -65,7 +65,7 @@
   "forwardsRefTo": "undefined",
   "filename": "/packages/x-date-pickers/src/StaticNextTimePicker/StaticNextTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker/\">Time Picker</a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_StaticNextTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_StaticNextTimePicker" }

--- a/docs/pages/x/api/date-pickers/static-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-time-picker.json
@@ -88,7 +88,7 @@
   "forwardsRefTo": "undefined",
   "filename": "/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker\">Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker/\">Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticTimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "StaticTimePicker" }

--- a/docs/pages/x/api/date-pickers/time-clock.json
+++ b/docs/pages/x/api/date-pickers/time-clock.json
@@ -58,7 +58,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/TimeClock/TimeClock.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker\">Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/time-picker/\">Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "TimeClock" },
     { "packageName": "@mui/x-date-pickers", "componentName": "TimeClock" }

--- a/docs/pages/x/api/date-pickers/time-field.json
+++ b/docs/pages/x/api/date-pickers/time-field.json
@@ -28,7 +28,7 @@
   "name": "TimeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiTimeField" },
   "filename": "/packages/x-date-pickers/src/TimeField/TimeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-field\">Time Field</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-field/\">Time Field</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "Unstable_TimeField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "Unstable_TimeField" }

--- a/docs/pages/x/api/date-pickers/time-picker.json
+++ b/docs/pages/x/api/date-pickers/time-picker.json
@@ -98,7 +98,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/TimePicker/TimePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker\">Time Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/legacy-time-picker/\">Time Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "TimePicker" },
     { "packageName": "@mui/x-date-pickers", "componentName": "TimePicker" }

--- a/docs/pages/x/api/date-pickers/year-calendar.json
+++ b/docs/pages/x/api/date-pickers/year-calendar.json
@@ -24,7 +24,7 @@
   "name": "YearCalendar",
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiYearCalendar" },
   "filename": "/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker\">Date Picker</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-picker/\">Date Picker</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "YearCalendar" },
     { "packageName": "@mui/x-date-pickers", "componentName": "YearCalendar" }

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -208,7 +208,7 @@ function findXDemos(
 
       return {
         name,
-        demoPathname: `/x/react-date-pickers/${pathnameMatches![1]}`,
+        demoPathname: `/x/react-date-pickers/${pathnameMatches![1]}/`,
       };
     });
 }


### PR DESCRIPTION
The server should normally do the 301 https://answers.netlify.com/t/no-trailing-slash-when-using-proxies/48790/12 but it happens client side by Next.js for now.

Before: https://next.mui.com/x/api/date-pickers/static-next-date-time-picker/#demos
After: https://deploy-preview-7197--material-ui-x.netlify.app/x/api/date-pickers/static-next-date-time-picker/#demos