### PR TITLE
[CHANGELOG] Clarify each plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,17 +155,25 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.9.0` / `@mui/x-data-grid-pro@v6.9.0` / `@mui/x-data-grid-premium@v6.9.0`
+### Data Grid
 
-#### Changes
+#### `@mui/x-data-grid@v6.9.0`
 
 - [DataGrid] Filtering performance: use unmemoized selectors by default (#9287) @romgrk
 - [DataGrid] Use container dimensions from `getComputedStyle` (#9236) @m4theushw
 - [l10n] Improve Brazilian Portuguese (pt-BR) locale (#9404) @julioAz
 
-### `@mui/x-date-pickers@v6.9.0` / `@mui/x-date-pickers-pro@v6.9.0`
+#### `@mui/x-data-grid-pro@v6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-data-grid@v6.9.0`.
+
+#### `@mui/x-data-grid-premium@v6.9.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+
+Same changes as in `@mui/x-data-grid-pro@v6.9.0`.
+
+### Date Pickers
+
+#### `@mui/x-date-pickers@v6.9.0`
 
 - [fields] Ensure `minutesStep` is respected by fields arrows up/down (#9338) @alexfauquette
 - [fields] Reset internal state when `referenceValue` changes (#9390) @adrianmxb
@@ -175,9 +183,11 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [pickers] Reduce date range calendar vertical border width (#9368) @oliviertassinari
 - [pickers] Reset fields internal state when pasting value (#9385) @alexfauquette
 
-### `@mui/x-charts@v6.0.0-alpha.0`
+#### `@mui/x-date-pickers-pro@v6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-date-pickers@v6.9.0`.
+
+### `@mui/x-charts@v6.0.0-alpha.0`
 
 - [charts] Allow to customize colors based on the theme mode (#9006) @alexfauquette
 - [charts] Prepare the charts release (#9361) @alexfauquette
@@ -213,9 +223,9 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@6.8.0` / `@mui/x-data-grid-pro@6.8.0` / `@mui/x-data-grid-premium@6.8.0`
+### Data Grid
 
-#### Changes
+#### `@mui/x-data-grid@6.8.0`
 
 - [DataGrid] Add missing styles to `overridesResolver` (#9248) @mrmuhammadali
 - [DataGrid] Keep column header menu icon always visible on touch devices (#9076) @cherniavskii
@@ -229,14 +239,26 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [DataGrid] Scroll performance improvements (#9037) @romgrk
 - [l10n] Improve Greek (el-GR) locale (#9292) @clytras
 
-### `@mui/x-date-pickers@6.8.0` / `@mui/x-date-pickers-pro@6.8.0`
+#### `@mui/x-data-grid-pro@6.8.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-data-grid@6.8.0`.
+
+#### `@mui/x-data-grid-premium@6.8.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+
+Same changes as in `@mui/x-data-grid-pro@6.8.0`.
+
+### Pickers
+
+#### `@mui/x-date-pickers@6.8.0`
 
 - [l10n] Add Greek (el-GR) locale (#9293) @clytras
 - [pickers] Add a `referenceDate` prop on `DateCalendar`, `MonthCalendar` and `YearCalendar` (#9260) @flaviendelangle
 - [pickers] Close the calendar when a shortcut is selected (#9080) @flaviendelangle
 - [pickers] Fix disabling for digital clock (#9300) @alexfauquette
+
+#### `@mui/x-date-pickers-pro@6.8.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+
+Same changes as in `@mui/x-date-pickers@6.8.0`.
 
 ### Docs
 
@@ -295,9 +317,9 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.7.0` / `@mui/x-data-grid-pro@v6.7.0` / `@mui/x-data-grid-premium@v6.7.0`
+### Data Grid
 
-#### Changes
+#### `@mui/x-data-grid@v6.7.0`
 
 - [DataGrid] Allow overflowing grid root element (#9179) @cherniavskii
 - [DataGrid] Fix module augmentation error when using `@mui/lab` (#9235) @cherniavskii
@@ -306,19 +328,34 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [DataGrid] Improve grouping performance for large datasets (#9200) @romgrk
 - [DataGrid] Increase threshold to trigger memory leak warning (#9263) @m4theushw
 - [DataGrid] Update data grid migration guide to include updated type (#9272) @MBilalShafi
-- [DataGridPro] Improve header filter menu visuals (#9181) @MBilalShafi
-- [DataGridPremium] Remove last line break on clipboard paste (#9163) @cherniavskii
 - [l10n] Improve Czech (cs-CZ) locale (#9266) @MartinSkarpa
 - [l10n] Improve German (de-DE) locale (#9259) @ximex
 - [l10n] Improve Turkish (tr-TR) locale (#9237) @MCErtan
 
-### `@mui/x-date-pickers@v6.7.0` / `@mui/x-date-pickers-pro@v6.7.0`
+#### `@mui/x-data-grid-pro@v6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-data-grid@v6.7.0`, plus:
+
+- [DataGridPro] Improve header filter menu visuals (#9181) @MBilalShafi
+
+#### `@mui/x-data-grid-premium@v6.7.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+
+Same changes as in `@mui/x-data-grid-pro@v6.7.0`, plus:
+
+- [DataGridPremium] Remove last line break on clipboard paste (#9163) @cherniavskii
+
+### Pickers
+
+#### `@mui/x-date-pickers@v6.7.0`
 
 - [l10n] Add Romanian (ro-RO) locale (#9257) @ximex
 - [l10n] Improve German (de-DE) locale (#9258) @ximex
 - [pickers] Apply dynamic default format depending on views for all desktop and mobile pickers (#9126) @flaviendelangle
+
+#### `@mui/x-date-pickers-pro@v6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+
+Same changes as in `@mui/x-date-pickers@v6.7.0`, plus:
+
 - [pickers] Update `DateRangePickerDay` props JSDoc (#9191) @stevus
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
 Same changes as in `@mui/x-data-grid@6.9.2`.
 
-#### `@mui/x-data-grid-premium@6.9.2`  [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
 
 Same changes as in `@mui/x-data-grid-pro@6.9.2`, plus:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
 ### Data Grid
 
-#### `@mui/x-data-grid@v6.9.2`
+#### `@mui/x-data-grid@6.9.2`
 
 - [DataGrid] Fix `RangeError` when using flex columns (#9554) @cherniavskii
 - [DataGrid] Fix React 17 editing bug (#9530) @romgrk
@@ -35,28 +35,28 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [DataGrid] Correctly reflect `TablePagination`'s `rowsPerPageOptions` shape to `pageSizeOptions` (#9438) @burakkgunduzz
 - [l10n] Improve Spanish (es-ES) locale (#9500) @fufex
 
-#### `@mui/x-data-grid-pro@v6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-data-grid@v6.9.2`.
+Same changes as in `@mui/x-data-grid@6.9.2`.
 
-#### `@mui/x-data-grid-premium@v6.9.2`  [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.2`  [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
 
-Same changes as in `@mui/x-data-grid-pro@v6.9.2`, plus:
+Same changes as in `@mui/x-data-grid-pro@6.9.2`, plus:
 
 - [DataGridPremium] Auto-scroll when making range selection (#8661) @m4theushw
 
 ### Date Pickers
 
-#### `@mui/x-date-pickers@v6.9.2`
+#### `@mui/x-date-pickers@6.9.2`
 
 - [pickers] Forward digital clock classes (#9555) @YoonjiJang
 - [pickers] Rename `internal` folder to `internals` on `@mui/x-date-picker-pro` (#9571) @flaviendelangle
 
-#### `@mui/x-date-pickers-pro@v6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-date-pickers@v6.9.2`.
+Same changes as in `@mui/x-date-pickers@6.9.2`.
 
-### `@mui/x-charts@6.0.0-alpha.2`
+### Charts / `@mui/x-charts@6.0.0-alpha.2`
 
 - [charts] Add pie chart component (#9395) @alexfauquette
 
@@ -90,7 +90,7 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 
 ### Data Grid
 
-#### `@mui/x-data-grid@v6.9.1`
+#### `@mui/x-data-grid@6.9.1`
 
 - [DataGrid] Add Joy UI `tooltip` and `loadingOverlay` slots (#9028) @cherniavskii
 - [DataGrid] Add section about enabling pagination on Pro and Premium (#8759) @joserodolfofreitas
@@ -100,20 +100,20 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [DataGrid] Fix `Maximum call stack size exceeded` error when using fractional width (#9516) @cherniavskii
 - [l10n] Improve Romanian (ro-RO) and Hungarian (hu-HU) translations (#9436) @noraleonte
 
-#### `@mui/x-data-grid-pro@v6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-data-grid@v6.9.1`, plus:
+Same changes as in `@mui/x-data-grid@6.9.1`, plus:
 
 - [DataGridPro] Don't throw error in column pinning (#9507) @romgrk
 - [DataGridPro] Fix bug with `checkboxSelection` and treeData/grouping (#9418) @romgrk
 
-#### `@mui/x-data-grid-premium@v6.9.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
 
-Same changes as in `@mui/x-data-grid-pro@v6.9.1`.
+Same changes as in `@mui/x-data-grid-pro@6.9.1`.
 
 ### Date Pickers
 
-#### `@mui/x-date-pickers@v6.9.1`
+#### `@mui/x-date-pickers@6.9.1`
 
 - [DateTimePicker] Scroll to Digital Clock section only when selection changes (#9434) @LukasTy
 - [pickers] Handle `keyDown` only when input is focused (#9481) @LukasTy
@@ -121,13 +121,11 @@ Same changes as in `@mui/x-data-grid-pro@v6.9.1`.
 - [l10n] Add Chinese (Hong Kong) (zh-HK) locale (#9468) @samchiu90
 - [l10n] Improve Romanian (ro-RO) translations (#9436) @noraleonte
 
-#### `@mui/x-date-pickers-pro@v6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-date-pickers@v6.9.1`.
+Same changes as in `@mui/x-date-pickers@6.9.1`.
 
-### Charts
-
-#### `@mui/x-charts@6.0.0-alpha.1`
+### Charts / `@mui/x-charts@6.0.0-alpha.1`
 
 - [charts] Take responsive container from data grid (#9497) @alexfauquette
 - [charts] Update README.md (#9426) @alexfauquette
@@ -181,23 +179,23 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
 ### Data Grid
 
-#### `@mui/x-data-grid@v6.9.0`
+#### `@mui/x-data-grid@6.9.0`
 
 - [DataGrid] Filtering performance: use unmemoized selectors by default (#9287) @romgrk
 - [DataGrid] Use container dimensions from `getComputedStyle` (#9236) @m4theushw
 - [l10n] Improve Brazilian Portuguese (pt-BR) locale (#9404) @julioAz
 
-#### `@mui/x-data-grid-pro@v6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-data-grid@v6.9.0`.
+Same changes as in `@mui/x-data-grid@6.9.0`.
 
-#### `@mui/x-data-grid-premium@v6.9.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
 
-Same changes as in `@mui/x-data-grid-pro@v6.9.0`.
+Same changes as in `@mui/x-data-grid-pro@6.9.0`.
 
 ### Date Pickers
 
-#### `@mui/x-date-pickers@v6.9.0`
+#### `@mui/x-date-pickers@6.9.0`
 
 - [fields] Ensure `minutesStep` is respected by fields arrows up/down (#9338) @alexfauquette
 - [fields] Reset internal state when `referenceValue` changes (#9390) @adrianmxb
@@ -207,11 +205,11 @@ Same changes as in `@mui/x-data-grid-pro@v6.9.0`.
 - [pickers] Reduce date range calendar vertical border width (#9368) @oliviertassinari
 - [pickers] Reset fields internal state when pasting value (#9385) @alexfauquette
 
-#### `@mui/x-date-pickers-pro@v6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-date-pickers@v6.9.0`.
+Same changes as in `@mui/x-date-pickers@6.9.0`.
 
-### `@mui/x-charts@v6.0.0-alpha.0`
+### Charts / `@mui/x-charts@6.0.0-alpha.0`
 
 - [charts] Allow to customize colors based on the theme mode (#9006) @alexfauquette
 - [charts] Prepare the charts release (#9361) @alexfauquette
@@ -271,7 +269,7 @@ Same changes as in `@mui/x-data-grid@6.8.0`.
 
 Same changes as in `@mui/x-data-grid-pro@6.8.0`.
 
-### Pickers
+### Date Pickers
 
 #### `@mui/x-date-pickers@6.8.0`
 
@@ -343,7 +341,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 
 ### Data Grid
 
-#### `@mui/x-data-grid@v6.7.0`
+#### `@mui/x-data-grid@6.7.0`
 
 - [DataGrid] Allow overflowing grid root element (#9179) @cherniavskii
 - [DataGrid] Fix module augmentation error when using `@mui/lab` (#9235) @cherniavskii
@@ -356,29 +354,29 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [l10n] Improve German (de-DE) locale (#9259) @ximex
 - [l10n] Improve Turkish (tr-TR) locale (#9237) @MCErtan
 
-#### `@mui/x-data-grid-pro@v6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-data-grid@v6.7.0`, plus:
+Same changes as in `@mui/x-data-grid@6.7.0`, plus:
 
 - [DataGridPro] Improve header filter menu visuals (#9181) @MBilalShafi
 
-#### `@mui/x-data-grid-premium@v6.7.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.7.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
 
-Same changes as in `@mui/x-data-grid-pro@v6.7.0`, plus:
+Same changes as in `@mui/x-data-grid-pro@6.7.0`, plus:
 
 - [DataGridPremium] Remove last line break on clipboard paste (#9163) @cherniavskii
 
 ### Pickers
 
-#### `@mui/x-date-pickers@v6.7.0`
+#### `@mui/x-date-pickers@6.7.0`
 
 - [l10n] Add Romanian (ro-RO) locale (#9257) @ximex
 - [l10n] Improve German (de-DE) locale (#9258) @ximex
 - [pickers] Apply dynamic default format depending on views for all desktop and mobile pickers (#9126) @flaviendelangle
 
-#### `@mui/x-date-pickers-pro@v6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-Same changes as in `@mui/x-date-pickers@v6.7.0`, plus:
+Same changes as in `@mui/x-date-pickers@6.7.0`, plus:
 
 - [pickers] Update `DateRangePickerDay` props JSDoc (#9191) @stevus
 
@@ -413,7 +411,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - 🌍 Improve Dutch (nl-NL) and French (fr-FR) locales on the data grid
 - 🌍 Add Vietnamese (vi-VN) locale on the pickers
 
-### `@mui/x-data-grid@v6.6.0` / `@mui/x-data-grid-pro@v6.6.0` / `@mui/x-data-grid-premium@v6.6.0`
+### `@mui/x-data-grid@6.6.0` / `@mui/x-data-grid-pro@6.6.0` / `@mui/x-data-grid-premium@6.6.0`
 
 #### Changes
 
@@ -431,7 +429,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [l10n] Improve Dutch (nl-NL) locale (#9043) @thedutchruben
 - [l10n] Improve French (fr-FR) locale (#9109) @Jul13nT
 
-### `@mui/x-date-pickers@v6.6.0` / `@mui/x-date-pickers-pro@v6.6.0`
+### `@mui/x-date-pickers@6.6.0` / `@mui/x-date-pickers-pro@6.6.0`
 
 #### Changes
 
@@ -546,7 +544,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.4.0` / `@mui/x-data-grid-pro@v6.4.0` / `@mui/x-data-grid-premium@v6.4.0`
+### `@mui/x-data-grid@6.4.0` / `@mui/x-data-grid-pro@6.4.0` / `@mui/x-data-grid-premium@6.4.0`
 
 #### Changes
 
@@ -556,12 +554,12 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [DataGrid] Add Joy UI pagination slot (#8871) @cherniavskii
 - [DataGrid] Extract `baseChip` slot (#8748) @cherniavskii
 - [DataGridPremium] Implement Clipboard import (#7389) @cherniavskii
-- [l10n] Improve French (fr-FR) locale (#8825) @vallereaugabriel
+- [l10n] Improve French (fr-FR) locale (#8825) @allereaugabriel
 - [l10n] Improve German (de-DE) locale (#8898) @marcauberer
 - [l10n] Improve Portuguese (pt-BR) locale (#8960) @Sorriso337
 - [l10n] Improve Ukrainian (uk-UA) locale (#8863) @Neonin
 
-### `@mui/x-date-pickers@v6.4.0` / `@mui/x-date-pickers-pro@v6.4.0`
+### `@mui/x-date-pickers@6.4.0` / `@mui/x-date-pickers-pro@6.4.0`
 
 #### Changes
 
@@ -595,7 +593,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.3.1` / `@mui/x-data-grid-pro@v6.3.1` / `@mui/x-data-grid-premium@v6.3.1`
+### `@mui/x-data-grid@6.3.1` / `@mui/x-data-grid-pro@6.3.1` / `@mui/x-data-grid-premium@6.3.1`
 
 #### Changes
 
@@ -606,7 +604,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [DataGrid] Add Joy UI slots (`Select`, `SelectOption`, `InputLabel`, `FormControl`) (#8747) @cherniavskii
 - [DataGridPremium] Fix expanded groups being collapsed after calling `updateRows` (#8823) @cherniavskii
 
-### `@mui/x-date-pickers@v6.3.1` / `@mui/x-date-pickers-pro@v6.3.1`
+### `@mui/x-date-pickers@6.3.1` / `@mui/x-date-pickers-pro@6.3.1`
 
 #### Changes
 
@@ -647,7 +645,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.3.0` / `@mui/x-data-grid-pro@v6.3.0` / `@mui/x-data-grid-premium@v6.3.0`
+### `@mui/x-data-grid@6.3.0` / `@mui/x-data-grid-pro@6.3.0` / `@mui/x-data-grid-premium@6.3.0`
 
 #### Changes
 
@@ -662,7 +660,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [l10n] Improve French (fr-FR) locale (#8704) @Jul13nT
 - [l10n] Improve Turkish (tr-TR) locale (#8783) @cccaaannn
 
-### `@mui/x-date-pickers@v6.3.0` / `@mui/x-date-pickers-pro@v6.3.0`
+### `@mui/x-date-pickers@6.3.0` / `@mui/x-date-pickers-pro@6.3.0`
 
 #### Changes
 
@@ -711,7 +709,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.2.1` / `@mui/x-data-grid-pro@v6.2.1` / `@mui/x-data-grid-premium@v6.2.1`
+### `@mui/x-data-grid@6.2.1` / `@mui/x-data-grid-pro@6.2.1` / `@mui/x-data-grid-premium@6.2.1`
 
 #### Changes
 
@@ -722,14 +720,14 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [DataGrid] Use stable ID for the placeholder filter item (#8603) @m4theushw
 - [DataGridPro] Virtualize row detail panels (#7969) @yaredtsy
 
-### `@mui/x-date-pickers@v6.2.1` / `@mui/x-date-pickers-pro@v6.2.1`
+### `@mui/x-date-pickers@6.2.1` / `@mui/x-date-pickers-pro@6.2.1`
 
 #### Changes
 
 - [pickers] Do not include the time in date components when going to today (#8657) @flaviendelangle
 - [pickers] Sync internal state with controlled value (#8674) @alexfauquette
 
-### `@mui/x-codemod@v6.2.1`
+### `@mui/x-codemod@6.2.1`
 
 #### Changes
 
@@ -769,16 +767,16 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.2.0` / `@mui/x-data-grid-pro@v6.2.0` / `@mui/x-data-grid-premium@v6.2.0`
+### `@mui/x-data-grid@6.2.0` / `@mui/x-data-grid-pro@6.2.0` / `@mui/x-data-grid-premium@6.2.0`
 
 #### Changes
 
 - [DataGrid] Reset selection state on `checkboxSelection` toggle (#8522) @MBilalShafi
 - [DataGrid] Use `baseSelect` slot instead of `baseTextField` with `select={true}` (#8110) @cherniavskii
-- [l10n] Improve French (fr-FR) locale (#8537) @vallereaugabriel
+- [l10n] Improve French (fr-FR) locale (#8537) @allereaugabriel
 - [l10n] Improve Urdu (ur-PK) locale (#8513) @SFARPak
 
-### `@mui/x-date-pickers@v6.2.0` / `@mui/x-date-pickers-pro@v6.2.0`
+### `@mui/x-date-pickers@6.2.0` / `@mui/x-date-pickers-pro@6.2.0`
 
 #### Changes
 
@@ -812,7 +810,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.1.0` / `@mui/x-data-grid-pro@v6.1.0` / `@mui/x-data-grid-premium@v6.1.0`
+### `@mui/x-data-grid@6.1.0` / `@mui/x-data-grid-pro@6.1.0` / `@mui/x-data-grid-premium@6.1.0`
 
 #### Changes
 
@@ -827,7 +825,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [l10n] Improve Portuguese (pt-BR) locale (#8480) @pwnedev
 - [l10n] Improve Russian (ru-RU) locale (#8510) @alexrapro
 
-### `@mui/x-date-pickers@v6.1.0` / `@mui/x-date-pickers-pro@v6.1.0`
+### `@mui/x-date-pickers@6.1.0` / `@mui/x-date-pickers-pro@6.1.0`
 
 #### Changes
 
@@ -869,7 +867,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.0.4` / `@mui/x-data-grid-pro@v6.0.4` / `@mui/x-data-grid-premium@v6.0.4`
+### `@mui/x-data-grid@6.0.4` / `@mui/x-data-grid-pro@6.0.4` / `@mui/x-data-grid-premium@6.0.4`
 
 #### Changes
 
@@ -887,7 +885,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [l10n] Improve Spanish (es-ES) locale (#8420) @martjanz
 - [l10n] Improve Swedish (sv-SE) locale (#8381) @BossElijah
 
-### `@mui/x-date-pickers@v6.0.4` / `@mui/x-date-pickers-pro@v6.0.4`
+### `@mui/x-date-pickers@6.0.4` / `@mui/x-date-pickers-pro@6.0.4`
 
 #### Changes
 
@@ -903,7 +901,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [l10n] Add Danish (da-DK) locale (#8379) @BossElijah
 - [l10n] Improve Swedish (sv-SE) locale (#8381) @BossElijah
 
-### `@mui/x-codemod@v6.0.4`
+### `@mui/x-codemod@6.0.4`
 
 #### Changes
 
@@ -930,7 +928,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.0.3` / `@mui/x-data-grid-pro@v6.0.3` / `@mui/x-data-grid-premium@v6.0.3`
+### `@mui/x-data-grid@6.0.3` / `@mui/x-data-grid-pro@6.0.3` / `@mui/x-data-grid-premium@6.0.3`
 
 #### Changes
 
@@ -940,7 +938,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [l10n] Improve Persian (fa-IR) locale (#8268) @fakhamatia
 - [l10n] improve Dutch (nl-NL) locale (#8317) @developenguin
 
-### `@mui/x-date-pickers@v6.0.3` / `@mui/x-date-pickers-pro@v6.0.3`
+### `@mui/x-date-pickers@6.0.3` / `@mui/x-date-pickers-pro@6.0.3`
 
 #### Changes
 
@@ -987,7 +985,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.2` / `@mui/x-data-grid-pro@v6.0.2` / `@mui/x-data-grid-premium@v6.0.2`
+### `@mui/x-data-grid@6.0.2` / `@mui/x-data-grid-pro@6.0.2` / `@mui/x-data-grid-premium@6.0.2`
 
 #### Changes
 
@@ -995,7 +993,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGrid] Remove warning when adding a custom column type (#8227) @m4theushw
 - [l10n] Improve Brazilian Portuguese (pt-BR) locale (#8198) @JoaoSerafim3001
 
-### `@mui/x-date-pickers@v6.0.2` / `@mui/x-date-pickers-pro@v6.0.2`
+### `@mui/x-date-pickers@6.0.2` / `@mui/x-date-pickers-pro@6.0.2`
 
 #### Changes
 
@@ -1037,7 +1035,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.1` / `@mui/x-data-grid-pro@v6.0.1` / `@mui/x-data-grid-premium@v6.0.1`
+### `@mui/x-data-grid@6.0.1` / `@mui/x-data-grid-pro@6.0.1` / `@mui/x-data-grid-premium@6.0.1`
 
 #### Changes
 
@@ -1045,7 +1043,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [DataGrid] Simplify `buildPrintWindow` (#8142) @oliviertassinari
 - [l10n] Improve French (fr-FR) locale (#8122) @MaherSamiGMC
 
-### `@mui/x-date-pickers@v6.0.1` / `@mui/x-date-pickers-pro@v6.0.1`
+### `@mui/x-date-pickers@6.0.1` / `@mui/x-date-pickers-pro@6.0.1`
 
 #### Changes
 
@@ -1096,7 +1094,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0` / `@mui/x-data-grid-pro@v6.0.0` / `@mui/x-data-grid-premium@v6.0.0`
+### `@mui/x-data-grid@6.0.0` / `@mui/x-data-grid-pro@6.0.0` / `@mui/x-data-grid-premium@6.0.0`
 
 #### Breaking changes
 
@@ -1119,7 +1117,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [l10n] Improve Czech (cs-CZ) locale (#8113) @BlastyCZ
 - [l10n] Improve Arabic (ar-SD) locale (#8100) @atf98
 
-### `@mui/x-date-pickers@v6.0.0` / `@mui/x-date-pickers-pro@v6.0.0`
+### `@mui/x-date-pickers@6.0.0` / `@mui/x-date-pickers-pro@6.0.0`
 
 #### Breaking changes
 
@@ -1177,7 +1175,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-beta.5` / `@mui/x-data-grid-pro@v6.0.0-beta.5` / `@mui/x-data-grid-premium@v6.0.0-beta.5`
+### `@mui/x-data-grid@6.0.0-beta.5` / `@mui/x-data-grid-pro@6.0.0-beta.5` / `@mui/x-data-grid-premium@6.0.0-beta.5`
 
 #### Changes
 
@@ -1187,7 +1185,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [DataGridPro] Add `Remove All` option in filter panel (#7326) @MBilalShafi
 - [DataGridPremium] Add web worker support for Excel export (#7770) @m4theushw
 
-### `@mui/x-date-pickers@v6.0.0-beta.5` / `@mui/x-date-pickers-pro@v6.0.0-beta.5`
+### `@mui/x-date-pickers@6.0.0-beta.5` / `@mui/x-date-pickers-pro@6.0.0-beta.5`
 
 #### Breaking changes
 
@@ -1202,7 +1200,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [fields] Clean the section object (#8009) @flaviendelangle
 - [pickers] Fix `textField` slot `error` prop propagation (#7987) @LukasTy
 
-### `@mui/x-codemod@v6.0.0-beta.5`
+### `@mui/x-codemod@6.0.0-beta.5`
 
 #### Changes
 
@@ -1229,17 +1227,17 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-beta.4` / `@mui/x-data-grid-pro@v6.0.0-beta.4` / `@mui/x-data-grid-premium@v6.0.0-beta.4`
+### `@mui/x-data-grid@6.0.0-beta.4` / `@mui/x-data-grid-pro@6.0.0-beta.4` / `@mui/x-data-grid-premium@6.0.0-beta.4`
 
 #### Changes
 
 - [DataGrid] Add interface for `singleSelect` column (#7685) @m4theushw
-- [DataGrid] Allow to pass props to the `TrapFocus` inside the panel wrapper (#7733) @Vivek-Prajapatii
+- [DataGrid] Allow to pass props to the `TrapFocus` inside the panel wrapper (#7733) @ivek-Prajapatii
 - [DataGrid] Avoid unnecessary rerenders after `updateRows` (#7857) @cherniavskii
 - [DataGridPro] Change cursor when dragging a column (#7725) @sai6855
 - [DataGridPremium] Fix `leafField` to have correct focus value (#7950) @MBilalShafi
 
-### `@mui/x-date-pickers@v6.0.0-beta.4` / `@mui/x-date-pickers-pro@v6.0.0-beta.4`
+### `@mui/x-date-pickers@6.0.0-beta.4` / `@mui/x-date-pickers-pro@6.0.0-beta.4`
 
 #### Changes
 
@@ -1248,7 +1246,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [fields] Support escaped characters on `Luxon` (#7888) @flaviendelangle
 - [pickers] Prepare new pickers for custom fields (#7806) @flaviendelangle
 
-### `@mui/x-codemod@v6.0.0-beta.4`
+### `@mui/x-codemod@6.0.0-beta.4`
 
 #### Changes
 
@@ -1278,7 +1276,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-beta.3` / `@mui/x-data-grid-pro@v6.0.0-beta.3` / `@mui/x-data-grid-premium@v6.0.0-beta.3`
+### `@mui/x-data-grid@6.0.0-beta.3` / `@mui/x-data-grid-pro@6.0.0-beta.3` / `@mui/x-data-grid-premium@6.0.0-beta.3`
 
 #### Changes
 
@@ -1290,7 +1288,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [DataGrid] Improve query selectors for selecting cell element (#7354) @yaredtsy
 - [l10n] Improve Brazilian Portuguese (pt-BR) locale (#7854) @ed-ateixeira
 
-### `@mui/x-date-pickers@v6.0.0-beta.3` / `@mui/x-date-pickers-pro@v6.0.0-beta.3`
+### `@mui/x-date-pickers@6.0.0-beta.3` / `@mui/x-date-pickers-pro@6.0.0-beta.3`
 
 #### Changes
 
@@ -1302,7 +1300,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [pickers] Ditch pickers `skipLibCheck` (#7808) @LukasTy
 - [pickers] Improve JSDoc and resulting API docs pages (#7847) @LukasTy
 
-### `@mui/x-codemod@v6.0.0-beta.3`
+### `@mui/x-codemod@6.0.0-beta.3`
 
 #### Changes
 
@@ -1336,7 +1334,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bug fixes
 
-### `@mui/x-data-grid@v6.0.0-beta.2` / `@mui/x-data-grid-pro@v6.0.0-beta.2` / `@mui/x-data-grid-premium@v6.0.0-beta.2`
+### `@mui/x-data-grid@6.0.0-beta.2` / `@mui/x-data-grid-pro@6.0.0-beta.2` / `@mui/x-data-grid-premium@6.0.0-beta.2`
 
 #### Changes
 
@@ -1344,20 +1342,20 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [DataGrid] Merge row styles with `componentsProps.row.style` (#7641) @marktoman
 - [l10n] Add Hungarian (hu-HU) locale (#7776) @noherczeg
 - [l10n] Add Urdu (ur-PK) locale (#6866) @MBilalShafi
-- [l10n] Improve French (fr-FR) locale (#7777) @Vivek-Prajapatii
+- [l10n] Improve French (fr-FR) locale (#7777) @ivek-Prajapatii
 - [l10n] Improve Italian (it-IT) locale (#7761) @simonecervini
 
-### `@mui/x-date-pickers@v6.0.0-beta.2` / `@mui/x-date-pickers-pro@v6.0.0-beta.2`
+### `@mui/x-date-pickers@6.0.0-beta.2` / `@mui/x-date-pickers-pro@6.0.0-beta.2`
 
 #### Changes
 
 - [fields] Support week day formats (#7392) @flaviendelangle
 - [pickers] Allow to initialize and control the `rangePosition` on all range components (#7764) @flaviendelangle
 - [pickers] Fix theme augmentation (#7800) @LukasTy
-- [pickers] Hide scrollbars in the date calendar container (#7766) @Vivek-Prajapatii
+- [pickers] Hide scrollbars in the date calendar container (#7766) @ivek-Prajapatii
 - [pickers] Remove the dependency on `rifm` (#7785) @alexfauquette
 
-### `@mui/x-codemod@v6.0.0-beta.2`
+### `@mui/x-codemod@6.0.0-beta.2`
 
 #### Changes
 
@@ -1390,7 +1388,7 @@ We'd like to offer a big thanks to the 17 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bug fixes
 
-### `@mui/x-data-grid@v6.0.0-beta.1` / `@mui/x-data-grid-pro@v6.0.0-beta.1` / `@mui/x-data-grid-premium@v6.0.0-beta.1`
+### `@mui/x-data-grid@6.0.0-beta.1` / `@mui/x-data-grid-pro@6.0.0-beta.1` / `@mui/x-data-grid-premium@6.0.0-beta.1`
 
 #### Changes
 
@@ -1402,9 +1400,9 @@ We'd like to offer a big thanks to the 17 contributors who made this release pos
 - [l10n] Add Slovak (sk-SK) translation for aggregation functions (#7702) @msidlo
 - [l10n] Add missing core locales for `MuiTablePagination` (#7717) @MBilalShafi
 - [l10n] Improve Spanish (es-ES) and Vietnamese (vi-VN) locale (#7634) @WiXSL and @SpacerZ
-- [l10n] Add Belarusian (be-BY) locale (#7646) @volhalink
+- [l10n] Add Belarusian (be-BY) locale (#7646) @olhalink
 
-### `@mui/x-date-pickers@v6.0.0-beta.1` / `@mui/x-date-pickers-pro@v6.0.0-beta.1`
+### `@mui/x-date-pickers@6.0.0-beta.1` / `@mui/x-date-pickers-pro@6.0.0-beta.1`
 
 #### Changes
 
@@ -1416,7 +1414,7 @@ We'd like to offer a big thanks to the 17 contributors who made this release pos
 - [l10n] Add Russian (ru-RU) locale (#7706) @rstmzh
 - [l10n] Improve Japanese (ja-JP) locale (#7624) @makoto14
 
-### `@mui/x-codemod@v6.0.0-beta.1`
+### `@mui/x-codemod@6.0.0-beta.1`
 
 #### Changes
 
@@ -1433,7 +1431,7 @@ We'd like to offer a big thanks to the 17 contributors who made this release pos
 
 ### Docs
 
-- [docs] Add info callout about available component `slots` (#7714) @Vivek-Prajapatii
+- [docs] Add info callout about available component `slots` (#7714) @ivek-Prajapatii
 - [docs] Add recipe for pinning grouped column (#7712) @MBilalShafi
 - [docs] Fix 404 links to picker API page @oliviertassinari
 - [docs] Update `DemoContainer` `components` prop using a codemod (#7574) @alexfauquette
@@ -1472,7 +1470,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bug fixes
 
-### `@mui/x-data-grid@v6.0.0-beta.0` / `@mui/x-data-grid-pro@v6.0.0-beta.0` / `@mui/x-data-grid-premium@v6.0.0-beta.0`
+### `@mui/x-data-grid@6.0.0-beta.0` / `@mui/x-data-grid-pro@6.0.0-beta.0` / `@mui/x-data-grid-premium@6.0.0-beta.0`
 
 #### Breaking changes
 
@@ -1579,7 +1577,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGridPremium] Keep focus on first selected cell (#7482) @m4theushw
 - [l10n] Update Swedish (sv-SE) locale (#7585) @MaanTyringe
 
-### `@mui/x-date-pickers@v6.0.0-beta.0` / `@mui/x-date-pickers-pro@v6.0.0-beta.0`
+### `@mui/x-date-pickers@6.0.0-beta.0` / `@mui/x-date-pickers-pro@6.0.0-beta.0`
 
 #### Breaking changes
 
@@ -1638,7 +1636,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [pickers] Stop using the `WrapperVariantContext` in `DateRangeCalendar` (#7488) @flaviendelangle
 - [l10n] Improve Italian (it-IT) locale (#7582) @marikadeveloper
 
-### `@mui/x-codemod@v6.0.0-beta.0`
+### `@mui/x-codemod@6.0.0-beta.0`
 
 #### Changes
 
@@ -1670,7 +1668,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.15` / `@mui/x-data-grid-pro@6.0.0-alpha.15` / `@mui/x-data-grid-premium@6.0.0-alpha.15`
+### `@mui/x-data-grid@6.0.0-alpha.15` / `@mui/x-data-grid-pro@6.0.0-alpha.15` / `@mui/x-data-grid-premium@6.0.0-alpha.15`
 
 #### Breaking changes
 
@@ -1789,7 +1787,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 #### Changes
 
 - [fields] Fix Android editing (#7444) @flaviendelangle
-- [pickers] Add Belarusian (be-BY) locale (#7395) @volhalink
+- [pickers] Add Belarusian (be-BY) locale (#7395) @olhalink
 - [pickers] Hide am/pm controls when there is no hour view (#7380) @flaviendelangle
 - [pickers] Hide the tabs by default on `DesktopNextDateTimePicker` (#7503) @flaviendelangle
 - [pickers] Refactor `shouldDisableTime` (#7299) @LukasTy
@@ -1828,7 +1826,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 📚 Many documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.14` / `@mui/x-data-grid-pro@v6.0.0-alpha.14` / `@mui/x-data-grid-premium@v6.0.0-alpha.14`
+### `@mui/x-data-grid@6.0.0-alpha.14` / `@mui/x-data-grid-pro@6.0.0-alpha.14` / `@mui/x-data-grid-premium@6.0.0-alpha.14`
 
 #### Breaking changes
 
@@ -1845,7 +1843,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [DataGrid] Remove remaining props from legacy editing API (#7381) @m4theushw
 - [DataGrid] Set default `GridCellParams['value']` type to `unknown` (#6959) @cherniavskii
 
-### `@mui/x-date-pickers@v6.0.0-alpha.14` / `@mui/x-date-pickers-pro@v6.0.0-alpha.14`
+### `@mui/x-date-pickers@6.0.0-alpha.14` / `@mui/x-date-pickers-pro@6.0.0-alpha.14`
 
 #### Breaking changes
 
@@ -1862,7 +1860,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [pickers] Remove the `PaperContent` slot from the new pickers (#7342) @flaviendelangle
 - [pickers] Use grid for modifying the layout (#6900) @alexfauquette
 
-### `@mui/x-codemod@v6.0.0-alpha.14`
+### `@mui/x-codemod@6.0.0-alpha.14`
 
 #### Changes
 
@@ -1985,7 +1983,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGrid] Remove `GridDensityType` enum (#7304) @cherniavskii
 - [DataGrid] Remove `rowHeight` and `headerHeight` from state (#7199) @DanailH
 - [DataGrid] Remove column separator to match table styles (#7067) @MBilalShafi
-- [DataGrid] Update Russian (ru-RU) locale (#7220) @VeceluXa
+- [DataGrid] Update Russian (ru-RU) locale (#7220) @eceluXa
 - [DataGridPro] Use row ID as `key` of the detail panels (#7302) @m4theushw
 - [DataGridPremium] Fix `exceljs` import with parcel (#7284) @alexfauquette
 
@@ -2054,7 +2052,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.12` / `@mui/x-data-grid-pro@v6.0.0-alpha.12` / `@mui/x-data-grid-premium@v6.0.0-alpha.12`
+### `@mui/x-data-grid@6.0.0-alpha.12` / `@mui/x-data-grid-pro@6.0.0-alpha.12` / `@mui/x-data-grid-premium@6.0.0-alpha.12`
 
 #### Breaking changes
 
@@ -2075,7 +2073,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [DataGridPro] Fix missing border in right-pinned columns (#4197) @cherniavskii
 - [DataGridPro] Fix wrong border color on skeleton cells (#7202) @cherniavskii
 
-### `@mui/x-date-pickers@v6.0.0-alpha.12` / `@mui/x-date-pickers-pro@v6.0.0-alpha.12`
+### `@mui/x-date-pickers@6.0.0-alpha.12` / `@mui/x-date-pickers-pro@6.0.0-alpha.12`
 
 #### Changes
 
@@ -2109,7 +2107,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - ✨ Fix lazy-loading feature not working in `DataGridPremium` (#7124) @m4theushw
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.11` / `@mui/x-data-grid-pro@v6.0.0-alpha.11` / `@mui/x-data-grid-premium@v6.0.0-alpha.11`
+### `@mui/x-data-grid@6.0.0-alpha.11` / `@mui/x-data-grid-pro@6.0.0-alpha.11` / `@mui/x-data-grid-premium@6.0.0-alpha.11`
 
 #### Breaking changes
 
@@ -2124,7 +2122,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [DataGridPremium] Add support for lazy-loading (#7124) @m4theushw
 - [DataGridPremium] Pass `groupId` to aggregation function (#7003) @m4theushw
 
-### `@mui/x-date-pickers@v6.0.0-alpha.11` / `@mui/x-date-pickers-pro@v6.0.0-alpha.11`
+### `@mui/x-date-pickers@6.0.0-alpha.11` / `@mui/x-date-pickers-pro@6.0.0-alpha.11`
 
 #### Breaking changes
 
@@ -2221,7 +2219,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.10` / `@mui/x-data-grid-pro@v6.0.0-alpha.10` / `@mui/x-data-grid-premium@v6.0.0-alpha.10`
+### `@mui/x-data-grid@6.0.0-alpha.10` / `@mui/x-data-grid-pro@6.0.0-alpha.10` / `@mui/x-data-grid-premium@6.0.0-alpha.10`
 
 ### Breaking changes
 
@@ -2255,7 +2253,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGridPremium] Use custom cell component for grouping cell by default (#6692) @cherniavskii
 - [l10n] Improve Ukrainian (uk-UA) locale (#7009) @rettoua
 
-### `@mui/x-date-pickers@v6.0.0-alpha.10` / `@mui/x-date-pickers-pro@v6.0.0-alpha.10`
+### `@mui/x-date-pickers@6.0.0-alpha.10` / `@mui/x-date-pickers-pro@6.0.0-alpha.10`
 
 #### Breaking changes
 
@@ -2318,7 +2316,7 @@ We'd like to offer a big thanks to the 14 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.9` / `@mui/x-data-grid-pro@v6.0.0-alpha.9` / `@mui/x-data-grid-premium@v6.0.0-alpha.9`
+### `@mui/x-data-grid@6.0.0-alpha.9` / `@mui/x-data-grid-pro@6.0.0-alpha.9` / `@mui/x-data-grid-premium@6.0.0-alpha.9`
 
 ### Breaking changes
 
@@ -2345,7 +2343,7 @@ We'd like to offer a big thanks to the 14 contributors who made this release pos
 - [DataGridPremium] Improve typing for theme in `styleOverrides` (#6920) @m4theushw
 - [l10n] Fix translation of `filterOperatorBefore` in Arabic (ar-SD) locale (#6884) @HassanGhazy
 
-### `@mui/x-date-pickers@v6.0.0-alpha.9` / `@mui/x-date-pickers-pro@v6.0.0-alpha.9`
+### `@mui/x-date-pickers@6.0.0-alpha.9` / `@mui/x-date-pickers-pro@6.0.0-alpha.9`
 
 #### Changes
 
@@ -2389,12 +2387,12 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.8` / `@mui/x-data-grid-pro@v6.0.0-alpha.8` / `@mui/x-data-grid-premium@v6.0.0-alpha.8`
+### `@mui/x-data-grid@6.0.0-alpha.8` / `@mui/x-data-grid-pro@6.0.0-alpha.8` / `@mui/x-data-grid-premium@6.0.0-alpha.8`
 
 #### Changes
 
 - [DataGrid] Fix `ErrorOverlay` not receiving defined input props (#6819) @banoth-ravinder
-- [DataGrid] Fix conflict with the latest version of `@types/react` (#6797) @vizv
+- [DataGrid] Fix conflict with the latest version of `@types/react` (#6797) @izv
 - [DataGrid] Make more `apiRef` methods private (#6700) @cherniavskii
 - [DataGrid] Provide a clear error message when upgrading (#6685) @oliviertassinari
 - [DataGridPremium] Allow to customize the indent of group expansion toggle (#6837) @MBilalShafi
@@ -2403,7 +2401,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [DataGridPro] Opt-out for column jump back on re-order (#6733) @gavbrennan
 - [l10n] Improve Finnish (fi-FI) locale (#6859) @RainoPikkarainen
 
-### `@mui/x-date-pickers@v6.0.0-alpha.8` / `@mui/x-date-pickers-pro@v6.0.0-alpha.8`
+### `@mui/x-date-pickers@6.0.0-alpha.8` / `@mui/x-date-pickers-pro@6.0.0-alpha.8`
 
 #### Breaking changes
 
@@ -2459,14 +2457,14 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.7` / `@mui/x-data-grid-pro@v6.0.0-alpha.7` / `@mui/x-data-grid-premium@v6.0.0-alpha.7`
+### `@mui/x-data-grid@6.0.0-alpha.7` / `@mui/x-data-grid-pro@6.0.0-alpha.7` / `@mui/x-data-grid-premium@6.0.0-alpha.7`
 
 #### Changes
 
 - [DataGrid] Fix cell focus causing scroll jump when virtualization enabled (#6785) @yaredtsy
 - [DataGrid] Remove items marked as `@deprecated` (#6505) @DanailH
 
-### `@mui/x-date-pickers@v6.0.0-alpha.7` / `@mui/x-date-pickers-pro@v6.0.0-alpha.7`
+### `@mui/x-date-pickers@6.0.0-alpha.7` / `@mui/x-date-pickers-pro@6.0.0-alpha.7`
 
 #### Changes
 
@@ -2509,7 +2507,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.6` / `@mui/x-data-grid-pro@v6.0.0-alpha.6` / `@mui/x-data-grid-premium@v6.0.0-alpha.6`
+### `@mui/x-data-grid@6.0.0-alpha.6` / `@mui/x-data-grid-pro@6.0.0-alpha.6` / `@mui/x-data-grid-premium@6.0.0-alpha.6`
 
 #### Breaking changes
 
@@ -2524,7 +2522,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [DataGrid] Remove `disableIgnoreModificationsIfProcessingProps` prop (#6640) @m4theushw
 - [DataGrid] Separate private and public `apiRef` properties (#6388) @cherniavskii
 
-### `@mui/x-date-pickers@v6.0.0-alpha.6` / `@mui/x-date-pickers-pro@v6.0.0-alpha.6`
+### `@mui/x-date-pickers@6.0.0-alpha.6` / `@mui/x-date-pickers-pro@6.0.0-alpha.6`
 
 #### Changes
 
@@ -2554,7 +2552,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - 🎁 Allow to disable the autofocus of the search field when opening the column visibility panel (#6444) @e-cloud
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.5` / `@mui/x-data-grid-pro@v6.0.0-alpha.5` / `@mui/x-data-grid-premium@v6.0.0-alpha.5`
+### `@mui/x-data-grid@6.0.0-alpha.5` / `@mui/x-data-grid-pro@6.0.0-alpha.5` / `@mui/x-data-grid-premium@6.0.0-alpha.5`
 
 #### Breaking changes
 
@@ -2578,7 +2576,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [DataGrid] Stop exporting `gridColumnsSelector` (#6693)
 - [l10n] Improve Bulgarian (bg-BG) locale (#6578) @AtanasVA
 
-### `@mui/x-date-pickers@v6.0.0-alpha.5` / `@mui/x-date-pickers-pro@v6.0.0-alpha.5`
+### `@mui/x-date-pickers@6.0.0-alpha.5` / `@mui/x-date-pickers-pro@6.0.0-alpha.5`
 
 #### Breaking changes
 
@@ -2672,7 +2670,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - 🐞 Bugfixes
 - 🌍 Improve Turkish (tr-TR) locale on the data grid and pickers (#6542) @ramazansancar
 
-### `@mui/x-data-grid@v6.0.0-alpha.4` / `@mui/x-data-grid-pro@v6.0.0-alpha.4` / `@mui/x-data-grid-premium@v6.0.0-alpha.4`
+### `@mui/x-data-grid@6.0.0-alpha.4` / `@mui/x-data-grid-pro@6.0.0-alpha.4` / `@mui/x-data-grid-premium@6.0.0-alpha.4`
 
 #### Breaking changes
 
@@ -2698,7 +2696,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [DataGrid] Rename selection props (#6556) @m4theushw
 - [l10n] Improve Turkish (tr-TR) locale on the data grid and pickers (#6542) @ramazansancar
 
-### `@mui/x-date-pickers@v6.0.0-alpha.4` / `@mui/x-date-pickers-pro@v6.0.0-alpha.4`
+### `@mui/x-date-pickers@6.0.0-alpha.4` / `@mui/x-date-pickers-pro@6.0.0-alpha.4`
 
 #### Breaking changes
 
@@ -2816,7 +2814,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.3` / `@mui/x-data-grid-pro@v6.0.0-alpha.3` / `@mui/x-data-grid-premium@v6.0.0-alpha.3`
+### `@mui/x-data-grid@6.0.0-alpha.3` / `@mui/x-data-grid-pro@6.0.0-alpha.3` / `@mui/x-data-grid-premium@6.0.0-alpha.3`
 
 #### Breaking changes
 
@@ -2850,7 +2848,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [DataGrid] Use generics instead of verbose state overrides (#6409) @cherniavskii
 - [DataGridPro] Allow to limit to one filter per column (#6333) @MBilalShafi
 
-### `@mui/x-date-pickers@v6.0.0-alpha.3` / `@mui/x-date-pickers-pro@v6.0.0-alpha.3`
+### `@mui/x-date-pickers@6.0.0-alpha.3` / `@mui/x-date-pickers-pro@6.0.0-alpha.3`
 
 #### Breaking changes
 
@@ -3013,7 +3011,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.2` / `@mui/x-data-grid-pro@v6.0.0-alpha.2` / `@mui/x-data-grid-premium@v6.0.0-alpha.2`
+### `@mui/x-data-grid@6.0.0-alpha.2` / `@mui/x-data-grid-pro@6.0.0-alpha.2` / `@mui/x-data-grid-premium@6.0.0-alpha.2`
 
 #### Breaking changes
 
@@ -3038,7 +3036,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGrid] Pass generics to the components in the theme augmentation (#6269) @cherniavskii
 - [DataGridPremium] Remove the aggregation from the experimental features (#6372) @flaviendelangle
 
-### `@mui/x-date-pickers@v6.0.0-alpha.2` / `@mui/x-date-pickers-pro@v6.0.0-alpha.2`
+### `@mui/x-date-pickers@6.0.0-alpha.2` / `@mui/x-date-pickers-pro@6.0.0-alpha.2`
 
 #### Breaking changes
 
@@ -3089,7 +3087,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.1` / `@mui/x-data-grid-pro@v6.0.0-alpha.1` / `@mui/x-data-grid-premium@v6.0.0-alpha.1`
+### `@mui/x-data-grid@6.0.0-alpha.1` / `@mui/x-data-grid-pro@6.0.0-alpha.1` / `@mui/x-data-grid-premium@6.0.0-alpha.1`
 
 #### Breaking changes
 
@@ -3149,7 +3147,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [DataGrid] Improve print support (#6273) @oliviertassinari
 - [DataGridPremium] Add missing `themeAugmentation` module (#6270) @cherniavskii
 
-### `@mui/x-date-pickers@v6.0.0-alpha.1` / `@mui/x-date-pickers-pro@v6.0.0-alpha.1`
+### `@mui/x-date-pickers@6.0.0-alpha.1` / `@mui/x-date-pickers-pro@6.0.0-alpha.1`
 
 #### Breaking changes
 
@@ -3221,7 +3219,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - 📚 Documentation improvements
 - 🐞 Bugfixes
 
-### `@mui/x-data-grid@v6.0.0-alpha.0` / `@mui/x-data-grid-pro@v6.0.0-alpha.0` / `@mui/x-data-grid-premium@v6.0.0-alpha.0`
+### `@mui/x-data-grid@6.0.0-alpha.0` / `@mui/x-data-grid-pro@6.0.0-alpha.0` / `@mui/x-data-grid-premium@6.0.0-alpha.0`
 
 #### Breaking changes
 
@@ -3258,7 +3256,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [DataGrid] Remove the `GridEvents` enum (#6003) @flaviendelangle
 - [DataGrid] Remove the deprecated `hide` column property (#5999) @flaviendelangle
 
-### `@mui/x-date-pickers@v6.0.0-alpha.0` / `@mui/x-date-pickers-pro@v6.0.0-alpha.0`
+### `@mui/x-date-pickers@6.0.0-alpha.0` / `@mui/x-date-pickers-pro@6.0.0-alpha.0`
 
 #### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,27 +25,38 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.9.2` / `@mui/x-data-grid-pro@v6.9.2` / `@mui/x-data-grid-premium@v6.9.2`
+### Data Grid
 
-#### Changes
+#### `@mui/x-data-grid@v6.9.2`
 
 - [DataGrid] Fix `RangeError` when using flex columns (#9554) @cherniavskii
 - [DataGrid] Fix React 17 editing bug (#9530) @romgrk
 - [DataGrid] Use `getRowId` in filtering (#9564) @romgrk
 - [DataGrid] Correctly reflect `TablePagination`'s `rowsPerPageOptions` shape to `pageSizeOptions` (#9438) @burakkgunduzz
-- [DataGridPremium] Auto-scroll when making range selection (#8661) @m4theushw
 - [l10n] Improve Spanish (es-ES) locale (#9500) @fufex
 
-### `@mui/x-date-pickers@v6.9.2` / `@mui/x-date-pickers-pro@v6.9.2`
+#### `@mui/x-data-grid-pro@v6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-data-grid@v6.9.2`.
+
+#### `@mui/x-data-grid-premium@v6.9.2`  [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+
+Same changes as in `@mui/x-data-grid-pro@v6.9.2`, plus:
+
+- [DataGridPremium] Auto-scroll when making range selection (#8661) @m4theushw
+
+### Date Pickers
+
+#### `@mui/x-date-pickers@v6.9.2`
 
 - [pickers] Forward digital clock classes (#9555) @YoonjiJang
 - [pickers] Rename `internal` folder to `internals` on `@mui/x-date-picker-pro` (#9571) @flaviendelangle
 
-### `@mui/x-charts@6.0.0-alpha.2`
+#### `@mui/x-date-pickers-pro@v6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-date-pickers@v6.9.2`.
+
+### `@mui/x-charts@6.0.0-alpha.2`
 
 - [charts] Add pie chart component (#9395) @alexfauquette
 
@@ -77,9 +88,9 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### `@mui/x-data-grid@v6.9.1` / `@mui/x-data-grid-pro@v6.9.1` / `@mui/x-data-grid-premium@v6.9.1`
+### Data Grid
 
-#### Changes
+#### `@mui/x-data-grid@v6.9.1`
 
 - [DataGrid] Add Joy UI `tooltip` and `loadingOverlay` slots (#9028) @cherniavskii
 - [DataGrid] Add section about enabling pagination on Pro and Premium (#8759) @joserodolfofreitas
@@ -87,13 +98,22 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [DataGrid] Add experimental API for faster filtering performance (#9254) @romgrk
 - [DataGrid] Fix `nextFieldToFocus` to always be a visible column field when <kbd>Tab</kbd> key is pressed (#8314) @yaredtsy
 - [DataGrid] Fix `Maximum call stack size exceeded` error when using fractional width (#9516) @cherniavskii
-- [DataGridPro] Don't throw error in column pinning (#9507) @romgrk
-- [DataGridPro] Fix bug with `checkboxSelection` and treeData/grouping (#9418) @romgrk
 - [l10n] Improve Romanian (ro-RO) and Hungarian (hu-HU) translations (#9436) @noraleonte
 
-### `@mui/x-date-pickers@v6.9.1` / `@mui/x-date-pickers-pro@v6.9.1`
+#### `@mui/x-data-grid-pro@v6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-data-grid@v6.9.1`, plus:
+
+- [DataGridPro] Don't throw error in column pinning (#9507) @romgrk
+- [DataGridPro] Fix bug with `checkboxSelection` and treeData/grouping (#9418) @romgrk
+
+#### `@mui/x-data-grid-premium@v6.9.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+
+Same changes as in `@mui/x-data-grid-pro@v6.9.1`.
+
+### Date Pickers
+
+#### `@mui/x-date-pickers@v6.9.1`
 
 - [DateTimePicker] Scroll to Digital Clock section only when selection changes (#9434) @LukasTy
 - [pickers] Handle `keyDown` only when input is focused (#9481) @LukasTy
@@ -101,9 +121,13 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [l10n] Add Chinese (Hong Kong) (zh-HK) locale (#9468) @samchiu90
 - [l10n] Improve Romanian (ro-RO) translations (#9436) @noraleonte
 
-### `@mui/x-charts@6.0.0-alpha.1`
+#### `@mui/x-date-pickers-pro@v6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
 
-#### Changes
+Same changes as in `@mui/x-date-pickers@v6.9.1`.
+
+### Charts
+
+#### `@mui/x-charts@6.0.0-alpha.1`
 
 - [charts] Take responsive container from data grid (#9497) @alexfauquette
 - [charts] Update README.md (#9426) @alexfauquette

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -15,6 +15,10 @@
 /r/x-data-grid-no-dimensions https://mui.com/x/react-data-grid/layout/ 302
 /r/x-technical-support https://mui.com/x/introduction/support/#technical-support 302
 /r/x-issue-template https://codesandbox.io/s/mui-x-issue-template-qtf00h 302
+/r/x-pro-svg https://mui.com/static/x/pro.svg 302
+/r/x-pro-svg-link https://mui.com/x/introduction/licensing/#pro-plan 302
+/r/x-premium-svg https://mui.com/static/x/premium.svg 302
+/r/x-premium-svg-link https://mui.com/x/introduction/licensing/#premium-plan 302
 
 # Legacy redirection
 


### PR DESCRIPTION
Today, we were talking about the Figma variable features and the struggle to know if the plans in this feature were available. This sparked this idea: What if we were to flatten the changelog to make it clear where the improvement is? Effectively, I'm continuing the discussion we started in https://www.notion.so/mui-org/How-to-display-the-changelogs-c8f46c2f2f9943d793b181aa53133785, going with Option A.

Here is a preview of what it could look like. The main objective for me is to help grow MUI X as a standalone open-source project, a step toward supporting Mantine, Chakra UI, Tailwind CSS, etc. as possible rendered layers. Without this change, developers might feel like MUI X is mostly paid features, but when you actually segment the changes, it becomes clear that the reality is.

---

Current: https://github.com/mui/mui-x/blob/master/CHANGELOG.md

<img width="881" alt="Screenshot 2023-06-24 at 02 46 52" src="https://github.com/mui/mui-x/assets/3165635/a7482f1e-ecd2-4188-be6e-2e5481dcfe94">

---

The proposal: https://github.com/oliviertassinari/mui-x/blob/changelog-rfc/CHANGELOG.md

<img width="772" alt="Screenshot 2023-06-24 at 02 48 11" src="https://github.com/mui/mui-x/assets/3165635/7134b29c-f7f5-4288-b58d-f32f05776894">

