### PR TITLE
[core] Avoid 301 links

### DIFF
--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -182,9 +182,7 @@ The naming of overridable interfaces uses a pattern like this:
 
 For example, for `columnMenu` slot, the interface name would be `ColumnMenuPropsOverrides`.
 
-<!-- #default-branch-switch -->
-
-This [file](https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts) lists all the interfaces for each slot which could be used for augmentation.
+This [file](https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts) lists all the interfaces for each slot which could be used for augmentation.
 
 ```tsx
 // augment the props for `toolbar` slot

--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -182,7 +182,9 @@ The naming of overridable interfaces uses a pattern like this:
 
 For example, for `columnMenu` slot, the interface name would be `ColumnMenuPropsOverrides`.
 
-This [file](https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts) lists all the interfaces for each slot which could be used for augmentation.
+<!-- #default-branch-switch -->
+
+This [file](https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts) lists all the interfaces for each slot which could be used for augmentation.
 
 ```tsx
 // augment the props for `toolbar` slot

--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -5,7 +5,7 @@
     "localeName": "Arabic (Sudan)",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/arSD.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/arSD.ts"
   },
   {
     "languageTag": "be-BY",
@@ -13,7 +13,7 @@
     "localeName": "Belarusian",
     "missingKeysCount": 1,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/beBY.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/beBY.ts"
   },
   {
     "languageTag": "bg-BG",
@@ -21,7 +21,7 @@
     "localeName": "Bulgarian",
     "missingKeysCount": 7,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/bgBG.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/bgBG.ts"
   },
   {
     "languageTag": "zh-CN",
@@ -29,7 +29,7 @@
     "localeName": "Chinese (Simplified)",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/zhCN.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/zhCN.ts"
   },
   {
     "languageTag": "zh-TW",
@@ -37,7 +37,7 @@
     "localeName": "Chinese (Taiwan)",
     "missingKeysCount": 8,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/zhTW.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/zhTW.ts"
   },
   {
     "languageTag": "cs-CZ",
@@ -45,7 +45,7 @@
     "localeName": "Czech",
     "missingKeysCount": 0,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/csCZ.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/csCZ.ts"
   },
   {
     "languageTag": "da-DK",
@@ -53,7 +53,7 @@
     "localeName": "Danish",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/daDK.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/daDK.ts"
   },
   {
     "languageTag": "nl-NL",
@@ -61,7 +61,7 @@
     "localeName": "Dutch",
     "missingKeysCount": 3,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/nlNL.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/nlNL.ts"
   },
   {
     "languageTag": "fi-FI",
@@ -69,7 +69,7 @@
     "localeName": "Finnish",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/fiFI.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/fiFI.ts"
   },
   {
     "languageTag": "fr-FR",
@@ -77,7 +77,7 @@
     "localeName": "French",
     "missingKeysCount": 8,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/frFR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/frFR.ts"
   },
   {
     "languageTag": "de-DE",
@@ -85,7 +85,7 @@
     "localeName": "German",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/deDE.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/deDE.ts"
   },
   {
     "languageTag": "el-GR",
@@ -93,7 +93,7 @@
     "localeName": "Greek",
     "missingKeysCount": 38,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/elGR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/elGR.ts"
   },
   {
     "languageTag": "he-IL",
@@ -101,7 +101,7 @@
     "localeName": "Hebrew",
     "missingKeysCount": 10,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/heIL.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/heIL.ts"
   },
   {
     "languageTag": "hu-HU",
@@ -109,7 +109,7 @@
     "localeName": "Hungarian",
     "missingKeysCount": 14,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/huHU.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/huHU.ts"
   },
   {
     "languageTag": "it-IT",
@@ -117,7 +117,7 @@
     "localeName": "Italian",
     "missingKeysCount": 8,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/itIT.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/itIT.ts"
   },
   {
     "languageTag": "ja-JP",
@@ -125,7 +125,7 @@
     "localeName": "Japanese",
     "missingKeysCount": 1,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/jaJP.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/jaJP.ts"
   },
   {
     "languageTag": "ko-KR",
@@ -133,7 +133,7 @@
     "localeName": "Korean",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/koKR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/koKR.ts"
   },
   {
     "languageTag": "nb-NO",
@@ -141,7 +141,7 @@
     "localeName": "Norwegian (bokmål)",
     "missingKeysCount": 8,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/nbNO.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/nbNO.ts"
   },
   {
     "languageTag": "fa-IR",
@@ -149,7 +149,7 @@
     "localeName": "Persian",
     "missingKeysCount": 0,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/faIR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/faIR.ts"
   },
   {
     "languageTag": "pl-PL",
@@ -157,7 +157,7 @@
     "localeName": "Polish",
     "missingKeysCount": 9,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/plPL.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/plPL.ts"
   },
   {
     "languageTag": "pt-BR",
@@ -165,7 +165,7 @@
     "localeName": "Portuguese (Brazil)",
     "missingKeysCount": 7,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/ptBR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ptBR.ts"
   },
   {
     "languageTag": "ro-RO",
@@ -173,7 +173,7 @@
     "localeName": "Romanian",
     "missingKeysCount": 8,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/roRO.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/roRO.ts"
   },
   {
     "languageTag": "ru-RU",
@@ -181,7 +181,7 @@
     "localeName": "Russian",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/ruRU.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ruRU.ts"
   },
   {
     "languageTag": "sk-SK",
@@ -189,7 +189,7 @@
     "localeName": "Slovak",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/skSK.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/skSK.ts"
   },
   {
     "languageTag": "es-ES",
@@ -197,7 +197,7 @@
     "localeName": "Spanish",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/esES.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/esES.ts"
   },
   {
     "languageTag": "sv-SE",
@@ -205,7 +205,7 @@
     "localeName": "Swedish",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/svSE.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/svSE.ts"
   },
   {
     "languageTag": "tr-TR",
@@ -213,7 +213,7 @@
     "localeName": "Turkish",
     "missingKeysCount": 2,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/trTR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/trTR.ts"
   },
   {
     "languageTag": "uk-UA",
@@ -221,7 +221,7 @@
     "localeName": "Ukrainian",
     "missingKeysCount": 7,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/ukUA.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ukUA.ts"
   },
   {
     "languageTag": "ur-PK",
@@ -229,7 +229,7 @@
     "localeName": "Urdu (Pakistan)",
     "missingKeysCount": 1,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/urPK.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/urPK.ts"
   },
   {
     "languageTag": "vi-VN",
@@ -237,6 +237,6 @@
     "localeName": "Vietnamese",
     "missingKeysCount": 9,
     "totalKeysCount": 94,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/locales/viVN.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/viVN.ts"
   }
 ]

