### PR TITLE
[experiment] Update the popper position when view change

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { styled, useThemeProps } from '@mui/material/styles';
 import {
+  unstable_useForkRef as useForkRef,
   unstable_composeClasses as composeClasses,
   unstable_useId as useId,
   unstable_useEventCallback as useEventCallback,
@@ -294,9 +295,11 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
 
   const selectedDays = React.useMemo(() => [value], [value]);
 
+  const internalRef = React.useRef(null);
+  const handleRef = useForkRef(ref, internalRef);
   return (
     <DateCalendarRoot
-      ref={ref}
+      ref={handleRef}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
       {...other}
@@ -322,6 +325,10 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
         className={classes.viewTransitionContainer}
         transKey={view}
         ownerState={ownerState}
+        onExited={() => {
+          const event = new CustomEvent('exitedView', { bubbles: true });
+          internalRef.current.dispatchEvent(event);
+        }}
       >
         <div>
           {view === 'year' && (

--- a/packages/x-date-pickers/src/DateCalendar/PickersFadeTransitionGroup.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/PickersFadeTransitionGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import Fade from '@mui/material/Fade';
+import Fade, { FadeProps } from '@mui/material/Fade';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/utils';
 import { TransitionGroup } from 'react-transition-group';
@@ -15,6 +15,7 @@ export interface PickersFadeTransitionGroupProps {
   reduceAnimations: boolean;
   transKey: React.Key;
   classes?: Partial<PickersFadeTransitionGroupClasses>;
+  onExited?: FadeProps['onExited'];
 }
 
 const useUtilityClasses = (ownerState: PickersFadeTransitionGroupProps) => {
@@ -42,7 +43,7 @@ const PickersFadeTransitionGroupRoot = styled(TransitionGroup, {
  */
 export function PickersFadeTransitionGroup(inProps: PickersFadeTransitionGroupProps) {
   const props = useThemeProps({ props: inProps, name: 'MuiPickersFadeTransitionGroup' });
-  const { children, className, reduceAnimations, transKey } = props;
+  const { children, className, reduceAnimations, transKey, onExited } = props;
   const classes = useUtilityClasses(props);
   if (reduceAnimations) {
     return children;
@@ -56,6 +57,7 @@ export function PickersFadeTransitionGroup(inProps: PickersFadeTransitionGroupPr
         unmountOnExit
         key={transKey}
         timeout={{ appear: animationDuration, enter: animationDuration / 2, exit: 0 }}
+        onExited={onExited}
       >
         {children}
       </Fade>

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -6,6 +6,7 @@ import MuiPopper, {
   PopperProps as MuiPopperProps,
   PopperPlacementType,
 } from '@mui/material/Popper';
+import { Instance } from '@popperjs/core';
 import MuiTrapFocus, {
   TrapFocusProps as MuiTrapFocusProps,
 } from '@mui/material/Unstable_TrapFocus';
@@ -363,8 +364,18 @@ export function PickersPopper(inProps: PickerPopperProps) {
     ownerState: props,
   });
 
+  const popperRef = React.useRef<Instance>(null);
+  React.useEffect(() => {
+    const callback = () => {
+      popperRef.current.update();
+    };
+    document.addEventListener('exitedView', callback);
+    return () => {
+      document.removeEventListener('exitedView', callback);
+    };
+  }, []);
   return (
-    <Popper {...popperProps}>
+    <Popper {...popperProps} popperRef={popperRef}>
       {({ TransitionProps, placement: popperPlacement }) => (
         <TrapFocus
           open={open}


### PR DESCRIPTION
Experiments on #9288

I added code to call the `update()` method of the popper instance as soon as the fadeout is over. But the result is not 