### PR TITLE
[DataGridPremium] Fix `leafField` to have correct focus value

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/rowGrouping/createGroupingColDef.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/rowGrouping/createGroupingColDef.tsx
@@ -178,6 +178,7 @@ export const createGroupingColDefForOneGroupingCriteria = ({
           const leafParams: GridRenderCellParams = {
             ...params.api.getCellParams(params.id, leafField!),
             api: params.api,
+            hasFocus: params.hasFocus,
           };
           if (leafColDef.renderCell) {
             return leafColDef.renderCell(leafParams);
@@ -308,6 +309,7 @@ export const createGroupingColDefForAllGroupingCriteria = ({
           const leafParams: GridRenderCellParams = {
             ...params.api.getCellParams(params.id, leafField!),
             api: params.api,
+            hasFocus: params.hasFocus,
           };
           if (leafColDef.renderCell) {
             return leafColDef.renderCell(leafParams);

--- a/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 // @ts-ignore Remove once the test utils are typed
-import { createRenderer, fireEvent, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act, userEvent } from '@mui/monorepo/test/utils';
 import {
   getColumnHeaderCell,
   getColumnHeadersTextContent,
   getColumnValues,
+  getCell,
 } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import {
@@ -813,6 +814,32 @@ describe('<DataGridPremium /> - Row Grouping', () => {
           'Custom leaf',
           'Custom leaf',
         ]);
+      });
+
+      it('should correctly pass `hasFocus` to `renderCell` defined on the leafColDef', () => {
+        const renderIdCell = spy((params) => `Focused: ${params.hasFocus}`);
+
+        render(
+          <Test
+            columns={[
+              {
+                field: 'id',
+                type: 'number',
+                renderCell: renderIdCell,
+              },
+              {
+                field: 'category1',
+              },
+            ]}
+            initialState={{ rowGrouping: { model: ['category1'] } }}
+            groupingColDef={{ leafField: 'id' }}
+            defaultGroupingExpansionDepth={-1}
+          />,
+        );
+
+        userEvent.mousePress(getCell(1, 0));
+        expect(renderIdCell.lastCall.firstArg.field).to.equal('id');
+        expect(getCell(1, 0)).to.have.text('Focused: true');
       });
     });
 

--- a/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
@@ -816,6 +816,7 @@ describe('<DataGridPremium /> - Row Grouping', () => {
         ]);
       });
 
+      // See https://github.com/mui/mui-x/issues/7949
       it('should correctly pass `hasFocus` to `renderCell` defined on the leafColDef', () => {
         const renderIdCell = spy((params) => `Focused: ${params.hasFocus}`);
 


### PR DESCRIPTION
Fixes #7949 

The `leafField` was borrowing `hasFocus` from the actual cell (not the grouping one where it's rendered) and passing it in `leafField.renderCell` due to which the user can not keep track of the true focused cell.

Before: https://codesandbox.io/s/hasfocus-for-row-grouping-leaves-tuw57o?file=/demo.tsx
After: https://codesandbox.io/s/hasfocus-for-row-grouping-leaves-forked-359w8j?file=/demo.tsx