### PR TITLE
[DataGrid] Avoid some allocations & preserve objects

### DIFF
--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
@@ -36,16 +36,15 @@ const GridVirtualScroller = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> }
 >(function GridVirtualScroller(props, ref) {
-  const { className, ...other } = props;
   const rootProps = useGridRootProps();
   const classes = useUtilityClasses(rootProps);
 
   return (
     <VirtualScrollerRoot
       ref={ref}
-      className={clsx(classes.root, className)}
+      {...props}
+      className={clsx(classes.root, props.className)}
       ownerState={rootProps}
-      {...other}
     />
   );
 });

--- a/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerContent.tsx
+++ b/packages/grid/x-data-grid/src/components/virtualization/GridVirtualScrollerContent.tsx
@@ -6,10 +6,10 @@ import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 
-type OwnerState = DataGridProcessedProps & { overflowedContent: boolean };
+type OwnerState = DataGridProcessedProps;
 
-const useUtilityClasses = (ownerState: OwnerState) => {
-  const { classes, overflowedContent } = ownerState;
+const useUtilityClasses = (props: DataGridProcessedProps, overflowedContent: boolean ) => {
+  const { classes } = props;
 
   const slots = {
     root: ['virtualScrollerContent', overflowedContent && 'virtualScrollerContent--overflowed'],
@@ -28,21 +28,16 @@ const GridVirtualScrollerContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> }
 >(function GridVirtualScrollerContent(props, ref) {
-  const { className, style, ...other } = props;
   const rootProps = useGridRootProps();
-  const ownerState = {
-    ...rootProps,
-    overflowedContent: !rootProps.autoHeight && style?.minHeight === 'auto',
-  };
-  const classes = useUtilityClasses(ownerState);
+  const overflowedContent = !rootProps.autoHeight && props.style?.minHeight === 'auto';
+  const classes = useUtilityClasses(rootProps, overflowedContent);
 
   return (
     <VirtualScrollerContentRoot
       ref={ref}
-      className={clsx(classes.root, className)}
-      ownerState={ownerState}
-      style={style}
-      {...other}
+      {...props}
+      ownerState={rootProps}
+      className={clsx(classes.root, props.className)}
     />
   );
 });

--- a/packages/grid/x-data-grid/src/hooks/core/useGridStateInitialization.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridStateInitialization.ts
@@ -19,12 +19,7 @@ export const useGridStateInitialization = <PrivateApi extends GridPrivateApiComm
   const registerControlState = React.useCallback<
     GridStatePrivateApi<PrivateApi['state']>['registerControlState']
   >((controlStateItem) => {
-    const { stateId, ...others } = controlStateItem;
-
-    controlStateMapRef.current[stateId] = {
-      ...others,
-      stateId,
-    };
+    controlStateMapRef.current[controlStateItem.stateId] = controlStateItem;
   }, []);
 
   const setState = React.useCallback<GridStateApi<PrivateApi['state']>['setState']>(

--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -108,12 +108,12 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   const totalHeaderHeight = getTotalHeaderHeight(apiRef, rootProps.columnHeaderHeight);
   const headerHeight = Math.floor(rootProps.columnHeaderHeight * densityFactor);
 
-  const setRenderContext = (nextRenderContext: GridRenderContext | null) => {
+  const setRenderContext = React.useCallback((nextRenderContext: GridRenderContext | null) => {
     if (renderContext && nextRenderContext && areRenderContextsEqual(renderContext, nextRenderContext)) {
       return;
     }
     setRenderContextRaw(nextRenderContext);
-  }
+  }, [])
 
   React.useEffect(() => {
     apiRef.current.columnHeadersContainerElementRef!.current!.scrollLeft = 0;
@@ -217,7 +217,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         updateInnerPosition(nextRenderContext);
       }
     },
-    [updateInnerPosition],
+    [updateInnerPosition, setRenderContext],
   );
 
   const handleColumnResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(

--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -11,7 +11,7 @@ import { GridEventListener } from '../../../models/events';
 import { GridColumnHeaderItem } from '../../../components/columnHeaders/GridColumnHeaderItem';
 import { getFirstColumnIndexToRender, getTotalHeaderHeight } from '../columns/gridColumnsUtils';
 import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
-import { getRenderableIndexes } from '../virtualization/useGridVirtualScroller';
+import { areRenderContextsEqual, getRenderableIndexes } from '../virtualization/useGridVirtualScroller';
 import { GridColumnGroupHeader } from '../../../components/columnHeaders/GridColumnGroupHeader';
 import { GridColumnGroup } from '../../../models/gridColumnGrouping';
 import { GridStateColDef } from '../../../models/colDef/gridColDef';
@@ -101,12 +101,19 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   const rootProps = useGridRootProps();
   const innerRef = React.useRef<HTMLDivElement>(null);
   const handleInnerRef = useForkRef(innerRefProp, innerRef);
-  const [renderContext, setRenderContext] = React.useState<GridRenderContext | null>(null);
+  const [renderContext, setRenderContextRaw] = React.useState<GridRenderContext | null>(null);
   const prevRenderContext = React.useRef<GridRenderContext | null>(renderContext);
   const prevScrollLeft = React.useRef(0);
   const currentPage = useGridVisibleRows(apiRef, rootProps);
   const totalHeaderHeight = getTotalHeaderHeight(apiRef, rootProps.columnHeaderHeight);
   const headerHeight = Math.floor(rootProps.columnHeaderHeight * densityFactor);
+
+  const setRenderContext = (nextRenderContext: GridRenderContext | null) => {
+    if (renderContext && nextRenderContext && areRenderContextsEqual(renderContext, nextRenderContext)) {
+      return;
+    }
+    setRenderContextRaw(nextRenderContext);
+  }
 
   React.useEffect(() => {
     apiRef.current.columnHeadersContainerElementRef!.current!.scrollLeft = 0;

--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -113,7 +113,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
       return;
     }
     setRenderContextRaw(nextRenderContext);
-  }, [])
+  }, [renderContext])
 
   React.useEffect(() => {
     apiRef.current.columnHeadersContainerElementRef!.current!.scrollLeft = 0;

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom';
 import {
   unstable_useForkRef as useForkRef,
   unstable_useEnhancedEffect as useEnhancedEffect,
+  unstable_useEventCallback as useEventCallback,
 } from '@mui/utils';
 import { useTheme } from '@mui/material/styles';
 import { defaultMemoize } from 'reselect';
@@ -80,7 +81,7 @@ export const getRenderableIndexes = ({
   ];
 };
 
-const areRenderContextsEqual = (context1: GridRenderContext, context2: GridRenderContext) => {
+export const areRenderContextsEqual = (context1: GridRenderContext, context2: GridRenderContext) => {
   if (context1 === context2) {
     return true;
   }
@@ -369,7 +370,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     apiRef.current.publishEvent('scrollPositionChange', params);
   }, [apiRef, computeRenderContext, containerDimensions.width, updateRenderContext]);
 
-  const handleScroll = (event: React.UIEvent) => {
+  const handleScroll = useEventCallback((event: React.UIEvent) => {
     const { scrollTop, scrollLeft } = event.currentTarget;
     scrollPosition.current.top = scrollTop;
     scrollPosition.current.left = scrollLeft;
@@ -432,15 +433,15 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
       });
       prevTotalWidth.current = columnsTotalWidth;
     }
-  };
+  });
 
