### PR TITLE
v5.17.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 
 #### Changes
 
-- Release to apply: [core] Fix the product license reference name (#7367)
+- [pickers] Fix the product license reference name (#7367)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## 5.17.18
+
 _Jan 5, 2023_
 
 We'd like to offer a big thanks to the 3 contributors who made this release possible. Here are some highlights ✨:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 5.17.18
+_Jan 5, 2023_
+
+We'd like to offer a big thanks to the 3 contributors who made this release possible. Here are some highlights ✨:
+
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v5.17.18` / `@mui/x-data-grid-pro@v5.17.18` / `@mui/x-data-grid-premium@v5.17.18`
+
+#### Changes
+
+- [DataGrid] Fix rows not rendering properly after height change (#7376) @cherniavskii
+- [DataGrid] Fix selected text in cell input not being copied in Firefox (#7330) @cherniavskii
+- [DataGridPremium] Export row grouping column menu components (#7308) @cherniavskii
+
+### `@mui/x-date-pickers@v5.0.13` / `@mui/x-date-pickers-pro@v5.0.13`
+
+#### Changes
+
+- Release to apply: [core] Fix the product license reference name (#7367)
+
+### Docs
+
+- [docs] Redirect translated pages (#7370) @cherniavskii
+
+### Core
+
+- [core] Fix release date (#7314) @DanailH
+- [core] Fix the product license reference name (#7367) @oliviertassinari
+- [core] Upgrade monorepo (#7344) @cherniavskii
+
 ## 5.17.17
 
 _Dec 24, 2022_
@@ -12,7 +43,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 - 🌍 Improve Russian (ru-RU) and Korean (ko-KR) locales
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@5.17.17` / `@mui/x-data-grid-pro@5.17.17` / `@mui/x-data-grid-premium@5.17.17`
+### `@mui/x-data-grid@v5.17.17` / `@mui/x-data-grid-pro@v5.17.17` / `@mui/x-data-grid-premium@v5.17.17`
 
 #### Changes
 
@@ -20,7 +51,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 - [DataGridPro] Use row ID as `key` of the detail panels (#7311) @m4theushw
 - [DataGridPremium] Fix `exceljs` import with parcel (#7285) @alexfauquette
 
-### `@mui/x-date-pickers@5.0.12` / `@mui/x-date-pickers-pro@5.0.12`
+### `@mui/x-date-pickers@v5.0.12` / `@mui/x-date-pickers-pro@v5.0.12`
 
 #### Changes
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "5.17.17",
+  "version": "5.17.18",
   "private": true,
   "author": "MUI Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.17.16",
+  "version": "5.17.18",
   "private": true,
   "scripts": {
     "start": "yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "5.17.17",
+  "version": "5.17.18",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.9",
     "@mui/base": "^5.0.0-alpha.97",
-    "@mui/x-data-grid-premium": "5.17.17",
+    "@mui/x-data-grid-premium": "5.17.18",
     "chance": "^1.1.8",
     "clsx": "^1.2.1",
     "lru-cache": "^7.14.0"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "5.17.17",
+  "version": "5.17.18",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,8 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.18.9",
     "@mui/utils": "^5.10.3",
-    "@mui/x-data-grid": "5.17.17",
-    "@mui/x-data-grid-pro": "5.17.17",
+    "@mui/x-data-grid": "5.17.18",
+    "@mui/x-data-grid-pro": "5.17.18",
     "@mui/x-license-pro": "5.17.12",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "5.17.17",
+  "version": "5.17.18",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.9",
     "@mui/utils": "^5.10.3",
-    "@mui/x-data-grid": "5.17.17",
+    "@mui/x-data-grid": "5.17.18",
     "@mui/x-license-pro": "5.17.12",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "5.17.17",
+  "version": "5.17.18",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -47,7 +47,7 @@
     "@date-io/luxon": "^2.15.0",
     "@date-io/moment": "^2.15.0",
     "@mui/utils": "^5.10.3",
-    "@mui/x-date-pickers": "5.0.12",
+    "@mui/x-date-pickers": "5.0.13",
     "@mui/x-license-pro": "5.17.12",
     "clsx": "^1.2.1",
     "prop-types": "^15.7.2",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",


### PR DESCRIPTION
### Prepare the release of the packages

The following steps must be proposed as a pull request.

- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [x] Update the root `package.json`'s version
- [x] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version`.
- [x] Fix manually the package version in `x-date-pickers/package.json` and `x-date-pickers-pro/package.json`.
- [x] Open PR with changes and wait for review and green CI.
- [x] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

```sh
git push upstream master:docs-v5 -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v5)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v5` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)