### PR TITLE
[docs] Add product name to "What's New" page title.

### DIFF
--- a/docs/data/whats-new.md
+++ b/docs/data/whats-new.md
@@ -1,4 +1,4 @@
-# ✨ What's new in v6? ✨
+# ✨ What's new in MUI X v6? ✨
 
 <p class="description">Discover the new features on the latest major version.</p>
 


### PR DESCRIPTION
# Summary

Followup on #7820.

Users landing from Material-UI might lose context and may need support to reorient.

Add "MUI X" to the page title to make it clearer (on the spot) that it is an X page.
 