### PR TITLE
[core] Add release documentation step detailing `x-codemod` package tag change

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,7 @@ The following steps must be proposed as a pull request.
 - [ ] Build the packages: `yarn release:build`.
 - [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
 - [ ] Push the newly created tag: `yarn release:tag`.
+- [ ] If `@mui/x-codemod` has been released, set the pre-release package `tag` to `latest` with: `npm dist-tag add @mui/x-codemod@<released_version> latest`.
 
 ### Publish the documentation
 


### PR DESCRIPTION
Add optional release documentation step detailing codemod package tag change.
Created [from discussion](https://mui-org.slack.com/archives/G011VC970AW/p1672962585159909?thread_ts=1672930784.808279&cid=G011VC970AW).