### PR TITLE
[DataGridPro] Don't throw error in column pinning

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
@@ -92,8 +92,13 @@ export const useGridColumnPinning = (
         return;
       }
 
+      const rowContainer = apiRef.current.virtualScrollerRef!.current!;
+      if (!rowContainer) {
+        return;
+      }
+
       const index = event.currentTarget.dataset.rowindex;
-      const rowElements = apiRef.current.virtualScrollerRef!.current!.querySelectorAll(
+      const rowElements = rowContainer.querySelectorAll(
         `.${gridClasses.row}[data-rowindex="${index}"]`,
       );
       rowElements.forEach((row) => {


### PR DESCRIPTION
Closes #9440 

Prevent an error from being thrown if a callback is called after the row container is unmounted.

Before: https://codesandbox.io/s/muidgridpro-pinnedcolumn-lazyloadroute-error-forked-73t2c6
After: https://codesandbox.io/s/muidgridpro-pinnedcolumn-lazyloadroute-error-forked-ng3cv4