### PR TITLE
[pickers] Fix date calendar `selected` & `disabled` day style

### DIFF
--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -162,8 +162,11 @@ const styleArg = ({ theme, ownerState }: { theme: Theme; ownerState: OwnerState 
       backgroundColor: (theme.vars || theme).palette.primary.dark,
     },
   },
-  [`&.${pickersDayClasses.disabled}`]: {
+  [`&.${pickersDayClasses.disabled}:not(.${pickersDayClasses.selected})`]: {
     color: (theme.vars || theme).palette.text.disabled,
+  },
+  [`&.${pickersDayClasses.disabled}&.${pickersDayClasses.selected}`]: {
+    opacity: 0.6,
   },
   ...(!ownerState.disableMargin && {
     margin: `0 ${DAY_MARGIN}px`,


### PR DESCRIPTION
Fix #8763 

Things changed:

- Do not apply the disabled (black with opacity -> gray) color to a selected & disabled day;
- Apply `opacity` to a disabled & selected day to achieve more consistent styling with the other disabled days and make it more visually clear that it's selected, but disabled;

Before issues can be seen in the issue.

### After:
![Screenshot 2023-04-27 at 10 00 46](https://user-images.githubusercontent.com/4941090/234785366-4efe0718-2644-4be8-9ad9-5817acc9881b.png)
![Screenshot 2023-04-27 at 10 00 57](https://user-images.githubusercontent.com/4941090/234785370-a3b00a62-aa7d-4ecb-abef-fa97857ad3fc.png)
