### PR TITLE
[docs] Add an info callout specifying the current state of desktop time view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
           command: |
             node --version
             yarn --version
-            docker info
+            swapon -s
       - restore_cache:
           name: Restore yarn cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ commands:
           command: |
             node --version
             yarn --version
-            swapon -s
       - restore_cache:
           name: Restore yarn cache
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ commands:
           command: |
             node --version
             yarn --version
+            docker info
       - restore_cache:
           name: Restore yarn cache
           keys:

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -12,9 +12,9 @@ materialDesign: https://m2.material.io/components/date-pickers
 <p class="description">The Date Time Picker component let the user select a date and time.</p>
 
 :::info
-The component by default currently does not ship with time picker view experience on **desktop**.
+The component by default currently does not ship with **time** picker view experience on **desktop**.
 It was a conscious decision and a first step towards having a more user friendly desktop experience [discussed in #4483](https://github.com/mui/mui-x/issues/4483).
-If a desktop view experience is essential, it can be reverted to following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
+If a desktop view experience is essential, it can be reverted by following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
 :::
 
 ## Basic usage

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -11,6 +11,12 @@ materialDesign: https://m2.material.io/components/date-pickers
 
 <p class="description">The Date Time Picker component let the user select a date and time.</p>
 
+:::info
+The component by default currently does not ship with time picker view experience on **desktop**.
+It was a conscious decision and a first step towards having a more user friendly desktop experience [discussed in #4483](https://github.com/mui/mui-x/issues/4483).
+If a desktop view experience is essential, it can be reverted to following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
+:::
+
 ## Basic usage
 
 {{"demo": "BasicDateTimePicker.js"}}

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -14,7 +14,7 @@ materialDesign: https://m2.material.io/components/date-pickers
 :::info
 The component by default currently does not ship with **time** picker view experience on **desktop**.
 It was a conscious decision and a first step towards having a more user friendly desktop experience [discussed in #4483](https://github.com/mui/mui-x/issues/4483).
-If a desktop view experience is essential, it can be reverted by following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
+If a desktop view experience is essential, you can revert to it by following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
 :::
 
 ## Basic usage

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -12,9 +12,9 @@ materialDesign: https://m2.material.io/components/time-pickers
 <p class="description">The Time Picker component let the user select a time.</p>
 
 :::info
-The component by default currently does not ship with time picker view experience on **desktop**.
+The component by default currently does not ship with **time** picker view experience on **desktop**.
 It was a conscious decision and a first step towards having a more user friendly desktop experience [discussed in #4483](https://github.com/mui/mui-x/issues/4483).
-If a desktop view experience is essential, it can be reverted to following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
+If a desktop view experience is essential, it can be reverted by following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
 :::
 
 ## Basic usage

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -11,6 +11,12 @@ materialDesign: https://m2.material.io/components/time-pickers
 
 <p class="description">The Time Picker component let the user select a time.</p>
 
+:::info
+The component by default currently does not ship with time picker view experience on **desktop**.
+It was a conscious decision and a first step towards having a more user friendly desktop experience [discussed in #4483](https://github.com/mui/mui-x/issues/4483).
+If a desktop view experience is essential, it can be reverted to following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
+:::
+
 ## Basic usage
 
 {{"demo": "BasicTimePicker.js"}}

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -14,7 +14,7 @@ materialDesign: https://m2.material.io/components/time-pickers
 :::info
 The component by default currently does not ship with **time** picker view experience on **desktop**.
 It was a conscious decision and a first step towards having a more user friendly desktop experience [discussed in #4483](https://github.com/mui/mui-x/issues/4483).
-If a desktop view experience is essential, it can be reverted by following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
+If a desktop view experience is essential, you can revert to it by following the suggestion [in the migration guide](/x/migration/migration-pickers-v5/#stop-rendering-a-clock-on-desktop).
 :::
 
 ## Basic usage

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 5 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 4 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",


### PR DESCRIPTION
Closes #7919 

Implement a suggestion mentioned in https://github.com/mui/mui-x/issues/7919#issuecomment-1427570586
