### PR TITLE
[codemod] Add more cases to `rename-selectors-and-events` codemod

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -100,15 +100,20 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
 ### State access
 
 - ✅ The `gridSelectionStateSelector` selector was renamed to `gridRowSelectionStateSelector`.
+- ✅ The `allGridColumnsFieldsSelector` selector was removed. Use `gridColumnFieldsSelector` instead.
+- ✅ The `allGridColumnsSelector` selector was removed. Use `gridColumnDefinitionsSelector` instead.
+- ✅ The `visibleGridColumnsSelector` selector was removed. Use `gridVisibleColumnDefinitionsSelector` instead.
+- ✅ The `filterableGridColumnsSelector` selector was removed. Use `gridFilterableColumnDefinitionsSelector` instead.
+- ✅ The `gridVisibleSortedRowIdsSelector` selector was renamed to `gridExpandedSortedRowIdsSelector`
+- ✅ The `gridVisibleSortedRowEntriesSelector` selector was renamed to `gridExpandedSortedRowEntriesSelector`.
+- ✅ The `gridVisibleRowCountSelector` selector was renamed to `gridExpandedRowCountSelector`.
+- ✅ The `gridVisibleSortedTopLevelRowEntriesSelector` selector was renamed to `gridFilteredSortedTopLevelRowEntriesSelector`.
+- ✅ The `gridVisibleTopLevelRowCountSelector` selector was renamed to `gridFilteredTopLevelRowCountSelector`.
+- ✅ The `getGridNumericColumnOperators` selector was removed. Use `getGridNumericOperators` instead.
 - The `gridColumnsSelector` selector was removed. Use more specific grid columns selectors instead.
-- The `allGridColumnsFieldsSelector` selector was removed. Use `gridColumnFieldsSelector` instead.
-- The `allGridColumnsSelector` selector was removed. Use `gridColumnDefinitionsSelector` instead.
-- The `visibleGridColumnsSelector` selector was removed. Use `gridVisibleColumnDefinitionsSelector` instead.
-- The `filterableGridColumnsSelector` selector was removed. Use `gridFilterableColumnDefinitionsSelector` instead.
 - The `filterableGridColumnsIdsSelector` selector was removed. Use `gridFilterableColumnLookupSelector` instead.
 - The `visibleGridColumnsLengthSelector` selector was removed. Use `gridVisibleColumnDefinitionsSelector` instead.
 - The `gridColumnsMetaSelector` selector was removed. Use `gridColumnsTotalWidthSelector` or `gridColumnPositionsSelector` instead.
-- The `getGridNumericColumnOperators` selector was removed. Use `getGridNumericOperators` instead.
 - The `gridVisibleRowsSelector` selector was removed. Use `gridExpandedSortedRowIdsSelector` instead.
 - The `gridRowGroupingStateSelector` selector was removed.
 - The `gridFilterStateSelector` selector was removed.
@@ -120,11 +125,6 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
 - The `gridEditRowsStateSelector` selector was removed.
 - The `apiRef.current.state.density.headerHeight` property was removed.
 - The `apiRef.current.state.density.rowHeight` property was removed.
-- ✅ The `gridVisibleSortedRowIdsSelector` selector was renamed to `gridExpandedSortedRowIdsSelector`
-- ✅ The `gridVisibleSortedRowEntriesSelector` selector was renamed to `gridExpandedSortedRowEntriesSelector`.
-- ✅ The `gridVisibleRowCountSelector` selector was renamed to `gridExpandedRowCountSelector`.
-- ✅ The `gridVisibleSortedTopLevelRowEntriesSelector` selector was renamed to `gridFilteredSortedTopLevelRowEntriesSelector`.
-- ✅ The `gridVisibleTopLevelRowCountSelector` selector was renamed to `gridFilteredTopLevelRowCountSelector`.
 
 ### Events
 

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -611,6 +611,11 @@ Rename selectors and events.
 -  const rowCount = useGridSelector(apiRef, gridVisibleRowCountSelector);
 -  const sortedTopLevelRowEntries = useGridSelector(apiRef, gridVisibleSortedTopLevelRowEntriesSelector);
 -  const topLevelRowCount = useGridSelector(apiRef, gridVisibleTopLevelRowCountSelector);
+-  const allGridColumnsFields = useGridSelector(apiRef, allGridColumnsFieldsSelector);
+-  const allGridColumns = useGridSelector(apiRef, allGridColumnsSelector);
+-  const visibleGridColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
+-  const filterableGridColumns = useGridSelector(apiRef, filterableGridColumnsSelector);
+-  const getGridNumericColumn = useGridSelector(apiRef, getGridNumericColumnOperators);
 +  useGridApiEventHandler('rowSelectionChange', handleEvent);
 +  apiRef.current.subscribeEvent('rowSelectionChange', handleEvent);
 +  const selection = useGridSelector(apiRef, gridRowSelectionStateSelector);
