### PR TITLE
[docs] Update `LocalizationProvider` `dateAdapter` with a link to doc

### DIFF
--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -331,6 +331,14 @@ const buildComponentDocumentation = async (options: {
         description +=
           ' See the <a href="/system/getting-started/the-sx-prop/">`sx` page</a> for more details.';
       }
+      // Parse and generate `@see` doc with a {@link}
+      const seeTag = prop.annotation.tags.find((tag) => tag.title === 'see');
+      if (seeTag && seeTag.description) {
+        description += ` ${seeTag.description.replace(
+          /{@link ([^|| ]*)[|| ]([^}]*)}/,
+          '<a href="$1">$2</a>',
+        )}`;
+      }
       componentApi.propDescriptions[propName] = linkify(description, documentedInterfaces, 'html');
 
       const jsdocDefaultValue = getJsdocDefaultValue(

--- a/docs/translations/api-docs/date-pickers/localization-provider.json
+++ b/docs/translations/api-docs/date-pickers/localization-provider.json
@@ -2,7 +2,7 @@
   "componentDescription": "@ignore - do not document.",
   "propDescriptions": {
     "adapterLocale": "Locale for the date library you are using",
-    "dateAdapter": "Date library adapter class function. See the <a href=\"https://next.mui.com/x/react-date-pickers/adapters-locale/#set-a-custom-locale\">available adapters page</a> for more details.",
+    "dateAdapter": "Date library adapter class function. See the localization provider <a href=\"https://next.mui.com/x/react-date-pickers/getting-started/#code-setup\">code setup section</a> for more details.",
     "dateFormats": "Formats that are used for any child pickers",
     "dateLibInstance": "Date library instance you are using, if it has some global overrides <code>jsx dateLibInstance={momentTimeZone} </code>",
     "localeText": "Locale for components texts"

--- a/docs/translations/api-docs/date-pickers/localization-provider.json
+++ b/docs/translations/api-docs/date-pickers/localization-provider.json
@@ -2,7 +2,7 @@
   "componentDescription": "@ignore - do not document.",
   "propDescriptions": {
     "adapterLocale": "Locale for the date library you are using",
-    "dateAdapter": "DateIO adapter class function",
+    "dateAdapter": "Date library adapter class function. See the <a href=\"https://next.mui.com/x/react-date-pickers/adapters-locale/#set-a-custom-locale\">available adapters page</a> for more details.",
     "dateFormats": "Formats that are used for any child pickers",
     "dateLibInstance": "Date library instance you are using, if it has some global overrides <code>jsx dateLibInstance={momentTimeZone} </code>",
     "localeText": "Locale for components texts"

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -30,7 +30,7 @@ export interface LocalizationProviderProps<TDate> {
   children?: React.ReactNode;
   /**
    * Date library adapter class function.
-   * @see See the {@link https://next.mui.com/x/react-date-pickers/adapters-locale/#set-a-custom-locale available adapters page} for more details.
+   * @see See the localization provider {@link https://next.mui.com/x/react-date-pickers/getting-started/#code-setup code setup section} for more details.
    */
   dateAdapter?: new (...args: any) => MuiPickersAdapter<TDate>;
   /** Formats that are used for any child pickers */

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -149,7 +149,7 @@ LocalizationProvider.propTypes = {
   children: PropTypes.node,
   /**
    * Date library adapter class function.
-   * @see See the {@link https://next.mui.com/x/react-date-pickers/adapters-locale/#set-a-custom-locale available adapters page} for more details.
+   * @see See the localization provider {@link https://next.mui.com/x/react-date-pickers/getting-started/#code-setup code setup section} for more details.
    */
   dateAdapter: PropTypes.func,
   /**

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -28,7 +28,10 @@ if (process.env.NODE_ENV !== 'production') {
 
 export interface LocalizationProviderProps<TDate> {
   children?: React.ReactNode;
-  /** DateIO adapter class function */
+  /**
+   * Date library adapter class function.
+   * @see See the {@link https://next.mui.com/x/react-date-pickers/adapters-locale/#set-a-custom-locale available adapters page} for more details.
+   */
   dateAdapter?: new (...args: any) => MuiPickersAdapter<TDate>;
   /** Formats that are used for any child pickers */
   dateFormats?: Partial<DateIOFormats>;
@@ -145,7 +148,8 @@ LocalizationProvider.propTypes = {
   adapterLocale: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   children: PropTypes.node,
   /**
-   * DateIO adapter class function
+   * Date library adapter class function.
+   * @see See the {@link https://next.mui.com/x/react-date-pickers/adapters-locale/#set-a-custom-locale available adapters page} for more details.
    */
   dateAdapter: PropTypes.func,
   /**


### PR DESCRIPTION
Created [from](https://mui-org.slack.com/archives/C041SDSF32L/p1675893700633939):
> What does DateAdapter mean, where do I find it, what are the options?
> sent from https://mui.com/x/api/date-pickers/localization-provider/

- Support parsing `@see` with `{@link}` JSDoc into an anchor
- Update `LocalizationProvider` `dateAdapter` JSDoc to no longer refer to `DateIO` and link to a doc

JSDoc example in IDE:
<img width="743" alt="Screenshot 2023-02-09 at 15 22 16" src="https://user-images.githubusercontent.com/4941090/217855297-317c0ad9-a6d5-4349-8ef6-1997c9ebb319.png">

Rendered [doc example](https://deploy-preview-7872--material-ui-x.netlify.app/x/api/date-pickers/localization-provider/#:~:text=you%20are%20using-,dateAdapter,-func).