### PR TITLE
[docs] Fix pickers dynamic data demo

### DIFF
--- a/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.js
+++ b/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.js
@@ -38,7 +38,8 @@ function ServerDay(props) {
   const { highlightedDays = [], day, outsideCurrentMonth, ...other } = props;
 
   const isSelected =
-    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) >= 0;
+    !props.outsideCurrentMonth &&
+    highlightedDays.some((highlightedDay) => highlightedDay === props.day.date());
 
   return (
     <Badge

--- a/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.js
+++ b/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.js
@@ -38,7 +38,7 @@ function ServerDay(props) {
   const { highlightedDays = [], day, outsideCurrentMonth, ...other } = props;
 
   const isSelected =
-    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) > 0;
+    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) >= 0;
 
   return (
     <Badge


### PR DESCRIPTION
In the code demo, despite having 3 highlighted days sent by the `fakeFetch()`, only 2 are shown with the badges.

Pre Fix:
![image](https://user-images.githubusercontent.com/37257700/209689401-ce78fdda-0c10-41fe-a858-d073cf29804f.png)

Post Fix:
![image](https://user-images.githubusercontent.com/37257700/209689449-6f49fd16-dc4a-4503-9858-048e71097c7a.png)

Signed-off-by: Naresh Jagadeesan <37257700+Infinage@users.noreply.github.com>