-  const handleWheel = (event: React.WheelEvent) => {
+  const handleWheel = useEventCallback((event: React.WheelEvent) => {
     apiRef.current.publishEvent('virtualScrollerWheel', {}, event);
-  };
+  });
 
-  const handleTouchMove = (event: React.TouchEvent) => {
+  const handleTouchMove = useEventCallback((event: React.TouchEvent) => {
     apiRef.current.publishEvent('virtualScrollerTouchMove', {}, event);
-  };
+  });
 
   const getRows = (
     params: {
@@ -638,13 +639,16 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     contentSize.height = getMinimalContentHeight(apiRef, rootProps.rowHeight); // Give room to show the overlay when there no rows.
   }
 
-  const rootStyle = {} as React.CSSProperties;
-  if (!needsHorizontalScrollbar) {
-    rootStyle.overflowX = 'hidden';
-  }
-  if (rootProps.autoHeight) {
-    rootStyle.overflowY = 'hidden';
-  }
+  const rootStyle = React.useMemo(() => {
+    const rootStyle = {} as React.CSSProperties;
+    if (!needsHorizontalScrollbar) {
+      rootStyle.overflowX = 'hidden';
+    }
+    if (rootProps.autoHeight) {
+      rootStyle.overflowY = 'hidden';
+    }
+    return rootStyle;
+  }, [needsHorizontalScrollbar, rootProps.autoHeight]);
 
   const getRenderContext = React.useCallback((): GridRenderContext => {
     return prevRenderContext.current!;
@@ -656,15 +660,15 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     renderContext,
     updateRenderZonePosition,
     getRows,
-    getRootProps: ({ style = {}, ...other } = {}) => ({
+    getRootProps: (props: { style?: object } = {}) => ({
       ref: handleRef,
       onScroll: handleScroll,
       onWheel: handleWheel,
       onTouchMove: handleTouchMove,
-      style: { ...style, ...rootStyle },
-      ...other,
+      ...props,
+      style: props.style ? { ...props.style, ...rootStyle } : rootStyle,
     }),
-    getContentProps: ({ style = {} } = {}) => ({ style: { ...style, ...contentSize } }),
+    getContentProps: ({ style }: { style?: object } = {}) => ({ style: style ? { ...style, ...contentSize } : contentSize }),
     getRenderZoneProps: () => ({ ref: renderZoneRef }),
   };
 };

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -640,14 +640,14 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
   }
 
   const rootStyle = React.useMemo(() => {
-    const rootStyle = {} as React.CSSProperties;
+    const style = {} as React.CSSProperties;
     if (!needsHorizontalScrollbar) {
-      rootStyle.overflowX = 'hidden';
+      style.overflowX = 'hidden';
     }
     if (rootProps.autoHeight) {
-      rootStyle.overflowY = 'hidden';
+      style.overflowY = 'hidden';
     }
-    return rootStyle;
+    return style;
   }, [needsHorizontalScrollbar, rootProps.autoHeight]);
 
   const getRenderContext = React.useCallback((): GridRenderContext => {
@@ -660,13 +660,13 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     renderContext,
     updateRenderZonePosition,
     getRows,
-    getRootProps: (props: { style?: object } = {}) => ({
+    getRootProps: (inputProps: { style?: object } = {}) => ({
       ref: handleRef,
       onScroll: handleScroll,
       onWheel: handleWheel,
       onTouchMove: handleTouchMove,
-      ...props,
-      style: props.style ? { ...props.style, ...rootStyle } : rootStyle,
+      ...inputProps,
+      style: inputProps.style ? { ...inputProps.style, ...rootStyle } : rootStyle,
     }),
     getContentProps: ({ style }: { style?: object } = {}) => ({ style: style ? { ...style, ...contentSize } : contentSize }),
     getRenderZoneProps: () => ({ ref: renderZoneRef }),


### PR DESCRIPTION
This PR has the dual purpose of removing some object allocations as well as preserving some objects to pass shallow equality comparisons. Most of these are the results of playing whack-a-mole with the reports of [why-did-you-render](https://github.com/welldone-software/why-did-you-render).