### PR TITLE
[docs] Remove `label` from demos where it reduces clarity

### DIFF
--- a/docs/data/date-pickers/adapters-locale/FieldPlaceholder.js
+++ b/docs/data/date-pickers/adapters-locale/FieldPlaceholder.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import 'dayjs/locale/de';
-import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { deDE } from '@mui/x-date-pickers/locales';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -11,17 +11,20 @@ export default function FieldPlaceholder() {
   return (
     <DemoContainer components={['DateField', 'DateField']}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <DateField label="English locale (default)" />
+        <DemoItem label="English locale (default)">
+          <DateField />
+        </DemoItem>
       </LocalizationProvider>
       <LocalizationProvider
         dateAdapter={AdapterDayjs}
         // Define the date locale to have the right format `day.month.year`.
         adapterLocale="de"
-        // Define the translations (component localization) to have the right placeholders.
-        // (e.g. `JJJJ` for the year)
+        // Define the translations to have the right placeholders (e.g. `JJJJ` for the year).
         localeText={germanLocale}
       >
-        <DateField label="German locale" />
+        <DemoItem label="German locale">
+          <DateField />
+        </DemoItem>
       </LocalizationProvider>
     </DemoContainer>
   );

--- a/docs/data/date-pickers/adapters-locale/FieldPlaceholder.tsx
+++ b/docs/data/date-pickers/adapters-locale/FieldPlaceholder.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import 'dayjs/locale/de';
-import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { deDE } from '@mui/x-date-pickers/locales';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -11,17 +11,20 @@ export default function FieldPlaceholder() {
   return (
     <DemoContainer components={['DateField', 'DateField']}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <DateField label="English locale (default)" />
+        <DemoItem label="English locale (default)">
+          <DateField />
+        </DemoItem>
       </LocalizationProvider>
       <LocalizationProvider
         dateAdapter={AdapterDayjs}
         // Define the date locale to have the right format `day.month.year`.
         adapterLocale="de"
-        // Define the translations (component localization) to have the right placeholders.
-        // (e.g. `JJJJ` for the year)
+        // Define the translations to have the right placeholders (e.g. `JJJJ` for the year).
         localeText={germanLocale}
       >
-        <DateField label="German locale" />
+        <DemoItem label="German locale">
+          <DateField />
+        </DemoItem>
       </LocalizationProvider>
     </DemoContainer>
   );

--- a/docs/data/date-pickers/adapters-locale/FieldPlaceholder.tsx.preview
+++ b/docs/data/date-pickers/adapters-locale/FieldPlaceholder.tsx.preview
@@ -1,13 +1,16 @@
 <LocalizationProvider dateAdapter={AdapterDayjs}>
-  <DateField label="English locale (default)" />
+  <DemoItem label="English locale (default)">
+    <DateField />
+  </DemoItem>
 </LocalizationProvider>
 <LocalizationProvider
   dateAdapter={AdapterDayjs}
   // Define the date locale to have the right format `day.month.year`.
   adapterLocale="de"
-  // Define the translations (component localization) to have the right placeholders.
-  // (e.g. `JJJJ` for the year)
+  // Define the translations to have the right placeholders (e.g. `JJJJ` for the year).
   localeText={germanLocale}
 >
-  <DateField label="German locale" />
+  <DemoItem label="German locale">
+    <DateField />
+  </DemoItem>
 </LocalizationProvider>

--- a/docs/data/date-pickers/overview/CommonlyUsedComponents.js
+++ b/docs/data/date-pickers/overview/CommonlyUsedComponents.js
@@ -71,7 +71,12 @@ export default function CommonlyUsedComponents() {
           }
           component="DateRangePicker"
         >
-          <DateRangePicker />
+          <DateRangePicker
+            localeText={{
+              start: '',
+              end: '',
+            }}
+          />
         </DemoItem>
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/overview/CommonlyUsedComponents.tsx
+++ b/docs/data/date-pickers/overview/CommonlyUsedComponents.tsx
@@ -72,7 +72,12 @@ export default function CommonlyUsedComponents() {
           }
           component="DateRangePicker"
         >
-          <DateRangePicker />
+          <DateRangePicker
+            localeText={{
+              start: '',
+              end: '',
+            }}
+          />
         </DemoItem>
       </DemoContainer>
     </LocalizationProvider>


### PR DESCRIPTION
Refactor demos where having `label` reduces the clarity of the idea that is trying to be portrayed.

## Comparison

### Before
![Screenshot 2023-03-28 at 16 00 44](https://user-images.githubusercontent.com/4941090/228244426-5b38ca55-4d67-4d7d-8d0e-37db6a48b3e1.png)

### After
![Screenshot 2023-03-28 at 16 00 49](https://user-images.githubusercontent.com/4941090/228244490-341f8136-55a6-4aa5-8a29-17c2290e1b1e.png)


___

### Before
![Screenshot 2023-03-28 at 16 00 05](https://user-images.githubusercontent.com/4941090/228244583-7f4faeaf-928f-4f63-b78a-eaf129705a91.png)

### After
![Screenshot 2023-03-28 at 16 00 16](https://user-images.githubusercontent.com/4941090/228244623-975d698d-8342-4f9a-aac9-3bf3d8144a0f.png)
