### PR TITLE
[docs] Polish pickers migration docs

### DIFF
--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -856,8 +856,9 @@ Component name changes are also reflected in `themeAugmentation`:
 
 ## Rename `components` to `slots` (optional)
 
-The `components` and `componentsProps` props is going to be renamed to `slots` and `slotProps` props respectively.
-This is a slow an ongoing effort between the different MUI libraries, that's why we chose to proceed with deprecating the existing `components` props as well as adding the new `slots` props.
+The `components` and `componentsProps` props is being renamed to `slots` and `slotProps` props respectively.
+This is a slow and ongoing effort between the different MUI libraries.
+To smooth the transition, pickers support both the `components` props which are deprecated, and the new `slots` props.
 
 If you would like to use the new API and do not want to see deprecated prop usage, consider running `rename-components-to-slots` codemod handling the prop renaming.
 

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -2,7 +2,7 @@
 
 <p class="description">This guide describes the changes needed to migrate the Date and Time Pickers from v5 to v6.</p>
 
-## Start using the alpha release
+## Start using the prerelease
 
 In `package.json`, change the version of the date pickers package to `next`.
 
@@ -11,7 +11,7 @@ In `package.json`, change the version of the date pickers package to `next`.
 +"@mui/x-date-pickers": "next",
 ```
 
-Using `next` ensures that it will always use the latest v6 alpha release, but you can also use a fixed version, like `6.0.0-alpha.0`.
+Using `next` ensures that it will always use the latest v6 alpha release, but you can also use a fixed version, like `6.0.0-beta.1`.
 
 Since v6 is a major release, it contains some changes that affect the public API.
 These changes were done for consistency, improve stability and make room for new features.
@@ -219,7 +219,7 @@ The `shouldDisableTime` prop signature has been changed. Either rename the prop 
 
 ### ✅ Do not import adapter from `@date-io`
 
-In v5, it was possible to import adapters either from `@date-io` or `@mui/x-date-pickers` which were the same.
+In v5, it was possible to import adapters either from either `@date-io` or `@mui/x-date-pickers` which were the same.
 In v6, the adapters are extended by `@mui/x-date-pickers` to support [fields components](/x/react-date-pickers/fields/).
 Which means adapters can not be imported from `@date-io` anymore. They need to be imported from `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`.
 Otherwise, some methods will be missing.
@@ -286,7 +286,7 @@ Component names in the theme have changed as well:
 
 ### ✅ Rename `date` prop to `value`
 
-The `date` prop has been renamed `value` on `MonthCalendar`, `YearCalendar`, `TimeClock`, and `DateCalendar` (components renamed in previous section):
+The `date` prop has been renamed to `value` on `MonthCalendar`, `YearCalendar`, `TimeClock`, and `DateCalendar` (components renamed in previous section):
 
 ```diff
 -<MonthPicker date={dayjs()} />
@@ -583,7 +583,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
 
 ### Action bar
 
-- The `action` prop of the `actionBar` component slot can no longer receive a callback.
+- The `actions` prop of the `actionBar` component slot can no longer receive a callback.
   Instead, you can pass a callback at the component slot props level
 
   ```diff
@@ -735,7 +735,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
 
 ### ✅ Left arrow button
 
-- The component slot `LeftArrowButton` has been renamed `PreviousIconButton`:
+- The component slot `LeftArrowButton` has been renamed to `PreviousIconButton`:
 
 ```diff
  <DatePicker
@@ -753,7 +753,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
 
 ### ✅ Right arrow button
 
-- The component slot `RightArrowButton` has been renamed `NextIconButton`:
+- The component slot `RightArrowButton` has been renamed to `NextIconButton`:
 
   ```diff
    <DatePicker
@@ -783,7 +783,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
 
 ### ✅ Input adornment
 
-- The `InputAdornmentProps` prop has been replaced by a `inputAdornment` component slot props:
+- The `InputAdornmentProps` prop has been replaced by an `inputAdornment` component slot props:
 
   ```diff
    <DatePicker
@@ -794,7 +794,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
 
 ### ✅ Open Picker Button
 
-- The `OpenPickerButtonProps` prop has been replaced by a `openPickerButton` component slot props:
+- The `OpenPickerButtonProps` prop has been replaced by an `openPickerButton` component slot props:
 
   ```diff
    <DatePicker
@@ -853,3 +853,16 @@ Component name changes are also reflected in `themeAugmentation`:
    },
  });
 ```
