### PR TITLE
[docs] Add info callout about available component `slots`

### DIFF
--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -6,12 +6,13 @@ components: DateTimePickerTabs
 
 # Custom components
 
-<p class="description">The date picker lets you customize sub-components.
+<p class="description">The date picker lets you customize sub-components.</p>
 
 :::info
-The components which can be customized are listed under `slots` section in DatePicker API Reference.
+The components that can be customized are listed under `slots` section in Date and Time Pickers [API Reference](/x/api/date-pickers/).
+For example, available Date Picker slots can be found [here](/x/api/date-pickers/date-picker/#slots).
 :::
-</p>
+
 
 ## Overriding components
 

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -13,7 +13,6 @@ The components that can be customized are listed under `slots` section in Date a
 For example, available Date Picker slots can be found [here](/x/api/date-pickers/date-picker/#slots).
 :::
 
-
 ## Overriding components
 
 You can override the internal elements of the component (known as "slots") using the `slots` prop.

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -6,7 +6,12 @@ components: DateTimePickerTabs
 
 # Custom components
 
-<p class="description">The date picker lets you customize sub-components.</p>
+<p class="description">The date picker lets you customize sub-components.
+
+:::info
+The components which can be customized are listed under `slots` section in DatePicker API Reference.
+:::
+</p>
 
 ## Overriding components
 


### PR DESCRIPTION
Fix #7683

information about the customizable components is added 