### PR TITLE
[pickers] Fix `MonthCalendar` and `YearCalendar` disabled validation

### DIFF
--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -140,29 +140,32 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
     }
   });
 
-  const isMonthDisabled = useEventCallback((month: TDate) => {
-    const firstEnabledMonth = utils.startOfMonth(
-      disablePast && utils.isAfter(now, minDate) ? now : minDate,
-    );
+  const isMonthDisabled = React.useCallback(
+    (month: TDate) => {
+      const firstEnabledMonth = utils.startOfMonth(
+        disablePast && utils.isAfter(now, minDate) ? now : minDate,
+      );
 
-    const lastEnabledMonth = utils.startOfMonth(
-      disableFuture && utils.isBefore(now, maxDate) ? now : maxDate,
-    );
+      const lastEnabledMonth = utils.startOfMonth(
+        disableFuture && utils.isBefore(now, maxDate) ? now : maxDate,
+      );
 
-    if (utils.isBefore(month, firstEnabledMonth)) {
-      return true;
-    }
+      if (utils.isBefore(month, firstEnabledMonth)) {
+        return true;
+      }
 
-    if (utils.isAfter(month, lastEnabledMonth)) {
-      return true;
-    }
+      if (utils.isAfter(month, lastEnabledMonth)) {
+        return true;
+      }
 
-    if (!shouldDisableMonth) {
-      return false;
-    }
+      if (!shouldDisableMonth) {
+        return false;
+      }
 
-    return shouldDisableMonth(month);
-  });
+      return shouldDisableMonth(month);
+    },
+    [disableFuture, disablePast, maxDate, minDate, now, shouldDisableMonth, utils],
+  );
 
   const handleMonthSelection = useEventCallback((event: React.MouseEvent, month: number) => {
     if (readOnly) {

--- a/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
@@ -154,5 +154,20 @@ describe('<MonthCalendar />', () => {
       fireEvent.click(jun);
       expect(onChange.callCount).to.equal(1);
     });
+
+    it('should disable months after initial render when "disableFuture" prop changes', () => {
+      const { setProps } = render(<MonthCalendar />);
+
+      const january = screen.getByText('Jan', { selector: 'button' });
+      const february = screen.getByText('Feb', { selector: 'button' });
+
+      expect(january).not.to.have.attribute('disabled');
+      expect(february).not.to.have.attribute('disabled');
+
+      setProps({ disableFuture: true });
+
+      expect(january).not.to.have.attribute('disabled');
+      expect(february).to.have.attribute('disabled');
+    });
   });
 });

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -142,24 +142,27 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
     }
   });
 
-  const isYearDisabled = useEventCallback((dateToValidate: TDate) => {
-    if (disablePast && utils.isBeforeYear(dateToValidate, now)) {
-      return true;
-    }
-    if (disableFuture && utils.isAfterYear(dateToValidate, now)) {
-      return true;
-    }
-    if (minDate && utils.isBeforeYear(dateToValidate, minDate)) {
-      return true;
-    }
-    if (maxDate && utils.isAfterYear(dateToValidate, maxDate)) {
-      return true;
-    }
-    if (shouldDisableYear && shouldDisableYear(dateToValidate)) {
-      return true;
-    }
-    return false;
-  });
+  const isYearDisabled = React.useCallback(
+    (dateToValidate: TDate) => {
+      if (disablePast && utils.isBeforeYear(dateToValidate, now)) {
+        return true;
+      }
+      if (disableFuture && utils.isAfterYear(dateToValidate, now)) {
+        return true;
+      }
+      if (minDate && utils.isBeforeYear(dateToValidate, minDate)) {
+        return true;
+      }
+      if (maxDate && utils.isAfterYear(dateToValidate, maxDate)) {
+        return true;
+      }
+      if (shouldDisableYear && shouldDisableYear(dateToValidate)) {
+        return true;
+      }
+      return false;
+    },
+    [disableFuture, disablePast, maxDate, minDate, now, shouldDisableYear, utils],
+  );
 
   const handleYearSelection = useEventCallback((event: React.MouseEvent, year: number) => {
     if (readOnly) {

--- a/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
@@ -6,7 +6,7 @@ import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { adapterToUse, createPickerRenderer } from 'test/utils/pickers-utils';
 
 describe('<YearCalendar />', () => {
-  const { render } = createPickerRenderer();
+  const { render } = createPickerRenderer({ clock: 'fake', clockConfig: new Date(2019, 0, 1) });
 
   it('allows to pick year standalone by click, `Enter` and `Space`', () => {
     const onChange = spy();
@@ -153,5 +153,20 @@ describe('<YearCalendar />', () => {
     act(() => button2019.focus());
     fireEvent.keyDown(button2019, { key: 'ArrowRight' });
     expect(document.activeElement).to.have.text('2020');
+  });
+
+  it('should disable years after initial render when "disableFuture" prop changes', () => {
+    const { setProps } = render(<YearCalendar />);
+
+    const year2019 = screen.getByText('2019', { selector: 'button' });
+    const year2020 = screen.getByText('2020', { selector: 'button' });
+
+    expect(year2019).not.to.have.attribute('disabled');
+    expect(year2020).not.to.have.attribute('disabled');
+
+    setProps({ disableFuture: true });
+
+    expect(year2019).not.to.have.attribute('disabled');
+    expect(year2020).to.have.attribute('disabled');
   });
 });


### PR DESCRIPTION
Fixes #9133 

Revert change made in https://github.com/mui/mui-x/pull/6034/files#diff-3d04258c1d5878605735157d4ee3e38af1a738cc4fc66d42727f04b7414f544cR168

These particular functions are never passed down to downstream components.
Using `useEventCallback` caused a function resolved before the current render to be called after the first render.

The regression has been introduced in `v6.0.0-alpha.0`.