### PR TITLE
[docs] Align `DateCalendar` demo views with labels

### DIFF
--- a/docs/data/date-pickers/date-calendar/DateCalendarViews.js
+++ b/docs/data/date-pickers/date-calendar/DateCalendarViews.js
@@ -10,13 +10,20 @@ export default function DateCalendarViews() {
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['DateCalendar', 'DateCalendar', 'DateCalendar']}>
         <DemoItem label={'"year", "month" and "day"'}>
-          <DateCalendar defaultValue={dayjs('2022-04-17')} />
+          <DateCalendar
+            defaultValue={dayjs('2022-04-17')}
+            views={['year', 'month', 'day']}
+          />
         </DemoItem>
         <DemoItem label={'"day"'}>
           <DateCalendar views={['day']} />
         </DemoItem>
         <DemoItem label={'"month" and "year"'}>
-          <DateCalendar defaultValue={dayjs('2022-04-17')} />
+          <DateCalendar
+            defaultValue={dayjs('2022-04-17')}
+            views={['month', 'year']}
+            openTo="month"
+          />
         </DemoItem>
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/date-calendar/DateCalendarViews.tsx
+++ b/docs/data/date-pickers/date-calendar/DateCalendarViews.tsx
@@ -10,13 +10,20 @@ export default function DateCalendarViews() {
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['DateCalendar', 'DateCalendar', 'DateCalendar']}>
         <DemoItem label={'"year", "month" and "day"'}>
-          <DateCalendar defaultValue={dayjs('2022-04-17')} />
+          <DateCalendar
+            defaultValue={dayjs('2022-04-17')}
+            views={['year', 'month', 'day']}
+          />
         </DemoItem>
         <DemoItem label={'"day"'}>
           <DateCalendar views={['day']} />
         </DemoItem>
         <DemoItem label={'"month" and "year"'}>
-          <DateCalendar defaultValue={dayjs('2022-04-17')} />
+          <DateCalendar
+            defaultValue={dayjs('2022-04-17')}
+            views={['month', 'year']}
+            openTo="month"
+          />
         </DemoItem>
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/date-calendar/DateCalendarViews.tsx.preview
+++ b/docs/data/date-pickers/date-calendar/DateCalendarViews.tsx.preview
@@ -1,9 +1,16 @@
 <DemoItem label={'"year", "month" and "day"'}>
-  <DateCalendar defaultValue={dayjs('2022-04-17')} />
+  <DateCalendar
+    defaultValue={dayjs('2022-04-17')}
+    views={['year', 'month', 'day']}
+  />
 </DemoItem>
 <DemoItem label={'"day"'}>
   <DateCalendar views={['day']} />
 </DemoItem>
 <DemoItem label={'"month" and "year"'}>
-  <DateCalendar defaultValue={dayjs('2022-04-17')} />
+  <DateCalendar
+    defaultValue={dayjs('2022-04-17')}
+    views={['month', 'year']}
+    openTo="month"
+  />
 </DemoItem>


### PR DESCRIPTION
Noticed that https://mui.com/x/react-date-pickers/date-calendar/#views demo lists demos with different views, but only one demo uses the correct views in line with the used label.

Changed the used views to align with the ones listed in the labels. The same views are used in the `DatePicker` demo page as well.