### PR TITLE
[docs] Fix SingleInputDateRangeField API generation

### DIFF
--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -69,7 +69,10 @@
   "slots": { "Input": { "default": "TextField", "type": { "name": "elementType" } } },
   "name": "SingleInputDateRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiSingleInputDateRangeField" },
+  "spread": true,
+  "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx",
+  "inheritance": null,
   "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
   "packages": [
     {

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import TextField from '@mui/material/TextField';
 import { describeConformance } from '@mui/monorepo/test/utils';
 import { describeRangeValidation } from '@mui/x-date-pickers-pro/tests/describeRangeValidation';
 import { Unstable_SingleInputDateRangeField as SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
@@ -9,7 +10,7 @@ describe('<SingleInputDateRangeField /> - Describes', () => {
 
   describeConformance(<SingleInputDateRangeField />, () => ({
     classes: {},
-    inheritComponent: 'div',
+    inheritComponent: TextField,
     render,
     muiName: 'MuiSingleInputDateRangeField',
     wrapMount: wrapPickerMount,


### PR DESCRIPTION
The test location is used to generate the API.

Before https://next--material-ui-x.netlify.app/x/api/date-pickers/single-input-date-range-field/

<img width="280" alt="Screenshot 2022-12-21 at 23 07 48" src="https://user-images.githubusercontent.com/3165635/209020159-d01d902a-d742-40b0-86e0-401254dfaf96.png">

After https://deploy-preview-7294--material-ui-x.netlify.app/x/api/date-pickers/single-input-date-range-field/

<img width="365" alt="Screenshot 2022-12-21 at 23 07 36" src="https://user-images.githubusercontent.com/3165635/209020138-0f26dc3f-727c-4282-910e-30d1ac0a8c77.png">

ℹ️ there are probably many more components that are impacted by this test name and location problem.