### PR TITLE
[docs] Use the mui-x Stack Overflow tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can search through existing issues and pull requests to see if someone has r
 
 Visit Stack Overflow to ask questions and read crowdsourced answers from expert developers in the MUI community, as well as MUI maintainers.
 
-[Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui) on Stack Overflow using the "mui" tag.
+[Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui-x) on Stack Overflow using the "mui-x" tag.
 
 ### Bugs and feature requests
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -14,7 +14,7 @@ You can search through existing issues and pull requests to see if someone has r
 
 Visit Stack Overflow to ask questions and read crowdsourced answers from expert developers in the MUI community, as well as MUI maintainers.
 
-[Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui) on Stack Overflow.
+[Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui-x) on Stack Overflow using the "mui-x" tag.
 
 ## Technical support
 


### PR DESCRIPTION
Since we are moving toward treating more each part of MUI as its own open-source project/product, to help them compete with community alternatives. We are making the developer feel like each project is more lazer focused on one problem and less "bloated".