### PR TITLE
[fields] Cleanup section order generation

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
@@ -5,7 +5,6 @@ import {
   splitFormatIntoSections,
   addPositionPropertiesToSections,
   createDateStrForInputFromSections,
-  getSectionOrder,
 } from '@mui/x-date-pickers/internals';
 import { DateRange, RangePosition } from '../models/range';
 import { splitDateRangeSections, removeLastSeparator } from './date-fields-utils';
@@ -142,15 +141,4 @@ export const rangeFieldValueManager: FieldValueManager<
     };
   },
   hasError: (error) => error[0] != null || error[1] != null,
-  getSectionOrder: (utils, localeText, format, isRTL) => {
-    const splitedFormat = splitFormatIntoSections(utils, localeText, format, null);
-    return getSectionOrder(
-      [
-        ...splitedFormat.slice(0, splitedFormat.length - 1),
-        { ...splitedFormat[splitedFormat.length - 1], endSeparator: ' – ' },
-        ...splitedFormat,
-      ],
-      isRTL,
-    );
-  },
 };

--- a/packages/x-date-pickers/src/internals/hooks/useField/index.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/index.ts
@@ -15,5 +15,4 @@ export {
   splitFormatIntoSections,
   addPositionPropertiesToSections,
   createDateStrForInputFromSections,
-  getSectionOrder,
 } from './useField.utils';

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useForkRef from '@mui/utils/useForkRef';
+import { useTheme } from '@mui/material/styles';
 import { useValidation } from '../validation/useValidation';
 import { useUtils } from '../useUtils';
 import {
@@ -12,7 +13,7 @@ import {
   UseFieldInternalProps,
   AvailableAdjustKeyCode,
 } from './useField.types';
-import { adjustSectionValue, isAndroid, cleanString } from './useField.utils';
+import { adjustSectionValue, isAndroid, cleanString, getSectionOrder } from './useField.utils';
 import { useFieldState } from './useFieldState';
 import { useFieldCharacterEditing } from './useFieldCharacterEditing';
 import { getActiveElement } from '../../utils/utils';
@@ -37,7 +38,6 @@ export const useField = <
     updateSectionValue,
     updateValueFromValueStr,
     setTempAndroidValueStr,
-    sectionOrder,
     sectionsValueBoundaries,
   } = useFieldState(params);
 
@@ -70,6 +70,12 @@ export const useField = <
   const inputRef = React.useRef<HTMLInputElement>(null);
   const handleRef = useForkRef(inputRefProp, inputRef);
   const focusTimeoutRef = React.useRef<NodeJS.Timeout | undefined>(undefined);
+  const theme = useTheme();
+
+  const sectionOrder = React.useMemo(
+    () => getSectionOrder(state.sections, theme.direction === 'rtl'),
+    [theme.direction, state.sections],
+  );
 
   const syncSelectionFromDOM = () => {
     if (readOnly) {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -348,21 +348,6 @@ export interface FieldValueManager<TValue, TDate, TSection extends FieldSection,
    * @returns {boolean} `true` if the current error is not empty.
    */
   hasError: (error: TError) => boolean;
-  /**
-   * Return a description of sections display order. This description is useful in RTL mode.
-   * @template TDate
-   * @param {MuiPickersAdapter<TDate>} utils The utils to manipulate the date.
-   * @param {PickersLocaleText<TDate>} localeText The translation object.
-   * @param {string} format The format from which sections are computed.
-   * @param {boolean} isRTL Is the field in right-to-left orientation.
-   * @returns {SectionOrdering} The description of sections order from left to right.
-   */
-  getSectionOrder: (
-    utils: MuiPickersAdapter<TDate>,
-    localeText: PickersLocaleText<TDate>,
-    format: string,
-    isRTL: boolean,
-  ) => SectionOrdering;
 }
 
 export interface UseFieldState<TValue, TSection extends FieldSection> {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useTheme } from '@mui/material/styles';
 import useControlled from '@mui/utils/useControlled';
 import { useUtils, useLocaleText, useLocalizationContext } from '../useUtils';
 import {
@@ -50,8 +49,6 @@ export const useFieldState = <
   const utils = useUtils<TDate>();
   const localeText = useLocaleText<TDate>();
   const adapter = useLocalizationContext<TDate>();
-  const theme = useTheme();
-  const isRTL = theme.direction === 'rtl';
 
   const {
     valueManager,
@@ -73,11 +70,6 @@ export const useFieldState = <
   const valueFromTheOutside = valueProp ?? firstDefaultValue.current ?? valueManager.emptyValue;
 
   const sectionsValueBoundaries = React.useMemo(() => getSectionsBoundaries<TDate>(utils), [utils]);
-
-  const sectionOrder = React.useMemo(
-    () => fieldValueManager.getSectionOrder(utils, localeText, format, isRTL),
-    [fieldValueManager, format, isRTL, localeText, utils],
-  );
 
   const placeholder = React.useMemo(
     () =>
@@ -414,7 +406,6 @@ export const useFieldState = <
     updateSectionValue,
     updateValueFromValueStr,
     setTempAndroidValueStr,
-    sectionOrder,
     sectionsValueBoundaries,
   };
 };

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -57,7 +57,6 @@ export {
   createDateStrForInputFromSections,
   addPositionPropertiesToSections,
   splitFormatIntoSections,
-  getSectionOrder,
 } from './hooks/useField';
 export type {
   UseFieldInternalProps,

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -8,7 +8,6 @@ import {
   addPositionPropertiesToSections,
   createDateStrForInputFromSections,
   splitFormatIntoSections,
-  getSectionOrder,
 } from '../hooks/useField/useField.utils';
 
 export type SingleItemPickerValueManager<
@@ -61,6 +60,4 @@ export const singleItemFieldValueManager: FieldValueManager<
   parseValueStr: (valueStr, referenceValue, parseDate) =>
     parseDate(valueStr.trim(), referenceValue),
   hasError: (error) => error != null,
-  getSectionOrder: (utils, localeText, format, isRTL) =>
-    getSectionOrder(splitFormatIntoSections(utils, localeText, format, null), isRTL),
 };


### PR DESCRIPTION
@alexfauquette is there something preventing us from using the sections from the state instead of calling `splitFormatIntoSections` just for the section order ?

It simplifies the whole data flow.