### PR TITLE
[pickers] Use the locale start of the week in `getWeekArray`

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -166,6 +166,15 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
     defaultDayjs.extend(weekOfYear);
   }
 
+  private setLocaleToValue = (value: Dayjs) => {
+    const expectedLocale = this.getCurrentLocaleCode();
+    if (expectedLocale === value.locale()) {
+      return value;
+    }
+
+    return value.locale(expectedLocale);
+  };
+
   private hasUTCPlugin = () => typeof defaultDayjs.utc !== 'undefined';
 
   private hasTimezonePlugin = () => typeof defaultDayjs.tz !== 'undefined';
@@ -603,8 +612,9 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
   };
 
   public getWeekArray = (value: Dayjs) => {
-    const start = value.startOf('month').startOf('week');
-    const end = value.endOf('month').endOf('week');
+    const cleanLocale = this.setLocaleToValue(value);
+    const start = cleanLocale.startOf('month').startOf('week');
+    const end = cleanLocale.endOf('month').endOf('week');
 
     let count = 0;
     let current = start;

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -138,6 +138,15 @@ export class AdapterMoment implements MuiPickersAdapter<Moment, string> {
     this.formats = { ...defaultFormats, ...formats };
   }
 
+  private setLocaleToValue = (value: Moment) => {
+    const expectedLocale = this.getCurrentLocaleCode();
+    if (expectedLocale === value.locale()) {
+      return value;
+    }
+
+    return value.locale(expectedLocale);
+  };
+
   private hasTimezonePlugin = () => typeof this.moment.tz !== 'undefined';
 
   private createSystemDate = (value: string | undefined): Moment => {
@@ -549,8 +558,9 @@ export class AdapterMoment implements MuiPickersAdapter<Moment, string> {
   };
 
   public getWeekArray = (value: Moment) => {
-    const start = value.clone().startOf('month').startOf('week');
-    const end = value.clone().endOf('month').endOf('week');
+    const cleanLocale = this.setLocaleToValue(value);
+    const start = cleanLocale.clone().startOf('month').startOf('week');
+    const end = cleanLocale.clone().endOf('month').endOf('week');
 
     let count = 0;
     let current = start;


### PR DESCRIPTION
Fixes #9174

`AdapterDateFns` and `AdapterDateFnsJalali` already passes the locale to the `startOfWeek` method
`AdapterLuxon` does not handle localized start of week