### PR TITLE
[fields] Clean the order of the tokens in the `formatTokenMap` of each adapter

### DIFF
--- a/packages/x-date-pickers/src/AdapterDateFns/index.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/index.ts
@@ -6,16 +6,25 @@ import getWeek from 'date-fns/getWeek';
 import { FieldFormatTokenMap, MuiPickersAdapter } from '../internals/models';
 
 const formatTokenMap: FieldFormatTokenMap = {
+  // Year
   y: 'year',
   yy: 'year',
   yyy: 'year',
   yyyy: 'year',
+
+  // Month
   M: 'month',
   MM: 'month',
   MMMM: { sectionType: 'month', contentType: 'letter' },
   MMM: { sectionType: 'month', contentType: 'letter' },
   LLL: { sectionType: 'month', contentType: 'letter' },
   LLLL: { sectionType: 'month', contentType: 'letter' },
+
+  // Day of the month
+  d: 'day',
+  dd: 'day',
+
+  // Day of the week
   E: { sectionType: 'weekDay', contentType: 'letter' },
   EE: { sectionType: 'weekDay', contentType: 'letter' },
   EEE: { sectionType: 'weekDay', contentType: 'letter' },
@@ -37,17 +46,23 @@ const formatTokenMap: FieldFormatTokenMap = {
   cccc: { sectionType: 'weekDay', contentType: 'letter' },
   ccccc: { sectionType: 'weekDay', contentType: 'letter' },
   cccccc: { sectionType: 'weekDay', contentType: 'letter' },
-  d: 'day',
-  dd: 'day',
+
+  // Meridiem
+  a: 'meridiem',
+  aa: 'meridiem',
+  aaa: 'meridiem',
+
+  // Hours
   H: 'hours',
   HH: 'hours',
   h: 'hours',
   hh: 'hours',
+
+  // Minutes
   mm: 'minutes',
+
+  // Seconds
   ss: 'seconds',
-  a: 'meridiem',
-  aa: 'meridiem',
-  aaa: 'meridiem',
 };
 
 export class AdapterDateFns extends BaseAdapterDateFns implements MuiPickersAdapter<Date> {

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/index.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/index.ts
@@ -6,27 +6,40 @@ import longFormatters from 'date-fns-jalali/_lib/format/longFormatters';
 import { FieldFormatTokenMap, MuiPickersAdapter } from '../internals/models';
 
 const formatTokenMap: FieldFormatTokenMap = {
+  // Year
   y: 'year',
   yy: 'year',
   yyy: 'year',
   yyyy: 'year',
+
+  // Month
   M: 'month',
   MM: 'month',
   MMMM: { sectionType: 'month', contentType: 'letter' },
   MMM: { sectionType: 'month', contentType: 'letter' },
   LLL: { sectionType: 'month', contentType: 'letter' },
   LLLL: { sectionType: 'month', contentType: 'letter' },
+
+  // Day of the month
   d: 'day',
   dd: 'day',
+
+  // Meridiem
+  a: 'meridiem',
+  aa: 'meridiem',
+  aaa: 'meridiem',
+
+  // Hours
   H: 'hours',
   HH: 'hours',
   h: 'hours',
   hh: 'hours',
+
+  // Minutes
   mm: 'minutes',
+
+  // Seconds
   ss: 'seconds',
-  a: 'meridiem',
-  aa: 'meridiem',
-  aaa: 'meridiem',
 };
 
 export class AdapterDateFnsJalali

--- a/packages/x-date-pickers/src/AdapterDayjs/index.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/index.ts
@@ -14,28 +14,43 @@ const localeNotFoundWarning = buildWarning([
 ]);
 
 const formatTokenMap: FieldFormatTokenMap = {
+  // Year
   YY: 'year',
   YYYY: 'year',
+
+  // Month
   M: 'month',
   MM: 'month',
   MMM: { sectionType: 'month', contentType: 'letter' },
   MMMM: { sectionType: 'month', contentType: 'letter' },
+
+  // Day of the month
   D: 'day',
   DD: 'day',
+
+  // Day of the week
   d: 'weekDay',
   dd: { sectionType: 'weekDay', contentType: 'letter' },
   ddd: { sectionType: 'weekDay', contentType: 'letter' },
   dddd: { sectionType: 'weekDay', contentType: 'letter' },
+
+  // Meridiem
+  A: 'meridiem',
+  a: 'meridiem',
+
+  // Hours
   H: 'hours',
   HH: 'hours',
   h: 'hours',
   hh: 'hours',
+
+  // Minutes
   m: 'minutes',
   mm: 'minutes',
+
+  // Seconds
   s: 'seconds',
   ss: 'seconds',
-  A: 'meridiem',
-  a: 'meridiem',
 };
 
 interface Opts {

--- a/packages/x-date-pickers/src/AdapterLuxon/index.ts
+++ b/packages/x-date-pickers/src/AdapterLuxon/index.ts
@@ -4,31 +4,12 @@ import BaseAdapterLuxon from '@date-io/luxon';
 import { FieldFormatTokenMap, MuiPickersAdapter } from '../internals/models';
 
 const formatTokenMap: FieldFormatTokenMap = {
-  s: 'seconds',
-  ss: 'seconds',
+  // Year
+  y: 'year',
+  yy: 'year',
+  yyyy: 'year',
 
-  m: 'minutes',
-  mm: 'minutes',
-
-  H: 'hours',
-  HH: 'hours',
-  h: 'hours',
-  hh: 'hours',
-
-  a: 'meridiem',
-
-  d: 'day',
-  dd: 'day',
-
-  c: 'weekDay',
-  ccc: { sectionType: 'weekDay', contentType: 'letter' },
-  cccc: { sectionType: 'weekDay', contentType: 'letter' },
-  ccccc: { sectionType: 'weekDay', contentType: 'letter' },
-  E: 'weekDay',
-  EEE: { sectionType: 'weekDay', contentType: 'letter' },
-  EEEE: { sectionType: 'weekDay', contentType: 'letter' },
-  EEEEE: { sectionType: 'weekDay', contentType: 'letter' },
-
+  // Month
   L: 'month',
   LL: 'month',
   LLL: { sectionType: 'month', contentType: 'letter' },
@@ -38,9 +19,36 @@ const formatTokenMap: FieldFormatTokenMap = {
   MMM: { sectionType: 'month', contentType: 'letter' },
   MMMM: { sectionType: 'month', contentType: 'letter' },
 
-  y: 'year',
-  yy: 'year',
-  yyyy: 'year',
+  // Day of the month
+  d: 'day',
+  dd: 'day',
+
+  // Day of the week
+  c: 'weekDay',
+  ccc: { sectionType: 'weekDay', contentType: 'letter' },
+  cccc: { sectionType: 'weekDay', contentType: 'letter' },
+  ccccc: { sectionType: 'weekDay', contentType: 'letter' },
+  E: 'weekDay',
+  EEE: { sectionType: 'weekDay', contentType: 'letter' },
+  EEEE: { sectionType: 'weekDay', contentType: 'letter' },
+  EEEEE: { sectionType: 'weekDay', contentType: 'letter' },
+
+  // Meridiem
+  a: 'meridiem',
+
+  // Hours
+  H: 'hours',
+  HH: 'hours',
+  h: 'hours',
+  hh: 'hours',
+
+  // Minutes
+  m: 'minutes',
+  mm: 'minutes',
+
+  // Seconds
+  s: 'seconds',
+  ss: 'seconds',
 };
 
 export class AdapterLuxon extends BaseAdapterLuxon implements MuiPickersAdapter<DateTime> {

--- a/packages/x-date-pickers/src/AdapterMoment/index.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/index.ts
@@ -5,6 +5,11 @@ import { FieldFormatTokenMap, MuiPickersAdapter } from '../internals/models';
 
 // From https://momentjs.com/docs/#/displaying/format/
 const formatTokenMap: FieldFormatTokenMap = {
+  // Year
+  Y: 'year',
+  YY: 'year',
+  YYYY: 'year',
+
   // Month
   M: 'month',
   MM: 'month',
@@ -23,16 +28,11 @@ const formatTokenMap: FieldFormatTokenMap = {
   ddd: { sectionType: 'weekDay', contentType: 'letter' },
   dddd: { sectionType: 'weekDay', contentType: 'letter' },
 
-  // Year
-  Y: 'year',
-  YY: 'year',
-  YYYY: 'year',
-
-  // AM / PM
+  // Meridiem
   A: 'meridiem',
   a: 'meridiem',
 
-  // Hour
+  // Hours
   H: 'hours',
   HH: 'hours',
   h: 'hours',
@@ -40,11 +40,11 @@ const formatTokenMap: FieldFormatTokenMap = {
   k: 'hours',
   kk: 'hours',
 
-  // Minute
+  // Minutes
   m: 'minutes',
   mm: 'minutes',
 
-  // Second
+  // Seconds
   s: 'seconds',
   ss: 'seconds',
 };

--- a/packages/x-date-pickers/src/AdapterMomentHijri/index.ts
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/index.ts
@@ -6,26 +6,26 @@ import { FieldFormatTokenMap, MuiPickersAdapter } from '../internals/models';
 
 // From https://momentjs.com/docs/#/displaying/format/
 const formatTokenMap: FieldFormatTokenMap = {
+  // Year
+  iY: 'year',
+  iYY: 'year',
+  iYYYY: 'year',
+
   // Month
   iM: 'month',
   iMM: 'month',
   iMMM: { sectionType: 'month', contentType: 'letter' },
   iMMMM: { sectionType: 'month', contentType: 'letter' },
 
-  // Day of Month
+  // Day of the month
   iD: 'day',
   iDD: 'day',
 
-  // Year
-  iY: 'year',
-  iYY: 'year',
-  iYYYY: 'year',
-
-  // AM / PM
+  // Meridiem
   A: 'meridiem',
   a: 'meridiem',
 
-  // Hour
+  // Hours
   H: 'hours',
   HH: 'hours',
   h: 'hours',
@@ -33,11 +33,11 @@ const formatTokenMap: FieldFormatTokenMap = {
   k: 'hours',
   kk: 'hours',
 
-  // Minute
+  // Minutes
   m: 'minutes',
   mm: 'minutes',
 
-  // Second
+  // Seconds
   s: 'seconds',
   ss: 'seconds',
 };

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/index.ts
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/index.ts
@@ -7,25 +7,25 @@ type Moment = defaultMoment.Moment;
 
 // From https://momentjs.com/docs/#/displaying/format/
 const formatTokenMap: FieldFormatTokenMap = {
+  // Year
+  jYY: 'year',
+  jYYYY: 'year',
+
   // Month
   jM: 'month',
   jMM: 'month',
   jMMM: { sectionType: 'month', contentType: 'letter' },
   jMMMM: { sectionType: 'month', contentType: 'letter' },
 
-  // Day of Month
+  // Day of the month
   jD: 'day',
   jDD: 'day',
 
-  // Year
-  jYY: 'year',
-  jYYYY: 'year',
-
-  // AM / PM
+  // Meridiem
   A: 'meridiem',
   a: 'meridiem',
 
-  // Hour
+  // Hours
   H: 'hours',
   HH: 'hours',
   h: 'hours',
@@ -33,11 +33,11 @@ const formatTokenMap: FieldFormatTokenMap = {
   k: 'hours',
   kk: 'hours',
 
-  // Minute
+  // Minutes
   m: 'minutes',
   mm: 'minutes',
 
-  // Second
+  // Seconds
   s: 'seconds',
   ss: 'seconds',
 };


### PR DESCRIPTION
No behavior change, will automerge