### PR TITLE
[DataGrid] refactor(DataGridPremium): improve grid excel export interface

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/export/gridExcelExportInterface.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/export/gridExcelExportInterface.ts
@@ -16,7 +16,7 @@ export interface GridExceljsProcessInput {
 }
 
 export interface ColumnsStylesInterface {
-  [field: string]: Excel.Style;
+  [field: string]: Partial<Excel.Style>;
 }
 
 /**

--- a/packages/grid/x-data-grid-premium/src/hooks/features/export/serializer/excelSerializer.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/export/serializer/excelSerializer.ts
@@ -270,7 +270,7 @@ const addColumnGroupingHeaders = (
 type SerializedColumns = Array<{
   key: string;
   width: number;
-  style: Excel.Style;
+  style: Partial<Excel.Style>;
   headerText: string;
 }>;
 


### PR DESCRIPTION
When specifying `excelOptions` -> `columnStyles` of the data grid's toolbar, I get the following error:
![Screenshot 2023-05-26 at 16 34 12](https://github.com/mui/mui-x/assets/7397373/c9cec78b-061c-46f2-a9b5-02a97f2c3a55)

I believe not all properties are required so in my change I used `Partial` to improve this.
