### PR TITLE
[DateTimePicker] Scroll to Digital Clock section only when selection changes

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -157,6 +157,10 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
         '[role="option"][aria-selected="true"]',
       );
       if (!selectedItem || previousSelected.current === selectedItem) {
+        // Handle setting the ref to null if the selected item is ever reset via UI
+        if (previousSelected.current !== selectedItem) {
+          previousSelected.current = selectedItem;
+        }
         return;
       }
       previousSelected.current = selectedItem;

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -120,6 +120,7 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
   ) {
     const containerRef = React.useRef<HTMLUListElement>(null);
     const handleRef = useForkRef(ref, containerRef);
+    const previousSelected = React.useRef<HTMLElement | null>(null);
 
     const props = useThemeProps({
       props: inProps,
@@ -155,9 +156,10 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
       const selectedItem = containerRef.current.querySelector<HTMLElement>(
         '[role="option"][aria-selected="true"]',
       );
-      if (!selectedItem) {
+      if (!selectedItem || previousSelected.current === selectedItem) {
         return;
       }
+      previousSelected.current = selectedItem;
       if (active && autoFocus) {
         selectedItem.focus();
       }


### PR DESCRIPTION
Fixes #9389 

This change results in a new compromise: we no longer scroll when selecting an already selected item.
Ant design also has the same compromise: https://ant.design/components/date-picker