### PR TITLE
[l10n] Improve Danish (da-DK) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -51,7 +51,7 @@
     "languageTag": "da-DK",
     "importName": "daDK",
     "localeName": "Danish",
-    "missingKeysCount": 2,
+    "missingKeysCount": 0,
     "totalKeysCount": 94,
     "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/daDK.ts/"
   },

--- a/packages/grid/x-data-grid/src/locales/daDK.ts
+++ b/packages/grid/x-data-grid/src/locales/daDK.ts
@@ -29,7 +29,7 @@ const daDKGrid: Partial<GridLocaleText> = {
   // Quick filter toolbar field
   toolbarQuickFilterPlaceholder: 'Søg…',
   toolbarQuickFilterLabel: 'Søg',
-  // toolbarQuickFilterDeleteIconLabel: 'Clear',
+  toolbarQuickFilterDeleteIconLabel: 'Ryd',
 
   // Export selector toolbar button text
   toolbarExport: 'Eksport',
@@ -134,7 +134,7 @@ const daDKGrid: Partial<GridLocaleText> = {
   unGroupColumn: (name) => `Fjern gruppéring efter ${name}`,
 
   // Master/detail
-  // detailPanelToggle: 'Detail panel toggle',
+  detailPanelToggle: 'Udvid/kollaps detaljepanel',
   expandDetailPanel: 'Udvid',
   collapseDetailPanel: 'Kollaps',
 


### PR DESCRIPTION
Translate the last missing data grid keys for the Danish locale