### PR TITLE
[DataGrid] Polish shortcut logic

### DIFF
--- a/docs/data/data-grid/events/events.json
+++ b/docs/data/data-grid/events/events.json
@@ -91,7 +91,7 @@
   {
     "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
     "name": "clipboardCopy",
-    "description": "Fired when the data is copied to the clipboard",
+    "description": "Fired when the data is copied to the clipboard.",
     "params": "string",
     "event": "MuiEvent<{}>",
     "componentProp": "onClipboardCopy"
@@ -227,7 +227,7 @@
   {
     "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
     "name": "headerSelectionCheckboxChange",
-    "description": "Fired when the value of the selection checkbox of the header is changed",
+    "description": "Fired when the value of the selection checkbox of the header is changed.",
     "params": "GridHeaderSelectionCheckboxParams",
     "event": "MuiEvent<{}>"
   },
@@ -370,7 +370,7 @@
   {
     "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
     "name": "rowSelectionCheckboxChange",
-    "description": "Fired when the value of the selection checkbox of a row is changed",
+    "description": "Fired when the value of the selection checkbox of a row is changed.",
     "params": "GridRowSelectionCheckboxParams",
     "event": "MuiEvent<React.ChangeEvent<HTMLElement>>"
   },

--- a/packages/grid/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
@@ -301,11 +301,7 @@ function defaultPasteResolver({
 }
 
 function isPasteShortcut(event: React.KeyboardEvent) {
-  const isModifierKeyPressed = event.ctrlKey || event.metaKey || event.altKey;
-  if (event.code === 'KeyV' && isModifierKeyPressed) {
-    return true;
-  }
-  return false;
+  return (event.ctrlKey || event.metaKey) && event.key === 'v';
 }
 
 export const useGridClipboardImport = (

--- a/packages/grid/x-data-grid/src/hooks/features/clipboard/useGridClipboard.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/clipboard/useGridClipboard.ts
@@ -74,10 +74,7 @@ export const useGridClipboard = (
 
   const handleCopy = React.useCallback(
     (event: KeyboardEvent) => {
-      const isModifierKeyPressed = event.ctrlKey || event.metaKey;
-      // event.code === 'KeyC' is not enough as event.code assume a QWERTY keyboard layout which would
-      // be wrong with a Dvorak keyboard (as if pressing J).
-      if (String.fromCharCode(event.keyCode) !== 'C' || !isModifierKeyPressed) {
+      if (!((event.ctrlKey || event.metaKey) && event.key === 'c')) {
         return;
       }
 

--- a/packages/grid/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -214,9 +214,8 @@ export const useGridRowEditing = (
         }
 
         if (reason) {
-          const rowParams = apiRef.current.getRowParams(params.id);
           const newParams: GridRowEditStopParams = {
-            ...rowParams,
+            ...apiRef.current.getRowParams(params.id),
             reason,
             field: params.field,
           };

--- a/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
@@ -525,11 +525,11 @@ export interface GridEventLookup
 
   // Selection
   /**
-   * Fired when the value of the selection checkbox of the header is changed
+   * Fired when the value of the selection checkbox of the header is changed.
    */
   headerSelectionCheckboxChange: { params: GridHeaderSelectionCheckboxParams };
   /**
-   * Fired when the value of the selection checkbox of a row is changed
+   * Fired when the value of the selection checkbox of a row is changed.
    */
   rowSelectionCheckboxChange: {
     params: GridRowSelectionCheckboxParams;
@@ -538,7 +538,7 @@ export interface GridEventLookup
 
   // Clipboard
   /**
-   * Fired when the data is copied to the clipboard
+   * Fired when the data is copied to the clipboard.
    */
   clipboardCopy: { params: string };
 

--- a/packages/grid/x-data-grid/src/utils/keyboardUtils.ts
+++ b/packages/grid/x-data-grid/src/utils/keyboardUtils.ts
@@ -15,11 +15,13 @@ export const isDeleteKeys = (key: string) => key === 'Delete' || key === 'Backsp
 
 // Non printable keys have a name, e.g. "ArrowRight", see the whole list:
 // https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
-// We need to ignore shortcuts, for example: select all:
+// So event.key.length === 1 is often enough.
+//
+// However, we also need to ignore shortcuts, for example: select all:
 // - Windows: Ctrl+A, event.ctrlKey is true
 // - macOS: ⌘ Command+A, event.metaKey is true
 export function isPrintableKey(event: React.KeyboardEvent<HTMLElement>): boolean {
-  return event.key.length === 1 && event.ctrlKey === false && event.metaKey === false;
+  return event.key.length === 1 && !event.ctrlKey && !event.metaKey;
 }
 
 export const GRID_MULTIPLE_SELECTION_KEYS = ['Meta', 'Control', 'Shift'];


### PR DESCRIPTION
This is an iteration on a couple of other PRs. These changes fixes two bugs:

1. <kbd>Option</kbd>+<kbd>V</kbd> doesn't work on https://mui.com/x/react-data-grid/clipboard/#clipboard-paste while it does now on https://deploy-preview-9220--material-ui-x.netlify.app/x/react-data-grid/clipboard/#clipboard-paste.
2. The paste shortcut on a Dvorak keyboard 