### PR TITLE
[pickers] Support invalid dates from the field

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
@@ -6,6 +6,7 @@ import {
   addPositionPropertiesToSections,
   createDateStrForInputFromSections,
   getSectionOrder,
+  areDatesEqual,
 } from '@mui/x-date-pickers/internals';
 import { DateRange, RangePosition } from '../models/range';
 import { splitDateRangeSections, removeLastSeparator } from './date-fields-utils';
@@ -28,7 +29,8 @@ export const rangeValueManager: RangePickerValueManager = {
   getTodayValue: (utils) => [utils.date()!, utils.date()!],
   cleanValue: (utils, value) =>
     value.map((date) => replaceInvalidDateByNull(utils, date)) as DateRange<any>,
-  areValuesEqual: (utils, a, b) => utils.isEqual(a[0], b[0]) && utils.isEqual(a[1], b[1]),
+  areValuesEqual: (utils, a, b) =>
+    areDatesEqual(utils, a[0], b[0]) && areDatesEqual(utils, a[1], b[1]),
   isSameError: (a, b) => b !== null && a[1] === b[1] && a[0] === b[0],
   defaultErrorState: [null, null],
 };

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { fireEvent, userEvent } from '@mui/monorepo/test/utils';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import {
+  createPickerRenderer,
+  getTextbox,
+  expectInputPlaceholder,
+  adapterToUse,
+  expectInputValue,
+  buildFieldInteractions,
+} from 'test/utils/pickers-utils';
+
+describe('<DesktopDatePicker /> - Field', () => {
+  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { clickOnInput } = buildFieldInteractions({ clock, render, Component: DesktopDatePicker });
+
+  it('should be able to reset a single section', () => {
+    render(<DesktopDatePicker format={adapterToUse.formats.monthAndDate} />);
+
+    const input = getTextbox();
+    expectInputPlaceholder(input, 'MMMM DD');
+    clickOnInput(input, 1);
+
+    fireEvent.change(input, { target: { value: 'N DD' } }); // Press "1"
+    expectInputValue(input, 'November DD');
+
+    fireEvent.change(input, { target: { value: 'November 4' } }); // Press "1"
+    expectInputValue(input, 'November 4');
+
+    userEvent.keyPress(input, { key: 'Backspace' });
+    expectInputValue(input, 'November DD');
+  });
+});

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -423,8 +423,7 @@ export const useField = <
 
   const inputHasFocus = inputRef.current && inputRef.current === getActiveElement(document);
   const shouldShowPlaceholder =
