### PR TITLE
[docs] Clarify the peer dependency with react

### DIFF
--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -8,7 +8,7 @@ Using your favorite package manager, install `@mui/x-data-grid-pro` or `@mui/x-d
 
 {{"component": "modules/components/DataGridInstallationInstructions.js"}}
 
-The grid package has a peer dependency on `@mui/material`.
+The Data Grid package has a peer dependency on `@mui/material`.
 If you are not already using it in your project, you can install it with:
 
 ```sh
@@ -21,19 +21,28 @@ yarn add @mui/material @emotion/react @emotion/styled
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) >= 17.0.2 and [react-dom](https://www.npmjs.com/package/react-dom) >= 17.0.2 are peer dependencies.
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
 
-MUI is using [emotion](https://emotion.sh/docs/introduction) as a styling engine by default. If you want to use [`styled-components`](https://styled-components.com/) instead, run:
+```json
+"peerDependencies": {
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
+},
+```
+
+### Style engine
+
+Material UI is using [Emotion](https://emotion.sh/docs/introduction) as a styling engine by default. If you want to use [`styled-components`](https://styled-components.com/) instead, run:
 
 ```sh
 // with npm
-npm install @mui/material @mui/styled-engine-sc styled-components
+npm install @mui/styled-engine-sc styled-components
 
 // with yarn
-yarn add @mui/material @mui/styled-engine-sc styled-components
+yarn add @mui/styled-engine-sc styled-components
 ```
 
-> 💡 Take a look at the [Styled Engine guide](/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
+Take a look at the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
 
 ## Quickstart
 

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -40,17 +40,28 @@ yarn add @mui/material @emotion/react @emotion/styled
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) >= 17.0.2 and [react-dom](https://www.npmjs.com/package/react-dom) >= 17.0.2 are peer dependencies.
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
 
-MUI is using [emotion](https://emotion.sh/docs/introduction) as a styling engine by default. If you want to use [`styled-components`](https://styled-components.com/) instead, run:
+```json
+"peerDependencies": {
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
+},
+```
+
+### Style engine
+
+Material UI is using [Emotion](https://emotion.sh/docs/introduction) as a styling engine by default. If you want to use [`styled-components`](https://styled-components.com/) instead, run:
 
 ```sh
 // with npm
-npm install @mui/material @mui/styled-engine-sc styled-components
+npm install @mui/styled-engine-sc styled-components
 
 // with yarn
-yarn add @mui/material @mui/styled-engine-sc styled-components
+yarn add @mui/styled-engine-sc styled-components
 ```
+
+Take a look at the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
 
 ## Setup your date library adapter
 

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@mui/icons-material": "^5.4.1",
     "@mui/material": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/grid/x-data-grid-premium/README.md
+++ b/packages/grid/x-data-grid-premium/README.md
@@ -21,8 +21,8 @@ This component has the following peer dependencies that you will need to install
 "peerDependencies": {
   "@mui/material": "^5.4.1",
   "@mui/system": "^5.4.1",
-  "react": "^17.0.2 || ^18.0.0",
-  "react-dom": "^17.0.2 || ^18.0.0"
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
 },
 ```
 

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/grid/x-data-grid-pro/README.md
+++ b/packages/grid/x-data-grid-pro/README.md
@@ -21,8 +21,8 @@ This component has the following peer dependencies that you will need to install
 "peerDependencies": {
   "@mui/material": "^5.4.1",
   "@mui/system": "^5.4.1",
-  "react": "^17.0.2 || ^18.0.0",
-  "react-dom": "^17.0.2 || ^18.0.0"
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
 },
 ```
 

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/grid/x-data-grid/README.md
+++ b/packages/grid/x-data-grid/README.md
@@ -21,8 +21,8 @@ This component has the following peer dependencies that you will need to install
 "peerDependencies": {
   "@mui/material": "^5.4.1",
   "@mui/system": "^5.4.1",
-  "react": "^17.0.2 || ^18.0.0",
-  "react-dom": "^17.0.2 || ^18.0.0"
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
 },
 ```
 

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -55,8 +55,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "@mui/material": "^5.4.1",
     "@mui/system": "^5.4.1",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -1,7 +1,7 @@
 # @mui/x-date-pickers-pro
 
 This package is the commercial edition of the date and time picker components.
-It's part of MUI X, an open core extension of MUI, with advanced components.
+It's part of MUI X, an open-core extension of MUI, with advanced components.
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @mui/x-date-pickers-pro
 ```
 
 Then install the date library of your choice (if not already installed).
-We currently support 4 different date-libraries:
+We currently support 4 different date libraries:
 
 - [date-fns](https://date-fns.org/)
 - [Day.js](https://day.js.org/)
@@ -37,12 +37,12 @@ This component has the following peer dependencies that you will need to install
   "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
-  "react": "^17.0.2 || ^18.0.0",
-  "react-dom": "^17.0.2 || ^18.0.0"
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
 },
 ```
 
-After installation completed, you have to set the `dateAdapter` prop of the `LocalizationProvider` accordingly.
+After completing the installation, you have to set the `dateAdapter` prop of the `LocalizationProvider` accordingly.
 The supported adapters are exported from `@mui/x-date-pickers-pro`.
 
 ```js

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -62,8 +62,8 @@
     "moment": "^2.29.4",
     "moment-hijri": "^2.1.2",
     "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@emotion/react": {

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -1,7 +1,7 @@
 # @mui/x-date-pickers
 
 This package is the community edition of the date and time picker components.
-It's part of MUI X, an open core extension of MUI, with advanced components.
+It's part of MUI X, an open-core extension of MUI, with advanced components.
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @mui/x-date-pickers
 ```
 
 Then install the date library of your choice (if not already installed).
-We currently support 4 different date-libraries:
+We currently support 4 different date libraries:
 
 - [date-fns](https://date-fns.org/)
 - [Day.js](https://day.js.org/)
@@ -37,12 +37,12 @@ This component has the following peer dependencies that you will need to install
   "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
-  "react": "^17.0.2 || ^18.0.0",
-  "react-dom": "^17.0.2 || ^18.0.0"
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
 },
 ```
 
-After installation completed, you have to set the `dateAdapter` prop of the `LocalizationProvider` accordingly.
+After completing the installation, you have to set the `dateAdapter` prop of the `LocalizationProvider` accordingly.
 The supported adapters are exported from `@mui/x-date-pickers`.
 
 ```jsx

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -64,8 +64,8 @@
     "moment": "^2.29.4",
     "moment-hijri": "^2.1.2",
     "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@emotion/react": {

--- a/packages/x-license-pro/package.json
+++ b/packages/x-license-pro/package.json
@@ -34,7 +34,7 @@
     "@mui/utils": "^5.12.3"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "setupFiles": [
     "<rootDir>/src/setupTests.js"


### PR DESCRIPTION
The problem with:

<img width="608" alt="Screenshot 2023-05-22 at 00 28 42" src="https://github.com/mui/mui-x/assets/3165635/0e92e9cb-49fb-472a-a906-2090553cb17b">

https://mui.com/x/react-data-grid/getting-started/#installation

is two folds:

1. It won't age well, https://jubianchi.github.io/semver-check/#/%3E%3D17.0.2/25.0.0

<img width="556" alt="Screenshot 2023-05-22 at 00 30 38" src="https://github.com/mui/mui-x/assets/3165635/e4307e14-2ae5-496f-afca-b52bf29d730c">

2. It's not clear what version is supported, it's actually the same issue as with 1. It makes developers confused https://mui-org.slack.com/archives/C041SDSF32L/p1683384455188729