### PR TITLE
[charts] Improve axis label and ticks label alignements

### DIFF
--- a/docs/data/charts/axis/AxisWithComposition.js
+++ b/docs/data/charts/axis/AxisWithComposition.js
@@ -35,6 +35,15 @@ export default function AxisWithComposition() {
       ]}
       width={600}
       height={500}
+      margin={{ left: 70, right: 70 }}
+      sx={{
+        [`.MuiAxis-left .MuiAxis-label`]: {
+          transform: 'rotate(-90deg) translate(0px, -20px)',
+        },
+        [`.MuiAxis-right .MuiAxis-label`]: {
+          transform: 'rotate(90deg) translate(0px, -20px)',
+        },
+      }}
     >
       <BarPlot />
       <LinePlot />

--- a/docs/data/charts/axis/AxisWithComposition.tsx
+++ b/docs/data/charts/axis/AxisWithComposition.tsx
@@ -35,6 +35,15 @@ export default function AxisWithComposition() {
       ]}
       width={600}
       height={500}
+      margin={{ left: 70, right: 70 }}
+      sx={{
+        [`.MuiAxis-left .MuiAxis-label`]: {
+          transform: 'rotate(-90deg) translate(0px, -20px)',
+        },
+        [`.MuiAxis-right .MuiAxis-label`]: {
+          transform: 'rotate(90deg) translate(0px, -20px)',
+        },
+      }}
     >
       <BarPlot />
       <LinePlot />

