### PR TITLE
[DataGridPremium] Fix expanded groups being collapsed after calling `updateRows`

### DIFF
--- a/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
@@ -2634,4 +2634,24 @@ describe('<DataGridPremium /> - Row Grouping', () => {
 
     await waitFor(() => expect(getCell(1, 3).textContent).to.equal('username 2'));
   });
+
+  // See https://github.com/mui/mui-x/issues/8580
+  it('should not collapse expanded groups after `updateRows`', async () => {
+    render(
+      <Test
+        columns={[{ field: 'id' }, { field: 'group' }, { field: 'username', width: 150 }]}
+        rows={[{ id: 1, group: 'A', username: 'username' }]}
+        rowGroupingModel={['group']}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'see children' }));
+
+    act(() => apiRef.current.updateRows([{ id: 1, group: 'A', username: 'username 2' }]));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'hide children' })).toBeVisible();
+    });
+    await waitFor(() => expect(getCell(1, 3).textContent).to.equal('username 2'));
+  });
 });

--- a/packages/grid/x-data-grid-pro/src/utils/tree/utils.ts
+++ b/packages/grid/x-data-grid-pro/src/utils/tree/utils.ts
@@ -34,13 +34,15 @@ export const getNodePathInTree = ({
   let node = tree[id] as GridGroupNode | GridLeafNode;
 
   while (node.id !== GRID_ROOT_GROUP_ID) {
-    path.unshift({
+    path.push({
       field: node.type === 'leaf' ? null : node.groupingField,
       key: node.groupingKey,
     });
 
     node = tree[node.parent!] as GridGroupNode | GridLeafNode;
   }
+
+  path.reverse();
 
   return path;
 };

--- a/packages/grid/x-data-grid-pro/src/utils/tree/utils.ts
+++ b/packages/grid/x-data-grid-pro/src/utils/tree/utils.ts
@@ -34,8 +34,8 @@ export const getNodePathInTree = ({
   let node = tree[id] as GridGroupNode | GridLeafNode;
 
   while (node.id !== GRID_ROOT_GROUP_ID) {
-    path.push({
-      field: (node as GridGroupNode).groupingField,
+    path.unshift({
+      field: node.type === 'leaf' ? null : node.groupingField,
       key: node.groupingKey,
     });
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/8580
Before: https://codesandbox.io/s/kind-lamarr-ofjvim
After: https://codesandbox.io/s/wild-http-h2gfjq

Fixes https://github.com/mui/mui-x/issues/8853
Before: https://codesandbox.io/s/cocky-sunset-f7qkjg
After: https://codesandbox.io/s/frosty-bassi-1hwexf

---

The issue comes down to this part where we update the row tree:

https://github.com/mui/mui-x/blob/1099111eb455dc8ab744388517fc2fe4a12bab2b/packages/grid/x-data-grid-pro/src/utils/tree/updateRowTree.ts#L61-L63

Here we compare `path` and `pathInPreviousTree`. But `isInSameGroup` always equals `false`, even if the groups have not been changed. Here are example values that are being compared:
```tsx
[{ field: undefined, key: "1" }, { field: 14, key: 14 }] // pathInPreviousTree
[{ key: 14, field: "age" }, { key: "1", field: null }] // path
```
There are two differences between `pathInPreviousTree` and `path`:
1. In `path`, the `null` value is used when the field is missing, but in `pathInPreviousTree`, `undefined` is used instead.
  This issue comes from a bug in `getNodePathInTree`
  https://github.com/mui/mui-x/blob/4d4fcb42d9c04050f61750607e32d295dd1bf0b7/packages/grid/x-data-grid-pro/src/utils/tree/utils.ts#L38
  Leaf nodes do not have `groupingField` property, therefore `field` should be set to `null` here. TS didn't warn about this because of the `as GridGroupNode` assertion.
	  ```diff
	  -field: (node as GridGroupNode).groupingField,
	  +field: node.type === 'leaf' ? null : node.groupingField,
	  ```
2. The order of items in the array is different, therefore `deepEqual` returns `false`.
  The order comes from `getNodePathInTree` as well, where `Array.push` is being used:
  https://github.com/mui/mui-x/blob/4d4fcb42d9c04050f61750607e32d295dd1bf0b7/packages/grid/x-data-grid-pro/src/utils/tree/utils.ts#L37
  The fix is to use `Array.unshift` to reverse the order of items.

TODO:
- [x] Explain the changes