### PR TITLE
[DataGrid] Improve grid resize performance

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -235,14 +235,14 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     });
   }, [rowsMeta.currentPageTotalHeight]);
 
-  const handleResize = React.useCallback<GridEventListener<'resize'>>((params) => {
+  const handleResize = React.useCallback<GridEventListener<'debouncedResize'>>((params) => {
     setContainerDimensions({
       width: params.width,
       height: params.height,
     });
   }, []);
 
-  useGridApiEventHandler(apiRef, 'resize', handleResize);
+  useGridApiEventHandler(apiRef, 'debouncedResize', handleResize);
 
   const updateRenderZonePosition = React.useCallback(
     (nextRenderContext: GridRenderContext) => {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/3894
Supersedes https://github.com/mui/mui-x/pull/5978

In v6, listening to `debouncedResize` is enough to reduce the amount of rerenders drastically.
I didn't dive deep into the reason behind it, but I suspect it has something to do with https://github.com/mui/mui-x/pull/7001 which [removed the children function from auto sizer](https://github.com/mui/mui-x/pull/7001/files/35807f9d338d59da1321fe3ea0b68e0d05fa6e46#diff-9e93b57cf45d5ec1fa25b84787828b6db8753bee011ce39e557fca891075ab7dR78)

Side note: merging https://github.com/mui/mui-x/pull/7857 will reduce the number of rerenders even more.

Before: https://codesandbox.io/s/datagriddemo-rendercell-call-count-v5-forked-gbk73
After: https://codesandbox.io/s/datagriddemo-rendercell-call-count-v5-forked-bmyjpv