### PR TITLE
[DataGrid] Remove Alt+C keyboard shortcut

### DIFF
--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -100,7 +100,6 @@ On macOS:
 |                                  <kbd class="key">Shift</kbd>+ Click on cell | Select the range of rows between the first and the last clicked rows |
 |              <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">A</kbd></kbd> | Select all rows                                                      |
 |              <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected rows                                     |
-|               <kbd><kbd class="key">Alt</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected rows, including headers                  |
 |                                   <kbd class="key">Ctrl</kbd>+ Click on cell | Enable multi-selection                                               |
 |                         <kbd class="key">Ctrl</kbd>+ Click on a selected row | Deselect the row                                                     |
 

--- a/packages/grid/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
@@ -71,15 +71,6 @@ describe('<DataGridPro /> - Clipboard', () => {
       expect(writeText.firstCall.args[0]).to.equal(['0\tNike', '1\tAdidas'].join('\r\n'));
     });
 
-    it('should include the headers when includeHeaders=true', () => {
-      render(<Test />);
-      act(() => apiRef.current.selectRows([0, 1]));
-      act(() => apiRef.current.unstable_copySelectedRowsToClipboard(true));
-      expect(writeText.firstCall.args[0]).to.equal(
-        ['id\tBrand', '0\tNike', '1\tAdidas'].join('\r\n'),
-      );
-    });
-
     ['ctrlKey', 'metaKey'].forEach((key) => {
       it(`should copy the selected rows to the clipboard when ${key} + C is pressed`, () => {
         render(<Test disableRowSelectionOnClick />);
@@ -89,16 +80,6 @@ describe('<DataGridPro /> - Clipboard', () => {
         fireEvent.keyDown(cell, { key: 'c', keyCode: 67, [key]: true });
         expect(writeText.firstCall.args[0]).to.equal(['0\tNike', '1\tAdidas'].join('\r\n'));
       });
-    });
-
-    it(`should copy the selected rows and headers to the clipboard when Alt + C is pressed`, () => {
-      render(<Test />);
-      act(() => apiRef.current.selectRows([0, 1]));
-      const cell = getCell(0, 0);
-      userEvent.mousePress(cell);
-      fireEvent.keyDown(cell, { key: 'c', keyCode: 67, altKey: true });
-      expect(writeText.callCount).to.equal(1, "writeText wasn't called");
-      expect(writeText.firstCall.args[0]).to.equal(['id\tBrand', '0\tNike'].join('\r\n'));
     });
   });
 });

--- a/packages/grid/x-data-grid/src/hooks/features/clipboard/useGridClipboard.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/clipboard/useGridClipboard.ts
@@ -48,32 +48,28 @@ function hasNativeSelection(element: HTMLInputElement) {
 export const useGridClipboard = (apiRef: React.MutableRefObject<GridPrivateApiCommunity>): void => {
   const copySelectedRowsToClipboard = React.useCallback<
     GridClipboardApi['unstable_copySelectedRowsToClipboard']
-  >(
-    (includeHeaders = false) => {
-      if (apiRef.current.getSelectedRows().size === 0) {
-        return;
-      }
+  >(() => {
+    if (apiRef.current.getSelectedRows().size === 0) {
+      return;
+    }
 
-      const data = apiRef.current.getDataAsCsv({
-        includeHeaders,
-        delimiter: '\t',
-      });
+    const data = apiRef.current.getDataAsCsv({
+      includeHeaders: false,
+      delimiter: '\t',
+    });
 
-      if (navigator.clipboard) {
-        navigator.clipboard.writeText(data).catch(() => {
-          writeToClipboardPolyfill(data);
-        });
-      } else {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(data).catch(() => {
         writeToClipboardPolyfill(data);
-      }
-    },
-    [apiRef],
-  );
+      });
+    } else {
+      writeToClipboardPolyfill(data);
+    }
+  }, [apiRef]);
 
   const handleKeydown = React.useCallback(
     (event: KeyboardEvent) => {
-      const isModifierKeyPressed = event.ctrlKey || event.metaKey || event.altKey;
-      // event.key === 'c' is not enough as alt+c can lead to ©, ç, or other characters on macOS.
+      const isModifierKeyPressed = event.ctrlKey || event.metaKey;
       // event.code === 'KeyC' is not enough as event.code assume a QWERTY keyboard layout which would
       // be wrong with a Dvorak keyboard (as if pressing J).
       if (String.fromCharCode(event.keyCode) !== 'C' || !isModifierKeyPressed) {
@@ -85,7 +81,7 @@ export const useGridClipboard = (apiRef: React.MutableRefObject<GridPrivateApiCo
         return;
       }
 
-      apiRef.current.unstable_copySelectedRowsToClipboard(event.altKey);
+      apiRef.current.unstable_copySelectedRowsToClipboard();
     },
     [apiRef],
   );

--- a/packages/grid/x-data-grid/src/models/api/gridClipboardApi.ts
+++ b/packages/grid/x-data-grid/src/models/api/gridClipboardApi.ts
@@ -5,8 +5,7 @@ export interface GridClipboardApi {
   /**
    * Copies the selected rows to the clipboard.
    * The fields will be separated by the TAB character.
-   * @param {boolean} includeHeaders Whether to include the headers or not. Default is `false`.
    * @ignore - do not document.
    */
-  unstable_copySelectedRowsToClipboard: (includeHeaders?: boolean) => void;
+  unstable_copySelectedRowsToClipboard: () => void;
 }


### PR DESCRIPTION
Relates to #3287 
Closes #5618 

## Changelog

### Breaking changes

- <kbd>Alt</kbd>(or <kbd>⌥ Option</kbd>) + <kbd>C</kbd> keyboard shortcut is no longer supported