### PR TITLE
[pickers] Improve Korean (ko-KR) locale

### DIFF
--- a/docs/data/date-pickers/localization/data.json
+++ b/docs/data/date-pickers/localization/data.json
@@ -67,7 +67,7 @@
     "languageTag": "ko-KR",
     "importName": "koKR",
     "localeName": "Korean",
-    "missingKeysCount": 16,
+    "missingKeysCount": 0,
     "totalKeysCount": 35,
     "githubLink": "https://github.com/mui/mui-x/blob/next/packages/x-date-pickers/src/locales/koKR.ts/"
   },

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -20,7 +20,10 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
     view === 'year'
       ? '연도 선택 화면에서 달력 화면으로 전환하기'
       : '달력 화면에서 연도 선택 화면으로 전환하기',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
+    isKeyboardInputOpen
+      ? `텍스트 입력 화면에서 ${viewType} 화면으로 전환하기`
+      : `${viewType} 화면에서 텍스트 입력 화면으로 전환하기`,
 
   // DateRange placeholders
   start: '시작',
@@ -33,10 +36,10 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
   todayButtonLabel: '오늘',
 
   // Toolbar titles
-  // datePickerToolbarTitle: 'Select date',
-  // dateTimePickerToolbarTitle: 'Select date & time',
-  // timePickerToolbarTitle: 'Select time',
-  // dateRangePickerToolbarTitle: 'Select date range',
+  datePickerToolbarTitle: '날짜 선택하기',
+  dateTimePickerToolbarTitle: '날짜 & 시간 선택하기',
+  timePickerToolbarTitle: '시간 선택하기',
+  dateRangePickerToolbarTitle: '날짜 범위 선택하기',
 
   // Clock labels
   clockLabelText: (view, time, adapter) =>
@@ -50,10 +53,10 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
   secondsClockNumberText: (seconds) => `${seconds}초`,
 
   // Calendar labels
-  // calendarWeekNumberHeaderLabel: 'Week number',
-  // calendarWeekNumberHeaderText: '#',
-  // calendarWeekNumberAriaLabelText: weekNumber => `Week ${weekNumber}`,
-  // calendarWeekNumberText: weekNumber => `${weekNumber}`,
+  calendarWeekNumberHeaderLabel: '주 번호',
+  calendarWeekNumberHeaderText: '#',
+  calendarWeekNumberAriaLabelText: (weekNumber) => `${weekNumber}번째 주`,
+  calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
   openDatePickerDialogue: (value, utils) =>
@@ -70,13 +73,13 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
   dateTableLabel: '선택한 날짜',
 
   // Field section placeholders
-  // fieldYearPlaceholder: params => 'Y'.repeat(params.digitAmount),
-  // fieldMonthPlaceholder: params => params.contentType === 'letter' ? 'MMMM' : 'MM',
-  // fieldDayPlaceholder: () => 'DD',
-  // fieldHoursPlaceholder: () => 'hh',
-  // fieldMinutesPlaceholder: () => 'mm',
-  // fieldSecondsPlaceholder: () => 'ss',
-  // fieldMeridiemPlaceholder: () => 'aa',
+  fieldYearPlaceholder: (params) => 'Y'.repeat(params.digitAmount),
+  fieldMonthPlaceholder: (params) => (params.contentType === 'letter' ? 'MMMM' : 'MM'),
+  fieldDayPlaceholder: () => 'DD',
+  fieldHoursPlaceholder: () => 'hh',
+  fieldMinutesPlaceholder: () => 'mm',
+  fieldSecondsPlaceholder: () => 'ss',
+  fieldMeridiemPlaceholder: () => 'aa',
 };
 
 export const koKR = getPickersLocalization(koKRPickers);


### PR DESCRIPTION
Resolves part of #3211 
Translated Korean locale text for `Date and Time Pickers`