### PR TITLE
[pickers] Reduce date range calendar vertical border width

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -72,7 +72,7 @@ const DateRangeCalendarMonthContainer = styled('div', {
   overridesResolver: (_, styles) => styles.monthContainer,
 })(({ theme }) => ({
   '&:not(:last-of-type)': {
-    borderRight: `2px solid ${(theme.vars || theme).palette.divider}`,
+    borderRight: `1px solid ${(theme.vars || theme).palette.divider}`,
   },
 }));
 


### PR DESCRIPTION
This 2px has been here since the very first version, e.g. https://material-ui-pickers-git-next-mui-org.vercel.app/demo/daterangepicker:

<img width="671" alt="Screenshot 2023-06-17 at 18 17 55" src="https://github.com/mui/mui-x/assets/3165635/00f3b913-1d79-4cec-9cff-367add6088a1">

However, it feels horrendous. Instead, we can use 1px, it should be enough. This is what MD2 documents:

<img width="544" alt="Screenshot 2023-06-17 at 18 18 47" src="https://github.com/mui/mui-x/assets/3165635/a869ad6f-0318-45f5-b13f-3a6e8308fe94">

https://m2.material.io/components/date-pickers#desktop-pickers

Note that the majority of the date range pickers we benchmark again have no borders at all: https://mui-org.notion.site/Date-Range-Picker-component-271834fb7d274531a9c44286c1d23d9c?pvs=4

Preview: https://deploy-preview-9368--material-ui-x.netlify.app/x/react-date-pickers/date-range-picker/

<img width="665" alt="Screenshot 2023-06-17 at 19 47 03" src="https://github.com/mui/mui-x/assets/3165635/a4d434c0-65da-4858-b2a3-c2ab5f2cb031">

### Context

This was very obvious on https://flights.teamout.com/, the date range picker UX on this page doesn't feel great.