### PR TITLE
[DataGridPro] Remove row pinning from experimental features

### DIFF
--- a/docs/data/data-grid/row-pinning/RowPinning.js
+++ b/docs/data/data-grid/row-pinning/RowPinning.js
@@ -42,12 +42,7 @@ const pinnedRows = {
 export default function RowPinning() {
   return (
     <div style={{ height: 500, width: '100%' }}>
-      <DataGridPro
-        columns={columns}
-        rows={rows}
-        pinnedRows={pinnedRows}
-        experimentalFeatures={{ rowPinning: true }}
-      />
+      <DataGridPro columns={columns} rows={rows} pinnedRows={pinnedRows} />
     </div>
   );
 }

--- a/docs/data/data-grid/row-pinning/RowPinning.tsx
+++ b/docs/data/data-grid/row-pinning/RowPinning.tsx
@@ -42,12 +42,7 @@ const pinnedRows: GridPinnedRowsProp = {
 export default function RowPinning() {
   return (
     <div style={{ height: 500, width: '100%' }}>
-      <DataGridPro
-        columns={columns}
-        rows={rows}
-        pinnedRows={pinnedRows}
-        experimentalFeatures={{ rowPinning: true }}
-      />
+      <DataGridPro columns={columns} rows={rows} pinnedRows={pinnedRows} />
     </div>
   );
 }

--- a/docs/data/data-grid/row-pinning/RowPinning.tsx.preview
+++ b/docs/data/data-grid/row-pinning/RowPinning.tsx.preview
@@ -1,5 +1,1 @@
-<DataGridPro
-  columns={columns}
-  rows={rows}
-  pinnedRows={pinnedRows}
-/>
+<DataGridPro columns={columns} rows={rows} pinnedRows={pinnedRows} />

--- a/docs/data/data-grid/row-pinning/RowPinning.tsx.preview
+++ b/docs/data/data-grid/row-pinning/RowPinning.tsx.preview
@@ -2,5 +2,4 @@
   columns={columns}
   rows={rows}
   pinnedRows={pinnedRows}
-  experimentalFeatures={{ rowPinning: true }}
 />

--- a/docs/data/data-grid/row-pinning/RowPinningWithActions.js
+++ b/docs/data/data-grid/row-pinning/RowPinningWithActions.js
@@ -129,12 +129,7 @@ export default function RowPinningWithActions() {
 
   return (
     <div style={{ height: 500, width: '100%' }}>
-      <DataGridPro
-        columns={columns}
-        pinnedRows={pinnedRows}
-        rows={rows}
-        experimentalFeatures={{ rowPinning: true }}
-      />
+      <DataGridPro columns={columns} pinnedRows={pinnedRows} rows={rows} />
     </div>
   );
 }

--- a/docs/data/data-grid/row-pinning/RowPinningWithActions.tsx
+++ b/docs/data/data-grid/row-pinning/RowPinningWithActions.tsx
@@ -65,7 +65,7 @@ export default function RowPinningWithActions() {
     };
   }, [pinnedRowsIds]);
 
