### PR TITLE
[pickers] Handle `keyDown` only when input is focused

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -40,6 +40,7 @@ const SingleInputDateRangeField = React.forwardRef(function SingleInputDateRange
   const {
     ref: inputRef,
     onPaste,
+    onKeyDown,
     inputMode,
     readOnly,
     ...fieldProps
@@ -53,7 +54,7 @@ const SingleInputDateRangeField = React.forwardRef(function SingleInputDateRange
       ref={ref}
       {...fieldProps}
       InputProps={{ ...fieldProps.InputProps, readOnly }}
-      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, ref: inputRef }}
+      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, onKeyDown, ref: inputRef }}
     />
   );
 }) as DateRangeFieldComponent;

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -41,6 +41,7 @@ const SingleInputDateTimeRangeField = React.forwardRef(function SingleInputDateT
   const {
     ref: inputRef,
     onPaste,
+    onKeyDown,
     inputMode,
     readOnly,
     ...fieldProps
@@ -54,7 +55,7 @@ const SingleInputDateTimeRangeField = React.forwardRef(function SingleInputDateT
       ref={ref}
       {...fieldProps}
       InputProps={{ ...fieldProps.InputProps, readOnly }}
-      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, ref: inputRef }}
+      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, onKeyDown, ref: inputRef }}
     />
   );
 }) as DateRangeFieldComponent;

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
@@ -40,6 +40,7 @@ const SingleInputTimeRangeField = React.forwardRef(function SingleInputTimeRange
   const {
     ref: inputRef,
     onPaste,
+    onKeyDown,
     inputMode,
     readOnly,
     ...fieldProps
@@ -53,7 +54,7 @@ const SingleInputTimeRangeField = React.forwardRef(function SingleInputTimeRange
       ref={ref}
       {...fieldProps}
       InputProps={{ ...fieldProps.InputProps, readOnly }}
-      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, ref: inputRef }}
+      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, onKeyDown, ref: inputRef }}
     />
   );
 }) as DateRangeFieldComponent;

--- a/packages/x-date-pickers/src/DateField/DateField.tsx
+++ b/packages/x-date-pickers/src/DateField/DateField.tsx
@@ -39,6 +39,7 @@ const DateField = React.forwardRef(function DateField<TDate>(
   const {
     ref: inputRef,
     onPaste,
+    onKeyDown,
     inputMode,
     readOnly,
     ...fieldProps
@@ -52,7 +53,7 @@ const DateField = React.forwardRef(function DateField<TDate>(
       ref={ref}
       {...fieldProps}
       InputProps={{ ...fieldProps.InputProps, readOnly }}
-      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, ref: inputRef }}
+      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, onKeyDown, ref: inputRef }}
     />
   );
 }) as DateFieldComponent;

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
@@ -41,6 +41,7 @@ const DateTimeField = React.forwardRef(function DateTimeField<TDate>(
   const {
     ref: inputRef,
     onPaste,
+    onKeyDown,
     inputMode,
     readOnly,
     ...fieldProps
@@ -54,7 +55,7 @@ const DateTimeField = React.forwardRef(function DateTimeField<TDate>(
       ref={ref}
       {...fieldProps}
       InputProps={{ ...fieldProps.InputProps, readOnly }}
-      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, ref: inputRef }}
+      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, onKeyDown, ref: inputRef }}
     />
   );
 }) as DateTimeFieldComponent;

--- a/packages/x-date-pickers/src/TimeField/TimeField.tsx
+++ b/packages/x-date-pickers/src/TimeField/TimeField.tsx
@@ -39,6 +39,7 @@ const TimeField = React.forwardRef(function TimeField<TDate>(
   const {
     ref: inputRef,
     onPaste,
+    onKeyDown,
     inputMode,
     readOnly,
     ...fieldProps
@@ -52,7 +53,7 @@ const TimeField = React.forwardRef(function TimeField<TDate>(
       ref={ref}
       {...fieldProps}
       InputProps={{ ...fieldProps.InputProps, readOnly }}
-      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, ref: inputRef }}
+      inputProps={{ ...fieldProps.inputProps, inputMode, onPaste, onKeyDown, ref: inputRef }}
     />
   );
 }) as TimeFieldComponent;


### PR DESCRIPTION
Fixes #9467

Aligning the `onKeyDown` management with the multi-input range fields approach, where `onKeyDown` is passed to the `inputProps` instead of `InputProps` to avoid handling it when clicking while the focus is on an adornment.