### PR TITLE
[data grid] Fix aggregation label alignment

### DIFF
--- a/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -32,6 +32,7 @@ const GridAggregationHeaderRoot = styled(Box, {
   [`&.${gridClasses['aggregationColumnHeader--alignCenter']}`]: {
     alignItems: 'center',
   },
+  position: 'relative',
 });
 
 const GridAggregationFunctionLabel = styled('div', {

--- a/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -32,7 +32,6 @@ const GridAggregationHeaderRoot = styled(Box, {
   [`&.${gridClasses['aggregationColumnHeader--alignCenter']}`]: {
     alignItems: 'center',
   },
-  position: 'relative',
 });
 
 const GridAggregationFunctionLabel = styled('div', {

--- a/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -42,8 +42,8 @@ const GridAggregationFunctionLabel = styled('div', {
   return {
     fontSize: theme.typography.caption.fontSize,
     lineHeight: theme.typography.caption.fontSize,
-    position:'absolute',
-    bottom:4,
+    position: 'absolute',
+    bottom: 4,
     fontWeight: theme.typography.fontWeightMedium,
     color: (theme.vars || theme).palette.primary.dark,
     textTransform: 'uppercase',

--- a/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -42,7 +42,8 @@ const GridAggregationFunctionLabel = styled('div', {
   return {
     fontSize: theme.typography.caption.fontSize,
     lineHeight: theme.typography.caption.fontSize,
-    marginTop: `calc(-2px - ${theme.typography.caption.fontSize})`,
+    position:'absolute',
+    bottom:4,
     fontWeight: theme.typography.fontWeightMedium,
     color: (theme.vars || theme).palette.primary.dark,
     textTransform: 'uppercase',

--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -178,6 +178,8 @@ export const GridRootStyles = styled('div', {
       flex: 1,
       whiteSpace: 'nowrap',
       overflow: 'hidden',
+      // to anchor the aggregation label
+      position: 'relative',
     },
     [`& .${gridClasses.columnHeaderTitleContainerContent}`]: {
       overflow: 'hidden',


### PR DESCRIPTION
# Preview 

https://deploy-preview-8694--material-ui-x.netlify.app/x/react-data-grid/aggregation/

# Problems
- Column titles with aggregation labels are not correctly aligned with other column titles. They are rendered slightly lower as shown with the red line below.
<img width="163" alt="zoom" src="https://user-images.githubusercontent.com/550141/233469764-629089cf-1dbf-4c87-a622-76db497830e7.png">

- The blue aggregation label is too close to the bottom. 

# Before
<img width="653" alt="Screenshot 2023-04-20 at 21 21 59" src="https://user-images.githubusercontent.com/550141/233469297-e6731260-e160-41ed-903f-ad63f3153bc4.png">

# After
<img width="653" alt="Screenshot 2023-04-20 at 21 36 54" src="https://user-images.githubusercontent.com/550141/233470343-a58fea0d-4dc9-4463-a19f-abdea741b42e.png">

