### PR TITLE
[l10n] Improve French (fr-FR) locale

### DIFF
--- a/packages/grid/x-data-grid/src/locales/frFR.ts
+++ b/packages/grid/x-data-grid/src/locales/frFR.ts
@@ -27,7 +27,7 @@ const frFRGrid: Partial<GridLocaleText> = {
     count > 1 ? `${count} filtres actifs` : `${count} filtre actif`,
 
   // Quick filter toolbar field
-  toolbarQuickFilterPlaceholder: 'Recherche…',
+  toolbarQuickFilterPlaceholder: 'Rechercher…',
   toolbarQuickFilterLabel: 'Recherche',
   toolbarQuickFilterDeleteIconLabel: 'Supprimer',
 
@@ -39,7 +39,7 @@ const frFRGrid: Partial<GridLocaleText> = {
   toolbarExportExcel: 'Télécharger pour Excel',
 
   // Columns panel text
-  columnsPanelTextFieldLabel: 'Chercher colonne',
+  columnsPanelTextFieldLabel: 'Chercher une colonne',
   columnsPanelTextFieldPlaceholder: 'Titre de la colonne',
   columnsPanelDragIconLabel: 'Réorganiser la colonne',
   columnsPanelShowAllButton: 'Tout afficher',
@@ -53,13 +53,13 @@ const frFRGrid: Partial<GridLocaleText> = {
   filterPanelOperator: 'Opérateur',
   filterPanelOperatorAnd: 'Et',
   filterPanelOperatorOr: 'Ou',
-  filterPanelColumns: 'Colonnes',
+  filterPanelColumns: 'Colonne',
   filterPanelInputLabel: 'Valeur',
   filterPanelInputPlaceholder: 'Filtrer la valeur',
 
   // Filter operators text
   filterOperatorContains: 'contient',
-  filterOperatorEquals: 'égal à',
+  filterOperatorEquals: 'est égal à',
   filterOperatorStartsWith: 'commence par',
   filterOperatorEndsWith: 'se termine par',
   filterOperatorIs: 'est',
@@ -100,7 +100,7 @@ const frFRGrid: Partial<GridLocaleText> = {
       : `${count.toLocaleString()} ligne sélectionnée`,
 
   // Total row amount footer text
-  footerTotalRows: 'Lignes totales :',
+  footerTotalRows: 'Total de lignes :',
 
   // Total visible row amount footer text
   footerTotalVisibleRows: (visibleCount, totalCount) =>


### PR DESCRIPTION
Hi,

I don't know what is the convention for this kind of pull request, where I'm not adding new translations but I'm trying to improve existing ones. I'll make a quick argument for each modification but feel free to give your opinion.

> 1.`toolbarQuickFilterPlaceholder: 'Rechercher…',`: Trying to use the same tense everywhere like `Exporter` that is in the head bar too

> 2.`columnsPanelTextFieldLabel: 'Chercher une colonne',`: Pronouns are also used in different places and it felt right to use it here too

> 3.`filterPanelColumns: 'Colonne',`: Here, the singular seems to be the right choice unless there will be multi-columns filters in the future?

> 4.`filterOperatorEquals: 'est égal à',`: Again here, for all the string comparison a verb is used (`contient`, `est vide`, ...), so it made sense to use a verb form too.

> 5.`footerTotalRows: 'Total de lignes :',`: This one is actually the one that made me do this PR. I think, it's just better like that.

I know, I can pass in my own text and translations for a professional usage but I thought it was worth modifying those. But that's also why I won't mind if the PR is not accepted and I won't do another one on this subject in that case.

Side not for `4.`: it could be extended to all the date comparison `est postérieur` instead of `postérieur`, `est égal ou antérieur` instead of `égal ou antérieur` but it seemed less troubling as it is the same form for all and long enough having to fit in a small box.