### PR TITLE
[docs] Remove no longer relevant range shortcuts section

### DIFF
--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -90,16 +90,6 @@ Make sure to spread `inputProps` correctly to the custom input component.
 
 You can find the documentation in the [Validation page](/x/react-date-pickers/validation/)
 
-## 🚧 Pre-defined range shortcuts
-
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #4563](https://github.com/mui/mui-x/issues/4563) if you want to see it land faster.
-:::
-
-Range shortcuts allows your users to select a commonly-used range in one click (eg: last week, last month, …)
-
 ## 🚧 Month Range Picker
 
 :::warning


### PR DESCRIPTION
The issue is already solved and solution is delivered and [documented](https://next.mui.com/x/react-date-pickers/date-range-picker/#add-shortcuts).