### PR TITLE
[DateRangePicker] Allow to override `slotProps.textField`

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -142,8 +142,8 @@ export const useDesktopRangePicker = <
     textField: (ownerState) => {
       const externalInputProps = resolveComponentProps(slotProps?.textField, ownerState);
       return {
-        ...externalInputProps,
         ...(ownerState.position === 'start' ? fieldSlotProps.startInput : fieldSlotProps.endInput),
+        ...externalInputProps,
       };
     },
     root: (ownerState) => {

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.types.ts
@@ -53,7 +53,11 @@ export interface UseDesktopRangePickerSlotsComponentsProps<TDate, TView extends 
   >;
   fieldRoot?: SlotComponentProps<typeof Stack, {}, unknown>;
   fieldSeparator?: SlotComponentProps<typeof Typography, {}, unknown>;
-  textField?: SlotComponentProps<typeof TextField, {}, unknown>;
+  textField?: SlotComponentProps<
+    typeof TextField,
+    {},
+    { position?: 'start' | 'end' } & Record<string, any>
+  >;
   toolbar?: ExportedBaseToolbarProps;
 }
 

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -124,8 +124,8 @@ export const useMobileRangePicker = <
       const externalInputProps = resolveComponentProps(innerSlotProps?.textField, ownerState);
       return {
         ...(isToolbarHidden && { id: `${labelId}-${ownerState.position}` }),
-        ...externalInputProps,
         ...(ownerState.position === 'start' ? fieldSlotProps.startInput : fieldSlotProps.endInput),
+        ...externalInputProps,
       };
     },
     root: (ownerState) => {

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.types.ts
@@ -48,7 +48,11 @@ export interface UseMobileRangePickerSlotsComponentsProps<TDate, TView extends D
   >;
   fieldRoot?: SlotComponentProps<typeof Stack, {}, unknown>;
   fieldSeparator?: SlotComponentProps<typeof Typography, {}, unknown>;
-  textField?: SlotComponentProps<typeof TextField, {}, unknown>;
+  textField?: SlotComponentProps<
+    typeof TextField,
+    {},
+    { position?: 'start' | 'end' } & Record<string, any>
+  >;
   toolbar?: ExportedBaseToolbarProps;
 }
 


### PR DESCRIPTION
Fixes #8196 