### PR TITLE
[DataGrid] Fix grid size calculation when `.MuiDataGrid-main` has border

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -222,8 +222,8 @@ export function useGridDimensions(
       return;
     }
 
-    const height = mainEl.offsetHeight || 0;
-    const width = mainEl.offsetWidth || 0;
+    const height = mainEl.clientHeight || 0;
+    const width = mainEl.clientWidth || 0;
 
     const win = ownerWindow(mainEl);
 

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/x-data-grid';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { getColumnHeaderCell, getColumnValues, getCell, getRow } from 'test/utils/helperFn';
+import { getColumnHeaderCell, getColumnValues, getCell, getRow, sleep } from 'test/utils/helperFn';
 
 describe('<DataGrid /> - Layout & Warnings', () => {
   const { clock, render } = createRenderer();
@@ -1039,5 +1039,33 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     expect(NoRowsOverlay.callCount).to.equal(0);
     setProps({ loading: false });
     expect(NoRowsOverlay.callCount).not.to.equal(0);
+  });
+
+  // See https://github.com/mui/mui-x/issues/8737
+  it('should not add horizontal scrollbar when .MuiDataGrid-main has border', async function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // Need layouting
+      this.skip();
+    }
+
+    render(
+      <div style={{ height: 300, width: 400, display: 'flex' }}>
+        <DataGrid
+          rows={[{ id: 1 }]}
+          columns={[{ field: 'id', flex: 1 }]}
+          sx={{ '.MuiDataGrid-main': { border: '2px solid red' } }}
+        />
+      </div>,
+    );
+
+    const virtualScroller = document.querySelector<HTMLElement>('.MuiDataGrid-virtualScroller')!;
+    const initialVirtualScrollerWidth = virtualScroller.clientWidth;
+
+    // It should not have a horizontal scrollbar
+    expect(virtualScroller.scrollWidth - virtualScroller.clientWidth).to.equal(0);
+
+    await sleep(200);
+    // The width should not increase infinitely
+    expect(virtualScroller.clientWidth).to.equal(initialVirtualScrollerWidth);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/8737

Scenario 1:
Before: https://codesandbox.io/s/data-grid-community-forked-3ctumy
After: https://codesandbox.io/s/data-grid-community-forked-4glro7

Scenario 2:
Before: https://codesandbox.io/s/sparkling-waterfall-3sdhkk?file=/demo.tsx
After: https://codesandbox.io/s/vigilant-curran-xgf9pt