### PR TITLE
[Grid] correctly reflect TablePagination's rowsPerPageOptions shape

### DIFF
--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -13,6 +13,13 @@ By default, each page contains 100 rows. The user can change the size of the pag
 
 You can configure the page size the user can choose from with the `pageSizeOptions` prop.
 
+It's possible to customize the options shown in the "Rows per page" select using the `pageSizeOptions` prop.
+You should either provide an array of:
+
+- **numbers**, each number will be used for the option's label and value.
+
+- **objects**, the `value` and `label` keys will be used respectively for the value and label of the option (useful for language strings such as 'All').
+
 {{"demo": "PageSizeCustomOptions.js", "bg": "inline"}}
 
 ### Automatic page size

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -180,7 +180,7 @@
     "onRowsScrollEnd": { "type": { "name": "func" } },
     "onSortModelChange": { "type": { "name": "func" } },
     "pageSizeOptions": {
-      "type": { "name": "arrayOf", "description": "Array&lt;number&gt;" },
+      "type": { "name": "arrayOf", "description": "Array&lt;number<br>&#124;&nbsp;{ label: string, value: number }&gt;" },
       "default": "[25, 50, 100]"
     },
     "pagination": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -159,7 +159,7 @@
     "onRowsScrollEnd": { "type": { "name": "func" } },
     "onSortModelChange": { "type": { "name": "func" } },
     "pageSizeOptions": {
-      "type": { "name": "arrayOf", "description": "Array&lt;number&gt;" },
+      "type": { "name": "arrayOf", "description": "Array&lt;number<br>&#124;&nbsp;{ label: string, value: number }&gt;" },
       "default": "[25, 50, 100]"
     },
     "pagination": { "type": { "name": "bool" } },

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -124,7 +124,7 @@
     "onRowSelectionModelChange": { "type": { "name": "func" } },
     "onSortModelChange": { "type": { "name": "func" } },
     "pageSizeOptions": {
-      "type": { "name": "arrayOf", "description": "Array&lt;number&gt;" },
+      "type": { "name": "arrayOf", "description": "Array&lt;number<br>&#124;&nbsp;{ label: string, value: number }&gt;" },
       "default": "[25, 50, 100]"
     },
     "paginationMode": {

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -773,7 +773,15 @@ DataGridPremiumRaw.propTypes = {
    * Select the pageSize dynamically using the component UI.
    * @default [25, 50, 100]
    */
-  pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+  pageSizeOptions: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.number.isRequired,
+      }),
+    ]),
+  ),
   /**
    * If `true`, pagination is enabled.
    * @default false

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -708,7 +708,15 @@ DataGridProRaw.propTypes = {
    * Select the pageSize dynamically using the component UI.
    * @default [25, 50, 100]
    */
-  pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+  pageSizeOptions: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.number.isRequired,
+      }),
+    ]),
+  ),
   /**
    * If `true`, pagination is enabled.
    * @default false

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -536,7 +536,15 @@ DataGridRaw.propTypes = {
    * Select the pageSize dynamically using the component UI.
    * @default [25, 50, 100]
    */
-  pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+  pageSizeOptions: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.number.isRequired,
+      }),
+    ]),
+  ),
   pagination: (props: any) => {
     if (props.pagination === false) {
       return new Error(

--- a/packages/grid/x-data-grid/src/joy/joySlots.tsx
+++ b/packages/grid/x-data-grid/src/joy/joySlots.tsx
@@ -363,10 +363,13 @@ const Pagination = React.forwardRef<
       <JoyFormControl orientation="horizontal" size="sm">
         <JoyFormLabel>Rows per page:</JoyFormLabel>
         <JoySelect<number> onChange={handleChangeRowsPerPage} value={pageSize}>
-          {pageSizeOptions.map((option) => {
+          {pageSizeOptions.map((option: number | { label: string; value: number }) => {
             return (
-              <Option value={option} key={option}>
-                {option}
+              <Option
+                value={typeof option !== 'number' && option.value ? option.value : option}
+                key={typeof option !== 'number' && option.label ? option.label : `${option}`}
+              >
+                {typeof option !== 'number' && option.label ? option.label : `${option}`}
               </Option>
             );
           })}

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -288,7 +288,7 @@ export interface DataGridPropsWithDefaultValues {
    * Select the pageSize dynamically using the component UI.
    * @default [25, 50, 100]
    */
-  pageSizeOptions: number[];
+  pageSizeOptions: Array<number | { value: number; label: string }>;
   /**
    * Sets the type of space between rows added by `getRowSpacing`.
    * @default "margin"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I have noticed that the Data Grids in this repository uses TablePagination component of material-ui which have a prop called rowsPerPageOptions. And the Data Grids rename it as pageSizeOptions but fails to reflect original type of this prop. The current pageSizeOptions prop says it only accepts array of numbers but in reality also accepts array of objects (with the keys of label and value) because TablePagination accepts it. So, I have made necessary changes to docs, prop-types, type, and to JoySlots code in order for users to make aware of this usage. 