### PR TITLE
[fields] Remove the warning about invalid adapter

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -26,9 +26,6 @@ export const useField = <
   params: UseFieldParams<TValue, TDate, TSection, TForwardedProps, TInternalProps>,
 ): UseFieldResponse<TForwardedProps> => {
   const utils = useUtils<TDate>();
-  if (!utils.formatTokenMap) {
-    throw new Error('This adapter is not compatible with the field components');
-  }
 
   const {
     state,


### PR DESCRIPTION
We now have a warning in `LocalizationProvider` checking that the adapter comes from our packages.
And all adapter from our packages have a token map.
So this warning is never usefull.