### PR TITLE
[pickers] Remove redundant `variants` in theme augmentation

### DIFF
--- a/packages/x-date-pickers-pro/src/themeAugmentation/components.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/components.d.ts
@@ -1,80 +1,65 @@
-import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@mui/material/styles';
+import { ComponentsProps, ComponentsOverrides } from '@mui/material/styles';
 
 export interface PickersProComponents<Theme = unknown> {
   MuiDateRangeCalendar?: {
     defaultProps?: ComponentsProps['MuiDateRangeCalendar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangeCalendar'];
-    variants?: ComponentsVariants['MuiDateRangeCalendar'];
   };
   MuiDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePicker'];
-    variants?: ComponentsVariants['MuiDateRangePicker'];
   };
   MuiDateRangePickerDay?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePickerDay'];
-    variants?: ComponentsVariants['MuiDateRangePickerDay'];
   };
   MuiDateRangePickerInput?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerInput'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePickerInput'];
-    variants?: ComponentsVariants['MuiDateRangePickerInput'];
   };
   MuiDateRangePickerToolbar?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerToolbar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePickerToolbar'];
-    variants?: ComponentsVariants['MuiDateRangePickerToolbar'];
   };
   MuiDateRangePickerViewDesktop?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerViewDesktop'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePickerViewDesktop'];
-    variants?: ComponentsVariants['MuiDateRangePickerViewDesktop'];
   };
   MuiDesktopDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopDateRangePicker'];
-    variants?: ComponentsVariants['MuiDesktopDateRangePicker'];
   };
   MuiDesktopNextDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopNextDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopNextDateRangePicker'];
-    variants?: ComponentsVariants['MuiDesktopNextDateRangePicker'];
   };
   MuiMobileDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiMobileDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMobileDateRangePicker'];
-    variants?: ComponentsVariants['MuiMobileDateRangePicker'];
   };
   MuiMobileNextDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiMobileNextDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMobileNextDateRangePicker'];
-    variants?: ComponentsVariants['MuiMobileNextDateRangePicker'];
   };
   MuiMultiInputDateRangeField?: {
     defaultProps?: ComponentsProps['MuiMultiInputDateRangeField'];
     styleOverrides?: ComponentsOverrides['MuiMultiInputDateRangeField'];
-    variants?: ComponentsVariants['MuiMultiInputDateRangeField'];
   };
   MuiNextDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiNextDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiNextDateRangePicker'];
-    variants?: ComponentsVariants['MuiNextDateRangePicker'];
   };
   MuiSingleInputDateRangeField?: {
     defaultProps?: ComponentsProps['MuiSingleInputDateRangeField'];
     styleOverrides?: ComponentsOverrides['MuiSingleInputDateRangeField'];
-    variants?: ComponentsVariants['MuiSingleInputDateRangeField'];
   };
   MuiStaticDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiStaticDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticDateRangePicker'];
-    variants?: ComponentsVariants['MuiStaticDateRangePicker'];
   };
   MuiStaticNextDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiStaticNextDateRangePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticNextDateRangePicker'];
-    variants?: ComponentsVariants['MuiStaticNextDateRangePicker'];
   };
 }
 

