### PR TITLE
[docs] Improve localization table progress bars

### DIFF
--- a/docs/src/modules/components/LocalizationTable.js
+++ b/docs/src/modules/components/LocalizationTable.js
@@ -9,29 +9,28 @@ import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 const Root = styled('div')(({ theme }) => ({
   position: 'relative',
   overflow: 'hidden',
-  width: 'fit-content',
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
   paddingLeft: theme.spacing(1),
   paddingRight: theme.spacing(1),
-  borderRadius: 5,
+  borderRadius: 4,
+  fontWeight: 500,
+  color: (theme.vars || theme).palette.text.secondary,
+
   '&.low': {
-    color: (theme.vars || theme).palette.error.contrastText,
-    backgroundColor: (theme.vars || theme).palette.error.light,
     '& .progress-bar': {
-      backgroundColor: (theme.vars || theme).palette.error.dark,
+      backgroundColor: (theme.vars || theme).palette.error.light,
     },
   },
   '&.medium': {
-    color: (theme.vars || theme).palette.warning.contrastText,
-    backgroundColor: (theme.vars || theme).palette.warning.light,
     '& .progress-bar': {
-      backgroundColor: (theme.vars || theme).palette.warning.dark,
+      backgroundColor: (theme.vars || theme).palette.warning.light,
     },
   },
   '&.high': {
-    color: (theme.vars || theme).palette.success.contrastText,
-    backgroundColor: (theme.vars || theme).palette.success.light,
     '& .progress-bar': {
-      backgroundColor: (theme.vars || theme).palette.success.dark,
+      backgroundColor: (theme.vars || theme).palette.success.light,
     },
   },
 }));
@@ -48,6 +47,14 @@ const Bar = styled('div')({
   left: 0,
   bottom: 0,
 });
+const Background = styled('div')({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(166, 170, 185, 0.25)',
+});
 
 const ProgressBar = React.memo(function ProgressBar(props) {
   const { numerator, denumerator } = props;
@@ -61,8 +68,9 @@ const ProgressBar = React.memo(function ProgressBar(props) {
         high: valueInPercent > 80,
       })}
     >
+      <Background className="progress-background" />
       <Bar className="progress-bar" style={{ right: `${100 - valueInPercent}%` }} />
-      <Value>{`${numerator}/${denumerator}`}</Value>
+      <Value>{numerator === denumerator ? 'done' : `${numerator}/${denumerator}`}</Value>
     </Root>
   );
 });

--- a/docs/src/modules/components/LocalizationTable.js
+++ b/docs/src/modules/components/LocalizationTable.js
@@ -106,7 +106,7 @@ const ProgressBar = React.memo(function ProgressBar(props) {
         }
       />
       <Bar className="progress-bar" style={{ right: `${100 - valueInPercent}%` }} />
-      <Value>{numerator === denumerator ? 'Done!🎉' : `${numerator}/${denumerator}`}</Value>
+      <Value>{numerator === denumerator ? 'Done! 🎉' : `${numerator}/${denumerator}`}</Value>
     </Root>
   );
 });

--- a/docs/src/modules/components/LocalizationTable.js
+++ b/docs/src/modules/components/LocalizationTable.js
@@ -3,34 +3,65 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';
+import { green } from '@mui/material/colors';
 import Link from 'docs/src/modules/components/Link';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 
 const Root = styled('div')(({ theme }) => ({
   position: 'relative',
   overflow: 'hidden',
-  width: '100%',
+  minWidth: '100%',
   display: 'flex',
   justifyContent: 'center',
   paddingLeft: theme.spacing(1),
   paddingRight: theme.spacing(1),
-  borderRadius: 4,
-  fontWeight: 500,
+  borderRadius: 5,
+  fontWeight: 600,
   color: (theme.vars || theme).palette.text.secondary,
 
   '&.low': {
+    color:
+      (theme.vars || theme).palette.mode === 'dark'
+        ? (theme.vars || theme).palette.text.primary
+        : (theme.vars || theme).palette.error.dark,
+
     '& .progress-bar': {
-      backgroundColor: (theme.vars || theme).palette.error.light,
+      backgroundColor: (theme.vars || theme).palette.error.main,
+      opacity: 0.3,
+    },
+    '& .progress-background': {
+      border: `1.5px solid ${(theme.vars || theme).palette.error.dark}`,
     },
   },
   '&.medium': {
+    color:
+      (theme.vars || theme).palette.mode === 'dark'
+        ? (theme.vars || theme).palette.text.primary
+        : (theme.vars || theme).palette.warning.dark,
+
     '& .progress-bar': {
-      backgroundColor: (theme.vars || theme).palette.warning.light,
+      backgroundColor: (theme.vars || theme).palette.warning.main,
+      opacity: 0.3,
+    },
+    '& .progress-background': {
+      border: `1.5px solid ${(theme.vars || theme).palette.warning.dark}`,
     },
   },
   '&.high': {
+    color:
+      (theme.vars || theme).palette.mode === 'dark'
+        ? (theme.vars || theme).palette.text.primary
+        : (theme.vars || theme).palette.success.dark,
+
     '& .progress-bar': {
-      backgroundColor: (theme.vars || theme).palette.success.light,
+      backgroundColor: (theme.vars || theme).palette.success.main,
+      opacity: 0.3,
+    },
+    '& .progress-background': {
+      border: `1.5px solid ${green[200]}`,
+      '&.completed': {
+        border: `1.5px solid ${(theme.vars || theme).palette.success.dark}`,
+      },
     },
   },
 }));
