### PR TITLE
[docs] Fix `Date Calendar` dynamic data demo

### DIFF
--- a/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.js
+++ b/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.js
@@ -37,7 +37,7 @@ function ServerDay(props) {
   const { highlightedDays = [], day, outsideCurrentMonth, ...other } = props;
 
   const isSelected =
-    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) > 0;
+    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) >= 0;
 
   return (
     <Badge

--- a/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.tsx
+++ b/docs/data/date-pickers/date-calendar/DateCalendarServerRequest.tsx
@@ -37,7 +37,7 @@ function ServerDay(props: PickersDayProps<Dayjs> & { highlightedDays?: number[] 
   const { highlightedDays = [], day, outsideCurrentMonth, ...other } = props;
 
   const isSelected =
-    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) > 0;
+    !props.outsideCurrentMonth && highlightedDays.indexOf(props.day.date()) >= 0;
 
   return (
     <Badge


### PR DESCRIPTION
Closes #7331

There was an error in the [Dynamic Data Example](https://mui.com/x/react-date-pickers/date-calendar/#DateCalendarServerRequest.tsx ) which did not allow to highlight the first day in the month.

I implemented a simple fix so that the index 0 is now also allowed.