@@ -619,6 +624,11 @@ Rename selectors and events.
 +  const rowCount = useGridSelector(apiRef, gridExpandedRowCountSelector);
 +  const sortedTopLevelRowEntries = useGridSelector(apiRef, gridFilteredSortedTopLevelRowEntriesSelector);
 +  const topLevelRowCount = useGridSelector(apiRef, gridFilteredTopLevelRowCountSelector);
++  const allGridColumnsFields = useGridSelector(apiRef, gridColumnFieldsSelector);
++  const allGridColumns = useGridSelector(apiRef, gridColumnDefinitionsSelector);
++  const visibleGridColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
++  const filterableGridColumns = useGridSelector(apiRef, gridFilterableColumnDefinitionsSelector);
++  const getGridNumericColumn = useGridSelector(apiRef, getGridNumericOperators);
  }
 ```
 

--- a/packages/x-codemod/src/util/renameIdentifiers.ts
+++ b/packages/x-codemod/src/util/renameIdentifiers.ts
@@ -54,7 +54,7 @@ const findDeepASTPath = (j, currentPath, currentIdentifiers) => {
  * @param {PreRequisiteUsage} preReqs
  * @returns {boolean}
  */
-const checkPreRequisitesSatisfied = (j, root, preReqs: PreRequisiteUsage): boolean => {
+export const checkPreRequisitesSatisfied = (j, root, preReqs: PreRequisiteUsage): boolean => {
   if (preReqs.packageRegex || preReqs.components) {
     // check if any of the components is imported from a package which satisfies `preReqs.packageRegex`
     const imports = root.find(j.ImportDeclaration);

--- a/packages/x-codemod/src/v6.0.0/data-grid/rename-selectors-and-events/actual.spec.js
+++ b/packages/x-codemod/src/v6.0.0/data-grid/rename-selectors-and-events/actual.spec.js
@@ -8,6 +8,11 @@ import {
   gridVisibleRowCountSelector,
   gridVisibleSortedTopLevelRowEntriesSelector,
   gridVisibleTopLevelRowCountSelector,
+  allGridColumnsFieldsSelector,
+  allGridColumnsSelector,
+  visibleGridColumnsSelector,
+  filterableGridColumnsSelector,
+  getGridNumericColumnOperators,
 } from '@mui/x-data-grid';
 
 const useGridSelector = (apiRef, selector) => {};
@@ -22,6 +27,11 @@ function App () {
   const rowCount = useGridSelector(apiRef, gridVisibleRowCountSelector);
   const sortedTopLevelRowEntries = useGridSelector(apiRef, gridVisibleSortedTopLevelRowEntriesSelector);
   const topLevelRowCount = useGridSelector(apiRef, gridVisibleTopLevelRowCountSelector);
+  const allGridColumnsFields = useGridSelector(apiRef, allGridColumnsFieldsSelector);
+  const allGridColumns = useGridSelector(apiRef, allGridColumnsSelector);
+  const visibleGridColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
+  const filterableGridColumns = useGridSelector(apiRef, filterableGridColumnsSelector);
+  const getGridNumericColumn = useGridSelector(apiRef, getGridNumericColumnOperators);
   return <DataGrid />;
 }
 

--- a/packages/x-codemod/src/v6.0.0/data-grid/rename-selectors-and-events/expected.spec.js
+++ b/packages/x-codemod/src/v6.0.0/data-grid/rename-selectors-and-events/expected.spec.js
@@ -8,6 +8,11 @@ import {
   gridExpandedRowCountSelector,
   gridFilteredSortedTopLevelRowEntriesSelector,
   gridFilteredTopLevelRowCountSelector,
+  gridColumnFieldsSelector,
+  gridColumnDefinitionsSelector,
+  gridVisibleColumnDefinitionsSelector,
+  gridFilterableColumnDefinitionsSelector,
+  getGridNumericOperators,
 } from '@mui/x-data-grid';
 
 const useGridSelector = (apiRef, selector) => {};
@@ -22,6 +27,11 @@ function App () {
   const rowCount = useGridSelector(apiRef, gridExpandedRowCountSelector);
   const sortedTopLevelRowEntries = useGridSelector(apiRef, gridFilteredSortedTopLevelRowEntriesSelector);
   const topLevelRowCount = useGridSelector(apiRef, gridFilteredTopLevelRowCountSelector);
+  const allGridColumnsFields = useGridSelector(apiRef, gridColumnFieldsSelector);
+  const allGridColumns = useGridSelector(apiRef, gridColumnDefinitionsSelector);
+  const visibleGridColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
+  const filterableGridColumns = useGridSelector(apiRef, gridFilterableColumnDefinitionsSelector);
+  const getGridNumericColumn = useGridSelector(apiRef, getGridNumericOperators);
   return <DataGrid />;
 }
 

--- a/packages/x-codemod/src/v6.0.0/data-grid/rename-selectors-and-events/index.ts
+++ b/packages/x-codemod/src/v6.0.0/data-grid/rename-selectors-and-events/index.ts
@@ -1,4 +1,5 @@
 import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
+import { PreRequisiteUsage, checkPreRequisitesSatisfied } from '../../../util/renameIdentifiers';
 
 const renamedSelectors = {
   gridSelectionStateSelector: 'gridRowSelectionStateSelector',
@@ -7,8 +8,19 @@ const renamedSelectors = {
   gridVisibleRowCountSelector: 'gridExpandedRowCountSelector',
   gridVisibleSortedTopLevelRowEntriesSelector: 'gridFilteredSortedTopLevelRowEntriesSelector',
   gridVisibleTopLevelRowCountSelector: 'gridFilteredTopLevelRowCountSelector',
+  allGridColumnsFieldsSelector: 'gridColumnFieldsSelector',
+  allGridColumnsSelector: 'gridColumnDefinitionsSelector',
+  visibleGridColumnsSelector: 'gridVisibleColumnDefinitionsSelector',
+  filterableGridColumnsSelector: 'gridFilterableColumnDefinitionsSelector',
+  getGridNumericColumnOperators: 'getGridNumericOperators',
 };
+
 const renamedEvents = { selectionChange: 'rowSelectionChange', rowsScroll: 'scrollPositionChange' };
+
+const preRequisites: PreRequisiteUsage = {
+  components: ['DataGrid', 'DataGridPro', 'DataGridPremium'],
+  packageRegex: /@mui\/x-data-grid(-pro|-premium)?/,
+};
 
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
   const j = api.jscodeshift;
@@ -19,24 +31,28 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
     trailingComma: true,
   };
 
-  // Rename the import and usage of renamed selectors
-  // - import { gridSelectionStateSelector } from '@mui/x-data-grid'
-  // + import { gridRowSelectionStateSelector } from '@mui/x-data-grid'
-  root
-    .find(j.Identifier)
-    .filter((path) => !!renamedSelectors[path.node.name])
-    .replaceWith((path) => j.identifier(renamedSelectors[path.node.name]));
+  const isGridUsed = checkPreRequisitesSatisfied(j, root, preRequisites);
 
-  // Rename the usage of renamed event literals
-  // - useGridApiEventHandler('selectionChange', handleEvent);
-  // - apiRef.current.subscribeEvent('selectionChange', handleEvent);
-  // + useGridApiEventHandler('rowSelectionChange', handleEvent);
-  // + apiRef.current.subscribeEvent('rowSelectionChange', handleEvent);
-  root
-    .find(j.CallExpression)
-    .find(j.Literal)
-    .filter((path) => !!renamedEvents[path.node.value as any])
-    .replaceWith((path) => j.literal(renamedEvents[path.node.value as any]));
+  if (isGridUsed) {
+    // Rename the import and usage of renamed selectors
+    // - import { gridSelectionStateSelector } from '@mui/x-data-grid'
+    // + import { gridRowSelectionStateSelector } from '@mui/x-data-grid'
+    root
+      .find(j.Identifier)
+      .filter((path) => !!renamedSelectors[path.node.name])
+      .replaceWith((path) => j.identifier(renamedSelectors[path.node.name]));
+
+    // Rename the usage of renamed event literals
+    // - useGridApiEventHandler('selectionChange', handleEvent);
+    // - apiRef.current.subscribeEvent('selectionChange', handleEvent);
+    // + useGridApiEventHandler('rowSelectionChange', handleEvent);
+    // + apiRef.current.subscribeEvent('rowSelectionChange', handleEvent);
+    root
+      .find(j.CallExpression)
+      .find(j.Literal)
+      .filter((path) => !!renamedEvents[path.node.value as any])
+      .replaceWith((path) => j.literal(renamedEvents[path.node.value as any]));
+  }
 
   return root.toSource(printOptions);
 }


### PR DESCRIPTION
Related to #7086 

- Add pre-reqs and more cases to the `rename-selectors-and-events` codemod
- Reorganize list of selector BCs to have handled with codemod on top