### PR TITLE
[pickers] Fix day calendar row and column index

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -229,6 +229,7 @@ function WrappedDay<TDate extends unknown>({
   isDateDisabled,
   currentMonthNumber,
   isViewFocused,
+  ...other
 }: Pick<PickersDayProps<TDate>, 'onFocus' | 'onBlur' | 'onKeyDown' | 'onDaySelect'> & {
   parentProps: DayCalendarProps<TDate>;
   day: TDate;
@@ -272,6 +273,7 @@ function WrappedDay<TDate extends unknown>({
       isAnimating: isMonthSwitchingAnimating,
       // it is used in date range dragging logic by accessing `dataset.timestamp`
       'data-timestamp': utils.toJsDate(day).valueOf(),
+      ...other,
     },
     ownerState: { ...parentProps, day, selected: isSelected },
   });
@@ -564,11 +566,14 @@ export function DayCalendar<TDate>(inProps: DayCalendarProps<TDate>) {
             role="rowgroup"
             className={classes.monthContainer}
           >
-            {weeksToDisplay.map((week) => (
+            {weeksToDisplay.map((week, index) => (
               <PickersCalendarWeek
                 role="row"
                 key={`week-${week[0]}`}
                 className={classes.weekContainer}
+                // fix issue of announcing row 1 as row 2
+                // caused by week day labels row
+                aria-rowindex={index + 1}
               >
                 {displayWeekNumber && (
                   <PickersCalendarWeekNumber
@@ -581,7 +586,7 @@ export function DayCalendar<TDate>(inProps: DayCalendarProps<TDate>) {
                     {localeText.calendarWeekNumberText(utils.getWeekNumber(week[0]))}
                   </PickersCalendarWeekNumber>
                 )}
-                {week.map((day) => (
+                {week.map((day, dayIndex) => (
                   <WrappedDay
                     key={(day as any).toString()}
                     parentProps={props}
@@ -595,6 +600,8 @@ export function DayCalendar<TDate>(inProps: DayCalendarProps<TDate>) {
                     isDateDisabled={isDateDisabled}
                     currentMonthNumber={currentMonthNumber}
                     isViewFocused={internalHasFocus}
+                    // fix issue of announcing column 1 as column 2 when `displayWeekNumber` is enabled
+                    aria-colindex={dayIndex + 1}
                   />
                 ))}
               </PickersCalendarWeek>


### PR DESCRIPTION
Fixes #6886 
Add explicit `aria-rowindex` on the week row and `aria-colindex` on the day to have correct numbers announced by the reader.
The indexes are skewed because of the week day label row and optional week number column.