### PR TITLE
[docs] Improve link from npm to docs

### DIFF
--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },
-  "homepage": "https://mui.com/x/react-date-pickers/getting-started/",
+  "homepage": "https://mui.com/x/react-date-pickers/",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },
-  "homepage": "https://mui.com/x/react-date-pickers/getting-started/",
+  "homepage": "https://mui.com/x/react-date-pickers/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },
-  "homepage": "https://mui.com/x/introduction/",
+  "homepage": "https://mui.com/x/introduction/licensing/",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The goal is to link the page of the docs that is covering as much ground as possible for the related npm package but without being too broad. 