### PR TITLE
[DataGrid] Use `baseSelect` slot instead of `baseTextField` with `select={true}`

### DIFF
--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
@@ -30,16 +30,25 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
     setFilterValueState(item.value || '');
   }, [item.value]);
 
+  const label = apiRef.current.getLocaleText('filterPanelInputLabel');
+
   return (
-    <rootProps.slots.baseFormControl {...rootProps.slotProps?.baseFormControl} variant="standard">
-      <rootProps.slots.baseInputLabel {...rootProps.slotProps?.baseInputLabel} id={labelId} shrink>
-        {apiRef.current.getLocaleText('filterPanelInputLabel')}
+    <React.Fragment>
+      <rootProps.slots.baseInputLabel
+        {...rootProps.slotProps?.baseInputLabel}
+        id={labelId}
+        shrink
+        variant="standard"
+      >
+        {label}
       </rootProps.slots.baseInputLabel>
       <rootProps.slots.baseSelect
         labelId={labelId}
         id={selectId}
+        label={label}
         value={filterValueState}
         onChange={onFilterChange}
+        variant="standard"
         native={isSelectNative}
         displayEmpty
         inputProps={{ ref: focusElementRef }}
@@ -68,6 +77,6 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
           {apiRef.current.getLocaleText('filterValueFalse')}
         </rootProps.slots.baseSelectOption>
       </rootProps.slots.baseSelect>
-    </rootProps.slots.baseFormControl>
+    </React.Fragment>
   );
 }

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { TextFieldProps } from '@mui/material/TextField';
+import { unstable_useId as useId } from '@mui/utils';
 import { GridFilterInputValueProps } from './GridFilterInputValueProps';
 import { useGridRootProps } from '../../../hooks/utils/useGridRootProps';
 
@@ -7,6 +8,9 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
   const { item, applyValue, apiRef, focusElementRef, ...others } = props;
   const [filterValueState, setFilterValueState] = React.useState(item.value || '');
   const rootProps = useGridRootProps();
+
+  const labelId = useId();
+  const selectId = useId();
 
   const baseSelectProps = rootProps.slotProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? true;
@@ -27,42 +31,43 @@ export function GridFilterInputBoolean(props: GridFilterInputValueProps & TextFi
   }, [item.value]);
 
   return (
-    <rootProps.slots.baseTextField
-      // TODO: use baseSelect slot
-      label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-      value={filterValueState}
-      onChange={onFilterChange}
-      select
-      variant="standard"
-      SelectProps={{
-        native: isSelectNative,
-        displayEmpty: true,
-        ...rootProps.slotProps?.baseSelect,
-      }}
-      InputLabelProps={{
-        shrink: true,
-      }}
-      inputRef={focusElementRef}
-      {...others}
-      {...rootProps.slotProps?.baseTextField}
-    >
-      <rootProps.slots.baseSelectOption {...baseSelectOptionProps} native={isSelectNative} value="">
-        {apiRef.current.getLocaleText('filterValueAny')}
-      </rootProps.slots.baseSelectOption>
-      <rootProps.slots.baseSelectOption
-        {...baseSelectOptionProps}
+    <rootProps.slots.baseFormControl {...rootProps.slotProps?.baseFormControl} variant="standard">
+      <rootProps.slots.baseInputLabel {...rootProps.slotProps?.baseInputLabel} id={labelId} shrink>
+        {apiRef.current.getLocaleText('filterPanelInputLabel')}
+      </rootProps.slots.baseInputLabel>
+      <rootProps.slots.baseSelect
+        labelId={labelId}
+        id={selectId}
+        value={filterValueState}
+        onChange={onFilterChange}
         native={isSelectNative}
-        value="true"
+        displayEmpty
+        inputProps={{ ref: focusElementRef }}
+        {...others}
+        {...baseSelectProps}
       >
-        {apiRef.current.getLocaleText('filterValueTrue')}
-      </rootProps.slots.baseSelectOption>
-      <rootProps.slots.baseSelectOption
-        {...baseSelectOptionProps}
-        native={isSelectNative}
-        value="false"
-      >
-        {apiRef.current.getLocaleText('filterValueFalse')}
-      </rootProps.slots.baseSelectOption>
-    </rootProps.slots.baseTextField>
+        <rootProps.slots.baseSelectOption
+          {...baseSelectOptionProps}
+          native={isSelectNative}
+          value=""
+        >
+          {apiRef.current.getLocaleText('filterValueAny')}
+        </rootProps.slots.baseSelectOption>
+        <rootProps.slots.baseSelectOption
+          {...baseSelectOptionProps}
+          native={isSelectNative}
+          value="true"
+        >
+          {apiRef.current.getLocaleText('filterValueTrue')}
+        </rootProps.slots.baseSelectOption>
+        <rootProps.slots.baseSelectOption
+          {...baseSelectOptionProps}
+          native={isSelectNative}
+          value="false"
+        >
+          {apiRef.current.getLocaleText('filterValueFalse')}
+        </rootProps.slots.baseSelectOption>
+      </rootProps.slots.baseSelect>
+    </rootProps.slots.baseFormControl>
   );
 }

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
@@ -124,16 +124,25 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
     return null;
   }
 
