### PR TITLE
[DataGrid] Allow multiple modules' augmentation

### DIFF
--- a/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts
+++ b/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts
@@ -47,7 +47,7 @@ export interface PanelPropsOverrides {}
 export interface PreferencesPanelPropsOverrides {}
 export interface RowPropsOverrides {}
 
-type SlotProps<Props, Overrides> = Partial<Props> & Overrides;
+type SlotProps<Props, Overrides> = Partial<Props & Overrides>;
 
 /**
  * Overrideable components props dynamically passed to the component at rendering.


### PR DESCRIPTION
Relates to #7968 

As shown in this [codesandbox](https://codesandbox.io/s/data-grid-community-forked-sv2j2g?file=/src/Test.tsx), with current typing, if user tries to augment the same interface twice in a same project, typescript makes them both mandatory which is not always the expectation.