### PR TITLE
[core] Simplify buildPrintWindow

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -38,6 +38,15 @@ type PrintWindowOnLoad = (
   >,
 ) => void;
 
+function buildPrintWindow(title?: string): HTMLIFrameElement {
+  const iframeEl = document.createElement('iframe');
+  iframeEl.style.position = 'absolute';
+  iframeEl.style.width = '0px';
+  iframeEl.style.height = '0px';
+  iframeEl.title = title || document.title;
+  return iframeEl;
+}
+
 /**
  * @requires useGridColumns (state)
  * @requires useGridFilter (state)
@@ -85,18 +94,6 @@ export const useGridPrintExport = (
       }),
     [apiRef],
   );
-
-  // TODO move outside of this scope and remove React.useCallback
-  const buildPrintWindow = React.useCallback((title?: string): HTMLIFrameElement => {
-    const iframeEl = document.createElement('iframe');
-
-    iframeEl.style.position = 'absolute';
-    iframeEl.style.width = '0px';
-    iframeEl.style.height = '0px';
-    iframeEl.title = title || document.title;
-
-    return iframeEl;
-  }, []);
 
   const handlePrintWindowLoad: PrintWindowOnLoad = React.useCallback(
     (printWindow, options): void => {
@@ -290,7 +287,6 @@ export const useGridPrintExport = (
       props,
       logger,
       apiRef,
-      buildPrintWindow,
       handlePrintWindowLoad,
       handlePrintWindowAfterPrint,
       updateGridColumnsForPrint,


### PR DESCRIPTION
a quick cleanup, should improve a bundle bundle size and runtime