### PR TITLE
[docs] Fix docs about nested import in `@mui/x-date-pickers-pro`

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -302,7 +302,14 @@ export default function ApiPage(props) {
   if (source === '@mui/x-date-pickers' || source === '@mui/x-date-pickers-pro') {
     packages.forEach((pkg) => {
       // e.g. import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-      imports.push(`import { ${pkg.componentName} } from '${pkg.packageName}/${componentName}';`);
+      if (
+        packages.length === 1 ||
+        pkg.packageName === '@mui/x-date-pickers-pro' ||
+        pkg.componentName.startsWith('Adapter') ||
+        pkg.componentName === 'LocalizationProvider'
+      ) {
+        imports.push(`import { ${pkg.componentName} } from '${pkg.packageName}/${componentName}';`);
+      }
     });
   }
 


### PR DESCRIPTION
Fix #8885

Before https://mui.com/x/api/date-pickers/mobile-time-picker/

<img width="780" alt="Screenshot 2023-05-13 at 13 13 23" src="https://github.com/mui/mui-x/assets/3165635/347eda7d-50a8-4cca-9992-89edcab5184b">

After https://deploy-preview-8936--material-ui-x.netlify.app/x/api/date-pickers/mobile-time-picker/