-  const columns = React.useMemo<GridColDef<typeof data[number]>[]>(
+  const columns = React.useMemo<GridColDef<(typeof data)[number]>[]>(
     () => [
       {
         field: 'actions',
@@ -138,12 +138,7 @@ export default function RowPinningWithActions() {
 
   return (
     <div style={{ height: 500, width: '100%' }}>
-      <DataGridPro
-        columns={columns}
-        pinnedRows={pinnedRows}
-        rows={rows}
-        experimentalFeatures={{ rowPinning: true }}
-      />
+      <DataGridPro columns={columns} pinnedRows={pinnedRows} rows={rows} />
     </div>
   );
 }

--- a/docs/data/data-grid/row-pinning/RowPinningWithActions.tsx.preview
+++ b/docs/data/data-grid/row-pinning/RowPinningWithActions.tsx.preview
@@ -2,5 +2,4 @@
   columns={columns}
   pinnedRows={pinnedRows}
   rows={rows}
-  experimentalFeatures={{ rowPinning: true }}
 />

--- a/docs/data/data-grid/row-pinning/RowPinningWithActions.tsx.preview
+++ b/docs/data/data-grid/row-pinning/RowPinningWithActions.tsx.preview
@@ -1,5 +1,1 @@
-<DataGridPro
-  columns={columns}
-  pinnedRows={pinnedRows}
-  rows={rows}
-/>
+<DataGridPro columns={columns} pinnedRows={pinnedRows} rows={rows} />

--- a/docs/data/data-grid/row-pinning/RowPinningWithPagination.js
+++ b/docs/data/data-grid/row-pinning/RowPinningWithPagination.js
@@ -38,7 +38,6 @@ export default function RowPinningWithPagination() {
         }}
         pagination
         pageSizeOptions={[5, 10, 25, 50, 100]}
-        experimentalFeatures={{ rowPinning: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/row-pinning/RowPinningWithPagination.tsx
+++ b/docs/data/data-grid/row-pinning/RowPinningWithPagination.tsx
@@ -38,7 +38,6 @@ export default function RowPinningWithPagination() {
         }}
         pagination
         pageSizeOptions={[5, 10, 25, 50, 100]}
-        experimentalFeatures={{ rowPinning: true }}
       />
     </div>
   );

--- a/docs/data/data-grid/row-pinning/RowPinningWithPagination.tsx.preview
+++ b/docs/data/data-grid/row-pinning/RowPinningWithPagination.tsx.preview
@@ -11,5 +11,4 @@
   }}
   pagination
   pageSizeOptions={[5, 10, 25, 50, 100]}
-  experimentalFeatures={{ rowPinning: true }}
 />

--- a/docs/data/data-grid/row-pinning/row-pinning.md
+++ b/docs/data/data-grid/row-pinning/row-pinning.md
@@ -8,15 +8,6 @@ title: Data Grid - Row pinning
 
 Pinned (or frozen, locked, or floating) rows are those visible at all times while the user scrolls the grid vertically.
 
-:::warning
-This feature is experimental, it needs to be explicitly activated using the `rowPinning` experimental feature flag.
-
-```tsx
-<DataGridPro experimentalFeatures={{ rowPinning: true }} {...otherProps} />
-```
-
-:::
-
 You can pin rows at the top or bottom of the grid by passing pinned rows data through the `pinnedRows` prop:
 
 ```tsx

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -377,6 +377,12 @@ Most of this breaking change is handled by `preset-safe` codemod but some furthe
   -  experimentalFeatures={{ newEditingApi: true }}
    />
   ```
+- ✅ The row pinning is no longer experimental. The flag `experimentalFeatures.rowPinning` can be removed now.
+  ```diff
+   <DataGridPremium
+  -  experimentalFeatures={{ rowPinning: true }}
+   />
+  ```
 - The `editCellPropsChange` event was removed. If you still need it please file a new issue so we can propose an alternative.
 - The `cellEditCommit` event was removed and the `processRowUpdate` prop can be used in place. More information, check the [docs](https://mui.com/x/react-data-grid/editing/#persistence) section about the topic.
 - The `editRowsModel` and `onEditRowsModelChange` props were removed. The [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props can be used to achieve the same goal.

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -77,7 +77,7 @@
     "experimentalFeatures": {
       "type": {
         "name": "shape",
-        "description": "{ columnGrouping?: bool, lazyLoading?: bool, rowPinning?: bool, warnIfFocusStateIsNotSynced?: bool }"
+        "description": "{ columnGrouping?: bool, lazyLoading?: bool, warnIfFocusStateIsNotSynced?: bool }"
       }
     },
     "filterMode": {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -66,7 +66,7 @@
     "experimentalFeatures": {
       "type": {
         "name": "shape",
-        "description": "{ columnGrouping?: bool, lazyLoading?: bool, rowPinning?: bool, warnIfFocusStateIsNotSynced?: bool }"
+        "description": "{ columnGrouping?: bool, lazyLoading?: bool, warnIfFocusStateIsNotSynced?: bool }"
       }
     },
     "filterMode": {

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -270,7 +270,6 @@ DataGridPremiumRaw.propTypes = {
   experimentalFeatures: PropTypes.shape({
     columnGrouping: PropTypes.bool,
     lazyLoading: PropTypes.bool,
-    rowPinning: PropTypes.bool,
     warnIfFocusStateIsNotSynced: PropTypes.bool,
   }),
   /**

--- a/packages/grid/x-data-grid-premium/src/tests/rowPinning.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowPinning.DataGridPremium.test.tsx
@@ -74,7 +74,6 @@ describe('<DataGridPremium /> - Row pinning', () => {
               top: [pinnedRow0],
               bottom: [pinnedRow1],
             }}
-            experimentalFeatures={{ rowPinning: true }}
           />
         </div>
       );

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -241,7 +241,6 @@ DataGridProRaw.propTypes = {
   experimentalFeatures: PropTypes.shape({
     columnGrouping: PropTypes.bool,
     lazyLoading: PropTypes.bool,
-    rowPinning: PropTypes.bool,
     warnIfFocusStateIsNotSynced: PropTypes.bool,
   }),
   /**

--- a/packages/grid/x-data-grid-pro/src/hooks/features/rowPinning/useGridRowPinning.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/rowPinning/useGridRowPinning.ts
@@ -38,10 +38,6 @@ function createPinnedRowsInternalCache(
 export const rowPinningStateInitializer: GridStateInitializer<
   Pick<DataGridProProcessedProps, 'pinnedRows' | 'getRowId' | 'experimentalFeatures'>
 > = (state, props, apiRef) => {
-  if (!props.experimentalFeatures?.rowPinning) {
-    return state;
-  }
-
   apiRef.current.caches.pinnedRows = createPinnedRowsInternalCache(
     props.pinnedRows,
     props.getRowId,
@@ -61,14 +57,10 @@ export const rowPinningStateInitializer: GridStateInitializer<
 
 export const useGridRowPinning = (
   apiRef: React.MutableRefObject<GridPrivateApiPro>,
-  props: Pick<DataGridProProcessedProps, 'pinnedRows' | 'getRowId' | 'experimentalFeatures'>,
+  props: Pick<DataGridProProcessedProps, 'pinnedRows' | 'getRowId'>,
 ): void => {
   const setPinnedRows = React.useCallback<GridRowPinningApi['unstable_setPinnedRows']>(
     (newPinnedRows) => {
-      if (!props.experimentalFeatures?.rowPinning) {
-        return;
-      }
-
       apiRef.current.caches.pinnedRows = createPinnedRowsInternalCache(
         newPinnedRows,
         props.getRowId,
@@ -76,7 +68,7 @@ export const useGridRowPinning = (
 
       apiRef.current.requestPipeProcessorsApplication('hydrateRows');
     },
-    [apiRef, props.experimentalFeatures?.rowPinning, props.getRowId],
+    [apiRef, props.getRowId],
   );
 
   useGridApiMethod(

--- a/packages/grid/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/grid/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -30,10 +30,6 @@ export interface GridExperimentalProFeatures extends GridExperimentalFeatures {
    * Enables the data grid to lazy load rows while scrolling.
    */
   lazyLoading: boolean;
-  /**
-   * Enables the ability for rows to be pinned in data grid.
-   */
-  rowPinning: boolean;
 }
 
 interface DataGridProPropsWithComplexDefaultValueBeforeProcessing

--- a/packages/grid/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
@@ -73,7 +73,6 @@ describe('<DataGridPro /> - Row pinning', () => {
             top: [pinnedRow0],
             bottom: [pinnedRow1],
           }}
-          experimentalFeatures={{ rowPinning: true }}
           {...props}
         />
       </div>
@@ -105,12 +104,7 @@ describe('<DataGridPro /> - Row pinning', () => {
 
       return (
         <div style={{ width: 302, height: 300 }}>
-          <DataGridPro
-            {...data}
-            autoHeight
-            pinnedRows={pinnedRows}
-            experimentalFeatures={{ rowPinning: true }}
-          />
+          <DataGridPro {...data} autoHeight pinnedRows={pinnedRows} />
         </div>
       );
     }
@@ -281,7 +275,6 @@ describe('<DataGridPro /> - Row pinning', () => {
               bottom: [pinnedRow1],
             }}
             getRowId={getRowId}
-            experimentalFeatures={{ rowPinning: true }}
           />
         </div>
       );
@@ -368,7 +361,6 @@ describe('<DataGridPro /> - Row pinning', () => {
               pinnedRows={{
                 top: [pinnedRow1, pinnedRow0],
               }}
-              experimentalFeatures={{ rowPinning: true }}
             />
           </div>
         );
@@ -411,7 +403,6 @@ describe('<DataGridPro /> - Row pinning', () => {
               pinnedRows={{
                 bottom: [pinnedRow0, pinnedRow1],
               }}
-              experimentalFeatures={{ rowPinning: true }}
             />
           </div>
         );
@@ -463,7 +454,6 @@ describe('<DataGridPro /> - Row pinning', () => {
                   right: ['price2M'],
                 },
               }}
-              experimentalFeatures={{ rowPinning: true }}
             />
           </div>
         );
@@ -703,7 +693,6 @@ describe('<DataGridPro /> - Row pinning', () => {
               top: [pinnedRow0],
               bottom: [pinnedRow1],
             }}
-            experimentalFeatures={{ rowPinning: true }}
           />
         </div>
       );

--- a/packages/x-codemod/src/v6.0.0/data-grid/remove-stabilized-experimentalFeatures/actual.spec.js
+++ b/packages/x-codemod/src/v6.0.0/data-grid/remove-stabilized-experimentalFeatures/actual.spec.js
@@ -6,7 +6,10 @@ import { DataGridPremium } from '@mui/x-data-grid-premium';
 function App() {
   return (
     <React.Fragment>
-      <DataGrid experimentalFeatures={{ newEditingApi: true }} />
+      <DataGrid experimentalFeatures={{ 
+        newEditingApi: true,
+        rowPinning: true
+      }} />
       <DataGridPro experimentalFeatures={{
         newEditingApi: true,
         rowPinning: true,

--- a/packages/x-codemod/src/v6.0.0/data-grid/remove-stabilized-experimentalFeatures/expected.spec.js
+++ b/packages/x-codemod/src/v6.0.0/data-grid/remove-stabilized-experimentalFeatures/expected.spec.js
@@ -7,12 +7,9 @@ function App() {
   return (
     <React.Fragment>
       <DataGrid />
-      <DataGridPro experimentalFeatures={{
-        rowPinning: true,
-      }} />
+      <DataGridPro />
       <DataGridPremium
         experimentalFeatures={{
-          rowPinning: true,
           columnGrouping: true,
         }} />
     </React.Fragment>

--- a/packages/x-codemod/src/v6.0.0/data-grid/remove-stabilized-experimentalFeatures/index.ts
+++ b/packages/x-codemod/src/v6.0.0/data-grid/remove-stabilized-experimentalFeatures/index.ts
@@ -3,7 +3,7 @@ import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
 
 const componentsNames = ['DataGrid', 'DataGridPro', 'DataGridPremium'];
 const propName = 'experimentalFeatures';
-const propKey = 'newEditingApi';
+const propKeys = ['newEditingApi', 'rowPinning'];
 
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
   const j = api.jscodeshift;
@@ -14,7 +14,9 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
     trailingComma: true,
   };
 
-  removeObjectProperty({ root, j, propName, componentsNames, propKey });
+  propKeys.forEach((propKey) => {
+    removeObjectProperty({ root, j, propName, componentsNames, propKey });
+  });
 
   return root.toSource(printOptions);
 }


### PR DESCRIPTION
Closes #8038 

## Changelog

### Highlight

- 🎁 The row pinning is no longer experimental.

  You can now use the row pinning without the `experimentalFeatures.rowPinning` flag enabled.

  ```diff
   <DataGridPro
  -  experimentalFeatures={{ rowPinning: true }}
   />
  ```