### PR TITLE
[l10n] Improve French (fr-FR) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -75,7 +75,7 @@
     "languageTag": "fr-FR",
     "importName": "frFR",
     "localeName": "French",
-    "missingKeysCount": 8,
+    "missingKeysCount": 2,
     "totalKeysCount": 94,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/frFR.ts"
   },

--- a/packages/grid/x-data-grid/src/locales/frFR.ts
+++ b/packages/grid/x-data-grid/src/locales/frFR.ts
@@ -145,11 +145,11 @@ const frFRGrid: Partial<GridLocaleText> = {
 
   // Aggregation
   aggregationMenuItemHeader: 'Aggrégation',
-  aggregationFunctionLabelSum: 'som',
-  aggregationFunctionLabelAvg: 'moy',
-  aggregationFunctionLabelMin: 'min',
-  aggregationFunctionLabelMax: 'max',
-  aggregationFunctionLabelSize: 'nbr',
+  aggregationFunctionLabelSum: 'Somme',
+  aggregationFunctionLabelAvg: 'Moyenne',
+  aggregationFunctionLabelMin: 'Minimum',
+  aggregationFunctionLabelMax: 'Maximum',
+  aggregationFunctionLabelSize: "Nombre d'éléments",
 };
 
 export const frFR: Localization = getGridLocalization(frFRGrid, frFRCore);

--- a/packages/grid/x-data-grid/src/locales/frFR.ts
+++ b/packages/grid/x-data-grid/src/locales/frFR.ts
@@ -144,12 +144,12 @@ const frFRGrid: Partial<GridLocaleText> = {
   rowReorderingHeaderName: 'Positionnement des lignes',
 
   // Aggregation
-  // aggregationMenuItemHeader: 'Aggregation',
-  // aggregationFunctionLabelSum: 'sum',
-  // aggregationFunctionLabelAvg: 'avg',
-  // aggregationFunctionLabelMin: 'min',
-  // aggregationFunctionLabelMax: 'max',
-  // aggregationFunctionLabelSize: 'size',
+  aggregationMenuItemHeader: 'Aggrégation',
+  aggregationFunctionLabelSum: 'som',
+  aggregationFunctionLabelAvg: 'moy',
+  aggregationFunctionLabelMin: 'min',
+  aggregationFunctionLabelMax: 'max',
+  aggregationFunctionLabelSize: 'nbr',
 };
 
 export const frFR: Localization = getGridLocalization(frFRGrid, frFRCore);

--- a/packages/grid/x-data-grid/src/locales/frFR.ts
+++ b/packages/grid/x-data-grid/src/locales/frFR.ts
@@ -144,7 +144,7 @@ const frFRGrid: Partial<GridLocaleText> = {
   rowReorderingHeaderName: 'Positionnement des lignes',
 
   // Aggregation
-  aggregationMenuItemHeader: 'Aggrégation',
+  aggregationMenuItemHeader: 'Agrégation',
   aggregationFunctionLabelSum: 'Somme',
   aggregationFunctionLabelAvg: 'Moyenne',
   aggregationFunctionLabelMin: 'Minimum',


### PR DESCRIPTION
https://github.com/mui/mui-x/issues/3211
Hi, I'm trying to translate aggregation literals. If it appears where I think it does, it's better to use abbreviation but not sure of the ones I chose. One could even argue that the English ones could be better understand by French speakers (except for `avg` maybe). Open to discussion.