### PR TITLE
[DataGridPro] Fix error after updating `columns` and `columnGroupingModel` at once

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/columnGrouping/useGridColumnGrouping.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columnGrouping/useGridColumnGrouping.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridStateInitializer } from '../../utils/useGridInitializeState';
-import { GridColumnNode, isLeaf } from '../../../models/gridColumnGrouping';
+import {
+  GridColumnGroupingModel,
+  GridColumnNode,
+  isLeaf,
+} from '../../../models/gridColumnGrouping';
 import {
   gridColumnGroupsLookupSelector,
   gridColumnGroupsUnwrappedModelSelector,
@@ -13,12 +17,7 @@ import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { getColumnGroupsHeaderStructure, unwrapGroupingColumnModel } from './gridColumnGroupsUtils';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridEventListener } from '../../../models/events';
-import {
-  gridColumnFieldsSelector,
-  // GridColumnsState,
-  gridVisibleColumnFieldsSelector,
-} from '../columns';
-import { useGridSelector } from '../../utils/useGridSelector';
+import { gridColumnFieldsSelector, gridVisibleColumnFieldsSelector } from '../columns';
 
 const createGroupLookup = (columnGroupingModel: GridColumnNode[]): GridColumnGroupLookup => {
   let groupLookup: GridColumnGroupLookup = {};
@@ -137,46 +136,53 @@ export const useGridColumnGrouping = (
     });
   }, [apiRef, props.columnGroupingModel]);
 
-  useGridApiEventHandler(apiRef, 'columnIndexChange', handleColumnIndexChange);
+  const updateColumnGroupingState = React.useCallback(
+    (columnGroupingModel: GridColumnGroupingModel | undefined) => {
+      if (!props.experimentalFeatures?.columnGrouping) {
+        return;
+      }
+      const columnFields = gridColumnFieldsSelector(apiRef);
+      const visibleColumnFields = gridVisibleColumnFieldsSelector(apiRef);
+      const groupLookup = createGroupLookup(columnGroupingModel ?? []);
+      const unwrappedGroupingModel = unwrapGroupingColumnModel(columnGroupingModel ?? []);
+      const columnGroupsHeaderStructure = getColumnGroupsHeaderStructure(
+        columnFields,
+        unwrappedGroupingModel,
+      );
+      const maxDepth =
+        visibleColumnFields.length === 0
+          ? 0
+          : Math.max(
+              ...visibleColumnFields.map((field) => unwrappedGroupingModel[field]?.length ?? 0),
+            );
 
-  const columnFields = useGridSelector(apiRef, gridColumnFieldsSelector);
-  const visibleColumnFields = useGridSelector(apiRef, gridVisibleColumnFieldsSelector);
+      apiRef.current.setState((state) => {
+        return {
+          ...state,
+          columnGrouping: {
+            lookup: groupLookup,
+            unwrappedGroupingModel,
+            headerStructure: columnGroupsHeaderStructure,
+            maxDepth,
+          },
+        };
+      });
+    },
+    [apiRef, props.experimentalFeatures?.columnGrouping],
+  );
+
+  useGridApiEventHandler(apiRef, 'columnIndexChange', handleColumnIndexChange);
+  useGridApiEventHandler(apiRef, 'columnsChange', () => {
+    updateColumnGroupingState(props.columnGroupingModel);
+  });
+  useGridApiEventHandler(apiRef, 'columnVisibilityModelChange', () => {
+    updateColumnGroupingState(props.columnGroupingModel);
+  });
+
   /**
    * EFFECTS
    */
   React.useEffect(() => {
-    if (!props.experimentalFeatures?.columnGrouping) {
-      return;
-    }
-    const groupLookup = createGroupLookup(props.columnGroupingModel ?? []);
-    const unwrappedGroupingModel = unwrapGroupingColumnModel(props.columnGroupingModel ?? []);
-    const columnGroupsHeaderStructure = getColumnGroupsHeaderStructure(
-      columnFields,
-      unwrappedGroupingModel,
-    );
-    const maxDepth =
-      visibleColumnFields.length === 0
-        ? 0
-        : Math.max(
-            ...visibleColumnFields.map((field) => unwrappedGroupingModel[field]?.length ?? 0),
-          );
-
-    apiRef.current.setState((state) => {
-      return {
-        ...state,
-        columnGrouping: {
-          lookup: groupLookup,
-          unwrappedGroupingModel,
-          headerStructure: columnGroupsHeaderStructure,
-          maxDepth,
-        },
-      };
-    });
-  }, [
-    apiRef,
-    columnFields,
-    visibleColumnFields,
-    props.columnGroupingModel,
-    props.experimentalFeatures?.columnGrouping,
-  ]);
+    updateColumnGroupingState(props.columnGroupingModel);
+  }, [updateColumnGroupingState, props.columnGroupingModel]);
 };

