### PR TITLE
[DataGrid] Add section about enabling pagination on Pro and Premium

### DIFF
--- a/docs/data/data-grid/pagination/PageSizeAutoPremium.js
+++ b/docs/data/data-grid/pagination/PageSizeAutoPremium.js
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import {
+  DataGridPremium,
+  GridToolbarContainer,
+  GridToolbarExport,
+} from '@mui/x-data-grid-premium';
+
+const rows = [
+  {
+    jobTitle: 'Head of Human Resources',
+    recruitmentDate: new Date(2020, 8, 12),
+    contract: 'full time',
+    id: 0,
+  },
+  {
+    jobTitle: 'Head of Sales',
+    recruitmentDate: new Date(2017, 3, 4),
+    contract: 'full time',
+    id: 1,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 11, 20),
+    contract: 'full time',
+    id: 2,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 10, 14),
+    contract: 'part time',
+    id: 3,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2017, 10, 29),
+    contract: 'part time',
+    id: 4,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 7, 21),
+    contract: 'full time',
+    id: 5,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 7, 20),
+    contract: 'intern',
+    id: 6,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2019, 6, 28),
+    contract: 'full time',
+    id: 7,
+  },
+  {
+    jobTitle: 'Head of Engineering',
+    recruitmentDate: new Date(2016, 3, 14),
+    contract: 'full time',
+    id: 8,
+  },
+  {
+    jobTitle: 'Tech lead front',
+    recruitmentDate: new Date(2016, 5, 17),
+    contract: 'full time',
+    id: 9,
+  },
+  {
+    jobTitle: 'Front-end developer',
+    recruitmentDate: new Date(2019, 11, 7),
+    contract: 'full time',
+    id: 10,
+  },
+  {
+    jobTitle: 'Tech lead devops',
+    recruitmentDate: new Date(2021, 7, 1),
+    contract: 'full time',
+    id: 11,
+  },
+  {
+    jobTitle: 'Tech lead back',
+    recruitmentDate: new Date(2017, 0, 12),
+    contract: 'full time',
+    id: 12,
+  },
+  {
+    jobTitle: 'Back-end developer',
+    recruitmentDate: new Date(2019, 2, 22),
+    contract: 'intern',
+    id: 13,
+  },
+  {
+    jobTitle: 'Back-end developer',
+    recruitmentDate: new Date(2018, 4, 19),
+    contract: 'part time',
+    id: 14,
+  },
+];
+
+const columns = [
+  { field: 'jobTitle', headerName: 'Job Title', width: 200 },
+  {
+    field: 'recruitmentDate',
+    headerName: 'Recruitment Date',
+    type: 'date',
+    width: 150,
+  },
+  {
+    field: 'contract',
+    headerName: 'Contract Type',
+    type: 'singleSelect',
+    valueOptions: ['full time', 'part time', 'intern'],
+    width: 150,
+  },
+];
+
+function CustomToolbar() {
+  return (
+    <GridToolbarContainer>
+      <GridToolbarExport />
+    </GridToolbarContainer>
+  );
+}
+
+export default function ExcelExport() {
+  return (
+    <div style={{ height: 320, width: '100%' }}>
+      <DataGridPremium
+        rows={rows}
+        columns={columns}
+        slots={{
+          toolbar: CustomToolbar,
+        }}
+        pagination
+        autoPageSize
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/pagination/PageSizeAutoPremium.js
+++ b/docs/data/data-grid/pagination/PageSizeAutoPremium.js
@@ -123,7 +123,7 @@ function CustomToolbar() {
   );
 }
 
-export default function ExcelExport() {
+export default function PageSizeAutoPremium() {
   return (
     <div style={{ height: 320, width: '100%' }}>
       <DataGridPremium

--- a/docs/data/data-grid/pagination/PageSizeAutoPremium.tsx
+++ b/docs/data/data-grid/pagination/PageSizeAutoPremium.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import {
+  DataGridPremium,
+  GridToolbarContainer,
+  GridToolbarExport,
+  GridColDef,
+  GridRowsProp,
+} from '@mui/x-data-grid-premium';
+
+const rows: GridRowsProp = [
+  {
+    jobTitle: 'Head of Human Resources',
+    recruitmentDate: new Date(2020, 8, 12),
+    contract: 'full time',
+    id: 0,
+  },
+  {
+    jobTitle: 'Head of Sales',
+    recruitmentDate: new Date(2017, 3, 4),
+    contract: 'full time',
+    id: 1,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 11, 20),
+    contract: 'full time',
+    id: 2,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 10, 14),
+    contract: 'part time',
+    id: 3,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2017, 10, 29),
+    contract: 'part time',
+    id: 4,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 7, 21),
+    contract: 'full time',
+    id: 5,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2020, 7, 20),
+    contract: 'intern',
+    id: 6,
+  },
+  {
+    jobTitle: 'Sales Person',
+    recruitmentDate: new Date(2019, 6, 28),
+    contract: 'full time',
+    id: 7,
+  },
+  {
+    jobTitle: 'Head of Engineering',
+    recruitmentDate: new Date(2016, 3, 14),
+    contract: 'full time',
+    id: 8,
+  },
+  {
+    jobTitle: 'Tech lead front',
+    recruitmentDate: new Date(2016, 5, 17),
+    contract: 'full time',
+    id: 9,
+  },
+  {
+    jobTitle: 'Front-end developer',
+    recruitmentDate: new Date(2019, 11, 7),
+    contract: 'full time',
+    id: 10,
+  },
+  {
+    jobTitle: 'Tech lead devops',
+    recruitmentDate: new Date(2021, 7, 1),
+    contract: 'full time',
+    id: 11,
+  },
+  {
+    jobTitle: 'Tech lead back',
+    recruitmentDate: new Date(2017, 0, 12),
+    contract: 'full time',
+    id: 12,
+  },
+  {
+    jobTitle: 'Back-end developer',
+    recruitmentDate: new Date(2019, 2, 22),
+    contract: 'intern',
+    id: 13,
+  },
+  {
+    jobTitle: 'Back-end developer',
+    recruitmentDate: new Date(2018, 4, 19),
+    contract: 'part time',
+    id: 14,
+  },
+];
+
+const columns: GridColDef[] = [
+  { field: 'jobTitle', headerName: 'Job Title', width: 200 },
+  {
+    field: 'recruitmentDate',
+    headerName: 'Recruitment Date',
+    type: 'date',
+    width: 150,
+  },
+  {
+    field: 'contract',
+    headerName: 'Contract Type',
+    type: 'singleSelect',
+    valueOptions: ['full time', 'part time', 'intern'],
+    width: 150,
+  },
+];
+
+function CustomToolbar() {
+  return (
+    <GridToolbarContainer>
+      <GridToolbarExport />
+    </GridToolbarContainer>
+  );
+}
+
+export default function ExcelExport() {
+  return (
+    <div style={{ height: 320, width: '100%' }}>
+      <DataGridPremium
+        rows={rows}
+        columns={columns}
+        slots={{
+          toolbar: CustomToolbar,
+        }}
+        pagination
+        autoPageSize
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/pagination/PageSizeAutoPremium.tsx
+++ b/docs/data/data-grid/pagination/PageSizeAutoPremium.tsx
@@ -125,7 +125,7 @@ function CustomToolbar() {
   );
 }
 
-export default function ExcelExport() {
+export default function PageSizeAutoPremium() {
   return (
     <div style={{ height: 320, width: '100%' }}>
       <DataGridPremium

--- a/docs/data/data-grid/pagination/PageSizeAutoPremium.tsx.preview
+++ b/docs/data/data-grid/pagination/PageSizeAutoPremium.tsx.preview
@@ -1,0 +1,9 @@
+<DataGridPremium
+  rows={rows}
+  columns={columns}
+  slots={{
+    toolbar: CustomToolbar,
+  }}
+  pagination
+  autoPageSize
+/>

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -2,14 +2,6 @@
 
 <p class="description">Easily paginate your rows and only fetch what you need.</p>
 
-:::warning
-The default pagination behavior depends on your plan.
-
-- On the `DataGrid`, pagination is enabled by default and can't be disabled
-- On the `DataGridPro`, pagination is disabled by default, use the `pagination` prop to enable it
-
-:::
-
 ## Size of the page
 
 The `DataGrid` (MIT license) is limited to pages of up to 100 rows.
@@ -32,6 +24,20 @@ You can't use both the `autoPageSize` and `autoHeight` props at the same time be
 :::
 
 {{"demo": "PageSizeAuto.js", "bg": "inline"}}
+
+## Pagination on Pro and Premium
+
+The default pagination behavior depends on your plan.
+
+- On the `DataGrid`, pagination is enabled by default and can't be disabled.
+- On the `DataGridPro` and `DataGridPremium`, pagination is disabled by default; use the `pagination` prop to enable it.
+
+The following example activates pagination on a `DataGridPremium` component.
+
+:::info
+On a side note, exported CSV and Excel files will contain the full data and disregard the pagination by default. To apply pagination on exported files, please check the available [row selectors](/x/react-data-grid/export/#exported-rows).
+:::
+{{"demo": "PageSizeAutoPremium.js", "bg": "inline"}}
 
 ## Pagination model
 


### PR DESCRIPTION
## Summary

There was no mention of Premium on the note about the default behavior of the `pagination` prop.

I changed the initial note into a section so it's available on the right-side navbar, added a demo using the prop and an explicit mention of the DataGridPremium so it's searchable on the page. 

## Preview

https://deploy-preview-8759--material-ui-x.netlify.app/x/react-data-grid/pagination/


