### PR TITLE
[core] Update package used to import LicenseInfo

### DIFF
--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -158,13 +158,14 @@ You only need to install the key once in your application.
 When using Next.js, you should call `setLicenseKey` in [`_app.js`](https://nextjs.org/docs/advanced-features/custom-app):
 
 ```tsx
+import { LicenseInfo } from '@mui/x-license-pro';
+
 LicenseInfo.setLicenseKey('YOUR_LICENSE_KEY');
 
-function MyApp({ Component, pageProps }) {
+export default function MyApp(props) {
+  const { Component, pageProps } = props;
   return <Component {...pageProps} />;
 }
-
-export default MyApp;
 ```
 
 :::

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -16,7 +16,7 @@ import { UserLanguageProvider } from 'docs/src/modules/utils/i18n';
 import DocsStyledEngineProvider from 'docs/src/modules/utils/StyledEngineProvider';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import findActivePage from 'docs/src/modules/utils/findActivePage';
-import { LicenseInfo } from '@mui/x-data-grid-pro';
+import { LicenseInfo } from '@mui/x-license-pro';
 
 // Remove the license warning from demonstration purposes
 LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);

--- a/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
@@ -3,8 +3,8 @@ import addYears from 'date-fns/addYears';
 import { expect } from 'chai';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer } from '@mui/monorepo/test/utils';
-import { DataGridPremium, LicenseInfo } from '@mui/x-data-grid-premium';
-import { generateLicense } from '@mui/x-license-pro';
+import { DataGridPremium } from '@mui/x-data-grid-premium';
+import { generateLicense, LicenseInfo } from '@mui/x-license-pro';
 
 describe('<DataGridPremium /> - License', () => {
   const { render } = createRenderer();

--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { LicenseInfo } from '@mui/x-data-grid-pro';
 // @ts-ignore Remove once the test utils are typed
 import { createRenderer } from '@mui/monorepo/test/utils';
-import { useLicenseVerifier } from '@mui/x-license-pro';
+import { useLicenseVerifier, LicenseInfo } from '@mui/x-license-pro';
 import { sharedLicenseStatuses } from './useLicenseVerifier';
 import { generateReleaseInfo } from '../verifyLicense';
 

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { LicenseInfo } from '@mui/x-data-grid-pro';
+import { LicenseInfo } from '@mui/x-license-pro';
 import TestViewer from 'test/regressions/TestViewer';
 import { useFakeTimers } from 'sinon';
 


### PR DESCRIPTION
Per https://github.com/mui/mui-x/issues/3969#issuecomment-1373914604.

We still need each package to export LicenseInfo as when we do a breaking change with the license package, we will need developers to be able to upgrade their component incrementally. 