### PR TITLE
v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## v6.0.1
+
+_Mar 9, 2023_
+
+We'd like to offer a big thanks to the 8 contributors who made this release possible. Here are some highlights ✨:
+
+- 🌍 Improve French (fr-FR) locale (#8122) @MaherSamiGMC
+- 📚 Documentation improvements
+- 🐞 Bugfixes
+
+### `@mui/x-data-grid@v6.0.1` / `@mui/x-data-grid-pro@v6.0.1` / `@mui/x-data-grid-premium@v6.0.1`
+
+#### Changes
+
+- [DataGrid] Fix `MenuProps.onClose` being overriden for single select edit component (#8174) @rohitnatesh
+- [l10n] Import French (fr-FR) locale (#8122) @MaherSamiGMC
+
+### `@mui/x-date-pickers@v6.0.1` / `@mui/x-date-pickers-pro@v6.0.1`
+
+#### Changes
+
+- [pickers] Add a runtime warning when a `renderInput` prop is passed to a picker (#8183) @flaviendelangle
+- [pickers] Don't pass `ownerState` to the `inputAdornment` slot (#8165) @flaviendelangle
+
+### Docs
+
+- [docs] Fix a typo in the migration guide (#8152) @flaviendelangle
+- [docs] Fix package version used in Codesandbox demos (#8125) @cherniavskii
+- [docs] Fix typos across codebase (#8126) @stavares843
+- [docs] Improve data grid quick filter documentation (#8109) @MBilalShafi
+- [docs] Improve link from npm to docs (#8141) @oliviertassinari
+- [docs] Remove test sections (#8177) @m4theushw
+
+### Core
+
+- [core] Simplify buildPrintWindow (#8142) @oliviertassinari
+- [core] Upgrade monorepo (#8162) @m4theushw
+
 ## 6.0.0
 
 _Mar 3, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 - [DataGrid] Fix `MenuProps.onClose` being overriden for single select edit component (#8174) @rohitnatesh
 - [l10n] Improve French (fr-FR) locale (#8122) @MaherSamiGMC
+- [DataGrid] Simplify `buildPrintWindow` (#8142) @oliviertassinari
 
 ### `@mui/x-date-pickers@v6.0.1` / `@mui/x-date-pickers-pro@v6.0.1`
 
@@ -38,7 +39,6 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 ### Core
 
-- [core] Simplify buildPrintWindow (#8142) @oliviertassinari
 - [core] Upgrade monorepo (#8162) @m4theushw
 
 ## 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## v6.0.1
+## 6.0.1
 
 _Mar 9, 2023_
 
@@ -17,7 +17,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 #### Changes
 
-- [DataGrid] Fix `MenuProps.onClose` being overriden for single select edit component (#8174) @rohitnatesh
+- [DataGrid] Fix `MenuProps.onClose` being overridden for single select edit component (#8174) @rohitnatesh
 - [DataGrid] Simplify `buildPrintWindow` (#8142) @oliviertassinari
 - [l10n] Improve French (fr-FR) locale (#8122) @MaherSamiGMC
 
@@ -33,7 +33,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [docs] Fix a typo in the migration guide (#8152) @flaviendelangle
 - [docs] Fix package version used in CodeSandbox demos (#8125) @cherniavskii
 - [docs] Fix typos across codebase (#8126) @stavares843
-- [docs] Improve data grid quick filter documentation (#8109) @MBilalShafi
+- [docs] Improve Data Grid quick filter documentation (#8109) @MBilalShafi
 - [docs] Improve link from npm to docs (#8141) @oliviertassinari
 - [docs] Remove test sections (#8177) @m4theushw
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 #### Changes
 
 - [DataGrid] Fix `MenuProps.onClose` being overriden for single select edit component (#8174) @rohitnatesh
-- [l10n] Import French (fr-FR) locale (#8122) @MaherSamiGMC
+- [l10n] Improve French (fr-FR) locale (#8122) @MaherSamiGMC
 
 ### `@mui/x-date-pickers@v6.0.1` / `@mui/x-date-pickers-pro@v6.0.1`
 
@@ -30,7 +30,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 ### Docs
 
 - [docs] Fix a typo in the migration guide (#8152) @flaviendelangle
-- [docs] Fix package version used in Codesandbox demos (#8125) @cherniavskii
+- [docs] Fix package version used in CodeSandbox demos (#8125) @cherniavskii
 - [docs] Fix typos across codebase (#8126) @stavares843
 - [docs] Improve data grid quick filter documentation (#8109) @MBilalShafi
 - [docs] Improve link from npm to docs (#8141) @oliviertassinari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 #### Changes
 
 - [DataGrid] Fix `MenuProps.onClose` being overriden for single select edit component (#8174) @rohitnatesh
-- [l10n] Improve French (fr-FR) locale (#8122) @MaherSamiGMC
 - [DataGrid] Simplify `buildPrintWindow` (#8142) @oliviertassinari
+- [l10n] Improve French (fr-FR) locale (#8122) @MaherSamiGMC
 
 ### `@mui/x-date-pickers@v6.0.1` / `@mui/x-date-pickers-pro@v6.0.1`
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "author": "MUI Team",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "scripts": {
     "start": "yarn && yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@mui/base": "^5.0.0-alpha.116",
-    "@mui/x-data-grid-premium": "6.0.0",
+    "@mui/x-data-grid-premium": "6.0.1",
     "chance": "^1.1.11",
     "clsx": "^1.2.1",
     "lru-cache": "^7.16.1"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,9 +44,9 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@mui/utils": "^5.11.7",
-    "@mui/x-data-grid": "6.0.0",
-    "@mui/x-data-grid-pro": "6.0.0",
-    "@mui/x-license-pro": "6.0.0",
+    "@mui/x-data-grid": "6.0.1",
+    "@mui/x-data-grid-pro": "6.0.1",
+    "@mui/x-license-pro": "6.0.1",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "exceljs": "^4.3.0",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,8 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@mui/utils": "^5.11.7",
-    "@mui/x-data-grid": "6.0.0",
-    "@mui/x-license-pro": "6.0.0",
+    "@mui/x-data-grid": "6.0.1",
+    "@mui/x-license-pro": "6.0.1",
     "@types/format-util": "^1.0.2",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -47,8 +47,8 @@
     "@date-io/luxon": "^2.16.1",
     "@date-io/moment": "^2.16.1",
     "@mui/utils": "^5.11.7",
-    "@mui/x-date-pickers": "6.0.0",
-    "@mui/x-license-pro": "6.0.0",
+    "@mui/x-date-pickers": "6.0.1",
+    "@mui/x-license-pro": "6.0.1",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
     "react-transition-group": "^4.4.5"

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license-pro",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",


### PR DESCRIPTION
### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.
- [ ] If `@mui/x-codemod` has been released, set the pre-release package `tag` to `latest` with: `npm dist-tag add @mui/x-codemod@<released_version> latest`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

<!-- #default-branch-switch -->

```sh
git push upstream master:docs-v6 -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v6)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v6` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)