### PR TITLE
[fields] Fix single input time range fields slot props

### DIFF
--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -91,7 +91,9 @@
       "default": "'outlined'"
     }
   },
-  "slots": { "Input": { "default": "TextField", "type": { "name": "elementType" } } },
+  "slots": {
+    "TextField": { "default": "TextField from '@mui/material'", "type": { "name": "elementType" } }
+  },
   "name": "SingleInputDateTimeRangeField",
   "styles": {
     "classes": ["root"],

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -86,7 +86,9 @@
       "default": "'outlined'"
     }
   },
-  "slots": { "Input": { "default": "TextField", "type": { "name": "elementType" } } },
+  "slots": {
+    "TextField": { "default": "TextField from '@mui/material'", "type": { "name": "elementType" } }
+  },
   "name": "SingleInputTimeRangeField",
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiSingleInputTimeRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx",

--- a/docs/translations/api-docs/date-pickers/single-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-time-range-field.json
@@ -49,5 +49,7 @@
     "variant": "The variant to use."
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } },
-  "slotDescriptions": { "Input": "Input rendered." }
+  "slotDescriptions": {
+    "TextField": "Form control with an input to render the value.\nReceives the same props as <code>@mui/material/TextField</code>."
+  }
 }

--- a/docs/translations/api-docs/date-pickers/single-input-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-time-range-field.json
@@ -44,5 +44,7 @@
     "variant": "The variant to use."
   },
   "classDescriptions": { "root": { "description": "Styles applied to the root element." } },
-  "slotDescriptions": { "Input": "Input rendered." }
+  "slotDescriptions": {
+    "TextField": "Form control with an input to render the value.\nReceives the same props as <code>@mui/material/TextField</code>."
+  }
 }

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -22,10 +22,10 @@ const SingleInputDateTimeRangeField = React.forwardRef(function SingleInputDateT
 
   const ownerState = themeProps;
 
-  const Input = slots?.input ?? components?.Input ?? TextField;
+  const Input = slots?.textField ?? components?.TextField ?? TextField;
   const inputProps: SingleInputDateTimeRangeFieldProps<TDate> = useSlotProps({
     elementType: Input,
-    externalSlotProps: componentsProps?.input,
+    externalSlotProps: slotProps?.textField ?? componentsProps?.textField,
     externalForwardedProps: other,
     ownerState,
   });

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.types.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.types.ts
@@ -58,12 +58,17 @@ export type SingleInputDateTimeRangeFieldOwnerState<TDate> =
 
 export interface SingleInputDateTimeRangeFieldSlotsComponent {
   /**
-   * Input rendered.
-   * @default TextField
+   * Form control with an input to render the value.
+   * Receives the same props as `@mui/material/TextField`.
+   * @default TextField from '@mui/material'
    */
-  Input?: React.ElementType;
+  TextField?: React.ElementType;
 }
 
 export interface SingleInputDateTimeRangeFieldSlotsComponentsProps<TDate> {
-  input?: SlotComponentProps<typeof TextField, {}, SingleInputDateTimeRangeFieldOwnerState<TDate>>;
+  textField?: SlotComponentProps<
+    typeof TextField,
+    {},
+    SingleInputDateTimeRangeFieldOwnerState<TDate>
+  >;
 }

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
@@ -23,10 +23,10 @@ const SingleInputTimeRangeField = React.forwardRef(function SingleInputTimeRange
 
   const ownerState = themeProps;
 
-  const Input = slots?.input ?? components?.Input ?? TextField;
+  const Input = slots?.textField ?? components?.TextField ?? TextField;
   const inputProps: SingleInputTimeRangeFieldProps<TDate> = useSlotProps({
     elementType: Input,
-    externalSlotProps: slotProps?.input ?? componentsProps?.input,
+    externalSlotProps: slotProps?.textField ?? componentsProps?.textField,
     externalForwardedProps: other,
     ownerState,
   });

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.types.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.types.ts
@@ -53,12 +53,13 @@ export type SingleInputTimeRangeFieldOwnerState<TDate> = SingleInputTimeRangeFie
 
 export interface SingleInputTimeRangeFieldSlotsComponent {
   /**
-   * Input rendered.
-   * @default TextField
+   * Form control with an input to render the value.
+   * Receives the same props as `@mui/material/TextField`.
+   * @default TextField from '@mui/material'
    */
-  Input?: React.ElementType;
+  TextField?: React.ElementType;
 }
 
 export interface SingleInputTimeRangeFieldSlotsComponentsProps<TDate> {
-  input?: SlotComponentProps<typeof TextField, {}, SingleInputTimeRangeFieldOwnerState<TDate>>;
+  textField?: SlotComponentProps<typeof TextField, {}, SingleInputTimeRangeFieldOwnerState<TDate>>;
 }


### PR DESCRIPTION
Noticed this misalignment when working on #7987 
- fix slot name issue;
- fix missing `slotProps?.textField ??` on `SingleInputDateTimeRangeField`;