### PR TITLE
[docs] Fix grid header filter link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 
 - 🚀 New date time picking UI on [`DesktopDateTimePicker`](https://mui.com/x/react-date-pickers/date-time-picker/)
 
-  <img src="https://user-images.githubusercontent.com/4941090/242533399-2b106390-8158-4aba-9ca4-b621c6310977.gif" width="628" />
+  <img src="https://github.com/mui/mui-x/assets/3165635/4e1fe9f9-03eb-4f23-99dd-80212b21fb23" width="840" height="506" />
 
 - 🚀 Performance improvements
 - 🐞 Bugfixes
@@ -79,7 +79,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [charts] Manage series stacking (#8888) @alexfauquette
 - [license] List side effects in the license package (#9092) @cherniavskii
 
-## v6.5.0
+## 6.5.0
 
 _May 19, 2023_
 
@@ -87,9 +87,9 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 
 - 💫 Introduce filtering on column headers for `DataGridPro` and `DataGridPremium`:
 
-  https://github.com/mui/mui-x/assets/12609561/c4c2bfec-59cf-4cab-932d-dc1983081de9
+  <img src="https://github.com/mui/mui-x/releases/download/v6.5.0/recording.gif" width="840" height="506" />
 
-  See [the documentation](https://mui.com/x/react-data-grid/filtering/#header-filters) for more information
+  See [the documentation](https://mui.com/x/react-data-grid/filtering/header-filters/) for more information
 
 - 🌍 Improve Hebrew (he-IL) and Czech (cs-CZ) locales
 - 📝 Support for editing on pinned rows
@@ -135,7 +135,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGrid] Memoize root props for better performance (#8942) @romgrk
 - [test] Skip flaky unit tests in JSDOM (#8994) @cherniavskii
 
-## v6.4.0
+## 6.4.0
 
 _May 12, 2023_
 
@@ -4168,7 +4168,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [docs] Revise and split up "Overview" page into "Introduction" (#4692) @samuelsycamore
 - [docs] Use `useKeepGroupedColumnsHiddren` from the grid package on remaining demo (#5382) @flaviendelangle
 
-## v5.12.3
+## 5.12.3
 
 _Jun 23, 2022_
 
@@ -4219,7 +4219,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [test] Throw if date adapter is not found (#5289) @cherniavskii
 - [test] Use mock for `ResizeObserver` (#5215) @m4theushw
 
-## v5.12.2
+## 5.12.2
 
 _Jun 16, 2022_
 
@@ -4262,7 +4262,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [core] Fix `GridColTypeDef` usage in demo (#5197) @cherniavskii
 - [test] Add `waitFor` before asserting height (#5203) @m4theushw
 
-## v5.12.1
+## 5.12.1
 
 _Jun 9, 2022_
 
@@ -4319,7 +4319,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [test] Fix dynamic row height test failing on Chrome (#5147) @m4theushw
 - [test] Remove delay on server demo for regression tests (#5131) @alexfauquette
 
-## v5.12.0
+## 5.12.0
 
 _May 31, 2022_
 
@@ -4400,7 +4400,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [test] Skip Safari and Firefox on broken tests (#4994) @alexfauquette
 - [test] Make argos screenshots stable (#5061) @m4theushw
 
-## v5.11.1
+## 5.11.1
 
 _May 20, 2022_
 
@@ -4492,7 +4492,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [core] Simplify rows cache management (#4933) @flaviendelangle
 - [core] Use internal icons for quick filter (#4912) @alexfauquette
 
-## v5.11.0
+## 5.11.0
 
 _May 13, 2022_
 
@@ -4636,7 +4636,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [test] Reset cleanup tracking on Karma tests (#4679) @m4theushw
 - [test] Restore `sinon` sandbox after each `karma` test (#4689) @m4theushw
 
-## v5.10.0
+## 5.10.0
 
 _Apr 25, 2022_
 
@@ -4672,7 +4672,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [core] Fix the README of the X packages (#4590) @flaviendelangle
 - [test] Fix test to not depend on screen resolution (#4587) @m4theushw
 
-## v5.9.0
+## 5.9.0
 
 _Apr 14, 2022_
 

--- a/docs/data/data-grid/filtering/header-filters.md
+++ b/docs/data/data-grid/filtering/header-filters.md
@@ -1,4 +1,4 @@
-# Data Grid - Header filters
+# Data Grid - Header filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Quickly accessible per-column filters on grid header.</p>
 

--- a/docs/data/data-grid/filtering/header-filters.md
+++ b/docs/data/data-grid/filtering/header-filters.md
@@ -1,3 +1,7 @@
+---
+title: Data Grid - Header filters
+---
+
 # Data Grid - Header filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Quickly accessible per-column filters on grid header.</p>

--- a/docs/data/data-grid/filtering/multi-filters.md
+++ b/docs/data/data-grid/filtering/multi-filters.md
@@ -1,4 +1,4 @@
-# Data Grid - Multi filters
+# Data Grid - Multi filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Apply multiple filters at the same time.</p>
 

--- a/docs/data/data-grid/filtering/multi-filters.md
+++ b/docs/data/data-grid/filtering/multi-filters.md
@@ -1,3 +1,7 @@
+---
+title: Data Grid - Multi filters
+---
+
 # Data Grid - Multi filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
 
 <p class="description">Apply multiple filters at the same time.</p>
@@ -7,7 +11,7 @@ The following demo lets you filter the rows according to several criteria at the
 
 {{"demo": "BasicExampleDataGridPro.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## One filter per column [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## One filter per column
 
 You can also limit to only one filter per column while still allowing to filter other columns. For this, use the [`filterColumns`](/x/api/data-grid/grid-filter-form/) and [`getColumnForNewFilter`](/x/api/data-grid/grid-filter-panel/) props available in `slotProps.filterPanel`.
 
@@ -20,7 +24,7 @@ This demo implements a basic use case to prevent showing multiple filters for on
 
 {{"demo": "DisableMultiFiltersDataGridPro.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Disable action buttons [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Disable action buttons
 
 To disable `Add filter` or `Remove all` buttons, pass `disableAddFilterButton` or `disableRemoveAllButton` to `componentsProps.filterPanel`.
 


### PR DESCRIPTION
The link to the header filter is broken, also add the missing plan icon in the header.

Side fix, the previews on the release page have design issues https://github.com/mui/mui-x/releases/tag/v6.6.0: sometimes no cursor, pixelization, hosted under a personal GitHub account not under the MUI org. I have also tried the big gif road rather than the video, seems to work.

Before: https://github.com/mui/mui-x/blob/master/CHANGELOG.md#660
After: https://github.com/oliviertassinari/mui-x/blob/19ee4a013f410559bfafc6bc6dc32e515bf999fe/CHANGELOG.md#660

Before: https://github.com/mui/mui-x/blob/master/CHANGELOG.md#v650
After: https://github.com/oliviertassinari/mui-x/blob/19ee4a013f410559bfafc6bc6dc32e515bf999fe/CHANGELOG.md#650