### PR TITLE
[core] Do not include playground pages in `yarn typescript` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ __diff_output__
 /.nyc_output
 /coverage
 /docs/.next
-/docs/pages/playground/
+/docs/pages/playground/*
+!/docs/pages/playground/tsconfig.json
 /docs/export
 /test/regressions/screenshots
 build

--- a/docs/pages/playground/tsconfig.json
+++ b/docs/pages/playground/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["*"],
+  "exclude": []
+}


### PR DESCRIPTION
We used to include playground pages in `docs/tsconfig.json` to get proper types in these files https://github.com/mui/mui-x/pull/5367

This has one downside - if you have outdated playground pages that do not compile, `yarn typescript` will also fail locally.

Playground pages were excluded in https://github.com/mui/mui-x/pull/8792/files#r1182249749, but broke TS compilation of these pages in IDE, as reported by @LukasTy :
![image](https://user-images.githubusercontent.com/13808724/235622183-d3fb1d7d-1374-4500-9c69-a3b68fac3d1d.png)

---
This PR fixes TS compilation of playground pages in IDE while excluding them from `yarn typescript`.