### PR TITLE
[DataGrid] Don't forward `editCellState` prop to DOM element

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -247,6 +247,7 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>((props, ref) =>
   const {
     align,
     children: childrenProp,
+    editCellState,
     colIndex,
     column,
     cellMode,


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/9486

Before: https://codesandbox.io/s/green-darkness-l6r228?file=/demo.tsx
After: https://codesandbox.io/s/mystifying-framework-4f9tf8?file=/demo.tsx