### PR TITLE
[docs] Redirect translated pages

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -44,6 +44,8 @@
 /x/api/date-pickers/clock-picker/ /x/api/date-pickers/time-clock/ 301
 /:lang/x/api/date-pickers/clock-picker/ /:lang/x/api/date-pickers/time-clock/ 301
 
+/:lang/x/* /x/:splat 301
+
 # 2023
 
 # Proxies


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/pull/34820#issuecomment-1334198189

Example:
https://deploy-preview-7341--material-ui-x.netlify.app/pt/x/api/data-grid/data-grid/
redirects to:
https://deploy-preview-7341--material-ui-x.netlify.app/x/api/data-grid/data-grid/

TODO:
- [ ] backport to the `master` branch