### PR TITLE
[DataGridPro] Prevent click event on sorting after a resize

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -412,9 +412,9 @@ export const useGridColumnResize = (
     doc.removeEventListener('touchend', handleTouchEnd);
     // The click event runs right after the mouseup event, we want to wait until it
     // has been canceled before removing our handler.
-    Promise.resolve().then(() => {
+    setTimeout(() => {
       doc.removeEventListener('click', handleClick, true);
-    });
+    }, 100);
   }, [
     apiRef,
     handleResizeMouseMove,

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -124,13 +124,6 @@ export const columnResizeStateInitializer: GridStateInitializer = (state) => ({
   columnResize: { resizingColumnField: '' },
 });
 
-// Prevent the click event if we have resized the column.
-// Fixes https://github.com/mui/mui-x/issues/4777
-const preventClick = (event: MouseEvent) => {
-  event.preventDefault();
-  event.stopImmediatePropagation();
-};
-
 /**
  * @requires useGridColumns (method, event)
  * TODO: improve experience for last column
@@ -306,7 +299,9 @@ export const useGridColumnResize = (
 
       doc.addEventListener('mousemove', handleResizeMouseMove);
       doc.addEventListener('mouseup', handleResizeMouseUp);
-      doc.addEventListener('click', preventClick, true);
+
+      // Fixes https://github.com/mui/mui-x/issues/4777
+      colElementRef.current.style.pointerEvents = 'none';
     });
 
   const handleTouchEnd = useEventCallback((nativeEvent: any) => {
@@ -410,12 +405,17 @@ export const useGridColumnResize = (
     doc.removeEventListener('mouseup', handleResizeMouseUp);
     doc.removeEventListener('touchmove', handleTouchMove);
     doc.removeEventListener('touchend', handleTouchEnd);
-    // The click event runs right after the mouseup event, we want to wait until it
-    // has been canceled before removing our handler.
-    setTimeout(() => {
-      doc.removeEventListener('click', preventClick, true);
-    }, 100);
-  }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd]);
+    if (colElementRef.current) {
+      colElementRef.current!.style.pointerEvents = 'unset';
+    }
+  }, [
+    apiRef,
+    colElementRef,
+    handleResizeMouseMove,
+    handleResizeMouseUp,
+    handleTouchMove,
+    handleTouchEnd,
+  ]);
 
   const handleResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
     ({ field }) => {

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -415,7 +415,7 @@ export const useGridColumnResize = (
     Promise.resolve().then(() => {
       doc.removeEventListener('click', handleClick, true);
     })
-  }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd]);
+  }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd, handleClick]);
 
   const handleResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
     ({ field }) => {

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -190,7 +190,7 @@ export const useGridColumnResize = (
     });
   };
 
-  const handleResizeMouseUp = useEventCallback((nativeEvent: MouseEvent) => {
+  const finishResize = (nativeEvent: MouseEvent) => {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     stopListening();
 
@@ -215,7 +215,16 @@ export const useGridColumnResize = (
     logger.debug(
       `Updating col ${colDefRef.current!.field} with new width: ${colDefRef.current!.width}`,
     );
+  }
+
+  // Prevent the click event if we have resized the column.
+  // Fixes https://github.com/mui/mui-x/issues/4777
+  const handleClick = useEventCallback((event: MouseEvent) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
   });
+
+  const handleResizeMouseUp = useEventCallback(finishResize);
 
   const handleResizeMouseMove = useEventCallback((nativeEvent: MouseEvent) => {
     // Cancel move in case some other element consumed a mouseup event and it was not fired.
@@ -297,6 +306,7 @@ export const useGridColumnResize = (
 
       doc.addEventListener('mousemove', handleResizeMouseMove);
       doc.addEventListener('mouseup', handleResizeMouseUp);
+      doc.addEventListener('click', handleClick, true);
     });
 
   const handleTouchEnd = useEventCallback((nativeEvent: any) => {
@@ -306,30 +316,7 @@ export const useGridColumnResize = (
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    stopListening();
-
-    apiRef.current.updateColumns([colDefRef.current!]);
-
-    clearTimeout(stopResizeEventTimeout.current);
-    stopResizeEventTimeout.current = setTimeout(() => {
-      apiRef.current.publishEvent('columnResizeStop', null, nativeEvent);
-      if (colDefRef.current) {
-        apiRef.current.publishEvent(
-          'columnWidthChange',
-          {
-            element: colElementRef.current,
-            colDef: colDefRef.current,
-            width: colDefRef.current?.computedWidth,
-          },
-          nativeEvent,
-        );
-      }
-    });
-
-    logger.debug(
-      `Updating col ${colDefRef.current!.field} with new width: ${colDefRef.current!.width}`,
-    );
+    finishResize(nativeEvent);
   });
 
   const handleTouchMove = useEventCallback((nativeEvent: any) => {
@@ -423,6 +410,11 @@ export const useGridColumnResize = (
     doc.removeEventListener('mouseup', handleResizeMouseUp);
     doc.removeEventListener('touchmove', handleTouchMove);
     doc.removeEventListener('touchend', handleTouchEnd);
+    // The click event runs right after the mouseup event, we want to wait until it
+    // has been canceled before removing our handler.
+    Promise.resolve().then(() => {
+      doc.removeEventListener('click', handleClick, true);
+    })
   }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd]);
 
   const handleResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -124,6 +124,13 @@ export const columnResizeStateInitializer: GridStateInitializer = (state) => ({
   columnResize: { resizingColumnField: '' },
 });
 
+// Prevent the click event if we have resized the column.
+// Fixes https://github.com/mui/mui-x/issues/4777
+const preventClick = (event: MouseEvent) => {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+};
+
 /**
  * @requires useGridColumns (method, event)
  * TODO: improve experience for last column
@@ -217,13 +224,6 @@ export const useGridColumnResize = (
     );
   };
 
-  // Prevent the click event if we have resized the column.
-  // Fixes https://github.com/mui/mui-x/issues/4777
-  const handleClick = useEventCallback((event: MouseEvent) => {
-    event.preventDefault();
-    event.stopImmediatePropagation();
-  });
-
   const handleResizeMouseUp = useEventCallback(finishResize);
 
   const handleResizeMouseMove = useEventCallback((nativeEvent: MouseEvent) => {
@@ -306,7 +306,7 @@ export const useGridColumnResize = (
 
       doc.addEventListener('mousemove', handleResizeMouseMove);
       doc.addEventListener('mouseup', handleResizeMouseUp);
-      doc.addEventListener('click', handleClick, true);
+      doc.addEventListener('click', preventClick, true);
     });
 
   const handleTouchEnd = useEventCallback((nativeEvent: any) => {
@@ -413,16 +413,9 @@ export const useGridColumnResize = (
     // The click event runs right after the mouseup event, we want to wait until it
     // has been canceled before removing our handler.
     setTimeout(() => {
-      doc.removeEventListener('click', handleClick, true);
+      doc.removeEventListener('click', preventClick, true);
     }, 100);
-  }, [
-    apiRef,
-    handleResizeMouseMove,
-    handleResizeMouseUp,
-    handleTouchMove,
-    handleTouchEnd,
-    handleClick,
-  ]);
+  }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd]);
 
   const handleResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
     ({ field }) => {

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -215,7 +215,7 @@ export const useGridColumnResize = (
     logger.debug(
       `Updating col ${colDefRef.current!.field} with new width: ${colDefRef.current!.width}`,
     );
-  }
+  };
 
   // Prevent the click event if we have resized the column.
   // Fixes https://github.com/mui/mui-x/issues/4777
@@ -414,8 +414,15 @@ export const useGridColumnResize = (
     // has been canceled before removing our handler.
     Promise.resolve().then(() => {
       doc.removeEventListener('click', handleClick, true);
-    })
-  }, [apiRef, handleResizeMouseMove, handleResizeMouseUp, handleTouchMove, handleTouchEnd, handleClick]);
+    });
+  }, [
+    apiRef,
+    handleResizeMouseMove,
+    handleResizeMouseUp,
+    handleTouchMove,
+    handleTouchEnd,
+    handleClick,
+  ]);
 
   const handleResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
     ({ field }) => {

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -101,6 +101,28 @@ describe('<DataGridPro /> - Columns', () => {
       expect(getCell(1, 0)).toHaveInlineStyle({ width: '110px' });
     });
 
+    /* XXX: Does not reproduce the original issue */
+    it('should not trigger a click on the header after resizing', () => {
+      const columns = [{ field: 'id', minWidth: 100 }, { field: 'brand', width: 100 }];
+      render(
+        <Test
+          columns={columns}
+          initialState={{
+            sorting: {
+              sortModel: [{ field: 'brand', sort: 'asc' }],
+            }
+          }}
+        />
+      );
+      const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`)!;
+      const header = document.querySelector(`.${gridClasses['columnHeader']}`)!;
+      fireEvent.mouseDown(separator, { clientX: 100 });
+      fireEvent.mouseMove(separator, { clientX: 90, buttons: 1 });
+      fireEvent.mouseUp(header);
+      const sortedCell = document.querySelector(`.${gridClasses['columnHeader--sorted']}`);
+      expect(sortedCell?.getAttribute('data-field')).to.equal('brand');
+    });
+
     it('should allow to resize columns with the touch', function test() {
       // Only run in supported browsers
       if (typeof Touch === 'undefined') {

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -103,16 +103,19 @@ describe('<DataGridPro /> - Columns', () => {
 
     /* XXX: Does not reproduce the original issue */
     it('should not trigger a click on the header after resizing', () => {
-      const columns = [{ field: 'id', minWidth: 100 }, { field: 'brand', width: 100 }];
+      const columns = [
+        { field: 'id', minWidth: 100 },
+        { field: 'brand', width: 100 },
+      ];
       render(
         <Test
           columns={columns}
           initialState={{
             sorting: {
               sortModel: [{ field: 'brand', sort: 'asc' }],
-            }
+            },
           }}
-        />
+        />,
       );
       const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`)!;
       const header = document.querySelector(`.${gridClasses['columnHeader']}`)!;

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -101,31 +101,6 @@ describe('<DataGridPro /> - Columns', () => {
       expect(getCell(1, 0)).toHaveInlineStyle({ width: '110px' });
     });
 
-    /* XXX: Does not reproduce the original issue */
-    it('should not trigger a click on the header after resizing', () => {
-      const columns = [
-        { field: 'id', minWidth: 100 },
-        { field: 'brand', width: 100 },
-      ];
-      render(
-        <Test
-          columns={columns}
-          initialState={{
-            sorting: {
-              sortModel: [{ field: 'brand', sort: 'asc' }],
-            },
-          }}
-        />,
-      );
-      const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`)!;
-      const header = document.querySelector(`.${gridClasses['columnHeader']}`)!;
-      fireEvent.mouseDown(separator, { clientX: 100 });
-      fireEvent.mouseMove(separator, { clientX: 90, buttons: 1 });
-      fireEvent.mouseUp(header);
-      const sortedCell = document.querySelector(`.${gridClasses['columnHeader--sorted']}`);
-      expect(sortedCell?.getAttribute('data-field')).to.equal('brand');
-    });
-
     it('should allow to resize columns with the touch', function test() {
       // Only run in supported browsers
       if (typeof Touch === 'undefined') {

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -101,30 +101,6 @@ describe('<DataGridPro /> - Columns', () => {
       expect(getCell(1, 0)).toHaveInlineStyle({ width: '110px' });
     });
 
-    it('should not trigger a click on the header after resizing', () => {
-      render(
-        <Test
-          columns={[
-            { field: 'id', minWidth: 100 },
-            { field: 'brand', width: 100 },
-          ]}
-          initialState={{
-            sorting: {
-              sortModel: [{ field: 'brand', sort: 'asc' }],
-            },
-          }}
-        />,
-      );
-      const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`)!;
-      const header = document.querySelector(`.${gridClasses.columnHeader}`)!;
-      fireEvent.mouseDown(separator, { clientX: 100 });
-      fireEvent.mouseMove(separator, { clientX: 90, buttons: 1 });
-      fireEvent.mouseUp(header);
-      fireEvent.click(header);
-      const sortedCell = document.querySelector(`.${gridClasses['columnHeader--sorted']}`);
-      expect(sortedCell?.getAttribute('data-field')).to.equal('brand');
-    });
-
     it('should allow to resize columns with the touch', function test() {
       // Only run in supported browsers
       if (typeof Touch === 'undefined') {

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -101,6 +101,30 @@ describe('<DataGridPro /> - Columns', () => {
       expect(getCell(1, 0)).toHaveInlineStyle({ width: '110px' });
     });
 
+    it('should not trigger a click on the header after resizing', () => {
+      render(
+        <Test
+          columns={[
+            { field: 'id', minWidth: 100 },
+            { field: 'brand', width: 100 },
+          ]}
+          initialState={{
+            sorting: {
+              sortModel: [{ field: 'brand', sort: 'asc' }],
+            },
+          }}
+        />,
+      );
+      const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`)!;
+      const header = document.querySelector(`.${gridClasses.columnHeader}`)!;
+      fireEvent.mouseDown(separator, { clientX: 100 });
+      fireEvent.mouseMove(separator, { clientX: 90, buttons: 1 });
+      fireEvent.mouseUp(header);
+      fireEvent.click(header);
+      const sortedCell = document.querySelector(`.${gridClasses['columnHeader--sorted']}`);
+      expect(sortedCell?.getAttribute('data-field')).to.equal('brand');
+    });
+
     it('should allow to resize columns with the touch', function test() {
       // Only run in supported browsers
       if (typeof Touch === 'undefined') {

--- a/test/e2e/fixtures/DataGridPro/NotResize.tsx
+++ b/test/e2e/fixtures/DataGridPro/NotResize.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+
+const baselineProps = {
+  rows: [
+    {
+      id: 0,
+      brand: 'Nike',
+    },
+    {
+      id: 1,
+      brand: 'Adidas',
+    },
+    {
+      id: 2,
+      brand: 'Puma',
+    },
+  ],
+  columns: [
+    { field: 'id', minWidth: 100 },
+    { field: 'brand', width: 100 },
+  ],
+};
+
+export default function NotResize() {
+  return (
+    <div style={{width: 300, height: 300}}>
+      <DataGridPro
+        {...baselineProps}
+        initialState={{
+          sorting: {
+            sortModel: [{ field: 'brand', sort: 'asc' }],
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/test/e2e/fixtures/DataGridPro/NotResize.tsx
+++ b/test/e2e/fixtures/DataGridPro/NotResize.tsx
@@ -24,7 +24,7 @@ const baselineProps = {
 
 export default function NotResize() {
   return (
-    <div style={{width: 300, height: 300}}>
+    <div style={{ width: 300, height: 300 }}>
       <DataGridPro
         {...baselineProps}
         initialState={{

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -228,8 +228,8 @@ describe('e2e', () => {
       const separator = await page.$('.MuiDataGrid-columnSeparator--resizable');
       const boundingBox = (await separator?.boundingBox())!;
 
-      const x = boundingBox.x + boundingBox.width / 2
-      const y = boundingBox.y + boundingBox.height / 2
+      const x = boundingBox.x + boundingBox.width / 2;
+      const y = boundingBox.y + boundingBox.height / 2;
 
       await page.mouse.move(x, y, { steps: 5 });
       await page.mouse.down();
@@ -237,8 +237,11 @@ describe('e2e', () => {
       await page.mouse.up();
 
       expect(
-        await page.evaluate(() =>
-          document.querySelector('.MuiDataGrid-columnHeader--sorted')!.getAttribute('data-field')!
+        await page.evaluate(
+          () =>
+            document
+              .querySelector('.MuiDataGrid-columnHeader--sorted')!
+              .getAttribute('data-field')!,
         ),
       ).to.equal('brand');
     });

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -221,6 +221,28 @@ describe('e2e', () => {
       expect(await page.locator('[role="row"]').first().textContent()).to.equal('yearbrand');
     });
 
+    // https://github.com/mui/mui-x/pull/9117
+    it('should not trigger sorting after resizing', async () => {
+      await renderFixture('DataGridPro/NotResize');
+
+      const separator = await page.$('.MuiDataGrid-columnSeparator--resizable');
+      const boundingBox = (await separator?.boundingBox())!;
+
+      const x = boundingBox.x + boundingBox.width / 2
+      const y = boundingBox.y + boundingBox.height / 2
+
+      await page.mouse.move(x, y, { steps: 5 });
+      await page.mouse.down();
+      await page.mouse.move(x - 20, y, { steps: 5 });
+      await page.mouse.up();
+
+      expect(
+        await page.evaluate(() =>
+          document.querySelector('.MuiDataGrid-columnHeader--sorted')!.getAttribute('data-field')!
+        ),
+      ).to.equal('brand');
+    });
+
     it('should select one row', async () => {
       await renderFixture('DataGrid/CheckboxSelection');
       await page.click('[role="row"][data-rowindex="0"] [role="cell"] input');


### PR DESCRIPTION
Closes #4777

Prevents click event that happen right after a column resize. They currently trigger a click on the column header (which changes the sorting) if the mouseup happens over the header.