### PR TITLE
[DateTimePicker] Fix `TimeClock` validation ignoring date by default

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import Typography from '@mui/material/Typography';
-import { SlotComponentProps } from '@mui/base';
-import { useSlotProps } from '@mui/base/utils';
+import { useSlotProps, SlotComponentProps } from '@mui/base/utils';
 import { styled, useTheme, useThemeProps } from '@mui/material/styles';
 import {
   unstable_composeClasses as composeClasses,

--- a/packages/x-date-pickers/src/DateTimePicker/shared.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/shared.tsx
@@ -177,7 +177,13 @@ export function useDateTimePickerDefaultizedProps<
     // TODO: Remove from public API
     disableIgnoringDatePartForTimeValidation:
       themeProps.disableIgnoringDatePartForTimeValidation ??
-      Boolean(themeProps.minDateTime || themeProps.maxDateTime),
+      Boolean(
+        themeProps.minDateTime ||
+          themeProps.maxDateTime ||
+          // allow time clock to correctly check time validity: https://github.com/mui/mui-x/issues/8520
+          themeProps.disablePast ||
+          themeProps.disableFuture,
+      ),
     disableFuture: themeProps.disableFuture ?? false,
     disablePast: themeProps.disablePast ?? false,
     minDate: applyDefaultDate(

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/describes.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/describes.DesktopDatePicker.test.tsx
@@ -21,6 +21,7 @@ describe('<DesktopDatePicker /> - Describes', () => {
     clock,
     views: ['year', 'month', 'day'],
     componentFamily: 'picker',
+    variant: 'desktop',
   }));
 
   describeValue(DesktopDatePicker, () => ({

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describes.DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describes.DesktopDateTimePicker.test.tsx
@@ -25,6 +25,7 @@ describe('<DesktopDateTimePicker /> - Describes', () => {
     clock,
     views: ['year', 'month', 'day', 'hours', 'minutes'],
     componentFamily: 'picker',
+    variant: 'desktop',
   }));
 
   describeValue(DesktopDateTimePicker, () => ({

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
@@ -23,6 +23,7 @@ describe('<DesktopTimePicker /> - Describes', () => {
     clock,
     views: ['hours', 'minutes'],
     componentFamily: 'picker',
+    variant: 'desktop',
   }));
 
   describeConformance(<DesktopTimePicker />, () => ({

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -15,7 +15,7 @@ import { describeValidation } from '@mui/x-date-pickers/tests/describeValidation
 describe('<MobileDateTimePicker />', () => {
   const { render, clock } = createPickerRenderer({
     clock: 'fake',
-    clockConfig: new Date('2018-01-01T00:00:00.000'),
+    clockConfig: new Date(2018, 2, 12, 8, 16, 0),
   });
 
   describeValidation(MobileDateTimePicker, () => ({
@@ -23,6 +23,7 @@ describe('<MobileDateTimePicker />', () => {
     clock,
     views: ['year', 'month', 'day', 'hours', 'minutes'],
     componentFamily: 'picker',
+    variant: 'mobile',
   }));
 
   it('should render date and time by default', () => {

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/describes.MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/describes.MobileDateTimePicker.test.tsx
@@ -13,13 +13,17 @@ import {
 import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker';
 
 describe('<MobileDateTimePicker /> - Describes', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render, clock } = createPickerRenderer({
+    clock: 'fake',
+    clockConfig: new Date(2018, 2, 12, 8, 16, 0),
+  });
 
   describeValidation(MobileDateTimePicker, () => ({
     render,
     clock,
-    views: ['year', 'month', 'day'],
+    views: ['year', 'day', 'hours', 'minutes'],
     componentFamily: 'picker',
+    variant: 'mobile',
   }));
 
   describeValue(MobileDateTimePicker, () => ({

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
@@ -20,13 +20,17 @@ import {
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 
 describe('<MobileTimePicker /> - Describes', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render, clock } = createPickerRenderer({
+    clock: 'fake',
+    clockConfig: new Date(2018, 2, 12, 8, 16, 0),
+  });
 
   describeValidation(MobileTimePicker, () => ({
     render,
     clock,
     views: ['hours', 'minutes'],
     componentFamily: 'picker',
+    variant: 'mobile',
   }));
 
   describeConformance(<MobileTimePicker />, () => ({

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.test.tsx
@@ -10,6 +10,7 @@ import { DateTimePickerTabs, DateTimePickerTabsProps } from '../DateTimePicker';
 describe('<StaticDateTimePicker />', () => {
   const { render, clock } = createPickerRenderer({
     clock: 'fake',
+    clockConfig: new Date(2018, 2, 12, 8, 16, 0),
   });
 
   describeValidation(StaticDateTimePicker, () => ({

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -13,7 +13,10 @@ import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
 import { describeValidation } from '@mui/x-date-pickers/tests/describeValidation';
 
 describe('<StaticTimePicker />', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render, clock } = createPickerRenderer({
+    clock: 'fake',
+    clockConfig: new Date(2018, 2, 12, 8, 16, 0),
+  });
 
   describeValidation(StaticTimePicker, () => ({
     render,

--- a/packages/x-date-pickers/src/tests/describeValidation/describeValidation.tsx
+++ b/packages/x-date-pickers/src/tests/describeValidation/describeValidation.tsx
@@ -6,11 +6,13 @@ import { testMonthViewValidation } from './testMonthViewValidation';
 import { testTextFieldValidation } from './testTextFieldValidation';
 import { testYearViewValidation } from './testYearViewValidation';
 import { DescribeValidationInputOptions } from './describeValidation.types';
+import { testMinutesViewValidation } from './testMinutesViewValidation';
 
 const TEST_SUITES = [
   testYearViewValidation,
   testMonthViewValidation,
   testDayViewValidation,
+  testMinutesViewValidation,
   testTextFieldValidation,
 ];
 

--- a/packages/x-date-pickers/src/tests/describeValidation/describeValidation.types.ts
+++ b/packages/x-date-pickers/src/tests/describeValidation/describeValidation.types.ts
@@ -10,6 +10,7 @@ export interface DescribeValidationInputOptions {
   after?: () => void;
   componentFamily: PickerComponentFamily;
   views: DateOrTimeView[];
+  variant?: 'mobile' | 'desktop';
 }
 
 export interface DescribeValidationOptions extends DescribeValidationInputOptions {

--- a/packages/x-date-pickers/src/tests/describeValidation/testMinutesViewValidation.tsx
+++ b/packages/x-date-pickers/src/tests/describeValidation/testMinutesViewValidation.tsx
@@ -5,7 +5,6 @@ import { adapterToUse } from 'test/utils/pickers-utils';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 
 const toMinutesLabel = (minutes: number | string) =>
-  // eslint-disable-next-line eqeqeq
   `${Number(minutes) < 10 ? `0${minutes}` : minutes} minutes`;
 
 export const testMinutesViewValidation: DescribeValidationTestSuite = (

--- a/packages/x-date-pickers/src/tests/describeValidation/testMinutesViewValidation.tsx
+++ b/packages/x-date-pickers/src/tests/describeValidation/testMinutesViewValidation.tsx
@@ -1,0 +1,205 @@
+import { expect } from 'chai';
+import * as React from 'react';
+import { screen } from '@mui/monorepo/test/utils';
+import { adapterToUse } from 'test/utils/pickers-utils';
+import { DescribeValidationTestSuite } from './describeValidation.types';
+
+const toMinutesLabel = (minutes: number | string) =>
+  // eslint-disable-next-line eqeqeq
+  `${Number(minutes) < 10 ? `0${minutes}` : minutes} minutes`;
+
+export const testMinutesViewValidation: DescribeValidationTestSuite = (
+  ElementToTest,
+  getOption,
+) => {
+  const { componentFamily, views, render, clock, withDate, withTime, variant } = getOption();
+
+  if (
+    !views.includes('minutes') ||
+    !variant ||
+    componentFamily !== 'picker' ||
+    variant === 'desktop'
+  ) {
+    return;
+  }
+
+  describe('minutes view:', () => {
+    const defaultProps = {
+      onChange: () => {},
+      open: true,
+      view: 'minutes',
+      openTo: 'minutes',
+      reduceAnimations: true,
+      ...(componentFamily.includes('legacy-')
+        ? {
+            componentsProps: { toolbar: { hidden: true } },
+          }
+        : { slotProps: { toolbar: { hidden: true } } }),
+    };
+
+    it('should apply shouldDisableTime', function test() {
+      render(
+        <ElementToTest
+          {...defaultProps}
+          value={adapterToUse.date(new Date(2018, 2, 12, 8, 15, 0))}
+          shouldDisableTime={(date) =>
+            adapterToUse.isAfter(date, adapterToUse.date(new Date(2018, 2, 12, 8, 20, 0)))
+          }
+        />,
+      );
+
+      expect(screen.getByRole('option', { name: toMinutesLabel('10') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('15') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('20') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('25') })).to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('30') })).to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('55') })).to.have.attribute(
+        'aria-disabled',
+      );
+    });
+
+    it('should apply disablePast', function test() {
+      let now;
+      function WithFakeTimer(props) {
+        now = adapterToUse.date(new Date());
+        return <ElementToTest value={now} {...props} />;
+      }
+      const { setProps } = render(<WithFakeTimer {...defaultProps} disablePast />);
+
+      const tomorrow = adapterToUse.addDays(now, 1);
+      const currentMinutes = adapterToUse.getMinutes(now);
+      const closestNowMinutesOptionValue = Math.floor(currentMinutes / 5) * 5;
+      const previousMinutesOptionValue = Math.floor(currentMinutes / 5) * 5 - 5;
+      const nextMinutesOptionValue = Math.floor(currentMinutes / 5) * 5 + 5;
+
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(previousMinutesOptionValue) }),
+      ).to.have.attribute('aria-disabled');
+      if (currentMinutes <= closestNowMinutesOptionValue) {
+        expect(
+          screen.getByRole('option', { name: toMinutesLabel(closestNowMinutesOptionValue) }),
+        ).not.to.have.attribute('aria-disabled');
+      } else {
+        expect(
+          screen.getByRole('option', { name: toMinutesLabel(closestNowMinutesOptionValue) }),
+        ).to.have.attribute('aria-disabled');
+      }
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(nextMinutesOptionValue) }),
+      ).not.to.have.attribute('aria-disabled');
+
+      // following validation is relevant only for DateTimePicker
+      if (!withDate || !withTime) {
+        return;
+      }
+
+      setProps({ value: tomorrow });
+      clock.runToLast();
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(previousMinutesOptionValue) }),
+      ).not.to.have.attribute('aria-disabled');
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(closestNowMinutesOptionValue) }),
+      ).not.to.have.attribute('aria-disabled');
+    });
+
+    it('should apply disableFuture', function test() {
+      let now;
+      function WithFakeTimer(props) {
+        now = adapterToUse.date(new Date());
+        return <ElementToTest value={now} {...props} />;
+      }
+      const { setProps } = render(<WithFakeTimer {...defaultProps} disableFuture />);
+
+      const yesterday = adapterToUse.addDays(now, -1);
+      const currentMinutes = adapterToUse.getMinutes(now);
+      const closestNowMinutesOptionValue = Math.floor(currentMinutes / 5) * 5;
+      const previousMinutesOptionValue = Math.floor(currentMinutes / 5) * 5 - 5;
+      const nextMinutesOptionValue = Math.floor(currentMinutes / 5) * 5 + 5;
+
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(previousMinutesOptionValue) }),
+      ).not.to.have.attribute('aria-disabled');
+      if (currentMinutes < closestNowMinutesOptionValue) {
+        expect(
+          screen.getByRole('option', { name: toMinutesLabel(closestNowMinutesOptionValue) }),
+        ).to.have.attribute('aria-disabled');
+      } else {
+        expect(
+          screen.getByRole('option', { name: toMinutesLabel(closestNowMinutesOptionValue) }),
+        ).not.to.have.attribute('aria-disabled');
+      }
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(nextMinutesOptionValue) }),
+      ).to.have.attribute('aria-disabled');
+
+      // following validation is relevant only for DateTimePicker
+      if (!withDate || !withTime) {
+        return;
+      }
+
+      setProps({ value: yesterday });
+      clock.runToLast();
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(previousMinutesOptionValue) }),
+      ).not.to.have.attribute('aria-disabled');
+      expect(
+        screen.getByRole('option', { name: toMinutesLabel(closestNowMinutesOptionValue) }),
+      ).not.to.have.attribute('aria-disabled');
+    });
+
+    it('should apply maxTime', function test() {
+      render(
+        <ElementToTest
+          {...defaultProps}
+          value={adapterToUse.date(new Date(2019, 5, 15, 11, 15, 0))}
+          maxTime={adapterToUse.date(new Date(2019, 5, 15, 11, 20, 0))}
+        />,
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('10') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('15') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('20') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('25') })).to.have.attribute(
+        'aria-disabled',
+      );
+    });
+
+    it('should apply minTime', function test() {
+      render(
+        <ElementToTest
+          {...defaultProps}
+          value={adapterToUse.date(new Date(2019, 5, 15, 11, 15, 0))}
+          minTime={adapterToUse.date(new Date(2019, 5, 15, 11, 10, 0))}
+        />,
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('0') })).to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('5') })).to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('10') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+      expect(screen.getByRole('option', { name: toMinutesLabel('15') })).not.to.have.attribute(
+        'aria-disabled',
+      );
+    });
+  });
+};


### PR DESCRIPTION
Fix #8520 

Change the default to include the date when validating `disablePast` and `disableFuture` in the `TimeClock`.
Fixes issue of TimeClock validation disabling all future or past time choices on any given day.