### PR TITLE
[docs] Link `API object` in the `apiRef` sections

### DIFF
--- a/docs/data/data-grid/cell-selection/cell-selection.md
+++ b/docs/data/data-grid/cell-selection/cell-selection.md
@@ -76,7 +76,7 @@ If a single cell is selected, all classes above are applied to the same element.
 
 ## apiRef
 
-The grid exposes a set of methods that enables all of these features using the imperative `apiRef`.
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
 
 :::warning
 Only use this API as the last option. Give preference to the props to control the grid.

--- a/docs/data/data-grid/column-pinning/column-pinning.md
+++ b/docs/data/data-grid/column-pinning/column-pinning.md
@@ -89,6 +89,8 @@ The demo below contains an example of both features enabled:
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 {{"demo": "ColumnPinningApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## API

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -431,6 +431,8 @@ See [Editing recipes](/x/react-data-grid/recipes-editing/) for more advanced use
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 {{"demo": "EditApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## API

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -399,6 +399,8 @@ You will be able to copy and paste items to and from the grid using the system c
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 :::warning
 Only use this API as the last option. Give preference to the props to control the grid.
 :::

--- a/docs/data/data-grid/filtering/filtering.md
+++ b/docs/data/data-grid/filtering/filtering.md
@@ -419,6 +419,8 @@ In the following demo, the quick filter value `"Saint Martin, Saint Lucia"` will
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 :::warning
 Only use this API as the last option. Give preference to the props to control the grid.
 :::

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -159,6 +159,8 @@ Notice that the toggle column is pinned to make sure that it will always be visi
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 {{"demo": "DetailPanelApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## API

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -116,6 +116,8 @@ You can customize the rendering of the pagination in the footer following [the c
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 :::warning
 Only use this API as the last option. Give preference to the props to control the grid.
 :::

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -338,10 +338,6 @@ See [Row grouping recipes](/x/react-data-grid/recipes-row-grouping/) for more ad
 
 The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
 
-The grid exposes a set of methods that enables all of these features using the imperative `apiRef`.
-
-To know more about how to use the `apiRef`, check the [API Object](/x/react-data-grid/api-object/) section.
-
 {{"demo": "RowGroupingApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## API

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -336,6 +336,12 @@ See [Row grouping recipes](/x/react-data-grid/recipes-row-grouping/) for more ad
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`.
+
+To know more about how to use the `apiRef`, check the [API Object](/x/react-data-grid/api-object/) section.
+
 {{"demo": "RowGroupingApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
 ## API

--- a/docs/data/data-grid/row-selection/row-selection.md
+++ b/docs/data/data-grid/row-selection/row-selection.md
@@ -83,7 +83,7 @@ The following demo shows the prop in action:
 
 ## apiRef
 
-The grid exposes a set of methods that enables all of these features using the imperative `apiRef`.
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
 
 :::warning
 Only use this API as the last option. Give preference to the props to control the grid.

--- a/docs/data/data-grid/scrolling/scrolling.md
+++ b/docs/data/data-grid/scrolling/scrolling.md
@@ -14,6 +14,8 @@ The following demo explores the usage of this API:
 
 ## apiRef
 
+The grid exposes a set of methods that enables all of these features using the imperative `apiRef`. To know more about how to use it, check the [API Object](/x/react-data-grid/api-object/) section.
+
 :::warning
 Only use this API as the last option. Give preference to the props to control the grid.
 :::


### PR DESCRIPTION
Closes #7629 