### PR TITLE
[DataGrid] Avoid allocations in `hydrateRowsMeta`

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
@@ -288,17 +288,16 @@ export const useGridDetailPanel = (
   const addDetailHeight = React.useCallback<GridPipeProcessor<'rowHeight'>>(
     (initialValue, row) => {
       if (!expandedRowIds || expandedRowIds.length === 0 || !expandedRowIds.includes(row.id)) {
-        return { ...initialValue, detail: 0 };
+        initialValue.detail = 0;
+        return initialValue;
       }
 
       updateCachesIfNeeded();
 
       const heightCache = gridDetailPanelExpandedRowsHeightCacheSelector(apiRef);
 
-      return {
-        ...initialValue,
-        detail: heightCache[row.id] ?? 0, // Fallback to zero because the cache might not be ready yet (e.g. page was changed)
-      };
+      initialValue.detail = heightCache[row.id] ?? 0; // Fallback to zero because the cache might not be ready yet (e.g. page was changed)
+      return initialValue;
     },
     [apiRef, expandedRowIds, updateCachesIfNeeded],
   );

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
@@ -144,15 +144,13 @@ export const useGridRowsMeta = (
         rowsHeightLookup.current[row.id].needsFirstMeasurement = false;
       }
 
-      const initialHeights = Object.entries(sizes).reduce<Record<string, number>>(
-        (acc, [key, size]) => {
-          if (/^base[A-Z]/.test(key)) {
-            acc[key] = size;
-          }
-          return acc;
-        },
-        {},
-      );
+      const initialHeights = {} as Record<string, number>;
+      /* eslint-disable-next-line no-restricted-syntax */
+      for (const key in sizes) {
+        if (/^base[A-Z]/.test(key)) {
+          initialHeights[key] = sizes[key];
+        }
+      }
       initialHeights.baseCenter = baseRowHeight;
 
       if (getRowSpacing) {
@@ -188,13 +186,15 @@ export const useGridRowsMeta = (
       let otherSizes = 0;
 
       const processedSizes = calculateRowProcessedSizes(row);
-      Object.entries(processedSizes).forEach(([size, value]) => {
-        if (/^base[A-Z]/.test(size)) {
+      /* eslint-disable-next-line no-restricted-syntax, guard-for-in */
+      for (const key in processedSizes) {
+        const value = processedSizes[key];
+        if (/^base[A-Z]/.test(key)) {
           maximumBaseSize = value > maximumBaseSize ? value : maximumBaseSize;
         } else {
           otherSizes += value;
         }
-      });
+      }
 
       return acc + maximumBaseSize + otherSizes;
     }, 0);

--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
@@ -144,7 +144,7 @@ export const useGridRowsMeta = (
         rowsHeightLookup.current[row.id].needsFirstMeasurement = false;
       }
 
-      const existingBaseSizes = Object.entries(sizes).reduce<Record<string, number>>(
+      const initialHeights = Object.entries(sizes).reduce<Record<string, number>>(
         (acc, [key, size]) => {
           if (/^base[A-Z]/.test(key)) {
             acc[key] = size;
@@ -153,12 +153,7 @@ export const useGridRowsMeta = (
         },
         {},
       );
-
-      // We use an object to make simple to check if a height is already added or not
-      const initialHeights: Record<string, number> = {
-        ...existingBaseSizes,
-        baseCenter: baseRowHeight,
-      };
+      initialHeights.baseCenter = baseRowHeight;
 
       if (getRowSpacing) {
         const indexRelativeToCurrentPage = apiRef.current.getRowIndexRelativeToVisibleRows(row.id);


### PR DESCRIPTION
This PR avoids object allocations in `hydrateRowsMeta`. For large datasets, the costs are quite high. This is compounded by the fact that we create our objects with `{ ...spread }`, and `_objectSpread2` is very expensive.

The results below are obtained by clearing the filters in the same example as in #9120 

<img src="https://github.com/mui/mui-x/assets/1423607/bbc0dd6e-4d4b-4aba-80ba-835c579551e9" width="350" />

| Before | After |
| --- | --- |
| ![Screenshot from 2023-05-25 22-45-53](https://github.com/mui/mui-x/assets/1423607/94bd2d23-3bfd-415d-9224-26504aac00e9) | ![Screenshot from 2023-05-25 22-42-43](https://github.com/mui/mui-x/assets/1423607/d31e23b8-23f8-4519-ac79-981d59c1d40b) |