### PR TITLE
[pickers] Fix `isValid` regression

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -518,7 +518,7 @@ export const usePickerValue = <
       props: { ...props, value: testedValue },
     });
 
-    return valueManager.hasError(error);
+    return !valueManager.hasError(error);
   };
 
   const layoutResponse: UsePickerValueLayoutResponse<TValue> = {


### PR DESCRIPTION
Fix an issue mentioned here: https://github.com/mui/mui-x/pull/8533#pullrequestreview-1376114851

Allows for correct shortcuts behavior.

### Before:
https://deploy-preview-8533--material-ui-x.netlify.app/x/react-date-pickers/shortcuts/

### After: 
https://deploy-preview-8543--material-ui-x.netlify.app/x/react-date-pickers/shortcuts/