### PR TITLE
[pickers] Fix layout `sx` propagation

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
@@ -58,7 +58,15 @@ export const useStaticPicker = <
           {...slotProps?.layout}
           slots={slots}
           slotProps={slotProps}
-          sx={sx}
+          sx={[
+            ...(Array.isArray(sx) ? sx : [sx]),
+            // eslint-disable-next-line no-nested-ternary
+            ...(slotProps?.layout?.sx === undefined
+              ? []
+              : Array.isArray(slotProps.layout.sx)
+              ? slotProps.layout.sx
+              : [slotProps.layout.sx]),
+          ]}
           className={clsx(className, slotProps?.layout?.className)}
           ref={ref}
         >


### PR DESCRIPTION
The following demo is broken because `sx` props overrides `splotProps.layout.sx`

https://next.mui.com/x/react-date-pickers/custom-layout/#orientation