### PR TITLE
[DataGridPro] checkboxSelection & treeData/grouping bug

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -704,6 +704,7 @@ describe('<DataGridPro /> - Tree Data', () => {
   });
 
   describe('regressions', () => {
+    // See https://github.com/mui/mui-x/issues/9402
     it('should not fail with checkboxSelection', () => {
       const initialRows = rowsWithoutGap;
       const { setProps } = render(<Test checkboxSelection rows={initialRows} />);

--- a/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -702,4 +702,17 @@ describe('<DataGridPro /> - Tree Data', () => {
       ]);
     });
   });
+
+  describe('regressions', () => {
+    it('should not fail with checkboxSelection', () => {
+      const initialRows = rowsWithoutGap;
+      const { setProps } = render(<Test checkboxSelection rows={initialRows} />);
+
+      const newRows = [...initialRows];
+      newRows.splice(7, 1);
+      setProps({
+        rows: newRows,
+      });
+    });
+  });
 });

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/gridPaginationSelector.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/gridPaginationSelector.ts
@@ -103,14 +103,18 @@ export const gridPaginationRowRangeSelector = createSelectorMemoized(
       topLevelRowAdded <= topLevelRowsInCurrentPageCount
     ) {
       const row = visibleSortedRowEntries[lastRowIndex];
-      const depth = rowTree[row.id].depth;
+      const depth = rowTree[row.id]?.depth;
 
-      if (topLevelRowAdded < topLevelRowsInCurrentPageCount || depth > 0) {
+      if (depth === undefined) {
         lastRowIndex += 1;
-      }
+      } else {
+        if (topLevelRowAdded < topLevelRowsInCurrentPageCount || depth > 0) {
+          lastRowIndex += 1;
+        }
 
-      if (depth === 0) {
-        topLevelRowAdded += 1;
+        if (depth === 0) {
+          topLevelRowAdded += 1;
+        }
       }
     }
 


### PR DESCRIPTION
Closes #9402

The selector tries to index a rowTree that refers to new values with an old value.