### PR TITLE
[pickers] Fix bug when fields have a unique section

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -244,7 +244,10 @@ export const useField = <
         activeSection.end -
         cleanString(activeSection.endSeparator || '').length;
 
-      keyPressed = cleanValueStr.slice(activeSection.start, activeSectionEndRelativeToNewValue);
+      keyPressed = cleanValueStr.slice(
+        activeSection.start + cleanString(activeSection.startSeparator || '').length,
+        activeSectionEndRelativeToNewValue,
+      );
     }
 
     if (isAndroid() && keyPressed.length === 0) {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -202,7 +202,8 @@ export const useField = <
     let keyPressed: string;
     if (
       selectedSectionIndexes.startIndex === 0 &&
-      selectedSectionIndexes.endIndex === state.sections.length - 1
+      selectedSectionIndexes.endIndex === state.sections.length - 1 &&
+      cleanValueStr.length === 1
     ) {
       keyPressed = cleanValueStr;
     } else {


### PR DESCRIPTION
Fix #9035

I thought it was a problem about the token parser, but no. It's the `onChange` which has a specific behavior when all tokens are selected.

This behavior has been added in #8330, such that when selecting the entire field by doing <kbd>Ctrl</kbd>+<kbd>A</kbd> pressing a key edit the first section.

This assumes that there is no `startSeparator` on the first/last `endSeparator` elements. shuch that when pressing 1 onchange get the pressed key (I'm using `||` to show selection range):

- `|hh:mm|` becomes `1` which is then transformed to `|01|:mm` by field code
- `it is |hh:mm|:00` becomes `it is 1:00` which not a valid value for `hh` so the field keep the previous state

The quick fix is to test if `onChange` has only one character