### PR TITLE
[DataGrid] Reset selection state on `checkboxSelection` toggle

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -22,7 +22,7 @@ import { gridExpandedSortedRowIdsSelector } from '../filter/gridFilterSelector';
 import { GRID_CHECKBOX_SELECTION_COL_DEF, GRID_ACTIONS_COLUMN_TYPE } from '../../../colDef';
 import { GridCellModes } from '../../../models/gridEditRowModel';
 import { isKeyboardEvent, isNavigationKey } from '../../../utils/keyboardUtils';
-import { getVisibleRows, useGridVisibleRows } from '../../utils/useGridVisibleRows';
+import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
 import { GridRowSelectionModel } from '../../../models';
 import { GRID_DETAIL_PANEL_TOGGLE_FIELD } from '../../../constants/gridDetailPanelToggleField';
@@ -110,8 +110,6 @@ export const useGridRowSelection = (
     checkboxSelection,
     disableMultipleRowSelection,
     disableRowSelectionOnClick,
-    pagination,
-    paginationMode,
     isRowSelectable: propIsRowSelectable,
   } = props;
 

--- a/packages/grid/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -585,46 +585,14 @@ export const useGridRowSelection = (
   }, [apiRef, isRowSelectable, isStateControlled, props.rowSelection]);
 
   React.useEffect(() => {
-    if (!props.rowSelection) {
+    if (!props.rowSelection || isStateControlled) {
       return;
     }
 
     const currentSelection = gridRowSelectionStateSelector(apiRef.current.state);
-
     if (!canHaveMultipleSelection && currentSelection.length > 1) {
-      const { rows: currentPageRows } = getVisibleRows(apiRef, {
-        pagination,
-        paginationMode,
-      });
-
-      const currentPageRowsLookup = currentPageRows.reduce<Record<GridRowId, true>>(
-        (acc, { id }) => {
-          acc[id] = true;
-          return acc;
-        },
-        {},
-      );
-
-      const firstSelectableRow = currentSelection.find((id) => {
-        let isSelectable = true;
-        if (isRowSelectable) {
-          isSelectable = isRowSelectable(id);
-        }
-        return isSelectable && currentPageRowsLookup[id]; // Check if the row is in the current page
-      });
-
-      apiRef.current.setRowSelectionModel(
-        firstSelectableRow !== undefined ? [firstSelectableRow] : [],
-      );
+      // See https://github.com/mui/mui-x/issues/8455
+      apiRef.current.setRowSelectionModel([]);
     }
-  }, [
-    apiRef,
-    canHaveMultipleSelection,
-    checkboxSelection,
-    disableMultipleRowSelection,
-    isRowSelectable,
-    pagination,
-    paginationMode,
-    props.rowSelection,
-  ]);
+  }, [apiRef, canHaveMultipleSelection, checkboxSelection, isStateControlled, props.rowSelection]);
 };

--- a/packages/grid/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -297,28 +297,16 @@ describe('<DataGrid /> - Row Selection', () => {
       expect(getSelectedRowIds()).to.deep.equal([0, 1, 2]);
     });
 
-    it('should keep only one selected row when turning off checkboxSelection', () => {
+    it('should reset selected rows when turning off checkboxSelection', () => {
       const { setProps } = render(<TestDataGridSelection checkboxSelection />);
       fireEvent.click(getCell(0, 0).querySelector('input')!);
       fireEvent.click(getCell(1, 0).querySelector('input')!);
       expect(getSelectedRowIds()).to.deep.equal([0, 1]);
       setProps({ checkboxSelection: false });
-      expect(getSelectedRowIds()).to.deep.equal([0]);
+      expect(getSelectedRowIds()).to.deep.equal([]);
     });
 
-    it('should keep only one selectable row as selected when turning off checkboxSelection', () => {
-      const { setProps } = render(<TestDataGridSelection checkboxSelection />);
-      fireEvent.click(getCell(0, 0).querySelector('input')!);
-      fireEvent.click(getCell(1, 0).querySelector('input')!);
-      expect(getSelectedRowIds()).to.deep.equal([0, 1]);
-      setProps({
-        checkboxSelection: false,
-        isRowSelectable: ({ id }: { id: GridRowId }) => Number(id) > 0,
-      });
-      expect(getSelectedRowIds()).to.deep.equal([1]);
-    });
-
-    it('should keep only the first row in the current page as selected when turning off checkboxSelection', () => {
+    it('should reset row selection in the current page as selected when turning off checkboxSelection', () => {
       const { setProps } = render(
         <TestDataGridSelection
           checkboxSelection
@@ -333,8 +321,8 @@ describe('<DataGrid /> - Row Selection', () => {
       fireEvent.click(getCell(2, 0).querySelector('input')!);
       expect(screen.getByText('2 rows selected')).not.to.equal(null);
       setProps({ checkboxSelection: false });
-      expect(getSelectedRowIds()).to.deep.equal([2]);
-      expect(screen.getByText('1 row selected')).not.to.equal(null);
+      expect(getSelectedRowIds()).to.deep.equal([]);
+      expect(screen.queryByText('2 row selected')).to.equal(null);
     });
 
     it('should set the correct aria-label on the column header checkbox', () => {


### PR DESCRIPTION
Fixes #8455 

Before: https://codesandbox.io/s/checkbox-selection-bug-iflfz4?file=/src/App.tsx
After: https://codesandbox.io/s/checkbox-selection-bug-forked-9juhyv?file=/src/App.tsx