+
+## Rename `components` to `slots` (optional)
+
+The `components` and `componentsProps` props is going to be renamed to `slots` and `slotProps` props respectively.
+This is a slow an ongoing effort between the different MUI libraries, that's why we chose to proceed with deprecating the existing `components` props as well as adding the new `slots` props.
+
+If you would like to use the new API and do not want to see deprecated prop usage, consider running `rename-components-to-slots` codemod handling the prop renaming.
+
+```sh
+npx @mui/x-codemod v6.0.0/pickers/rename-components-to-slots <path>
+```
+
+Take a look at [the RFC](https://github.com/mui/material-ui/issues/33416) for more information.

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -856,7 +856,7 @@ Component name changes are also reflected in `themeAugmentation`:
 
 ## Rename `components` to `slots` (optional)
 
-The `components` and `componentsProps` props is being renamed to `slots` and `slotProps` props respectively.
+The `components` and `componentsProps` props are being renamed to `slots` and `slotProps` props respectively.
 This is a slow and ongoing effort between the different MUI libraries.
 To smooth the transition, pickers support both the `components` props which are deprecated, and the new `slots` props.
 

--- a/packages/x-codemod/src/codemod.ts
+++ b/packages/x-codemod/src/codemod.ts
@@ -116,10 +116,7 @@ yargs
     handler: run,
   })
   .scriptName('npx @mui/x-codemod')
-  .example(
-    '$0 v6.0.0/localization-provider-rename-locale src',
-    'Run "localization-provider-rename-locale" codemod on "src" path',
-  )
+  .example('$0 v6.0.0/preset-safe src', 'Run "preset-safe" codemod on "src" path')
   .example(
     '$0 v6.0.0/component-rename-prop src -- --component=DataGrid --from=prop --to=newProp',
     'Run "component-rename-prop" codemod in "src" path on "DataGrid" component with custom "from" and "to" arguments',

--- a/packages/x-codemod/src/util/addComponentsSlots.js
+++ b/packages/x-codemod/src/util/addComponentsSlots.js
@@ -1,14 +1,14 @@
 /**
- * Recusive function that:
+ * Recursive function that:
  * Return a jscodeshift object with `value` associated to path.
  * The path can be such as 'tabs.hidden' which will return `{ tabs: { hidden: value } }`.
  * If object is not null, path/value will be added respecting the other properties of the object.
  */
 export const addItemToObject = (path, value, object, j) => {
-  const splitedPath = path.split('.');
+  const splittedPath = path.split('.');
 
   // Final case where we have to add the property to the object.
-  if (splitedPath.length === 1) {
+  if (splittedPath.length === 1) {
     const propertyToAdd = j.objectProperty(j.identifier(path), value);
     if (object === null) {
       return j.objectExpression([propertyToAdd]);
@@ -20,8 +20,8 @@ export const addItemToObject = (path, value, object, j) => {
     ]);
   }
 
-  const remainingPath = splitedPath.slice(1).join('.');
-  const targetKey = splitedPath[0];
+  const remainingPath = splittedPath.slice(1).join('.');
+  const targetKey = splittedPath[0];
 
   if (object === null) {
     // Simplest case, no object to take into consideration

--- a/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/actual-props.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/actual-props.spec.js
@@ -1,9 +1,9 @@
-import { NextDatePicker } from '@mui/x-date-pickers';
-import { NextDateRangePicker } from '@mui/x-date-pickers-pro';
+import { DatePicker } from '@mui/x-date-pickers';
+import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import TextField from '@mui/material/TextField';
 
 <div>
-  <NextDateRangePicker
+  <DateRangePicker
     componentsProps={{
       layout: {
         sx: {
@@ -15,7 +15,7 @@ import TextField from '@mui/material/TextField';
       Layout: test,
     }}
   />
-  <NextDatePicker
+  <DatePicker
     components={{
       Layout: CustomLayout,
     }}

--- a/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/expected-props.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/expected-props.spec.js
@@ -1,9 +1,9 @@
-import { NextDatePicker } from '@mui/x-date-pickers';
-import { NextDateRangePicker } from '@mui/x-date-pickers-pro';
+import { DatePicker } from '@mui/x-date-pickers';
+import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import TextField from '@mui/material/TextField';
 
 <div>
-  <NextDateRangePicker
+  <DateRangePicker
     slotProps={{
       layout: {
         sx: {
@@ -15,7 +15,7 @@ import TextField from '@mui/material/TextField';
       layout: test,
     }}
   />
-  <NextDatePicker
+  <DatePicker
     slots={{
       layout: CustomLayout,
     }}


### PR DESCRIPTION
- Add "Rename `components` to `slots`" section
- Fix typos
- Fix `codemod` script examples message to contain a valid example