--- a/packages/x-date-pickers/src/themeAugmentation/components.d.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/components.d.ts
@@ -1,250 +1,201 @@
-import { ComponentsProps, ComponentsOverrides, ComponentsVariants } from '@mui/material/styles';
+import { ComponentsProps, ComponentsOverrides } from '@mui/material/styles';
 
 export interface PickerComponents<Theme = unknown> {
   MuiCalendarOrClockPicker?: {
     defaultProps?: ComponentsProps['MuiCalendarOrClockPicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiCalendarOrClockPicker'];
-    variants?: ComponentsVariants['MuiCalendarOrClockPicker'];
   };
   MuiClock?: {
     defaultProps?: ComponentsProps['MuiClock'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiClock'];
-    variants?: ComponentsVariants['MuiClock'];
   };
   MuiClockNumber?: {
     defaultProps?: ComponentsProps['MuiClockNumber'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiClockNumber'];
-    variants?: ComponentsVariants['MuiClockNumber'];
   };
   MuiClockPointer?: {
     defaultProps?: ComponentsProps['MuiClockPointer'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiClockPointer'];
-    variants?: ComponentsVariants['MuiClockPointer'];
   };
   MuiDateCalendar?: {
     defaultProps?: ComponentsProps['MuiDateCalendar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateCalendar'];
-    variants?: ComponentsVariants['MuiDateCalendar'];
   };
   MuiDateField?: {
     defaultProps?: ComponentsProps['MuiDateField'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateField'];
-    variants?: ComponentsVariants['MuiDateField'];
   };
   MuiDatePicker?: {
     defaultProps?: ComponentsProps['MuiDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDatePicker'];
-    variants?: ComponentsVariants['MuiDatePicker'];
   };
   MuiDatePickerToolbar?: {
     defaultProps?: ComponentsProps['MuiDatePickerToolbar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDatePickerToolbar'];
-    variants?: ComponentsVariants['MuiDatePickerToolbar'];
   };
   MuiDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateTimePicker'];
-    variants?: ComponentsVariants['MuiDateTimePicker'];
   };
   MuiDateTimePickerTabs?: {
     defaultProps?: ComponentsProps['MuiDateTimePickerTabs'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateTimePickerTabs'];
-    variants?: ComponentsVariants['MuiDateTimePickerTabs'];
   };
   MuiDateTimePickerToolbar?: {
     defaultProps?: ComponentsProps['MuiDateTimePickerToolbar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateTimePickerToolbar'];
-    variants?: ComponentsVariants['MuiDateTimePickerToolbar'];
   };
   MuiDayCalendar?: {
     defaultProps?: ComponentsProps['MuiDayCalendar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDayCalendar'];
-    variants?: ComponentsVariants['MuiDayCalendar'];
   };
   MuiDayCalendarSkeleton?: {
     defaultProps?: ComponentsProps['MuiDayCalendarSkeleton'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDayCalendarSkeleton'];
-    variants?: ComponentsVariants['MuiDayCalendarSkeleton'];
   };
   MuiDesktopDatePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopDatePicker'];
-    variants?: ComponentsVariants['MuiDesktopDatePicker'];
   };
   MuiDesktopDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopDateTimePicker'];
-    variants?: ComponentsVariants['MuiDesktopDateTimePicker'];
   };
   MuiDesktopNextDatePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopNextDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopNextDatePicker'];
-    variants?: ComponentsVariants['MuiDesktopNextDatePicker'];
   };
   MuiDesktopNextDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopNextDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopNextDateTimePicker'];
-    variants?: ComponentsVariants['MuiDesktopNextDateTimePicker'];
   };
   MuiDesktopNextTimePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopNextTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopNextTimePicker'];
-    variants?: ComponentsVariants['MuiDesktopNextTimePicker'];
   };
   MuiDesktopTimePicker?: {
     defaultProps?: ComponentsProps['MuiDesktopTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDesktopTimePicker'];
-    variants?: ComponentsVariants['MuiDesktopTimePicker'];
   };
   MuiLocalizationProvider?: {
     defaultProps?: ComponentsProps['MuiLocalizationProvider'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiLocalizationProvider'];
-    variants?: ComponentsVariants['MuiLocalizationProvider'];
   };
   MuiMobileNextDatePicker?: {
     defaultProps?: ComponentsProps['MuiMobileNextDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMobileNextDatePicker'];
-    variants?: ComponentsVariants['MuiMobileNextDatePicker'];
   };
   MuiMobileNextDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiMobileNextDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMobileNextDateTimePicker'];
-    variants?: ComponentsVariants['MuiMobileNextDateTimePicker'];
   };
   MuiMobileNextTimePicker?: {
     defaultProps?: ComponentsProps['MuiMobileNextTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMobileNextTimePicker'];
-    variants?: ComponentsVariants['MuiMobileNextTimePicker'];
   };
   MuiMonthCalendar?: {
     defaultProps?: ComponentsProps['MuiMonthCalendar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMonthCalendar'];
-    variants?: ComponentsVariants['MuiMonthCalendar'];
   };
   MuiNextDatePicker?: {
     defaultProps?: ComponentsProps['MuiNextDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiNextDatePicker'];
-    variants?: ComponentsVariants['MuiNextDatePicker'];
   };
   MuiNextDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiNextDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiNextDateTimePicker'];
-    variants?: ComponentsVariants['MuiNextDateTimePicker'];
   };
   MuiNextTimePicker?: {
     defaultProps?: ComponentsProps['MuiNextTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiNextTimePicker'];
-    variants?: ComponentsVariants['MuiNextTimePicker'];
   };
   MuiPickersArrowSwitcher?: {
     defaultProps?: ComponentsProps['MuiPickersArrowSwitcher'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersArrowSwitcher'];
-    variants?: ComponentsVariants['MuiPickersArrowSwitcher'];
   };
   MuiPickersCalendarHeader?: {
     defaultProps?: ComponentsProps['MuiPickersCalendarHeader'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersCalendarHeader'];
-    variants?: ComponentsVariants['MuiPickersCalendarHeader'];
   };
   MuiPickersDay?: {
     defaultProps?: ComponentsProps['MuiPickersDay'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersDay'];
-    variants?: ComponentsVariants['MuiPickersDay'];
   };
   MuiPickersFadeTransitionGroup?: {
     defaultProps?: ComponentsProps['MuiPickersFadeTransitionGroup'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersFadeTransitionGroup'];
-    variants?: ComponentsVariants['MuiPickersFadeTransitionGroup'];
   };
   MuiPickersMonth?: {
     defaultProps?: ComponentsProps['MuiPickersMonth'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersMonth'];
-    variants?: ComponentsVariants['MuiPickersMonth'];
   };
   MuiPickersPopper?: {
     defaultProps?: ComponentsProps['MuiPickersPopper'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersPopper'];
-    variants?: ComponentsVariants['MuiPickersPopper'];
   };
   MuiPickersSlideTransition?: {
     defaultProps?: ComponentsProps['MuiPickersSlideTransition'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersSlideTransition'];
-    variants?: ComponentsVariants['MuiPickersSlideTransition'];
   };
   MuiPickerStaticWrapper?: {
     defaultProps?: ComponentsProps['MuiPickerStaticWrapper'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickerStaticWrapper'];
-    variants?: ComponentsVariants['MuiPickerStaticWrapper'];
   };
   MuiPickersToolbar?: {
     defaultProps?: ComponentsProps['MuiPickersToolbar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersToolbar'];
-    variants?: ComponentsVariants['MuiPickersToolbar'];
   };
   MuiPickersToolbarButton?: {
     defaultProps?: ComponentsProps['MuiPickersToolbarButton'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersToolbarButton'];
-    variants?: ComponentsVariants['MuiPickersToolbarButton'];
   };
   MuiPickersToolbarText?: {
     defaultProps?: ComponentsProps['MuiPickersToolbarText'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersToolbarText'];
-    variants?: ComponentsVariants['MuiPickersToolbarText'];
   };
   MuiPickersLayout?: {
     defaultProps?: ComponentsProps['MuiPickersLayout'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersLayout'];
-    variants?: ComponentsVariants['MuiPickersLayout'];
   };
   MuiPickersYear?: {
     defaultProps?: ComponentsProps['MuiPickersYear'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiPickersYear'];
-    variants?: ComponentsVariants['MuiPickersYear'];
   };
   MuiStaticDatePicker?: {
     defaultProps?: ComponentsProps['MuiStaticDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticDatePicker'];
-    variants?: ComponentsVariants['MuiStaticDatePicker'];
   };
   MuiStaticDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiStaticDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticDateTimePicker'];
-    variants?: ComponentsVariants['MuiStaticDateTimePicker'];
   };
   MuiStaticNextDatePicker?: {
     defaultProps?: ComponentsProps['MuiStaticNextDatePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticNextDatePicker'];
-    variants?: ComponentsVariants['MuiStaticNextDatePicker'];
   };
   MuiStaticNextDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiStaticNextDateTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticNextDateTimePicker'];
-    variants?: ComponentsVariants['MuiStaticNextDateTimePicker'];
   };
   MuiStaticNextTimePicker?: {
     defaultProps?: ComponentsProps['MuiStaticNextTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticNextTimePicker'];
-    variants?: ComponentsVariants['MuiStaticNextTimePicker'];
   };
   MuiStaticTimePicker?: {
     defaultProps?: ComponentsProps['MuiStaticTimePicker'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiStaticTimePicker'];
-    variants?: ComponentsVariants['MuiStaticTimePicker'];
   };
   MuiTimeClock?: {
     defaultProps?: ComponentsProps['MuiTimeClock'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiTimeClock'];
-    variants?: ComponentsVariants['MuiTimeClock'];
   };
   MuiTimePickerToolbar?: {
     defaultProps?: ComponentsProps['MuiTimePickerToolbar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiTimePickerToolbar'];
-    variants?: ComponentsVariants['MuiTimePickerToolbar'];
   };
   MuiYearCalendar?: {
     defaultProps?: ComponentsProps['MuiYearCalendar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiYearCalendar'];
-    variants?: ComponentsVariants['MuiYearCalendar'];
   };
 }
 


### PR DESCRIPTION
`variants` are not supported by any component in `mui-x` repository.
Most of mui-core components do have variants and so they have additional typing and logic to support additional variants extension.
In pickers case we did not even support it anywhere.

This is technically a breaking change, but it would not impact anyone as those fields served no purpose. It was just a mistake on our side.

If you think that we should include it in the migration docs—we could do it, but I see little to no purpose in it... 🙈 