### PR TITLE
[docs] Smooth performance animation

### DIFF
--- a/docs/data/data-grid/performance/GridWithReactMemo.js
+++ b/docs/data/data-grid/performance/GridWithReactMemo.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import { teal } from '@mui/material/colors';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import { DataGridPro, GridRow, GridColumnHeaders } from '@mui/x-data-grid-pro';
 import { useDemoData } from '@mui/x-data-grid-generator';
@@ -11,13 +10,17 @@ const TraceUpdates = React.forwardRef((props, ref) => {
   const handleRef = useForkRef(rootRef, ref);
 
   React.useEffect(() => {
-    rootRef.current?.classList.add('updating');
+    const root = rootRef.current;
+    root.classList.add('updating');
+    root.classList.add('updated');
 
     const timer = setTimeout(() => {
-      rootRef.current?.classList.remove('updating');
-    }, 500);
+      root.classList.remove('updating');
+    }, 360);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+    };
   });
 
   return <Component ref={handleRef} {...other} />;
@@ -47,12 +50,18 @@ export default function GridWithReactMemo() {
       sx={{
         height: 400,
         width: '100%',
-        '&&& .updating': (theme) => ({
-          background: teal[theme.palette.mode === 'dark' ? 900 : 100],
-          transition: theme.transitions.create('background', {
-            duration: theme.transitions.duration.standard,
-          }),
-        }),
+        '&&& .updated': {
+          transition: (theme) =>
+            theme.transitions.create(['background-color', 'outline'], {
+              duration: theme.transitions.duration.standard,
+            }),
+        },
+        '&&& .updating': {
+          backgroundColor: 'rgb(92 199 68 / 25%)',
+          outline: '1px solid rgb(92 199 68 / 35%)',
+          outlineOffset: '-1px',
+          transition: 'none',
+        },
       }}
     >
       <DataGridPro

--- a/docs/data/data-grid/performance/GridWithReactMemo.tsx
+++ b/docs/data/data-grid/performance/GridWithReactMemo.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import { teal } from '@mui/material/colors';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import { DataGridPro, GridRow, GridColumnHeaders } from '@mui/x-data-grid-pro';
 import { useDemoData } from '@mui/x-data-grid-generator';
@@ -11,13 +10,17 @@ const TraceUpdates = React.forwardRef<any, any>((props, ref) => {
   const handleRef = useForkRef(rootRef, ref);
 
   React.useEffect(() => {
-    rootRef.current?.classList.add('updating');
+    const root = rootRef.current;
+    root!.classList.add('updating');
+    root!.classList.add('updated');
 
     const timer = setTimeout(() => {
-      rootRef.current?.classList.remove('updating');
-    }, 500);
+      root!.classList.remove('updating');
+    }, 360);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+    };
   });
 
   return <Component ref={handleRef} {...other} />;
@@ -47,12 +50,18 @@ export default function GridWithReactMemo() {
       sx={{
         height: 400,
         width: '100%',
-        '&&& .updating': (theme) => ({
-          background: teal[theme.palette.mode === 'dark' ? 900 : 100],
-          transition: theme.transitions.create('background', {
-            duration: theme.transitions.duration.standard,
-          }),
-        }),
+        '&&& .updated': {
+          transition: (theme) =>
+            theme.transitions.create(['background-color', 'outline'], {
+              duration: theme.transitions.duration.standard,
+            }),
+        },
+        '&&& .updating': {
+          backgroundColor: 'rgb(92 199 68 / 25%)',
+          outline: '1px solid rgb(92 199 68 / 35%)',
+          outlineOffset: '-1px',
+          transition: 'none',
+        },
       }}
     >
       <DataGridPro


### PR DESCRIPTION
Since #7846, we have a great performance demo, however, I noticed that we could improve the design of the animation, so I did for fun (overkill PR):

https://github.com/mui/mui-x/assets/3165635/0e65996c-acb4-41e8-b112-4ae7786a6dcd

https://mui.com/x/react-data-grid/performance/#memoize-inner-components-with-react-memo. It smoothly appears (feels a bit laggy) and then instantly disappears (feels a bit brutal). I think that it should be reversed like Chrome whose repaints feel great:

https://github.com/mui/mui-x/assets/3165635/7f044954-0b81-41fa-a252-a10d8b88d9a9

For the colors, we could consider picking the ones of React Dev Tools' UX, but it feels a bit cheap:

https://github.com/mui/mui-x/assets/3165635/fa775e24-4a58-4f05-b7e6-8604c4c03edf

Here is how it looks now: https://deploy-preview-8986--material-ui-x.netlify.app/x/react-data-grid/performance/#memoize-inner-components-with-react-memo

https://github.com/mui/mui-x/assets/3165635/81afd717-8f18-491a-b17f-e359e010bce9
