### PR TITLE
[pickers] Update peer dependency versions

### DIFF
--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -34,8 +34,8 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.4.1",
-  "@mui/system": "^5.4.1",
+  "@mui/material": "^5.8.6",
+  "@mui/system": "^5.8.0",
   "react": "^17.0.2 || ^18.0.0",
   "react-dom": "^17.0.2 || ^18.0.0"
 },

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -54,8 +54,8 @@
     "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
-    "@mui/material": "^5.4.1",
-    "@mui/system": "^5.4.1",
+    "@mui/material": "^5.8.6",
+    "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",
     "dayjs": "^1.10.7",
     "luxon": "^3.0.2",

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -34,8 +34,8 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.4.1",
-  "@mui/system": "^5.4.1",
+  "@mui/material": "^5.8.6",
+  "@mui/system": "^5.8.0",
   "react": "^17.0.2 || ^18.0.0",
   "react-dom": "^17.0.2 || ^18.0.0"
 },

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -62,8 +62,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.4.1",
-    "@mui/system": "^5.4.1",
+    "@mui/material": "^5.8.6",
+    "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",
     "date-fns-jalali": "^2.13.0-0",
     "dayjs": "^1.10.7",


### PR DESCRIPTION
Fix #8530 
Also tested and updated the minimum viable `@mui/system` version.

`5.8.6` is the minimum version exposing `useSlotProps`.