### PR TITLE
[docs] Fix a typo in the migration guide

### DIFF
--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -426,7 +426,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
   ```diff
    <DatePicker
   -  renderInput={(inputProps) => <TextField {...props} variant="outlined" />}
-  +  componentsProps={{ input: { variant: 'outlined' }}
+  +  componentsProps={{ textField: { variant: 'outlined' }}
    />
 
    <DateRangePicker
@@ -437,7 +437,7 @@ For example, the `ToolbarComponent` has been replaced by a `Toolbar` component s
   -      <TextField {...endProps} variant="outlined" />
   -    </React.Fragment>
   -  )}
-  +  componentsProps={{ input: { variant: 'outlined' }}
+  +  componentsProps={{ textField: { variant: 'outlined' }}
    />
   ```
 

--- a/packages/x-codemod/src/v6.0.0/pickers/migrate-to-components-componentsProps/actual.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/migrate-to-components-componentsProps/actual.spec.js
@@ -14,7 +14,7 @@ import { DatePicker } from '@mui/x-date-pickers';
 
 <DatePicker
   componentsProps={{
-    input: {
+    textField: {
       InputProps: { color: 'secondary' },
     },
   }} />;


### PR DESCRIPTION
Fixes  #8151