### PR TITLE
[charts] Adapt line and scatter the band scale

### DIFF
--- a/packages/x-charts/src/Highlight/Highlight.tsx
+++ b/packages/x-charts/src/Highlight/Highlight.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { InteractionContext } from '../context/InteractionProvider';
 import { CartesianContext } from '../context/CartesianContextProvider';
-import { isBandScale } from '../hooks/useScale';
+import { getValueToPositionMapper, isBandScale } from '../hooks/useScale';
 
 export type HighlightProps = {
   highlight: {
@@ -32,7 +32,7 @@ export const Highlight = React.forwardRef<SVGPathElement, HighlightProps>(functi
   //   interactionApi?.listenYAxis(USED_Y_AXIS_ID);
   // }, [USED_X_AXIS_ID, USED_Y_AXIS_ID, interactionApi]);
 
-  if (isBandScale(xScale)) {
+  if (isBandScale(xScale) && !xHighlight) {
     if (axis.x === null) {
       return null;
     }
@@ -51,11 +51,13 @@ export const Highlight = React.forwardRef<SVGPathElement, HighlightProps>(functi
       />
     );
   }
+
+  const getXPosition = getValueToPositionMapper(xScale)
   return (
     <React.Fragment>
       {xHighlight && axis.x !== null && (
         <path
-          d={`M ${xScale(axis.x.value)} ${yScale(yScale.domain()[0])} L ${xScale(
+          d={`M ${getXPosition(axis.x.value)} ${yScale(yScale.domain()[0])} L ${getXPosition(
             axis.x.value,
           )} ${yScale(yScale.domain().at(-1))}`}
           stroke="black"

--- a/packages/x-charts/src/Highlight/Highlight.tsx
+++ b/packages/x-charts/src/Highlight/Highlight.tsx
@@ -52,7 +52,7 @@ export const Highlight = React.forwardRef<SVGPathElement, HighlightProps>(functi
     );
   }
 
-  const getXPosition = getValueToPositionMapper(xScale)
+  const getXPosition = getValueToPositionMapper(xScale);
   return (
     <React.Fragment>
       {xHighlight && axis.x !== null && (

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -7,6 +7,7 @@ import { LineElement } from './LineElement';
 import { AreaElement } from './AreaElement';
 import { useInteractionItemProps } from '../hooks/useInteractionItemProps';
 import { MarkElement } from './MarkElement';
+import { getValueToPositionMapper } from '../hooks/useScale';
 
 export function LinePlot() {
   const seriesData = React.useContext(SeriesContext).line;
@@ -41,7 +42,7 @@ export function LinePlot() {
         {Object.keys(seriesPerAxis).flatMap((key) => {
           const [xAxisKey, yAxisKey] = key.split('-');
 
-          const xScale = xAxis[xAxisKey].scale;
+          const xScale = getValueToPositionMapper(xAxis[xAxisKey].scale);
           const yScale = yAxis[yAxisKey].scale;
           const xData = xAxis[xAxisKey].data;
 
@@ -83,7 +84,7 @@ export function LinePlot() {
         {Object.keys(seriesPerAxis).flatMap((key) => {
           const [xAxisKey, yAxisKey] = key.split('-');
 
-          const xScale = xAxis[xAxisKey].scale;
+          const xScale = getValueToPositionMapper(xAxis[xAxisKey].scale);
           const yScale = yAxis[yAxisKey].scale;
           const xData = xAxis[xAxisKey].data;
 
@@ -122,7 +123,7 @@ export function LinePlot() {
         {Object.keys(seriesPerAxis).flatMap((key) => {
           const [xAxisKey, yAxisKey] = key.split('-');
 
-          const xScale = xAxis[xAxisKey].scale;
+          const xScale = getValueToPositionMapper(xAxis[xAxisKey].scale);
           const yScale = yAxis[yAxisKey].scale;
           const xData = xAxis[xAxisKey].data;
 

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -8,6 +8,7 @@ import { AreaElement } from './AreaElement';
 import { useInteractionItemProps } from '../hooks/useInteractionItemProps';
 import { MarkElement } from './MarkElement';
 import { getValueToPositionMapper } from '../hooks/useScale';
+import getCurveFactory from '../internals/getCurve';
 
 export function LinePlot() {
   const seriesData = React.useContext(SeriesContext).line;
@@ -59,10 +60,10 @@ export function LinePlot() {
             .x((d) => xScale(d.x))
             .y0((d) => yScale(d.y[0]))
             .y1((d) => yScale(d.y[1]));
-
           return stackingGroups.flatMap((groupIds) => {
             return groupIds.flatMap((seriesId) => {
               const stackedData = series[seriesId].stackedData;
+              const curve = getCurveFactory(series[seriesId].curve);
               const d3Data = xData?.map((x, index) => ({ x, y: stackedData[index] }));
 
               return (
@@ -70,7 +71,7 @@ export function LinePlot() {
                   <AreaElement
                     key={seriesId}
                     id={seriesId}
-                    d={areaPath(d3Data) || undefined}
+                    d={areaPath.curve(curve)(d3Data) || undefined}
                     color={series[seriesId].area.color ?? series[seriesId].color}
                     {...getInteractionItemProps({ type: 'line', seriesId })}
                   />
@@ -104,13 +105,14 @@ export function LinePlot() {
           return stackingGroups.flatMap((groupIds) => {
             return groupIds.flatMap((seriesId) => {
               const stackedData = series[seriesId].stackedData;
+              const curve = getCurveFactory(series[seriesId].curve);
               const d3Data = xData?.map((x, index) => ({ x, y: stackedData[index] }));
 
               return (
                 <LineElement
                   key={seriesId}
                   id={seriesId}
-                  d={linePath(d3Data) || undefined}
+                  d={linePath.curve(curve)(d3Data) || undefined}
                   color={series[seriesId].color}
                   {...getInteractionItemProps({ type: 'line', seriesId })}
                 />

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ScatterSeriesType } from '../models/seriesType/scatter';
-import { D3Scale } from '../hooks/useScale';
+import { D3Scale, getValueToPositionMapper } from '../hooks/useScale';
 import { useInteractionItemProps } from '../hooks/useInteractionItemProps';
 
 export interface ScatterProps {
@@ -14,6 +14,8 @@ export interface ScatterProps {
 export function Scatter(props: ScatterProps) {
   const { series, xScale, yScale, color, markerSize } = props;
 
+  const getXPosition = getValueToPositionMapper(xScale);
+  const getYPosition = getValueToPositionMapper(yScale);
   const getInteractionItemProps = useInteractionItemProps();
 
   return (
@@ -24,7 +26,7 @@ export function Scatter(props: ScatterProps) {
           cx={0}
           cy={0}
           r={markerSize}
-          transform={`translate(${xScale(x as number)}, ${yScale(y as number)})`}
+          transform={`translate(${getXPosition(x)}, ${getYPosition(y)})`}
           fill={color}
           {...getInteractionItemProps({ type: 'scatter', seriesId: series.id, dataIndex })}
         />

--- a/packages/x-charts/src/hooks/useScale.ts
+++ b/packages/x-charts/src/hooks/useScale.ts
@@ -50,3 +50,16 @@ export function getScale(scaleName: ScaleName | undefined): D3Scale {
 export function isBandScale(scale: D3Scale): scale is ScaleBand<any> | ScalePoint<any> {
   return (scale as ScaleBand<any> | ScalePoint<any>).bandwidth !== undefined;
 }
+
+/**
+ * For a given scale return a function that map value to their position.
+ * Usefull when dealing with specific scale such as band.
+ * @param scale The scale to use
+ * @returns (value: any) => number
+ */
+export function getValueToPositionMapper(scale: D3Scale) {
+  if (isBandScale(scale)) {
+    return (value: any) => scale(value)! + scale.bandwidth() / 2;
+  }
+  return (value: any) => scale(value) as number;
+}

--- a/packages/x-charts/src/internals/getCurve.ts
+++ b/packages/x-charts/src/internals/getCurve.ts
@@ -1,0 +1,51 @@
+import {
+  curveCatmullRom,
+  curveLinear,
+  curveMonotoneX,
+  curveMonotoneY,
+  curveNatural,
+  curveStep,
+  curveStepAfter,
+  curveStepBefore,
+} from 'd3-shape';
+
+export type CurveType =
+  | 'catmullRom'
+  | 'linear'
+  | 'monotoneX'
+  | 'monotoneY'
+  | 'natural'
+  | 'step'
+  | 'stepBefore'
+  | 'stepAfter';
+
+export default function getCurveFactory(curveType?: CurveType) {
+  switch (curveType) {
+    case 'catmullRom': {
+      return curveCatmullRom.alpha(0.5);
+    }
+    case 'linear': {
+      return curveLinear;
+    }
+    case 'monotoneX': {
+      return curveMonotoneX;
+    }
+    case 'monotoneY': {
+      return curveMonotoneY;
+    }
+    case 'natural': {
+      return curveNatural;
+    }
+    case 'step': {
+      return curveStep;
+    }
+    case 'stepBefore': {
+      return curveStepBefore;
+    }
+    case 'stepAfter': {
+      return curveStepAfter;
+    }
+    default:
+      return curveNatural;
+  }
+}

--- a/packages/x-charts/src/internals/getCurve.ts
+++ b/packages/x-charts/src/internals/getCurve.ts
@@ -46,6 +46,6 @@ export default function getCurveFactory(curveType?: CurveType) {
       return curveStepAfter;
     }
     default:
-      return curveNatural;
+      return curveMonotoneX;
   }
 }

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -1,3 +1,4 @@
+import { CurveType } from '../../internals/getCurve';
 import { DefaultizedProps } from '../helpers';
 import { CartesianSeriesType, CommonSeriesType, DefaultizedCommonSeriesType } from './common';
 
@@ -6,6 +7,7 @@ export interface LineSeriesType extends CommonSeriesType, CartesianSeriesType {
   data: number[];
   stack?: string;
   area?: any;
+  curve?: CurveType;
 }
 
 /**


### PR DESCRIPTION

To simplify the PR review, commits titles have a meaning

---

## Unify position, between band and interpolation scales

If you run `scale(value)` for most of the scaling, the answer is unique.

Except for band scale which returns the start of the band whereas w would like the middle to have nice looking between bar and lines plots

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://user-images.githubusercontent.com/45398769/233652745-46ca7ecc-3657-4c20-9bac-131c7508971c.png"/>
 <td><img src="https://user-images.githubusercontent.com/45398769/233652590-64ecdde0-1c3a-4f39-a6e6-bd09f319f547.png" />
</table>

## Allows customizing line interpolation

Add a parameter `curve` to series with `type: 'line'` such that user con chose the line interpolation

![image](https://user-images.githubusercontent.com/45398769/233667207-2d530e09-2553-4521-abd7-6dd64ab86067.png)
