### PR TITLE
[charts] Enforce axis `min`/`max` over the `nice()` method

### DIFF
--- a/docs/data/charts/axis/ScaleExample.js
+++ b/docs/data/charts/axis/ScaleExample.js
@@ -8,8 +8,8 @@ export default function ScaleExample() {
     <LineChart
       xAxis={[{ data: sample }]}
       yAxis={[
-        { id: 'linearAxis', scaleType: 'linear', max: 110 },
-        { id: 'logAxis', scaleType: 'log', max: 110 },
+        { id: 'linearAxis', scaleType: 'linear' },
+        { id: 'logAxis', scaleType: 'log' },
       ]}
       series={[
         { yAxisKey: 'linearAxis', data: sample, label: 'linear' },

--- a/docs/data/charts/axis/ScaleExample.tsx
+++ b/docs/data/charts/axis/ScaleExample.tsx
@@ -8,8 +8,8 @@ export default function ScaleExample() {
     <LineChart
       xAxis={[{ data: sample }]}
       yAxis={[
-        { id: 'linearAxis', scaleType: 'linear', max: 110 },
-        { id: 'logAxis', scaleType: 'log', max: 110 },
+        { id: 'linearAxis', scaleType: 'linear' },
+        { id: 'logAxis', scaleType: 'log' },
       ]}
       series={[
         { yAxisKey: 'linearAxis', data: sample, label: 'linear' },

--- a/docs/data/charts/axis/ScaleExample.tsx.preview
+++ b/docs/data/charts/axis/ScaleExample.tsx.preview
@@ -1,8 +1,8 @@
 <LineChart
   xAxis={[{ data: sample }]}
   yAxis={[
-    { id: 'linearAxis', scaleType: 'linear', max: 110 },
-    { id: 'logAxis', scaleType: 'log', max: 110 },
+    { id: 'linearAxis', scaleType: 'linear' },
+    { id: 'logAxis', scaleType: 'log' },
   ]}
   series={[
     { yAxisKey: 'linearAxis', data: sample, label: 'linear' },

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -143,10 +143,14 @@ export function CartesianContextProvider({
       const extremums = [axis.min ?? minData, axis.max ?? maxData];
       const ticksNumber = getTicksNumber({ ...axis, range });
 
+      const niceScale = getScale(scaleType, extremums, range).nice(ticksNumber);
+      const niceDomain = niceScale.domain();
+      const domain = [axis.min ?? niceDomain[0], axis.max ?? niceDomain[1]];
+
       completedXAxis[axis.id] = {
         ...axis,
         scaleType,
-        scale: getScale(scaleType, extremums, range),
+        scale: niceScale.domain(domain),
         ticksNumber,
       } as AxisDefaultized<typeof scaleType>;
     });
@@ -176,10 +180,15 @@ export function CartesianContextProvider({
       }
       const extremums = [axis.min ?? minData, axis.max ?? maxData];
       const ticksNumber = getTicksNumber({ ...axis, range });
+
+      const niceScale = getScale(scaleType, extremums, range).nice(ticksNumber);
+      const niceDomain = niceScale.domain();
+      const domain = [axis.min ?? niceDomain[0], axis.max ?? niceDomain[1]];
+
       completedYAxis[axis.id] = {
         ...axis,
         scaleType,
-        scale: getScale(scaleType, extremums, range).nice(ticksNumber),
+        scale: niceScale.domain(domain),
         ticksNumber,
       } as AxisDefaultized<typeof scaleType>;
     });

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -129,23 +129,24 @@ export function CartesianContextProvider({
       const [minData, maxData] = getAxisExtremum(axis, xExtremumGetters, isDefaultAxis);
 
       const scaleType = axis.scaleType ?? 'linear';
-      const domain = [drawingArea.left, drawingArea.left + drawingArea.width];
+      const range = [drawingArea.left, drawingArea.left + drawingArea.width];
 
       if (scaleType === 'band') {
         completedXAxis[axis.id] = {
           ...axis,
           scaleType,
-          scale: scaleBand(axis.data!, domain),
+          scale: scaleBand(axis.data!, range),
           ticksNumber: axis.data!.length,
         };
         return;
       }
       const extremums = [axis.min ?? minData, axis.max ?? maxData];
-      const ticksNumber = getTicksNumber({ ...axis, domain });
+      const ticksNumber = getTicksNumber({ ...axis, range });
+
       completedXAxis[axis.id] = {
         ...axis,
         scaleType,
-        scale: getScale(scaleType, extremums, domain).nice(ticksNumber),
+        scale: getScale(scaleType, extremums, range),
         ticksNumber,
       } as AxisDefaultized<typeof scaleType>;
     });
@@ -161,24 +162,24 @@ export function CartesianContextProvider({
     allYAxis.forEach((axis, axisIndex) => {
       const isDefaultAxis = axisIndex === 0;
       const [minData, maxData] = getAxisExtremum(axis, yExtremumGetters, isDefaultAxis);
-      const domain = [drawingArea.top + drawingArea.height, drawingArea.top];
+      const range = [drawingArea.top + drawingArea.height, drawingArea.top];
 
       const scaleType: ScaleName = axis.scaleType ?? 'linear';
       if (scaleType === 'band') {
         completedYAxis[axis.id] = {
           ...axis,
           scaleType,
-          scale: scaleBand(axis.data!, domain),
+          scale: scaleBand(axis.data!, range),
           ticksNumber: axis.data!.length,
         };
         return;
       }
       const extremums = [axis.min ?? minData, axis.max ?? maxData];
-      const ticksNumber = getTicksNumber({ ...axis, domain });
+      const ticksNumber = getTicksNumber({ ...axis, range });
       completedYAxis[axis.id] = {
         ...axis,
         scaleType,
-        scale: getScale(scaleType, extremums, domain).nice(ticksNumber),
+        scale: getScale(scaleType, extremums, range).nice(ticksNumber),
         ticksNumber,
       } as AxisDefaultized<typeof scaleType>;
     });

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -9,12 +9,12 @@ export type TickParams = {
 
 export function getTicksNumber(
   params: TickParams & {
-    domain: any[];
+    range: any[];
   },
 ) {
-  const { maxTicks = 999, minTicks = 2, tickSpacing = 50, domain } = params;
+  const { maxTicks = 999, minTicks = 2, tickSpacing = 50, range } = params;
 
-  const estimatedTickNumber = Math.floor(Math.abs(domain[1] - domain[0]) / tickSpacing);
+  const estimatedTickNumber = Math.floor(Math.abs(range[1] - range[0]) / tickSpacing);
   return Math.min(maxTicks, Math.max(minTicks, estimatedTickNumber));
 }
 


### PR DESCRIPTION
In previous PR, I introduced the D3 `nice()` function to round the default extremums values. For example, having the axis going from 0 to 200 when data varies between 2 and 185.

But this axis cleaning is don at the end of the process. So if user specify a `min` or `max` values, it will be override by this `nice()` function.

This PR has 2 commits:

1. first is a renaming to follow D3 naming convention:
  - `domain` is in the values space
  - `range` is in the drawing pace (the value in px used in the rendering)
2. the fix of the bug

The bug is especially visible in the following [demo](https://mui.com/x/react-charts/axis/#axis-sub-domain) since you can modify axis min/max values 1 by 1, but the axis will update 5 by 5 on a large screen.