### PR TITLE
[docs] Add a warning in the migration guide for people re-enabling the clock on desktop

### DIFF
--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -130,7 +130,7 @@ const theme = createTheme({
 ```
 
 :::success
-If you are using TypeScript, please make sure you added the [theme augmentation](/x/react-date-pickers/base-concepts/#typescript) to your project.
+If you are using TypeScript, please make sure to add the [theme augmentation](/x/react-date-pickers/base-concepts/#typescript) to your project.
 :::
 
 ### Remove the keyboard view

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -129,7 +129,7 @@ const theme = createTheme({
 });
 ```
 
-:::warning
+:::success
 If you are using TypeScript, please make sure you added the [theme augmentation](/x/react-date-pickers/base-concepts/#typescript) to your project.
 :::
 

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -129,6 +129,10 @@ const theme = createTheme({
 });
 ```
 
+:::warning
+If you are using TypeScript, please make sure you added the [theme augmentation](/x/react-date-pickers/base-concepts/#typescript) to your project.
+:::
+
 ### Remove the keyboard view
 
 The picker components no longer have a keyboard view to render the input inside the modal on mobile.


### PR DESCRIPTION
Should solve #8161 (keeping it open until I have a feedback)