### PR TITLE
[docs] Update shortcuts page to use slotProps

### DIFF
--- a/docs/data/date-pickers/shortcuts/shortcuts.md
+++ b/docs/data/date-pickers/shortcuts/shortcuts.md
@@ -21,7 +21,7 @@ You can use `slotProps.shortcuts` to customize this prop. For example to add a s
 
 ```jsx
 <DatePicker
-  componentsProps={{
+  slotProps={{
     shortcuts: {
       items: [
         {


### PR DESCRIPTION
In the documentation, the code example is behind the latest changes (use `slotProps`, not `componentProps`)