### PR TITLE
[DataGrid] Add `getTogglableColumns` to `Hide all` and `Show all` actions

### DIFF
--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -147,9 +147,10 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
     (isVisible: boolean) => {
       const currentModel = gridColumnVisibilityModelSelector(apiRef);
       const newModel = { ...currentModel };
+      const togglableColumns = getTogglableColumns ? getTogglableColumns(columns) : null;
 
       columns.forEach((col) => {
-        if (col.hideable) {
+        if (col.hideable && (togglableColumns == null || togglableColumns.includes(col.field))) {
           if (isVisible) {
             // delete the key from the model instead of setting it to `true`
             delete newModel[col.field];
@@ -161,7 +162,7 @@ function GridColumnsPanel(props: GridColumnsPanelProps) {
 
       return apiRef.current.setColumnVisibilityModel(newModel);
     },
-    [apiRef, columns],
+    [apiRef, columns, getTogglableColumns],
   );
 
   const handleSearchValueChange = React.useCallback(

--- a/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
@@ -311,24 +311,50 @@ describe('<DataGridPro /> - Columns Visibility', () => {
     expect(screen.queryByRole('button', { name: 'Show all' })).to.equal(null);
   });
 
-  it('should control columns shown in columns panel using `getTogglableColumns` prop', () => {
-    const getTogglableColumns = (cols: GridColDef[]) =>
-      cols.filter((column) => column.field !== 'idBis').map((column) => column.field);
-    render(
-      <TestDataGrid
-        slots={{
-          toolbar: GridToolbar,
-        }}
-        slotProps={{
-          columnsPanel: {
-            getTogglableColumns,
-          },
-        }}
-      />,
-    );
+  describe('prop: `getTogglableColumns`', () => {
+    it('should control columns shown in columns panel using `getTogglableColumns` prop', () => {
+      const getTogglableColumns = (cols: GridColDef[]) =>
+        cols.filter((column) => column.field !== 'idBis').map((column) => column.field);
+      render(
+        <TestDataGrid
+          slots={{
+            toolbar: GridToolbar,
+          }}
+          slotProps={{
+            columnsPanel: {
+              getTogglableColumns,
+            },
+          }}
+        />,
+      );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Select columns' }));
-    expect(screen.queryByRole('checkbox', { name: 'id' })).not.to.equal(null);
-    expect(screen.queryByRole('checkbox', { name: 'idBis' })).to.equal(null);
+      fireEvent.click(screen.getByRole('button', { name: 'Select columns' }));
+      expect(screen.queryByRole('checkbox', { name: 'id' })).not.to.equal(null);
+      expect(screen.queryByRole('checkbox', { name: 'idBis' })).to.equal(null);
+    });
+
+    it('should avoid toggling columns provided by `getTogglableColumns` prop on `Show all` or `Hide all`', () => {
+      const getTogglableColumns = (cols: GridColDef[]) =>
+        cols.filter((column) => column.field !== 'idBis').map((column) => column.field);
+      render(
+        <TestDataGrid
+          slots={{
+            toolbar: GridToolbar,
+          }}
+          slotProps={{
+            columnsPanel: {
+              getTogglableColumns,
+            },
+          }}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Select columns' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Hide all' }));
+      expect(getColumnHeadersTextContent()).to.deep.equal(['idBis']);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Show all' }));
+      expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'idBis']);
+    });
   });
 });


### PR DESCRIPTION
Relates to #8401 

Previously I didn't add this callback to the `toggleAllColumns` method, but after playing around with the demo a bit, I feel the user's expectation could be to also have this callback honored when pressing Hide all and Show all buttons. I am open to feedback/suggestions on this though.

It may be useful in cases like avoiding blank grid state (when user accidentally hides all the columns and the state is not reversible)

Preview: https://deploy-preview-8496--material-ui-x.netlify.app/x/react-data-grid/column-visibility/#customize-the-list-of-columns-in-panel