### PR TITLE
[core] Remove `cross-fetch` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -93,7 +93,6 @@
     "@babel/preset-typescript": "^7.21.4",
     "@types/doctrine": "^0.0.5",
     "cpy-cli": "^4.2.0",
-    "cross-fetch": "^3.1.5",
     "gm": "^1.25.0",
     "typescript-to-proptypes": "^2.2.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5282,13 +5282,6 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/pull/9055

The bump [would introduce](https://github.com/mui/mui-x/pull/9055/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR10335) a secondary `node-fetch` package, although, the `cross-fetch` itself does not seem to be used at all... 🤷 