-    !inputHasFocus &&
-    (!state.value || valueManager.areValuesEqual(utils, state.value, valueManager.emptyValue));
+    !inputHasFocus && valueManager.areValuesEqual(utils, state.value, valueManager.emptyValue);
 
   React.useImperativeHandle(unstableFieldRef, () => ({
     getSections: () => state.sections,

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -130,12 +130,6 @@ interface UsePickerValueAction<DraftValue, TError> {
    */
   skipOnChangeCall?: boolean;
   /**
-   * If `true`, force firing the `onChange` callback
-   * This field takes precedence over `skipOnChangeCall`
-   * @default false
-   */
-  forceOnChangeCall?: boolean;
-  /**
    * Context passed from a deeper component (a field or a calendar).
    */
   contextFromField?: FieldChangeHandlerContext<TError>;
@@ -362,9 +356,8 @@ export const usePickerValue = <
     });
 
     if (
-      params.forceOnChangeCall ||
-      (!params.skipOnChangeCall &&
-        !valueManager.areValuesEqual(utils, dateState.committed, params.value))
+      !params.skipOnChangeCall &&
+      !valueManager.areValuesEqual(utils, dateState.committed, params.value)
     ) {
       setValue(params.value);
 

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -313,17 +313,12 @@ export const usePickerValue = <
   const utils = useUtils<TDate>();
   const adapter = useLocalizationContext<TDate>();
 
-  const [rawValue, setValue] = useControlled({
+  const [value, setValue] = useControlled({
     controlled: inValue,
     default: defaultValue ?? valueManager.emptyValue,
     name: 'usePickerValue',
     state: 'value',
   });
-
-  const value = React.useMemo(
-    () => valueManager.cleanValue(utils, rawValue),
-    [valueManager, utils, rawValue],
-  );
 
   const [selectedSections, setSelectedSections] = useControlled({
     controlled: selectedSectionsProp,
@@ -417,8 +412,6 @@ export const usePickerValue = <
     setDate({
       value: valueManager.emptyValue,
       action: 'acceptAndClose',
-      // force `onChange` in cases like input (value) === `Invalid date`
-      forceOnChangeCall: !valueManager.areValuesEqual(utils, value as any, valueManager.emptyValue),
     });
   });
 
@@ -427,8 +420,6 @@ export const usePickerValue = <
     setDate({
       value: dateState.draft,
       action: 'acceptAndClose',
-      // force `onChange` in cases like input (value) === `Invalid date`
-      forceOnChangeCall: !valueManager.areValuesEqual(utils, dateState.committed, dateState.draft),
     });
   });
 
@@ -512,8 +503,13 @@ export const usePickerValue = <
     onSelectedSectionsChange: handleFieldSelectedSectionsChange,
   };
 
+  const viewValue = React.useMemo(
+    () => valueManager.cleanValue(utils, dateState.draft),
+    [utils, valueManager, dateState.draft],
+  );
+
   const viewResponse: UsePickerValueViewsResponse<TValue> = {
-    value: dateState.draft,
+    value: viewValue,
     onChange: handleChange,
     onClose: handleClose,
     open: isOpen,
@@ -533,7 +529,7 @@ export const usePickerValue = <
 
   const layoutResponse: UsePickerValueLayoutResponse<TValue> = {
     ...actions,
-    value: dateState.draft,
+    value: viewValue,
     onChange: handleChangeAndCommit,
     isValid,
   };

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -131,7 +131,7 @@ export type { DefaultizedProps, MakeOptional } from './models/helpers';
 export type { DateOrTimeView, DateView, TimeView } from './models/views';
 export type { WrapperVariant } from './models/common';
 
-export { applyDefaultDate, replaceInvalidDateByNull } from './utils/date-utils';
+export { applyDefaultDate, replaceInvalidDateByNull, areDatesEqual } from './utils/date-utils';
 export {
   executeInTheNextEventLoopTick,
   getActiveElement,

--- a/packages/x-date-pickers/src/internals/utils/date-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.ts
@@ -101,3 +101,11 @@ export const applyDefaultDate = <TDate>(
 
   return value;
 };
+
+export const areDatesEqual = <TDate>(utils: MuiPickersAdapter<TDate>, a: TDate, b: TDate) => {
+  if (!utils.isValid(a) && a != null && !utils.isValid(b) && b != null) {
+    return true;
+  }
+
+  return utils.isEqual(a, b);
+};

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -3,7 +3,7 @@ import type { DateValidationError } from '../hooks/validation/useDateValidation'
 import type { TimeValidationError } from '../hooks/validation/useTimeValidation';
 import type { DateTimeValidationError } from '../hooks/validation/useDateTimeValidation';
 import type { FieldSection, FieldValueManager } from '../hooks/useField';
-import { replaceInvalidDateByNull } from './date-utils';
+import { areDatesEqual, replaceInvalidDateByNull } from './date-utils';
 import {
   addPositionPropertiesToSections,
   createDateStrForInputFromSections,
@@ -21,7 +21,7 @@ export const singleItemValueManager: SingleItemPickerValueManager = {
   emptyValue: null,
   getTodayValue: (utils) => utils.date()!,
   cleanValue: replaceInvalidDateByNull,
-  areValuesEqual: (utils, a, b) => utils.isEqual(a, b),
+  areValuesEqual: areDatesEqual,
   isSameError: (a, b) => a === b,
   defaultErrorState: null,
 };


### PR DESCRIPTION
Fixes #8296 
Fixes a bug caused by #8287 (not released yet) and #8082

If you clean a section in the field, it now cleans the entire field when used inside a picker ?

Why ? Because the picker replaces `Invalid Date` by `null` in its internal state, to when you clean a section, the field fires `onChange` with the invalid date (#8082), the picker replaces it with `null` and the field updates the sections based on this new value (the fix from #8287 uncovered this broken behavior).

____

The views don't like invalid dates.
That's something we should probably improve at some point.
For now, I just allows to store `Invalid Date` in the picker state and instead replace it with `null` before passing it to the views.
That way the field does receive the `Invalid Date` it asked for.
I also changed the behavior of `valueManager.areValuesEqual` so that two invalid dates are considered equal (otherwise we have an infinite loop).