### PR TITLE
[docs] Fix pro license links to point to the same page

### DIFF
--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Range Field [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Date Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">The Date Range Field components let the user select a date range with the keyboard.</p>
 

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Time Range Field [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Date Time Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">The Date Time Range Field let the user select a range of dates with an explicit starting and ending time with the keyboard.</p>
 

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Time Range Field [<span class="plan-pro"></span>](https://mui.com/store/items/mui-x-pro/)
+# Time Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">The Time Range Field let the user select a range of time with the keyboard.</p>
 


### PR DESCRIPTION
We've discussed that a few pro plan links are pointing to the store, while most other cases point to the licensing page.
The former were updated.