### PR TITLE
[DataGridPro] Emit `columnWidthChange` event on `touchEnd` of column resize

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -297,6 +297,17 @@ export const useGridColumnResize = (
     clearTimeout(stopResizeEventTimeout.current);
     stopResizeEventTimeout.current = setTimeout(() => {
       apiRef.current.publishEvent('columnResizeStop', null, nativeEvent);
+      if (colDefRef.current) {
+        apiRef.current.publishEvent(
+          'columnWidthChange',
+          {
+            element: colElementRef.current,
+            colDef: colDefRef.current,
+            width: colDefRef.current?.computedWidth,
+          },
+          nativeEvent,
+        );
+      }
     });
 
     logger.debug(


### PR DESCRIPTION
Fixes #8658 

Before: https://codesandbox.io/s/datagridpro-oncolumnwidthchange-issue-on-mobile-touchend-vvoion?file=/src/App.tsx
After: https://codesandbox.io/s/datagridpro-oncolumnwidthchange-issue-on-mobile-touchend-forked-lhph3v?file=/package.json

(To visualize the problem, open https://vvoion.csb.app/ on a mobile device and try to resize a column, no log will be shown on screen, now check https://lhph3v.csb.app/ it should print a log produced by `columnWidthChange` event)