### PR TITLE
[docs] Use `@next` tag in grid and pickers installation instructions

### DIFF
--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -6,6 +6,10 @@
 
 Using your favorite package manager, install `@mui/x-data-grid-pro` or `@mui/x-data-grid-premium` for the commercial version, or `@mui/x-data-grid` for the free community version.
 
+:::warning
+Note we're using the `next` tag to download the latest v6 **beta** version.
+:::
+
 {{"component": "modules/components/DataGridInstallationInstructions.js"}}
 
 The grid package has a peer dependency on `@mui/material`.

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -6,13 +6,7 @@
 
 Using your favorite package manager, install `@mui/x-data-grid-pro` or `@mui/x-data-grid-premium` for the commercial version, or `@mui/x-data-grid` for the free community version.
 
-```sh
-// with npm
-npm install @mui/x-data-grid
-
-// with yarn
-yarn add @mui/x-data-grid
-```
+{{"component": "modules/components/DataGridInstallationInstructions.js"}}
 
 The grid package has a peer dependency on `@mui/material`.
 If you are not already using it in your project, you can install it with:

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -20,6 +20,10 @@ Using your favorite package manager, install:
 - `@mui/x-date-pickers` for the free community version or `@mui/x-date-pickers-pro` for the commercial version.
 - The date library to manipulate the date.
 
+:::warning
+Note we're using the `next` tag to download the latest v6 **beta** version.
+:::
+
 {{"component": "modules/components/PickersInstallationInstructions.js"}}
 
 :::info

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -1,4 +1,3 @@
-/* eslint-disable  material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -3,9 +3,9 @@ import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 
 const packages = {
-  Community: '@mui/x-data-grid',
-  Pro: '@mui/x-data-grid-pro',
-  Premium: '@mui/x-data-grid-premium',
+  Community: '@mui/x-data-grid@next',
+  Pro: '@mui/x-data-grid-pro@next',
+  Premium: '@mui/x-data-grid-premium@next',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -1,0 +1,13 @@
+/* eslint-disable  material-ui/no-hardcoded-labels */
+import * as React from 'react';
+import InstallationInstructions from './InstallationInstructions';
+
+const packages = {
+  Community: '@mui/x-data-grid',
+  Pro: '@mui/x-data-grid-pro',
+  Premium: '@mui/x-data-grid-premium',
+};
+
+export default function DataGridInstallationInstructions() {
+  return <InstallationInstructions packages={packages} />;
+}

