### PR TITLE
[DataGridPro] Improve typing for `getColumnForNewFilter` method

### DIFF
--- a/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.js
+++ b/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.js
@@ -30,7 +30,7 @@ export default function DisableMultiFiltersDataGridPro() {
         (colDef) => colDef.filterable && !filteredFields.includes(colDef.field),
       )
       .find((colDef) => colDef.filterOperators?.length);
-    return columnForNewFilter?.field;
+    return columnForNewFilter?.field ?? null;
   };
 
   return (

--- a/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.tsx
+++ b/docs/data/data-grid/filtering/DisableMultiFiltersDataGridPro.tsx
@@ -38,7 +38,7 @@ export default function DisableMultiFiltersDataGridPro() {
         (colDef) => colDef.filterable && !filteredFields.includes(colDef.field),
       )
       .find((colDef) => colDef.filterOperators?.length);
-    return columnForNewFilter?.field;
+    return columnForNewFilter?.field ?? null;
   };
 
   return (

--- a/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
@@ -90,7 +90,7 @@ describe('<DataGridPro /> - Filter', () => {
       const columnForNewFilter = columns
         .filter((colDef) => colDef.filterable && !filteredFields.includes(colDef.field))
         .find((colDef) => colDef.filterOperators?.length);
-      return columnForNewFilter?.field;
+      return columnForNewFilter?.field ?? null;
     };
 
     render(

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
@@ -27,9 +27,9 @@ export interface GridFilterPanelProps
   /**
    * Function that returns the next filter item to be picked as default filter.
    * @param {GetColumnForNewFilterArgs} args Currently configured filters and columns.
-   * @returns {GridColDef['field']} The field to be used for the next filter.
+   * @returns {GridColDef['field']} The field to be used for the next filter or `null` to prevent adding a filter.
    */
-  getColumnForNewFilter?: (args: GetColumnForNewFilterArgs) => GridColDef['field'];
+  getColumnForNewFilter?: (args: GetColumnForNewFilterArgs) => GridColDef['field'] | null;
   /**
    * Props passed to each filter form.
    */
@@ -108,6 +108,10 @@ const GridFilterPanel = React.forwardRef<HTMLDivElement, GridFilterPanelProps>(
           columns: filterableColumns,
         });
 
+        if (nextFieldName === null) {
+          return null;
+        }
+
         nextColumnWithOperator = filterableColumns.find(({ field }) => field === nextFieldName);
       } else {
         nextColumnWithOperator = filterableColumns.find((colDef) => colDef.filterOperators?.length);
@@ -134,6 +138,10 @@ const GridFilterPanel = React.forwardRef<HTMLDivElement, GridFilterPanelProps>(
         currentFilters: currentFilters as GridFilterItem[],
         columns: filterableColumns,
       });
+
+      if (nextColumnFieldName === null) {
+        return null;
+      }
 
       const nextColumnWithOperator = filterableColumns.find(
         ({ field }) => field === nextColumnFieldName,
@@ -284,7 +292,7 @@ GridFilterPanel.propTypes = {
   /**
    * Function that returns the next filter item to be picked as default filter.
    * @param {GetColumnForNewFilterArgs} args Currently configured filters and columns.
-   * @returns {GridColDef['field']} The field to be used for the next filter.
+   * @returns {GridColDef['field']} The field to be used for the next filter or `null` to prevent adding a filter.
    */
   getColumnForNewFilter: PropTypes.func,
   /**


### PR DESCRIPTION
Related to #4872, #6333

Emerged during working on #7968 

**Problem:**
The return type (`GridColDef['field']`) of `getColumnForNewFilter` was not correct, in some cases (when the intention is to not add a filter) the expected return value was `undefined` but the type definition didn't allow it.

**Solution:**
Added `| null` to the return type to handle the use case of not adding a new filter. Why not `| undefined`? As `null` is more explicit than `undefined` and depicts the action taken is intended.