### PR TITLE
[DataGrid] Use unformatted number and boolean values for CSV serialization

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
@@ -481,7 +481,9 @@ describe('<DataGridPro /> - Export', () => {
         );
       }
       render(<TestCaseCSVExport />);
-      expect(apiRef.current.getDataAsCsv()).to.equal(['id,isAdmin', '0,Yes', '1,No'].join('\r\n'));
+      expect(apiRef.current.getDataAsCsv()).to.equal(
+        ['id,isAdmin', '0,true', '1,false'].join('\r\n'),
+      );
     });
 
     it('should warn when a value of a field is an object and no `valueFormatter` is provided', () => {

--- a/packages/grid/x-data-grid/src/colDef/gridBooleanColDef.tsx
+++ b/packages/grid/x-data-grid/src/colDef/gridBooleanColDef.tsx
@@ -6,10 +6,8 @@ import { gridNumberComparator } from '../hooks/features/sorting/gridSortingUtils
 import { getGridBooleanOperators } from './gridBooleanOperators';
 import { GridValueFormatterParams } from '../models/params/gridCellParams';
 
-function gridBooleanFormatter({ value, api }: GridValueFormatterParams) {
-  return value
-    ? api.getLocaleText('booleanCellTrueLabel')
-    : api.getLocaleText('booleanCellFalseLabel');
+function gridBooleanFormatter({ value }: GridValueFormatterParams) {
+  return String(value);
 }
 
 export const GRID_BOOLEAN_COL_DEF: GridColTypeDef<boolean | null, any> = {

--- a/packages/grid/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -37,7 +37,13 @@ const serializeRow = (
         objectFormattedValueWarning();
       }
     }
-    return serializeCellValue(cellParams.formattedValue, delimiterCharacter);
+    let valueToSerialize: any;
+    if (column.type === 'number') {
+      valueToSerialize = cellParams.value;
+    } else {
+      valueToSerialize = cellParams.formattedValue;
+    }
+    return serializeCellValue(valueToSerialize, delimiterCharacter);
   });
 
 interface BuildCSVOptions {

--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridCsvExport.tsx
@@ -23,8 +23,8 @@ import {
 export const useGridCsvExport = (apiRef: React.MutableRefObject<GridPrivateApiCommunity>): void => {
   const logger = useGridLogger(apiRef, 'useGridCsvExport');
 
-  const getDataAsCsv = React.useCallback(
-    (options: GridCsvExportOptions = {}): string => {
+  const getDataAsCsv = React.useCallback<GridCsvExportApi['getDataAsCsv']>(
+    (options = {}) => {
       logger.debug(`Get data as CSV`);
 
       const exportedColumns = getColumnsToExport({


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-x/pull/7389, necessary for https://github.com/mui/mui-x/issues/199.
Otherwise it won't be possible to properly parse these values when pasting from clipboard.

## Changelog

### Breaking changes

- CSV export: `number` and `boolean` columns will export raw unformatted values instead of formatted values:
  ```diff
  - $11,000.05
  + 11000.05
  ```
  
  ```diff
  - yes
  + true
  ```