### PR TITLE
[fields] Fix Safari input selection resetting regression

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -334,9 +334,11 @@ export const useField = <
 
   useEnhancedEffect(() => {
     if (selectedSectionIndexes == null) {
-      if (inputRef.current!.selectionStart !== 0 || inputRef.current!.selectionEnd !== 0) {
-        // Ensure input selection range is in sync with component selection indexes
-        inputRef.current!.setSelectionRange(0, 0);
+      if (inputRef.current!.scrollLeft) {
+        // Ensure that input content is not marked as selected.
+        // setting selection range to 0 causes issues in Safari.
+        // https://bugs.webkit.org/show_bug.cgi?id=224425
+        inputRef.current!.scrollLeft = 0;
       }
       return;
     }

--- a/packages/x-date-pickers/src/tests/describeValue/testPickerOpenCloseLifeCycle.tsx
+++ b/packages/x-date-pickers/src/tests/describeValue/testPickerOpenCloseLifeCycle.tsx
@@ -84,7 +84,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<any, 'picker'>
       expect(onClose.callCount).to.equal(pickerParams.variant === 'mobile' ? 0 : 1);
     });
 
-    it('should not select any field section after closing on mobile', () => {
+    it('should not select input content after closing on mobile', () => {
       if (pickerParams.variant !== 'mobile') {
         return;
       }
@@ -98,8 +98,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<any, 'picker'>
       } else {
         textbox = getTextbox();
       }
-      expect(textbox.selectionStart).to.be.equal(0);
-      expect(textbox.selectionEnd).to.be.equal(0);
+      expect(textbox.scrollLeft).to.be.equal(0);
     });
 
     it('should call onChange, onClose and onAccept when selecting a value and `props.closeOnSelect` is true', () => {


### PR DESCRIPTION
Fixes #8283 

The previous (initial) implementation was causing a regression due to the fact that in Safari calling `setSelectionRange` causes the input to receive focus.
Source: https://bugs.webkit.org/show_bug.cgi?id=224425

P.S. The state of pickers in Safari is not ideal, there are other, less severe issues that I observed, but they would need a separate investigation on how to solve them.