### PR TITLE
[core] Upgrade monorepo

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,8 +2526,8 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.10.14"
-  resolved "https://github.com/mui/material-ui.git#2f27c2eafdf04f278c94a483b76ca6ec925903e9"
+  version "5.10.16"
+  resolved "https://github.com/mui/material-ui.git#2abad795e4890829deb0fb40204a100b547a3873"
 
 "@mui/private-theming@^5.10.3":
   version "5.10.3"


### PR DESCRIPTION
To pull https://github.com/mui/material-ui/pull/34820 in and hide the language selector on the `master` branch:
<img width="373" alt="Screenshot 2022-12-29 at 16 23 09" src="https://user-images.githubusercontent.com/13808724/209974726-a406b07c-36b5-4b01-9566-efe86da654f4.png">

I didn't upgrade to the latest version to make it simpler and avoid introducing more changes like in https://github.com/mui/mui-x/pull/7307.