### PR TITLE
[DateTimePicker] Ensure toolbar `viewType` is correctly updated

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -11,6 +11,7 @@ import {
   DateTimePickerToolbarClasses,
   getDateTimePickerToolbarUtilityClass,
 } from './dateTimePickerToolbarClasses';
+import { resolveViewTypeFromView } from './shared';
 
 export interface DateTimePickerToolbarProps<TDate> extends BaseToolbarProps<TDate, TDate | null> {
   classes?: Partial<DateTimePickerToolbarClasses>;
@@ -122,6 +123,7 @@ export function DateTimePickerToolbar<TDate extends unknown>(
       isMobileKeyboardViewOpen={isMobileKeyboardViewOpen}
       toggleMobileKeyboardView={toggleMobileKeyboardView}
       className={classes.root}
+      viewType={resolveViewTypeFromView(openView)}
       {...other}
       isLandscape={false}
       ownerState={ownerState}

--- a/packages/x-date-pickers/src/DateTimePicker/shared.ts
+++ b/packages/x-date-pickers/src/DateTimePicker/shared.ts
@@ -7,7 +7,7 @@ import { DateTimeValidationError } from '../internals/hooks/validation/useDateTi
 import { ValidationProps } from '../internals/hooks/validation/useValidation';
 import { BasePickerProps } from '../internals/models/props/basePickerProps';
 import { ExportedDateInputProps } from '../internals/components/PureDateInput';
-import { CalendarOrClockPickerView } from '../internals/models';
+import { CalendarOrClockPickerView, ViewType } from '../internals/models';
 import { PickerStateValueManager } from '../internals/hooks/usePickerState';
 import { parsePickerInputValue, parseNonNullablePickerDate } from '../internals/utils/date-utils';
 import { BaseToolbarProps } from '../internals/models/props/baseToolbarProps';
@@ -145,4 +145,15 @@ export const dateTimePickerValueManager: PickerStateValueManager<any, any, any> 
   getTodayValue: (utils) => utils.date()!,
   parseInput: parsePickerInputValue,
   areValuesEqual: (utils, a, b) => utils.isEqual(a, b),
+};
+
+export const resolveViewTypeFromView = (view: CalendarOrClockPickerView): ViewType => {
+  switch (view) {
+    case 'year':
+    case 'month':
+    case 'day':
+      return 'calendar';
+    default:
+      return 'clock';
+  }
 };

--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -13,6 +13,7 @@ import {
   pickersToolbarClasses,
   PickersToolbarClasses,
 } from './pickersToolbarClasses';
+import { ViewType } from '../models';
 
 export interface PickersToolbarProps<TDate, TValue>
   extends Pick<
@@ -20,7 +21,7 @@ export interface PickersToolbarProps<TDate, TValue>
     'getMobileKeyboardInputViewButtonText' | 'isMobileKeyboardViewOpen' | 'toggleMobileKeyboardView'
   > {
   className?: string;
-  viewType?: 'calendar' | 'clock';
+  viewType?: ViewType;
   isLandscape: boolean;
   landscapeDirection?: 'row' | 'column';
   toolbarTitle: React.ReactNode;
@@ -83,7 +84,7 @@ const PickersToolbarPenIconButton = styled(IconButton, {
   ownerState: PickersToolbarProps<any, any>;
 }>({});
 
-const getViewTypeIcon = (viewType: 'calendar' | 'clock') =>
+const getViewTypeIcon = (viewType: ViewType) =>
   viewType === 'clock' ? <Clock color="inherit" /> : <Calendar color="inherit" />;
 
 type PickersToolbarComponent = (<TDate, TValue>(

--- a/packages/x-date-pickers/src/internals/models/props/baseToolbarProps.ts
+++ b/packages/x-date-pickers/src/internals/models/props/baseToolbarProps.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CalendarOrClockPickerView } from '../views';
+import { CalendarOrClockPickerView, ViewType } from '../views';
 import type { PickerOnChangeFn } from '../../hooks/useViews';
 import type { ExportedCalendarPickerProps } from '../../../CalendarPicker/CalendarPicker';
 import type { ExportedClockPickerProps } from '../../../ClockPicker/ClockPicker';
@@ -15,12 +15,12 @@ export interface BaseToolbarProps<TDate, TValue>
    * Text for aria label of the button switching between input and interactive view.
    * @deprecated Use the translation key `inputModeToggleButtonAriaLabel` instead, see https://mui.com/x/react-date-pickers/localization
    * @param {boolean} isKeyboardInputOpen Indicates if the interface is the keyboard input.
-   * @param {'calendar' | 'clock' } viewType Indicates if the interface is about a date or a time.
+   * @param {ViewType} viewType Indicates if the interface is about a date or a time.
    * @returns {string} The arial label
    */
   getMobileKeyboardInputViewButtonText?: (
     isKeyboardInputOpen: boolean,
-    viewType: 'calendar' | 'clock',
+    viewType: ViewType,
   ) => string;
   isLandscape: boolean;
   onChange: PickerOnChangeFn<TDate>;

--- a/packages/x-date-pickers/src/internals/models/views.ts
+++ b/packages/x-date-pickers/src/internals/models/views.ts
@@ -3,3 +3,5 @@ export type CalendarPickerView = 'year' | 'day' | 'month';
 export type ClockPickerView = 'hours' | 'minutes' | 'seconds';
 
 export type CalendarOrClockPickerView = CalendarPickerView | ClockPickerView;
+
+export type ViewType = 'calendar' | 'clock';

--- a/packages/x-date-pickers/src/locales/csCZ.ts
+++ b/packages/x-date-pickers/src/locales/csCZ.ts
@@ -26,7 +26,7 @@ const csCZPickers: PickersLocaleText<any> = {
     view === 'year'
       ? 'roční zobrazení otevřeno, přepněte do zobrazení kalendáře'
       : 'zobrazení kalendáře otevřeno, přepněte do zobrazení roku',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `Zobrazení pro zadávání textu je otevřené, přepněte do zobrazení ${pickerViews[viewType]}`
       : `Zobrazení ${pickerViews[viewType]} je otevřené, přepněte do zobrazení textového pole`,

--- a/packages/x-date-pickers/src/locales/deDE.ts
+++ b/packages/x-date-pickers/src/locales/deDE.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 // maps ClockPickerView to its translation
 const clockViews = {
@@ -15,7 +14,7 @@ const pickerViews = {
   clock: 'Uhransicht',
 };
 
-const deDEPickers: Partial<PickersLocaleText<any>> = {
+const deDEPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Letzter Monat',
   nextMonth: 'Nächster Monat',
@@ -23,11 +22,11 @@ const deDEPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'Letzte Ansicht öffnen',
   openNextView: 'Nächste Ansicht öffnen',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'Jahresansicht ist geöffnet, zur Kalenderansicht wechseln'
       : 'Kalenderansicht ist geöffnet, zur Jahresansicht wechseln',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `Texteingabeansicht ist geöffnet, zur ${pickerViews[viewType]} wechseln`
       : `${pickerViews[viewType]} ist geöffnet, zur Texteingabeansicht wechseln`,

--- a/packages/x-date-pickers/src/locales/enUS.ts
+++ b/packages/x-date-pickers/src/locales/enUS.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 // This object is not Partial<PickersLocaleText> because it is the default values
 
@@ -12,11 +11,11 @@ const enUSPickers: PickersLocaleText<any> = {
   // View navigation
   openPreviousView: 'open previous view',
   openNextView: 'open next view',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'year view is open, switch to calendar view'
       : 'calendar view is open, switch to year view',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `text input view is open, go to ${viewType} view`
       : `${viewType} view is open, go to text input view`,

--- a/packages/x-date-pickers/src/locales/esES.ts
+++ b/packages/x-date-pickers/src/locales/esES.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const views = {
   hours: 'las horas',
@@ -8,7 +7,7 @@ const views = {
   seconds: 'los segundos',
 };
 
-const esESPickers: Partial<PickersLocaleText<any>> = {
+const esESPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Último mes',
   nextMonth: 'Próximo mes',
@@ -16,11 +15,11 @@ const esESPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'abrir la última vista',
   openNextView: 'abrir la siguiente vista',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'la vista del año está abierta, cambie a la vista de calendario'
       : 'la vista de calendario está abierta, cambie a la vista del año',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `la vista de entrada de texto está abierta, ir a la vista ${viewType}`
       : `la vista ${viewType} está abierta, ir a la vista de entrada de texto`,

--- a/packages/x-date-pickers/src/locales/faIR.ts
+++ b/packages/x-date-pickers/src/locales/faIR.ts
@@ -1,8 +1,7 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
-const faIRPickers: Partial<PickersLocaleText<any>> = {
+const faIRPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'ماه گذشته',
   nextMonth: 'ماه آینده',
@@ -10,11 +9,11 @@ const faIRPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'نمای قبلی',
   openNextView: 'نمای بعدی',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'نمای سال باز است، رفتن به نمای تقویم'
       : 'نمای تقویم باز است، رفتن به نمای سال',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `نمای ورودی متن باز است، رفتن به نمای ${viewType}`
       : `نمای ${viewType} باز است، رفتن به نمای ورودی متن`,

--- a/packages/x-date-pickers/src/locales/fiFI.ts
+++ b/packages/x-date-pickers/src/locales/fiFI.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const views = {
   hours: 'tunnit',
@@ -13,7 +12,7 @@ const viewTranslation = {
   clock: 'kello',
 };
 
-const fiFIPickers: Partial<PickersLocaleText<any>> = {
+const fiFIPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Edellinen kuukausi',
   nextMonth: 'Seuraava kuukausi',
@@ -21,11 +20,11 @@ const fiFIPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'avaa edellinen kuukausi',
   openNextView: 'avaa seuraava kuukausi',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'vuosinäkymä on auki, vaihda kalenterinäkymään'
       : 'kalenterinäkymä on auki, vaihda vuosinäkymään',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `tekstikenttä on auki, mene ${viewTranslation[viewType]}näkymään`
       : `${viewTranslation[viewType]}näkymä on auki, mene tekstikenttään`,

--- a/packages/x-date-pickers/src/locales/frFR.ts
+++ b/packages/x-date-pickers/src/locales/frFR.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const views = {
   hours: 'heures',
@@ -21,11 +20,11 @@ const frFRPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'Ouvrir la vue précédente',
   openNextView: 'Ouvrir la vue suivante',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'La vue année est ouverte, ouvrir la vue calendrier'
       : 'La vue calendrier est ouverte, ouvrir la vue année',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `passer du champ text au ${viewTranslation[viewType]}`
       : `passer du ${viewTranslation[viewType]} au champ text`,

--- a/packages/x-date-pickers/src/locales/isIS.ts
+++ b/packages/x-date-pickers/src/locales/isIS.ts
@@ -1,8 +1,7 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
-const isISPickers: Partial<PickersLocaleText<any>> = {
+const isISPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Fyrri mánuður',
   nextMonth: 'Næsti mánuður',
@@ -10,14 +9,11 @@ const isISPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'opna fyrri skoðun',
   openNextView: 'opna næstu skoðun',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'ársskoðun er opin, skipta yfir í dagatalsskoðun'
       : 'dagatalsskoðun er opin, skipta yfir í ársskoðun',
-  inputModeToggleButtonAriaLabel: (
-    isKeyboardInputOpen: boolean,
-    viewType: 'calendar' | 'clock',
-  ) => {
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => {
     const viewTypeTranslated = viewType === 'calendar' ? 'dagatals' : 'klukku';
     return isKeyboardInputOpen
       ? `textainnsláttur er opinn, fara í ${viewTypeTranslated}skoðun`

--- a/packages/x-date-pickers/src/locales/itIT.ts
+++ b/packages/x-date-pickers/src/locales/itIT.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const views = {
   hours: 'le ore',
@@ -8,7 +7,7 @@ const views = {
   seconds: 'i secondi',
 };
 
-const itITPickers: Partial<PickersLocaleText<any>> = {
+const itITPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Mese precedente',
   nextMonth: 'Mese successivo',
@@ -16,11 +15,11 @@ const itITPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'apri la vista precedente',
   openNextView: 'apri la vista successiva',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? "la vista dell'anno è aperta, passare alla vista del calendario"
       : "la vista dell'calendario è aperta, passare alla vista dell'anno",
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `la vista del campo di testo è aperta, passare alla vista ${viewType}`
       : `la vista aperta è: ${viewType}, vai alla vista del campo di testo`,

--- a/packages/x-date-pickers/src/locales/jaJP.ts
+++ b/packages/x-date-pickers/src/locales/jaJP.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 // maps ClockPickerView to its translation
 const clockViews = {
@@ -15,7 +14,7 @@ const pickerViews = {
   clock: '時計表示',
 };
 
-const jaJPPickers: Partial<PickersLocaleText<any>> = {
+const jaJPPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: '先月',
   nextMonth: '来月',
@@ -23,11 +22,11 @@ const jaJPPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: '前の表示を開く',
   openNextView: '次の表示を開く',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? '年選択表示からカレンダー表示に切り替える'
       : 'カレンダー表示から年選択表示に切り替える',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `テキスト入力表示から${pickerViews[viewType]}に切り替える`
       : `${pickerViews[viewType]}からテキスト入力表示に切り替える`,

--- a/packages/x-date-pickers/src/locales/nbNO.ts
+++ b/packages/x-date-pickers/src/locales/nbNO.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const nbNOPickers: Partial<PickersLocaleText<any>> = {
   // Calendar navigation
@@ -10,11 +9,11 @@ const nbNOPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'åpne forrige visning',
   openNextView: 'åpne neste visning',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'årsvisning er åpen, bytt til kalendervisning'
       : 'kalendervisning er åpen, bytt til årsvisning',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
 
   // DateRange placeholders
   start: 'Start',

--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const nlNLPickers: Partial<PickersLocaleText<any>> = {
   // Calendar navigation
@@ -10,11 +9,11 @@ const nlNLPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'open vorige view',
   openNextView: 'open volgende view',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'jaarweergave is geopend, schakel over naar kalenderweergave'
       : 'kalenderweergave is geopend, switch naar jaarweergave',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
 
   // DateRange placeholders
   start: 'Start',

--- a/packages/x-date-pickers/src/locales/plPL.ts
+++ b/packages/x-date-pickers/src/locales/plPL.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const plPLPickers: Partial<PickersLocaleText<any>> = {
   // Calendar navigation
@@ -10,11 +9,11 @@ const plPLPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'otwórz poprzedni widok',
   openNextView: 'otwórz następny widok',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'otwarty jest widok roku, przełącz na widok kalendarza'
       : 'otwarty jest widok kalendarza, przełącz na widok roku',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
 
   // DateRange placeholders
   start: 'Początek',

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const ptBRPickers: Partial<PickersLocaleText<any>> = {
   // Calendar navigation
@@ -10,11 +9,11 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'Abrir próxima seleção',
   openNextView: 'Abrir seleção anterior',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'Seleção de ano está aberta, alternando para seleção de calendário'
       : 'Seleção de calendários está aberta, alternando para seleção de ano',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
 
   // DateRange placeholders
   start: 'Início',

--- a/packages/x-date-pickers/src/locales/ruRU.ts
+++ b/packages/x-date-pickers/src/locales/ruRU.ts
@@ -26,7 +26,7 @@ const ruRUPickers: PickersLocaleText<any> = {
     view === 'year'
       ? 'открыт годовой вид, переключить на календарный вид'
       : 'открыт календарный вид, переключить на годовой вид',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `Открыт текстовый вид, перейти на ${viewTypes[viewType]} вид`
       : `Открыт ${viewTypes[viewType]} вид, перейти на текстовый вид`,

--- a/packages/x-date-pickers/src/locales/svSE.ts
+++ b/packages/x-date-pickers/src/locales/svSE.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const svSEPickers: Partial<PickersLocaleText<any>> = {
   // Calendar navigation
@@ -10,11 +9,11 @@ const svSEPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'öppna föregående vy',
   openNextView: 'öppna nästa vy',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'årsvyn är öppen, byt till kalendervy'
       : 'kalendervyn är öppen, byt till årsvy',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
 
   // DateRange placeholders
   start: 'Start',

--- a/packages/x-date-pickers/src/locales/trTR.ts
+++ b/packages/x-date-pickers/src/locales/trTR.ts
@@ -1,8 +1,7 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
-const trTRPickers: Partial<PickersLocaleText<any>> = {
+const trTRPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Önceki ay',
   nextMonth: 'Sonraki ay',
@@ -10,11 +9,11 @@ const trTRPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'sonraki görünüm',
   openNextView: 'önceki görünüm',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'yıl görünümü açık, takvim görünümüne geç'
       : 'takvim görünümü açık, yıl görünümüne geç',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `metin girişi görünümü açık, şuraya gidin: ${viewType} görünümü`
       : `${viewType} görünüm açık, metin girişi görünümüne gidin`,

--- a/packages/x-date-pickers/src/locales/ukUA.ts
+++ b/packages/x-date-pickers/src/locales/ukUA.ts
@@ -1,8 +1,7 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
-const ukUAPickers: Partial<PickersLocaleText<any>> = {
+const ukUAPickers: PickersLocaleText<any> = {
   // Calendar navigation
   previousMonth: 'Попередній місяць',
   nextMonth: 'Наступний місяць',
@@ -10,11 +9,11 @@ const ukUAPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: 'відкрити попередній вигляд',
   openNextView: 'відкрити наступний вигляд',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year'
       ? 'річний вигляд відкрито, перейти до календарного вигляду'
       : 'календарний вигляд відкрито, перейти до річного вигляду',
-  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') =>
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) =>
     isKeyboardInputOpen
       ? `текстове поле відкрите, перейти до  ${viewType} вигляду`
       : `${viewType} вигляд наразі відкрито, перейти до текстового поля`,

--- a/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
+++ b/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
@@ -1,4 +1,9 @@
-import { CalendarPickerView, ClockPickerView, MuiPickersAdapter } from '../../internals/models';
+import {
+  CalendarPickerView,
+  ClockPickerView,
+  MuiPickersAdapter,
+  ViewType,
+} from '../../internals/models';
 /**
  * Set the types of the texts in the grid.
  */
@@ -14,10 +19,7 @@ export interface PickersLocaleText<TDate> {
   start: string;
   end: string;
   calendarViewSwitchingButtonAriaLabel: (currentView: CalendarPickerView) => string;
-  inputModeToggleButtonAriaLabel: (
-    isKeyboardInputOpen: boolean,
-    viewType: 'calendar' | 'clock',
-  ) => string;
+  inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: ViewType) => string;
   clockLabelText: (
     view: ClockPickerView,
     time: TDate | null,

--- a/packages/x-date-pickers/src/locales/zhCN.ts
+++ b/packages/x-date-pickers/src/locales/zhCN.ts
@@ -1,6 +1,5 @@
 import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
-import { CalendarPickerView } from '../internals/models';
 
 const views = {
   hours: '小时',
@@ -16,9 +15,9 @@ const zhCNPickers: Partial<PickersLocaleText<any>> = {
   // View navigation
   openPreviousView: '前一个视图',
   openNextView: '下一个视图',
-  calendarViewSwitchingButtonAriaLabel: (view: CalendarPickerView) =>
+  calendarViewSwitchingButtonAriaLabel: (view) =>
     view === 'year' ? '年视图已打开，切换为日历视图' : '日历视图已打开，切换为年视图',
-  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen: boolean, viewType: 'calendar' | 'clock') => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
+  // inputModeToggleButtonAriaLabel: (isKeyboardInputOpen, viewType) => isKeyboardInputOpen ? `text input view is open, go to ${viewType} view` : `${viewType} view is open, go to text input view`,
 
   // DateRange placeholders
   start: '开始',


### PR DESCRIPTION
Noticed that the `aria-label` on the editing mode button doesn't change when switching tabs or changing view by clicking toolbar sections.

- ensure the `viewType` is dynamically updated from `DateTimePickerToolbar`;
- create a type for `'calendar' | 'clock'`
- remove redundant types in localization files