### PR TITLE
[pickers] Ditch pickers `skipLibCheck`

### DIFF
--- a/packages/x-date-pickers-pro/tsconfig.json
+++ b/packages/x-date-pickers-pro/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    // @date-io libraries produce duplicate type `DateType`
-    "skipLibCheck": true,
     "types": ["react", "mocha", "node"]
   },
   "include": [

--- a/packages/x-date-pickers/tsconfig.json
+++ b/packages/x-date-pickers/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-    // @date-io libraries produce duplicate type `DateType`
-    "skipLibCheck": true,
     "types": ["react", "mocha", "node"]
   },
   "include": [

--- a/patches/@date-io+date-fns+2.16.0.patch
+++ b/patches/@date-io+date-fns+2.16.0.patch
@@ -1,0 +1,9 @@
+diff --git a/node_modules/@date-io/date-fns/type/index.d.ts b/node_modules/@date-io/date-fns/type/index.d.ts
+index 983d68a..e21d4e7 100644
+--- a/node_modules/@date-io/date-fns/type/index.d.ts
++++ b/node_modules/@date-io/date-fns/type/index.d.ts
+@@ -1,3 +1,3 @@
+-declare module "@date-io/type" {
++declare module "@date-io/date-fns/type" {
+   export type DateType = Date;
+ }

--- a/patches/@date-io+date-fns-jalali+2.16.0.patch
+++ b/patches/@date-io+date-fns-jalali+2.16.0.patch
@@ -1,0 +1,9 @@
+diff --git a/node_modules/@date-io/date-fns-jalali/type/index.d.ts b/node_modules/@date-io/date-fns-jalali/type/index.d.ts
+index 983d68a..569aec4 100644
+--- a/node_modules/@date-io/date-fns-jalali/type/index.d.ts
++++ b/node_modules/@date-io/date-fns-jalali/type/index.d.ts
+@@ -1,3 +1,3 @@
+-declare module "@date-io/type" {
++declare module "@date-io/date-fns-jalali/type" {
+   export type DateType = Date;
+ }

--- a/patches/@date-io+dayjs+2.16.0.patch
+++ b/patches/@date-io+dayjs+2.16.0.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/@date-io/dayjs/type/index.d.ts b/node_modules/@date-io/dayjs/type/index.d.ts
+index 006c7b5..183494a 100644
+--- a/node_modules/@date-io/dayjs/type/index.d.ts
++++ b/node_modules/@date-io/dayjs/type/index.d.ts
+@@ -1,4 +1,4 @@
+-declare module "@date-io/type" {
++declare module "@date-io/dayjs/type" {
+   import { Dayjs } from "dayjs";
+ 
+   export type DateType = Dayjs;

--- a/patches/@date-io+hijri+2.16.1.patch
+++ b/patches/@date-io+hijri+2.16.1.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/@date-io/hijri/type/index.d.ts b/node_modules/@date-io/hijri/type/index.d.ts
+index 49d51ac..ffb0968 100644
+--- a/node_modules/@date-io/hijri/type/index.d.ts
++++ b/node_modules/@date-io/hijri/type/index.d.ts
+@@ -1,4 +1,4 @@
+-declare module "@date-io/type" {
++declare module "@date-io/moment-hijri/type" {
+   import { Moment } from "moment-hijri";
+ 
+   export type DateType = Moment;

--- a/patches/@date-io+luxon+2.16.1.patch
+++ b/patches/@date-io+luxon+2.16.1.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/@date-io/luxon/type/index.d.ts b/node_modules/@date-io/luxon/type/index.d.ts
+index 6288b4e..9c93558 100644
+--- a/node_modules/@date-io/luxon/type/index.d.ts
++++ b/node_modules/@date-io/luxon/type/index.d.ts
+@@ -1,4 +1,4 @@
+-declare module "@date-io/type" {
++declare module "@date-io/luxon/type" {
+   import { DateTime } from "luxon";
+ 
+   export type DateType = DateTime;

--- a/patches/@date-io+moment+2.16.1.patch
+++ b/patches/@date-io+moment+2.16.1.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/@date-io/moment/type/index.d.ts b/node_modules/@date-io/moment/type/index.d.ts
+index 93e75db..bda7019 100644
+--- a/node_modules/@date-io/moment/type/index.d.ts
++++ b/node_modules/@date-io/moment/type/index.d.ts
+@@ -1,4 +1,4 @@
+-declare module "@date-io/type" {
++declare module "@date-io/moment/type" {
+   import { Moment } from "moment";
+ 
+   export type DateType = Moment;

--- a/patches/date-fns-jalali+2.13.0-0.patch
+++ b/patches/date-fns-jalali+2.13.0-0.patch
@@ -1,0 +1,1807 @@
+diff --git a/node_modules/date-fns-jalali/typings.d.ts b/node_modules/date-fns-jalali/typings.d.ts
+index ff89673..0502c2b 100644
+--- a/node_modules/date-fns-jalali/typings.d.ts
++++ b/node_modules/date-fns-jalali/typings.d.ts
+@@ -26,13 +26,13 @@ interface CurriedFn4<A, B, C, D, R> {
+ 
+ // Type Aliases
+ 
+-type Interval = {
++type IntervalJalali = {
+   start: Date | number
+   end: Date | number
+ }
+-type IntervalAliased = Interval
++type IntervalAliasedJalali = IntervalJalali
+ 
+-type Locale = {
++type LocaleJalali = {
+   code?: string
+   formatDistance?: (...args: Array<any>) => any
+   formatRelative?: (...args: Array<any>) => any
+@@ -62,9 +62,9 @@ type Locale = {
+     firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+   }
+ }
+-type LocaleAliased = Locale
++type LocaleAliasedJalali = LocaleJalali
+ 
+-type Duration = {
++type DurationJalali = {
+   years?: number
+   months?: number
+   weeks?: number
+@@ -73,16 +73,16 @@ type Duration = {
+   minutes?: number
+   seconds?: number
+ }
+-type DurationAliased = Duration
++type DurationAliasedJalali = DurationJalali
+ 
+ // Exported Type Aliases
+ 
+ declare module 'date-fns-jalali' {
+-  export type Interval = IntervalAliased
++  export type Interval = IntervalAliasedJalali
+ 
+-  export type Locale = LocaleAliased
++  export type Locale = LocaleAliasedJalali
+ 
+-  export type Duration = DurationAliased
++  export type Duration = DurationAliasedJalali
+ }
+ 
+ // Regular Functions
+@@ -3858,7 +3858,7 @@ declare module 'date-fns-jalali/toDate/index.js' {
+ // FP Functions
+ 
+ declare module 'date-fns-jalali/fp' {
+-  const add: CurriedFn2<Duration, Date | number, Date>
++  const add: CurriedFn2<DurationJalali, Date | number, Date>
+   namespace add {}
+ 
+   const addBusinessDays: CurriedFn2<number, Date | number, Date>
+@@ -3894,15 +3894,15 @@ declare module 'date-fns-jalali/fp' {
+   const addYears: CurriedFn2<number, Date | number, Date>
+   namespace addYears {}
+ 
+-  const areIntervalsOverlapping: CurriedFn2<Interval, Interval, boolean>
++  const areIntervalsOverlapping: CurriedFn2<IntervalJalali, IntervalJalali, boolean>
+   namespace areIntervalsOverlapping {}
+ 
+   const areIntervalsOverlappingWithOptions: CurriedFn3<
+     {
+       inclusive?: boolean
+     },
+-    Interval,
+-    Interval,
++    IntervalJalali,
++    IntervalJalali,
+     boolean
+   >
+   namespace areIntervalsOverlappingWithOptions {}
+@@ -3971,7 +3971,7 @@ declare module 'date-fns-jalali/fp' {
+   const differenceInCalendarWeeksWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date | number,
+@@ -4024,22 +4024,22 @@ declare module 'date-fns-jalali/fp' {
+   const differenceInYears: CurriedFn2<Date | number, Date | number, number>
+   namespace differenceInYears {}
+ 
+-  const eachDayOfInterval: CurriedFn1<Interval, Date[]>
++  const eachDayOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachDayOfInterval {}
+ 
+   const eachDayOfIntervalWithOptions: CurriedFn2<
+     {
+       step?: number
+     },
+-    Interval,
++    IntervalJalali,
+     Date[]
+   >
+   namespace eachDayOfIntervalWithOptions {}
+ 
+-  const eachMonthOfInterval: CurriedFn1<Interval, Date[]>
++  const eachMonthOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachMonthOfInterval {}
+ 
+-  const eachWeekendOfInterval: CurriedFn1<Interval, Date[]>
++  const eachWeekendOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachWeekendOfInterval {}
+ 
+   const eachWeekendOfMonth: CurriedFn1<Date | number, Date[]>
+@@ -4048,20 +4048,20 @@ declare module 'date-fns-jalali/fp' {
+   const eachWeekendOfYear: CurriedFn1<Date | number, Date[]>
+   namespace eachWeekendOfYear {}
+ 
+-  const eachWeekOfInterval: CurriedFn1<Interval, Date[]>
++  const eachWeekOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachWeekOfInterval {}
+ 
+   const eachWeekOfIntervalWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+-    Interval,
++    IntervalJalali,
+     Date[]
+   >
+   namespace eachWeekOfIntervalWithOptions {}
+ 
+-  const eachYearOfInterval: CurriedFn1<Interval, Date[]>
++  const eachYearOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachYearOfInterval {}
+ 
+   const endOfDay: CurriedFn1<Date | number, Date>
+@@ -4106,7 +4106,7 @@ declare module 'date-fns-jalali/fp' {
+   const endOfWeekWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -4127,7 +4127,7 @@ declare module 'date-fns-jalali/fp' {
+ 
+   const formatDistanceStrictWithOptions: CurriedFn3<
+     {
+-      locale?: Locale
++      locale?: LocaleJalali
+       roundingMethod?: 'floor' | 'ceil' | 'round'
+       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+       addSuffix?: boolean
+@@ -4140,7 +4140,7 @@ declare module 'date-fns-jalali/fp' {
+ 
+   const formatDistanceWithOptions: CurriedFn3<
+     {
+-      locale?: Locale
++      locale?: LocaleJalali
+       addSuffix?: boolean
+       includeSeconds?: boolean
+     },
+@@ -4166,7 +4166,7 @@ declare module 'date-fns-jalali/fp' {
+   >
+   namespace formatISO9075WithOptions {}
+ 
+-  const formatISODuration: CurriedFn1<Duration, string>
++  const formatISODuration: CurriedFn1<DurationJalali, string>
+   namespace formatISODuration {}
+ 
+   const formatISOWithOptions: CurriedFn2<
+@@ -4185,7 +4185,7 @@ declare module 'date-fns-jalali/fp' {
+   const formatRelativeWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date | number,
+@@ -4214,7 +4214,7 @@ declare module 'date-fns-jalali/fp' {
+       useAdditionalWeekYearTokens?: boolean
+       firstWeekContainsDate?: number
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     string,
+     Date | number,
+@@ -4267,7 +4267,7 @@ declare module 'date-fns-jalali/fp' {
+   const getMonth: CurriedFn1<Date | number, number>
+   namespace getMonth {}
+ 
+-  const getOverlappingDaysInIntervals: CurriedFn2<Interval, Interval, number>
++  const getOverlappingDaysInIntervals: CurriedFn2<IntervalJalali, IntervalJalali, number>
+   namespace getOverlappingDaysInIntervals {}
+ 
+   const getQuarter: CurriedFn1<Date | number, number>
+@@ -4291,7 +4291,7 @@ declare module 'date-fns-jalali/fp' {
+   const getWeekOfMonthWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -4304,7 +4304,7 @@ declare module 'date-fns-jalali/fp' {
+   const getWeeksInMonthWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -4315,7 +4315,7 @@ declare module 'date-fns-jalali/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -4329,7 +4329,7 @@ declare module 'date-fns-jalali/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -4339,7 +4339,7 @@ declare module 'date-fns-jalali/fp' {
+   const getYear: CurriedFn1<Date | number, number>
+   namespace getYear {}
+ 
+-  const intervalToDuration: CurriedFn1<Interval, Duration>
++  const intervalToDuration: CurriedFn1<IntervalJalali, DurationJalali>
+   namespace intervalToDuration {}
+ 
+   const isAfter: CurriedFn2<Date | number, Date | number, boolean>
+@@ -4402,7 +4402,7 @@ declare module 'date-fns-jalali/fp' {
+   const isSameWeekWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date | number,
+@@ -4434,7 +4434,7 @@ declare module 'date-fns-jalali/fp' {
+   const isWeekend: CurriedFn1<Date | number, boolean>
+   namespace isWeekend {}
+ 
+-  const isWithinInterval: CurriedFn2<Interval, Date | number, boolean>
++  const isWithinInterval: CurriedFn2<IntervalJalali, Date | number, boolean>
+   namespace isWithinInterval {}
+ 
+   const lastDayOfDecade: CurriedFn1<Date | number, Date>
+@@ -4467,7 +4467,7 @@ declare module 'date-fns-jalali/fp' {
+   const lastDayOfWeekWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -4510,7 +4510,7 @@ declare module 'date-fns-jalali/fp' {
+       useAdditionalWeekYearTokens?: boolean
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     string,
+@@ -4558,7 +4558,7 @@ declare module 'date-fns-jalali/fp' {
+   const setDayWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     number,
+     Date | number,
+@@ -4600,7 +4600,7 @@ declare module 'date-fns-jalali/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     number,
+     Date | number,
+@@ -4615,7 +4615,7 @@ declare module 'date-fns-jalali/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     number,
+     Date | number,
+@@ -4659,7 +4659,7 @@ declare module 'date-fns-jalali/fp' {
+   const startOfWeekWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -4673,7 +4673,7 @@ declare module 'date-fns-jalali/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -4683,7 +4683,7 @@ declare module 'date-fns-jalali/fp' {
+   const startOfYear: CurriedFn1<Date | number, Date>
+   namespace startOfYear {}
+ 
+-  const sub: CurriedFn2<Duration, Date | number, Date>
++  const sub: CurriedFn2<DurationJalali, Date | number, Date>
+   namespace sub {}
+ 
+   const subBusinessDays: CurriedFn2<number, Date | number, Date>
+@@ -7715,7 +7715,7 @@ declare module 'date-fns-jalali/fp/toDate/index.js' {
+ // ECMAScript Module Functions
+ 
+ declare module 'date-fns-jalali/esm' {
+-  function add(date: Date | number, duration: Duration): Date
++  function add(date: Date | number, duration: DurationJalali): Date
+   namespace add {}
+ 
+   function addBusinessDays(date: Date | number, amount: number): Date
+@@ -7752,8 +7752,8 @@ declare module 'date-fns-jalali/esm' {
+   namespace addYears {}
+ 
+   function areIntervalsOverlapping(
+-    intervalLeft: Interval,
+-    intervalRight: Interval,
++    intervalLeft: IntervalJalali,
++    intervalRight: IntervalJalali,
+     options?: {
+       inclusive?: boolean
+     }
+@@ -7821,7 +7821,7 @@ declare module 'date-fns-jalali/esm' {
+     dateLeft: Date | number,
+     dateRight: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): number
+@@ -7894,17 +7894,17 @@ declare module 'date-fns-jalali/esm' {
+   namespace differenceInYears {}
+ 
+   function eachDayOfInterval(
+-    interval: Interval,
++    interval: IntervalJalali,
+     options?: {
+       step?: number
+     }
+   ): Date[]
+   namespace eachDayOfInterval {}
+ 
+-  function eachMonthOfInterval(interval: Interval): Date[]
++  function eachMonthOfInterval(interval: IntervalJalali): Date[]
+   namespace eachMonthOfInterval {}
+ 
+-  function eachWeekendOfInterval(interval: Interval): Date[]
++  function eachWeekendOfInterval(interval: IntervalJalali): Date[]
+   namespace eachWeekendOfInterval {}
+ 
+   function eachWeekendOfMonth(date: Date | number): Date[]
+@@ -7914,15 +7914,15 @@ declare module 'date-fns-jalali/esm' {
+   namespace eachWeekendOfYear {}
+ 
+   function eachWeekOfInterval(
+-    interval: Interval,
++    interval: IntervalJalali,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date[]
+   namespace eachWeekOfInterval {}
+ 
+-  function eachYearOfInterval(interval: Interval): Date[]
++  function eachYearOfInterval(interval: IntervalJalali): Date[]
+   namespace eachYearOfInterval {}
+ 
+   function endOfDay(date: Date | number): Date
+@@ -7966,7 +7966,7 @@ declare module 'date-fns-jalali/esm' {
+   function endOfWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -7982,7 +7982,7 @@ declare module 'date-fns-jalali/esm' {
+     date: Date | number,
+     format: string,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: number
+       useAdditionalWeekYearTokens?: boolean
+@@ -7997,7 +7997,7 @@ declare module 'date-fns-jalali/esm' {
+     options?: {
+       includeSeconds?: boolean
+       addSuffix?: boolean
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+   namespace formatDistance {}
+@@ -8009,7 +8009,7 @@ declare module 'date-fns-jalali/esm' {
+       addSuffix?: boolean
+       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+       roundingMethod?: 'floor' | 'ceil' | 'round'
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+   namespace formatDistanceStrict {}
+@@ -8019,7 +8019,7 @@ declare module 'date-fns-jalali/esm' {
+     options?: {
+       includeSeconds?: boolean
+       addSuffix?: boolean
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+   namespace formatDistanceToNow {}
+@@ -8030,7 +8030,7 @@ declare module 'date-fns-jalali/esm' {
+       addSuffix?: boolean
+       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+       roundingMethod?: 'floor' | 'ceil' | 'round'
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+   namespace formatDistanceToNowStrict {}
+@@ -8053,14 +8053,14 @@ declare module 'date-fns-jalali/esm' {
+   ): string
+   namespace formatISO9075 {}
+ 
+-  function formatISODuration(duration: Duration): string
++  function formatISODuration(duration: DurationJalali): string
+   namespace formatISODuration {}
+ 
+   function formatRelative(
+     date: Date | number,
+     baseDate: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): string
+@@ -8123,8 +8123,8 @@ declare module 'date-fns-jalali/esm' {
+   namespace getMonth {}
+ 
+   function getOverlappingDaysInIntervals(
+-    intervalLeft: Interval,
+-    intervalRight: Interval
++    intervalLeft: IntervalJalali,
++    intervalRight: IntervalJalali
+   ): number
+   namespace getOverlappingDaysInIntervals {}
+ 
+@@ -8143,7 +8143,7 @@ declare module 'date-fns-jalali/esm' {
+   function getWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -8153,7 +8153,7 @@ declare module 'date-fns-jalali/esm' {
+   function getWeekOfMonth(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): number
+@@ -8162,7 +8162,7 @@ declare module 'date-fns-jalali/esm' {
+   function getWeeksInMonth(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): number
+@@ -8171,7 +8171,7 @@ declare module 'date-fns-jalali/esm' {
+   function getWeekYear(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -8181,7 +8181,7 @@ declare module 'date-fns-jalali/esm' {
+   function getYear(date: Date | number): number
+   namespace getYear {}
+ 
+-  function intervalToDuration(interval: Interval): Duration
++  function intervalToDuration(interval: IntervalJalali): DurationJalali
+   namespace intervalToDuration {}
+ 
+   function isAfter(date: Date | number, dateToCompare: Date | number): boolean
+@@ -8269,7 +8269,7 @@ declare module 'date-fns-jalali/esm' {
+     dateLeft: Date | number,
+     dateRight: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): boolean
+@@ -8308,7 +8308,7 @@ declare module 'date-fns-jalali/esm' {
+   function isThisWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): boolean
+@@ -8338,7 +8338,7 @@ declare module 'date-fns-jalali/esm' {
+   function isWeekend(date: Date | number): boolean
+   namespace isWeekend {}
+ 
+-  function isWithinInterval(date: Date | number, interval: Interval): boolean
++  function isWithinInterval(date: Date | number, interval: IntervalJalali): boolean
+   namespace isWithinInterval {}
+ 
+   function isYesterday(date: Date | number): boolean
+@@ -8367,7 +8367,7 @@ declare module 'date-fns-jalali/esm' {
+   function lastDayOfWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -8390,7 +8390,7 @@ declare module 'date-fns-jalali/esm' {
+     formatString: string,
+     referenceDate: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       useAdditionalWeekYearTokens?: boolean
+@@ -8439,7 +8439,7 @@ declare module 'date-fns-jalali/esm' {
+     date: Date | number,
+     day: number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -8479,7 +8479,7 @@ declare module 'date-fns-jalali/esm' {
+     date: Date | number,
+     week: number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -8490,7 +8490,7 @@ declare module 'date-fns-jalali/esm' {
+     date: Date | number,
+     weekYear: number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -8536,7 +8536,7 @@ declare module 'date-fns-jalali/esm' {
+   function startOfWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -8545,7 +8545,7 @@ declare module 'date-fns-jalali/esm' {
+   function startOfWeekYear(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -8558,7 +8558,7 @@ declare module 'date-fns-jalali/esm' {
+   function startOfYesterday(): Date
+   namespace startOfYesterday {}
+ 
+-  function sub(date: Date | number, duration: Duration): Date
++  function sub(date: Date | number, duration: DurationJalali): Date
+   namespace sub {}
+ 
+   function subBusinessDays(date: Date | number, amount: number): Date
+@@ -11485,7 +11485,7 @@ declare module 'date-fns-jalali/esm/toDate/index.js' {
+ // ECMAScript Module FP Functions
+ 
+ declare module 'date-fns-jalali/esm/fp' {
+-  const add: CurriedFn2<Duration, Date | number, Date>
++  const add: CurriedFn2<DurationJalali, Date | number, Date>
+   namespace add {}
+ 
+   const addBusinessDays: CurriedFn2<number, Date | number, Date>
+@@ -11521,15 +11521,15 @@ declare module 'date-fns-jalali/esm/fp' {
+   const addYears: CurriedFn2<number, Date | number, Date>
+   namespace addYears {}
+ 
+-  const areIntervalsOverlapping: CurriedFn2<Interval, Interval, boolean>
++  const areIntervalsOverlapping: CurriedFn2<IntervalJalali, IntervalJalali, boolean>
+   namespace areIntervalsOverlapping {}
+ 
+   const areIntervalsOverlappingWithOptions: CurriedFn3<
+     {
+       inclusive?: boolean
+     },
+-    Interval,
+-    Interval,
++    IntervalJalali,
++    IntervalJalali,
+     boolean
+   >
+   namespace areIntervalsOverlappingWithOptions {}
+@@ -11598,7 +11598,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const differenceInCalendarWeeksWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date | number,
+@@ -11651,22 +11651,22 @@ declare module 'date-fns-jalali/esm/fp' {
+   const differenceInYears: CurriedFn2<Date | number, Date | number, number>
+   namespace differenceInYears {}
+ 
+-  const eachDayOfInterval: CurriedFn1<Interval, Date[]>
++  const eachDayOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachDayOfInterval {}
+ 
+   const eachDayOfIntervalWithOptions: CurriedFn2<
+     {
+       step?: number
+     },
+-    Interval,
++    IntervalJalali,
+     Date[]
+   >
+   namespace eachDayOfIntervalWithOptions {}
+ 
+-  const eachMonthOfInterval: CurriedFn1<Interval, Date[]>
++  const eachMonthOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachMonthOfInterval {}
+ 
+-  const eachWeekendOfInterval: CurriedFn1<Interval, Date[]>
++  const eachWeekendOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachWeekendOfInterval {}
+ 
+   const eachWeekendOfMonth: CurriedFn1<Date | number, Date[]>
+@@ -11675,20 +11675,20 @@ declare module 'date-fns-jalali/esm/fp' {
+   const eachWeekendOfYear: CurriedFn1<Date | number, Date[]>
+   namespace eachWeekendOfYear {}
+ 
+-  const eachWeekOfInterval: CurriedFn1<Interval, Date[]>
++  const eachWeekOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachWeekOfInterval {}
+ 
+   const eachWeekOfIntervalWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+-    Interval,
++    IntervalJalali,
+     Date[]
+   >
+   namespace eachWeekOfIntervalWithOptions {}
+ 
+-  const eachYearOfInterval: CurriedFn1<Interval, Date[]>
++  const eachYearOfInterval: CurriedFn1<IntervalJalali, Date[]>
+   namespace eachYearOfInterval {}
+ 
+   const endOfDay: CurriedFn1<Date | number, Date>
+@@ -11733,7 +11733,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const endOfWeekWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -11754,7 +11754,7 @@ declare module 'date-fns-jalali/esm/fp' {
+ 
+   const formatDistanceStrictWithOptions: CurriedFn3<
+     {
+-      locale?: Locale
++      locale?: LocaleJalali
+       roundingMethod?: 'floor' | 'ceil' | 'round'
+       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+       addSuffix?: boolean
+@@ -11767,7 +11767,7 @@ declare module 'date-fns-jalali/esm/fp' {
+ 
+   const formatDistanceWithOptions: CurriedFn3<
+     {
+-      locale?: Locale
++      locale?: LocaleJalali
+       addSuffix?: boolean
+       includeSeconds?: boolean
+     },
+@@ -11793,7 +11793,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   >
+   namespace formatISO9075WithOptions {}
+ 
+-  const formatISODuration: CurriedFn1<Duration, string>
++  const formatISODuration: CurriedFn1<DurationJalali, string>
+   namespace formatISODuration {}
+ 
+   const formatISOWithOptions: CurriedFn2<
+@@ -11812,7 +11812,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const formatRelativeWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date | number,
+@@ -11841,7 +11841,7 @@ declare module 'date-fns-jalali/esm/fp' {
+       useAdditionalWeekYearTokens?: boolean
+       firstWeekContainsDate?: number
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     string,
+     Date | number,
+@@ -11894,7 +11894,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const getMonth: CurriedFn1<Date | number, number>
+   namespace getMonth {}
+ 
+-  const getOverlappingDaysInIntervals: CurriedFn2<Interval, Interval, number>
++  const getOverlappingDaysInIntervals: CurriedFn2<IntervalJalali, IntervalJalali, number>
+   namespace getOverlappingDaysInIntervals {}
+ 
+   const getQuarter: CurriedFn1<Date | number, number>
+@@ -11918,7 +11918,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const getWeekOfMonthWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -11931,7 +11931,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const getWeeksInMonthWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -11942,7 +11942,7 @@ declare module 'date-fns-jalali/esm/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -11956,7 +11956,7 @@ declare module 'date-fns-jalali/esm/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     number
+@@ -11966,7 +11966,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const getYear: CurriedFn1<Date | number, number>
+   namespace getYear {}
+ 
+-  const intervalToDuration: CurriedFn1<Interval, Duration>
++  const intervalToDuration: CurriedFn1<IntervalJalali, DurationJalali>
+   namespace intervalToDuration {}
+ 
+   const isAfter: CurriedFn2<Date | number, Date | number, boolean>
+@@ -12029,7 +12029,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const isSameWeekWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date | number,
+@@ -12061,7 +12061,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const isWeekend: CurriedFn1<Date | number, boolean>
+   namespace isWeekend {}
+ 
+-  const isWithinInterval: CurriedFn2<Interval, Date | number, boolean>
++  const isWithinInterval: CurriedFn2<IntervalJalali, Date | number, boolean>
+   namespace isWithinInterval {}
+ 
+   const lastDayOfDecade: CurriedFn1<Date | number, Date>
+@@ -12094,7 +12094,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const lastDayOfWeekWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -12137,7 +12137,7 @@ declare module 'date-fns-jalali/esm/fp' {
+       useAdditionalWeekYearTokens?: boolean
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     string,
+@@ -12185,7 +12185,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const setDayWithOptions: CurriedFn3<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     number,
+     Date | number,
+@@ -12227,7 +12227,7 @@ declare module 'date-fns-jalali/esm/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     number,
+     Date | number,
+@@ -12242,7 +12242,7 @@ declare module 'date-fns-jalali/esm/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     number,
+     Date | number,
+@@ -12286,7 +12286,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const startOfWeekWithOptions: CurriedFn2<
+     {
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -12300,7 +12300,7 @@ declare module 'date-fns-jalali/esm/fp' {
+     {
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+-      locale?: Locale
++      locale?: LocaleJalali
+     },
+     Date | number,
+     Date
+@@ -12310,7 +12310,7 @@ declare module 'date-fns-jalali/esm/fp' {
+   const startOfYear: CurriedFn1<Date | number, Date>
+   namespace startOfYear {}
+ 
+-  const sub: CurriedFn2<Duration, Date | number, Date>
++  const sub: CurriedFn2<DurationJalali, Date | number, Date>
+   namespace sub {}
+ 
+   const subBusinessDays: CurriedFn2<number, Date | number, Date>
+@@ -15342,223 +15342,223 @@ declare module 'date-fns-jalali/esm/fp/toDate/index.js' {
+ // Regular Locales
+ 
+ declare module 'date-fns-jalali/locale' {
+-  const af: Locale
++  const af: LocaleJalali
+   namespace af {}
+ 
+-  const ar: Locale
++  const ar: LocaleJalali
+   namespace ar {}
+ 
+-  const arDZ: Locale
++  const arDZ: LocaleJalali
+   namespace arDZ {}
+ 
+-  const arMA: Locale
++  const arMA: LocaleJalali
+   namespace arMA {}
+ 
+-  const arSA: Locale
++  const arSA: LocaleJalali
+   namespace arSA {}
+ 
+-  const az: Locale
++  const az: LocaleJalali
+   namespace az {}
+ 
+-  const be: Locale
++  const be: LocaleJalali
+   namespace be {}
+ 
+-  const bg: Locale
++  const bg: LocaleJalali
+   namespace bg {}
+ 
+-  const bn: Locale
++  const bn: LocaleJalali
+   namespace bn {}
+ 
+-  const ca: Locale
++  const ca: LocaleJalali
+   namespace ca {}
+ 
+-  const cs: Locale
++  const cs: LocaleJalali
+   namespace cs {}
+ 
+-  const cy: Locale
++  const cy: LocaleJalali
+   namespace cy {}
+ 
+-  const da: Locale
++  const da: LocaleJalali
+   namespace da {}
+ 
+-  const de: Locale
++  const de: LocaleJalali
+   namespace de {}
+ 
+-  const el: Locale
++  const el: LocaleJalali
+   namespace el {}
+ 
+-  const enAU: Locale
++  const enAU: LocaleJalali
+   namespace enAU {}
+ 
+-  const enCA: Locale
++  const enCA: LocaleJalali
+   namespace enCA {}
+ 
+-  const enGB: Locale
++  const enGB: LocaleJalali
+   namespace enGB {}
+ 
+-  const enUS: Locale
++  const enUS: LocaleJalali
+   namespace enUS {}
+ 
+-  const eo: Locale
++  const eo: LocaleJalali
+   namespace eo {}
+ 
+-  const es: Locale
++  const es: LocaleJalali
+   namespace es {}
+ 
+-  const et: Locale
++  const et: LocaleJalali
+   namespace et {}
+ 
+-  const faIR: Locale
++  const faIR: LocaleJalali
+   namespace faIR {}
+ 
+-  const fajalaliIR: Locale
++  const fajalaliIR: LocaleJalali
+   namespace fajalaliIR {}
+ 
+-  const fi: Locale
++  const fi: LocaleJalali
+   namespace fi {}
+ 
+-  const fil: Locale
++  const fil: LocaleJalali
+   namespace fil {}
+ 
+-  const fr: Locale
++  const fr: LocaleJalali
+   namespace fr {}
+ 
+-  const frCA: Locale
++  const frCA: LocaleJalali
+   namespace frCA {}
+ 
+-  const frCH: Locale
++  const frCH: LocaleJalali
+   namespace frCH {}
+ 
+-  const gl: Locale
++  const gl: LocaleJalali
+   namespace gl {}
+ 
+-  const gu: Locale
++  const gu: LocaleJalali
+   namespace gu {}
+ 
+-  const he: Locale
++  const he: LocaleJalali
+   namespace he {}
+ 
+-  const hi: Locale
++  const hi: LocaleJalali
+   namespace hi {}
+ 
+-  const hr: Locale
++  const hr: LocaleJalali
+   namespace hr {}
+ 
+-  const hu: Locale
++  const hu: LocaleJalali
+   namespace hu {}
+ 
+-  const hy: Locale
++  const hy: LocaleJalali
+   namespace hy {}
+ 
+-  const id: Locale
++  const id: LocaleJalali
+   namespace id {}
+ 
+-  const is: Locale
++  const is: LocaleJalali
+   namespace is {}
+ 
+-  const it: Locale
++  const it: LocaleJalali
+   namespace it {}
+ 
+-  const ja: Locale
++  const ja: LocaleJalali
+   namespace ja {}
+ 
+-  const ka: Locale
++  const ka: LocaleJalali
+   namespace ka {}
+ 
+-  const kk: Locale
++  const kk: LocaleJalali
+   namespace kk {}
+ 
+-  const kn: Locale
++  const kn: LocaleJalali
+   namespace kn {}
+ 
+-  const ko: Locale
++  const ko: LocaleJalali
+   namespace ko {}
+ 
+-  const lt: Locale
++  const lt: LocaleJalali
+   namespace lt {}
+ 
+-  const lv: Locale
++  const lv: LocaleJalali
+   namespace lv {}
+ 
+-  const mk: Locale
++  const mk: LocaleJalali
+   namespace mk {}
+ 
+-  const ms: Locale
++  const ms: LocaleJalali
+   namespace ms {}
+ 
+-  const mt: Locale
++  const mt: LocaleJalali
+   namespace mt {}
+ 
+-  const nb: Locale
++  const nb: LocaleJalali
+   namespace nb {}
+ 
+-  const nl: Locale
++  const nl: LocaleJalali
+   namespace nl {}
+ 
+-  const nlBE: Locale
++  const nlBE: LocaleJalali
+   namespace nlBE {}
+ 
+-  const nn: Locale
++  const nn: LocaleJalali
+   namespace nn {}
+ 
+-  const pl: Locale
++  const pl: LocaleJalali
+   namespace pl {}
+ 
+-  const pt: Locale
++  const pt: LocaleJalali
+   namespace pt {}
+ 
+-  const ptBR: Locale
++  const ptBR: LocaleJalali
+   namespace ptBR {}
+ 
+-  const ro: Locale
++  const ro: LocaleJalali
+   namespace ro {}
+ 
+-  const ru: Locale
++  const ru: LocaleJalali
+   namespace ru {}
+ 
+-  const sk: Locale
++  const sk: LocaleJalali
+   namespace sk {}
+ 
+-  const sl: Locale
++  const sl: LocaleJalali
+   namespace sl {}
+ 
+-  const sr: Locale
++  const sr: LocaleJalali
+   namespace sr {}
+ 
+-  const srLatn: Locale
++  const srLatn: LocaleJalali
+   namespace srLatn {}
+ 
+-  const sv: Locale
++  const sv: LocaleJalali
+   namespace sv {}
+ 
+-  const ta: Locale
++  const ta: LocaleJalali
+   namespace ta {}
+ 
+-  const te: Locale
++  const te: LocaleJalali
+   namespace te {}
+ 
+-  const th: Locale
++  const th: LocaleJalali
+   namespace th {}
+ 
+-  const tr: Locale
++  const tr: LocaleJalali
+   namespace tr {}
+ 
+-  const ug: Locale
++  const ug: LocaleJalali
+   namespace ug {}
+ 
+-  const uk: Locale
++  const uk: LocaleJalali
+   namespace uk {}
+ 
+-  const uz: Locale
++  const uz: LocaleJalali
+   namespace uz {}
+ 
+-  const vi: Locale
++  const vi: LocaleJalali
+   namespace vi {}
+ 
+-  const zhCN: Locale
++  const zhCN: LocaleJalali
+   namespace zhCN {}
+ 
+-  const zhTW: Locale
++  const zhTW: LocaleJalali
+   namespace zhTW {}
+ }
+ 
+@@ -16660,223 +16660,223 @@ declare module 'date-fns-jalali/locale/zh-TW/index.js' {
+ // ECMAScript Module Locales
+ 
+ declare module 'date-fns-jalali/esm/locale' {
+-  const af: Locale
++  const af: LocaleJalali
+   namespace af {}
+ 
+-  const ar: Locale
++  const ar: LocaleJalali
+   namespace ar {}
+ 
+-  const arDZ: Locale
++  const arDZ: LocaleJalali
+   namespace arDZ {}
+ 
+-  const arMA: Locale
++  const arMA: LocaleJalali
+   namespace arMA {}
+ 
+-  const arSA: Locale
++  const arSA: LocaleJalali
+   namespace arSA {}
+ 
+-  const az: Locale
++  const az: LocaleJalali
+   namespace az {}
+ 
+-  const be: Locale
++  const be: LocaleJalali
+   namespace be {}
+ 
+-  const bg: Locale
++  const bg: LocaleJalali
+   namespace bg {}
+ 
+-  const bn: Locale
++  const bn: LocaleJalali
+   namespace bn {}
+ 
+-  const ca: Locale
++  const ca: LocaleJalali
+   namespace ca {}
+ 
+-  const cs: Locale
++  const cs: LocaleJalali
+   namespace cs {}
+ 
+-  const cy: Locale
++  const cy: LocaleJalali
+   namespace cy {}
+ 
+-  const da: Locale
++  const da: LocaleJalali
+   namespace da {}
+ 
+-  const de: Locale
++  const de: LocaleJalali
+   namespace de {}
+ 
+-  const el: Locale
++  const el: LocaleJalali
+   namespace el {}
+ 
+-  const enAU: Locale
++  const enAU: LocaleJalali
+   namespace enAU {}
+ 
+-  const enCA: Locale
++  const enCA: LocaleJalali
+   namespace enCA {}
+ 
+-  const enGB: Locale
++  const enGB: LocaleJalali
+   namespace enGB {}
+ 
+-  const enUS: Locale
++  const enUS: LocaleJalali
+   namespace enUS {}
+ 
+-  const eo: Locale
++  const eo: LocaleJalali
+   namespace eo {}
+ 
+-  const es: Locale
++  const es: LocaleJalali
+   namespace es {}
+ 
+-  const et: Locale
++  const et: LocaleJalali
+   namespace et {}
+ 
+-  const faIR: Locale
++  const faIR: LocaleJalali
+   namespace faIR {}
+ 
+-  const fajalaliIR: Locale
++  const fajalaliIR: LocaleJalali
+   namespace fajalaliIR {}
+ 
+-  const fi: Locale
++  const fi: LocaleJalali
+   namespace fi {}
+ 
+-  const fil: Locale
++  const fil: LocaleJalali
+   namespace fil {}
+ 
+-  const fr: Locale
++  const fr: LocaleJalali
+   namespace fr {}
+ 
+-  const frCA: Locale
++  const frCA: LocaleJalali
+   namespace frCA {}
+ 
+-  const frCH: Locale
++  const frCH: LocaleJalali
+   namespace frCH {}
+ 
+-  const gl: Locale
++  const gl: LocaleJalali
+   namespace gl {}
+ 
+-  const gu: Locale
++  const gu: LocaleJalali
+   namespace gu {}
+ 
+-  const he: Locale
++  const he: LocaleJalali
+   namespace he {}
+ 
+-  const hi: Locale
++  const hi: LocaleJalali
+   namespace hi {}
+ 
+-  const hr: Locale
++  const hr: LocaleJalali
+   namespace hr {}
+ 
+-  const hu: Locale
++  const hu: LocaleJalali
+   namespace hu {}
+ 
+-  const hy: Locale
++  const hy: LocaleJalali
+   namespace hy {}
+ 
+-  const id: Locale
++  const id: LocaleJalali
+   namespace id {}
+ 
+-  const is: Locale
++  const is: LocaleJalali
+   namespace is {}
+ 
+-  const it: Locale
++  const it: LocaleJalali
+   namespace it {}
+ 
+-  const ja: Locale
++  const ja: LocaleJalali
+   namespace ja {}
+ 
+-  const ka: Locale
++  const ka: LocaleJalali
+   namespace ka {}
+ 
+-  const kk: Locale
++  const kk: LocaleJalali
+   namespace kk {}
+ 
+-  const kn: Locale
++  const kn: LocaleJalali
+   namespace kn {}
+ 
+-  const ko: Locale
++  const ko: LocaleJalali
+   namespace ko {}
+ 
+-  const lt: Locale
++  const lt: LocaleJalali
+   namespace lt {}
+ 
+-  const lv: Locale
++  const lv: LocaleJalali
+   namespace lv {}
+ 
+-  const mk: Locale
++  const mk: LocaleJalali
+   namespace mk {}
+ 
+-  const ms: Locale
++  const ms: LocaleJalali
+   namespace ms {}
+ 
+-  const mt: Locale
++  const mt: LocaleJalali
+   namespace mt {}
+ 
+-  const nb: Locale
++  const nb: LocaleJalali
+   namespace nb {}
+ 
+-  const nl: Locale
++  const nl: LocaleJalali
+   namespace nl {}
+ 
+-  const nlBE: Locale
++  const nlBE: LocaleJalali
+   namespace nlBE {}
+ 
+-  const nn: Locale
++  const nn: LocaleJalali
+   namespace nn {}
+ 
+-  const pl: Locale
++  const pl: LocaleJalali
+   namespace pl {}
+ 
+-  const pt: Locale
++  const pt: LocaleJalali
+   namespace pt {}
+ 
+-  const ptBR: Locale
++  const ptBR: LocaleJalali
+   namespace ptBR {}
+ 
+-  const ro: Locale
++  const ro: LocaleJalali
+   namespace ro {}
+ 
+-  const ru: Locale
++  const ru: LocaleJalali
+   namespace ru {}
+ 
+-  const sk: Locale
++  const sk: LocaleJalali
+   namespace sk {}
+ 
+-  const sl: Locale
++  const sl: LocaleJalali
+   namespace sl {}
+ 
+-  const sr: Locale
++  const sr: LocaleJalali
+   namespace sr {}
+ 
+-  const srLatn: Locale
++  const srLatn: LocaleJalali
+   namespace srLatn {}
+ 
+-  const sv: Locale
++  const sv: LocaleJalali
+   namespace sv {}
+ 
+-  const ta: Locale
++  const ta: LocaleJalali
+   namespace ta {}
+ 
+-  const te: Locale
++  const te: LocaleJalali
+   namespace te {}
+ 
+-  const th: Locale
++  const th: LocaleJalali
+   namespace th {}
+ 
+-  const tr: Locale
++  const tr: LocaleJalali
+   namespace tr {}
+ 
+-  const ug: Locale
++  const ug: LocaleJalali
+   namespace ug {}
+ 
+-  const uk: Locale
++  const uk: LocaleJalali
+   namespace uk {}
+ 
+-  const uz: Locale
++  const uz: LocaleJalali
+   namespace uz {}
+ 
+-  const vi: Locale
++  const vi: LocaleJalali
+   namespace vi {}
+ 
+-  const zhCN: Locale
++  const zhCN: LocaleJalali
+   namespace zhCN {}
+ 
+-  const zhTW: Locale
++  const zhTW: LocaleJalali
+   namespace zhTW {}
+ }
+ 
+@@ -17978,7 +17978,7 @@ declare module 'date-fns-jalali/esm/locale/zh-TW/index.js' {
+ // dateFns Global Interface
+ 
+ interface dateFns {
+-  add(date: Date | number, duration: Duration): Date
++  add(date: Date | number, duration: DurationJalali): Date
+ 
+   addBusinessDays(date: Date | number, amount: number): Date
+ 
+@@ -18003,8 +18003,8 @@ interface dateFns {
+   addYears(date: Date | number, amount: number): Date
+ 
+   areIntervalsOverlapping(
+-    intervalLeft: Interval,
+-    intervalRight: Interval,
++    intervalLeft: IntervalJalali,
++    intervalRight: IntervalJalali,
+     options?: {
+       inclusive?: boolean
+     }
+@@ -18055,7 +18055,7 @@ interface dateFns {
+     dateLeft: Date | number,
+     dateRight: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): number
+@@ -18095,29 +18095,29 @@ interface dateFns {
+   differenceInYears(dateLeft: Date | number, dateRight: Date | number): number
+ 
+   eachDayOfInterval(
+-    interval: Interval,
++    interval: IntervalJalali,
+     options?: {
+       step?: number
+     }
+   ): Date[]
+ 
+-  eachMonthOfInterval(interval: Interval): Date[]
++  eachMonthOfInterval(interval: IntervalJalali): Date[]
+ 
+-  eachWeekendOfInterval(interval: Interval): Date[]
++  eachWeekendOfInterval(interval: IntervalJalali): Date[]
+ 
+   eachWeekendOfMonth(date: Date | number): Date[]
+ 
+   eachWeekendOfYear(date: Date | number): Date[]
+ 
+   eachWeekOfInterval(
+-    interval: Interval,
++    interval: IntervalJalali,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date[]
+ 
+-  eachYearOfInterval(interval: Interval): Date[]
++  eachYearOfInterval(interval: IntervalJalali): Date[]
+ 
+   endOfDay(date: Date | number): Date
+ 
+@@ -18149,7 +18149,7 @@ interface dateFns {
+   endOfWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -18162,7 +18162,7 @@ interface dateFns {
+     date: Date | number,
+     format: string,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: number
+       useAdditionalWeekYearTokens?: boolean
+@@ -18176,7 +18176,7 @@ interface dateFns {
+     options?: {
+       includeSeconds?: boolean
+       addSuffix?: boolean
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+ 
+@@ -18187,7 +18187,7 @@ interface dateFns {
+       addSuffix?: boolean
+       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+       roundingMethod?: 'floor' | 'ceil' | 'round'
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+ 
+@@ -18196,7 +18196,7 @@ interface dateFns {
+     options?: {
+       includeSeconds?: boolean
+       addSuffix?: boolean
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+ 
+@@ -18206,7 +18206,7 @@ interface dateFns {
+       addSuffix?: boolean
+       unit?: 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
+       roundingMethod?: 'floor' | 'ceil' | 'round'
+-      locale?: Locale
++      locale?: LocaleJalali
+     }
+   ): string
+ 
+@@ -18226,13 +18226,13 @@ interface dateFns {
+     }
+   ): string
+ 
+-  formatISODuration(duration: Duration): string
++  formatISODuration(duration: DurationJalali): string
+ 
+   formatRelative(
+     date: Date | number,
+     baseDate: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): string
+@@ -18277,8 +18277,8 @@ interface dateFns {
+   getMonth(date: Date | number): number
+ 
+   getOverlappingDaysInIntervals(
+-    intervalLeft: Interval,
+-    intervalRight: Interval
++    intervalLeft: IntervalJalali,
++    intervalRight: IntervalJalali
+   ): number
+ 
+   getQuarter(date: Date | number): number
+@@ -18292,7 +18292,7 @@ interface dateFns {
+   getWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -18301,7 +18301,7 @@ interface dateFns {
+   getWeekOfMonth(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): number
+@@ -18309,7 +18309,7 @@ interface dateFns {
+   getWeeksInMonth(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): number
+@@ -18317,7 +18317,7 @@ interface dateFns {
+   getWeekYear(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -18325,7 +18325,7 @@ interface dateFns {
+ 
+   getYear(date: Date | number): number
+ 
+-  intervalToDuration(interval: Interval): Duration
++  intervalToDuration(interval: IntervalJalali): DurationJalali
+ 
+   isAfter(date: Date | number, dateToCompare: Date | number): boolean
+ 
+@@ -18371,7 +18371,7 @@ interface dateFns {
+     dateLeft: Date | number,
+     dateRight: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): boolean
+@@ -18397,7 +18397,7 @@ interface dateFns {
+   isThisWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): boolean
+@@ -18418,7 +18418,7 @@ interface dateFns {
+ 
+   isWeekend(date: Date | number): boolean
+ 
+-  isWithinInterval(date: Date | number, interval: Interval): boolean
++  isWithinInterval(date: Date | number, interval: IntervalJalali): boolean
+ 
+   isYesterday(date: Date | number): boolean
+ 
+@@ -18440,7 +18440,7 @@ interface dateFns {
+   lastDayOfWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -18458,7 +18458,7 @@ interface dateFns {
+     formatString: string,
+     referenceDate: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+       useAdditionalWeekYearTokens?: boolean
+@@ -18501,7 +18501,7 @@ interface dateFns {
+     date: Date | number,
+     day: number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -18530,7 +18530,7 @@ interface dateFns {
+     date: Date | number,
+     week: number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -18540,7 +18540,7 @@ interface dateFns {
+     date: Date | number,
+     weekYear: number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -18573,7 +18573,7 @@ interface dateFns {
+   startOfWeek(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+     }
+   ): Date
+@@ -18581,7 +18581,7 @@ interface dateFns {
+   startOfWeekYear(
+     date: Date | number,
+     options?: {
+-      locale?: Locale
++      locale?: LocaleJalali
+       weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+       firstWeekContainsDate?: 1 | 2 | 3 | 4 | 5 | 6 | 7
+     }
+@@ -18591,7 +18591,7 @@ interface dateFns {
+ 
+   startOfYesterday(): Date
+ 
+-  sub(date: Date | number, duration: Duration): Date
++  sub(date: Date | number, duration: DurationJalali): Date
+ 
+   subBusinessDays(date: Date | number, amount: number): Date
+ 


### PR DESCRIPTION
Related to https://github.com/dmtrKovalenko/date-io/issues/52

If we were able to remove `skipLibCheck: "true"`, we would avoid most issues like https://github.com/mui/mui-x/issues/7779

Currently, our authored `.d.ts` files are ignored by `tsc` and thus, any issues in them can slip unnoticed by both human eye as well as CI steps.

It's not the most robust solution as package bumps might need changes, but IMHO it's worth the added type safety in our authored `d.ts` files. 🙈 🤞 

- Fix `@date-io` adapters type declaration module names to be uniquely scoped (seems like it should originally be something like that)
- Rename `date-fns-jalali` duplicated typing type names to avoid tsc issues