### PR TITLE
[DataGridPremium] Fix aggregation initial state causing issue with quick filter

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/wrapColumnWithAggregation.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/wrapColumnWithAggregation.tsx
@@ -204,7 +204,7 @@ export const wrapColumnWithAggregationValue = ({
     // TODO: Add custom root id
     const groupId = cellAggregationPosition === 'inline' ? id : rowNode.parent ?? '';
 
-    const aggregationResult = gridAggregationLookupSelector(apiRef)[groupId]?.[field];
+    const aggregationResult = gridAggregationLookupSelector(apiRef)?.[groupId]?.[field];
     if (!aggregationResult || aggregationResult.position !== cellAggregationPosition) {
       return null;
     }


### PR DESCRIPTION
Fixes #8419 

For some weird reason, when using both `rowGrouping` and `quickFilter` initial states along with the `aggregation`, the `aggregation.aggregationLookup` becomes `undefined` on the initial render.

The fix resolves the issue apparently, but we may need to dig a bit deeper into why the issue is occurring in the first place.

Before: https://codesandbox.io/s/aggregation-grouping-quick-filter-broken-09nu8h
After: https://codesandbox.io/s/aggregation-grouping-quick-filter-broken-forked-vb6gto?file=/demo.js