### PR TITLE
[test] Support all adapters on the field tests about the formats

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/format.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/format.DateField.test.tsx
@@ -1,41 +1,40 @@
 import * as React from 'react';
 import { screen } from '@mui/monorepo/test/utils';
-import { createPickerRenderer, expectInputValue, adapterToUse } from 'test/utils/pickers-utils';
+import { expectInputValue } from 'test/utils/pickers-utils';
 import { DateField } from '@mui/x-date-pickers/DateField';
+import { describeAdapters } from '@mui/x-date-pickers/tests/describeAdapters';
 
-describe('<DateField /> - Format', () => {
-  const { render } = createPickerRenderer();
-
+describeAdapters('<DateField /> - Format', DateField, ({ render, adapter }) => {
   it('should support escaped characters in start separator', () => {
-    const { start: startChar, end: endChar } = adapterToUse.escapedCharacters;
+    const { start: startChar, end: endChar } = adapter.escapedCharacters;
     // For Day.js: "[Escaped] YYYY"
     const { setProps } = render(
-      <DateField format={`${startChar}Escaped${endChar} ${adapterToUse.formats.year}`} />,
+      <DateField format={`${startChar}Escaped${endChar} ${adapter.formats.year}`} />,
     );
     const input = screen.getByRole('textbox');
     expectInputValue(input, 'Escaped YYYY');
 
-    setProps({ value: adapterToUse.date(new Date(2019, 0, 1)) });
+    setProps({ value: adapter.date(new Date(2019, 0, 1)) });
     expectInputValue(input, 'Escaped 2019');
   });
 
   it('should support escaped characters between sections separator', () => {
-    const { start: startChar, end: endChar } = adapterToUse.escapedCharacters;
+    const { start: startChar, end: endChar } = adapter.escapedCharacters;
     // For Day.js: "MMMM [Escaped] YYYY"
     const { setProps } = render(
       <DateField
-        format={`${adapterToUse.formats.month} ${startChar}Escaped${endChar} ${adapterToUse.formats.year}`}
+        format={`${adapter.formats.month} ${startChar}Escaped${endChar} ${adapter.formats.year}`}
       />,
     );
     const input = screen.getByRole('textbox');
     expectInputValue(input, 'MMMM Escaped YYYY');
 
-    setProps({ value: adapterToUse.date(new Date(2019, 0, 1)) });
+    setProps({ value: adapter.date(new Date(2019, 0, 1)) });
     expectInputValue(input, 'January Escaped 2019');
   });
 
   it('should support nested escaped characters', function test() {
-    const { start: startChar, end: endChar } = adapterToUse.escapedCharacters;
+    const { start: startChar, end: endChar } = adapter.escapedCharacters;
     // If your start character and end character are equal
     // Then you can't have nested escaped characters
     if (startChar === endChar) {
@@ -45,29 +44,29 @@ describe('<DateField /> - Format', () => {
     // For Day.js: "MMMM [Escaped[] YYYY"
     const { setProps } = render(
       <DateField
-        format={`${adapterToUse.formats.month} ${startChar}Escaped ${startChar}${endChar} ${adapterToUse.formats.year}`}
+        format={`${adapter.formats.month} ${startChar}Escaped ${startChar}${endChar} ${adapter.formats.year}`}
       />,
     );
     const input = screen.getByRole('textbox');
     expectInputValue(input, 'MMMM Escaped [ YYYY');
 
-    setProps({ value: adapterToUse.date(new Date(2019, 0, 1)) });
+    setProps({ value: adapter.date(new Date(2019, 0, 1)) });
     expectInputValue(input, 'January Escaped [ 2019');
   });
 
   it('should support several escaped parts', function test() {
-    const { start: startChar, end: endChar } = adapterToUse.escapedCharacters;
+    const { start: startChar, end: endChar } = adapter.escapedCharacters;
 
     // For Day.js: "[Escaped] MMMM [Escaped] YYYY"
     const { setProps } = render(
       <DateField
-        format={`${startChar}Escaped${endChar} ${adapterToUse.formats.month} ${startChar}Escaped${endChar} ${adapterToUse.formats.year}`}
+        format={`${startChar}Escaped${endChar} ${adapter.formats.month} ${startChar}Escaped${endChar} ${adapter.formats.year}`}
       />,
     );
     const input = screen.getByRole('textbox');
     expectInputValue(input, 'Escaped MMMM Escaped YYYY');
 
-    setProps({ value: adapterToUse.date(new Date(2019, 0, 1)) });
+    setProps({ value: adapter.date(new Date(2019, 0, 1)) });
     expectInputValue(input, 'Escaped January Escaped 2019');
   });
 });


### PR DESCRIPTION
Follow up #7888 and #7868
I don't think we should do it for all the tests (the selection for example is not very adapter-bound).
But for the format, the test could fail on some adapters (and was failing on Luxon) so I think that's worth adding those.