### PR TITLE
[pickers] Fix time picker `viewRenderers` overriding

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/shared.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/shared.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useThemeProps } from '@mui/material/styles';
 import { DefaultizedProps } from '../internals/models/helpers';
-import { DateOrTimeView, DateTimeValidationError, TimeView } from '../models';
+import { DateOrTimeView, DateTimeValidationError } from '../models';
 import { useDefaultDates, useUtils } from '../internals/hooks/useUtils';
 import {
   DateCalendarSlotsComponent,
@@ -36,6 +36,7 @@ import { TimeViewRendererProps } from '../timeViewRenderers';
 import { applyDefaultViewProps } from '../internals/utils/views';
 import { uncapitalizeObjectKeys, UncapitalizeObjectKeys } from '../internals/utils/slots-migration';
 import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/clock';
+import { TimeViewWithMeridiem } from '../internals/models';
 
 export interface BaseDateTimePickerSlotsComponent<TDate>
   extends DateCalendarSlotsComponent<TDate>,
@@ -107,7 +108,7 @@ export interface BaseDateTimePickerProps<TDate>
       TDate | null,
       DateOrTimeView,
       DateViewRendererProps<TDate, DateOrTimeView> &
-        TimeViewRendererProps<TimeView, BaseClockProps<TDate, TimeView>>,
+        TimeViewRendererProps<TimeViewWithMeridiem, BaseClockProps<TDate, TimeViewWithMeridiem>>,
       {}
     >
   >;

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -56,9 +56,13 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   const actionBarActions: PickersActionBarAction[] = shouldRenderTimeInASingleColumn
     ? []
     : ['accept'];
-  const views: readonly TimeViewWithMeridiem[] = defaultizedProps.ampm
-    ? [...defaultizedProps.views, 'meridiem']
-    : defaultizedProps.views;
+  // Need to avoid adding the `meridiem` view when unexpected renderer is specified
+  const shouldHoursRendererContainMeridiemView =
+    viewRenderers.hours?.name === renderMultiSectionDigitalClockTimeView.name;
+  const views: readonly TimeViewWithMeridiem[] =
+    defaultizedProps.ampm && shouldHoursRendererContainMeridiemView
+      ? [...defaultizedProps.views, 'meridiem']
+      : defaultizedProps.views;
 
   // Props with the default values specific to the desktop variant
   const props = {

--- a/packages/x-date-pickers/src/TimeClock/TimeClock.types.ts
+++ b/packages/x-date-pickers/src/TimeClock/TimeClock.types.ts
@@ -6,6 +6,7 @@ import {
 import { UncapitalizeObjectKeys } from '../internals/utils/slots-migration';
 import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/clock';
 import { TimeView } from '../models';
+import { TimeViewWithMeridiem } from '../internals/models';
 
 export interface ExportedTimeClockProps<TDate> extends ExportedBaseClockProps<TDate> {
   /**
@@ -19,9 +20,9 @@ export interface TimeClockSlotsComponent extends PickersArrowSwitcherSlotsCompon
 
 export interface TimeClockSlotsComponentsProps extends PickersArrowSwitcherSlotsComponentsProps {}
 
-export interface TimeClockProps<TDate>
+export interface TimeClockProps<TDate, TView extends TimeViewWithMeridiem = TimeView>
   extends ExportedTimeClockProps<TDate>,
-    BaseClockProps<TDate, TimeView> {
+    BaseClockProps<TDate, TView> {
   /**
    * Override or extend the styles applied to the component.
    */

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
@@ -37,10 +37,10 @@ type PickerViewRenderer<
 export type PickerViewRendererLookup<
   TValue,
   TView extends DateOrTimeViewWithMeridiem,
-  TExternalProps extends PickerViewsRendererBaseExternalProps<TView>,
+  TExternalProps extends PickerViewsRendererBaseExternalProps<any>,
   TAdditionalProps extends {},
 > = {
-  [K in TView]: PickerViewRenderer<TValue, TView, TExternalProps, TAdditionalProps> | null;
+  [K in TView]: PickerViewRenderer<TValue, K, TExternalProps, TAdditionalProps> | null;
 };
 
 /**

--- a/packages/x-date-pickers/src/internals/models/props/clock.ts
+++ b/packages/x-date-pickers/src/internals/models/props/clock.ts
@@ -61,7 +61,7 @@ export interface BaseClockProps<TDate, TView extends TimeViewWithMeridiem>
 
 export interface DesktopOnlyTimePickerProps<TDate>
   extends Omit<ExportedDigitalClockProps<TDate>, 'timeStep'>,
-    Omit<ExportedMultiSectionDigitalClockProps<TDate>, 'timeStep'> {
+    Omit<ExportedMultiSectionDigitalClockProps<TDate>, 'timeSteps'> {
   /**
    * Amount of time options below or at which the single column time renderer is used.
    * @default 24

--- a/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
+++ b/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
@@ -181,12 +181,7 @@ export const renderMultiSectionDigitalClockTimeView = <TDate extends unknown>({
   disableIgnoringDatePartForTimeValidation,
   timeSteps,
   skipDisabled,
-}: TimeViewRendererProps<
-  TimeViewWithMeridiem,
-  Omit<MultiSectionDigitalClockProps<TDate>, 'timeSteps'> &
-    Omit<DigitalClockProps<TDate>, 'timeStep'> &
-    Pick<TimePickerProps<TDate>, 'timeSteps'>
->) => (
+}: TimeViewRendererProps<TimeViewWithMeridiem, MultiSectionDigitalClockProps<TDate>>) => (
   <MultiSectionDigitalClock<TDate>
     view={view}
     onViewChange={onViewChange}

--- a/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
+++ b/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
@@ -50,13 +50,13 @@ export const renderTimeViewClock = <TDate extends unknown>({
   autoFocus,
   showViewSwitcher,
   disableIgnoringDatePartForTimeValidation,
-}: TimeViewRendererProps<TimeView, TimeClockProps<TDate>>) => (
+}: TimeViewRendererProps<TimeViewWithMeridiem, TimeClockProps<TDate, TimeViewWithMeridiem>>) => (
   <TimeClock<TDate>
-    view={view}
+    view={view as TimeView}
     onViewChange={onViewChange}
-    focusedView={focusedView}
+    focusedView={focusedView as TimeView}
     onFocusedViewChange={onFocusedViewChange}
-    views={views.filter(isTimeView)}
+    views={views.filter(isTimeView) as TimeView[]}
     value={value}
     defaultValue={defaultValue}
     onChange={onChange}


### PR DESCRIPTION
Fixes #8821

- Adjust `viewRenderers` typing to allow for both `TimeClock` as well as `DigitalClock` overriding.
- Avoid appending the `meridiem` view when some other renderer than `renderMultiSectionDigitalClockTimeView` is provided to the `hours` renderer. (i.e. providing `renderTimeViewClock`).
- Fix viewRenderers individual view entry typing to contain only the relevant `views` key. This allows passing `hours: renderDigitalClockTimeView` without errors complaining that the views have all possible views instead of only the one that is being overridden.
- Small typing fixes/improvements