### PR TITLE
[test] Add a few inheritComponent

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import TextField from '@mui/material/TextField';
 import { describeConformance } from '@mui/monorepo/test/utils';
 import { describeRangeValidation } from '@mui/x-date-pickers-pro/tests/describeRangeValidation';
 import { Unstable_SingleInputDateRangeField as SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
@@ -9,7 +10,7 @@ describe('<SingleInputDateRangeField /> - Describes', () => {
 
   describeConformance(<SingleInputDateRangeField />, () => ({
     classes: {},
-    inheritComponent: 'div',
+    inheritComponent: TextField,
     render,
     muiName: 'MuiSingleInputDateRangeField',
     wrapMount: wrapPickerMount,

--- a/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { describeConformance, screen, userEvent } from '@mui/monorepo/test/utils';
+import TextField from '@mui/material/TextField';
 import { describeValidation } from '@mui/x-date-pickers/tests/describeValidation';
 import { describeValue } from '@mui/x-date-pickers/tests/describeValue';
 import { Unstable_DateField as DateField } from '@mui/x-date-pickers/DateField';
@@ -18,7 +19,7 @@ describe('<DateField /> - Describes', () => {
 
   describeConformance(<DateField />, () => ({
     classes: {},
-    inheritComponent: 'div',
+    inheritComponent: TextField,
     render,
     muiName: 'MuiDateField',
     wrapMount: wrapPickerMount,

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { describeConformance, fireEvent, screen } from '@mui/monorepo/test/utils';
+import ButtonBase from '@mui/material/ButtonBase';
 import { PickersDay, pickersDayClasses as classes } from '@mui/x-date-pickers/PickersDay';
 import { adapterToUse, wrapPickerMount, createPickerRenderer } from 'test/utils/pickers-utils';
 
@@ -17,7 +18,7 @@ describe('<PickersDay />', () => {
     />,
     () => ({
       classes,
-      inheritComponent: 'button',
+      inheritComponent: ButtonBase,
       render,
       wrapMount: wrapPickerMount,
       muiName: 'MuiPickersDay',


### PR DESCRIPTION
Extract the finer grain test of inheritComponent from #7294.

An example of failure message when the `inheritComponent` value is wrong:

<img width="741" alt="Screenshot 2022-12-30 at 16 52 42" src="https://user-images.githubusercontent.com/3165635/210088683-8d7eadf8-214e-4d7b-b54d-f80d81411f8f.png">
