### PR TITLE
[DataGridPro] feat add last row for infinite scroll rows with intersection observer element 

### DIFF
--- a/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
@@ -424,7 +424,7 @@ const DataGridProVirtualScroller = React.forwardRef<
         )}
         <GridVirtualScrollerRenderZone {...getRenderZoneProps()}>
           {mainRows}
-          <div id='mui-data-grid-last-row-id' />
+          <div id="mui-data-grid-last-row-id" style={{ minHeight: 1 }} />
         </GridVirtualScrollerRenderZone>
         {rightRenderContext && (
           <VirtualScrollerPinnedColumns

--- a/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/DataGridProVirtualScroller.tsx
@@ -424,6 +424,7 @@ const DataGridProVirtualScroller = React.forwardRef<
         )}
         <GridVirtualScrollerRenderZone {...getRenderZoneProps()}>
           {mainRows}
+          <div id='mui-data-grid-last-row-id' />
         </GridVirtualScrollerRenderZone>
         {rightRenderContext && (
           <VirtualScrollerPinnedColumns


### PR DESCRIPTION
This feature is adding an empty div with id `mui-data-grid-last-row-id` this empty div is used for proper infinite scroll purpose, we cant depend on `onRowsScrollEnd` callback for infinite scroll or cursor-based pagination. 

Problem:
For eg. DataGridPro with height 1000px, calling backend infinite scroll with limit 2 items, hence backend returning 2 items and next cursor, the 2 items are rendered on the DataGrid however unable to scroll, as 1 row took 50px only, hence unable handle next cursor infinite scroll.

<video width="320" height="240" src="https://user-images.githubusercontent.com/77238199/211150444-7b469fb4-2fc5-49f0-b836-9e984d537c5a.mov"></video>
as the video shown, the items loaded from backend but unable to scroll, hence cant fetch again for another cursor items...with the onRowsScrollEnd callback...

Solution:
Infinite scroll should be handle with IntersectionObserver native js api. With the id empty div we can observe the element in viewport and then fetch next cursor items.
Note*: the empty div with id must be always at the last items of the scroll list.

```
 const handleObserver = useCallback(
    (entries) => {
      if (isFetching) {
        return;
      }
      const [target] = entries;

      if (target.isIntersecting && hasNextPage) {
        fetchNextPage();
      }
    },
    [fetchNextPage, hasNextPage, isFetching]
  );

  useEffect(() => {
    const observer = new IntersectionObserver(handleObserver, { threshold: 0 });

    // https://flaviocopes.com/node-process-nexttick/
    // Calling setTimeout(() => {}, 0) will execute the function at the end of next tick,
    // much later than when using nextTick() which prioritizes the call and executes it just
    // before the beginning of the next tick.
    // the settimeout is prevent observe the last row div before the virtual scroll are rendered.
    setTimeout(() => {
      const element = document.getElementById("mui-data-grid-last-row-id");
      if (element) {
        observer.observe(element);
      }
    });

    return () => {
      const element = document.getElementById("mui-data-grid-last-row-id");
      if (element) {
        observer.unobserve(element);
      }
    };
  }, [fetchNextPage, hasNextPage, handleObserver]);
```

Result:
<video width="320" height="240" src="https://user-images.githubusercontent.com/77238199/211143690-a73b8b76-4ddb-4f2b-be8d-f089ba905464.mp4"></video>

I think i have presented the proof of concept and the practical way of implementing the infinite scroll list or cursor based pagination. However i unable to implement it via slot hence I hope maintainer can add it as slot. The slot must always at the last item of the scroll list.


