### PR TITLE
[core] Add PR template and update the contributions guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
+
+- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,4 @@ There are, however, a few differences:
 
 - The default GitHub branch might be different.
 - The local documentation site opens on a different port: 3001 instead of 3000.
+- You would need to sign a contributor license agreement (CLA) if the PR changes code located in the following folders: `x-data-grid-pro`, `x-data-grid-premium`, `x-date-pickers-pro`


### PR DESCRIPTION
We didn't have a PR template so I added one. In addition, I added a line in the contribution guide related to CLA. Hopefully, this will streamline the PR contributions a bit.