### PR TITLE
[DataGrid] Fix grid state not being updated after print preview is closed

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -274,9 +274,14 @@ export const useGridPrintExport = (
       } else {
         printWindow.onload = () => {
           handlePrintWindowLoad(printWindow, options);
-          printWindow.contentWindow!.onafterprint = () => {
-            handlePrintWindowAfterPrint(printWindow);
-          };
+
+          const mediaQueryList = printWindow.contentWindow!.matchMedia('print');
+          mediaQueryList.addEventListener('change', (mql) => {
+            const isAfterPrint = mql.matches === false;
+            if (isAfterPrint) {
+              handlePrintWindowAfterPrint(printWindow);
+            }
+          });
         };
         doc.current!.body.appendChild(printWindow);
       }


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/7630

Starting from Chromium 109, [the `afterprint` event is not being emitted](https://stackoverflow.com/questions/75129430/window-onafterprint-not-working-if-window-print-is-called-via-js#comment132603442_75129430).

So I used [`matchMedia`](https://caniuse.com/matchmedia) and [`MediaQueryList`](https://caniuse.com/?search=MediaQueryList) instead.

Before: https://codesandbox.io/s/hopeful-dijkstra-1ciqso (only reproducible with Chromium 109)
After: https://codesandbox.io/s/clever-lamarr-vb5tbr

TODO:

- [ ] Backport to the `master` branch