### PR TITLE
[core] Fix Next.js warning

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -12,7 +12,7 @@ const workspaceRoot = path.join(__dirname, '../');
 
 module.exports = withDocsInfra({
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
-  assetPrefix: process.env.DEPLOY_ENV === 'development' ? '' : '/x',
+  assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',
   env: {
     ENABLE_AD: process.env.ENABLE_AD,
     LIB_VERSION: pkg.version,


### PR DESCRIPTION
<img width="754" alt="Screenshot 2023-01-29 at 17 07 49" src="https://user-images.githubusercontent.com/3165635/215339138-c9840936-5a07-44b3-9abc-81f0dabf8190.png">

The fix replicates the docs https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix