### PR TITLE
[pickers] Add `@mui/base` to `peerDependencies`

### DIFF
--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -34,6 +34,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
+  "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
   "react": "^17.0.2 || ^18.0.0",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -54,6 +54,7 @@
     "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
+    "@mui/base": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.6",
     "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -54,18 +54,32 @@
     "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.9.0",
+    "@emotion/styled": "^11.8.1",
     "@mui/base": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.6",
     "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",
+    "date-fns-jalali": "^2.13.0-0",
     "dayjs": "^1.10.7",
     "luxon": "^3.0.2",
     "moment": "^2.29.4",
+    "moment-hijri": "^2.1.2",
+    "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0",
     "react": "^17.0.2 || ^18.0.0",
     "react-dom": "^17.0.2 || ^18.0.0"
   },
   "peerDependenciesMeta": {
+    "@emotion/react": {
+      "optional": true
+    },
+    "@emotion/styled": {
+      "optional": true
+    },
     "date-fns": {
+      "optional": true
+    },
+    "date-fns-jalali": {
       "optional": true
     },
     "dayjs": {
@@ -75,6 +89,12 @@
       "optional": true
     },
     "moment": {
+      "optional": true
+    },
+    "moment-hijri": {
+      "optional": true
+    },
+    "moment-jalaali": {
       "optional": true
     }
   },

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -34,6 +34,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
+  "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
   "react": "^17.0.2 || ^18.0.0",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -62,6 +62,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
+    "@mui/base": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.6",
     "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -76,16 +76,19 @@
     "react-dom": "^17.0.2 || ^18.0.0"
   },
   "peerDependenciesMeta": {
-    "date-fns": {
-      "optional": true
-    },
-    "dayjs": {
-      "optional": true
-    },
     "@emotion/react": {
       "optional": true
     },
     "@emotion/styled": {
+      "optional": true
+    },
+    "date-fns": {
+      "optional": true
+    },
+    "date-fns-jalali": {
+      "optional": true
+    },
+    "dayjs": {
       "optional": true
     },
     "luxon": {
@@ -98,9 +101,6 @@
       "optional": true
     },
     "moment-jalaali": {
-      "optional": true
-    },
-    "date-fns-jalali": {
       "optional": true
     }
   },


### PR DESCRIPTION
Avoids an issue discovered https://github.com/mui/mui-x/issues/8530#issuecomment-1503915419

Also synced all `peerDependencies` between community and pro packages.