+  const label = apiRef.current.getLocaleText('filterPanelInputLabel');
+
   return (
-    <rootProps.slots.baseFormControl {...rootProps.slotProps?.baseFormControl} variant="standard">
-      <rootProps.slots.baseInputLabel {...rootProps.slotProps?.baseInputLabel} id={labelId} shrink>
-        {apiRef.current.getLocaleText('filterPanelInputLabel')}
+    <React.Fragment>
+      <rootProps.slots.baseInputLabel
+        {...rootProps.slotProps?.baseInputLabel}
+        id={labelId}
+        shrink
+        variant="standard"
+      >
+        {label}
       </rootProps.slots.baseInputLabel>
       <rootProps.slots.baseSelect
         id={id}
+        label={label}
         labelId={labelId}
         value={filterValueState}
         onChange={onFilterChange}
+        variant="standard"
         type={type || 'text'}
         inputProps={{
           ref: focusElementRef,
@@ -152,7 +161,7 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
           baseSelectOptionProps: rootProps.slotProps?.baseSelectOption,
         })}
       </rootProps.slots.baseSelect>
-    </rootProps.slots.baseFormControl>
+    </React.Fragment>
   );
 }
 

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputSingleSelect.tsx
@@ -59,12 +59,10 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
   } = props;
   const [filterValueState, setFilterValueState] = React.useState(item.value ?? '');
   const id = useId();
+  const labelId = useId();
   const rootProps = useGridRootProps();
 
-  const baseSelectProps = rootProps.slotProps?.baseSelect || {};
-  const isSelectNative = baseSelectProps.native ?? true;
-
-  const baseSelectOptionProps = rootProps.slotProps?.baseSelectOption || {};
+  const isSelectNative = rootProps.slotProps?.baseSelect?.native ?? true;
 
   let resolvedColumn: GridSingleSelectColDef | null = null;
   if (item.field) {
@@ -127,36 +125,34 @@ function GridFilterInputSingleSelect(props: GridFilterInputSingleSelectProps) {
   }
 
   return (
-    <rootProps.slots.baseTextField
-      // TODO: use baseSelect slot
-      id={id}
-      label={apiRef.current.getLocaleText('filterPanelInputLabel')}
-      placeholder={apiRef.current.getLocaleText('filterPanelInputPlaceholder')}
-      value={filterValueState}
-      onChange={onFilterChange}
-      variant="standard"
-      type={type || 'text'}
-      InputLabelProps={{
-        shrink: true,
-      }}
-      inputRef={focusElementRef}
-      select
-      SelectProps={{
-        native: isSelectNative,
-        ...rootProps.slotProps?.baseSelect,
-      }}
-      {...others}
-      {...rootProps.slotProps?.baseTextField}
-    >
-      {renderSingleSelectOptions({
-        column: resolvedColumn,
-        OptionComponent: rootProps.slots.baseSelectOption,
-        getOptionLabel,
-        getOptionValue,
-        isSelectNative,
-        baseSelectOptionProps,
-      })}
-    </rootProps.slots.baseTextField>
+    <rootProps.slots.baseFormControl {...rootProps.slotProps?.baseFormControl} variant="standard">
+      <rootProps.slots.baseInputLabel {...rootProps.slotProps?.baseInputLabel} id={labelId} shrink>
+        {apiRef.current.getLocaleText('filterPanelInputLabel')}
+      </rootProps.slots.baseInputLabel>
+      <rootProps.slots.baseSelect
+        id={id}
+        labelId={labelId}
+        value={filterValueState}
+        onChange={onFilterChange}
+        type={type || 'text'}
+        inputProps={{
+          ref: focusElementRef,
+          placeholder: apiRef.current.getLocaleText('filterPanelInputPlaceholder'),
+        }}
+        native={isSelectNative}
+        {...others}
+        {...rootProps.slotProps?.baseSelect}
+      >
+        {renderSingleSelectOptions({
+          column: resolvedColumn,
+          OptionComponent: rootProps.slots.baseSelectOption,
+          getOptionLabel,
+          getOptionValue,
+          isSelectNative,
+          baseSelectOptionProps: rootProps.slotProps?.baseSelectOption,
+        })}
+      </rootProps.slots.baseSelect>
+    </rootProps.slots.baseFormControl>
   );
 }
 


### PR DESCRIPTION
I've noticed this problem in https://github.com/mui/mui-x/pull/8067 where I added a custom `baseTextfield` component and it turned out that the boolean select in the filter panel is now a regular text field:
<img width="535" alt="Screenshot 2023-03-02 at 21 43 16" src="https://user-images.githubusercontent.com/13808724/222547393-c65c5053-dabe-45b5-9e16-36fb3e432a69.png">

If it was using `baseSelect` rather than `baseTextField`, the default Material UI select component would have been used (I didn't override the `baseSelect` with a Joy UI one yet)