### PR TITLE
[DataGrid] Remove the `columnTypes` prop

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -42,6 +42,7 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
   The old behavior can be restored by using `apiRef.current.stopRowEditMode({ ignoreModifications: true })` or `apiRef.current.stopCellEditMode({ ignoreModifications: true })`.
 - The `onColumnVisibilityChange` prop was removed. Use `onColumnVisibilityModelChange` instead.
 - The `components.Header` slot was removed. Use `components.Toolbar` slot instead.
+- The `columnTypes` prop was removed. For custom column types see [Custom column types](/x/react-data-grid/column-definition/#custom-column-types) docs.
 
 ### State access
 

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -31,7 +31,6 @@
     "classes": { "type": { "name": "object" } },
     "columnBuffer": { "type": { "name": "number" }, "default": "3" },
     "columnThreshold": { "type": { "name": "number" }, "default": "3" },
-    "columnTypes": { "type": { "name": "object" } },
     "columnVisibilityModel": { "type": { "name": "object" } },
     "components": { "type": { "name": "object" } },
     "componentsProps": { "type": { "name": "object" } },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -22,7 +22,6 @@
     "classes": { "type": { "name": "object" } },
     "columnBuffer": { "type": { "name": "number" }, "default": "3" },
     "columnThreshold": { "type": { "name": "number" }, "default": "3" },
-    "columnTypes": { "type": { "name": "object" } },
     "columnVisibilityModel": { "type": { "name": "object" } },
     "components": { "type": { "name": "object" } },
     "componentsProps": { "type": { "name": "object" } },

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -15,7 +15,6 @@
     "classes": { "type": { "name": "object" } },
     "columnBuffer": { "type": { "name": "number" }, "default": "3" },
     "columnThreshold": { "type": { "name": "number" }, "default": "3" },
-    "columnTypes": { "type": { "name": "object" } },
     "columnVisibilityModel": { "type": { "name": "object" } },
     "components": { "type": { "name": "object" } },
     "componentsProps": { "type": { "name": "object" } },

--- a/docs/translations/api-docs/data-grid/data-grid-premium-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium-pt.json
@@ -16,7 +16,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium-zh.json
@@ -16,7 +16,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium.json
@@ -16,7 +16,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
@@ -13,7 +13,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
@@ -13,7 +13,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -13,7 +13,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pt.json
@@ -12,7 +12,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-zh.json
@@ -12,7 +12,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -12,7 +12,6 @@
     "columnBuffer": "Number of extra columns to be rendered before/after the visible slice.",
     "columns": "Set of columns of type GridColDef[].",
     "columnThreshold": "Number of rows from the <code>columnBuffer</code> that can be visible before a new slice is rendered.",
-    "columnTypes": "Extend native column types with your new column types.",
     "columnVisibilityModel": "Set the column visibility model of the grid. If defined, the grid will ignore the <code>hide</code> property in <a href=\"/x/api/data-grid/grid-col-def/\">GridColDef</a>.",
     "components": "Overrideable components.",
     "componentsProps": "Overrideable components props dynamically passed to the component at rendering.",

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -145,10 +145,6 @@ DataGridPremiumRaw.propTypes = {
    */
   columnThreshold: PropTypes.number,
   /**
-   * Extend native column types with your new column types.
-   */
-  columnTypes: PropTypes.object,
-  /**
    * Set the column visibility model of the grid.
    * If defined, the grid will ignore the `hide` property in [[GridColDef]].
    */

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -126,10 +126,6 @@ DataGridProRaw.propTypes = {
    */
   columnThreshold: PropTypes.number,
   /**
-   * Extend native column types with your new column types.
-   */
-  columnTypes: PropTypes.object,
-  /**
    * Set the column visibility model of the grid.
    * If defined, the grid will ignore the `hide` property in [[GridColDef]].
    */

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -119,10 +119,6 @@ DataGridRaw.propTypes = {
    */
   columnThreshold: PropTypes.number,
   /**
-   * Extend native column types with your new column types.
-   */
-  columnTypes: PropTypes.object,
-  /**
    * Set the column visibility model of the grid.
    * If defined, the grid will ignore the `hide` property in [[GridColDef]].
    */

--- a/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -8,7 +8,7 @@ import {
   GridColumnsInitialState,
 } from './gridColumnsInterfaces';
 import { GridColumnTypesRecord } from '../../../models';
-import { DEFAULT_GRID_COL_TYPE_KEY, getGridDefaultColumnTypes } from '../../../colDef';
+import { DEFAULT_GRID_COL_TYPE_KEY } from '../../../colDef';
 import { GridStateCommunity } from '../../../models/gridStateCommunity';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridColDef, GridStateColDef } from '../../../models/colDef/gridColDef';
@@ -22,26 +22,6 @@ import { gridColumnGroupsHeaderMaxDepthSelector } from '../columnGrouping/gridCo
 export const COLUMNS_DIMENSION_PROPERTIES = ['maxWidth', 'minWidth', 'width', 'flex'] as const;
 
 export type GridColumnDimensionProperties = typeof COLUMNS_DIMENSION_PROPERTIES[number];
-
-export const computeColumnTypes = (customColumnTypes: GridColumnTypesRecord = {}) => {
-  const mergedColumnTypes: GridColumnTypesRecord = { ...getGridDefaultColumnTypes() };
-
-  Object.entries(customColumnTypes).forEach(([colType, colTypeDef]) => {
-    if (mergedColumnTypes[colType]) {
-      mergedColumnTypes[colType] = {
-        ...mergedColumnTypes[colType],
-        ...colTypeDef,
-      };
-    } else {
-      mergedColumnTypes[colType] = {
-        ...mergedColumnTypes[colTypeDef.extendType || DEFAULT_GRID_COL_TYPE_KEY],
-        ...colTypeDef,
-      };
-    }
-  });
-
-  return mergedColumnTypes;
-};
 
 /**
  * Computes width for flex columns.

--- a/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
@@ -30,21 +30,21 @@ import {
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
 import {
   hydrateColumnsWidth,
-  computeColumnTypes,
   createColumnsState,
   mergeColumnsState,
   COLUMNS_DIMENSION_PROPERTIES,
 } from './gridColumnsUtils';
 import { GridPreferencePanelsValue } from '../preferencesPanel';
+import { getGridDefaultColumnTypes } from '../../../colDef';
+
+const defaultColumnTypes = getGridDefaultColumnTypes();
 
 export const columnsStateInitializer: GridStateInitializer<
-  Pick<DataGridProcessedProps, 'columnVisibilityModel' | 'initialState' | 'columnTypes' | 'columns'>
+  Pick<DataGridProcessedProps, 'columnVisibilityModel' | 'initialState' | 'columns'>
 > = (state, props, apiRef) => {
-  const columnsTypes = computeColumnTypes(props.columnTypes);
-
   const columnsState = createColumnsState({
     apiRef,
-    columnTypes: columnsTypes,
+    columnTypes: defaultColumnTypes,
     columnsToUpsert: props.columns,
     initialState: props.initialState?.columns,
     columnVisibilityModel:
@@ -71,7 +71,6 @@ export function useGridColumns(
     | 'columns'
     | 'columnVisibilityModel'
     | 'onColumnVisibilityModelChange'
-    | 'columnTypes'
     | 'components'
     | 'componentsProps'
     | 'disableColumnSelector'
@@ -80,10 +79,7 @@ export function useGridColumns(
 ): void {
   const logger = useGridLogger(apiRef, 'useGridColumns');
 
-  const columnTypes = React.useMemo(
-    () => computeColumnTypes(props.columnTypes),
-    [props.columnTypes],
-  );
+  const columnTypes = defaultColumnTypes;
 
   const previousColumnsProp = React.useRef(props.columns);
   const previousColumnTypesProp = React.useRef(columnTypes);

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -12,7 +12,6 @@ import { GridRowIdGetter, GridRowsProp, GridValidRowModel } from '../gridRows';
 import { GridEventListener } from '../events';
 import { GridCallbackDetails, GridLocaleText } from '../api';
 import { GridApiCommunity } from '../api/gridApiCommunity';
-import type { GridColumnTypesRecord } from '../colDef';
 import type { GridColDef } from '../colDef/gridColDef';
 import { GridClasses } from '../../constants/gridClasses';
 import {
@@ -358,10 +357,6 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<GridClasses>;
-  /**
-   * Extend native column types with your new column types.
-   */
-  columnTypes?: GridColumnTypesRecord;
   /**
    * Set the total number of rows, if it is different from the length of the value `rows` prop.
    * If some rows have children (for instance in the tree data), this number represents the amount of top level rows.

--- a/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -74,23 +74,6 @@ describe('<DataGrid /> - Filter', () => {
       expect(getColumnValues(0)).to.deep.equal(['Adidas', 'Puma']);
     });
 
-    it('should apply the model when filtering extended columns', () => {
-      render(
-        <TestCase
-          rows={[
-            { id: 0, price: 0 },
-            { id: 1, price: 1 },
-          ]}
-          columnTypes={{ price: { extendType: 'number' } }}
-          columns={[{ field: 'price', type: 'price' }]}
-          filterModel={{
-            items: [{ field: 'price', operator: '=', value: 1 }],
-          }}
-        />,
-      );
-      expect(getColumnValues(0)).to.deep.equal(['1']);
-    });
-
     it('should apply the model when row prop changes', () => {
       render(
         <TestCase

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -812,49 +812,6 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       ) as Element;
       expect(virtualScrollerContent.clientHeight).to.equal(virtualScroller.clientHeight);
     });
-
-    // See https://github.com/mui/mui-x/issues/4113
-    it('should preserve default width constraints when extending default column type', () => {
-      const rows = [{ id: 1, value: 1 }];
-      const columns = [{ field: 'id', type: 'number' }];
-
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            rows={rows}
-            columns={columns}
-            columnTypes={{
-              number: {},
-            }}
-          />
-        </div>,
-      );
-
-      // default `width` should be used
-      expect(getCell(0, 0).offsetWidth).to.equal(100);
-    });
-
-    it('should allow to override default width constraints when extending default column type', () => {
-      const rows = [{ id: 1, value: 1 }];
-      const columns = [{ field: 'id', type: 'number' }];
-
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            rows={rows}
-            columns={columns}
-            columnTypes={{
-              number: {
-                width: 10,
-                minWidth: 200,
-              },
-            }}
-          />
-        </div>,
-      );
-
-      expect(getCell(0, 0).offsetWidth).to.equal(200);
-    });
   });
 
   describe('warnings', () => {


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/242

### Changelog

#### Breaking changes

- The `columnTypes` prop was removed. For custom column types see [Custom column types](/x/react-data-grid/column-definition/#custom-column-types) docs.