### PR TITLE
[DataGrid] Allow overflowing grid root element

### DIFF
--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -116,6 +116,7 @@ export const GridRootStyles = styled('div', {
     height: '100%',
     display: 'flex',
     minWidth: 0, // See https://github.com/mui/mui-x/issues/8547
+    minHeight: 0,
     flexDirection: 'column',
     overflowAnchor: 'none', // Keep the same scrolling position
     [`&.${gridClasses.autoHeight}`]: {

--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -115,7 +115,7 @@ export const GridRootStyles = styled('div', {
     outline: 'none',
     height: '100%',
     display: 'flex',
-    overflow: 'hidden',
+    minWidth: 0, // See https://github.com/mui/mui-x/issues/8547
     flexDirection: 'column',
     overflowAnchor: 'none', // Keep the same scrolling position
     [`&.${gridClasses.autoHeight}`]: {

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1058,7 +1058,7 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     expect(NoRowsOverlay.callCount).not.to.equal(0);
   });
 
-  describe('sould not overflow parent', () => {
+  describe('should not overflow parent', () => {
     before(function beforeHook() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip(); // Doesn't work with mocked window.getComputedStyle


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/8547#issuecomment-1570304743

I have no idea why the visual regressions were not reported in https://github.com/mui/mui-x/pull/8577