### PR TITLE
[Range Calendar] onChange status is not correct when updating a range

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -241,7 +241,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
 
       onRangePositionChange(nextSelection);
 
-      const isFullRangeSelected = rangePosition === 'end' && isRangeValid(utils, newRange);
+      const isFullRangeSelected = isRangeValid(utils, newRange);
 
       setValue(newRange);
       onChange?.(newRange, isFullRangeSelected ? 'finish' : 'partial');


### PR DESCRIPTION
Removed additional wrong condition of rangePosition === 'end' , as it wasn't required