### PR TITLE
[pickers] Hide am/pm controls when their is no hour view

### DIFF
--- a/packages/x-date-pickers/src/TimeClock/TimeClock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/TimeClock.tsx
@@ -137,7 +137,7 @@ const TimeClockRoot = styled(PickerViewRoot, {
   flexDirection: 'column',
 });
 
-const TimeCLockArrowSwitcher = styled(PickersArrowSwitcher, {
+const TimeClockArrowSwitcher = styled(PickersArrowSwitcher, {
   name: 'MuiTimeClock',
   slot: 'ArrowSwitcher',
   overridesResolver: (props, styles) => styles.arrowSwitcher,
@@ -416,7 +416,7 @@ export const TimeClock = React.forwardRef(function TimeClock<TDate extends unkno
       sx={sx}
     >
       {showViewSwitcher && (
-        <TimeCLockArrowSwitcher
+        <TimeClockArrowSwitcher
           className={classes.arrowSwitcher}
           components={components}
           componentsProps={componentsProps}
@@ -432,7 +432,7 @@ export const TimeClock = React.forwardRef(function TimeClock<TDate extends unkno
 
       <Clock<TDate>
         autoFocus={autoFocus}
-        ampmInClock={ampmInClock}
+        ampmInClock={ampmInClock && views.includes('hours')}
         value={value}
         type={view}
         ampm={ampm}

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -141,7 +141,7 @@ export function TimePickerToolbar<TDate extends unknown>(inProps: TimePickerTool
   const localeText = useLocaleText<TDate>();
 
   const theme = useTheme();
-  const showAmPmControl = Boolean(ampm && !ampmInClock);
+  const showAmPmControl = Boolean(ampm && !ampmInClock && views.includes('hours'));
   const { meridiemMode, handleMeridiemChange } = useMeridiemMode(value, ampm, onChange);
 
   const formatHours = (time: TDate) =>


### PR DESCRIPTION
While working on #7339, I noticed that a time picker with just the `minutes` and `seconds` view was renderting `MM:SS AM` in the toolbar, which is confusing.