--- a/docs/data/data-grid/localization/localization.md
+++ b/docs/data/data-grid/localization/localization.md
@@ -6,6 +6,8 @@ The default locale of MUI is English (United States). If you want to use other l
 
 ## Translation keys
 
+<!-- #default-branch-switch -->
+
 You can use the `localeText` prop to pass in your own text and translations.
 You can find all the translation keys supported in [the source](https://github.com/mui/mui-x/blob/HEAD/packages/grid/x-data-grid/src/constants/localeTextConstants.ts)
 in the GitHub repository.

--- a/docs/data/date-pickers/localization/data.json
+++ b/docs/data/date-pickers/localization/data.json
@@ -5,7 +5,7 @@
     "localeName": "Belarusian",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/beBY.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/beBY.ts"
   },
   {
     "languageTag": "zh-CN",
@@ -13,7 +13,7 @@
     "localeName": "Chinese (Simplified)",
     "missingKeysCount": 16,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/zhCN.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/zhCN.ts"
   },
   {
     "languageTag": "cs-CZ",
@@ -21,7 +21,7 @@
     "localeName": "Czech",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/csCZ.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/csCZ.ts"
   },
   {
     "languageTag": "nl-NL",
@@ -29,7 +29,7 @@
     "localeName": "Dutch",
     "missingKeysCount": 8,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/nlNL.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/nlNL.ts"
   },
   {
     "languageTag": "fi-FI",
@@ -37,7 +37,7 @@
     "localeName": "Finnish",
     "missingKeysCount": 12,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/fiFI.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/fiFI.ts"
   },
   {
     "languageTag": "fr-FR",
@@ -45,7 +45,7 @@
     "localeName": "French",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/frFR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/frFR.ts"
   },
   {
     "languageTag": "de-DE",
@@ -53,7 +53,7 @@
     "localeName": "German",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/deDE.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/deDE.ts"
   },
   {
     "languageTag": "he-IL",
@@ -61,7 +61,7 @@
     "localeName": "Hebrew",
     "missingKeysCount": 12,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/heIL.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/heIL.ts"
   },
   {
     "languageTag": "hu-HU",
@@ -69,7 +69,7 @@
     "localeName": "Hungarian",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/huHU.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/huHU.ts"
   },
   {
     "languageTag": "is-IS",
@@ -77,7 +77,7 @@
     "localeName": "Icelandic",
     "missingKeysCount": 12,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/isIS.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/isIS.ts"
   },
   {
     "languageTag": "it-IT",
@@ -85,7 +85,7 @@
     "localeName": "Italian",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/itIT.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/itIT.ts"
   },
   {
     "languageTag": "ja-JP",
@@ -93,7 +93,7 @@
     "localeName": "Japanese",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/jaJP.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/jaJP.ts"
   },
   {
     "languageTag": "ko-KR",
@@ -101,7 +101,7 @@
     "localeName": "Korean",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/koKR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/koKR.ts"
   },
   {
     "languageTag": "nb-NO",
@@ -109,7 +109,7 @@
     "localeName": "Norwegian (bokmål)",
     "missingKeysCount": 16,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/nbNO.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/nbNO.ts"
   },
   {
     "languageTag": "fa-IR",
@@ -117,7 +117,7 @@
     "localeName": "Persian",
     "missingKeysCount": 0,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/faIR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/faIR.ts"
   },
   {
     "languageTag": "pl-PL",
@@ -125,7 +125,7 @@
     "localeName": "Polish",
     "missingKeysCount": 8,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/plPL.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/plPL.ts"
   },
   {
     "languageTag": "pt-BR",
@@ -133,7 +133,7 @@
     "localeName": "Portuguese (Brazil)",
     "missingKeysCount": 12,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/ptBR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/ptBR.ts"
   },
   {
     "languageTag": "ru-RU",
@@ -141,7 +141,7 @@
     "localeName": "Russian",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/ruRU.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/ruRU.ts"
   },
   {
     "languageTag": "es-ES",
@@ -149,7 +149,7 @@
     "localeName": "Spanish",
     "missingKeysCount": 12,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/esES.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/esES.ts"
   },
   {
     "languageTag": "sv-SE",
@@ -157,7 +157,7 @@
     "localeName": "Swedish",
     "missingKeysCount": 16,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/svSE.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/svSE.ts"
   },
   {
     "languageTag": "tr-TR",
@@ -165,7 +165,7 @@
     "localeName": "Turkish",
     "missingKeysCount": 5,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/trTR.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/trTR.ts"
   },
   {
     "languageTag": "uk-UA",
@@ -173,7 +173,7 @@
     "localeName": "Ukrainian",
     "missingKeysCount": 1,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/ukUA.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/ukUA.ts"
   },
   {
     "languageTag": "ur-PK",
@@ -181,6 +181,6 @@
     "localeName": "Urdu (Pakistan)",
     "missingKeysCount": 8,
     "totalKeysCount": 35,
-    "githubLink": "https://github.com/mui/mui-x/blob/-/packages/x-date-pickers/src/locales/urPK.ts/"
+    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/urPK.ts"
   }
 ]

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -25,7 +25,7 @@
     "directory": "packages/x-codemod"
   },
   "license": "MIT",
