### PR TITLE
[DataGrid] Update data grid migration guide to include updated type

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -86,7 +86,7 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
   | `showColumnRightBorder`    | `showColumnVerticalBorder`    |
   | `headerHeight`             | `columnHeaderHeight`          |
 
-- The corresponding type for rowSelectionModel was renamed from `GridSelectionModel` to `GridRowSelectionModel`.
+- The corresponding type for `rowSelectionModel` (previously `selectionModel`) was renamed from `GridSelectionModel` to `GridRowSelectionModel`.
 
 ### Removed props
 

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -86,6 +86,8 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
   | `showColumnRightBorder`    | `showColumnVerticalBorder`    |
   | `headerHeight`             | `columnHeaderHeight`          |
 
+- The corresponding type for rowSelectionModel was renamed from `GridSelectionModel` to `GridRowSelectionModel`.
+
 ### Removed props
 
 - The `disableIgnoreModificationsIfProcessingProps` prop was removed and its behavior when `true` was incorporated as the default behavior.


### PR DESCRIPTION
Fixes #9271 

It might be obvious for some users that if `selectionModel` -> `rowSelectionModel` change is done, their corresponding types should also be updated `GridSelectionModel` -> `GridRowSelectionModel`, but some users may get confused with this. Also, since both these types old and renamed one are exported in v5 and v6, someone may be searching directly for it in the migration guide.