### PR TITLE
[test] Use `fake` clock on `MobileDateRangePicker`

### DIFF
--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
@@ -7,7 +7,7 @@ import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/picke
 import { DateRange } from '@mui/x-date-pickers-pro';
 
 describe('<MobileDateRangePicker />', () => {
-  const { render } = createPickerRenderer();
+  const { render } = createPickerRenderer({ clock: 'fake' });
 
   describe('picker state', () => {
     it('should open when focusing the start input', () => {


### PR DESCRIPTION
Try fixing sometimes unexpectedly failing 2 `MobileDateRangePicker` [tests](https://app.circleci.com/pipelines/github/mui/mui-x/37668/workflows/d6e325f4-bc0f-404c-9ce3-4770d66cfb1f/jobs/216366/parallel-runs/0/steps/0-107).