### PR TITLE
[docs] Fix 404 links to customization Material UI APIs

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -232,6 +232,9 @@ export default function ApiPage(props) {
     packages,
   } = pageContent;
 
+  const defaultPropsLink = '/material-ui/customization/theme-components/#default-props';
+  const styleOverridesLink = '/material-ui/customization/theme-components/#global-style-overrides';
+
   const {
     componentDescription,
     componentDescriptionToc = [],
@@ -355,10 +358,10 @@ export default function ApiPage(props) {
             <Heading hash="component-name" />
             <span
               dangerouslySetInnerHTML={{
-                __html: t('api-docs.styleOverrides').replace(
-                  /{{componentStyles\.name}}/,
-                  componentStyles.name,
-                ),
+                __html: t('api-docs.styleOverrides')
+                  .replace(/{{componentStyles\.name}}/, componentStyles.name)
+                  .replace(/{{defaultPropsLink}}/, defaultPropsLink)
+                  .replace(/{{styleOverridesLink}}/, styleOverridesLink),
               }}
             />
           </React.Fragment>


### PR DESCRIPTION
Fix https://app.ahrefs.com/site-audit/3992793/28/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2Ccompliant%2CincomingAllLinks%2Corigin&filterId=91013c8aafad4fe1f7a0ad504eccad42&issueId=c64da643-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating

See the bug on https://mui.com/x/api/date-pickers/date-picker/#component-name

<img width="733" alt="Screenshot 2023-03-10 at 11 47 49" src="https://user-images.githubusercontent.com/3165635/224296799-2e2a6421-74e4-4999-a43a-a2b5805e9894.png">

---

The issue was introduced with https://github.com/mui/material-ui/pull/36008. MUI X uses the translations of the docs-infra. This reinforces that we should remove the duplication of the `ApiPage` component from MUI X to use the docs-infra.

After: https://deploy-preview-8200--material-ui-x.netlify.app/x/api/date-pickers/date-picker/#component-name