### PR TITLE
[DataGrid] Register `getLocaleText` synchronously

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/core/useGridLocaleText.tsx
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridLocaleText.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { GridApiCommunity } from '../../models/api/gridApiCommunity';
 import { GridLocaleTextApi } from '../../models/api/gridLocaleTextApi';
-import { useGridApiMethod } from '../utils/useGridApiMethod';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 
 export const useGridLocaleText = (
@@ -18,9 +17,5 @@ export const useGridLocaleText = (
     [props.localeText],
   );
 
-  const localeTextApi: GridLocaleTextApi = {
-    getLocaleText,
-  };
-
-  useGridApiMethod(apiRef, localeTextApi, 'LocaleTextApi');
+  apiRef.current.getLocaleText = getLocaleText;
 };

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1046,6 +1046,28 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       );
       expect(document.querySelector('[title="Ordenar"]')).not.to.equal(null);
     });
+
+    it('should allow to change localeText on the fly', () => {
+      function TestCase(props: Partial<DataGridProps>) {
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid
+              {...baselineProps}
+              components={{
+                Toolbar: GridToolbar,
+              }}
+              {...props}
+            />
+          </div>
+        );
+      }
+      const { setProps, getByText } = render(
+        <TestCase localeText={{ toolbarDensity: 'Density' }} />,
+      );
+      expect(getByText('Density')).not.to.equal(null);
+      setProps({ localeText: { toolbarDensity: 'Densidade' } });
+      expect(getByText('Densidade')).not.to.equal(null);
+    });
   });
 
   describe('Error', () => {


### PR DESCRIPTION
Backports https://github.com/mui/mui-x/pull/8029