### PR TITLE
[DataGrid] Remove `GridDensityType` enum

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -180,6 +180,7 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
 - The `GridActionsColDef` interface was removed. Use `GridColDef` instead.
 - The `GridEnrichedColDef` type was removed. Use `GridColDef` instead.
 - The `GridStateColDef` type was removed.
+- The `GridDensityTypes` enum was removed. Use `GridDensity` type instead.
 
   If you use it to type `searchPredicate` - use `GridColumnsPanelProps['searchPredicate']` instead.
 

--- a/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -8,7 +8,7 @@ import {
 } from '../models/props/DataGridProps';
 import { GRID_DEFAULT_LOCALE_TEXT } from '../constants';
 import { DATA_GRID_DEFAULT_SLOTS_COMPONENTS } from '../constants/defaultGridSlotsComponents';
-import { GridDensityTypes, GridEditModes, GridSlotsComponent, GridValidRowModel } from '../models';
+import { GridEditModes, GridSlotsComponent, GridValidRowModel } from '../models';
 
 const DATA_GRID_FORCED_PROPS: { [key in DataGridForcedPropsKey]?: DataGridProcessedProps[key] } = {
   disableMultipleColumnsFiltering: true,
@@ -37,7 +37,7 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
   columnThreshold: 3,
   rowThreshold: 3,
   rowSelection: true,
-  density: GridDensityTypes.Standard,
+  density: 'standard',
   disableExtendRowFullWidth: false,
   disableColumnFilter: false,
   disableColumnMenu: false,

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
@@ -5,7 +5,7 @@ import { ButtonProps } from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { gridDensityValueSelector } from '../../hooks/features/density/densitySelector';
-import { GridDensity, GridDensityTypes } from '../../models/gridDensity';
+import { GridDensity } from '../../models/gridDensity';
 import { isHideMenuKey, isTabKey } from '../../utils/keyboardUtils';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridSelector } from '../../hooks/utils/useGridSelector';
