### PR TITLE
[DataGrid] Fix `MenuProps.onClose` being overriden for single select edit component

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -67,6 +67,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
 
   const baseSelectProps = rootProps.slotProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? false;
+  const { MenuProps, ...otherSlotProps } = rootProps.slotProps?.baseSelect || {};
 
   useEnhancedEffect(() => {
     if (hasFocus) {
@@ -144,12 +145,13 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
       onOpen={handleOpen}
       MenuProps={{
         onClose: handleClose,
+        ...MenuProps,
       }}
       error={error}
       native={isSelectNative}
       fullWidth
       {...other}
-      {...rootProps.slotProps?.baseSelect}
+      {...otherSlotProps}
     >
       {valueOptions.map((valueOption) => {
         const value = getOptionValue(valueOption);

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -67,7 +67,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
 
   const baseSelectProps = rootProps.slotProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? false;
-  const { MenuProps, ...otherSlotProps } = rootProps.slotProps?.baseSelect || {};
+  const { MenuProps, ...baseSelectProps } = rootProps.slotProps?.baseSelect || {};
 
   useEnhancedEffect(() => {
     if (hasFocus) {
@@ -151,7 +151,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
       native={isSelectNative}
       fullWidth
       {...other}
-      {...otherSlotProps}
+      {...baseSelectProps}
     >
       {valueOptions.map((valueOption) => {
         const value = getOptionValue(valueOption);

--- a/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -67,7 +67,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
 
   const baseSelectProps = rootProps.slotProps?.baseSelect || {};
   const isSelectNative = baseSelectProps.native ?? false;
-  const { MenuProps, ...baseSelectProps } = rootProps.slotProps?.baseSelect || {};
+  const { MenuProps, ...otherBaseSelectProps } = rootProps.slotProps?.baseSelect || {};
 
   useEnhancedEffect(() => {
     if (hasFocus) {
@@ -151,7 +151,7 @@ function GridEditSingleSelectCell(props: GridEditSingleSelectCellProps) {
       native={isSelectNative}
       fullWidth
       {...other}
-      {...baseSelectProps}
+      {...otherBaseSelectProps}
     >
       {valueOptions.map((valueOption) => {
         const value = getOptionValue(valueOption);


### PR DESCRIPTION
Fixes #8166

Before: https://codesandbox.io/s/bug-reproduction-h06vvj?file=/src/App.tsx
After: https://codesandbox.io/s/bug-reproduction-forked-z0f82v?file=/src/App.tsx