### PR TITLE
[pickers] Ensure `key` is passed without object spreading

### DIFF
--- a/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
+++ b/packages/x-date-pickers/src/CalendarPicker/DayPicker.tsx
@@ -426,7 +426,7 @@ export function DayPicker<TDate>(inProps: DayPickerProps<TDate>) {
                   return renderDay ? (
                     renderDay(day, validSelectedDays, pickersDayProps)
                   ) : (
-                    <PickersDay key={pickersDayProps.key} {...pickersDayProps} />
+                    <PickersDay {...pickersDayProps} key={pickersDayProps.key} />
                   );
                 })}
               </PickersCalendarWeek>


### PR DESCRIPTION
Fix #7546