### PR TITLE
[l10n] aggregation Slovak translation

### DIFF
--- a/packages/grid/x-data-grid/src/locales/skSK.ts
+++ b/packages/grid/x-data-grid/src/locales/skSK.ts
@@ -177,12 +177,12 @@ const skSKGrid: Partial<GridLocaleText> = {
   rowReorderingHeaderName: 'Preusporiadávanie riadkov',
 
   // Aggregation
-  // aggregationMenuItemHeader: 'Aggregation',
-  // aggregationFunctionLabelSum: 'sum',
-  // aggregationFunctionLabelAvg: 'avg',
-  // aggregationFunctionLabelMin: 'min',
-  // aggregationFunctionLabelMax: 'max',
-  // aggregationFunctionLabelSize: 'size',
+  aggregationMenuItemHeader: 'Agregácia',
+  aggregationFunctionLabelSum: 'suma',
+  aggregationFunctionLabelAvg: 'priemer',
+  aggregationFunctionLabelMin: 'min',
+  aggregationFunctionLabelMax: 'max',
+  aggregationFunctionLabelSize: 'počet',
 };
 
 export const skSK: Localization = getGridLocalization(skSKGrid, skSKCore);


### PR DESCRIPTION
Adds missing aggregation translation for Slovak language (sk-SK) locale - https://github.com/mui/mui-x/issues/3211.