### PR TITLE
Update MultiSectionDigitalClockSection.tsx static height to maxHeight

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -70,7 +70,7 @@ const MultiSectionDigitalClockSectionRoot = styled(MenuList, {
       display: 'block',
       content: '""',
       // subtracting the height of one item, extra margin and borders to make sure the max height is correct
-      height: 'calc(100% - 40px - 6px)',
+      maxHeight: 'calc(100% - 40px - 6px)',
     },
   }),
 );


### PR DESCRIPTION
The time picker is taking extra space, which you get when scroll to the bottom, due to the static height, Is it better to make it max height, rather than a height? or may be this could be removed totaly

