### PR TITLE
[pickers] Sync internal state with controlled value

### DIFF
--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -5,7 +5,13 @@ import { fireEvent, screen, userEvent } from '@mui/monorepo/test/utils';
 import { PickersDay } from '@mui/x-date-pickers/PickersDay';
 import { DayCalendarSkeleton } from '@mui/x-date-pickers/DayCalendarSkeleton';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
-import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/pickers-utils';
+import {
+  createPickerRenderer,
+  adapterToUse,
+  openPicker,
+  getTextbox,
+  expectInputValue,
+} from 'test/utils/pickers-utils';
 
 describe('<MobileDatePicker />', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake', clockConfig: new Date() });
@@ -228,6 +234,26 @@ describe('<MobileDatePicker />', () => {
       fireEvent.click(screen.getByText('OK', { selector: 'button' }));
 
       expect(onAccept.callCount).to.equal(1);
+    });
+
+    it('should update internal state when controled value is updated', () => {
+      const value = adapterToUse.date(new Date(2019, 0, 1));
+
+      const { setProps } = render(<MobileDatePicker value={value} />);
+
+      // Set a date
+      expectInputValue(getTextbox(), '01/01/2019');
+
+      // Clean value using external control
+      setProps({ value: null });
+      expectInputValue(getTextbox(), '');
+
+      // Open and Dismiss the picker
+      userEvent.mousePress(screen.getByRole('textbox'));
+      userEvent.keyPress(document.activeElement!, { key: 'Escape' });
+
+      // Verrify it's still a clean value
+      expectInputValue(getTextbox(), '');
     });
   });
 

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -210,6 +210,25 @@ describe('<MobileDatePicker />', () => {
       expect(onOpen.callCount).to.equal(1);
       expect(screen.queryByRole('dialog')).toBeVisible();
     });
+
+    it('should call `onAccept` even if controlled', () => {
+      const onAccept = spy();
+
+      function ControledMobileDatePicker(props) {
+        const [value, setValue] = React.useState(null);
+
+        return <MobileDatePicker {...props} value={value} onChange={setValue} />;
+      }
+
+      render(<ControledMobileDatePicker onAccept={onAccept} />);
+
+      userEvent.mousePress(screen.getByRole('textbox'));
+
+      fireEvent.click(screen.getByText('15', { selector: 'button' }));
+      fireEvent.click(screen.getByText('OK', { selector: 'button' }));
+
+      expect(onAccept.callCount).to.equal(1);
+    });
   });
 
   describe('localization', () => {

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -251,6 +251,7 @@ describe('<MobileDatePicker />', () => {
       // Open and Dismiss the picker
       userEvent.mousePress(screen.getByRole('textbox'));
       userEvent.keyPress(document.activeElement!, { key: 'Escape' });
+      clock.runToLast();
 
       // Verrify it's still a clean value
       expectInputValue(getTextbox(), '');

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -253,7 +253,7 @@ describe('<MobileDatePicker />', () => {
       userEvent.keyPress(document.activeElement!, { key: 'Escape' });
       clock.runToLast();
 
-      // Verrify it's still a clean value
+      // Verify it's still a clean value
       expectInputValue(getTextbox(), '');
     });
   });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -281,7 +281,13 @@ export const usePickerValue = <
     (dateState.lastControlledValue === undefined ||
       !valueManager.areValuesEqual(utils, dateState.lastControlledValue, inValue))
   ) {
-    setDateState((prev) => ({ ...prev, lastControlledValue: inValue, draft: inValue }));
+    setDateState((prev) => ({
+      ...prev,
+      lastCommittedValue: inValue,
+      lastPublishedValue: inValue,
+      lastControlledValue: inValue,
+      draft: inValue,
+    }));
   }
 
   const handleClear = useEventCallback(() => {

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -270,23 +270,23 @@ export const usePickerValue = <
     }
   });
 
-  React.useEffect(() => {
-    if (isOpen) {
-      setDateState((prev) => ({ ...prev, lastCommittedValue: dateState.draft }));
-    }
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
-
   if (
     inValue !== undefined &&
     (dateState.lastControlledValue === undefined ||
       !valueManager.areValuesEqual(utils, dateState.lastControlledValue, inValue))
   ) {
+    const isUpdateComingFromPicker = valueManager.areValuesEqual(utils, dateState.draft, inValue);
     setDateState((prev) => ({
       ...prev,
-      lastCommittedValue: inValue,
-      lastPublishedValue: inValue,
       lastControlledValue: inValue,
-      draft: inValue,
+      ...(isUpdateComingFromPicker
+        ? {}
+        : {
+            lastCommittedValue: inValue,
+            lastPublishedValue: inValue,
+            draft: inValue,
+            hasBeenModifiedSinceMount: true,
+          }),
     }));
   }
 


### PR DESCRIPTION
Fix #8663
Fix #8684

If we update the controlled value with a side effect, the new value should be committed and published. Otherwise dismiss and cancel action will be incoherent with what the dev implemented