### PR TITLE
[pickers] Fix `minutesStep` validation prop behavior

### DIFF
--- a/packages/x-date-pickers-pro/src/internal/models/dateTimeRange.ts
+++ b/packages/x-date-pickers-pro/src/internal/models/dateTimeRange.ts
@@ -4,6 +4,7 @@ import {
   DefaultizedProps,
   MakeOptional,
   UseFieldInternalProps,
+  DateTimeValidationProps,
 } from '@mui/x-date-pickers/internals';
 import { BaseRangeProps, DayRangeValidationProps } from './dateRange';
 import { DateRange } from './range';
@@ -18,15 +19,8 @@ export interface UseDateTimeRangeFieldProps<TDate>
     DayRangeValidationProps<TDate>,
     TimeValidationProps<TDate>,
     BaseDateValidationProps<TDate>,
+    DateTimeValidationProps<TDate>,
     BaseRangeProps {
-  /**
-   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
-   */
-  minDateTime?: TDate;
-  /**
-   * Maximal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
-   */
-  maxDateTime?: TDate;
   /**
    * 12h/24h view for hour selection clock.
    * @default `utils.is12HourCycleInCurrentLocale()`

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.types.ts
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.types.ts
@@ -7,6 +7,7 @@ import { DefaultizedProps, MakeOptional } from '../internals/models/helpers';
 import {
   BaseDateValidationProps,
   BaseTimeValidationProps,
+  DateTimeValidationProps,
   DayValidationProps,
   MonthValidationProps,
   TimeValidationProps,
@@ -30,20 +31,13 @@ export interface UseDateTimeFieldProps<TDate>
     YearValidationProps<TDate>,
     BaseDateValidationProps<TDate>,
     TimeValidationProps<TDate>,
-    BaseTimeValidationProps {
+    BaseTimeValidationProps,
+    DateTimeValidationProps<TDate> {
   /**
    * 12h/24h view for hour selection clock.
    * @default `utils.is12HourCycleInCurrentLocale()`
    */
   ampm?: boolean;
-  /**
-   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
-   */
-  minDateTime?: TDate;
-  /**
-   * Maximal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
-   */
-  maxDateTime?: TDate;
 }
 
 export type UseDateTimeFieldDefaultizedProps<TDate> = DefaultizedProps<

--- a/packages/x-date-pickers/src/DateTimePicker/shared.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/shared.tsx
@@ -19,7 +19,11 @@ import {
   DateTimePickerTabsProps,
   ExportedDateTimePickerTabsProps,
 } from './DateTimePickerTabs';
