### PR TITLE
[docs] Remove "product" markdown header

### DIFF
--- a/docs/data/charts/areas-demo/areas-demo.md
+++ b/docs/data/charts/areas-demo/areas-demo.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Areas demonstration
 ---
 

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Axis
 ---
 

--- a/docs/data/charts/bar-demo/bar-demo.md
+++ b/docs/data/charts/bar-demo/bar-demo.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Bar demonstration
 ---
 

--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Bars
 ---
 

--- a/docs/data/charts/funnel/funnel.md
+++ b/docs/data/charts/funnel/funnel.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Funnel
 ---
 

--- a/docs/data/charts/gantt/gantt.md
+++ b/docs/data/charts/gantt/gantt.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Gantt
 ---
 

--- a/docs/data/charts/heat-map/heat-map.md
+++ b/docs/data/charts/heat-map/heat-map.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Heat map
 ---
 

--- a/docs/data/charts/legend/legend.md
+++ b/docs/data/charts/legend/legend.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Legend
 ---
 

--- a/docs/data/charts/line-demo/line-demo.md
+++ b/docs/data/charts/line-demo/line-demo.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Line demonstration
 ---
 

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Lines
 ---
 

--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -1,5 +1,7 @@
 ---
 title: React Chart components
+githubLabel: 'component: charts'
+packageName: '@mui/x-charts'
 ---
 
 # Charts - Overview
@@ -7,6 +9,8 @@ title: React Chart components
 <p class="description">This page groups general topics that are common to multiple charts.</p>
 
 > ⚠️ This library is in the alpha phase. This means it might receive some breaking changes if they are needed to improve the components.
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Overview
 

--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Overview
 ---
 

--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Overview
+title: React Chart components
 ---
 
 # Charts - Overview

--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Pie
 ---
 

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Radar
 ---
 

--- a/docs/data/charts/sankey/sankey.md
+++ b/docs/data/charts/sankey/sankey.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Sankey
 ---
 

--- a/docs/data/charts/scatter-demo/scatter-demo.md
+++ b/docs/data/charts/scatter-demo/scatter-demo.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Scatter demonstration
 ---
 

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Scatter
 ---
 

--- a/docs/data/charts/stacking/stacking.md
+++ b/docs/data/charts/stacking/stacking.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Stacking
 ---
 

--- a/docs/data/charts/styling/styling.md
+++ b/docs/data/charts/styling/styling.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Styling
 ---
 

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Tooltip
 ---
 

--- a/docs/data/charts/tree-map/tree-map.md
+++ b/docs/data/charts/tree-map/tree-map.md
@@ -1,5 +1,4 @@
 ---
-product: charts
 title: Charts - Tree map
 ---
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -9,9 +9,9 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 
 <p class="description">A fast and extendable react data table and react data grid. It's a feature-rich component available in MIT or Commercial versions.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
-
 The component leverages the power of React and TypeScript, to provide the best UX while manipulating an unlimited set of data. It comes with an intuitive API for real-time updates, accessibility, as well as theming and custom templates, all with blazing fast performance.
+
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Overview
 

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - Date localization
 components: LocalizationProvider
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time Picker - Base concepts
 packageName: '@mui/x-date-pickers'
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -10,8 +10,6 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 <p class="description">The Date and Time pickers expose a lot of components to fit your every need.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
-
 ## Controlled value
 
 All the components have a `value` / `onChange` API to set and control the values:

--- a/docs/data/date-pickers/calendar-systems/calendar-systems.md
+++ b/docs/data/date-pickers/calendar-systems/calendar-systems.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - Calendar systems
 components: LocalizationProvider
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - Custom subcomponents
 components: DateTimePickerTabs
 ---

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - Custom field
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/date-pickers/custom-layout/custom-layout.md
+++ b/docs/data/date-pickers/custom-layout/custom-layout.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - Custom layout
 components: PickersActionBar, PickersLayout
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Calendar component
 components: DateCalendar, MonthCalendar, YearCalendar, PickersDay, DayCalendarSkeleton
 githubLabel: 'component: DatePicker'

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Field component
 components: DateField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Picker component
 components: DatePicker, DesktopDatePicker, MobileDatePicker, StaticDatePicker
 githubLabel: 'component: DatePicker'

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Range Calendar component
 components: DateRangeCalendar
 githubLabel: 'component: DateRangePicker'

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Range Field components
 components: MultiInputDateRangeField, SingleInputDateRangeField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Range Picker component
 components: DateRangePicker, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker, DateRangeCalendar, DateRangePickerDay
 githubLabel: 'component: DateRangePicker'

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Field component
 components: DateTimeField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Time Picker component
 components: DateTimePicker, DesktopDateTimePicker, MobileDateTimePicker, StaticDateTimePicker
 githubLabel: 'component: DateTimePicker'

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Time Range Field components
 components: MultiInputDateTimeRangeField, SingleInputDateTimeRangeField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Time Range Picker component
 githubLabel: 'component: DateTimeRangePicker'
 packageName: '@mui/x-date-pickers-pro'

