### PR TITLE
[pickers] Add a runtime warning when a `renderInput` prop is passed to a picker

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
@@ -4,6 +4,13 @@ import { usePickerValue } from './usePickerValue';
 import { usePickerViews } from './usePickerViews';
 import { usePickerLayoutProps } from './usePickerLayoutProps';
 import { InferError } from '../validation/useValidation';
+import { buildWarning } from '../../utils/warning';
+
+const renderInputWarning = buildWarning([
+  'The `renderInput` prop has been removed in version 6.0 of the Date and Time Pickers',
+  'You can replace it with the `textField` component slot in most cases',
+  'For more information, please have a look at the migration guide (https://mui.com/x/migration/migration-pickers-v5/#input-renderer-required-in-v5).',
+]);
 
 export const usePicker = <
   TValue,
@@ -24,6 +31,10 @@ export const usePicker = <
   TView,
   InferError<TExternalProps>
 > => {
+  if (process.env.NODE_ENV !== 'production') {
+    renderInputWarning();
+  }
+
   const pickerValueResponse = usePickerValue({
     props,
     valueManager,

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
@@ -32,7 +32,9 @@ export const usePicker = <
   InferError<TExternalProps>
 > => {
   if (process.env.NODE_ENV !== 'production') {
-    renderInputWarning();
+    if ((props as any).renderInput != null) {
+      renderInputWarning();
+    }
   }
 
   const pickerValueResponse = usePickerValue({

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
@@ -6,9 +6,9 @@ import { usePickerLayoutProps } from './usePickerLayoutProps';
 import { InferError } from '../validation/useValidation';
 import { buildWarning } from '../../utils/warning';
 
-const renderInputWarning = buildWarning([
-  'The `renderInput` prop has been removed in version 6.0 of the Date and Time Pickers',
-  'You can replace it with the `textField` component slot in most cases',
+const warnRenderInputIsDefined = buildWarning([
+  'The `renderInput` prop has been removed in version 6.0 of the Date and Time Pickers.',
+  'You can replace it with the `textField` component slot in most cases.',
   'For more information, please have a look at the migration guide (https://mui.com/x/migration/migration-pickers-v5/#input-renderer-required-in-v5).',
 ]);
 
@@ -33,7 +33,7 @@ export const usePicker = <
 > => {
   if (process.env.NODE_ENV !== 'production') {
     if ((props as any).renderInput != null) {
-      renderInputWarning();
+      warnRenderInputIsDefined();
     }
   }
 


### PR DESCRIPTION


Fixes #8176