### PR TITLE
[pickers] Update focus when opening a UI view

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/tests/keyboard.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/keyboard.DateCalendar.test.tsx
@@ -122,5 +122,20 @@ describe('<DateCalendar /> keyboard interactions', () => {
         });
       });
     });
+
+    describe('navigate months', () => {
+      it('should keep focus on arrow when swiching month', () => {
+        render(<DateCalendar />);
+
+        const nextMonthButton = screen.getByRole('button', { name: 'Next month' });
+        act(() => nextMonthButton.focus());
+        // Don't care about what's focused.
+        // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
+        fireEvent.keyDown(document.activeElement!, { key: 'Enter' });
+
+        clock.runToLast();
+        expect(document.activeElement).toHaveAccessibleName('Next month');
+      });
+    });
   });
 });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
@@ -219,6 +219,7 @@ export const usePickerViews = <
     if (newView !== view) {
       setView(newView);
     }
+    setFocusedView(newView, true);
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const layoutProps: UsePickerViewsLayoutResponse<TView> = {

--- a/packages/x-date-pickers/src/internals/hooks/useViews.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useViews.tsx
@@ -161,10 +161,12 @@ export function useViews<TValue, TView extends DateOrTimeView>({
 
   const handleFocusedViewChange = useEventCallback((viewToFocus: TView, hasFocus: boolean) => {
     if (hasFocus) {
+      // Focus event
       setFocusedView(viewToFocus);
     } else {
-      setFocusedView((prevFocusedView) =>
-        viewToFocus === prevFocusedView ? null : prevFocusedView,
+      // Blur event
+      setFocusedView(
+        (prevFocusedView) => (viewToFocus === prevFocusedView ? null : prevFocusedView), // If false the blur is due to view swiching
       );
     }
 


### PR DESCRIPTION
Fix #7177

I did not find any effect taking care of setting the focus on open.

Why did it work the first time you open the popper and not after?

Because in `useDesktopPicker` we can see that `usePicker` is called with `autoFocusView: true` but `autoFocus` is only here for the first render (it set the default focused vie to `'day'` instead of `'null'`)