### PR TITLE
[docs] Sync h1 with sidenav link

### DIFF
--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -1,4 +1,4 @@
-# Data Grid - Components
+# Data Grid - Custom subcomponents
 
 <p class="description">The grid is highly customizable. Override components using the <code>slots</code> prop.</p>
 

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -1,12 +1,12 @@
 ---
 product: date-pickers
-title: Date and Time pickers - Localized dates
+title: Date and Time pickers - Date localization
 components: LocalizationProvider
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 
-# Localized dates
+# Date localization
 
 <p class="description">Date and Time Pickers support formats from different locales.</p>
 

--- a/docs/data/date-pickers/calendar-systems/calendar-systems.md
+++ b/docs/data/date-pickers/calendar-systems/calendar-systems.md
@@ -1,12 +1,12 @@
 ---
 product: date-pickers
-title: Date and Time pickers - Support for other calendar systems
+title: Date and Time pickers - Calendar systems
 components: LocalizationProvider
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 
-# Support for other calendar systems
+# Calendar systems
 
 <p class="description">Use the Date and Time Pickers with non-Gregorian calendars.</p>
 

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -1,10 +1,10 @@
 ---
 product: date-pickers
-title: Date and Time pickers - Custom components
+title: Date and Time pickers - Custom subcomponents
 components: DateTimePickerTabs
 ---
 
-# Custom components
+# Custom subcomponents
 
 <p class="description">The date picker lets you customize subcomponents.</p>
 

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -1,12 +1,12 @@
 ---
 product: date-pickers
-title: React Fields components
+title: React Date Fields components
 components: DateField, TimeField, DateTimeField, MultiInputDateRangeField, SingleInputDateRangeField, MultiInputTimeRangeField, SingleInputTimeRangeField, MultiInputDateTimeRangeField, SingleInputDateTimeRangeField
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 
-# Fields
+# Fields component
 
 <p class="description">The field components let the user input date and time values with a keyboard and refined keyboard navigation.</p>
 

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -1,12 +1,12 @@
 ---
 product: date-pickers
-title: Date and Time Pickers - Localization
+title: Date and Time Pickers - Component localization
 components: LocalizationProvider
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 
-# Date and Time Pickers - Localization
+# Component localization
 
 <p class="description">Date and Time Pickers support translations between languages.</p>
 

--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -1,6 +1,5 @@
 ---
 product: date-pickers
-title: Date and Time Pickers - Validation
 components: DatePicker, DesktopDatePicker, MobileDatePicker, StaticDatePicker, TimePicker, DesktopTimePicker, MobileTimePicker, StaticTimePicker, DateTimePicker, DesktopDateTimePicker, MobileDateTimePicker, StaticDateTimePicker, DateRangePicker, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -93,7 +93,7 @@ const pages: MuiPage[] = [
       },
       { pathname: '/x/react-data-grid/export' },
       { pathname: '/x/react-data-grid/clipboard', title: 'Copy and paste', newFeature: true },
-      { pathname: '/x/react-data-grid/components' },
+      { pathname: '/x/react-data-grid/components', title: 'Custom subcomponents' },
       { pathname: '/x/react-data-grid/style' },
       { pathname: '/x/react-data-grid/localization' },
       { pathname: '/x/react-data-grid/scrolling' },

--- a/docs/pages/x/api/date-pickers/date-field.json
+++ b/docs/pages/x/api/date-pickers/date-field.json
@@ -101,7 +101,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/DateField/DateField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-field/\">Date Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-field/\">Date Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateField" }

--- a/docs/pages/x/api/date-pickers/date-time-field.json
+++ b/docs/pages/x/api/date-pickers/date-time-field.json
@@ -114,7 +114,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-field/\">Date Time Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-field/\">Date Time Field</a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateTimeField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateTimeField" }

--- a/docs/pages/x/api/date-pickers/date-time-picker-tabs.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker-tabs.json
@@ -20,7 +20,7 @@
   "name": "DateTimePickerTabs",
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiDateTimePickerTabs" },
   "filename": "/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/custom-components/\">Custom components</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/custom-components/\">Custom subcomponents</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DateTimePickerTabs" },
     { "packageName": "@mui/x-date-pickers", "componentName": "DateTimePickerTabs" }

--- a/docs/pages/x/api/date-pickers/localization-provider.json
+++ b/docs/pages/x/api/date-pickers/localization-provider.json
@@ -16,7 +16,7 @@
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiLocalizationProvider" },
   "filename": "/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/adapters-locale/\">Localized dates</a></li>\n<li><a href=\"/x/react-date-pickers/calendar-systems/\">Support for other calendar systems</a></li>\n<li><a href=\"/x/react-date-pickers/localization/\">Localization</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/adapters-locale/\">Date localization</a></li>\n<li><a href=\"/x/react-date-pickers/calendar-systems/\">Calendar systems</a></li>\n<li><a href=\"/x/react-date-pickers/localization/\">Component localization</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "LocalizationProvider" },
     { "packageName": "@mui/x-date-pickers", "componentName": "LocalizationProvider" }

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
@@ -76,7 +76,7 @@
   "name": "MultiInputDateRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMultiInputDateRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MultiInputDateRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
@@ -89,7 +89,7 @@
   "name": "MultiInputDateTimeRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMultiInputDateTimeRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MultiInputDateTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
@@ -84,7 +84,7 @@
   "name": "MultiInputTimeRangeField",
   "styles": { "classes": [], "globalClasses": {}, "name": "MuiMultiInputTimeRangeField" },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MultiInputTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -99,7 +99,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "SingleInputDateRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -116,7 +116,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "SingleInputDateTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -107,7 +107,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "SingleInputTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/time-field.json
+++ b/docs/pages/x/api/date-pickers/time-field.json
@@ -105,7 +105,7 @@
   "styles": { "classes": ["root"], "globalClasses": {}, "name": "MuiTimeField" },
   "filename": "/packages/x-date-pickers/src/TimeField/TimeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields</a></li>\n<li><a href=\"/x/react-date-pickers/time-field/\">Time Field</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-field/\">Time Field</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "TimeField" },
     { "packageName": "@mui/x-date-pickers", "componentName": "TimeField" }


### PR DESCRIPTION
When browsing the docs, I believe that making the H1 of the page match with the side nav link that was clicked leads to a better UX. It becomes clear that the page that is now displayed is actually the page you clicked on. Otherwise, you might think you are on the wrong tab.