### PR TITLE
[docs] Fix missing props on the `GridFilterPanel` API page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,6 +81,18 @@ module.exports = {
     'jsdoc/require-returns': ['error', { contexts: ['TSFunctionType'] }],
     'jsdoc/require-returns-type': ['error', { contexts: ['TSFunctionType'] }],
     'jsdoc/require-returns-description': ['error', { contexts: ['TSFunctionType'] }],
+    'jsdoc/no-bad-blocks': [
+      'error',
+      {
+        ignore: [
+          'ts-check',
+          'ts-expect-error',
+          'ts-ignore',
+          'ts-nocheck',
+          'typescript-to-proptypes-ignore',
+        ],
+      },
+    ],
     // Fixes false positive when using both `inputProps` and `InputProps` on the same example
     // See https://stackoverflow.com/questions/42367236/why-am-i-getting-this-warning-no-duplicate-props-allowed-react-jsx-no-duplicate
     'react/jsx-no-duplicate-props': [1, { ignoreCase: false }],

--- a/docs/pages/x/api/data-grid/grid-filter-panel.json
+++ b/docs/pages/x/api/data-grid/grid-filter-panel.json
@@ -1,6 +1,8 @@
 {
   "props": {
     "columnsSort": { "type": { "name": "enum", "description": "'asc'<br>&#124;&nbsp;'desc'" } },
+    "disableAddFilterButton": { "type": { "name": "bool" } },
+    "disableRemoveAllButton": { "type": { "name": "bool" } },
     "filterFormProps": {
       "type": {
         "name": "shape",

--- a/docs/translations/api-docs/data-grid/grid-filter-panel.json
+++ b/docs/translations/api-docs/data-grid/grid-filter-panel.json
@@ -2,6 +2,8 @@
   "componentDescription": "",
   "propDescriptions": {
     "columnsSort": "Changes how the options in the columns selector should be ordered. If not specified, the order is derived from the <code>columns</code> prop.",
+    "disableAddFilterButton": "If <code>true</code>, the <code>Add filter</code> button will not be displayed.",
+    "disableRemoveAllButton": "If <code>true</code>, the <code>Remove all</code> button will be disabled",
     "filterFormProps": "Props passed to each filter form.",
     "getColumnForNewFilter": "Function that returns the next filter item to be picked as default filter.<br><br><strong>Signature:</strong><br><code>function(args: GetColumnForNewFilterArgs) =&gt; void</code><br><em>args:</em> Currently configured filters and columns.",
     "logicOperators": "Sets the available logic operators.",

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -66,19 +66,19 @@ export interface GridColumnsPanelProps extends GridPanelWrapperProps {
    */
   sort?: 'asc' | 'desc';
   searchPredicate?: (column: GridColDef, searchValue: string) => boolean;
-  /*
+  /**
    * If `true`, the column search field will be focused automatically.
    * If `false`, the first column switch input will be focused automatically.
    * This helps to avoid input keyboard panel to popup automatically on touch devices.
    * @default true
    */
   autoFocusSearchField?: boolean;
-  /*
+  /**
    * If `true`, the `Hide all` button will not be displayed.
    * @default false
    */
   disableHideAllButton?: boolean;
-  /*
+  /**
    * If `true`, the `Show all` button will be disabled
    * @default false
    */

--- a/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridColumnsPanel.tsx
@@ -292,8 +292,22 @@ GridColumnsPanel.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * If `true`, the column search field will be focused automatically.
+   * If `false`, the first column switch input will be focused automatically.
+   * This helps to avoid input keyboard panel to popup automatically on touch devices.
+   * @default true
+   */
   autoFocusSearchField: PropTypes.bool,
+  /**
+   * If `true`, the `Hide all` button will not be displayed.
+   * @default false
+   */
   disableHideAllButton: PropTypes.bool,
+  /**
+   * If `true`, the `Show all` button will be disabled
+   * @default false
+   */
   disableShowAllButton: PropTypes.bool,
   /**
    * Returns the list of togglable columns.

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
@@ -44,12 +44,12 @@ export interface GridFilterPanelProps
     | 'filterColumns'
   >;
 
-  /*
+  /**
    * If `true`, the `Add filter` button will not be displayed.
    * @default false
    */
   disableAddFilterButton?: boolean;
-  /*
+  /**
    * If `true`, the `Remove all` button will be disabled
    * @default false
    */

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
@@ -279,7 +279,15 @@ GridFilterPanel.propTypes = {
    * If not specified, the order is derived from the `columns` prop.
    */
   columnsSort: PropTypes.oneOf(['asc', 'desc']),
+  /**
+   * If `true`, the `Add filter` button will not be displayed.
+   * @default false
+   */
   disableAddFilterButton: PropTypes.bool,
+  /**
+   * If `true`, the `Remove all` button will be disabled
+   * @default false
+   */
   disableRemoveAllButton: PropTypes.bool,
   /**
    * Props passed to each filter form.


### PR DESCRIPTION
While reviewing https://github.com/mui/mui-x/pull/9074, I noticed that `disableAddFilterButton` and `disableRemoveAllButton` are not documented on this page: https://mui.com/x/api/data-grid/grid-filter-panel/