### PR TITLE
[docs] Fix require context path to avoid duplicate key creation

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.js
+++ b/docs/pages/x/api/data-grid/data-grid-premium.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/data-grid',
     false,
-    /\/data-grid-premium(-[a-z]{2})?\.json$/,
+    /\.\/data-grid-premium(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/data-grid/data-grid-pro.js
+++ b/docs/pages/x/api/data-grid/data-grid-pro.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/data-grid',
     false,
-    /\/data-grid-pro(-[a-z]{2})?\.json$/,
+    /\.\/data-grid-pro(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/data-grid/data-grid.js
+++ b/docs/pages/x/api/data-grid/data-grid.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/data-grid',
     false,
-    /\/data-grid(-[a-z]{2})?\.json$/,
+    /\.\/data-grid(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/data-grid/grid-filter-form.js
+++ b/docs/pages/x/api/data-grid/grid-filter-form.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/data-grid',
     false,
-    /\/grid-filter-form(-[a-z]{2})?\.json$/,
+    /\.\/grid-filter-form(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/data-grid/grid-filter-panel.js
+++ b/docs/pages/x/api/data-grid/grid-filter-panel.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/data-grid',
     false,
-    /\/grid-filter-panel(-[a-z]{2})?\.json$/,
+    /\.\/grid-filter-panel(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-calendar.js
+++ b/docs/pages/x/api/date-pickers/date-calendar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-calendar(-[a-z]{2})?\.json$/,
+    /\.\/date-calendar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-field.js
+++ b/docs/pages/x/api/date-pickers/date-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-field(-[a-z]{2})?\.json$/,
+    /\.\/date-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-picker-toolbar.js
+++ b/docs/pages/x/api/date-pickers/date-picker-toolbar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-picker-toolbar(-[a-z]{2})?\.json$/,
+    /\.\/date-picker-toolbar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-picker.js
+++ b/docs/pages/x/api/date-pickers/date-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-picker(-[a-z]{2})?\.json$/,
+    /\.\/date-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-range-calendar.js
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-range-calendar(-[a-z]{2})?\.json$/,
+    /\.\/date-range-calendar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-range-picker-day.js
+++ b/docs/pages/x/api/date-pickers/date-range-picker-day.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-range-picker-day(-[a-z]{2})?\.json$/,
+    /\.\/date-range-picker-day(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-range-picker-toolbar.js
+++ b/docs/pages/x/api/date-pickers/date-range-picker-toolbar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-range-picker-toolbar(-[a-z]{2})?\.json$/,
+    /\.\/date-range-picker-toolbar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-range-picker.js
+++ b/docs/pages/x/api/date-pickers/date-range-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-range-picker(-[a-z]{2})?\.json$/,
+    /\.\/date-range-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-time-field.js
+++ b/docs/pages/x/api/date-pickers/date-time-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-time-field(-[a-z]{2})?\.json$/,
+    /\.\/date-time-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-time-picker-tabs.js
+++ b/docs/pages/x/api/date-pickers/date-time-picker-tabs.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-time-picker-tabs(-[a-z]{2})?\.json$/,
+    /\.\/date-time-picker-tabs(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-time-picker-toolbar.js
+++ b/docs/pages/x/api/date-pickers/date-time-picker-toolbar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-time-picker-toolbar(-[a-z]{2})?\.json$/,
+    /\.\/date-time-picker-toolbar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/date-time-picker.js
+++ b/docs/pages/x/api/date-pickers/date-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/date-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/day-calendar-skeleton.js
+++ b/docs/pages/x/api/date-pickers/day-calendar-skeleton.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/day-calendar-skeleton(-[a-z]{2})?\.json$/,
+    /\.\/day-calendar-skeleton(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.js
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/desktop-date-picker(-[a-z]{2})?\.json$/,
+    /\.\/desktop-date-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.js
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/desktop-date-range-picker(-[a-z]{2})?\.json$/,
+    /\.\/desktop-date-range-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.js
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/desktop-date-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/desktop-date-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/desktop-time-picker.js
+++ b/docs/pages/x/api/date-pickers/desktop-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/desktop-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/desktop-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/localization-provider.js
+++ b/docs/pages/x/api/date-pickers/localization-provider.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/localization-provider(-[a-z]{2})?\.json$/,
+    /\.\/localization-provider(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.js
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/mobile-date-picker(-[a-z]{2})?\.json$/,
+    /\.\/mobile-date-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.js
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/mobile-date-range-picker(-[a-z]{2})?\.json$/,
+    /\.\/mobile-date-range-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.js
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/mobile-date-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/mobile-date-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/mobile-time-picker.js
+++ b/docs/pages/x/api/date-pickers/mobile-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/mobile-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/mobile-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/month-calendar.js
+++ b/docs/pages/x/api/date-pickers/month-calendar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/month-calendar(-[a-z]{2})?\.json$/,
+    /\.\/month-calendar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.js
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/multi-input-date-range-field(-[a-z]{2})?\.json$/,
+    /\.\/multi-input-date-range-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.js
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/multi-input-date-time-range-field(-[a-z]{2})?\.json$/,
+    /\.\/multi-input-date-time-range-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.js
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/multi-input-time-range-field(-[a-z]{2})?\.json$/,
+    /\.\/multi-input-time-range-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/pickers-action-bar.js
+++ b/docs/pages/x/api/date-pickers/pickers-action-bar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/pickers-action-bar(-[a-z]{2})?\.json$/,
+    /\.\/pickers-action-bar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/pickers-day.js
+++ b/docs/pages/x/api/date-pickers/pickers-day.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/pickers-day(-[a-z]{2})?\.json$/,
+    /\.\/pickers-day(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/pickers-layout.js
+++ b/docs/pages/x/api/date-pickers/pickers-layout.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/pickers-layout(-[a-z]{2})?\.json$/,
+    /\.\/pickers-layout(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/pickers-shortcuts.js
+++ b/docs/pages/x/api/date-pickers/pickers-shortcuts.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/pickers-shortcuts(-[a-z]{2})?\.json$/,
+    /\.\/pickers-shortcuts(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.js
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/single-input-date-range-field(-[a-z]{2})?\.json$/,
+    /\.\/single-input-date-range-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.js
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/single-input-date-time-range-field(-[a-z]{2})?\.json$/,
+    /\.\/single-input-date-time-range-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.js
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/single-input-time-range-field(-[a-z]{2})?\.json$/,
+    /\.\/single-input-time-range-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/static-date-picker.js
+++ b/docs/pages/x/api/date-pickers/static-date-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/static-date-picker(-[a-z]{2})?\.json$/,
+    /\.\/static-date-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.js
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/static-date-range-picker(-[a-z]{2})?\.json$/,
+    /\.\/static-date-range-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.js
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/static-date-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/static-date-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/static-time-picker.js
+++ b/docs/pages/x/api/date-pickers/static-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/static-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/static-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/time-clock.js
+++ b/docs/pages/x/api/date-pickers/time-clock.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/time-clock(-[a-z]{2})?\.json$/,
+    /\.\/time-clock(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/time-field.js
+++ b/docs/pages/x/api/date-pickers/time-field.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/time-field(-[a-z]{2})?\.json$/,
+    /\.\/time-field(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/time-picker-toolbar.js
+++ b/docs/pages/x/api/date-pickers/time-picker-toolbar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/time-picker-toolbar(-[a-z]{2})?\.json$/,
+    /\.\/time-picker-toolbar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/time-picker.js
+++ b/docs/pages/x/api/date-pickers/time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/time-picker(-[a-z]{2})?\.json$/,
+    /\.\/time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/pages/x/api/date-pickers/year-calendar.js
+++ b/docs/pages/x/api/date-pickers/year-calendar.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/year-calendar(-[a-z]{2})?\.json$/,
+    /\.\/year-calendar(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -516,7 +516,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/${project.documentationFolderName}',
     false,
-    /\\/${kebabCase(reactApi.name)}(-[a-z]{2})?\\.json$/,
+    /\\.\\/${kebabCase(reactApi.name)}(-[a-z]{2})?\\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
 


### PR DESCRIPTION
Fix discussion: https://mui-org.slack.com/archives/C03SUL8TC1M/p1674819479627859
Based on comment by Olivier: https://mui-org.slack.com/archives/C03SUL8TC1M/p1675012202019609?thread_ts=1674819479.627859&cid=C03SUL8TC1M

[This is](https://github.com/mui/mui-x/commit/a83de42d62e45a452e197492600781e5e38b6146) the only relevant change.

> I faced a similar problem 3 months ago: https://github.com/mui/mui-x/pull/6242. It looks like:
Next.js set resolve.modules for webpack to be modules: [ 'node_modules', '/Users/oliviertassinari/mui-x' ], https://webpack.js.org/configuration/resolve/#resolvemodules. So per https://github.com/webpack/webpack/issues/12087#issuecomment-737532578, we need to do:
```diff
diff --git a/docs/pages/x/api/date-pickers/date-time-picker.js b/docs/pages/x/api/date-pickers/date-time-picker.js
index 2bec19c5b..1f3fd6759 100644
--- a/docs/pages/x/api/date-pickers/date-time-picker.js
+++ b/docs/pages/x/api/date-pickers/date-time-picker.js
@@ -12,7 +12,7 @@ Page.getInitialProps = () => {
   const req = require.context(
     'docsx/translations/api-docs/date-pickers',
     false,
-    /\/date-time-picker(-[a-z]{2})?\.json$/,
+    /\.\/date-time-picker(-[a-z]{2})?\.json$/,
   );
   const descriptions = mapApiPageTranslations(req);
```
> It removes the warning. I think to apply to all the MUI Core API pages as well, we require the files twice (console log req.keys()), once is enough. While investigating, I also noticed that removing the webpack alias solves the warning and doesn't break anything. Maybe something to do as well (relying on TypeScript alias and Babel's plugin alias)