### PR TITLE
[docs] Fix wrong reference to currentView

### DIFF
--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -169,7 +169,9 @@ This callback receives the current view and the value to be tested:
 
 ```tsx
 // Disables the hours between 12 AM and 3 PM.
-shouldDisableTime={(timeValue, view) => currentView === 'hours' && timeValue > 12 && timeValue < 15}
+shouldDisableTime={(timeValue, view) =>
+  view === 'hours' && timeValue > 12 && timeValue < 15
+}
 
 // Disables the last quarter of each hour.
 shouldDisableTime={(timeValue, view) => view === 'minutes' && timeValue >= 45};
@@ -201,13 +203,15 @@ For now, you can not use `maxDateTime` and `maxTime` together.
 `maxDateTime` will override the `maxTime` behavior—Same for `minDateTime`/`minTime`
 
 ```tsx
-// Disable the values between 6 PM and midnight for every day (tomorrow 5 PM is not disabled).
+// Disable the values between 6 PM and midnight for every day
+// (tomorrow 5 PM is not disabled).
 <DateTimePicker maxTime={dayjs().set('hour', 18).startOf('hour')} />
 
 // Disable the values after today 6 PM (tomorrow 5 PM is disabled).
 <DateTimePicker maxDateTime={dayjs().set('hour', 18).startOf('hour')} />
 
-// Disable the values between midnight and 6 PM for every day (yesterday 5 PM is not disabled).
+// Disable the values between midnight and 6 PM for every day
+// (yesterday 5 PM is not disabled).
 <DateTimePicker minTime={dayjs().set('hour', 18).startOf('hour')} />
 
 // Disable the values before today 6 PM (yesterday 5 PM is disabled).


### PR DESCRIPTION
```diff
-shouldDisableTime={(timeValue, view) => currentView === 'hours' && timeValue > 12 && timeValue < 15}
+shouldDisableTime={(timeValue, view) => view === 'hours' && timeValue > 12 && timeValue < 15}
```

I also fix the scrollbar in:

<img width="736" alt="Screenshot 2023-01-08 at 17 14 16" src="https://user-images.githubusercontent.com/3165635/211207228-98096c91-c268-4868-8c2a-66ffef2f5912.png">

for 13" screens

https://next.mui.com/x/react-date-pickers/validation/#disable-specific-times