--- a/docs/src/modules/components/InstallationInstructions.tsx
+++ b/docs/src/modules/components/InstallationInstructions.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable  material-ui/no-hardcoded-labels */
+import * as React from 'react';
+// @ts-expect-error
+import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+import Stack from '@mui/material/Stack';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+
+const defaultPackageManagers = {
+  yarn: 'yarn add',
+  npm: 'npm install',
+};
+
+export default function InstallationInstructions(props: {
+  packages: Record<string, string>;
+  peerDependency?: {
+    label: string;
+    packages: string[];
+    installationComment?: string;
+  };
+  packageManagers: Record<string, string>;
+}) {
+  const { packages, packageManagers = defaultPackageManagers, peerDependency = null } = props;
+  const packagesTypes = Object.keys(packages);
+  const packageManagersNames = Object.keys(packageManagers);
+
+  const [licenseType, setLicenseType] = React.useState(packagesTypes[0]);
+  const [packageManger, setPackageManger] = React.useState(packageManagersNames[0]);
+  const [libraryUsed, setLibraryUsed] = React.useState(
+    peerDependency ? peerDependency.packages[0] : null,
+  );
+
+  const handlePackageMangerChange = (
+    event: React.MouseEvent<HTMLElement>,
+    nextPackageManager: string,
+  ) => {
+    if (nextPackageManager !== null) {
+      setPackageManger(nextPackageManager);
+    }
+  };
+
+  const handleLicenseTypeChange = (
+    event: React.MouseEvent<HTMLElement>,
+    nextLicenseType: string,
+  ) => {
+    if (nextLicenseType !== null) {
+      setLicenseType(nextLicenseType);
+    }
+  };
+
+  const commands = [`${packageManagers[packageManger]} ${packages[licenseType]}`];
+
+  if (peerDependency) {
+    commands.push('');
+    if (peerDependency.installationComment) {
+      commands.push(peerDependency.installationComment);
+    }
+    commands.push(`${packageManagers[packageManger]} ${libraryUsed}`);
+  }
+
+  return (
+    <Stack sx={{ width: '100%' }} px={{ xs: 3, sm: 0 }}>
+      <Stack direction="row" spacing={2}>
+        <ToggleButtonGroup
+          value={packageManger}
+          exclusive
+          onChange={handlePackageMangerChange}
+          size="small"
+        >
+          {packageManagersNames.map((key) => (
+            <ToggleButton value={key} key={key}>
+              {key}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        <ToggleButtonGroup
+          value={licenseType}
+          exclusive
+          onChange={handleLicenseTypeChange}
+          size="small"
+        >
+          {packagesTypes.map((key) => (
+            <ToggleButton value={key} key={key}>
+              {key}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        {peerDependency ? (
+          <TextField
+            size="small"
+            label={peerDependency.label}
+            value={libraryUsed}
+            onChange={(event) => {
+              setLibraryUsed(event.target.value);
+            }}
+            select
+          >
+            {peerDependency.packages.map((packageName) => (
+              <MenuItem key={packageName} value={packageName}>
+                {packageName}
+              </MenuItem>
+            ))}
+          </TextField>
+        ) : null}
+      </Stack>
+      <HighlightedCode sx={{ width: '100%' }} code={commands.join('\n')} language="sh" />
+    </Stack>
+  );
+}

--- a/docs/src/modules/components/InstallationInstructions.tsx
+++ b/docs/src/modules/components/InstallationInstructions.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable  material-ui/no-hardcoded-labels */
 import * as React from 'react';
 // @ts-expect-error
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -1,4 +1,3 @@
-/* eslint-disable  material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -3,8 +3,8 @@ import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 
 const packages = {
-  Community: '@mui/x-date-pickers',
-  Pro: '@mui/x-date-pickers-pro',
+  Community: '@mui/x-date-pickers@next',
+  Pro: '@mui/x-date-pickers-pro@next',
 };
 
 const peerDependency = {

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -1,83 +1,18 @@
 /* eslint-disable  material-ui/no-hardcoded-labels */
 import * as React from 'react';
-import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
-import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
-import MenuItem from '@mui/material/MenuItem';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
+import InstallationInstructions from './InstallationInstructions';
 
-const libraries = ['dayjs', 'date-fns', 'luxon', 'moment'];
+const packages = {
+  Community: '@mui/x-date-pickers',
+  Pro: '@mui/x-date-pickers-pro',
+};
+
+const peerDependency = {
+  label: 'Date library',
+  installationComment: '// Install date library (if not already installed)',
+  packages: ['dayjs', 'date-fns', 'luxon', 'moment'],
+};
 
 export default function PickersInstallationInstructions() {
-  const [licenceType, setLicenceType] = React.useState('community');
-  const [packageManger, setPackageManger] = React.useState('yarn');
-  const [libraryUsed, setLibraryUsed] = React.useState('dayjs');
-
-  const handlePackageMangerChange = (event, nextPackageManager) => {
-    if (nextPackageManager !== null) {
-      setPackageManger(nextPackageManager);
-    }
-  };
-
-  const handleLicenceTypeChange = (event, nextLicenseType) => {
-    if (nextLicenseType !== null) {
-      setLicenceType(nextLicenseType);
-    }
-  };
-
-  const handleLibraryUsedChange = (event) => {
-    setLibraryUsed(event.target.value);
-  };
-
-  const installationCLI = packageManger === 'npm' ? 'npm install ' : 'yarn add ';
-  const componentPackage =
-    licenceType === 'pro' ? '@mui/x-date-pickers-pro' : '@mui/x-date-pickers';
-
-  const commandLines = [
-    `// Install component (${licenceType} version)`,
-    `${installationCLI}${componentPackage}`,
-    '',
-    `// Install date library (if not already installed)`,
-    `${installationCLI}${libraryUsed}`,
-  ].join('\n');
-
-  return (
-    <Stack sx={{ width: '100%' }} px={{ xs: 3, sm: 0 }}>
-      <Stack direction="row" spacing={2}>
-        <ToggleButtonGroup
-          value={packageManger}
-          exclusive
-          onChange={handlePackageMangerChange}
-          size="small"
-        >
-          <ToggleButton value="yarn">yarn</ToggleButton>
-          <ToggleButton value="npm">npm</ToggleButton>
-        </ToggleButtonGroup>
-        <ToggleButtonGroup
-          value={licenceType}
-          exclusive
-          onChange={handleLicenceTypeChange}
-          size="small"
-        >
-          <ToggleButton value="community">community</ToggleButton>
-          <ToggleButton value="pro">pro</ToggleButton>
-        </ToggleButtonGroup>
-        <TextField
-          size="small"
-          label="Date library"
-          value={libraryUsed}
-          onChange={handleLibraryUsedChange}
-          select
-        >
-          {libraries.map((lib) => (
-            <MenuItem key={lib} value={lib}>
-              {lib}
-            </MenuItem>
-          ))}
-        </TextField>
-      </Stack>
-      <HighlightedCode sx={{ width: '100%' }} code={commandLines} language="sh" />
-    </Stack>
-  );
+  return <InstallationInstructions packages={packages} peerDependency={peerDependency} />;
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -14,6 +14,7 @@
   "include": [
     "pages/**/*.ts*",
     "data/**/*",
+    "src/modules/components/**/*",
     "../node_modules/@mui/material/themeCssVarsAugmentation"
   ],
   "exclude": ["docs/.next", "docs/export"]


### PR DESCRIPTION
- Use the `@next` tag in installation instructions (for both data grid and pickers) so that the latest prerelease version is installed (currently beta.2)
- Make data grid installation instructions interactive (pickers docs already had this):

<img width="634" alt="Screenshot 2023-02-03 at 12 47 19" src="https://user-images.githubusercontent.com/13808724/216596872-df53f81a-9c89-4a2a-9a8f-60a9030c6d33.png">

Preview: https://deploy-preview-7814--material-ui-x.netlify.app/x/react-data-grid/getting-started/#installation