### PR TITLE
Align codemod version with other packages

### DIFF
--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-codemod",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "bin": "./codemod.js",
   "private": false,
   "author": "MUI Team",


### PR DESCRIPTION
Made a mistake in https://github.com/mui/mui-x/pull/8258 of not aligning `x-codemod` version with other packages. 🤦 