### PR TITLE
[docs] Improve contrast on data grid navigation

### DIFF
--- a/docs/data/data-grid/scrolling/scrolling.md
+++ b/docs/data/data-grid/scrolling/scrolling.md
@@ -10,7 +10,7 @@ If the row or column index is not present, the data grid will not do any movemen
 
 The following demo explores the usage of this API:
 
-{{"demo": "ScrollPlayground.js", "bg": true}}
+{{"demo": "ScrollPlayground.js", "bg": "inline"}}
 
 ## apiRef
 


### PR DESCRIPTION
https://mui.com/x/react-data-grid/scrolling/#scrolling-to-specific-cells feels pretty bad with this grey background, there isn't enough contrast. I saw this in https://mui-org.slack.com/archives/C041SDSF32L/p1678786680764649?thread_ts=1678783975.763379&cid=C041SDSF32L.

Preview: https://deploy-preview-8239--material-ui-x.netlify.app/x/react-data-grid/scrolling/#scrolling-to-specific-cells.