### PR TITLE
[fields] Reset internal state when referenceValue changes

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -955,7 +955,7 @@ describe('<DateField /> - Editing', () => {
     });
 
     it('should reset the input query state on an unfocused field', () => {
-      const { setProps } = render(<DateField value={null} />);
+      const { setProps } = render(<DateField />);
       const input = getTextbox();
 
       clickOnInput(input, 0);
@@ -990,6 +990,7 @@ describe('<DateField /> - Editing', () => {
       });
 
       fireEvent.change(input, { target: { value: '11/23/2' } }); // Press "2"
+      expectInputValue(input, '11/23/0002');
       fireEvent.change(input, { target: { value: '11/23/1' } }); // Press "0"
       expectInputValue(input, '11/23/0021');
     });

--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -953,6 +953,46 @@ describe('<DateField /> - Editing', () => {
       clickOnInput(input, 0);
       expectInputValue(input, 'MM/DD/YYYY');
     });
+
+    it('should reset the input query state on an unfocused field', () => {
+      const { setProps } = render(<DateField value={null} />);
+      const input = getTextbox();
+
+      clickOnInput(input, 0);
+
+      fireEvent.change(input, { target: { value: '1/DD/YYYY' } }); // Press "1"
+      expectInputValue(input, '01/DD/YYYY');
+
+      fireEvent.change(input, { target: { value: '11/DD/YYYY' } }); // Press "1"
+      expectInputValue(input, '11/DD/YYYY');
+
+      fireEvent.change(input, { target: { value: '11/2/YYYY' } }); // Press "2"
+      fireEvent.change(input, { target: { value: '11/5/YYYY' } }); // Press "5"
+      expectInputValue(input, '11/25/YYYY');
+
+      fireEvent.change(input, { target: { value: '11/25/2' } }); // Press "2"
+      fireEvent.change(input, { target: { value: '11/25/0' } }); // Press "0"
+      expectInputValue(input, '11/25/0020');
+
+      act(() => {
+        input.blur();
+      });
+
+      setProps({ value: adapter.date(new Date(2022, 10, 23)) });
+      expectInputValue(input, '11/23/2022');
+
+      // not using clickOnInput here because it will call `runLast` on the fake timer
+      act(() => {
+        fireEvent.mouseDown(input);
+        fireEvent.mouseUp(input);
+        input.setSelectionRange(6, 9);
+        fireEvent.click(input);
+      });
+
+      fireEvent.change(input, { target: { value: '11/23/2' } }); // Press "2"
+      fireEvent.change(input, { target: { value: '11/23/1' } }); // Press "0"
+      expectInputValue(input, '11/23/0021');
+    });
   });
 
   describeAdapters(

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -420,6 +420,12 @@ export const useField = <
   }, [valueManager, validationError, error]);
 
   React.useEffect(() => {
+    if (!inputError && !selectedSectionIndexes) {
+      resetCharacterQuery();
+    }
+  }, [state.referenceValue, selectedSectionIndexes, inputError]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  React.useEffect(() => {
     // Select the right section when focused on mount (`autoFocus = true` on the input)
     if (inputRef.current && inputRef.current === document.activeElement) {
       setSelectedSections('all');


### PR DESCRIPTION
Guys, just saw your [PR](https://github.com/mui/mui-x/pull/9385) for solving https://github.com/mui/mui-x/issues/9357, thought I might contribute my findings, since I think the underlying issue is still not solved. For example, let's say I have a managed datepicker with a value passed from the outside. If the value passed in changes, the internal query state is not cleared and the same problem can be observed that I've described in https://github.com/mui/mui-x/issues/9357.

In the issue @alexfauquette noted that the internal state could be cleared whenever...
> the value is updated for another reason than typing digits

This got me thinking a bit and I saw that you guys also keep track of a `referenceValue`, which, according to the docs, only changes, if...

> [...] It is updated whenever we have a valid date (for the range picker we update only the portion of the range that is valid).

I don't have much insight into your code base, but after some investigation, I think calling `resetCharacterQuery` whenever the `referenceValue` changes and there is no `inputError` present should completely solve the issue.

Also, since you've commented in my issue as well, mentioning @flaviendelangle.
Would be great to have your opinions on the proposed change, there are some open issues since the tests didn't run locally, I am probably missing something here...