--- a/docs/data/date-pickers/digital-clock/digital-clock.md
+++ b/docs/data/date-pickers/digital-clock/digital-clock.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Digital Clock component
 components: DigitalClock, MultiSectionDigitalClock
 githubLabel: 'component: TimePicker'

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Date Fields components
 components: DateField, TimeField, DateTimeField, MultiInputDateRangeField, SingleInputDateRangeField, MultiInputTimeRangeField, SingleInputTimeRangeField, MultiInputDateTimeRangeField, SingleInputDateTimeRangeField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -10,8 +10,6 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 <p class="description">Get started with the Date and Time pickers. Install the package, configure your application and start using the components.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
-
 ## Installation
 
 Using your favorite package manager, install:

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time Picker - Getting started
 packageName: '@mui/x-date-pickers'
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time Pickers - Component localization
 components: LocalizationProvider
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/overview/overview.md
+++ b/docs/data/date-pickers/overview/overview.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time Picker React components
 packageName: '@mui/x-date-pickers'
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/shortcuts/shortcuts.md
+++ b/docs/data/date-pickers/shortcuts/shortcuts.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - Shortcuts
 components: PickersShortcuts
 ---

--- a/docs/data/date-pickers/time-clock/time-clock.md
+++ b/docs/data/date-pickers/time-clock/time-clock.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Time Clock component
 components: TimeClock
 githubLabel: 'component: TimePicker'

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Time Field component
 components: TimeField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Time Picker component
 components: TimePicker, DesktopTimePicker, MobileTimePicker, StaticTimePicker
 githubLabel: 'component: TimePicker'

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Time Range Field components
 components: MultiInputTimeRangeField, SingleInputTimeRangeField
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: React Time Range Picker component
 githubLabel: 'component: TimeRangePicker'
 packageName: '@mui/x-date-pickers-pro'

--- a/docs/data/date-pickers/timezone/timezone.md
+++ b/docs/data/date-pickers/timezone/timezone.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 title: Date and Time pickers - UTC and timezones
 components: LocalizationProvider
 githubLabel: 'component: pickers'

--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -1,5 +1,4 @@
 ---
-product: date-pickers
 components: DatePicker, DesktopDatePicker, MobileDatePicker, StaticDatePicker, TimePicker, DesktopTimePicker, MobileTimePicker, StaticTimePicker, DateTimePicker, DesktopDateTimePicker, MobileDateTimePicker, StaticDateTimePicker, DateRangePicker, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/migration/migration-data-grid-v4/migration-data-grid-v4.md
+++ b/docs/data/migration/migration-data-grid-v4/migration-data-grid-v4.md
@@ -1,3 +1,7 @@
+---
+productId: x-data-grid
+---
+
 # Migration from v4 to v5
 
 <p class="description">This guide describes the changes needed to migrate the Data Grid from v4 to v5.</p>

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -1,3 +1,7 @@
+---
+productId: x-data-grid
+---
+
 # Migration from v5 to v6
 
 <!-- #default-branch-switch -->

--- a/docs/data/migration/migration-pickers-lab/migration-pickers-lab.md
+++ b/docs/data/migration/migration-pickers-lab/migration-pickers-lab.md
@@ -1,3 +1,7 @@
+---
+productId: x-date-pickers
+---
+
 # Migration from the lab
 
 <p class="description">MUI date and time pickers are now available on MUI X!</p>

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -1,3 +1,7 @@
+---
+productId: x-date-pickers
+---
+
 # Migration from v5 to v6
 
 <!-- #default-branch-switch -->


### PR DESCRIPTION
A quick fix related to https://github.com/mui/material-ui/pull/37729, AFAIK, these header `product` properties have no logic associated with them, it's noise, we rely on the URL. I have only added them on the migration pages where we can't be URL based, and where a change in the docs-infra could make these headers valuable to improve the Algolia search UX