### PR TITLE
[docs] Improve link to support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Support ❔
-    url: https://mui.com/getting-started/support/
+    url: https://mui.com/x/introduction/support/
     about: I need support with MUI X.


### PR DESCRIPTION
It updates this link:

<img width="1198" alt="Screenshot 2023-03-05 at 18 19 35" src="https://user-images.githubusercontent.com/3165635/222975677-b1790e64-f54a-4ee6-95af-4f43e7ed1f3c.png">

https://github.com/mui/mui-x/issues/new/choose

I noticed this possible opportunity while I was writing: https://www.notion.so/mui-org/RFC-MUI-X-paid-support-verification-b8fa22d65bb2437c8d6beab5b7f29b5a