### PR TITLE
[DataGrid] Fix `autoHeight` not working properly inside of a flex container

### DIFF
--- a/packages/grid/x-data-grid/src/components/GridAutoSizer.tsx
+++ b/packages/grid/x-data-grid/src/components/GridAutoSizer.tsx
@@ -136,7 +136,11 @@ const GridAutoSizer = React.forwardRef<HTMLDivElement, AutoSizerProps>(function 
   return (
     <div
       ref={handleRef}
-      style={{ flex: disableHeight ? 0 : '1 1 0px', overflow: 'auto', ...style }}
+      style={{
+        flex: disableHeight ? 0 : '1 1 0px',
+        overflow: disableHeight ? 'visible' : 'auto',
+        ...style,
+      }}
       {...other}
     >
       {state.height === null && state.width === null ? null : children}

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -663,8 +663,34 @@ describe('<DataGrid /> - Layout & Warnings', () => {
             />
           </div>,
         );
+        const rowsHeight = rowHeight * baselineProps.rows.length;
         expect(document.querySelector('.MuiDataGrid-main')!.clientHeight).to.equal(
-          columnHeaderHeight + rowHeight * baselineProps.rows.length,
+          columnHeaderHeight + rowsHeight,
+        );
+        expect(document.querySelector('.MuiDataGrid-virtualScroller')!.clientHeight).to.equal(
+          rowsHeight,
+        );
+      });
+
+      it('should have the correct intrinsic height inside of a flex container', () => {
+        const columnHeaderHeight = 40;
+        const rowHeight = 30;
+        render(
+          <div style={{ display: 'flex' }}>
+            <DataGrid
+              {...baselineProps}
+              columnHeaderHeight={columnHeaderHeight}
+              rowHeight={rowHeight}
+              autoHeight
+            />
+          </div>,
+        );
+        const rowsHeight = rowHeight * baselineProps.rows.length;
+        expect(document.querySelector('.MuiDataGrid-main')!.clientHeight).to.equal(
+          columnHeaderHeight + rowsHeight,
+        );
+        expect(document.querySelector('.MuiDataGrid-virtualScroller')!.clientHeight).to.equal(
+          rowsHeight,
         );
       });
 


### PR DESCRIPTION
Fixes the regression introduced in https://github.com/mui/mui-x/pull/7001 (see "Before" preview below)

Before: https://deploy-preview-7001--material-ui-x.netlify.app/x/react-data-grid/events/#catalog-of-events
After: https://deploy-preview-7701--material-ui-x.netlify.app/x/react-data-grid/events/#catalog-of-events