### PR TITLE
[docs] Reduce layout shift in grid demo

### DIFF
--- a/docs/data/data-grid/demo/PopularFeaturesDemo.js
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.js
@@ -8,7 +8,6 @@ import {
 } from '@mui/x-data-grid-premium';
 import Link from '@mui/material/Link';
 import Chip from '@mui/material/Chip';
-import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import ArrowUp from '@mui/icons-material/KeyboardArrowUp';
@@ -202,11 +201,7 @@ function getChipProperties(plan) {
 function PlanTag(props) {
   const chipPropperties = getChipProperties(props.plan);
   const avatar = !chipPropperties.avatarLink ? undefined : (
-    <Avatar
-      src={chipPropperties.avatarLink}
-      imgProps={{ width: 21, height: 24 }}
-      alt=""
-    />
+    <img src={chipPropperties.avatarLink} width={21} height={24} alt="" />
   );
 
   return (
@@ -216,7 +211,6 @@ function PlanTag(props) {
         backgroundColor: chipPropperties.color,
         color: 'rgba(0, 0, 0, 0.87)',
         '& .MuiChip-avatar': {
-          borderRadius: 0,
           width: 21,
         },
       }}

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.js
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.js
@@ -188,21 +188,25 @@ export const featuresSet = [
   },
 ];
 
-const getChipProperties = (plan) => {
-  switch (plan.toLowerCase()) {
-    case 'premium':
+function getChipProperties(plan) {
+  switch (plan) {
+    case 'Premium':
       return { avatarLink: '/static/x/premium.svg', color: '#ffecc8' };
-    case 'pro':
+    case 'Pro':
       return { avatarLink: '/static/x/pro.svg', color: '#c8e9ff' };
     default:
       return { avatarLink: undefined, color: '#c8ffdb' };
   }
-};
+}
 
 function PlanTag(props) {
   const chipPropperties = getChipProperties(props.plan);
   const avatar = !chipPropperties.avatarLink ? undefined : (
-    <Avatar src={chipPropperties.avatarLink} imgProps={{ width: 21 }} alt="" />
+    <Avatar
+      src={chipPropperties.avatarLink}
+      imgProps={{ width: 21, height: 24 }}
+      alt=""
+    />
   );
 
   return (
@@ -213,7 +217,7 @@ function PlanTag(props) {
         color: 'rgba(0, 0, 0, 0.87)',
         '& .MuiChip-avatar': {
           borderRadius: 0,
-          width: 'auto',
+          width: 21,
         },
       }}
       label={props.plan}
@@ -236,8 +240,8 @@ function RowDemo(props) {
   const panelColor = theme.palette.mode === 'dark' ? 'transparent' : '#efefef';
 
   return (
-    <Box sx={{ py: 2, background: panelColor }}>
-      <Box style={{ width: '90%', margin: 'auto', background: gridBgColor }}>
+    <Box sx={{ py: 2, backgroundColor: panelColor }}>
+      <Box sx={{ width: '90%', margin: 'auto', backgroundColor: gridBgColor }}>
         {row.demo}
       </Box>
     </Box>
@@ -380,7 +384,7 @@ export default function PopularFeaturesDemo() {
   }, []);
 
   return (
-    <div style={{ minHeight: 1000, width: '100%' }}>
+    <Box sx={{ minHeight: 1000, width: '100%' }}>
       <DataGridPremium
         apiRef={apiRef}
         autoHeight
@@ -426,6 +430,6 @@ export default function PopularFeaturesDemo() {
         hideFooter
         groupingColDef={memoizedGroupingDef}
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.js
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.js
@@ -202,13 +202,20 @@ const getChipProperties = (plan) => {
 function PlanTag(props) {
   const chipPropperties = getChipProperties(props.plan);
   const avatar = !chipPropperties.avatarLink ? undefined : (
-    <Avatar src={chipPropperties.avatarLink} />
+    <Avatar src={chipPropperties.avatarLink} imgProps={{ width: 21 }} alt="" />
   );
 
   return (
     <Chip
       avatar={avatar}
-      sx={{ background: chipPropperties.color, color: 'rgba(0, 0, 0, 0.87)' }}
+      sx={{
+        backgroundColor: chipPropperties.color,
+        color: 'rgba(0, 0, 0, 0.87)',
+        '& .MuiChip-avatar': {
+          borderRadius: 0,
+          width: 'auto',
+        },
+      }}
       label={props.plan}
     />
   );
@@ -373,7 +380,7 @@ export default function PopularFeaturesDemo() {
   }, []);
 
   return (
-    <div style={{ height: 'fit-content', width: '100%' }}>
+    <div style={{ minHeight: 1000, width: '100%' }}>
       <DataGridPremium
         apiRef={apiRef}
         autoHeight

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
@@ -203,21 +203,25 @@ export const featuresSet: Row[] = [
   },
 ];
 
-const getChipProperties = (plan: string) => {
-  switch (plan.toLowerCase()) {
-    case 'premium':
+function getChipProperties(plan: string) {
+  switch (plan) {
+    case 'Premium':
       return { avatarLink: '/static/x/premium.svg', color: '#ffecc8' };
-    case 'pro':
+    case 'Pro':
       return { avatarLink: '/static/x/pro.svg', color: '#c8e9ff' };
     default:
       return { avatarLink: undefined, color: '#c8ffdb' };
   }
-};
+}
 
 function PlanTag(props: { plan: string }) {
   const chipPropperties = getChipProperties(props.plan);
   const avatar = !chipPropperties.avatarLink ? undefined : (
-    <Avatar src={chipPropperties.avatarLink} imgProps={{ width: 21 }} alt="" />
+    <Avatar
+      src={chipPropperties.avatarLink}
+      imgProps={{ width: 21, height: 24 }}
+      alt=""
+    />
   );
   return (
     <Chip
@@ -227,7 +231,7 @@ function PlanTag(props: { plan: string }) {
         color: 'rgba(0, 0, 0, 0.87)',
         '& .MuiChip-avatar': {
           borderRadius: 0,
-          width: 'auto',
+          width: 21,
         },
       }}
       label={props.plan}
@@ -250,8 +254,8 @@ function RowDemo(props: { row: Row }) {
   const panelColor = theme.palette.mode === 'dark' ? 'transparent' : '#efefef';
 
   return (
-    <Box sx={{ py: 2, background: panelColor }}>
-      <Box style={{ width: '90%', margin: 'auto', background: gridBgColor }}>
+    <Box sx={{ py: 2, backgroundColor: panelColor }}>
+      <Box sx={{ width: '90%', margin: 'auto', backgroundColor: gridBgColor }}>
         {row.demo}
       </Box>
     </Box>
@@ -400,7 +404,7 @@ export default function PopularFeaturesDemo() {
   }, []);
 
   return (
-    <div style={{ minHeight: 1000, width: '100%' }}>
+    <Box sx={{ minHeight: 1000, width: '100%' }}>
       <DataGridPremium
         apiRef={apiRef}
         autoHeight
@@ -446,6 +450,6 @@ export default function PopularFeaturesDemo() {
         hideFooter
         groupingColDef={memoizedGroupingDef}
       />
-    </div>
+    </Box>
   );
 }

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
@@ -217,12 +217,19 @@ const getChipProperties = (plan: string) => {
 function PlanTag(props: { plan: string }) {
   const chipPropperties = getChipProperties(props.plan);
   const avatar = !chipPropperties.avatarLink ? undefined : (
-    <Avatar src={chipPropperties.avatarLink} />
+    <Avatar src={chipPropperties.avatarLink} imgProps={{ width: 21 }} alt="" />
   );
   return (
     <Chip
       avatar={avatar}
-      sx={{ background: chipPropperties.color, color: 'rgba(0, 0, 0, 0.87)' }}
+      sx={{
+        backgroundColor: chipPropperties.color,
+        color: 'rgba(0, 0, 0, 0.87)',
+        '& .MuiChip-avatar': {
+          borderRadius: 0,
+          width: 'auto',
+        },
+      }}
       label={props.plan}
     />
   );
@@ -393,7 +400,7 @@ export default function PopularFeaturesDemo() {
   }, []);
 
   return (
-    <div style={{ height: 'fit-content', width: '100%' }}>
+    <div style={{ minHeight: 1000, width: '100%' }}>
       <DataGridPremium
         apiRef={apiRef}
         autoHeight

--- a/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.tsx
@@ -13,7 +13,6 @@ import {
 } from '@mui/x-data-grid-premium';
 import Link from '@mui/material/Link';
 import Chip from '@mui/material/Chip';
-import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import ArrowUp from '@mui/icons-material/KeyboardArrowUp';
@@ -217,11 +216,7 @@ function getChipProperties(plan: string) {
 function PlanTag(props: { plan: string }) {
   const chipPropperties = getChipProperties(props.plan);
   const avatar = !chipPropperties.avatarLink ? undefined : (
-    <Avatar
-      src={chipPropperties.avatarLink}
-      imgProps={{ width: 21, height: 24 }}
-      alt=""
-    />
+    <img src={chipPropperties.avatarLink} width={21} height={24} alt="" />
   );
   return (
     <Chip
@@ -230,7 +225,6 @@ function PlanTag(props: { plan: string }) {
         backgroundColor: chipPropperties.color,
         color: 'rgba(0, 0, 0, 0.87)',
         '& .MuiChip-avatar': {
-          borderRadius: 0,
           width: 21,
         },
       }}


### PR DESCRIPTION
Found in https://app.ahrefs.com/site-audit/3523498/70/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cpsi_request_status%2Cpsi_crux_cls_percentile%2Cpsi_crux_cls_category%2Cpsi_crux_fid_percentile%2Cpsi_crux_fid_category%2Cpsi_crux_lcp_percentile%2Cpsi_crux_lcp_category%2Cpsi_lighthouse_score%2Cpsi_lighthouse_cls_value%2Cpsi_lighthouse_tbt_value%2Cpsi_lighthouse_lcp_value%2Cdepth%2Ccompliant%2CincomingLinks%2Corigin&filterId=3bc4bee7603e9aee6c8c313b286e2a72&issueId=09a46610-1538-11ec-a251-0aa06bfc17da

It can also be seen in https://pagespeed.web.dev/analysis/https-mui-com-x-react-data-grid-demo/ugrve9dtg8?form_factor=desktop

<img width="312" alt="Screenshot 2023-05-27 at 20 16 53" src="https://github.com/mui/mui-x/assets/3165635/05e34c15-75eb-4003-a482-1b8ab68ab621">

I have added a min height of 1000px. This avoids the layout shift from the scrollbar and avoid seeing the footer.

Before: https://mui.com/x/react-data-grid/demo/
After: https://deploy-preview-9132--material-ui-x.netlify.app/x/react-data-grid/demo/

--- 

A side fix, we missed `alt=""` on the img

<img width="777" alt="Screenshot 2023-05-27 at 20 16 17" src="https://github.com/mui/mui-x/assets/3165635/e1be1d75-a500-4a10-b5cb-0f27f704b353">