--- a/docs/data/charts/stacking/StackOrderDemo.js
+++ b/docs/data/charts/stacking/StackOrderDemo.js
@@ -116,10 +116,9 @@ export default function StackOrderDemo() {
         sx={{
           '.MuiAxis-bottom': {
             '.MuiAxis-tickLabel': {
-              transform: 'translate(0, 23px) rotate(45deg)',
-            },
-            '.MuiAxis-label': {
-              transform: 'translate(400px, 50px)',
+              transform: 'rotate(45deg)',
+              alignmentBaseline: 'hanging',
+              textAnchor: 'start',
             },
           },
         }}

--- a/docs/data/charts/stacking/StackOrderDemo.tsx
+++ b/docs/data/charts/stacking/StackOrderDemo.tsx
@@ -112,10 +112,9 @@ export default function StackOrderDemo() {
         sx={{
           '.MuiAxis-bottom': {
             '.MuiAxis-tickLabel': {
-              transform: 'translate(0, 23px) rotate(45deg)',
-            },
-            '.MuiAxis-label': {
-              transform: 'translate(400px, 50px)',
+              transform: 'rotate(45deg)',
+              alignmentBaseline: 'hanging',
+              textAnchor: 'start',
             },
           },
         }}

--- a/packages/x-charts/src/XAxis/XAxis.tsx
+++ b/packages/x-charts/src/XAxis/XAxis.tsx
@@ -93,7 +93,7 @@ function XAxis(inProps: XAxisProps) {
       {label && (
         <Label
           transform={`translate(${left + width / 2}, ${
-            positionSigne * (tickFontSize + tickSize + 20)
+            positionSigne * (tickFontSize + tickSize + 2)
           })`}
           sx={{
             fontSize: labelFontSize,

--- a/packages/x-charts/src/XAxis/XAxis.tsx
+++ b/packages/x-charts/src/XAxis/XAxis.tsx
@@ -32,7 +32,7 @@ const defaultProps = {
   position: 'bottom',
   disableLine: false,
   disableTicks: false,
-  tickFontSize: 10,
+  tickFontSize: 12,
   labelFontSize: 14,
   tickSize: 6,
 } as const;
@@ -93,7 +93,7 @@ function XAxis(inProps: XAxisProps) {
       {label && (
         <Label
           transform={`translate(${left + width / 2}, ${
-            positionSigne * (tickFontSize + tickSize + 2)
+            positionSigne * (tickFontSize + tickSize + 10)
           })`}
           sx={{
             fontSize: labelFontSize,

--- a/packages/x-charts/src/XAxis/XAxis.tsx
+++ b/packages/x-charts/src/XAxis/XAxis.tsx
@@ -7,7 +7,13 @@ import { DrawingContext } from '../context/DrawingProvider';
 import useTicks from '../hooks/useTicks';
 import { XAxisProps } from '../models/axis';
 import { getAxisUtilityClass } from '../Axis/axisClasses';
-import { Line, Tick, TickLabel, Label } from '../internals/components/AxisSharedComponents';
+import {
+  Line,
+  Tick,
+  TickLabel,
+  Label,
+  AxisRoot,
+} from '../internals/components/AxisSharedComponents';
 
 const useUtilityClasses = (ownerState: XAxisProps & { theme: Theme }) => {
   const { classes, position } = ownerState;
@@ -61,7 +67,7 @@ function XAxis(inProps: XAxisProps) {
   const positionSigne = position === 'bottom' ? 1 : -1;
 
   return (
-    <g
+    <AxisRoot
       transform={`translate(0, ${position === 'bottom' ? top + height : top})`}
       className={classes.root}
     >
@@ -73,7 +79,7 @@ function XAxis(inProps: XAxisProps) {
         <g key={index} transform={`translate(${offset}, 0)`} className={classes.tickContainer}>
           {!disableTicks && <Tick y2={positionSigne * tickSize} className={classes.tick} />}
           <TickLabel
-            transform={`translate(0, ${positionSigne * (tickFontSize + tickSize + 2)})`}
+            y={positionSigne * (tickSize + 3)}
             sx={{
               fontSize: tickFontSize,
             }}
@@ -97,7 +103,7 @@ function XAxis(inProps: XAxisProps) {
           {label}
         </Label>
       )}
-    </g>
+    </AxisRoot>
   );
 }
 

--- a/packages/x-charts/src/YAxis/YAxis.tsx
+++ b/packages/x-charts/src/YAxis/YAxis.tsx
@@ -6,7 +6,13 @@ import { CartesianContext } from '../context/CartesianContextProvider';
 import { DrawingContext } from '../context/DrawingProvider';
 import useTicks from '../hooks/useTicks';
 import { YAxisProps } from '../models/axis';
-import { Line, Tick, TickLabel, Label } from '../internals/components/AxisSharedComponents';
+import {
+  Line,
+  Tick,
+  TickLabel,
+  Label,
+  AxisRoot,
+} from '../internals/components/AxisSharedComponents';
 import { getAxisUtilityClass } from '../Axis/axisClasses';
 
 const useUtilityClasses = (ownerState: YAxisProps & { theme: Theme }) => {
@@ -63,7 +69,7 @@ function YAxis(inProps: YAxisProps) {
   const positionSigne = position === 'right' ? 1 : -1;
 
   return (
-    <g
+    <AxisRoot
       transform={`translate(${position === 'right' ? left + width : left}, 0)`}
       className={classes.root}
     >
@@ -75,7 +81,7 @@ function YAxis(inProps: YAxisProps) {
         <g key={index} transform={`translate(0, ${offset})`} className={classes.tickContainer}>
           {!disableTicks && <Tick x2={positionSigne * tickSize} className={classes.tick} />}
           <TickLabel
-            transform={`translate(${positionSigne * (tickFontSize + tickSize + 2)}, 0)`}
+            x={`${positionSigne * (tickSize + 2)}`}
             sx={{
               fontSize: tickFontSize,
             }}
@@ -99,7 +105,7 @@ function YAxis(inProps: YAxisProps) {
           {label}
         </Label>
       )}
-    </g>
+    </AxisRoot>
   );
 }
 

--- a/packages/x-charts/src/YAxis/YAxis.tsx
+++ b/packages/x-charts/src/YAxis/YAxis.tsx
@@ -33,7 +33,7 @@ const defaultProps = {
   position: 'left',
   disableLine: false,
   disableTicks: false,
-  tickFontSize: 10,
+  tickFontSize: 12,
   labelFontSize: 14,
   tickSize: 6,
 } as const;
@@ -69,7 +69,7 @@ function YAxis(inProps: YAxisProps) {
   const positionSigne = position === 'right' ? 1 : -1;
 
   const labelRefPoint = {
-    x: positionSigne * (3 * tickFontSize + tickSize + 2),
+    x: positionSigne * (tickFontSize + tickSize + 10),
     y: top + height / 2,
   };
   return (

--- a/packages/x-charts/src/YAxis/YAxis.tsx
+++ b/packages/x-charts/src/YAxis/YAxis.tsx
@@ -68,6 +68,10 @@ function YAxis(inProps: YAxisProps) {
 
   const positionSigne = position === 'right' ? 1 : -1;
 
+  const labelRefPoint = {
+    x: positionSigne * (3 * tickFontSize + tickSize + 2),
+    y: top + height / 2,
+  };
   return (
     <AxisRoot
       transform={`translate(${position === 'right' ? left + width : left}, 0)`}
@@ -94,11 +98,11 @@ function YAxis(inProps: YAxisProps) {
 
       {label && (
         <Label
-          transform={`translate(${positionSigne * (tickFontSize + tickSize + 20)}, ${
-            top + height / 2
-          }) rotate(${positionSigne * 90})`}
+          {...labelRefPoint}
           sx={{
             fontSize: labelFontSize,
+            transform: `rotate(${positionSigne * 90}deg)`,
+            transformOrigin: `${labelRefPoint.x}px ${labelRefPoint.y}px`,
           }}
           className={classes.label}
         >

--- a/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
+++ b/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
@@ -1,5 +1,28 @@
 import { styled } from '@mui/material/styles';
 
+export const AxisRoot = styled('g', {
+  name: 'MuiChartsAxis',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})({
+  '&.MuiAxis-directionY': {
+    '.MuiAxis-tickLabel': { alignmentBaseline: 'middle' },
+    '.MuiAxis-label': { alignmentBaseline: 'baseline', textAnchor: 'middle' },
+  },
+  '&.MuiAxis-left': {
+    '.MuiAxis-tickLabel': { alignmentBaseline: 'middle', textAnchor: 'end' },
+  },
+  '&.MuiAxis-right': {
+    '.MuiAxis-tickLabel': { alignmentBaseline: 'middle', textAnchor: 'start' },
+  },
+  '&.MuiAxis-bottom': {
+    '.MuiAxis-tickLabel, .MuiAxis-label': { alignmentBaseline: 'hanging', textAnchor: 'middle' },
+  },
+  '&.MuiAxis-top': {
+    '.MuiAxis-tickLabel, .MuiAxis-label': { alignmentBaseline: 'baseline', textAnchor: 'middle' },
+  },
+});
+
 export const Line = styled('line', {
   name: 'MuiChartsAxis',
   slot: 'Line',
@@ -25,7 +48,6 @@ export const TickLabel = styled('text', {
 })(({ theme }) => ({
   ...theme.typography.caption,
   fill: theme.palette.text.primary,
-  textAnchor: 'middle',
 }));
 
 export const Label = styled('text', {
@@ -35,5 +57,4 @@ export const Label = styled('text', {
 })(({ theme }) => ({
   ...theme.typography.body1,
   fill: theme.palette.text.primary,
-  textAnchor: 'middle',
 }));

--- a/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
+++ b/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
@@ -10,10 +10,10 @@ export const AxisRoot = styled('g', {
     '.MuiAxis-label': { alignmentBaseline: 'baseline', textAnchor: 'middle' },
   },
   '&.MuiAxis-left': {
-    '.MuiAxis-tickLabel': { alignmentBaseline: 'middle', textAnchor: 'end' },
+    '.MuiAxis-tickLabel': { alignmentBaseline: 'central', textAnchor: 'end' },
   },
   '&.MuiAxis-right': {
-    '.MuiAxis-tickLabel': { alignmentBaseline: 'middle', textAnchor: 'start' },
+    '.MuiAxis-tickLabel': { alignmentBaseline: 'central', textAnchor: 'start' },
   },
   '&.MuiAxis-bottom': {
     '.MuiAxis-tickLabel, .MuiAxis-label': { alignmentBaseline: 'hanging', textAnchor: 'middle' },


### PR DESCRIPTION
The code taken from hackathon was relying on the font size to place labels.

Instead I use:
- [`alignmentBaseline`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline) and [`textAnchor`](https://developer.mozilla.org/fr/docs/Web/SVG/Attribute/text-anchor) to place labels at the extremity of ticks
- use the `x` and `y` properties to place tet, to let devs use the `transform` property if they need it


For this kind of PR, Argos is super useful 😁