### PR TITLE
[docs] Fix version redirect

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -251,7 +251,7 @@ function AppWrapper(props) {
                 }
               : {
                   text: `v6`,
-                  href: `https://next.mui.com${languagePrefix}/components/data-grid/`,
+                  href: `https://mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
                 }),
           },
           {
@@ -262,7 +262,7 @@ function AppWrapper(props) {
                 }
               : {
                   text: `v5`,
-                  href: `https://v5.mui.com${languagePrefix}/components/data-grid/`,
+                  href: `https://v5.mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
                 }),
           },
         ],


### PR DESCRIPTION
Fix the link in the docs header

![image](https://github.com/mui/mui-x/assets/45398769/de319b4f-5de5-4528-bfd2-2a32e87707e3)


Need to be added to v5 docs