-  "homepage": "https://github.com/mui/mui-x/blob/-/packages/x-codemod",
+  "homepage": "https://github.com/mui/mui-x/tree/master/packages/x-codemod",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -9,11 +9,13 @@ import * as yargs from 'yargs';
 import { Octokit } from '@octokit/rest';
 import { retry } from '@octokit/plugin-retry';
 import localeNames from './localeNames';
+import nextConfig from '../docs/next.config';
 
 const MyOctokit = Octokit.plugin(retry);
 
 const GIT_ORGANIZATION = 'mui';
 const GIT_REPO = 'mui-x';
+// https://github.com/mui/mui-x/issues/3211
 const L10N_ISSUE_ID = 3211;
 const SOURCE_CODE_REPO = `https://github.com/${GIT_ORGANIZATION}/${GIT_REPO}`;
 
@@ -308,7 +310,6 @@ const generateDocReport = async (
       if (info == null) {
         return;
       }
-      const githubLink = `${SOURCE_CODE_REPO}/blob/-/${info.path}/`;
 
       const languageTag = `${importName.slice(0, 2).toLowerCase()}-${importName
         .slice(2)
@@ -329,7 +330,7 @@ const generateDocReport = async (
         localeName,
         missingKeysCount: infoPerPackage[packageKey].missingKeys.length,
         totalKeysCount: baseTranslationsNumber[packageKey],
-        githubLink,
+        githubLink: `${nextConfig.env.SOURCE_CODE_ROOT_URL}/${info.path}`,
       });
     });
 


### PR DESCRIPTION
This surfaces in https://app.ahrefs.com/site-audit/3523498/61/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CcontentType%2Cdepth%2Credirect%2CincomingAllLinks&filterId=b3b75b6257a370fcf9f1f73befb5deb5&issueId=c64d8847-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating. 

It's a good opportunity to use a link to the base branch so that once we change the default branch, the links on the stable version of the docs stay correct.