### PR TITLE
[DataGrid] Fix row with ids matching Object prototype

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
@@ -79,7 +79,7 @@ export const useGridRowsMeta = (
       autoHeight: boolean; // Determines if the row has dynamic height
       needsFirstMeasurement: boolean; // Determines if the row was never measured. If true, use the estimated height as row height.
     };
-  }>({});
+  }>(Object.create(null));
 
   // Inspired by https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/utils/CellSizeAndPositionManager.js
   const lastMeasuredRowIndex = React.useRef(-1);

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -536,7 +536,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
       prevGetRowProps.current !== getRowProps || prevRootRowStyle.current !== rootRowStyle;
 
     if (invalidatesCachedRowStyle) {
-      rowStyleCache.current = {};
+      rowStyleCache.current = Object.create(null);
     }
 
     const rows: JSX.Element[] = [];

--- a/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -140,7 +140,7 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
   });
   const prevTotalWidth = React.useRef(columnsTotalWidth);
 
-  const rowStyleCache = React.useRef<Record<GridRowId, any>>({});
+  const rowStyleCache = React.useRef<Record<GridRowId, any>>(Object.create(null));
   const prevGetRowProps = React.useRef<UseGridVirtualScrollerProps['getRowProps']>();
   const prevRootRowStyle = React.useRef<GridRowProps['style']>();
 

--- a/packages/grid/x-data-grid/src/tests/DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/DataGrid.test.tsx
@@ -43,4 +43,23 @@ describe('<DataGrid />', () => {
     expect(document.querySelector('[data-custom-id="grid-1"]')).to.equal(gridRef.current);
     expect(document.querySelector('[aria-label="Grid one"]')).to.equal(gridRef.current);
   });
+
+  it('should not fail when row have IDs match Object prototype keys (constructor, hasOwnProperty, etc)', () => {
+    const rows = [
+      { id: 'a', col1: 'Hello', col2: 'World' },
+      { id: 'constructor', col1: 'DataGridPro', col2: 'is Awesome' },
+      { id: 'hasOwnProperty', col1: 'MUI', col2: 'is Amazing' },
+    ];
+
+    const columns = [
+      { field: 'col1', headerName: 'Column 1', width: 150 },
+      { field: 'col2', headerName: 'Column 2', width: 150 },
+    ];
+
+    render(
+      <div style={{ height: 300, width: '100%' }}>
+        <DataGrid rows={rows} columns={columns} />
+      </div>,
+    );
+  });
 });


### PR DESCRIPTION
Closes #9264 

Avoid failing if the rows have ids like `constructor`.