### PR TITLE
[DataGrid] Fix column header tooltip not showing when the title is truncated

### DIFF
--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -63,10 +63,13 @@ function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
   const [tooltip, setTooltip] = React.useState('');
 
   const handleMouseOver: React.MouseEventHandler<HTMLDivElement> = React.useCallback(() => {
-    if (!description && titleRef.current && isOverflown(titleRef.current)) {
-      setTooltip(label);
-    } else {
-      setTooltip('');
+    if (!description && titleRef?.current) {
+      const isOver = isOverflown(titleRef.current);
+      if (isOver) {
+        setTooltip(label);
+      } else {
+        setTooltip('');
+      }
     }
   }, [description, label]);
 

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -62,7 +62,7 @@ function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
   const titleRef = React.useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = React.useState('');
 
-  const handleMouseOver: React.MouseEventHandler<HTMLDivElement> = React.useCallback(() => {
+  const handleMouseOver = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
     if (!description && titleRef?.current) {
       const isOver = isOverflown(titleRef.current);
       if (isOver) {

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -57,27 +57,17 @@ export interface GridColumnHeaderTitleProps {
 
 // No React.memo here as if we display the sort icon, we need to recalculate the isOver
 function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
-  const { label, description, columnWidth } = props;
+  const { label, description } = props;
   const rootProps = useGridRootProps();
   const titleRef = React.useRef<HTMLDivElement>(null);
-  const [tooltip, setTooltip] = React.useState('');
 
-  React.useEffect(() => {
-    if (!description && titleRef && titleRef.current) {
-      const isOver = isOverflown(titleRef.current);
-      if (isOver) {
-        setTooltip(label);
-      } else {
-        setTooltip('');
-      }
-    }
-  }, [titleRef, columnWidth, description, label]);
+  let tooltip = description;
+  if (!tooltip && titleRef?.current && isOverflown(titleRef.current)) {
+    tooltip = label || '';
+  }
 
   return (
-    <rootProps.slots.baseTooltip
-      title={description || tooltip}
-      {...rootProps.slotProps?.baseTooltip}
-    >
+    <rootProps.slots.baseTooltip title={tooltip} {...rootProps.slotProps?.baseTooltip}>
       <ColumnHeaderInnerTitle ref={titleRef}>{label}</ColumnHeaderInnerTitle>
     </rootProps.slots.baseTooltip>
   );

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -60,15 +60,24 @@ function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
   const { label, description } = props;
   const rootProps = useGridRootProps();
   const titleRef = React.useRef<HTMLDivElement>(null);
+  const [tooltip, setTooltip] = React.useState('');
 
-  let tooltip = description;
-  if (!tooltip && titleRef?.current && isOverflown(titleRef.current)) {
-    tooltip = label || '';
-  }
+  const handleMouseOver: React.MouseEventHandler<HTMLDivElement> = React.useCallback(() => {
+    if (!description && titleRef.current && isOverflown(titleRef.current)) {
+      setTooltip(label);
+    } else {
+      setTooltip('');
+    }
+  }, [description, label]);
 
   return (
-    <rootProps.slots.baseTooltip title={tooltip} {...rootProps.slotProps?.baseTooltip}>
-      <ColumnHeaderInnerTitle ref={titleRef}>{label}</ColumnHeaderInnerTitle>
+    <rootProps.slots.baseTooltip
+      title={description || tooltip}
+      {...rootProps.slotProps?.baseTooltip}
+    >
+      <ColumnHeaderInnerTitle onMouseOver={handleMouseOver} ref={titleRef}>
+        {label}
+      </ColumnHeaderInnerTitle>
     </rootProps.slots.baseTooltip>
   );
 }


### PR DESCRIPTION
Fixes #8406

Before - https://codesandbox.io/s/datagrid-column-header-tooltip-not-rendering-4n99kg?file=/src/App.tsx

After - https://codesandbox.io/s/third-approach-for-title-overflow-tooltip-64lc9h
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30684703/228607848-b0f84b06-ae78-4a22-aaea-c2f542d1014b.gif)
