### PR TITLE
[docs] Fix date pickers typo in the docs 

### DIFF
--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -26,7 +26,7 @@ If you need to change the formatting of the text to conform to a given locale, v
 ### Using the theme
 
 To translate all your components from `@mui/x-date-pickers` and `@mui/x-date-pickers-pro`,
-you just have to import the locale from `@mui/x-date-pickers` (see the [list of supported locales below](#supported-locales)).
+import the locale from `@mui/x-date-pickers` (see the [list of supported locales below](#supported-locales)).
 
 ```jsx
 import { createTheme, ThemeProvider } from '@mui/material/styles';

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -26,7 +26,7 @@ If you need to change the formatting of the text to conform to a given locale, v
 ### Using the theme
 
 To translate all your components from `@mui/x-date-pickers` and `@mui/x-date-pickers-pro`,
-you just have to import the locale from `@mui/x-date-pikers` (see the [list of supported locales below](#supported-locales)).
+you just have to import the locale from `@mui/x-date-pickers` (see the [list of supported locales below](#supported-locales)).
 
 ```jsx
 import { createTheme, ThemeProvider } from '@mui/material/styles';


### PR DESCRIPTION
It should be "@mui/x-date-pickers", not "@mui/x-date-pikers"