### PR TITLE
[docs] Fix links pointing to next.mui.com and update monorepo

### DIFF
--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -14,11 +14,11 @@ materialDesign: https://material.io/components/date-pickers
 :::success
 This component has received several major improvements on the new **v6 beta**:
 
-- [Fields: the new default input for pickers](https://next.mui.com/x/react-date-pickers/fields/).
-- [Improved layout customization](https://next.mui.com/x/react-date-pickers/custom-layout/)
-- [Shortcuts for picking specific dates in a calendar](https://next.mui.com/x/react-date-pickers/shortcuts/)
+- [Fields: the new default input for pickers](https://mui.com/x/react-date-pickers/fields/).
+- [Improved layout customization](https://mui.com/x/react-date-pickers/custom-layout/)
+- [Shortcuts for picking specific dates in a calendar](https://mui.com/x/react-date-pickers/shortcuts/)
 
-You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the DatePicker](https://next.mui.com/x/react-date-pickers/date-picker/) for more information.
+You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the DatePicker](https://mui.com/x/react-date-pickers/date-picker/) for more information.
 :::
 
 Date pickers are displayed with:

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -14,12 +14,12 @@ materialDesign: https://material.io/components/date-pickers
 :::success
 This component has received several major improvements on the new **v6 beta**:
 
-- [Fields: the new default input for pickers](https://next.mui.com/x/react-date-pickers/fields/).
-- [Improved layout customization](https://next.mui.com/x/react-date-pickers/custom-layout/)
-- [Shortcuts for picking specific dates in a calendar](https://next.mui.com/x/react-date-pickers/shortcuts/)
-- [Edit date ranges with drag and drop](https://next.mui.com/x/react-date-pickers/date-range-calendar/)
+- [Fields: the new default input for pickers](https://mui.com/x/react-date-pickers/fields/).
+- [Improved layout customization](https://mui.com/x/react-date-pickers/custom-layout/)
+- [Shortcuts for picking specific dates in a calendar](https://mui.com/x/react-date-pickers/shortcuts/)
+- [Edit date ranges with drag and drop](https://mui.com/x/react-date-pickers/date-range-calendar/)
 
-You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the DateRangePicker](https://next.mui.com/x/react-date-pickers/date-range-picker/) for more information.
+You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the DateRangePicker](https://mui.com/x/react-date-pickers/date-range-picker/) for more information.
 :::
 
 ## Basic usage

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -14,11 +14,11 @@ materialDesign: https://material.io/components/date-pickers
 :::success
 This component has received several major improvements on the new **v6 beta**:
 
-- [Fields: the new default input for pickers](https://next.mui.com/x/react-date-pickers/fields/).
-- [Improved layout customization](https://next.mui.com/x/react-date-pickers/custom-layout/)
-- [Shortcuts for picking specific dates in a calendar](https://next.mui.com/x/react-date-pickers/shortcuts/)
+- [Fields: the new default input for pickers](https://mui.com/x/react-date-pickers/fields/).
+- [Improved layout customization](https://mui.com/x/react-date-pickers/custom-layout/)
+- [Shortcuts for picking specific dates in a calendar](https://mui.com/x/react-date-pickers/shortcuts/)
 
-You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the DateTimePicker](https://next.mui.com/x/react-date-pickers/date-time-picker/) for more information.
+You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the DateTimePicker](https://mui.com/x/react-date-pickers/date-time-picker/) for more information.
 :::
 
 It allows the user to select both date and time with the same control.

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -14,10 +14,10 @@ materialDesign: https://material.io/components/time-pickers
 :::success
 This component has received several major improvements on the new **v6 beta**:
 
-- [Fields: the new default input for pickers](https://next.mui.com/x/react-date-pickers/fields/).
-- [Improved layout customization](https://next.mui.com/x/react-date-pickers/custom-layout/)
+- [Fields: the new default input for pickers](https://mui.com/x/react-date-pickers/fields/).
+- [Improved layout customization](https://mui.com/x/react-date-pickers/custom-layout/)
 
-You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the TimePicker](https://next.mui.com/x/react-date-pickers/time-picker/) for more information.
+You can also take a look at [the dedicated blog post](https://mui.com/blog/v6-beta-pickers/) and the [new documentation of the TimePicker](https://mui.com/x/react-date-pickers/time-picker/) for more information.
 :::
 
 The selected time is indicated by the filled circle at the end of the clock hand.

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -3,7 +3,7 @@ import type { MuiPage } from '@mui/monorepo/docs/src/MuiPage';
 const pages: MuiPage[] = [
   {
     pathname: 'https://mui.com/blog/mui-x-v6/',
-    title: "✨ v6 is out ✨",
+    title: '✨ v6 is out ✨',
     icon: 'VisibilityIcon',
   },
   {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -6,7 +6,12 @@ const pkg = require('../package.json');
 const dataGridPkg = require('../packages/grid/x-data-grid/package.json');
 const datePickersPkg = require('../packages/x-date-pickers/package.json');
 const { findPages } = require('./src/modules/utils/find');
-const { LANGUAGES, LANGUAGES_SSR } = require('./config');
+const {
+  LANGUAGES,
+  LANGUAGES_SSR,
+  LANGUAGES_IGNORE_PAGES,
+  LANGUAGES_IN_PROGRESS,
+} = require('./config');
 
 const workspaceRoot = path.join(__dirname, '../');
 
@@ -68,6 +73,8 @@ module.exports = withDocsInfra({
                   {
                     loader: require.resolve('@mui/monorepo/packages/markdown/loader'),
                     options: {
+                      ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
+                      languagesInProgress: LANGUAGES_IN_PROGRESS,
                       env: {
                         SOURCE_CODE_REPO: options.config.env.SOURCE_CODE_REPO,
                         LIB_VERSION: options.config.env.LIB_VERSION,

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -14,6 +14,7 @@ import { CodeVariantProvider } from 'docs/src/modules/utils/codeVariant';
 import { CodeCopyProvider } from 'docs/src/modules/utils/CodeCopy';
 import { UserLanguageProvider } from 'docs/src/modules/utils/i18n';
 import DocsStyledEngineProvider from 'docs/src/modules/utils/StyledEngineProvider';
+import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import findActivePage from 'docs/src/modules/utils/findActivePage';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
@@ -208,11 +209,87 @@ function AppWrapper(props) {
     ];
   }
 
+  const { canonicalAs } = pathnameToLanguage(router.asPath);
+
   const pageContextValue = React.useMemo(() => {
     const { activePage, activePageParents } = findActivePage(pages, router.pathname);
 
-    return { activePage, activePageParents, pages };
-  }, [router.pathname]);
+    const languagePrefix = pageProps.userLanguage === 'en' ? '' : `/${pageProps.userLanguage}`;
+
+    let productIdentifier = {
+      name: 'Advanced components',
+      metadata: 'MUI X',
+    };
+
+    if (
+      canonicalAs.startsWith('/x/react-data-grid/') ||
+      canonicalAs.startsWith('/x/api/data-grid/')
+    ) {
+      productIdentifier = {
+        name: 'Data Grid',
+        metadata: 'MUI X',
+        versions: [
+          {
+            text: 'v6',
+            ...(process.env.DATA_GRID_VERSION.startsWith('6')
+              ? {
+                  text: `v${process.env.DATA_GRID_VERSION}`,
+                  current: true,
+                }
+              : {
+                  href: `https://mui.com${languagePrefix}/components/data-grid/`,
+                }),
+          },
+          {
+            text: 'v5',
+            ...(process.env.DATA_GRID_VERSION.startsWith('5')
+              ? {
+                  text: `v${process.env.DATA_GRID_VERSION}`,
+                  current: true,
+                }
+              : {
+                  href: `https://v5.mui.com${languagePrefix}/components/data-grid/`,
+                }),
+          },
+          { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
+        ],
+      };
+    } else if (
+      canonicalAs.startsWith('/x/react-date-pickers/') ||
+      canonicalAs.startsWith('/x/api/date-pickers/')
+    ) {
+      productIdentifier = {
+        name: 'Date pickers',
+        metadata: 'MUI X',
+        versions: [
+          {
+            ...(process.env.DATE_PICKERS_VERSION.startsWith('6')
+              ? {
+                  text: `v${process.env.DATE_PICKERS_VERSION}`,
+                  current: true,
+                }
+              : {
+                  text: `v6`,
+                  href: `https://mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
+                }),
+          },
+          {
+            ...(process.env.DATE_PICKERS_VERSION.startsWith('5')
+              ? {
+                  text: `v${process.env.DATE_PICKERS_VERSION}`,
+                  current: true,
+                }
+              : {
+                  text: `v5`,
+                  href: `https://v5.mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
+                }),
+          },
+        ],
+      };
+    }
+
+    return { activePage, activePageParents, pages, productIdentifier };
+  }, [canonicalAs, pageProps.userLanguage, router.pathname]);
 
   // Replicate change reverted in https://github.com/mui/material-ui/pull/35969/files#r1089572951
   // Fixes playground styles in dark mode.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
+    "@mui/base": "^5.0.0-alpha.121",
     "@mui/icons-material": "^5.11.11",
     "@mui/material": "^5.11.11",
     "@mui/monorepo": "https://github.com/mui/material-ui.git#master",

--- a/packages/x-date-pickers-pro/tsconfig.json
+++ b/packages/x-date-pickers-pro/tsconfig.json
@@ -5,5 +5,9 @@
     "skipLibCheck": true,
     "types": ["react", "mocha", "node"]
   },
-  "include": ["src/**/*", "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts"]
+  "include": [
+    "src/**/*",
+    "../../test/utils/addChaiAssertions.ts",
+    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts" 
+  ]
 }

--- a/packages/x-date-pickers/tsconfig.json
+++ b/packages/x-date-pickers/tsconfig.json
@@ -5,5 +5,9 @@
     "skipLibCheck": true,
     "types": ["react", "mocha", "node"]
   },
-  "include": ["src/**/*", "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts"]
+  "include": [
+    "src/**/*",
+    "../../test/utils/addChaiAssertions.ts",
+    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts" 
+  ]
 }

--- a/packages/x-license-pro/tsconfig.json
+++ b/packages/x-license-pro/tsconfig.json
@@ -4,5 +4,9 @@
     "types": ["react", "mocha", "node"],
     "noImplicitAny": true
   },
-  "include": ["src/**/*", "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts"]
+  "include": [
+    "src/**/*",
+    "../../test/utils/addChaiAssertions.ts",
+    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts" 
+  ]
 }

--- a/test/utils/addChaiAssertions.ts
+++ b/test/utils/addChaiAssertions.ts
@@ -1,0 +1,38 @@
+import chai from 'chai';
+
+// https://stackoverflow.com/a/46755166/3406963
+declare global {
+  namespace Chai {
+    interface Assertion {
+      /**
+       * Matcher with useful error messages if the dates don't match.
+       */
+      toEqualDateTime(expected: any): void;
+    }
+  }
+}
+
+chai.use((chaiAPI, utils) => {
+  chai.Assertion.addMethod('toEqualDateTime', function toEqualDateTime(expectedDate, message) {
+    // eslint-disable-next-line no-underscore-dangle
+    const actualDate = this._obj;
+
+    // Luxon dates don't have a `toISOString` function, we need to convert to the JS date first
+    const cleanActualDate =
+      typeof actualDate.toJSDate === 'function' ? actualDate.toJSDate() : actualDate;
+
+    let cleanExpectedDate;
+    if (typeof expectedDate === 'string') {
+      cleanExpectedDate = new Date(expectedDate);
+    } else if (typeof expectedDate.toJSDate === 'function') {
+      cleanExpectedDate = expectedDate.toJSDate();
+    } else {
+      cleanExpectedDate = expectedDate;
+    }
+
+    const assertion = new chai.Assertion(cleanActualDate.toISOString(), message);
+    // TODO: Investigate if `as any` can be removed after https://github.com/DefinitelyTyped/DefinitelyTyped/issues/48634 is resolved.
+    utils.transferFlags(this as any, assertion, false);
+    assertion.to.equal(cleanExpectedDate.toISOString());
+  });
+});

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -1,5 +1,6 @@
 import './licenseRelease';
 import './licenseKey';
+import './addChaiAssertions';
 import { unstable_resetCleanupTracking } from '@mui/x-data-grid';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingPro } from '@mui/x-data-grid-pro';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,8 +2526,8 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.11.12"
-  resolved "https://github.com/mui/material-ui.git#aff4ec6a8d5d4e9526a3b81123fdca4f0ddb666a"
+  version "5.13.4"
+  resolved "https://github.com/mui/material-ui.git#0d3aba1c9433dc5dd79dd9af6821c25b48d6f4f7"
 
 "@mui/private-theming@^5.11.11":
   version "5.11.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,6 +1296,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.16.7", "@babel/template@^7.18.10", "@babel/template@^7.18.6", "@babel/template@^7.6.0":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -1441,10 +1448,22 @@
   dependencies:
     "@emotion/memoize" "^0.8.0"
 
+"@emotion/is-prop-valid@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
+  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+
 "@emotion/memoize@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
 "@emotion/react@^11.10.4":
   version "11.10.4"
@@ -2479,6 +2498,20 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/base@^5.0.0-alpha.121":
+  version "5.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.5.tgz#b566f3beb1eb2823139eabaf52014cf7be900015"
+  integrity sha512-vy3TWLQYdGNecTaufR4wDNQFV2WEg6wRPi6BVbx6q1vP3K1mbxIn1+XOqOzfYBXjFHvMx0gZAo2TgWbaqfgvAA==
+  dependencies:
+    "@babel/runtime" "^7.22.5"
+    "@emotion/is-prop-valid" "^1.2.1"
+    "@mui/types" "^7.2.4"
+    "@mui/utils" "^5.13.6"
+    "@popperjs/core" "^2.11.8"
+    clsx "^1.2.1"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
 "@mui/core-downloads-tracker@^5.11.11":
   version "5.11.11"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.11.tgz#eb5b3f0900ad96a72a37f85fca11545d47a7bc10"
@@ -2590,6 +2623,11 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.3.tgz#06faae1c0e2f3a31c86af6f28b3a4a42143670b9"
   integrity sha512-tZ+CQggbe9Ol7e/Fs5RcKwg/woU+o8DCtOnccX6KmbBc7YrfqMYEYuaIcXHuhpT880QwNkZZ3wQwvtlDFA2yOw==
 
+"@mui/types@^7.2.4":
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.4.tgz#b6fade19323b754c5c6de679a38f068fd50b9328"
+  integrity sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==
+
 "@mui/utils@^5.10.3", "@mui/utils@^5.11.11":
   version "5.11.11"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.11.11.tgz#c5dddc80c02dc76bd95f492550a5a616548e5557"
@@ -2598,6 +2636,17 @@
     "@babel/runtime" "^7.21.0"
     "@types/prop-types" "^15.7.5"
     "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
+"@mui/utils@^5.13.6":
+  version "5.13.6"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.13.6.tgz#aa29d75de59577585b9f23891b03592d40459ed7"
+  integrity sha512-ggNlxl5NPSbp+kNcQLmSig6WVB0Id+4gOxhx644987v4fsji+CSXc+MFYLocFB/x4oHtzCUlSzbVHlJfP/fXoQ==
+  dependencies:
+    "@babel/runtime" "^7.22.5"
+    "@types/prop-types" "^15.7.5"
+    "@types/react-is" "^18.2.0"
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
@@ -3118,6 +3167,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@react-spring/animated@~9.2.0":
   version "9.2.4"
   resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.2.4.tgz#062ecc0fdfef89f2541a42d8500428b70035f879"
@@ -3556,6 +3610,13 @@
   version "16.7.1"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.1.tgz#d3f1c68c358c00ce116b55ef5410cf486dd08539"
   integrity sha512-dMLFD2cCsxtDgMkTydQCM0PxDq8vwc6uN5M/jRktDfYvH3nQj6pjC9OrCXS2lKlYoYTNJorI/dI8x9dpLshexQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@^18.2.0":
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-18.2.1.tgz#61d01c2a6fc089a53520c0b66996d458fdc46863"
+  integrity sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
In this PR I remove the markdown links that were pointing to next.mui.com

And I upgrade monorepo to get access to the PR https://github.com/mui/material-ui/pull/35078 which introduced the option to modify headers link into mui-x instead of having to to a PR in core

