### PR TITLE
[core] Optimize `renovate` rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -80,6 +80,7 @@
         "@mui/joy",
         "@mui/icons-material",
         "@mui/base",
+        "@mui/styles",
         "@mui/system",
         "@mui/utils"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,10 @@
       "matchPackageNames": ["react", "react-dom", "react-is", "react-test-renderer"]
     },
     {
+      "groupName": "React router",
+      "matchPackageNames": ["react-router", "react-router-dom"]
+    },
+    {
       "groupName": "typescript-eslint",
       "matchPackagePatterns": "@typescript-eslint/*"
     },


### PR DESCRIPTION
- Add `@mui/styles` to the `MUI Core` bump group (should avoid a separate `@mui/styles` bump PR and pointless CI runs)
- Create a `React router` group bumping both `react-router` and `react-router-dom` as they are always released in tandem and result in double PR/CI. 🙈 