### PR TITLE
[datagrid] `onRowsScrollEnd` should trigger even if initial data row heights is less than table height

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.ts
@@ -32,6 +32,14 @@ export const useGridInfiniteLoader = (
 
   const isInScrollBottomArea = React.useRef<boolean>(false);
 
+  // Set isInScrollBottomArea to false when new rows are being added,
+  // indicating that the scroll position is no longer at the bottom of the content.
+  React.useEffect(() => {
+    if (isInScrollBottomArea.current) {
+      isInScrollBottomArea.current = false;
+    }
+  }, [currentPage.rows.length, isInScrollBottomArea]);
+
   const handleRowsScrollEnd = React.useCallback(
     (scrollPosition: GridScrollParams) => {
       const dimensions = apiRef.current.getRootDimensions();


### PR DESCRIPTION
Fixes #4184

**Problem**

Currently, the `onRowsScrollEnd` function is not triggering if the initial data row height is less than the table height. This is because, after `onRowsScrollEnd` is called once, it must leave the bottom area to be called again so that it will not be fired infinitely.

**solution**

Set `isInScrollBottomArea` to false when new rows are being added, indicating that the scroll position is no longer at the bottom of the content.

before https://codesandbox.io/s/sleepy-farrell-uo38ju?file=/demo.tsx
after https://codesandbox.io/s/jovial-glitter-k9ok92?file=/demo.tsx 