### PR TITLE
[docs] Improve and reorganize sections on editing page

### DIFF
--- a/docs/data/data-grid/editing/BasicEditingGrid.js
+++ b/docs/data/data-grid/editing/BasicEditingGrid.js
@@ -16,7 +16,14 @@ export default function BasicEditingGrid() {
 
 const columns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/BasicEditingGrid.tsx
+++ b/docs/data/data-grid/editing/BasicEditingGrid.tsx
@@ -16,7 +16,14 @@ export default function BasicEditingGrid() {
 
 const columns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/BasicRowEditingGrid.js
+++ b/docs/data/data-grid/editing/BasicRowEditingGrid.js
@@ -16,7 +16,14 @@ export default function BasicRowEditingGrid() {
 
 const columns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/BasicRowEditingGrid.tsx
+++ b/docs/data/data-grid/editing/BasicRowEditingGrid.tsx
@@ -16,7 +16,14 @@ export default function BasicRowEditingGrid() {
 
 const columns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/DisableStopEditModeOnFocusOut.js
+++ b/docs/data/data-grid/editing/DisableStopEditModeOnFocusOut.js
@@ -24,7 +24,14 @@ export default function DisableStopEditModeOnFocusOut() {
 
 const columns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/DisableStopEditModeOnFocusOut.tsx
+++ b/docs/data/data-grid/editing/DisableStopEditModeOnFocusOut.tsx
@@ -31,7 +31,14 @@ export default function DisableStopEditModeOnFocusOut() {
 
 const columns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
@@ -12,6 +12,7 @@ import {
   DataGridPro,
   GridToolbarContainer,
   GridActionsCellItem,
+  GridRowEditStopReasons,
 } from '@mui/x-data-grid-pro';
 import {
   randomCreatedDate,
@@ -21,9 +22,8 @@ import {
 
 const roles = ['Market', 'Finance', 'Development'];
 const randomRole = () => {
-  let random = Math.random() * roles.length;
-  let index = Math.floor(random);
-  return roles[index];
+  const randomIndex = Math.floor(Math.random() * roles.length);
+  return roles[randomIndex];
 };
 
 const initialRows = [
@@ -95,7 +95,9 @@ export default function FullFeaturedCrudGrid() {
   const [rowModesModel, setRowModesModel] = React.useState({});
 
   const handleRowEditStop = (params, event) => {
-    event.defaultMuiPrevented = true;
+    if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+      event.defaultMuiPrevented = true;
+    }
   };
 
   const handleEditClick = (id) => () => {

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
@@ -182,7 +182,7 @@ export default function FullFeaturedCrudGrid() {
             <GridActionsCellItem
               icon={<CancelIcon />}
               label="Cancel"
-              className="primary"
+              className="textPrimary"
               onClick={handleCancelClick(id)}
               color="inherit"
             />,

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
@@ -16,45 +16,51 @@ import {
 import {
   randomCreatedDate,
   randomTraderName,
-  randomUpdatedDate,
   randomId,
 } from '@mui/x-data-grid-generator';
+
+const roles = ['Market', 'Finance', 'Development'];
+const randomRole = () => {
+  let random = Math.random() * roles.length;
+  let index = Math.floor(random);
+  return roles[index];
+};
 
 const initialRows = [
   {
     id: randomId(),
     name: randomTraderName(),
     age: 25,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 36,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 19,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 28,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 23,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
 ];
 
@@ -87,10 +93,6 @@ EditToolbar.propTypes = {
 export default function FullFeaturedCrudGrid() {
   const [rows, setRows] = React.useState(initialRows);
   const [rowModesModel, setRowModesModel] = React.useState({});
-
-  const handleRowEditStart = (params, event) => {
-    event.defaultMuiPrevented = true;
-  };
 
   const handleRowEditStop = (params, event) => {
     event.defaultMuiPrevented = true;
@@ -132,20 +134,29 @@ export default function FullFeaturedCrudGrid() {
 
   const columns = [
     { field: 'name', headerName: 'Name', width: 180, editable: true },
-    { field: 'age', headerName: 'Age', type: 'number', editable: true },
     {
-      field: 'dateCreated',
-      headerName: 'Date Created',
+      field: 'age',
+      headerName: 'Age',
+      type: 'number',
+      width: 80,
+      align: 'left',
+      headerAlign: 'left',
+      editable: true,
+    },
+    {
+      field: 'joinDate',
+      headerName: 'Join date',
       type: 'date',
       width: 180,
       editable: true,
     },
     {
-      field: 'lastLogin',
-      headerName: 'Last Login',
-      type: 'dateTime',
+      field: 'role',
+      headerName: 'Department',
       width: 220,
       editable: true,
+      type: 'singleSelect',
+      valueOptions: ['Market', 'Finance', 'Development'],
     },
     {
       field: 'actions',
@@ -161,12 +172,15 @@ export default function FullFeaturedCrudGrid() {
             <GridActionsCellItem
               icon={<SaveIcon />}
               label="Save"
+              sx={{
+                color: 'primary.main',
+              }}
               onClick={handleSaveClick(id)}
             />,
             <GridActionsCellItem
               icon={<CancelIcon />}
               label="Cancel"
-              className="textPrimary"
+              className="primary"
               onClick={handleCancelClick(id)}
               color="inherit"
             />,
@@ -211,7 +225,6 @@ export default function FullFeaturedCrudGrid() {
         editMode="row"
         rowModesModel={rowModesModel}
         onRowModesModelChange={handleRowModesModelChange}
-        onRowEditStart={handleRowEditStart}
         onRowEditStop={handleRowEditStop}
         processRowUpdate={processRowUpdate}
         slots={{

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -27,41 +27,48 @@ import {
   randomId,
 } from '@mui/x-data-grid-generator';
 
+const roles = ['Market', 'Finance', 'Development'];
+const randomRole = () => {
+  let random = Math.random() * roles.length;
+  let index = Math.floor(random);
+  return roles[index];
+};
+
 const initialRows: GridRowsProp = [
   {
     id: randomId(),
     name: randomTraderName(),
     age: 25,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 36,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 19,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 28,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
   {
     id: randomId(),
     name: randomTraderName(),
     age: 23,
-    dateCreated: randomCreatedDate(),
-    lastLogin: randomUpdatedDate(),
+    joinDate: randomCreatedDate(),
+    role: randomRole(),
   },
 ];
 
@@ -96,13 +103,6 @@ function EditToolbar(props: EditToolbarProps) {
 export default function FullFeaturedCrudGrid() {
   const [rows, setRows] = React.useState(initialRows);
   const [rowModesModel, setRowModesModel] = React.useState<GridRowModesModel>({});
-
-  const handleRowEditStart = (
-    params: GridRowParams,
-    event: MuiEvent<React.SyntheticEvent>,
-  ) => {
-    event.defaultMuiPrevented = true;
-  };
 
   const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
     event.defaultMuiPrevented = true;
@@ -144,20 +144,29 @@ export default function FullFeaturedCrudGrid() {
 
   const columns: GridColDef[] = [
     { field: 'name', headerName: 'Name', width: 180, editable: true },
-    { field: 'age', headerName: 'Age', type: 'number', editable: true },
     {
-      field: 'dateCreated',
-      headerName: 'Date Created',
+      field: 'age',
+      headerName: 'Age',
+      type: 'number',
+      width: 80,
+      align: 'left',
+      headerAlign: 'left',
+      editable: true,
+    },
+    {
+      field: 'joinDate',
+      headerName: 'Join date',
       type: 'date',
       width: 180,
       editable: true,
     },
     {
-      field: 'lastLogin',
-      headerName: 'Last Login',
-      type: 'dateTime',
+      field: 'role',
+      headerName: 'Department',
       width: 220,
       editable: true,
+      type: 'singleSelect',
+      valueOptions: ['Market', 'Finance', 'Development'],
     },
     {
       field: 'actions',
@@ -173,12 +182,15 @@ export default function FullFeaturedCrudGrid() {
             <GridActionsCellItem
               icon={<SaveIcon />}
               label="Save"
+              sx={{
+                color: 'primary.main',
+              }}
               onClick={handleSaveClick(id)}
             />,
             <GridActionsCellItem
               icon={<CancelIcon />}
               label="Cancel"
-              className="textPrimary"
+              className="primary"
               onClick={handleCancelClick(id)}
               color="inherit"
             />,
@@ -223,7 +235,6 @@ export default function FullFeaturedCrudGrid() {
         editMode="row"
         rowModesModel={rowModesModel}
         onRowModesModelChange={handleRowModesModelChange}
-        onRowEditStart={handleRowEditStart}
         onRowEditStop={handleRowEditStop}
         processRowUpdate={processRowUpdate}
         slots={{

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -12,26 +12,23 @@ import {
   GridRowModes,
   DataGridPro,
   GridColDef,
-  GridRowParams,
-  MuiEvent,
   GridToolbarContainer,
   GridActionsCellItem,
   GridEventListener,
   GridRowId,
   GridRowModel,
+  GridRowEditStopReasons,
 } from '@mui/x-data-grid-pro';
 import {
   randomCreatedDate,
   randomTraderName,
-  randomUpdatedDate,
   randomId,
 } from '@mui/x-data-grid-generator';
 
 const roles = ['Market', 'Finance', 'Development'];
 const randomRole = () => {
-  let random = Math.random() * roles.length;
-  let index = Math.floor(random);
-  return roles[index];
+  const randomIndex = Math.floor(Math.random() * roles.length);
+  return roles[randomIndex];
 };
 
 const initialRows: GridRowsProp = [
@@ -103,9 +100,11 @@ function EditToolbar(props: EditToolbarProps) {
 export default function FullFeaturedCrudGrid() {
   const [rows, setRows] = React.useState(initialRows);
   const [rowModesModel, setRowModesModel] = React.useState<GridRowModesModel>({});
-
+  
   const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
-    event.defaultMuiPrevented = true;
+    if (params.reason === GridRowEditStopReasons.rowFocusOut) {
+      event.defaultMuiPrevented = true;
+    }
   };
 
   const handleEditClick = (id: GridRowId) => () => {

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -100,7 +100,7 @@ function EditToolbar(props: EditToolbarProps) {
 export default function FullFeaturedCrudGrid() {
   const [rows, setRows] = React.useState(initialRows);
   const [rowModesModel, setRowModesModel] = React.useState<GridRowModesModel>({});
-  
+
   const handleRowEditStop: GridEventListener<'rowEditStop'> = (params, event) => {
     if (params.reason === GridRowEditStopReasons.rowFocusOut) {
       event.defaultMuiPrevented = true;

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -189,7 +189,7 @@ export default function FullFeaturedCrudGrid() {
             <GridActionsCellItem
               icon={<CancelIcon />}
               label="Cancel"
-              className="primary"
+              className="textPrimary"
               onClick={handleCancelClick(id)}
               color="inherit"
             />,

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
@@ -4,7 +4,6 @@
   editMode="row"
   rowModesModel={rowModesModel}
   onRowModesModelChange={handleRowModesModelChange}
-  onRowEditStart={handleRowEditStart}
   onRowEditStop={handleRowEditStop}
   processRowUpdate={processRowUpdate}
   slots={{

--- a/docs/data/data-grid/editing/IsCellEditableGrid.js
+++ b/docs/data/data-grid/editing/IsCellEditableGrid.js
@@ -30,7 +30,14 @@ export default function IsCellEditableGrid() {
 
 const columns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/IsCellEditableGrid.tsx
+++ b/docs/data/data-grid/editing/IsCellEditableGrid.tsx
@@ -30,7 +30,14 @@ export default function IsCellEditableGrid() {
 
 const columns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/ServerSidePersistence.js
+++ b/docs/data/data-grid/editing/ServerSidePersistence.js
@@ -69,7 +69,14 @@ export default function ServerSidePersistence() {
 
 const columns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/ServerSidePersistence.tsx
+++ b/docs/data/data-grid/editing/ServerSidePersistence.tsx
@@ -86,7 +86,14 @@ export default function ServerSidePersistence() {
 
 const columns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/data/data-grid/editing/StartEditButtonGrid.js
@@ -147,7 +147,14 @@ export default function StartEditButtonGrid() {
 
 const columns = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/data/data-grid/editing/StartEditButtonGrid.tsx
@@ -160,7 +160,14 @@ export default function StartEditButtonGrid() {
 
 const columns: GridColDef[] = [
   { field: 'name', headerName: 'Name', width: 180, editable: true },
-  { field: 'age', headerName: 'Age', type: 'number', editable: true },
+  {
+    field: 'age',
+    headerName: 'Age',
+    type: 'number',
+    editable: true,
+    align: 'left',
+    headerAlign: 'left',
+  },
   {
     field: 'dateCreated',
     headerName: 'Date Created',

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -2,6 +2,18 @@
 
 <p class="description">The data grid has built-in support for cell and row editing.</p>
 
+## Full-featured CRUD component
+
+The Data Grid can be used to visualize data, but it also allows editing a data set.
+
+The following demo shows a full-featured CRUD (Create, Read, Update, Delete) typically found in enterprise applications.
+
+::: info
+You will find the details of each editing API in the next sections.
+:::
+
+{{"demo": "FullFeaturedCrudGrid.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Making a column editable
 
 You can make a column editable by enabling the `editable` property in its [column definition](/x/api/data-grid/grid-col-def/):
@@ -414,14 +426,6 @@ By design, when changing the value of a cell all `preProcessEditCellProps` callb
 This lets you apply conditional validation where the value of a cell impacts the validation status of another cell in the same row.
 If you only want to run validation when the value has changed, check if the `hasChanged` param is `true`.
 :::
-
-### Full-featured CRUD component
-
-Row editing makes it possible to create a full-featured CRUD (Create, Read, Update, Delete) component similar to those found in enterprise applications.
-In the following demo, the typical ways to start and stop editing are all disabled.
-Instead, use the buttons available in each row or in the toolbar.
-
-{{"demo": "FullFeaturedCrudGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Advanced use cases
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -4,8 +4,7 @@
 
 ## Full-featured CRUD component
 
-The Data Grid can be used to visualize data, but it also allows editing a data set.
-
+The Data Grid is not only a data visualization tool. It offers built-in editing features for you to manage your data set.
 The following demo shows a full-featured CRUD (Create, Read, Update, Delete) typically found in enterprise applications.
 
 ::: info
@@ -23,18 +22,43 @@ You can make a column editable by enabling the `editable` property in its [colum
 ```
 
 This lets the user edit any cell from the specified column.
-By default, only one cell at a time can have its `editMode` prop set to `"edit"`.
-To let your users edit all cells in a given row simultaneously, set the `editMode` prop to `"row"`.
-For more information, see [the section on row editing](#row-editing).
 
 The following demo shows an example of how to make all columns editable.
-Play with it by double-clicking or pressing <kbd class="key">Enter</kbd> in any cell from this column:
+Play with it by double-clicking or pressing <kbd class="key">Enter</kbd> in any cell.
 
 {{"demo": "BasicEditingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
+## Editing the entire row
+
+By default, only one cell can be editable at a time.
+But you can let your user edit all cells in a row simultaneously.
+
+To enable this behavior, set the `editMode` prop on the Data Grid to `"row"`. Note that you'll still need to set the `editable` property in each column definition to specify which of them are editable; the same basic rules for cell editing also apply to row editing.
+
+```tsx
+<DataGrid editMode="row" columns={[{ field: 'name', editable: true }]} />
+```
+
+The following demo illustrates how row editing works.
+The user can [start](#start-editing) and [stop](#stop-editing) editing a row using the same actions as those provided for cell editing (e.g. double-clicking a cell).
+
+{{"demo": "BasicRowEditingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
+
+:::warning
+By design, when changing the value of a cell all `preProcessEditCellProps` callbacks from other columns are also called.
+This lets you apply conditional validation where the value of a cell impacts the validation status of another cell in the same row.
+If you only want to run validation when the value has changed, check if the `hasChanged` param is `true`.
+
+For more details on how to use `preProcessEditCellProps`, please check the editing [validation](#validation) section.
+:::
+
+## Switching between edit and view modes
+
+Each cell and row has two modes: `edit` and `view`. When in `edit` mode, users can directly change the content of a cell or a row.
+
 ### Start editing
 
-Users can start editing a cell (or row if `editMode="row"`) with any of the following actions:
+When a cell is in `view` mode, users can start editing a cell (or row if `editMode="row"`) with any of the following actions:
 
 - Double-clicking a cell
 - Pressing <kbd class="key">Enter</kbd>, <kbd class="key">Backspace</kbd> or <kbd class="key">Delete</kbd>—note that the latter two options both delete any existing content
@@ -53,7 +77,7 @@ Users can start editing a cell (or row if `editMode="row"`) with any of the foll
 
 ### Stop editing
 
-When a cell is in edit mode, the user can stop editing with any of the following interactions:
+When a cell is in `edit` mode, the user can stop editing with any of the following interactions:
 
 - Pressing <kbd class="key">Escape</kbd>—this also reverts any changes made
 - Pressing <kbd class="key">Tab</kbd>—this also saves any changes made
@@ -86,6 +110,29 @@ When a cell is in edit mode, the user can stop editing with any of the following
   });
   ```
 
+### Listening edit events
+
+The interactions that [start](#start-editing) and [stop](#stop-editing) trigger `'cellEditStart'` and `'cellEditStop'` [events](/x/react-data-grid/events/), respectively.
+For [row editing](#editing-the-entire-row), the events are `'rowEditStart'` and `'rowEditStop'`.
+You can control how these events are handled to customize editing behavior.
+
+For convenience, you can also listen to these events using their respective props:
+
+- `onCellEditStart`
+- `onCellEditStop`
+- `onRowEditStart`
+- `onRowEditStop`
+
+These events and props are called with an object containing the row ID and column field of the cell that is being edited.
+The object also contains a `reason` param that specifies which type of interaction caused the event to be fired—for instance, `'cellDoubleClick'` when a double-click initiates edit mode.
+
+The following demo shows how to prevent the user from exiting edit mode when clicking outside of a cell.
+To do this, the `onCellEditStop` prop is used to check if the `reason` is `'cellFocusOut'`.
+If that condition is true, it [disables](/x/react-data-grid/events/#disabling-the-default-behavior) the default event behavior.
+In this context, the user can only stop editing a cell by pressing <kbd class="key">Enter</kbd>, <kbd class="key">Escape</kbd> or <kbd class="key">Tab</kbd>.
+
+{{"demo": "DisableStopEditModeOnFocusOut.js", "bg": "inline"}}
+
 ### Disable editing of specific cells within a row
 
 The `editable` property controls which cells are editable at the column level.
@@ -96,6 +143,62 @@ In the following demo, only the rows with an even `Age` value are editable.
 The editable cells have a green background for better visibility.
 
 {{"demo": "IsCellEditableGrid.js", "bg": "inline"}}
+
+## Server-side persistence
+
+### The `processRowUpdate` callback
+
+When the user performs an action to [stop editing](#stop-editing), the `processRowUpdate` callback is triggered.
+Use it to send the new values to the server and save them into a database or other storage method.
+The callback is called with two arguments:
+
+1. The updated row with the new values returned by the [`valueSetter`](#value-parser-and-value-setter).
+2. The original values of the row before editing.
+
+Please note the `processRowUpdate` must return the row object to update the Data Grid internal state.
+The value returned is used later as an argument on a call to `apiRef.current.updateRows`.
+
+```tsx
+<DataGrid
+  rows={rows}
+  columns={columns}
+  processRowUpdate={(updatedRow, originalRow) =>
+    mySaveOnServerFunction(updatedRow, originalRow)
+  }
+  onProcessRowUpdateError={handleProcessRowUpdateError}
+/>
+```
+
+### Server validation
+
+If you need to cancel the save process on `processRowUpdate`—for instance, when a database validation fails, or the user wants to reject the changes—there are two options:
+
+1. Reject the promise so that the internal state is not updated and the cell remains in edit mode.
+2. Resolve the promise with the second argument (original row before editing), so that the internal state is not updated, and the cell exits edit mode.
+
+The following demo implements the first option: rejecting the promise.
+Instead of [validating](#validation) while typing, it simulates validation on the server.
+If the new name is empty, the promise responsible for saving the row will be rejected, and the cell will remain in edit mode.
+
+The demo also shows that `processRowUpdate` can pre-process the row model that will be saved into the internal state.
+
+Additionally, `onProcessRowUpdateError` is called to display the error message.
+
+To exit edit mode, press <kbd class="key">Escape</kbd> or enter a valid name.
+
+{{"demo": "ServerSidePersistence.js", "bg": "inline", "defaultCodeOpen": false}}
+
+### Confirm before saving
+
+The second option—resolving the promise with the second argument—lets the user cancel the save process by rejecting the changes and exiting the edit mode.
+In this case, `processRowUpdate` is resolved with the original value(s) of the row.
+
+The following demo shows how this approach can be used to ask for confirmation before sending the data to the server.
+If the user accepts the change, the internal state is updated with the values.
+But if the changes are rejected, the internal state remains unchanged, and the cell is reverted back to its original value.
+The demo also employs validation to prevent entering an empty name.
+
+{{"demo": "AskConfirmationBeforeSave.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Value parser and value setter
 
@@ -132,32 +235,47 @@ The `valueParser` capitalizes the value entered, and the `valueSetter` splits th
 
 {{"demo": "ValueParserSetterGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Events
+## Validation
 
-The mouse and keyboard interactions that [start](#start-editing) and [stop](#stop-editing) cell editing do so by triggering the `'cellEditStart'` and `'cellEditStop'` [events](/x/react-data-grid/events/), respectively.
-For row editing, the events are `'rowEditStart'` and `'rowEditStop'`.
-You can control how these events are handled to customize editing behavior.
+If the column definition sets a callback for the `preProcessEditCellProps` property, then it will be called each time a new value is entered into a cell from this column.
+This property lets you pre-process the props that are passed to the edit component.
+The `preProcessEditCellProps` callback is called with an object containing the following attributes:
 
-For convenience, you can also listen to these events using their respective props:
+- `id`: the row ID
+- `row`: the row model containing the value(s) of the cell or row before entering edit mode
+- `props`: the props, containing the value after the value parser, that are passed to the edit component
+- `hasChanged`: determines if `props.value` is different from the last time this callback was called
 
-- `onCellEditStart`
-- `onCellEditStop`
-- `onRowEditStart`
-- `onRowEditStop`
+Data validation is one type of pre-processing that can be done in this way.
+To validate the data entered, pass a callback to `preProcessEditCellProps` checking if `props.value` is valid.
+If the new value is invalid, set `props.error` to a truthy value and return the modified props, as shown in the example below.
+When the user tries to save the updated value, the change will be rejected if the error attribute is truthy (invalid).
 
-These events and props are called with an object containing the row ID and column field of the cell that is being edited.
-The object also contains a `reason` param that specifies which type of interaction caused the event to be fired—for instance, `'cellDoubleClick'` when a double-click initiates edit mode.
+```tsx
+const columns: GridColDef[] = [
+  {
+    field: 'firstName',
+    preProcessEditCellProps: (params: GridPreProcessEditCellProps) => {
+      const hasError = params.props.value.length < 3;
+      return { ...params.props, error: hasError };
+    },
+  },
+];
+```
 
-The following demo shows how to prevent the user from exiting edit mode when clicking outside of a cell.
-To do this, the `onCellEditStop` prop is used to check if the `reason` is `'cellFocusOut'`.
-If that condition is true, it [disables](/x/react-data-grid/events/#disabling-the-default-behavior) the default event behavior.
-In this context, the user can only stop editing a cell by pressing <kbd class="key">Enter</kbd>, <kbd class="key">Escape</kbd> or <kbd class="key">Tab</kbd>.
+:::warning
+Changing `props.value` inside the callback has no effect. To pre-process it, use a [value parser](#value-parser-and-value-setter).
+:::
 
-{{"demo": "DisableStopEditModeOnFocusOut.js", "bg": "inline"}}
+The demo below contains an example of server-side data validation.
+In this case, the callback returns a promise that resolves to the modified props.
+Note that the value passed to `props.error` is passed directly to the edit component as the `error` prop.
+While the promise is not resolved, the edit component will receive an `isProcessingProps` prop with value equal to `true`.
 
-## Controlled mode
+{{"demo": "ValidateServerNameGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
-Each cell and row has two modes: `edit` and `view`.
+## Controlled model
+
 You can control the active mode using the props `cellModesModel` and `rowModesModel` (only works if `editMode="row"`).
 
 The `cellModesModel` prop accepts an object containing the `mode` (and additional options) for a given column field, in a given row, as in the following example.
@@ -205,83 +323,6 @@ The options passed to both model props only take effect when `mode` changes.
 Updating the params of a cell or row, but keeping the same `mode`, makes the cell or row to stay in the same mode.
 Also, removing one field or row ID from the object will not cause the missing cell or row to go to `"view"` mode.
 :::
-
-## Validation
-
-If the column definition sets a callback for the `preProcessEditCellProps` property, then it will be called each time a new value is entered into a cell from this column.
-This property lets you pre-process the props that are passed to the edit component.
-The `preProcessEditCellProps` callback is called with an object containing the following attributes:
-
-- `id`: the row ID
-- `row`: the row model containing the value(s) of the cell or row before entering edit mode
-- `props`: the props, containing the value after the value parser, that are passed to the edit component
-- `hasChanged`: determines if `props.value` is different from the last time this callback was called
-
-Data validation is one type of pre-processing that can be done in this way.
-To validate the data entered, pass a callback to `preProcessEditCellProps` checking if `props.value` is valid.
-If the new value is invalid, set `props.error` to a truthy value and return the modified props, as shown in the example below.
-When the user tries to save the updated value, the change will be rejected if the error attribute is truthy (invalid).
-
-```tsx
-const columns: GridColDef[] = [
-  {
-    field: 'firstName',
-    preProcessEditCellProps: (params: GridPreProcessEditCellProps) => {
-      const hasError = params.props.value.length < 3;
-      return { ...params.props, error: hasError };
-    },
-  },
-];
-```
-
-:::warning
-Changing `props.value` inside the callback has no effect. To pre-process it, use a [value parser](#value-parser-and-value-setter).
-:::
-
-The demo below contains an example of server-side data validation.
-In this case, the callback returns a promise that resolves to the modified props.
-Note that the value passed to `props.error` is passed directly to the edit component as the `error` prop.
-While the promise is not resolved, the edit component will receive an `isProcessingProps` prop with value equal to `true`.
-
-{{"demo": "ValidateServerNameGrid.js", "bg": "inline", "defaultCodeOpen": false}}
-
-## Persistence
-
-The `processRowUpdate` prop is called when the user performs an action to [stop editing](#stop-editing).
-Use this prop to send the new values to the server and save them into a database or other storage method.
-The prop is called with two arguments:
-
-1. the updated row with the new values after passing through the `valueSetter`
-2. the values of the row before the cell or row was edited
-
-Once the row is saved, `processRowUpdate` must return the row object that will be used to update the internal state.
-The value returned is used as an argument to a call to `apiRef.current.updateRows`.
-
-If you need to cancel the save process while calling `processRowUpdate`—for instance, when a database validation fails, or the user wants to reject the changes—there are two options:
-
-1. Reject the promise so that the internal state is not updated and the cell remains in edit mode
-2. Resolve the promise with the second argument—the original value(s)—so that the internal state is not updated, but the cell exits edit mode
-
-The following demo implements the first option: rejecting the promise.
-Instead of [validating](#validation) while typing, it validates in the server.
-If the new name is empty, then the promise responsible for saving the row will be rejected and the cell will remain in edit mode.
-Additionally, `onProcessRowUpdateError` is called to display the error message.
-The demo also shows that `processRowUpdate` can be used to pre-process the row model that will be saved into the internal state.
-To exit edit mode, press <kbd class="key">Escape</kbd> or enter a valid name.
-
-{{"demo": "ServerSidePersistence.js", "bg": "inline", "defaultCodeOpen": false}}
-
-### Ask for confirmation before saving
-
-The second option—resolving the promise with the second argument—lets the user cancel the save process by rejecting the changes and exiting edit mode.
-In this case, `processRowUpdate` is resolved with the second argument—the original value(s) of the cell or row.
-
-The following demo shows how this approach can be used to ask for confirmation before sending the data to the server.
-If the user accepts the change, the internal state is updated with the values.
-But if the changes are rejected, the internal state remains unchanged, and the cell is reverted back to its original value.
-The demo also employs validation to prevent entering an empty name.
-
-{{"demo": "AskConfirmationBeforeSave.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Create your own edit component
 
@@ -404,27 +445,6 @@ The following demo implements an edit component with auto-stop, based on a nativ
 :::warning
 Avoid using edit components with auto-stop in columns that use long-running `preProcessEditCellProps` because the UI will freeze while waiting for `apiRef.current.setEditCellValue`.
 Instead, use the provided interactions to exit edit mode.
-:::
-
-## Row editing
-
-Row editing lets the user edit all cells in a row simultaneously.
-The same basic rules for cell editing also apply to row editing.
-To enable it, change the `editMode` prop to `"row"`, then follow the same guidelines as those for cell editing to set the `editable` property in the definition of the columns that the user can edit.
-
-```tsx
-<DataGrid editMode="row" columns={[{ field: 'name', editable: true }]} />
-```
-
-The following demo illustrates how row editing works.
-The user can [start](#start-editing) and [stop](#stop-editing) editing a row using the same actions as those provided for cell editing (e.g. double-clicking a cell).
-
-{{"demo": "BasicRowEditingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
-
-:::warning
-By design, when changing the value of a cell all `preProcessEditCellProps` callbacks from other columns are also called.
-This lets you apply conditional validation where the value of a cell impacts the validation status of another cell in the same row.
-If you only want to run validation when the value has changed, check if the `hasChanged` param is `true`.
 :::
 
 ## Advanced use cases

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -4,7 +4,7 @@
 
 ## Full-featured CRUD
 
-The Data Grid is not only a data visualization tool. It offers built-in editing features for you to manage your data set.
+The data grid is not only a data visualization tool. It offers built-in editing features for you to manage your data set.
 The following demo shows a full-featured CRUD (Create, Read, Update, Delete) typically found in enterprise applications.
 
 :::info
@@ -34,7 +34,7 @@ Play with it by double-clicking or pressing <kbd class="key">Enter</kbd> on any 
 By default, only one cell can be editable at a time.
 But you can let your user edit all cells in a row simultaneously.
 
-To enable this behavior, set the `editMode` prop on the Data Grid to `"row"`. Note that you'll still need to set the `editable` property in each column definition to specify which of them are editable; the same basic rules for cell editing also apply to row editing.
+To enable this behavior, set the `editMode` prop on the Data Grid to `"row"`. Note that you still need to set the `editable` property in each column definition to specify which of them are editable; the same basic rules for cell editing also apply to row editing.
 
 ```tsx
 <DataGrid editMode="row" columns={[{ field: 'name', editable: true }]} />
@@ -156,7 +156,7 @@ The callback is called with two arguments:
 1. The updated row with the new values returned by the [`valueSetter`](#value-parser-and-value-setter).
 2. The original values of the row before editing.
 
-Please note the `processRowUpdate` must return the row object to update the Data Grid internal state.
+Please note that the `processRowUpdate` must return the row object to update the Data Grid internal state.
 The value returned is used later as an argument on a call to `apiRef.current.updateRows`.
 
 ```tsx
@@ -164,7 +164,7 @@ The value returned is used later as an argument on a call to `apiRef.current.upd
   rows={rows}
   columns={columns}
   processRowUpdate={(updatedRow, originalRow) =>
-    mySaveOnServerFunction(updatedRow, originalRow)
+    mySaveOnServerFunction(updatedRow);
   }
   onProcessRowUpdateError={handleProcessRowUpdateError}
 />

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -28,7 +28,7 @@ Play with it by double-clicking or pressing <kbd class="key">Enter</kbd> on any 
 
 {{"demo": "BasicEditingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Editing the entire row
+## Row editing
 
 By default, only one cell can be editable at a time.
 But you can let your user edit all cells in a row simultaneously.
@@ -113,7 +113,7 @@ When a cell is in `edit` mode, the user can stop editing with any of the followi
 ### Listening edit events
 
 The interactions that [start](#start-editing) and [stop](#stop-editing) trigger `'cellEditStart'` and `'cellEditStop'` [events](/x/react-data-grid/events/), respectively.
-For [row editing](#editing-the-entire-row), the events are `'rowEditStart'` and `'rowEditStop'`.
+For [row editing](#row-editing), the events are `'rowEditStart'` and `'rowEditStop'`.
 You can control how these events are handled to customize editing behavior.
 
 For convenience, you can also listen to these events using their respective props:

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -2,7 +2,7 @@
 
 <p class="description">The data grid has built-in support for cell and row editing.</p>
 
-## Full-featured CRUD component
+## Full-featured CRUD
 
 The Data Grid is not only a data visualization tool. It offers built-in editing features for you to manage your data set.
 The following demo shows a full-featured CRUD (Create, Read, Update, Delete) typically found in enterprise applications.

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -15,9 +15,10 @@ You will find the details of each editing API in the next sections.
 
 ## Making a column editable
 
-You can make a column editable by enabling the `editable` property in its [column definition](/x/api/data-grid/grid-col-def/):
+You can make a column editable by enabling the `editable` property in its [column definition](/x/api/data-grid/grid-col-def/).
 
-This lets the user edit any cell from the column 'name' but not 'id'.
+This lets the user edit any cell from the specified columns.
+For example, with the code snippet bellow, users can edit cells in the column 'name' but not in the column 'id'.
 
 ```tsx
 <DataGrid columns={[{ field: 'id' }, { field: 'name', editable: true }]} />

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -7,8 +7,8 @@
 The Data Grid is not only a data visualization tool. It offers built-in editing features for you to manage your data set.
 The following demo shows a full-featured CRUD (Create, Read, Update, Delete) typically found in enterprise applications.
 
-::: info
-You will find the details of each editing API in the next sections.
+:::info
+You will find the details of the editing API in the next sections.
 :::
 
 {{"demo": "FullFeaturedCrudGrid.js", "bg": "inline", "defaultCodeOpen": false}}
@@ -18,7 +18,7 @@ You will find the details of each editing API in the next sections.
 You can make a column editable by enabling the `editable` property in its [column definition](/x/api/data-grid/grid-col-def/).
 
 This lets the user edit any cell from the specified columns.
-For example, with the code snippet bellow, users can edit cells in the column 'name' but not in the column 'id'.
+For example, with the code snippet below, users can edit cells in the `name` column, but not in the `id` column.
 
 ```tsx
 <DataGrid columns={[{ field: 'id' }, { field: 'name', editable: true }]} />
@@ -111,7 +111,7 @@ When a cell is in `edit` mode, the user can stop editing with any of the followi
   });
   ```
 
-### Listening edit events
+### Editing events
 
 The interactions that [start](#start-editing) and [stop](#stop-editing) trigger `'cellEditStart'` and `'cellEditStop'` [events](/x/react-data-grid/events/), respectively.
 For [row editing](#row-editing), the events are `'rowEditStart'` and `'rowEditStop'`.

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -170,7 +170,7 @@ The value returned is used later as an argument on a call to `apiRef.current.upd
 />
 ```
 
-### Server validation
+### Server-side validation
 
 If you need to cancel the save process on `processRowUpdate`—for instance, when a database validation fails, or the user wants to reject the changes—there are two options:
 

--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -17,14 +17,14 @@ You will find the details of each editing API in the next sections.
 
 You can make a column editable by enabling the `editable` property in its [column definition](/x/api/data-grid/grid-col-def/):
 
+This lets the user edit any cell from the column 'name' but not 'id'.
+
 ```tsx
-<DataGrid columns={[{ field: 'name', editable: true }]} />
+<DataGrid columns={[{ field: 'id' }, { field: 'name', editable: true }]} />
 ```
 
-This lets the user edit any cell from the specified column.
-
 The following demo shows an example of how to make all columns editable.
-Play with it by double-clicking or pressing <kbd class="key">Enter</kbd> in any cell.
+Play with it by double-clicking or pressing <kbd class="key">Enter</kbd> on any cell.
 
 {{"demo": "BasicEditingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
## Summary

Based on user feedback* and [analytics](https://analytics.google.com/analytics/web/#/report/content-event-events/a106598593w159022482p160376982/_u.date00=20230313&_u.date01=20230327&_r.drilldown=analytics.eventCategory:demo,analytics.eventAction:expand&explorer-table.plotKeys=%5B%5D&explorer-table.filter=data-grid~2Fediting&explorer-table.rowStart=0&explorer-table.rowCount=25/).

> After a couple years of using the datagrid, this is my first need to edit.  I have to think 99 out of 100 developers just come here to find the best practice to simply edit a row and have it saved to a state variable.... or do something to commit the change.  If that's here, it's very hard to find as much of it is far more complicated that it needs to be.  I'm guessing someone else wrote this versus all your other components.

> sent from https://v5.mui.com/x/react-data-grid/editing/#full-featured-crud-component

## Preview

https://deploy-preview-8431--material-ui-x.netlify.app/x/react-data-grid/editing

## Remaining improvements noticed on the first demo

- [ ] No tab from editing cells to edit actions (leaving the last cell to actions column triggers rowEditStop)
- [ ] Inconsistent editing style for select column
- [ ] Elevation of rows in edit mode feels weird with shadows only on bottom