### PR TITLE
[docs] Reduce list of dependencies in Codesandbox/Stackblitz demos

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -36,12 +36,6 @@ ponyfillGlobal.muiDocConfig = {
 
     newDeps['@mui/material'] = versions['@mui/material'];
 
-    if (newDeps['@mui/x-data-grid-premium']) {
-      // TODO: remove when https://github.com/mui/material-ui/pull/32492 is released
-      // use `import 'exceljs'` in demonstrations instead
-      newDeps.exceljs = versions.exceljs;
-    }
-
     if (newDeps['@mui/x-data-grid-generator']) {
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
     }

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -34,34 +34,19 @@ ponyfillGlobal.muiDocConfig = {
   csbIncludePeerDependencies: (deps, { versions }) => {
     const newDeps = { ...deps };
 
+    newDeps['@mui/material'] = versions['@mui/material'];
+
     if (newDeps['@mui/x-data-grid-premium']) {
-      newDeps['@mui/x-data-grid-pro'] = versions['@mui/x-data-grid-pro'];
       // TODO: remove when https://github.com/mui/material-ui/pull/32492 is released
       // use `import 'exceljs'` in demonstrations instead
       newDeps.exceljs = versions.exceljs;
     }
 
-    if (newDeps['@mui/x-data-grid-pro']) {
-      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
-    }
-
-    if (newDeps['@mui/x-data-grid']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
-    }
-
     if (newDeps['@mui/x-data-grid-generator']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
-      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid']; // TS types are imported from @mui/x-data-grid
-      newDeps['@mui/x-data-grid-pro'] = versions['@mui/x-data-grid-pro']; // Some TS types are imported from @mui/x-data-grid-pro
-    }
-
-    if (newDeps['@mui/x-date-pickers-pro']) {
-      newDeps['@mui/x-date-pickers'] = versions['@mui/x-date-pickers'];
     }
 
     if (newDeps['@mui/x-date-pickers']) {
-      newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['date-fns'] = versions['date-fns'];
     }
 

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -40,7 +40,7 @@ ponyfillGlobal.muiDocConfig = {
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
     }
 
-    if (newDeps['@mui/x-date-pickers']) {
+    if (newDeps['@mui/x-date-pickers'] || newDeps['@mui/x-date-pickers-pro']) {
       newDeps['date-fns'] = versions['date-fns'];
     }
 


### PR DESCRIPTION
There is no need to include packages that are already listed in package `dependencies` as they're installed automatically:
1. It makes it easier to lock the package's version - instead of locking the version for `@mui/x-data-grid-premium`, `@mui/x-data-grid-pro`, and `@mui/x-data-grid` packages, it would be enough to lock the version of `@mui/x-data-grid-premium`.
2. It makes it harder to use out-of-sync versions of the packages

For the demo that is using `@mui/x-data-grid-premium` the following dependencies won't be included:
```diff
"@emotion/react": "latest",
"@emotion/styled": "latest",
"@mui/icons-material": "latest",
"@mui/material": "latest",
-"@mui/x-data-grid": "latest",
"@mui/x-data-grid-generator": "latest",
"@mui/x-data-grid-premium": "latest",
-"@mui/x-data-grid-pro": "latest",
-"@types/exceljs": "latest",
"@types/react": "latest",
"@types/react-dom": "latest",
-"exceljs": "latest",
"react": "latest",
"react-dom": "latest",
"typescript": "latest"
```