### PR TITLE
[pickers] Fix focus jumping on Safari

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -388,7 +388,7 @@ export const useField = <
       // On multi input range pickers we want to update selection range only for the active input
       // This helps avoiding the focus jumping on Safari https://github.com/mui/mui-x/issues/9003
       // because WebKit implements the `setSelectionRange` based on the spec: https://bugs.webkit.org/show_bug.cgi?id=224425
-      if (inputRef.current && document.activeElement === inputRef.current) {
+      if (inputRef.current && inputRef.current === getActiveElement(document)) {
         inputRef.current!.setSelectionRange(selectionStart, selectionEnd);
       }
       // Even reading this variable seems to do the trick, but also setting it just to make use of it

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -385,7 +385,12 @@ export const useField = <
     ) {
       // Fix scroll jumping on iOS browser: https://github.com/mui/mui-x/issues/8321
       const currentScrollTop = inputRef.current!.scrollTop;
-      inputRef.current!.setSelectionRange(selectionStart, selectionEnd);
+      // On multi input range pickers we want to update selection range only for the active input
+      // This helps avoiding the focus jumping on Safari https://github.com/mui/mui-x/issues/9003
+      // because WebKit implements the `setSelectionRange` based on the spec: https://bugs.webkit.org/show_bug.cgi?id=224425
+      if (inputRef.current && document.activeElement === inputRef.current) {
+        inputRef.current!.setSelectionRange(selectionStart, selectionEnd);
+      }
       // Even reading this variable seems to do the trick, but also setting it just to make use of it
       inputRef.current!.scrollTop = currentScrollTop;
     }


### PR DESCRIPTION
Fix #9003

`setSelectionRange` implementation on Safari/WebKit is strictly based on spec, where calling this method is only allowed on the focused element, hence, WebKit focuses the element before executing the `setSelectionRange` logic: https://bugs.webkit.org/show_bug.cgi?id=224425

In the case of pickers using MultiInput range fields, the `setSelectionRange` is being called on both inputs and that is causing the focus to jump between the two.

Ensuring that the `setSelectionRange` is being set only on the active element seems to fix the issue. 🤔 