### PR TITLE
[docs] Explain the `shouldDisableTime` migration more in-depth

### DIFF
--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -164,7 +164,7 @@ At some point, the mobile pickers should have a prop allowing to have an editabl
 
 The `shouldDisableTime` prop signature has been changed.
 Previously it did receive `value` as a `number` of hours, minutes, or seconds. Now it will receive the date object (based on the used adapter).
-This will allow more powerful usage and will enable the introduction of different time selection views.
+This will allow more powerful usage and will be compatible with the future digital time selection view.
 
 Either rename the prop to the newly added, but deprecated `shouldDisableClock` or refactor usage to account for the change in prop type.
 The codemod will take care of renaming the prop to keep the existing functionality but feel free to update to the new `shouldDisableTime` prop on your own.

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -164,7 +164,7 @@ At some point, the mobile pickers should have a prop allowing to have an editabl
 
 The `shouldDisableTime` prop signature has been changed.
 Previously it did receive `value` as a `number` of hours, minutes, or seconds. Now it will receive the date object (based on the used adapter).
-It was done to allow for more powerful usage as well as enable the introduction of different time selection views.
+This will allow more powerful usage and will enable the introduction of different time selection views.
 
 Either rename the prop to the newly added, but deprecated `shouldDisableClock` or refactor usage to account for the change in prop type.
 The codemod will take care of renaming the prop to keep the existing functionality but feel free to update to the new `shouldDisableTime` prop on your own.

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -160,9 +160,14 @@ The picker components no longer have a keyboard view to render the input inside 
 At some point, the mobile pickers should have a prop allowing to have an editable field without opening the modal.
 :::
 
-### ✅ Rename `shouldDisableTime` prop
+### ✅ Rename or refactor `shouldDisableTime` prop
 
-The `shouldDisableTime` prop signature has been changed. Either rename the prop to `shouldDisableClock` or refactor usage.
+The `shouldDisableTime` prop signature has been changed.
+Previously it did receive `value` as a `number` of hours, minutes, or seconds. Now it will receive the date object (based on the used adapter).
+It was done to allow for more powerful usage as well as enable the introduction of different time selection views.
+
+Either rename the prop to the newly added, but deprecated `shouldDisableClock` or refactor usage to account for the change in prop type.
+The codemod will take care of renaming the prop to keep the existing functionality but feel free to update to the new `shouldDisableTime` prop on your own.
 
 ```diff
  <DateTimePicker


### PR DESCRIPTION
Fixes #8346 

Extended the `shouldDisableTime` migration documentation to increase the clarity on what has happened, what the codemod will handle, and what should the user do.