### PR TITLE
[fields] Fix iOS browser scroll jumping when entering data

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -363,7 +363,11 @@ export const useField = <
       selectionStart !== inputRef.current!.selectionStart ||
       selectionEnd !== inputRef.current!.selectionEnd
     ) {
+      // Fix scroll jumping on iOS browser: https://github.com/mui/mui-x/issues/8321
+      const currentScrollTop = inputRef.current!.scrollTop;
       inputRef.current!.setSelectionRange(selectionStart, selectionEnd);
+      // Even reading this variable seems to do the trick, but also setting it just to make use of it
+      inputRef.current!.scrollTop = currentScrollTop;
     }
   });
 


### PR DESCRIPTION
Fixes #8321 

I'm honestly not sure, why it help stop the scroll jumping, even though the `scrollTop` is always 0 as far as I've tested. 🤷 
After all native Apple software is the "new IE" of the world. 😆 