### PR TITLE
[Datagrid] Memoize root props

### DIFF
--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useThemeProps } from '@mui/material/styles';
 import { DATA_GRID_PRO_PROPS_DEFAULT_VALUES, GRID_DEFAULT_LOCALE_TEXT } from '@mui/x-data-grid-pro';
-import { computeSlots, uncapitalizeObjectKeys } from '@mui/x-data-grid-pro/internals';
+import { computeProps, computeSlots, uncapitalizeObjectKeys } from '@mui/x-data-grid-pro/internals';
 import {
   DataGridPremiumProps,
   DataGridPremiumProcessedProps,
@@ -28,10 +28,12 @@ export const DATA_GRID_PREMIUM_PROPS_DEFAULT_VALUES: DataGridPremiumPropsWithDef
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_PREMIUM_DEFAULT_SLOTS_COMPONENTS)!;
 
 export const useDataGridPremiumProps = (inProps: DataGridPremiumProps) => {
-  const { components, componentsProps, ...themedProps } = useThemeProps({
-    props: inProps,
-    name: 'MuiDataGrid',
-  });
+  const [components, componentsProps, themedProps] = computeProps(
+    useThemeProps({
+      props: inProps,
+      name: 'MuiDataGrid',
+    }),
+  );
 
   const localeText = React.useMemo(
     () => ({ ...GRID_DEFAULT_LOCALE_TEXT, ...themedProps.localeText }),

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useThemeProps } from '@mui/material/styles';
 import { DATA_GRID_PRO_PROPS_DEFAULT_VALUES, GRID_DEFAULT_LOCALE_TEXT } from '@mui/x-data-grid-pro';
-import { computeProps, computeSlots, uncapitalizeObjectKeys } from '@mui/x-data-grid-pro/internals';
+import { computeSlots, useProps, uncapitalizeObjectKeys } from '@mui/x-data-grid-pro/internals';
 import {
   DataGridPremiumProps,
   DataGridPremiumProcessedProps,
@@ -28,7 +28,7 @@ export const DATA_GRID_PREMIUM_PROPS_DEFAULT_VALUES: DataGridPremiumPropsWithDef
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_PREMIUM_DEFAULT_SLOTS_COMPONENTS)!;
 
 export const useDataGridPremiumProps = (inProps: DataGridPremiumProps) => {
-  const [components, componentsProps, themedProps] = computeProps(
+  const [components, componentsProps, themedProps] = useProps(
     useThemeProps({
       props: inProps,
       name: 'MuiDataGrid',

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
@@ -5,7 +5,7 @@ import {
   DATA_GRID_PROPS_DEFAULT_VALUES,
   GridValidRowModel,
 } from '@mui/x-data-grid';
-import { computeProps, computeSlots, uncapitalizeObjectKeys } from '@mui/x-data-grid/internals';
+import { computeSlots, uncapitalizeObjectKeys, useProps } from '@mui/x-data-grid/internals';
 import {
   DataGridProProps,
   DataGridProProcessedProps,
@@ -34,7 +34,7 @@ export const DATA_GRID_PRO_PROPS_DEFAULT_VALUES: DataGridProPropsWithDefaultValu
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_PRO_DEFAULT_SLOTS_COMPONENTS)!;
 
 export const useDataGridProProps = <R extends GridValidRowModel>(inProps: DataGridProProps<R>) => {
-  const [components, componentsProps, themedProps] = computeProps(
+  const [components, componentsProps, themedProps] = useProps(
     useThemeProps({
       props: inProps,
       name: 'MuiDataGrid',

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
@@ -5,7 +5,7 @@ import {
   DATA_GRID_PROPS_DEFAULT_VALUES,
   GridValidRowModel,
 } from '@mui/x-data-grid';
-import { computeSlots, uncapitalizeObjectKeys } from '@mui/x-data-grid/internals';
+import { computeProps, computeSlots, uncapitalizeObjectKeys } from '@mui/x-data-grid/internals';
 import {
   DataGridProProps,
   DataGridProProcessedProps,
@@ -34,10 +34,12 @@ export const DATA_GRID_PRO_PROPS_DEFAULT_VALUES: DataGridProPropsWithDefaultValu
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_PRO_DEFAULT_SLOTS_COMPONENTS)!;
 
 export const useDataGridProProps = <R extends GridValidRowModel>(inProps: DataGridProProps<R>) => {
-  const { components, componentsProps, ...themedProps } = useThemeProps({
-    props: inProps,
-    name: 'MuiDataGrid',
-  });
+  const [components, componentsProps, themedProps] = computeProps(
+    useThemeProps({
+      props: inProps,
+      name: 'MuiDataGrid',
+    }),
+  );
 
   const localeText = React.useMemo(
     () => ({ ...GRID_DEFAULT_LOCALE_TEXT, ...themedProps.localeText }),

--- a/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -10,8 +10,8 @@ import { GRID_DEFAULT_LOCALE_TEXT } from '../constants';
 import { DATA_GRID_DEFAULT_SLOTS_COMPONENTS } from '../constants/defaultGridSlotsComponents';
 import { GridEditModes, GridSlotsComponent, GridValidRowModel } from '../models';
 import {
-  computeProps,
   computeSlots,
+  useProps,
   uncapitalizeObjectKeys,
   UncapitalizeObjectKeys,
 } from '../internals/utils';
@@ -81,7 +81,7 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_DEFAULT_SLOTS_COMPONENTS)!;
 
 export const useDataGridProps = <R extends GridValidRowModel>(inProps: DataGridProps<R>) => {
-  const [components, componentsProps, themedProps] = computeProps(
+  const [components, componentsProps, themedProps] = useProps(
     useThemeProps({
       props: inProps,
       name: 'MuiDataGrid',

--- a/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -9,7 +9,12 @@ import {
 import { GRID_DEFAULT_LOCALE_TEXT } from '../constants';
 import { DATA_GRID_DEFAULT_SLOTS_COMPONENTS } from '../constants/defaultGridSlotsComponents';
 import { GridEditModes, GridSlotsComponent, GridValidRowModel } from '../models';
-import { computeSlots, uncapitalizeObjectKeys, UncapitalizeObjectKeys } from '../internals/utils';
+import {
+  computeProps,
+  computeSlots,
+  uncapitalizeObjectKeys,
+  UncapitalizeObjectKeys,
+} from '../internals/utils';
 
 const DATA_GRID_FORCED_PROPS: { [key in DataGridForcedPropsKey]?: DataGridProcessedProps[key] } = {
   disableMultipleColumnsFiltering: true,
@@ -76,10 +81,12 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_DEFAULT_SLOTS_COMPONENTS)!;
 
 export const useDataGridProps = <R extends GridValidRowModel>(inProps: DataGridProps<R>) => {
-  const { components, componentsProps, ...themedProps } = useThemeProps({
-    props: inProps,
-    name: 'MuiDataGrid',
-  });
+  const [components, componentsProps, themedProps] = computeProps(
+    useThemeProps({
+      props: inProps,
+      name: 'MuiDataGrid',
+    }),
+  );
 
   const localeText = React.useMemo(
     () => ({ ...GRID_DEFAULT_LOCALE_TEXT, ...themedProps.localeText }),

--- a/packages/grid/x-data-grid/src/internals/utils/computeProps.ts
+++ b/packages/grid/x-data-grid/src/internals/utils/computeProps.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { GridSlotsComponentsProps } from '../../models/gridSlotsComponentsProps';
+import { GridSlotsComponent } from '../../models';
+
+interface WithComponents {
+  components?: Partial<GridSlotsComponent>;
+  componentsProps?: GridSlotsComponentsProps;
+}
+
+export function computeProps<T extends WithComponents>(allProps: T) {
+  return React.useMemo(() => {
+    const { components, componentsProps, ...themedProps } = allProps;
+    return [components, componentsProps, themedProps] as const;
+  }, [allProps]);
+}

--- a/packages/grid/x-data-grid/src/internals/utils/index.ts
+++ b/packages/grid/x-data-grid/src/internals/utils/index.ts
@@ -1,3 +1,3 @@
-export * from './computeProps';
 export * from './computeSlots';
 export * from './slotsMigration';
+export * from './useProps';

--- a/packages/grid/x-data-grid/src/internals/utils/index.ts
+++ b/packages/grid/x-data-grid/src/internals/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './computeProps';
 export * from './computeSlots';
 export * from './slotsMigration';

--- a/packages/grid/x-data-grid/src/internals/utils/useProps.ts
+++ b/packages/grid/x-data-grid/src/internals/utils/useProps.ts
@@ -7,7 +7,7 @@ interface WithComponents {
   componentsProps?: GridSlotsComponentsProps;
 }
 
-export function computeProps<T extends WithComponents>(allProps: T) {
+export function useProps<T extends WithComponents>(allProps: T) {
   return React.useMemo(() => {
     const { components, componentsProps, ...themedProps } = allProps;
     return [components, componentsProps, themedProps] as const;


### PR DESCRIPTION
Closes #8932

This PR partially fixes the performance issues in the issue linked above by memoizing the grid root props. Previously, even if the props values were not changing, the destructuring of props into `...themedProps` was creating a new props object at every rerender of `DataGrid`, which triggered a re-render of all `GridRow` components.

The reason why I say that this PR partially fixes the issue is that if the user does something like below, then the props are going to be recomputed at every render because the `slots` object changes at every render, which will trigger all rows to be re-rendered.

```tsx
<DataGrid
  {...someProps}
  slots={{ row: MemoizedRow }}
/>
```

I think that a more thorough and general solution that expands beyond just `GridRow` would be to replace `useGridRootProps()` by a hook that selects & depends on a partial copy of the root props, so that subcomponents that depend on some of the props re-render only when those specific props change, and not when any of the root props change. This could be done in this PR instead but represents a larger investment & change, so I would like to have some thoughts on that.

| Before | After |
| --- | --- |
| ![Screenshot from 2023-05-10 22-17-21](https://github.com/mui/mui-x/assets/1423607/4da06ccf-3493-4129-8a82-e4c7f3020567) | ![Screenshot from 2023-05-10 05-47-22](https://github.com/mui/mui-x/assets/1423607/de6389c1-93b9-4ba9-9656-46a062765d94) |
