### PR TITLE
[DataGrid] Deprecate pagination page count selector

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/pagination/gridPaginationSelector.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/gridPaginationSelector.ts
@@ -45,12 +45,22 @@ export const gridPageSizeSelector = createSelector(
 /**
  * Get the amount of pages needed to display all the rows if the pagination is enabled
  * @category Pagination
+ * @deprecated Use `gridPageSizeSelector`, `gridFilteredTopLevelRowCountSelector`, and `rootProps.rowCount` to calculate it
  */
 export const gridPageCountSelector = createSelector(
   gridPaginationModelSelector,
   gridFilteredTopLevelRowCountSelector,
-  (paginationModel, visibleTopLevelRowCount) =>
-    getPageCount(visibleTopLevelRowCount, paginationModel.pageSize),
+
+  (paginationModel, visibleTopLevelRowCount) => {
+    console.warn(
+      [
+        `MUI: Do not use \`gridPageCountSelector\` with \`rowCount\` prop.`,
+        `Use \`gridPageSizeSelector\`, \`gridFilteredTopLevelRowCountSelector\`,`,
+        `and \`rootProps.rowCount\`/\`gridFilteredTopLevelRowCountSelector\` to calculate page count instead`,
+      ].join('\n'),
+    );
+    return getPageCount(visibleTopLevelRowCount, paginationModel.pageSize);
+  },
 );
 
 /**


### PR DESCRIPTION
Fixes #8450 

## Changelog

The `gridPageCountSelector` was deprecated. It may provide an incorrect value when used with the `rowCount` prop. Use specific selectors and props instead:

```diff
-const pageCount = useGridSelector(apiRef, gridPageCountSelector);
+const pageSize = useGridSelector(apiRef, gridPageSizeSelector);
+const visibleTopLevelRowCount = useGridSelector(apiRef, gridFilteredTopLevelRowCountSelector);
+const rowCount = rootProps.rowCount ?? visibleTopLevelRowCount;
+const pageCount = getPageCount(rowCount, pageSize);
```