### PR TITLE
[pickers] Fix pickers view not receiving focus after closing

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -458,11 +458,6 @@ export function DayCalendar<TDate>(inProps: DayCalendarProps<TDate>) {
   const handleFocus = useEventCallback((event: React.FocusEvent<HTMLButtonElement>, day: TDate) =>
     focusDay(day),
   );
-  const handleBlur = useEventCallback((event: React.FocusEvent<HTMLButtonElement>, day: TDate) => {
-    if (internalHasFocus && utils.isSameDay(internalFocusedDay, day)) {
-      onFocusedViewChange?.(false);
-    }
-  });
 
   const currentMonthNumber = utils.getMonth(currentMonth);
   const validSelectedDays = React.useMemo(
@@ -590,7 +585,6 @@ export function DayCalendar<TDate>(inProps: DayCalendarProps<TDate>) {
                     focusableDay={focusableDay}
                     onKeyDown={handleKeyDown}
                     onFocus={handleFocus}
-                    onBlur={handleBlur}
                     onDaySelect={handleDaySelect}
                     isDateDisabled={isDateDisabled}
                     currentMonthNumber={currentMonthNumber}


### PR DESCRIPTION
Fixes #7177 

Removing this interesting `handleBlur` function solves the issue of focus being lost after closing picker view.
The issue is that there is nothing re-setting the focused view after opening the picker. This could be the second approach to explore in order to fix the issue.
But maybe you can confirm what edge case does this blur handler cover? I fail to think of one and there are no tests expecting this behaviour...