### PR TITLE
[Data grid] Reverse unselect all behavior

### DIFF
--- a/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -90,7 +90,8 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const params: GridHeaderSelectionCheckboxParams = {
-        value: isIndeterminate ? !event.target.checked : event.target.checked,
+        isIndeterminate,
+        value: event.target.checked,
       };
 
       apiRef.current.publishEvent('headerSelectionCheckboxChange', params);

--- a/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -90,7 +90,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const params: GridHeaderSelectionCheckboxParams = {
-        value: event.target.checked,
+        value: isIndeterminate ? !event.target.checked : event.target.checked,
       };
 
       apiRef.current.publishEvent('headerSelectionCheckboxChange', params);

--- a/packages/grid/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -445,7 +445,7 @@ export const useGridRowSelection = (
         ? gridPaginatedVisibleSortedGridRowIdsSelector(apiRef)
         : gridExpandedSortedRowIdsSelector(apiRef);
 
-      apiRef.current.selectRows(rowsToBeSelected, params.value);
+      apiRef.current.selectRows(rowsToBeSelected, params.isIndeterminate ? !params.value : params.value);
     },
     [apiRef, props.checkboxSelectionVisibleOnly, props.pagination],
   );

--- a/packages/grid/x-data-grid/src/models/params/gridHeaderSelectionCheckboxParams.ts
+++ b/packages/grid/x-data-grid/src/models/params/gridHeaderSelectionCheckboxParams.ts
@@ -1,3 +1,4 @@
 export interface GridHeaderSelectionCheckboxParams {
   value: boolean;
+  isIndeterminate?: boolean;
 }


### PR DESCRIPTION
Hi everyone, thanks for the continued effort of this package 🙌 

This PR will change the behavior of the `select all rows` checkbox of the `DataGrid` component. Currently, if there is at least one row selected, checking this checkbox unselects everything. As mentionend in #7753 this behavior might not be what the user expects.
With this PR, checking the checkbox leads to always checking all rows if there is already at least one selected row.

Closes #7753 