### PR TITLE
[DataGrid] Fix handling of non-numeric values returned by `getRowHeight` prop

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
@@ -99,7 +99,7 @@ export const useGridRowsMeta = (
           rowsHeightLookup.current[row.id].autoHeight = true;
         } else {
           // Default back to base rowHeight if getRowHeight returns null or undefined.
-          baseRowHeight = rowHeightFromUser ?? rowHeight;
+          baseRowHeight = typeof rowHeightFromUser === 'number' ? rowHeightFromUser : rowHeight;
           rowsHeightLookup.current[row.id].needsFirstMeasurement = false;
           rowsHeightLookup.current[row.id].autoHeight = false;
         }


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/7669