### PR TITLE
[pickers] Fix field section selection on `DateTimePicker`

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -118,7 +118,7 @@ export const useField = <
     // The ref is guaranteed to be resolved at this point.
     const input = inputRef.current;
 
-    clearTimeout(focusTimeoutRef.current);
+    window.clearTimeout(focusTimeoutRef.current);
     focusTimeoutRef.current = setTimeout(() => {
       // The ref changed, the component got remounted, the focus event is no longer relevant.
       if (!input || input !== inputRef.current) {
@@ -363,12 +363,15 @@ export const useField = <
   });
 
   useEnhancedEffect(() => {
+    if (!inputRef.current) {
+      return;
+    }
     if (selectedSectionIndexes == null) {
-      if (inputRef.current!.scrollLeft) {
+      if (inputRef.current.scrollLeft) {
         // Ensure that input content is not marked as selected.
         // setting selection range to 0 causes issues in Safari.
         // https://bugs.webkit.org/show_bug.cgi?id=224425
-        inputRef.current!.scrollLeft = 0;
+        inputRef.current.scrollLeft = 0;
       }
       return;
     }
@@ -384,19 +387,19 @@ export const useField = <
     }
 
     if (
-      selectionStart !== inputRef.current!.selectionStart ||
-      selectionEnd !== inputRef.current!.selectionEnd
+      selectionStart !== inputRef.current.selectionStart ||
+      selectionEnd !== inputRef.current.selectionEnd
     ) {
       // Fix scroll jumping on iOS browser: https://github.com/mui/mui-x/issues/8321
-      const currentScrollTop = inputRef.current!.scrollTop;
+      const currentScrollTop = inputRef.current.scrollTop;
       // On multi input range pickers we want to update selection range only for the active input
       // This helps avoiding the focus jumping on Safari https://github.com/mui/mui-x/issues/9003
       // because WebKit implements the `setSelectionRange` based on the spec: https://bugs.webkit.org/show_bug.cgi?id=224425
-      if (inputRef.current && inputRef.current === getActiveElement(document)) {
-        inputRef.current!.setSelectionRange(selectionStart, selectionEnd);
+      if (inputRef.current === getActiveElement(document)) {
+        inputRef.current.setSelectionRange(selectionStart, selectionEnd);
       }
       // Even reading this variable seems to do the trick, but also setting it just to make use of it
-      inputRef.current!.scrollTop = currentScrollTop;
+      inputRef.current.scrollTop = currentScrollTop;
     }
   });
 

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
@@ -203,12 +203,14 @@ export const usePickerViews = <
   }
 
   useEnhancedEffect(() => {
+    // Handle case of `DateTimePicker` without time renderers
     if (currentViewMode === 'field' && open) {
       onClose();
-      onSelectedSectionsChange('hours');
-
       setTimeout(() => {
+        // focusing the input before the range selection is done
+        // calling `onSelectedSectionsChange` outside of timeout results in an inconsistent behavior between Safari And Chrome
         inputRef?.current!.focus();
+        onSelectedSectionsChange(view);
       });
     }
   }, [view]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes #9326 

Calling the field selection before the field is focused and in different even loop cycles results in inconsistencies and Chrome not marking the selected section correctly, but it would work fine on Safari.
Calling them both in the same timeout results in consistent visual behavior, albeit with a slight flickering (visible input focusing and instant selected range selection).