### PR TITLE
[field] Prevent date change on `TimeField` arrow edition

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/useSingleInputDateRangeField.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/useSingleInputDateRangeField.ts
@@ -70,6 +70,6 @@ export const useSingleInputDateRangeField = <TDate, TChildProps extends {}>({
     valueManager: rangeValueManager,
     fieldValueManager: rangeFieldValueManager,
     validator: validateDateRange,
-    supportedDateSections: ['year', 'month', 'day'],
+    valueType: 'date',
   });
 };

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/useSingleInputDateTimeRangeField.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/useSingleInputDateTimeRangeField.ts
@@ -90,6 +90,6 @@ export const useSingleInputDateTimeRangeField = <TDate, TChildProps extends {}>(
     valueManager: rangeValueManager,
     fieldValueManager: rangeFieldValueManager,
     validator: validateDateTimeRange,
-    supportedDateSections: ['year', 'month', 'day', 'hours', 'minutes', 'seconds', 'meridiem'],
+    valueType: 'date-time',
   });
 };

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/useSingleInputTimeRangeField.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/useSingleInputTimeRangeField.ts
@@ -67,6 +67,6 @@ export const useSingleInputTimeRangeField = <TDate, TChildProps extends {}>({
     valueManager: rangeValueManager,
     fieldValueManager: rangeFieldValueManager,
     validator: validateTimeRange,
-    supportedDateSections: ['hours', 'minutes', 'seconds', 'meridiem'],
+    valueType: 'time',
   });
 };

--- a/packages/x-date-pickers/src/DateField/useDateField.ts
+++ b/packages/x-date-pickers/src/DateField/useDateField.ts
@@ -74,6 +74,6 @@ export const useDateField = <TDate, TChildProps extends {}>({
     valueManager: singleItemValueManager,
     fieldValueManager: singleItemFieldValueManager,
     validator: validateDate,
-    supportedDateSections: ['year', 'month', 'day'],
+    valueType: 'date',
   });
 };

--- a/packages/x-date-pickers/src/DateTimeField/useDateTimeField.ts
+++ b/packages/x-date-pickers/src/DateTimeField/useDateTimeField.ts
@@ -96,6 +96,6 @@ export const useDateTimeField = <TDate, TChildProps extends {}>({
     valueManager: singleItemValueManager,
     fieldValueManager: singleItemFieldValueManager,
     validator: validateDateTime,
-    supportedDateSections: ['year', 'month', 'day', 'hours', 'minutes', 'seconds', 'meridiem'],
+    valueType: 'date-time',
   });
 };

--- a/packages/x-date-pickers/src/TimeField/useTimeField.ts
+++ b/packages/x-date-pickers/src/TimeField/useTimeField.ts
@@ -75,6 +75,6 @@ export const useTimeField = <TDate, TChildProps extends {}>({
     valueManager: singleItemValueManager,
     fieldValueManager: singleItemFieldValueManager,
     validator: validateTime,
-    supportedDateSections: ['hours', 'minutes', 'seconds', 'meridiem'],
+    valueType: 'time',
   });
 };

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -60,6 +60,7 @@ export const useField = <
     fieldValueManager,
     valueManager,
     validator,
+    valueType,
   } = params;
 
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -294,15 +295,24 @@ export const useField = <
 
         updateSectionValue({
           activeSection,
-          setSectionValueOnDate: (activeDate) => ({
-            date: adjustDateSectionValue(
+          setSectionValueOnDate: (activeDate) => {
+            let date = adjustDateSectionValue(
               utils,
               activeDate,
               activeSection.dateSectionName,
               event.key as AvailableAdjustKeyCode,
-            ),
-            shouldGoToNextSection: false,
-          }),
+            );
+
+            // If the field only supports time editing, then we should never go to the previous / next day.
+            if (valueType === 'time') {
+              date = utils.mergeDateAndTime(activeDate, date);
+            }
+
+            return {
+              date,
+              shouldGoToNextSection: false,
+            };
+          },
           setSectionValueOnSections: () => ({
             sectionValue: adjustInvalidDateSectionValue(
               utils,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -22,7 +22,7 @@ export interface UseFieldParams<
     InferError<TInternalProps>,
     UseFieldValidationProps<TValue, TInternalProps>
   >;
-  supportedDateSections: MuiDateSectionName[];
+  valueType: FieldValueType;
 }
 
 export interface UseFieldInternalProps<TValue, TError> {
@@ -334,6 +334,8 @@ export type AvailableAdjustKeyCode =
   | 'PageDown'
   | 'Home'
   | 'End';
+
+export type FieldValueType = 'date' | 'time' | 'date-time';
 
 export type SectionNeighbors = {
   [sectionIndex: number]: {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -4,6 +4,7 @@ import {
   FieldSectionsValueBoundaries,
   SectionNeighbors,
   SectionOrdering,
+  FieldValueType,
 } from './useField.types';
 import { MuiPickersAdapter, MuiDateSectionName } from '../../models';
 import { PickersLocaleText } from '../../../locales/utils/pickersLocaleTextApi';
@@ -635,8 +636,16 @@ let warnedOnceInvalidSection = false;
 
 export const validateSections = <TSection extends FieldSection>(
   sections: TSection[],
-  supportedSections: MuiDateSectionName[],
+  valueType: FieldValueType,
 ) => {
+  const supportedSections: MuiDateSectionName[] = [];
+  if (['date', 'date-time'].includes(valueType)) {
+    supportedSections.push('day', 'month', 'year');
+  }
+  if (['time', 'date-time'].includes(valueType)) {
+    supportedSections.push('hours', 'minutes', 'seconds', 'meridiem');
+  }
+
   if (process.env.NODE_ENV !== 'production') {
     if (!warnedOnceInvalidSection) {
       const invalidSection = sections.find(

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -73,7 +73,7 @@ export const useFieldState = <
   const {
     valueManager,
     fieldValueManager,
-    supportedDateSections,
+    valueType,
     validator,
     internalProps,
     internalProps: {
@@ -109,7 +109,7 @@ export const useFieldState = <
       valueFromTheOutside,
       format,
     );
-    validateSections(sections, supportedDateSections);
+    validateSections(sections, valueType);
 
     return {
       sections,
@@ -405,7 +405,7 @@ export const useFieldState = <
       state.value,
       format,
     );
-    validateSections(sections, supportedDateSections);
+    validateSections(sections, valueType);
     setState((prevState) => ({
       ...prevState,
       sections,


### PR DESCRIPTION
[Behavior before](https://codesandbox.io/s/date-and-time-pickers-forked-fepeji)
[Behavior after](https://codesandbox.io/s/date-and-time-pickers-forked-onxvj9)

Press `ArrowUp`, the old one should go to the 8th of April, not the new one.

Maybe some people want the old behavior and if so we could introduce a prop to support it.
But the new behavior feels more coherent to me, especially with time range pickers were the behavior is very weird when we have `12:00 - 15:00` rendered but the field is in error because the `15:00` is actually in the day before.