### PR TITLE
[charts] Simplify the switch between responsive and fix dimensions

### DIFF
--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { BarPlot } from './BarPlot';
-import { ChartContainer, ChartContainerProps } from '../ChartContainer';
+import { ResponsiveChartContainer, ResponsiveChartContainerProps } from '../ResponsiveChartContainer';
 import { Axis, AxisProps } from '../Axis';
 import { BarSeriesType } from '../models/seriesType/bar';
 import { MakeOptional } from '../models/helpers';
@@ -9,7 +9,7 @@ import { DEFAULT_X_AXIS_KEY } from '../constants';
 import { Tooltip, TooltipProps } from '../Tooltip';
 import { Highlight, HighlightProps } from '../Highlight';
 
-export interface BarChartProps extends Omit<ChartContainerProps, 'series'>, AxisProps {
+export interface BarChartProps extends Omit<ResponsiveChartContainerProps, 'series'>, AxisProps {
   series: MakeOptional<BarSeriesType, 'type'>[];
   tooltip?: TooltipProps;
   highlight?: HighlightProps;
@@ -35,7 +35,7 @@ function BarChart(props: BarChartProps) {
   } = props;
 
   return (
-    <ChartContainer
+    <ResponsiveChartContainer
       series={series.map((s) => ({ type: 'bar', ...s }))}
       width={width}
       height={height}
@@ -63,7 +63,7 @@ function BarChart(props: BarChartProps) {
       <Highlight {...highlight} />
       <Tooltip {...tooltip} />
       {children}
-    </ChartContainer>
+    </ResponsiveChartContainer>
   );
 }
 

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { LinePlot } from './LinePlot';
-import { ChartContainer, ChartContainerProps } from '../ChartContainer';
+import { ResponsiveChartContainer, ResponsiveChartContainerProps } from '../ResponsiveChartContainer';
 import { Axis, AxisProps } from '../Axis/Axis';
 import { LineSeriesType } from '../models/seriesType/line';
 import { MakeOptional } from '../models/helpers';
@@ -9,7 +9,7 @@ import { DEFAULT_X_AXIS_KEY } from '../constants';
 import { Tooltip, TooltipProps } from '../Tooltip';
 import { Highlight, HighlightProps } from '../Highlight';
 
-export interface LineChartProps extends Omit<ChartContainerProps, 'series'>, AxisProps {
+export interface LineChartProps extends Omit<ResponsiveChartContainerProps, 'series'>, AxisProps {
   series: MakeOptional<LineSeriesType, 'type'>[];
   tooltip?: TooltipProps;
   highlight?: HighlightProps;
@@ -34,7 +34,7 @@ function LineChart(props: LineChartProps) {
   } = props;
 
   return (
-    <ChartContainer
+    <ResponsiveChartContainer
       series={series.map((s) => ({ type: 'line', ...s }))}
       width={width}
       height={height}
@@ -62,7 +62,7 @@ function LineChart(props: LineChartProps) {
       <Highlight {...highlight} />
       <Tooltip {...tooltip} />
       {children}
-    </ChartContainer>
+    </ResponsiveChartContainer>
   );
 }
 

--- a/packages/x-charts/src/ResponsiveChartContainer/index.tsx
+++ b/packages/x-charts/src/ResponsiveChartContainer/index.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { ChartContainer, ChartContainerProps } from '../ChartContainer';
+import { MakeOptional } from '../models/helpers';
 
-const useChartDimensions = (): [React.RefObject<HTMLDivElement>, number, number] => {
+const useChartDimensions = (
+  inWidth?: number,
+  inHeight?: number,
+): [React.RefObject<HTMLDivElement>, number, number] => {
   const ref = React.useRef<HTMLDivElement>(null);
 
   const [width, setWidth] = React.useState(0);
@@ -10,32 +14,39 @@ const useChartDimensions = (): [React.RefObject<HTMLDivElement>, number, number]
 
   React.useEffect(() => {
     const element = ref.current;
-    if (element === null) {
+    if (element === null || (inHeight !== undefined && inWidth !== undefined)) {
       return () => {};
     }
 
     const resizeObserver = new ResizeObserver((entries) => {
       if (Array.isArray(entries) && entries.length) {
         const entry = entries[0];
-        setWidth(entry.contentRect.width);
-        setHeight(entry.contentRect.height);
+        if (inWidth === undefined) {
+          setWidth(entry.contentRect.width);
+        }
+        if (inHeight === undefined) {
+          setHeight(entry.contentRect.height);
+        }
       }
     });
     resizeObserver.observe(element);
 
     return () => resizeObserver.disconnect();
-  }, [height, width]);
+  }, [height, inHeight, inWidth, width]);
 
-  return [ref, width, height];
+  return [ref, inWidth ?? width, inHeight ?? height];
 };
 
-export type ResponsiveChartContainerProps = Omit<ChartContainerProps, 'width' | 'height'>;
+export type ResponsiveChartContainerProps = MakeOptional<ChartContainerProps, 'width' | 'height'>;
 
 export function ResponsiveChartContainer(props: ResponsiveChartContainerProps) {
-  const [containerRef, width, height] = useChartDimensions();
+  const [containerRef, width, height] = useChartDimensions(props.width, props.height);
 
   return (
-    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+    <div
+      ref={containerRef}
+      style={{ width: props.width ?? '100%', height: props.height ?? '100%', padding: 0 }}
+    >
       <ChartContainer {...props} width={width} height={height} />
     </div>
   );

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { ScatterPlot } from './ScatterPlot';
-import { ChartContainer, ChartContainerProps } from '../ChartContainer';
+import { ResponsiveChartContainer, ResponsiveChartContainerProps } from '../ResponsiveChartContainer';
 import { Axis, AxisProps } from '../Axis';
 import { ScatterSeriesType } from '../models/seriesType/scatter';
 import { MakeOptional } from '../models/helpers';
 import { Tooltip, TooltipProps } from '../Tooltip';
 import { Highlight, HighlightProps } from '../Highlight';
 
-export interface ScatterChartProps extends Omit<ChartContainerProps, 'series'>, AxisProps {
+export interface ScatterChartProps extends Omit<ResponsiveChartContainerProps, 'series'>, AxisProps {
   series: MakeOptional<ScatterSeriesType, 'type'>[];
   tooltip?: TooltipProps;
   highlight?: HighlightProps;
@@ -34,7 +34,7 @@ function ScatterChart(props: ScatterChartProps) {
   } = props;
 
   return (
-    <ChartContainer
+    <ResponsiveChartContainer
       series={series.map((s) => ({ type: 'scatter', ...s }))}
       width={width}
       height={height}
@@ -49,7 +49,7 @@ function ScatterChart(props: ScatterChartProps) {
       <Highlight x="none" y="none" {...highlight} />
       <Tooltip trigger="item" {...tooltip} />
       {children}
-    </ChartContainer>
+    </ResponsiveChartContainer>
   );
 }
 


### PR DESCRIPTION
Instead of having to use the wrapper `ResponsiveChartsContainer` to make charts responsive, All the charts components now have the option to not defined `width` and/or `height`. In such case, the undefined value will be responsive to the available space.