### PR TITLE
[pickers] Move `hasError` from `fieldValueManager` to `valueManager`

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
@@ -30,15 +30,11 @@ export const rangeValueManager: RangePickerValueManager = {
   areValuesEqual: (utils, a, b) =>
     areDatesEqual(utils, a[0], b[0]) && areDatesEqual(utils, a[1], b[1]),
   isSameError: (a, b) => b !== null && a[1] === b[1] && a[0] === b[0],
+  hasError: (error) => error[0] != null || error[1] != null,
   defaultErrorState: [null, null],
 };
 
-export const rangeFieldValueManager: FieldValueManager<
-  DateRange<any>,
-  any,
-  RangeFieldSection,
-  DateRangeValidationError | TimeRangeValidationError | DateTimeRangeValidationError
-> = {
+export const rangeFieldValueManager: FieldValueManager<DateRange<any>, any, RangeFieldSection> = {
   updateReferenceValue: (utils, value, prevReferenceValue) => {
     const shouldKeepStartDate = value[0] != null && utils.isValid(value[0]);
     const shouldKeepEndDate = value[1] != null && utils.isValid(value[1]);
@@ -144,5 +140,4 @@ export const rangeFieldValueManager: FieldValueManager<
       }),
     };
   },
-  hasError: (error) => error[0] != null || error[1] != null,
 };

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -398,8 +398,8 @@ export const useField = <
       return error;
     }
 
-    return fieldValueManager.hasError(validationError);
-  }, [fieldValueManager, validationError, error]);
+    return valueManager.hasError(validationError);
+  }, [valueManager, validationError, error]);
 
   React.useEffect(() => {
     // Select the right section when focused on mount (`autoFocus = true` on the input)

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -15,7 +15,7 @@ export interface UseFieldParams<
   forwardedProps: TForwardedProps;
   internalProps: TInternalProps;
   valueManager: PickerValueManager<TValue, TDate, InferError<TInternalProps>>;
-  fieldValueManager: FieldValueManager<TValue, TDate, TSection, InferError<TInternalProps>>;
+  fieldValueManager: FieldValueManager<TValue, TDate, TSection>;
   validator: Validator<
     TValue,
     TDate,
@@ -193,7 +193,7 @@ export type FieldSelectedSectionsIndexes = {
   shouldSelectBoundarySelectors?: boolean;
 };
 
-export interface FieldValueManager<TValue, TDate, TSection extends FieldSection, TError> {
+export interface FieldValueManager<TValue, TDate, TSection extends FieldSection> {
   /**
    * Creates the section list from the current value.
    * The `prevSections` are used on the range fields to avoid losing the sections of a partially filled date when editing the other date.
@@ -261,13 +261,6 @@ export interface FieldValueManager<TValue, TDate, TSection extends FieldSection,
     value: TValue,
     prevReferenceValue: TValue,
   ) => TValue;
-  /**
-   * Checks if the current error is empty or not.
-   * @template TError
-   * @param {TError} error The current error.
-   * @returns {boolean} `true` if the current error is not empty.
-   */
-  hasError: (error: TError) => boolean;
 }
 
 export interface UseFieldState<TValue, TSection extends FieldSection> {

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -65,6 +65,13 @@ export interface PickerValueManager<TValue, TDate, TError> {
    */
   isSameError: (error: TError, prevError: TError | null) => boolean;
   /**
+   * Checks if the current error is empty or not.
+   * @template TError
+   * @param {TError} error The current error.
+   * @returns {boolean} `true` if the current error is not empty.
+   */
+  hasError: (error: TError) => boolean;
+  /**
    * The value identifying no error, used to initialise the error state.
    */
   defaultErrorState: TError;
@@ -506,14 +513,13 @@ export const usePickerValue = <
   };
 
   const isValid = (testedValue: TValue) => {
-    const validationResponse = validator({
+    const error = validator({
       adapter,
       value: testedValue,
       props: { ...props, value: testedValue },
     });
-    return Array.isArray(testedValue)
-      ? (validationResponse as any[]).every((v) => v === null)
-      : validationResponse === null;
+
+    return valueManager.hasError(error);
   };
 
   const layoutResponse: UsePickerValueLayoutResponse<TValue> = {

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -24,15 +24,11 @@ export const singleItemValueManager: SingleItemPickerValueManager = {
   cleanValue: replaceInvalidDateByNull,
   areValuesEqual: areDatesEqual,
   isSameError: (a, b) => a === b,
+  hasError: (error) => error != null,
   defaultErrorState: null,
 };
 
-export const singleItemFieldValueManager: FieldValueManager<
-  any,
-  any,
-  FieldSection,
-  DateValidationError | TimeValidationError | DateTimeValidationError
-> = {
+export const singleItemFieldValueManager: FieldValueManager<any, any, FieldSection> = {
   updateReferenceValue: (utils, value, prevReferenceValue) =>
     value == null || !utils.isValid(value) ? prevReferenceValue : value,
   getSectionsFromValue: (utils, date, prevSections, isRTL, getSectionsFromDate) => {
@@ -59,5 +55,4 @@ export const singleItemFieldValueManager: FieldValueManager<
   }),
   parseValueStr: (valueStr, referenceValue, parseDate) =>
     parseDate(valueStr.trim(), referenceValue),
-  hasError: (error) => error != null,
 };


### PR DESCRIPTION
Slightly improve the abstraction in `usePickerValue` by using the `hasError` method
`fieldValueManager` has now only methods really related to the field.