### PR TITLE
[DateRangePicker] Propagate `rangePosition` to view

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.tsx
@@ -53,7 +53,10 @@ export const useStaticRangePicker = <
     valueManager,
     validator,
     autoFocusView: autoFocus ?? false,
-    additionalViewProps: {},
+    additionalViewProps: {
+      rangePosition,
+      onRangePositionChange: setRangePosition,
+    },
     wrapperVariant: displayStaticWrapperAs,
   });
 


### PR DESCRIPTION
Fix to propagate `rangePosition` to view—same as we do for desktop and mobile picker versions.
It fixes the issue of view not being aware of the currently selecting range position and thus:
- not changing selected toolbar range position after start or end date is selected
- always showing preview highlighting range styling for start position