### PR TITLE
[pickers] Hide scrollbars in the date calendar container

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickerViewRoot/PickerViewRoot.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerViewRoot/PickerViewRoot.tsx
@@ -2,7 +2,7 @@ import { styled } from '@mui/material/styles';
 import { DIALOG_WIDTH, VIEW_HEIGHT } from '../../constants/dimensions';
 
 export const PickerViewRoot = styled('div')({
-  overflowX: 'hidden',
+  overflow: 'hidden',
   width: DIALOG_WIDTH,
   maxHeight: VIEW_HEIGHT,
   display: 'flex',


### PR DESCRIPTION
Preview: https://deploy-preview-7766--material-ui-x.netlify.app/x/react-date-pickers/date-picker/#available-components

Jittery behaviour of calendar component fixed #7756 