### PR TITLE
[DateRangePicker] Fix slide transition by avoiding useless component re-rendering

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -458,6 +458,11 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
     },
   } as DayCalendarSlotsComponentsProps<TDate>;
 
+  const calendarMonths = React.useMemo(
+    () => Array.from({ length: calendars }).map((_, index) => index),
+    [calendars],
+  );
+
   const visibleMonths = React.useMemo(
     () =>
       Array.from({ length: calendars }).map((_, index) =>
@@ -499,11 +504,8 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
       {...other}
     >
       <Watermark packageName="x-date-pickers-pro" releaseInfo={releaseInfo} />
-      {visibleMonths.map((month, index) => (
-        <DateRangeCalendarMonthContainer
-          key={(month as any).toString()}
-          className={classes.monthContainer}
-        >
+      {calendarMonths.map((month, index) => (
+        <DateRangeCalendarMonthContainer key={month} className={classes.monthContainer}>
           {calendars === 1 ? (
             <PickersCalendarHeader
               views={['day']}
@@ -532,7 +534,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
               slots={slots}
               slotProps={slotProps}
             >
-              {utils.format(month, 'monthAndYear')}
+              {utils.format(visibleMonths[month], 'monthAndYear')}
             </DateRangeCalendarArrowSwitcher>
           )}
 
@@ -547,7 +549,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
             reduceAnimations={reduceAnimations}
             selectedDays={value}
             onSelectedDaysChange={handleSelectedDayChange}
-            currentMonth={month}
+            currentMonth={visibleMonths[month]}
             TransitionProps={CalendarTransitionProps}
             shouldDisableDate={wrappedShouldDisableDate}
             showDaysOutsideCurrentMonth={calendars === 1 && showDaysOutsideCurrentMonth}


### PR DESCRIPTION
Fixes a regression of slide transition not being present.
Current v5:

https://user-images.githubusercontent.com/4941090/217871906-667cb2ae-b69e-4491-beb6-7edf0f03ca16.mov

Current v6:

https://user-images.githubusercontent.com/4941090/217871966-479d4595-da1a-4ee3-931f-97bf14ea3fcc.mov

Updated [v6 calendar](https://deploy-preview-7874--material-ui-x.netlify.app/x/react-date-pickers/date-range-calendar/#basic-usage)