@@ -53,12 +84,13 @@ const Background = styled('div')({
   left: 0,
   right: 0,
   bottom: 0,
-  backgroundColor: 'rgba(166, 170, 185, 0.25)',
+  borderRadius: 5,
 });
 
 const ProgressBar = React.memo(function ProgressBar(props) {
   const { numerator, denumerator } = props;
-  const valueInPercent = Math.floor((numerator / denumerator) * 100);
+  const valueInPercent =
+    numerator === denumerator ? 100 : Math.floor((numerator / denumerator) * 95);
 
   return (
     <Root
@@ -68,9 +100,13 @@ const ProgressBar = React.memo(function ProgressBar(props) {
         high: valueInPercent > 80,
       })}
     >
-      <Background className="progress-background" />
+      <Background
+        className={
+          numerator === denumerator ? 'progress-background completed' : 'progress-background'
+        }
+      />
       <Bar className="progress-bar" style={{ right: `${100 - valueInPercent}%` }} />
-      <Value>{numerator === denumerator ? 'done' : `${numerator}/${denumerator}`}</Value>
+      <Value>{numerator === denumerator ? 'Done!🎉' : `${numerator}/${denumerator}`}</Value>
     </Root>
   );
 });


### PR DESCRIPTION
Before: https://deploy-preview-9030--material-ui-x.netlify.app/x/react-data-grid/localization/#supported-locales
After: https://deploy-preview-9033--material-ui-x.netlify.app/x/react-data-grid/localization/#supported-locales

Closes #7101 

Improvements to the progress bar:
- gave all bars more horizontal space (100%) for more readability & to avoid the inconsistency currently happening when we have fewer digits displaying. 
- Changed the background to a neutral color for more contrast 
- using the lighter version of the colors gives an overall softer look
- since the difference between 35/36 and 36/36 is still not very distinguishable, I changed the text displayed when the translation is complete to 'done' (another option would have been to use an emoji for this - which would look nice - but not sure how accessible it is 🤔 )

This is what the table looks like after the changes:
 
![curent](https://github.com/mui/mui-x/assets/72460825/8e92a45b-975b-46e7-ac74-2246c934bc46)
![current dark](https://github.com/mui/mui-x/assets/72460825/10eb023a-0156-421b-b739-affca508fafb)

Another idea was to use darker and lighter versions of the same colors within a progress bar, to distinguish the background from the bar itself, but the green progress bars with higher values look strange:

![colors light](https://github.com/mui/mui-x/assets/72460825/d1624b1d-f028-41a4-8f01-5a9fc877c3ea)
![colors dark](https://github.com/mui/mui-x/assets/72460825/260ae707-137e-4e7e-a9c3-2aac6e37649a)

Using red as the background for the progress bar seems to create enough contrast, but the overall look feels disruptive

![red dark](https://github.com/mui/mui-x/assets/72460825/68c90a04-02f6-4439-bce7-00bf9ce4ad55)
![red light](https://github.com/mui/mui-x/assets/72460825/043a5ea1-b281-41d4-bd27-bc6ce50292a7)
