### PR TITLE
[DateRangeCalendar] Ignore `calendars` prop on mobile

### DIFF
--- a/packages/x-date-pickers-pro/src/MobileNextDateRangePicker/MobileNextDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileNextDateRangePicker/MobileNextDateRangePicker.tsx
@@ -33,7 +33,7 @@ const MobileNextDateRangePicker = React.forwardRef(function MobileNextDateRangeP
   const props = {
     ...defaultizedProps,
     viewRenderers,
-    calendars: defaultizedProps.calendars ?? 1,
+    calendars: 1,
     views: ['day'] as const,
     openTo: 'day' as const,
     showToolbar: defaultizedProps.showToolbar ?? true,


### PR DESCRIPTION
Fixes an inconsistency between the doc and the actual behavior

https://github.com/mui/mui-x/blob/e472a0e6848d68a115e278408e973acddbfdc4de/docs/data/date-pickers/date-range-picker/date-range-picker.md?plain=1#L79