### PR TITLE
[docs] Fix productId logic

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -181,6 +181,8 @@ function AppWrapper(props) {
     productId = 'x-data-grid';
   } else if (canonicalAs.startsWith('/x/api/date-pickers/')) {
     productId = 'x-date-pickers';
+  } else if (canonicalAs.startsWith('/x/api/charts/')) {
+    productId = 'x-charts';
   }
 
   React.useEffect(() => {

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -172,7 +172,16 @@ function AppWrapper(props) {
   const { children, emotionCache, pageProps } = props;
 
   const router = useRouter();
-  const { productId, productCategoryId } = getProductInfoFromUrl(router.asPath);
+  const { productId: productIdRaw, productCategoryId } = getProductInfoFromUrl(router.asPath);
+  const { canonicalAs } = pathnameToLanguage(router.asPath);
+  let productId = productIdRaw;
+
+  // Not respecting URL convention, ad-hoc workaround
+  if (canonicalAs.startsWith('/x/api/data-grid/')) {
+    productId = 'x-data-grid';
+  } else if (canonicalAs.startsWith('/x/api/date-pickers/')) {
+    productId = 'x-date-pickers';
+  }
 
   React.useEffect(() => {
     loadDependencies();
@@ -192,11 +201,8 @@ function AppWrapper(props) {
     ];
   }
 
-  const { canonicalAs } = pathnameToLanguage(router.asPath);
-
   const pageContextValue = React.useMemo(() => {
     const { activePage, activePageParents } = findActivePage(pages, router.pathname);
-
     const languagePrefix = pageProps.userLanguage === 'en' ? '' : `/${pageProps.userLanguage}`;
 
     let productIdentifier = {
@@ -209,10 +215,7 @@ function AppWrapper(props) {
       ],
     };
 
-    if (
-      canonicalAs.startsWith('/x/react-data-grid/') ||
-      canonicalAs.startsWith('/x/api/data-grid/')
-    ) {
+    if (productId === 'x-data-grid') {
       productIdentifier = {
         metadata: 'MUI X',
         name: 'Data Grid',
@@ -222,10 +225,7 @@ function AppWrapper(props) {
           { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
         ],
       };
-    } else if (
-      canonicalAs.startsWith('/x/react-date-pickers/') ||
-      canonicalAs.startsWith('/x/api/date-pickers/')
-    ) {
+    } else if (productId === 'x-date-pickers') {
       productIdentifier = {
         metadata: 'MUI X',
         name: 'Date Pickers',
@@ -239,8 +239,14 @@ function AppWrapper(props) {
       };
     }
 
-    return { activePage, activePageParents, pages, productIdentifier };
-  }, [canonicalAs, pageProps.userLanguage, router.pathname]);
+    return {
+      activePage,
+      activePageParents,
+      pages,
+      productIdentifier,
+      productId,
+    };
+  }, [productId, pageProps.userLanguage, router.pathname]);
 
   // Replicate change reverted in https://github.com/mui/material-ui/pull/35969/files#r1089572951
   // Fixes playground styles in dark mode.


### PR DESCRIPTION
Fix the "productId" logic. Here are reproduction of the bugs:

1. See the source of https://mui.com/x/api/data-grid/grid-toolbar-quick-filter/

<img width="336" alt="Screenshot 2023-06-24 at 18 01 55" src="https://github.com/mui/mui-x/assets/3165635/c4bd95fd-d726-4b22-a8a1-c9c1847a7227">

This prevents Algolia's crawler from correctly updating its index. After the fix https://deploy-preview-9451--material-ui-x.netlify.app/x/api/data-grid/grid-toolbar-quick-filter/

<img width="402" alt="Screenshot 2023-06-24 at 18 07 27" src="https://github.com/mui/mui-x/assets/3165635/3fd2b52e-b61c-4254-86d2-6f8a583dfe3d">

2. https://dashboard.algolia.com/apps/TZGZ85B9TB/analytics/no-results/material-ui?from=2023-06-17&to=2023-06-23&tags=product%3Aundefined

<img width="650" alt="Screenshot 2023-06-24 at 18 02 52" src="https://github.com/mui/mui-x/assets/3165635/ab7acb25-9814-4dad-8924-44eb97d8a159">

The date picker custom `<DemoContainer>` component is the most searched query with no results, but it's not labeled as being part of the date picker. It's currently `undefined`.