### PR TITLE
[pickers] Add support for UTC on moment adapter

### DIFF
--- a/docs/data/date-pickers/adapters-locale/UTCMoment.js
+++ b/docs/data/date-pickers/adapters-locale/UTCMoment.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import moment from 'moment';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+
+export default function UTCMoment() {
+  const [value, setValue] = React.useState(null);
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterMoment} dateLibInstance={moment.utc}>
+      <Stack spacing={2}>
+        <DateTimePicker value={value} onChange={(newValue) => setValue(newValue)} />
+        <Typography>Value: {value == null ? 'null' : value.format()}</Typography>
+      </Stack>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/adapters-locale/UTCMoment.tsx
+++ b/docs/data/date-pickers/adapters-locale/UTCMoment.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import moment, { Moment } from 'moment';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+
+export default function UTCMoment() {
+  const [value, setValue] = React.useState<Moment | null>(null);
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterMoment} dateLibInstance={moment.utc}>
+      <Stack spacing={2}>
+        <DateTimePicker value={value} onChange={(newValue) => setValue(newValue)} />
+        <Typography>Value: {value == null ? 'null' : value.format()}</Typography>
+      </Stack>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/adapters-locale/UTCMoment.tsx.preview
+++ b/docs/data/date-pickers/adapters-locale/UTCMoment.tsx.preview
@@ -1,0 +1,2 @@
+<DateTimePicker value={value} onChange={(newValue) => setValue(newValue)} />
+<Typography>Value: {value == null ? 'null' : value.format()}</Typography>

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -215,6 +215,33 @@ To use UTC dates with `dayjs`, you have to:
 
 {{"demo": "UTCDayjs.js", "defaultCodeOpen": false}}
 
+### With moment
+
+To use UTC dates with `moment`, you have to:
+
+1. Pass `moment.utc` to `LocalizationProvider` `dateLibInstance` prop:
+
+   ```tsx
+   <LocalizationProvider dateAdapter={AdapterMoment} dateLibInstance={moment.utc}>
+     {children}
+   </LocalizationProvider>
+   ```
+
+2. Always pass dates created with `moment.utc`:
+
+   ```tsx
+   <DateTimePicker
+     // ✅ Valid props
+     value={moment.utc()}
+     minDate={moment.utc().startOf('month')}
+     // ❌ Invalid props
+     value={moment()}
+     minDate={moment().startOf('month')}
+   />
+   ```
+
+{{"demo": "UTCMoment.js", "defaultCodeOpen": false}}
+
 ### Other libraries
 
 UTC support is an ongoing topic.

--- a/packages/x-date-pickers/src/AdapterMoment/index.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/index.ts
@@ -72,7 +72,7 @@ export class AdapterMoment
       .map((token) => {
         const firstCharacter = token[0];
         if (firstCharacter === 'L' || firstCharacter === ';') {
-          return this.moment
+          return defaultMoment
             .localeData(this.getCurrentLocaleCode())
             .longDateFormat(token as LongDateFormatKey);
         }
@@ -82,6 +82,10 @@ export class AdapterMoment
       .join('');
   };
 
+  public getCurrentLocaleCode = () => {
+    return this.locale || defaultMoment.locale();
+  };
+
   // Redefined here just to show how it can be written using expandFormat
   public getFormatHelperText = (format: string) => {
     return this.expandFormat(format).replace(/a/gi, '(a|p)m').toLocaleLowerCase();
@@ -89,5 +93,13 @@ export class AdapterMoment
 
   public getWeekNumber = (date: defaultMoment.Moment) => {
     return date.week();
+  };
+
+  public getWeekdays = () => {
+    return defaultMoment.weekdaysShort(true);
+  };
+
+  public is12HourCycleInCurrentLocale = () => {
+    return /A|a/.test(defaultMoment.localeData(this.getCurrentLocaleCode()).longDateFormat('LT'));
   };
 }


### PR DESCRIPTION
[Doc preview](https://deploy-preview-8031--material-ui-x.netlify.app/x/react-date-pickers/adapters-locale/#with-moment-2)

`moment.utc` does not have the static properties (same issue we had for `dayjs`).

I think we could update the JSDoc of `dateLibInstance` to say that it's the instance we use to parse dates, not the instance we use for the rest.

