### PR TITLE
[core] Remove `rifm` dependency

### DIFF
--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -51,8 +51,7 @@
     "@mui/x-license-pro": "6.0.0-beta.0",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
-    "react-transition-group": "^4.4.5",
-    "rifm": "^0.12.1"
+    "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
     "@mui/material": "^5.4.1",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -57,8 +57,7 @@
     "@types/react-transition-group": "^4.4.5",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
-    "react-transition-group": "^4.4.5",
-    "rifm": "^0.12.1"
+    "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
     "@emotion/react": "^11.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12731,11 +12731,6 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rifm@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.12.1.tgz#8fa77f45b7f1cda2a0068787ac821f0593967ac4"
-  integrity sha512-OGA1Bitg/dSJtI/c4dh90svzaUPt228kzFsUkJbtA2c964IqEAwWXeL9ZJi86xWv3j5SMqRvGULl7bA6cK0Bvg==
-
 rimraf@2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"


### PR DESCRIPTION
Since we remove the mask utils, we do not need to keep RIFM - React Input Format & Mask in the dependencies