### PR TITLE
[docs] Fix `GridCellParams` signature in migration guide

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -458,7 +458,7 @@ Most of this breaking change is handled by `preset-safe` codemod but some furthe
 
   ```diff
   -renderCell: (params: GridRenderCellParams<number>) => {
-  +renderCell: (params: GridRenderCellParams<any, any, number>) => {
+  +renderCell: (params: GridRenderCellParams<any, number>) => {
   ```
 
 - The `GridErrorOverlay` component was removed.


### PR DESCRIPTION
This was pointed out by our user through docs feedback.