### PR TITLE
[core] Lock `@types/node` on v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@types/chai-dom": "^1.11.0",
     "@types/enzyme": "^3.10.12",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^20.1.4",
+    "@types/node": "^18.16.14",
     "@types/prettier": "^2.7.2",
     "@types/react": "^18.2.4",
     "@types/react-dom": "^18.2.4",
@@ -191,6 +191,7 @@
   },
   "dependencies": {},
   "resolutions": {
-    "**/react-is": "^18.2.0"
+    "**/react-is": "^18.2.0",
+    "**/@types/node": "<19"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,11 @@
       "matchPackagePatterns": "@typescript-eslint/*"
     },
     {
+      "groupName": "@types/node",
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "< 19.0.0"
+    },
+    {
       "groupName": "bundling fixtures",
       "matchPaths": ["test/bundling/fixtures/**/package.json"],
       "schedule": "every 6 months on the first day of the month"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2999,15 +2999,10 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=10.0.0", "@types/node@^20.1.4":
-  version "20.1.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.4.tgz#83f148d2d1f5fe6add4c53358ba00d97fc4cdb71"
-  integrity sha512-At4pvmIOki8yuwLtd7BNHl3CiWNbtclUbNtScGx4OHfBd4/oWoJC8KRCIxXwkdndzhxOsPXihrsOoydxBjlE9Q==
-
-"@types/node@^14.0.1":
-  version "14.18.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.36.tgz#c414052cb9d43fab67d679d5f3c641be911f5835"
-  integrity sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==
+"@types/node@*", "@types/node@<19", "@types/node@>= 8", "@types/node@>=10.0.0", "@types/node@^14.0.1", "@types/node@^18.16.14":
+  version "18.16.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.14.tgz#ab67bb907f1146afc6fedb9ce60ae8a99c989631"
+  integrity sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Closes #9060

Address https://github.com/mui/mui-x/pull/9060#pullrequestreview-1441631866

Locking it on v18 as we plan to stick with v18 (current LTS) for CI as discussed here https://github.com/mui/material-ui/pull/37173