-import { BaseDateValidationProps, BaseTimeValidationProps } from '../internals/models/validation';
+import {
+  BaseDateValidationProps,
+  BaseTimeValidationProps,
+  DateTimeValidationProps,
+} from '../internals/models/validation';
 import { LocalizedComponent, PickersInputLocaleText } from '../locales/utils/pickersLocaleTextApi';
 import {
   DateTimePickerToolbar,
@@ -64,20 +68,13 @@ export interface BaseDateTimePickerSlotsComponentsProps<TDate>
 export interface BaseDateTimePickerProps<TDate>
   extends BasePickerInputProps<TDate | null, TDate, DateOrTimeView, DateTimeValidationError>,
     Omit<ExportedDateCalendarProps<TDate>, 'onViewChange'>,
-    ExportedBaseClockProps<TDate> {
+    ExportedBaseClockProps<TDate>,
+    DateTimeValidationProps<TDate> {
   /**
    * Display ampm controls under the clock (instead of in the toolbar).
    * @default true on desktop, false on mobile
    */
   ampmInClock?: boolean;
-  /**
-   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
-   */
-  minDateTime?: TDate;
-  /**
-   * Maximal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
-   */
-  maxDateTime?: TDate;
   /**
    * Overridable components.
    * @default {}

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -113,6 +113,7 @@ export type {
   MonthValidationProps,
   YearValidationProps,
   DayValidationProps,
+  DateTimeValidationProps,
 } from './models/validation';
 
 export { applyDefaultDate, replaceInvalidDateByNull, areDatesEqual } from './utils/date-utils';

--- a/packages/x-date-pickers/src/internals/models/validation.ts
+++ b/packages/x-date-pickers/src/internals/models/validation.ts
@@ -114,3 +114,17 @@ export interface YearValidationProps<TDate> {
    */
   shouldDisableYear?: (year: TDate) => boolean;
 }
+
+/**
+ * Props used to validate a date time value.
+ */
+export interface DateTimeValidationProps<TDate> {
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
+  minDateTime?: TDate;
+  /**
+   * Maximal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
+  maxDateTime?: TDate;
+}

--- a/packages/x-date-pickers/src/internals/utils/validation/extractValidationProps.ts
+++ b/packages/x-date-pickers/src/internals/utils/validation/extractValidationProps.ts
@@ -1,4 +1,22 @@
-const VALIDATION_PROP_NAMES = [
+import {
+  BaseDateValidationProps,
+  BaseTimeValidationProps,
+  DateTimeValidationProps,
+  DayValidationProps,
+  MonthValidationProps,
+  TimeValidationProps,
+  YearValidationProps,
+} from '../../models/validation';
+
+const VALIDATION_PROP_NAMES: (
+  | keyof BaseTimeValidationProps
+  | keyof BaseDateValidationProps<any>
+  | keyof TimeValidationProps<any>
+  | keyof YearValidationProps<any>
+  | keyof MonthValidationProps<any>
+  | keyof DayValidationProps<any>
+  | keyof DateTimeValidationProps<any>
+)[] = [
   'disablePast',
   'disableFuture',
   'minDate',
@@ -12,8 +30,8 @@ const VALIDATION_PROP_NAMES = [
   'shouldDisableYear',
   'shouldDisableClock',
   'shouldDisableTime',
-  'minuteStep',
-] as const;
+  'minutesStep',
+];
 
 type ValidationPropNames = (typeof VALIDATION_PROP_NAMES)[number];
 

--- a/packages/x-date-pickers/src/tests/describeValidation/testTextFieldValidation.tsx
+++ b/packages/x-date-pickers/src/tests/describeValidation/testTextFieldValidation.tsx
@@ -449,5 +449,34 @@ export const testTextFieldValidation: DescribeValidationTestSuite = (ElementToTe
       expect(onErrorMock.lastCall.args[0]).to.equal(null);
       expect(screen.getByRole('textbox')).to.have.attribute('aria-invalid', 'false');
     });
+
+    it('should apply minutesStep', function test() {
+      if (['picker', 'field'].includes(componentFamily) && !withTime) {
+        return;
+      }
+
+      const onErrorMock = spy();
+      const { setProps } = render(
+        <ElementToTest
+          onError={onErrorMock}
+          value={adapterToUse.date(new Date(2019, 5, 15, 10, 15))}
+          minutesStep={30}
+        />,
+      );
+      if (withTime) {
+        expect(onErrorMock.callCount).to.equal(1);
+        expect(onErrorMock.lastCall.args[0]).to.equal('minutesStep');
+        expect(screen.getByRole('textbox')).to.have.attribute('aria-invalid', 'true');
+
+        setProps({ value: adapterToUse.date(new Date(2019, 5, 15, 10, 30)) });
+
+        expect(onErrorMock.callCount).to.equal(2);
+        expect(onErrorMock.lastCall.args[0]).to.equal(null);
+        expect(screen.getByRole('textbox')).to.have.attribute('aria-invalid', 'false');
+      } else {
+        expect(onErrorMock.callCount).to.equal(0);
+        expect(screen.getByRole('textbox')).to.have.attribute('aria-invalid', 'false');
+      }
+    });
   });
 };


### PR DESCRIPTION
Fixes #8774 

The prop name had a typo and thus was not correctly extracted where needed.
The only relevant functional change is this line: https://github.com/mui/mui-x/compare/master...LukasTy:fix-minutes-step-validation?expand=1#diff-bd535b311395403beb06c0752755b96f8ffc56ede0aa626b670e6d8b6d8f48b6R33

- Added tests covering the behavior;
- Strict typed the validation prop names;
- Created a co-located type for `DateTimeValidationProps`;