### PR TITLE
[DataGridPro] Fix wrong border color on skeleton cells

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridSkeletonCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridSkeletonCell.tsx
@@ -24,7 +24,7 @@ const useUtilityClasses = (ownerState: OwnerState) => {
   const { align, classes } = ownerState;
 
   const slots = {
-    root: ['cell', 'cellSkeleton', `cell--text${capitalize(align)}`],
+    root: ['cell', 'cellSkeleton', `cell--text${capitalize(align)}`, 'withBorderColor'],
   };
 
   return composeClasses(slots, getDataGridUtilityClass, classes);


### PR DESCRIPTION
Fixes small visual bug introduced in https://github.com/mui/mui-x/pull/4197

Before: 
<img width="837" alt="Screenshot 2022-12-14 at 15 47 26" src="https://user-images.githubusercontent.com/13808724/207628537-dda37cc8-2579-4fac-aaa5-ffcf26579d8c.png">
After:
<img width="831" alt="Screenshot 2022-12-14 at 15 47 08" src="https://user-images.githubusercontent.com/13808724/207628563-a6674ea0-6262-4a9a-bcb1-498b8f34eb56.png">