@@ -31,25 +31,25 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
       {
         icon: <rootProps.components.DensityCompactIcon />,
         label: apiRef.current.getLocaleText('toolbarDensityCompact'),
-        value: GridDensityTypes.Compact,
+        value: 'compact',
       },
       {
         icon: <rootProps.components.DensityStandardIcon />,
         label: apiRef.current.getLocaleText('toolbarDensityStandard'),
-        value: GridDensityTypes.Standard,
+        value: 'standard',
       },
       {
         icon: <rootProps.components.DensityComfortableIcon />,
         label: apiRef.current.getLocaleText('toolbarDensityComfortable'),
-        value: GridDensityTypes.Comfortable,
+        value: 'comfortable',
       },
     ];
 
     const startIcon = React.useMemo<React.ReactElement>(() => {
       switch (densityValue) {
-        case GridDensityTypes.Compact:
+        case 'compact':
           return <rootProps.components.DensityCompactIcon />;
-        case GridDensityTypes.Comfortable:
+        case 'comfortable':
           return <rootProps.components.DensityComfortableIcon />;
         default:
           return <rootProps.components.DensityStandardIcon />;

--- a/packages/grid/x-data-grid/src/hooks/features/density/useGridDensity.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/density/useGridDensity.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { GridDensity, GridDensityTypes } from '../../../models/gridDensity';
+import { GridDensity } from '../../../models/gridDensity';
 import { useGridLogger } from '../../utils/useGridLogger';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { GridDensityApi } from '../../../models/api/gridDensityApi';
-import { GridDensityState } from './densityState';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { gridDensitySelector } from './densitySelector';
 import { isDeepEqual } from '../../../utils/utils';
@@ -13,31 +12,17 @@ import { GridStateInitializer } from '../../utils/useGridInitializeState';
 export const COMPACT_DENSITY_FACTOR = 0.7;
 export const COMFORTABLE_DENSITY_FACTOR = 1.3;
 
-const getUpdatedDensityState = (newDensity: GridDensity): GridDensityState => {
-  switch (newDensity) {
-    case GridDensityTypes.Compact:
-      return {
-        value: newDensity,
-        factor: COMPACT_DENSITY_FACTOR,
-      };
-    case GridDensityTypes.Comfortable:
-      return {
-        value: newDensity,
-        factor: COMFORTABLE_DENSITY_FACTOR,
-      };
-    default:
-      return {
-        value: newDensity,
-        factor: 1,
-      };
-  }
+const DENSITY_FACTORS: Record<GridDensity, number> = {
+  compact: COMPACT_DENSITY_FACTOR,
+  comfortable: COMFORTABLE_DENSITY_FACTOR,
+  standard: 1,
 };
 
 export const densityStateInitializer: GridStateInitializer<
   Pick<DataGridProcessedProps, 'density' | 'headerHeight' | 'rowHeight'>
 > = (state, props) => ({
   ...state,
-  density: getUpdatedDensityState(props.density),
+  density: { value: props.density, factor: DENSITY_FACTORS[props.density] },
 });
 
 export const useGridDensity = (
@@ -51,7 +36,7 @@ export const useGridDensity = (
       logger.debug(`Set grid density to ${newDensity}`);
       apiRef.current.setState((state) => {
         const currentDensityState = gridDensitySelector(state);
-        const newDensityState = getUpdatedDensityState(newDensity);
+        const newDensityState = { value: newDensity, factor: DENSITY_FACTORS[newDensity] };
 
         if (isDeepEqual(currentDensityState, newDensityState)) {
           return state;

--- a/packages/grid/x-data-grid/src/models/api/gridDensityApi.ts
+++ b/packages/grid/x-data-grid/src/models/api/gridDensityApi.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { GridDensity, GridDensityTypes } from '../gridDensity';
+import { GridDensity } from '../gridDensity';
 
 export interface GridDensityOption {
   icon: React.ReactElement;
   label: string;
-  value: GridDensityTypes;
+  value: GridDensity;
 }
 
 /**

--- a/packages/grid/x-data-grid/src/models/gridDensity.ts
+++ b/packages/grid/x-data-grid/src/models/gridDensity.ts
@@ -2,14 +2,3 @@
  * Available densities.
  */
 export type GridDensity = 'compact' | 'standard' | 'comfortable';
-
-/**
- * Density enum.
- */
-enum GridDensityTypes {
-  Compact = 'compact',
-  Standard = 'standard',
-  Comfortable = 'comfortable',
-}
-
-export { GridDensityTypes };

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -226,7 +226,6 @@
   { "name": "GridDensityOption", "kind": "Interface" },
   { "name": "gridDensitySelector", "kind": "Variable" },
   { "name": "GridDensityState", "kind": "Interface" },
-  { "name": "GridDensityTypes", "kind": "Enum" },
   { "name": "gridDensityValueSelector", "kind": "Variable" },
   { "name": "GridDetailPanelApi", "kind": "Interface" },
   { "name": "gridDetailPanelExpandedRowIdsSelector", "kind": "Variable" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -200,7 +200,6 @@
   { "name": "GridDensityOption", "kind": "Interface" },
   { "name": "gridDensitySelector", "kind": "Variable" },
   { "name": "GridDensityState", "kind": "Interface" },
-  { "name": "GridDensityTypes", "kind": "Enum" },
   { "name": "gridDensityValueSelector", "kind": "Variable" },
   { "name": "GridDetailPanelApi", "kind": "Interface" },
   { "name": "gridDetailPanelExpandedRowIdsSelector", "kind": "Variable" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -184,7 +184,6 @@
   { "name": "GridDensityOption", "kind": "Interface" },
   { "name": "gridDensitySelector", "kind": "Variable" },
   { "name": "GridDensityState", "kind": "Interface" },
-  { "name": "GridDensityTypes", "kind": "Enum" },
   { "name": "gridDensityValueSelector", "kind": "Variable" },
   { "name": "GridDimensions", "kind": "Interface" },
   { "name": "GridDimensionsApi", "kind": "Interface" },


### PR DESCRIPTION
Context: https://github.com/mui/mui-x/pull/7199#discussion_r1048802214

### Changelog

#### Breaking changes

- The `GridDensityTypes` enum was removed. Use `GridDensity` type instead.