### PR TITLE
[docs] Add missing upcoming flag without issue

### DIFF
--- a/docs/data/charts/funnel/funnel.md
+++ b/docs/data/charts/funnel/funnel.md
@@ -3,13 +3,14 @@ product: charts
 title: Charts - Funnel
 ---
 
-# Charts - Funnel
+# Charts - Funnel 🚧
 
 <p class="description">Funnel charts allows to express quantity evolution along a process, such as audience engagement.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #7929](https://github.com/mui/mui-x/issues/7929) if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/7929).
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #7929](https://github.com/mui/mui-x/issues/7929) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/charts/gantt/gantt.md
+++ b/docs/data/charts/gantt/gantt.md
@@ -3,13 +3,14 @@ product: charts
 title: Charts - Gantt
 ---
 
-# Charts - Sankey
+# Charts - Gantt 🚧
 
 <p class="description">Gantt charts can illustrate a product schedule and the relationships between its various activities.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #8732](https://github.com/mui/mui-x/issues/8732) if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/8732).
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #8732](https://github.com/mui/mui-x/issues/8732) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/charts/heat-map/heat-map.md
+++ b/docs/data/charts/heat-map/heat-map.md
@@ -3,13 +3,14 @@ product: charts
 title: Charts - Heat map
 ---
 
-# Charts - Heat map
+# Charts - Heat map 🚧
 
 <p class="description">Heat map charts allows to highlight correlation between categories.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #7926](https://github.com/mui/mui-x/issues/7926) if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/7926).
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #7926](https://github.com/mui/mui-x/issues/7926) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -3,13 +3,14 @@ product: charts
 title: Charts - Pie
 ---
 
-# Charts - Pie
+# Charts - Pie 🚧
 
 <p class="description">Pie charts express portions of a whole, using arcs or angles within a circle.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #7884](https://github.com/mui/mui-x/issues/7884) if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/7884).
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #7884](https://github.com/mui/mui-x/issues/7884) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -3,13 +3,14 @@ product: charts
 title: Charts - Radar
 ---
 
-# Charts - Radar
+# Charts - Radar 🚧
 
 <p class="description">Radar allows to compare multivariate data in a 2D chart.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #7925](https://github.com/mui/mui-x/issues/7925) if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/7925).
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #7925](https://github.com/mui/mui-x/issues/7925) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/charts/sankey/sankey.md
+++ b/docs/data/charts/sankey/sankey.md
@@ -3,13 +3,14 @@ product: charts
 title: Charts - Sankey
 ---
 
-# Charts - Sankey
+# Charts - Sankey 🚧
 
 <p class="description">Chart lines can express flows between different entities.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #7930](https://github.com/mui/mui-x/issues/7930) if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/7930).
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #7930](https://github.com/mui/mui-x/issues/7930) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/charts/tree-map/tree-map.md
+++ b/docs/data/charts/tree-map/tree-map.md
@@ -7,9 +7,10 @@ title: Charts - Tree map
 
 <p class="description">Tree map allows to display data with a hierarchical structure.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #7924(https://github.com/mui/mui-x/issues/7924 if you want to see it land faster.
->
-> 💬 To have a solution that meets your needs, leave a comment on the [same issue](https://github.com/mui/mui-x/issues/7924.
-> If you already have a use case for this component, or if you are facing a pain-point with your current solution.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #7924](https://github.com/mui/mui-x/issues/7924) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -77,19 +77,27 @@ In the example below, the `Full name` column group can be divided, but not other
 
 ## Manage group visibility 🚧
 
-:::warning
-This feature isn't implemented yet. It's coming.
-:::
-
-The column group should allow to switch between an extended/collapsed view which hide/show some columns
-
-## Reordering groups 🚧[<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+The column group should allow to switch between an extended/collapsed view which hide/show some columns.
 
 :::warning
 This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #6651](https://github.com/mui/mui-x/issues/6651) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
-Users could drag and drop group header to move all the group children at once
+## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)🚧
+
+Users could drag and drop group header to move all the group children at once, [like they can already do it with normal columns](/x/react-data-grid/column-ordering/).
+
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #9448](https://github.com/mui/mui-x/issues/9448) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::
 
 ## API
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -2,7 +2,7 @@
 title: Data Grid - Pivoting
 ---
 
-# Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)🚧
 
 <p class="description">Turn a column values into columns.</p>
 
@@ -10,6 +10,8 @@ title: Data Grid - Pivoting
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #214](https://github.com/mui/mui-x/issues/214) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 Pivoting will allow you to take a columns values and turn them into columns.

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -316,12 +316,14 @@ const rows = apiRef.current.getRowGroupChildren({
 
 {{"demo": "RowGroupingGetRowGroupChildren.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## 🚧 Row group panel
+## Row group panel 🚧
 
 :::warning
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #5235](https://github.com/mui/mui-x/issues/5235) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 With this panel, your users will be able to control which columns are used for grouping just by dragging them inside the panel.

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -83,6 +83,8 @@ For now, row reordering is disabled if sorting is applied to the data grid.
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #4821](https://github.com/mui/mui-x/issues/4821) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 ## Reordering rows with tree data 🚧
@@ -91,6 +93,8 @@ This feature isn't implemented yet. It's coming.
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #4821](https://github.com/mui/mui-x/issues/4821) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 ## API

--- a/docs/data/data-grid/row-spanning/row-spanning.md
+++ b/docs/data/data-grid/row-spanning/row-spanning.md
@@ -1,4 +1,4 @@
-# Data Grid - Row spanning
+# Data Grid - Row spanning 🚧
 
 <p class="description">Span cells across several columns.</p>
 
@@ -6,6 +6,8 @@
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #207](https://github.com/mui/mui-x/issues/207) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 Each cell takes up the width of one row.

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -113,12 +113,14 @@ You can limit the sorting to the top-level rows with the `disableChildrenSorting
 > const invalidRows = [{ path: ['A'] }, { path: ['B'] }, { path: ['A', 'A'] }];
 > ```
 
-## Children lazy-loading
+## Children lazy-loading 🚧
 
 :::warning
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #3377](https://github.com/mui/mui-x/issues/3377) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 Alternatively, you can achieve a similar behavior by implementing this feature outside the component as shown below.

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -105,6 +105,8 @@ You can find the documentation in the [Validation page](/x/react-date-pickers/va
 This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #4995](https://github.com/mui/mui-x/issues/4995) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
 The Month Range Picker allows setting a range of months.

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -6,10 +6,14 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Date Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Date Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)🚧
 
 <p class="description">The Date Time Range Picker let the user select a range of dates with an explicit starting and ending time.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #4547](https://github.com/mui/mui-x/issues/4547) if you want to see it land faster.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #4547](https://github.com/mui/mui-x/issues/4547) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -6,10 +6,14 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)🚧
 
 <p class="description">The Time Range Picker let the user select a range of time.</p>
 
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #4460](https://github.com/mui/mui-x/issues/4460) if you want to see it land faster.
+:::warning
+This feature isn't implemented yet. It's coming.
+
+👍 Upvote [issue #4460](https://github.com/mui/mui-x/issues/4460) if you want to see it land faster.
+
+Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::


### PR DESCRIPTION
We have two waiting for upvotes warnings in the docs without corresponding GitHub issue: https://mui.com/x/react-data-grid/column-groups/#manage-group-visibility. This leads to developers asking questions like https://mui.zendesk.com/agent/tickets/9359. We now link #6651 and #9448.

Instead, let's link them all, I have used the opportunity to normalize the message. 