### PR TITLE
[pickers] Don't pass `ownerState` to the `inputAdornment` slot

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -69,7 +69,7 @@ export const useDesktopPicker = <
   });
 
   const InputAdornment = slots.inputAdornment ?? MuiInputAdornment;
-  const inputAdornmentProps = useSlotProps({
+  const { ownerState: inputAdornmentOwnerState, ...inputAdornmentProps } = useSlotProps({
     elementType: InputAdornment,
     externalSlotProps: innerSlotProps?.inputAdornment,
     additionalProps: {


### PR DESCRIPTION
Fixes #8164