### PR TITLE
[core] Fix the product license reference name

### DIFF
--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -124,8 +124,8 @@ async function addLicense(packageData) {
   const license = `/** @license MUI X v${packageData.version}
  *
  * This source code is licensed under the ${
-   packageData.license === 'MIT' ? 'MIT license' : 'commercial license'
- } found in the
+   packageData.license === 'MIT' ? 'MIT' : 'commercial'
+ } license found in the
  * LICENSE file in the root directory of this source tree.
  */
 `;

--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -121,9 +121,11 @@ async function prepend(file, string) {
 }
 
 async function addLicense(packageData) {
-  const license = `/** @license MUI v${packageData.version}
+  const license = `/** @license MUI X v${packageData.version}
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the ${
+   packageData.license === 'MIT' ? 'MIT license' : 'commercial license'
+ } found in the
  * LICENSE file in the root directory of this source tree.
  */
 `;


### PR DESCRIPTION
To change https://unpkg.com/@mui/x-date-pickers-pro@5.0.12/node/index.js. It matches with https://unpkg.com/browse/react-dom@18.2.0/cjs/react-dom-server.node.production.min.js.

And no, it's not MIT.

Related to https://github.com/mui/material-ui/pull/35703