### PR TITLE
[pickers] Do not include the time in date components when going to today

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -57,6 +57,7 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
   const { renderPicker } = useDesktopRangePicker<TDate, 'day', typeof props>({
     props,
     valueManager: rangeValueManager,
+    valueType: 'date',
     validator: validateDateRange,
   });
 

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -57,6 +57,7 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
   const { renderPicker } = useMobileRangePicker<TDate, 'day', typeof props>({
     props,
     valueManager: rangeValueManager,
+    valueType: 'date',
     validator: validateDateRange,
   });
 

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -49,6 +49,7 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
   const { renderPicker } = useStaticRangePicker<TDate, 'day', typeof props>({
     props,
     valueManager: rangeValueManager,
+    valueType: 'date',
     validator: validateDateRange,
     ref,
   });

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -35,8 +35,7 @@ export const useDesktopRangePicker = <
   TExternalProps extends UseDesktopRangePickerProps<TDate, TView, any, TExternalProps>,
 >({
   props,
-  valueManager,
-  validator,
+  ...pickerParams
 }: UseDesktopRangePickerParams<TDate, TView, TExternalProps>) => {
   useLicenseVerifier('x-date-pickers-pro', releaseInfo);
 
@@ -76,10 +75,9 @@ export const useDesktopRangePicker = <
     TExternalProps,
     DesktopRangePickerAdditionalViewProps
   >({
+    ...pickerParams,
     props,
-    valueManager,
     wrapperVariant: 'desktop',
-    validator,
     autoFocusView: true,
     additionalViewProps: {
       rangePosition,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useDesktopRangePicker/useDesktopRangePicker.types.ts
@@ -88,7 +88,7 @@ export interface UseDesktopRangePickerParams<
       TExternalProps,
       DesktopRangePickerAdditionalViewProps
     >,
-    'valueManager' | 'validator'
+    'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
 }

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -34,8 +34,7 @@ export const useMobileRangePicker = <
   TExternalProps extends UseMobileRangePickerProps<TDate, TView, any, TExternalProps>,
 >({
   props,
-  valueManager,
-  validator,
+  ...pickerParams
 }: UseMobileRangePickerParams<TDate, TView, TExternalProps>) => {
   useLicenseVerifier('x-date-pickers-pro', releaseInfo);
 
@@ -72,10 +71,9 @@ export const useMobileRangePicker = <
     TExternalProps,
     MobileRangePickerAdditionalViewProps
   >({
+    ...pickerParams,
     props,
-    valueManager,
     wrapperVariant: 'mobile',
-    validator,
     autoFocusView: true,
     additionalViewProps: {
       rangePosition,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useMobileRangePicker/useMobileRangePicker.types.ts
@@ -83,7 +83,7 @@ export interface UseMobileRangePickerParams<
       TExternalProps,
       MobileRangePickerAdditionalViewProps
     >,
-    'valueManager' | 'validator'
+    'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
 }

--- a/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.tsx
@@ -32,9 +32,8 @@ export const useStaticRangePicker = <
   TExternalProps extends UseStaticRangePickerProps<TDate, TView, any, TExternalProps>,
 >({
   props,
-  valueManager,
-  validator,
   ref,
+  ...pickerParams
 }: UseStaticRangePickerParams<TDate, TView, TExternalProps>) => {
   const { localeText, slots, slotProps, className, sx, displayStaticWrapperAs, autoFocus } = props;
 
@@ -48,9 +47,8 @@ export const useStaticRangePicker = <
     TExternalProps,
     {}
   >({
+    ...pickerParams,
     props,
-    valueManager,
-    validator,
     autoFocusView: autoFocus ?? false,
     additionalViewProps: {
       rangePosition,

--- a/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/internal/hooks/useStaticRangePicker/useStaticRangePicker.types.ts
@@ -50,7 +50,7 @@ export interface UseStaticRangePickerParams<
   TExternalProps extends UseStaticRangePickerProps<TDate, TView, any, TExternalProps>,
 > extends Pick<
     UsePickerParams<DateRange<TDate>, TDate, TView, RangeFieldSection, TExternalProps, {}>,
-    'valueManager' | 'validator'
+    'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
   /**

--- a/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internal/utils/valueManagers.ts
@@ -24,7 +24,10 @@ export type RangePickerValueManager<
 
 export const rangeValueManager: RangePickerValueManager = {
   emptyValue: [null, null],
-  getTodayValue: (utils) => [utils.date()!, utils.date()!],
+  getTodayValue: (utils, valueType) =>
+    valueType === 'date'
+      ? [utils.startOfDay(utils.date())!, utils.startOfDay(utils.date())!]
+      : [utils.date()!, utils.date()!],
   cleanValue: (utils, value) =>
     value.map((date) => replaceInvalidDateByNull(utils, date)) as DateRange<any>,
   areValuesEqual: (utils, a, b) =>

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -65,6 +65,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   const { renderPicker } = useDesktopPicker<TDate, DateView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'date',
     getOpenDialogAriaText: localeText.openDatePickerDialogue,
     validator: validateDate,
   });

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -74,6 +74,7 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
   const { renderPicker } = useDesktopPicker<TDate, DateOrTimeView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'date-time',
     getOpenDialogAriaText: localeText.openDatePickerDialogue,
     validator: validateDateTime,
   });

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -66,6 +66,7 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   const { renderPicker } = useDesktopPicker<TDate, TimeView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'time',
     getOpenDialogAriaText: localeText.openTimePickerDialogue,
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -8,7 +8,7 @@ import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/pickers-utils';
 
 describe('<MobileDatePicker />', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake', clockConfig: new Date() });
+  const { render } = createPickerRenderer({ clock: 'fake' });
 
   it('allows to change only year', () => {
     const onChangeMock = spy();
@@ -189,14 +189,12 @@ describe('<MobileDatePicker />', () => {
         slotProps={{ actionBar: { actions: ['today'] } }}
       />,
     );
-    const start = adapterToUse.date();
     userEvent.mousePress(screen.getByRole('textbox'));
-    clock.tick(10);
     fireEvent.click(screen.getByText(/today/i));
 
     expect(handleClose.callCount).to.equal(1);
     expect(handleChange.callCount).to.equal(1);
-    expect(adapterToUse.getDiff(handleChange.args[0][0], start)).to.equal(10);
+    expect(handleChange.args[0][0]).toEqualDateTime(adapterToUse.startOfDay(adapterToUse.date()));
   });
 
   describe('picker state', () => {

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -61,6 +61,7 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
   const { renderPicker } = useMobilePicker<TDate, DateView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'date',
     getOpenDialogAriaText: localeText.openDatePickerDialogue,
     validator: validateDate,
   });

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -71,6 +71,7 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
   const { renderPicker } = useMobilePicker<TDate, DateOrTimeView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'date-time',
     getOpenDialogAriaText: localeText.openDatePickerDialogue,
     validator: validateDateTime,
   });

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -63,6 +63,7 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
   const { renderPicker } = useMobilePicker<TDate, TimeView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'time',
     getOpenDialogAriaText: localeText.openTimePickerDialogue,
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -49,6 +49,7 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
   const { renderPicker } = useStaticPicker<TDate, DateView, typeof props>({
     props,
     valueManager: singleItemValueManager,
+    valueType: 'date',
     validator: validateDate,
     ref,
   });

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -60,8 +60,9 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
   const { renderPicker } = useStaticPicker<TDate, DateOrTimeView, typeof props>({
     props,
     valueManager: singleItemValueManager,
-    ref,
+    valueType: 'date-time',
     validator: validateDateTime,
+    ref,
   });
 
   return renderPicker();

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
@@ -51,8 +51,9 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
   const { renderPicker } = useStaticPicker<TDate, TimeView, typeof props>({
     props,
     valueManager: singleItemValueManager,
-    ref,
+    valueType: 'time',
     validator: validateTime,
+    ref,
   });
 
   return renderPicker();

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -25,9 +25,8 @@ export const useDesktopPicker = <
   TExternalProps extends UseDesktopPickerProps<TDate, TView, any, TExternalProps>,
 >({
   props,
-  valueManager,
   getOpenDialogAriaText,
-  validator,
+  ...pickerParams
 }: UseDesktopPickerParams<TDate, TView, TExternalProps>) => {
   const {
     slots,
@@ -59,10 +58,9 @@ export const useDesktopPicker = <
     shouldRestoreFocus,
     fieldProps: pickerFieldProps,
   } = usePicker<TDate | null, TDate, TView, FieldSection, TExternalProps, {}>({
+    ...pickerParams,
     props,
     inputRef: internalInputRef,
-    valueManager,
-    validator,
     autoFocusView: true,
     additionalViewProps: {},
     wrapperVariant: 'desktop',

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
@@ -118,7 +118,7 @@ export interface UseDesktopPickerParams<
   TExternalProps extends UseDesktopPickerProps<TDate, TView, any, TExternalProps>,
 > extends Pick<
     UsePickerParams<TDate | null, TDate, TView, FieldSection, TExternalProps, {}>,
-    'valueManager' | 'validator'
+    'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
   getOpenDialogAriaText: (date: TDate | null, utils: MuiPickersAdapter<TDate>) => string;

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -4,6 +4,7 @@ import {
   FieldSection,
   FieldSelectedSections,
   MuiPickersAdapter,
+  FieldValueType,
 } from '../../../models';
 import type { PickerValueManager } from '../usePicker';
 import { InferError, Validator } from '../validation/useValidation';
@@ -314,8 +315,6 @@ export type AvailableAdjustKeyCode =
   | 'PageDown'
   | 'Home'
   | 'End';
-
-export type FieldValueType = 'date' | 'time' | 'date-time';
 
 export type SectionNeighbors = {
   [sectionIndex: number]: {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -3,11 +3,10 @@ import {
   FieldSectionsValueBoundaries,
   SectionNeighbors,
   SectionOrdering,
-  FieldValueType,
   FieldSectionWithoutPosition,
   FieldSectionValueBoundaries,
 } from './useField.types';
-import { FieldSectionType, FieldSection, MuiPickersAdapter } from '../../../models';
+import { FieldSectionType, FieldValueType, FieldSection, MuiPickersAdapter } from '../../../models';
 import { PickersLocaleText } from '../../../locales/utils/pickersLocaleTextApi';
 
 export const getDateSectionConfigFromFormatToken = <TDate>(

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -101,7 +101,7 @@ export const useFieldState = <
       referenceValue: fieldValueManager.updateReferenceValue(
         utils,
         valueFromTheOutside,
-        valueManager.getTodayValue(utils),
+        valueManager.getTodayValue(utils, valueType),
       ),
       tempValueStrAndroid: null,
     };

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -24,9 +24,8 @@ export const useMobilePicker = <
   TExternalProps extends UseMobilePickerProps<TDate, TView, any, TExternalProps>,
 >({
   props,
-  valueManager,
   getOpenDialogAriaText,
-  validator,
+  ...pickerParams
 }: UseMobilePickerParams<TDate, TView, TExternalProps>) => {
   const {
     slots,
@@ -54,10 +53,9 @@ export const useMobilePicker = <
     renderCurrentView,
     fieldProps: pickerFieldProps,
   } = usePicker<TDate | null, TDate, TView, FieldSection, TExternalProps, {}>({
+    ...pickerParams,
     props,
     inputRef: internalInputRef,
-    valueManager,
-    validator,
     autoFocusView: true,
     additionalViewProps: {},
     wrapperVariant: 'mobile',

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.types.ts
@@ -87,7 +87,7 @@ export interface UseMobilePickerParams<
   TExternalProps extends UseMobilePickerProps<TDate, TView, any, TExternalProps>,
 > extends Pick<
     UsePickerParams<TDate | null, TDate, TView, FieldSection, TExternalProps, {}>,
-    'valueManager' | 'validator'
+    'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
   getOpenDialogAriaText: (date: TDate | null, utils: MuiPickersAdapter<TDate>) => string;

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
@@ -22,6 +22,7 @@ export const usePicker = <
 >({
   props,
   valueManager,
+  valueType,
   wrapperVariant,
   inputRef,
   additionalViewProps,
@@ -43,6 +44,7 @@ export const usePicker = <
   const pickerValueResponse = usePickerValue({
     props,
     valueManager,
+    valueType,
     wrapperVariant,
     validator,
   });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
@@ -46,7 +46,7 @@ export interface UsePickerParams<
   TAdditionalProps extends {},
 > extends Pick<
       UsePickerValueParams<TValue, TDate, TSection, TExternalProps>,
-      'valueManager' | 'wrapperVariant' | 'validator'
+      'valueManager' | 'valueType' | 'wrapperVariant' | 'validator'
     >,
     Pick<
       UsePickerViewParams<TValue, TView, TExternalProps, TAdditionalProps>,

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -131,6 +131,7 @@ export const usePickerValue = <
 >({
   props,
   valueManager,
+  valueType,
   wrapperVariant,
   validator,
 }: UsePickerValueParams<TValue, TDate, TSection, TExternalProps>): UsePickerValueResponse<
@@ -318,7 +319,7 @@ export const usePickerValue = <
 
   const handleSetToday = useEventCallback(() => {
     updateDate({
-      value: valueManager.getTodayValue(utils),
+      value: valueManager.getTodayValue(utils, valueType),
       name: 'setValueFromAction',
       pickerAction: 'today',
     });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
@@ -2,7 +2,12 @@ import { FieldChangeHandlerContext, UseFieldInternalProps } from '../useField';
 import { InferError, Validator } from '../validation/useValidation';
 import { UseFieldValidationProps } from '../useField/useField.types';
 import { WrapperVariant } from '../../models/common';
-import { FieldSection, FieldSelectedSections, MuiPickersAdapter } from '../../../models';
+import {
+  FieldSection,
+  FieldSelectedSections,
+  FieldValueType,
+  MuiPickersAdapter,
+} from '../../../models';
 
 export interface PickerValueManager<TValue, TDate, TError> {
   /**
@@ -26,9 +31,10 @@ export interface PickerValueManager<TValue, TDate, TError> {
    * Method returning the value to set when clicking the "Today" button
    * @template TDate, TValue
    * @param {MuiPickersAdapter<TDate>} utils The adapter.
+   * @param {FieldValueType} valueType The type of the value being edited.
    * @returns {TValue} The value to set when clicking the "Today" button.
    */
-  getTodayValue: (utils: MuiPickersAdapter<TDate>) => TValue;
+  getTodayValue: (utils: MuiPickersAdapter<TDate>, valueType: FieldValueType) => TValue;
   /**
    * Method parsing the input value to replace all invalid dates by `null`.
    * @template TDate, TValue
@@ -224,6 +230,7 @@ export interface UsePickerValueParams<
 > {
   props: TExternalProps;
   valueManager: PickerValueManager<TValue, TDate, InferError<TExternalProps>>;
+  valueType: FieldValueType;
   wrapperVariant: WrapperVariant;
   validator: Validator<
     TValue,

--- a/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.tsx
@@ -26,9 +26,8 @@ export const useStaticPicker = <
   TExternalProps extends UseStaticPickerProps<TDate, TView, any, TExternalProps>,
 >({
   props,
-  valueManager,
-  validator,
   ref,
+  ...pickerParams
 }: UseStaticPickerParams<TDate, TView, TExternalProps>) => {
   const { localeText, slots, slotProps, className, sx, displayStaticWrapperAs, autoFocus } = props;
 
@@ -40,9 +39,8 @@ export const useStaticPicker = <
     TExternalProps,
     {}
   >({
+    ...pickerParams,
     props,
-    valueManager,
-    validator,
     autoFocusView: autoFocus ?? false,
     additionalViewProps: {},
     wrapperVariant: displayStaticWrapperAs,

--- a/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useStaticPicker/useStaticPicker.types.ts
@@ -70,7 +70,7 @@ export interface UseStaticPickerParams<
   TExternalProps extends UseStaticPickerProps<TDate, TView, any, TExternalProps>,
 > extends Pick<
     UsePickerParams<TDate | null, TDate, TView, FieldSection, TExternalProps, {}>,
-    'valueManager' | 'validator'
+    'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
   /**

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -20,7 +20,8 @@ export type SingleItemPickerValueManager<
 
 export const singleItemValueManager: SingleItemPickerValueManager = {
   emptyValue: null,
-  getTodayValue: (utils) => utils.date()!,
+  getTodayValue: (utils, valueType) =>
+    valueType === 'date' ? utils.startOfDay(utils.date())! : utils.date()!,
   cleanValue: replaceInvalidDateByNull,
   areValuesEqual: areDatesEqual,
   isSameError: (a, b) => a === b,

--- a/packages/x-date-pickers/src/models/fields.ts
+++ b/packages/x-date-pickers/src/models/fields.ts
@@ -11,6 +11,8 @@ export type FieldSectionType =
   | 'seconds'
   | 'meridiem';
 
+export type FieldValueType = 'date' | 'time' | 'date-time';
+
 export interface FieldSection {
   /**
    * Value of the section, as rendered inside the input.

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -122,6 +122,7 @@
   { "name": "FieldSection", "kind": "Interface" },
   { "name": "FieldSectionType", "kind": "TypeAlias" },
   { "name": "FieldSelectedSections", "kind": "TypeAlias" },
+  { "name": "FieldValueType", "kind": "TypeAlias" },
   { "name": "fiFI", "kind": "Variable" },
   { "name": "frFR", "kind": "Variable" },
   { "name": "getDateCalendarUtilityClass", "kind": "Variable" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -91,6 +91,7 @@
   { "name": "FieldSection", "kind": "Interface" },
   { "name": "FieldSectionType", "kind": "TypeAlias" },
   { "name": "FieldSelectedSections", "kind": "TypeAlias" },
+  { "name": "FieldValueType", "kind": "TypeAlias" },
   { "name": "fiFI", "kind": "Variable" },
   { "name": "frFR", "kind": "Variable" },
   { "name": "getDateCalendarUtilityClass", "kind": "Variable" },


### PR DESCRIPTION
Fixes #8616

Note that if a user uses `TimePicker` and presses `Today`, it will contain the current second even if the views do not.
We could be smarter and limit to the smallest section / view present, but I'm not sure it's worth the complexity.
Skipping the time seems to solve most of the pain.