### PR TITLE
Fix Mui Data Grid Pro style lost when print current view in the Export function

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -177,7 +177,12 @@ export const useGridPrintExport = (
       }
 
       if (normalizeOptions.copyStyles) {
-        const headStyleElements = doc.current!.querySelectorAll("style, link[rel='stylesheet']");
+        const rootCandidate = gridRootElement!.getRootNode();
+        const root =
+          rootCandidate.constructor.name === 'ShadowRoot'
+            ? (rootCandidate as ShadowRoot)
+            : doc.current;
+        const headStyleElements = root!.querySelectorAll("style, link[rel='stylesheet']");
 
         for (let i = 0; i < headStyleElements.length; i += 1) {
           const node = headStyleElements[i];


### PR DESCRIPTION
This is to fix Mui Data Grid Pro style lost when print current view in the Export function #8646