### PR TITLE
[docs] Remove charts path structure from side navigation menu.

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -427,23 +427,6 @@ const pages: MuiPage[] = [
       },
     ],
   },
-  {
-    pathname: '/x/react-charts-group',
-    title: 'Charts 🚧',
-    icon: 'ChartIcon',
-    children: [
-      { pathname: '/x/react-charts', title: '🚧 Overview' },
-      { pathname: '/x/react-charts/bars', title: '🚧 Bars' },
-      { pathname: '/x/react-charts/lines', title: '🚧 Lines' },
-      { pathname: '/x/react-charts/areas', title: '🚧 Areas' },
-      { pathname: '/x/react-charts/scatter', title: '🚧 Scatter' },
-      { pathname: '/x/react-charts/heat-map', title: '🚧 Heat map' },
-      { pathname: '/x/react-charts/funnel', title: '🚧 Funnel' },
-      { pathname: '/x/react-charts/radar', title: '🚧 Radar' },
-      { pathname: '/x/react-charts/sankey', title: '🚧 Sankey' },
-      { pathname: '/x/react-charts/tree-map', title: '🚧 Tree map' },
-    ],
-  },
 ];
 
 export default pages;


### PR DESCRIPTION
## Summary

We're in a very early phase with the charts, and although I agree we can employ the opportunity to add links to the issues for upvoting, I think we need at least a good overview page to make them public.