--- a/packages/grid/x-data-grid/src/tests/columnsGrouping.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnsGrouping.DataGrid.test.tsx
@@ -285,6 +285,47 @@ describe('<DataGrid /> - Column grouping', () => {
         },
       });
     });
+
+    // See https://github.com/mui/mui-x/issues/8602
+    it('should not throw when both `columns` and `columnGroupingModel` are updated', () => {
+      const defaultProps = getDefaultProps(2);
+      const { setProps } = render(
+        <TestDataGrid
+          nbColumns={0}
+          {...defaultProps}
+          columnGroupingModel={[
+            {
+              groupId: 'testGroup',
+              children: [{ field: 'col1' }, { field: 'col2' }],
+            },
+          ]}
+        />,
+      );
+
+      setProps({
+        columns: [...defaultProps.columns, { field: 'newColumn' }],
+        columnGroupingModel: [
+          {
+            groupId: 'testGroup',
+            children: [{ field: 'col1' }, { field: 'col2' }, { field: 'newColumn' }],
+          },
+        ],
+      });
+
+      const row1Headers = document.querySelectorAll<HTMLElement>(
+        '[aria-rowindex="1"] [role="columnheader"]',
+      );
+      const row2Headers = document.querySelectorAll<HTMLElement>(
+        '[aria-rowindex="2"] [role="columnheader"]',
+      );
+
+      expect(
+        Array.from(row1Headers).map((header) => header.getAttribute('aria-colindex')),
+      ).to.deep.equal(['1']);
+      expect(
+        Array.from(row2Headers).map((header) => header.getAttribute('aria-colindex')),
+      ).to.deep.equal(['1', '2', '3']);
+    });
   });
 
   // TODO: remove the skip. I failed to test if an error is thrown


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/8602

Before: https://codesandbox.io/s/data-grid-pro-version-6-1-0-bp39li?file=/demo.js
After: https://codesandbox.io/s/data-grid-pro-version-6-1-0-d8mm7r?file=/demo.js

## The problem

The problem comes from this effect where column grouping is recalculated:

https://github.com/mui/mui-x/blob/970124e990bb677cd867fcc49842fb7454fa9cb2/packages/grid/x-data-grid/src/hooks/features/columnGrouping/useGridColumnGrouping.ts#L147-L181

The main dependencies of this effect are:
- `columnFields` coming from columns state
- `visibleColumnFields` coming from columns state
- `props.columnGroupingModel` coming from props

The problem is that after updating both `columns` and `columnGroupingModel` props, the effect is triggered by `columnGroupingModel` prop change, while `columnFields` and `visibleColumnFields` come from the previous state and do not reflect the new `columns` prop. 

## The solution

The first solution I had was to move `columnFields` and `visibleColumnFields` calculation to the effect itself:
```tsx
React.useEffect(() => {
  const columnFields = /** ... **/;
  const visibleColumnFields = /** ... **/;
  /** ... **/
}, [columnFields, visibleColumnFields, props.columnGroupingModel]);
```

But it was still important to keep `columnFields, visibleColumnFields` as effect dependencies, even though they're not being used inside the effect. This works, but it didn't feel right.

Instead, I decided to use the effect to only track `props.columnGroupingModel` dependency.
And for `columnFields` and `visibleColumnFields` - use `columnsChange`, `columnVisibilityModelChange`, and `columnIndexChange` events - similar to what we do in `useGridFilter` hook:
https://github.com/mui/mui-x/blob/970124e990bb677cd867fcc49842fb7454fa9cb2/packages/grid/x-data-grid/src/hooks/features/filter/useGridFilter.tsx#L435-L457

TODO:
- [x] update PR description to explain the changes
- [x] add unit tests