### PR TITLE
[core] Update to Node v18 for `l10n` GitHub CI

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - run: echo "${{ github.actor }}"
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 14
+          node-version: 18
           cache: 'yarn' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: yarn install
         env:


### PR DESCRIPTION
Came from https://github.com/mui/material-ui/pull/37604 to ensure consistency. This job runs only on `master` and `next` branches.