### PR TITLE
[DataGrid] Fix tabbing between `actions` cells in edit mode

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -39,6 +39,7 @@ import {
   GridRowEditStopReasons,
   GridRowEditStartReasons,
 } from '../../../models/params/gridRowParams';
+import { GRID_ACTIONS_COLUMN_TYPE } from '../../../colDef';
 
 const missingOnProcessRowUpdateErrorWarning = buildWarning(
   [
@@ -188,9 +189,13 @@ export const useGridRowEditing = (
         } else if (event.key === 'Enter') {
           reason = GridRowEditStopReasons.enterKeyDown;
         } else if (event.key === 'Tab') {
-          const columnFields = gridColumnFieldsSelector(apiRef).filter((field) =>
-            apiRef.current.isCellEditable(apiRef.current.getCellParams(params.id, field)),
-          );
+          const columnFields = gridColumnFieldsSelector(apiRef).filter((field) => {
+            const column = apiRef.current.getColumn(field);
+            if (column.type === GRID_ACTIONS_COLUMN_TYPE) {
+              return true;
+            }
+            return apiRef.current.isCellEditable(apiRef.current.getCellParams(params.id, field));
+          });
 
           if (event.shiftKey) {
             if (params.field === columnFields[0]) {


### PR DESCRIPTION
This PR will enable the Actions columns on the DataGrid for tabbing, which is necessary for accessibility / keyboard-only users to make edits to a row.

Please see related issue for more context: https://github.com/mui/mui-x/issues/9250