### PR TITLE
[DataGrid] Remove tag limit from `isAnyOf` operator input

### DIFF
--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleSingleSelect.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleSingleSelect.tsx
@@ -18,7 +18,6 @@ export interface GridFilterInputMultipleSingleSelectProps
       | 'id'
       | 'filterOptions'
       | 'isOptionEqualToValue'
-      | 'limitTags'
       | 'multiple'
       | 'color'
     >,
@@ -132,7 +131,6 @@ function GridFilterInputMultipleSingleSelect(props: GridFilterInputMultipleSingl
   return (
     <Autocomplete<ValueOptions, true, false, true>
       multiple
-      limitTags={1}
       options={resolvedValueOptions}
       isOptionEqualToValue={isOptionEqualToValue}
       filterOptions={filter}

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -57,7 +57,6 @@ function GridFilterInputMultipleValue(props: GridFilterInputMultipleValueProps) 
     <Autocomplete<string, true, false, true>
       multiple
       freeSolo
-      limitTags={1}
       options={[]}
       filterOptions={(options, params) => {
         const { inputValue } = params;


### PR DESCRIPTION
Fixes #6213

Preview: https://deploy-preview-7592--material-ui-x.netlify.app/x/react-data-grid/filtering/#multi-filtering