### PR TITLE
[DataGrid] Improve inference of column operator getters

### DIFF
--- a/packages/grid/x-data-grid/src/colDef/gridBooleanOperators.ts
+++ b/packages/grid/x-data-grid/src/colDef/gridBooleanOperators.ts
@@ -3,7 +3,7 @@ import { GridFilterItem } from '../models/gridFilterItem';
 import { GridFilterOperator } from '../models/gridFilterOperator';
 import { convertLegacyOperators } from './utils';
 
-export const getGridBooleanOperators = (): GridFilterOperator<any, boolean | null, any>[] =>
+export const getGridBooleanOperators = () =>
   convertLegacyOperators([
     {
       value: 'is',
@@ -19,4 +19,4 @@ export const getGridBooleanOperators = (): GridFilterOperator<any, boolean | nul
       },
       InputComponent: GridFilterInputBoolean,
     },
-  ]);
+  ] as const satisfies ReadonlyArray<Omit<GridFilterOperator<any, boolean | null, any>, 'getApplyFilterFn'>>);

--- a/packages/grid/x-data-grid/src/colDef/gridDateOperators.ts
+++ b/packages/grid/x-data-grid/src/colDef/gridDateOperators.ts
@@ -44,7 +44,7 @@ function buildApplyFilterFn(
   };
 }
 
-export const getGridDateOperators = (showTime?: boolean): GridFilterOperator<any, Date, any>[] =>
+export const getGridDateOperators = (showTime?: boolean) =>
   convertLegacyOperators([
     {
       value: 'is',
@@ -117,4 +117,4 @@ export const getGridDateOperators = (showTime?: boolean): GridFilterOperator<any
       },
       requiresFilterValue: false,
     },
-  ]);
+  ] as const satisfies ReadonlyArray<Omit<GridFilterOperator<any, Date, any>, 'getApplyFilterFn'>>);

--- a/packages/grid/x-data-grid/src/colDef/gridNumericOperators.ts
+++ b/packages/grid/x-data-grid/src/colDef/gridNumericOperators.ts
@@ -24,7 +24,7 @@ export const getGridNumericQuickFilterFn = tagInternalFilter(
   },
 );
 
-export const getGridNumericOperators = (): GridFilterOperator<any, number | string | null, any>[] =>
+export const getGridNumericOperators = () =>
   convertLegacyOperators([
     {
       value: '=',
@@ -158,4 +158,4 @@ export const getGridNumericOperators = (): GridFilterOperator<any, number | stri
       InputComponent: GridFilterInputMultipleValue,
       InputComponentProps: { type: 'number' },
     },
-  ]);
+  ] as const satisfies ReadonlyArray<Omit<GridFilterOperator<any, number | string | null, any>, 'getApplyFilterFn'>>);

--- a/packages/grid/x-data-grid/src/colDef/gridSingleSelectOperators.ts
+++ b/packages/grid/x-data-grid/src/colDef/gridSingleSelectOperators.ts
@@ -11,7 +11,7 @@ const parseObjectValue = (value: unknown) => {
   return value.value;
 };
 
-export const getGridSingleSelectOperators = (): GridFilterOperator[] =>
+export const getGridSingleSelectOperators = () =>
   convertLegacyOperators([
     {
       value: 'is',
@@ -44,4 +44,4 @@ export const getGridSingleSelectOperators = (): GridFilterOperator[] =>
       },
       InputComponent: GridFilterInputMultipleSingleSelect,
     },
-  ]);
+  ] as const satisfies ReadonlyArray<Omit<GridFilterOperator, 'getApplyFilterFn'>>);

--- a/packages/grid/x-data-grid/src/colDef/gridStringOperators.ts
+++ b/packages/grid/x-data-grid/src/colDef/gridStringOperators.ts
@@ -19,9 +19,7 @@ export const getGridStringQuickFilterFn = tagInternalFilter(
   },
 );
 
-export const getGridStringOperators = (
-  disableTrim: boolean = false,
-): GridFilterOperator<any, number | string | null, any>[] =>
+export const getGridStringOperators = (disableTrim: boolean = false) =>
   convertLegacyOperators([
     {
       value: 'contains',
@@ -121,4 +119,4 @@ export const getGridStringOperators = (
       },
       InputComponent: GridFilterInputMultipleValue,
     },
-  ]);
+  ] as const satisfies ReadonlyArray<Omit<GridFilterOperator<any, number | string | null, any>, 'getApplyFilterFn'>>);

--- a/packages/grid/x-data-grid/src/colDef/utils.ts
+++ b/packages/grid/x-data-grid/src/colDef/utils.ts
@@ -37,9 +37,9 @@ export function convertFilterV7ToLegacy(fn: GetApplyFilterFnV7): GetApplyFilterF
   });
 }
 
-export function convertLegacyOperators(
-  ops: Omit<GridFilterOperator, 'getApplyFilterFn'>[],
-): GridFilterOperator[] {
+export function convertLegacyOperators<
+  const Op extends Omit<GridFilterOperator, 'getApplyFilterFn'>,
+>(ops: ReadonlyArray<Op>) {
   return ops.map((op) => {
     return {
       ...op,

--- a/packages/grid/x-data-grid/src/tests/types/colDef.types.ts
+++ b/packages/grid/x-data-grid/src/tests/types/colDef.types.ts
@@ -1,0 +1,56 @@
+import { Equal, Expect } from './typesTestsUtils';
+import { getGridNumericOperators } from '../../colDef/gridNumericOperators';
+import { getGridStringOperators } from '../../colDef/gridStringOperators';
+import { getGridBooleanOperators } from '../../colDef/gridBooleanOperators';
+import { getGridSingleSelectOperators } from '../../colDef/gridSingleSelectOperators';
+import { getGridDateOperators } from '../../colDef/gridDateOperators';
+
+export declare namespace Tests_getGridNumericOperators {
+  type ResolvedValue = ReturnType<typeof getGridNumericOperators>[number]['value'];
+
+  // Make sure the return type for "value" is correct and not simply "string"
+  type Test = Expect<
+    Equal<
+      ResolvedValue,
+      '<=' | 'isEmpty' | 'isNotEmpty' | 'isAnyOf' | '=' | '!=' | '>' | '>=' | '<'
+    >
+  >;
+}
+
+export declare namespace Tests_getGridStringOperators {
+  type ResolvedValue = ReturnType<typeof getGridStringOperators>[number]['value'];
+
+  // Make sure the return type for "value" is correct and not simply "string"
+  type Test = Expect<
+    Equal<
+      ResolvedValue,
+      'isEmpty' | 'isNotEmpty' | 'isAnyOf' | 'contains' | 'equals' | 'startsWith' | 'endsWith'
+    >
+  >;
+}
+
+export declare namespace Tests_getGridBooleanOperators {
+  type ResolvedValue = ReturnType<typeof getGridBooleanOperators>[number]['value'];
+
+  // Make sure the return type for "value" is correct and not simply "string"
+  type Test = Expect<Equal<ResolvedValue, 'is'>>;
+}
+
+export declare namespace Tests_getGridSingleSelectOperators {
+  type ResolvedValue = ReturnType<typeof getGridSingleSelectOperators>[number]['value'];
+
+  // Make sure the return type for "value" is correct and not simply "string"
+  type Test = Expect<Equal<ResolvedValue, 'isAnyOf' | 'is' | 'not'>>;
+}
+
+export declare namespace Tests_getGridDateOperators {
+  type ResolvedValue = ReturnType<typeof getGridDateOperators>[number]['value'];
+
+  // Make sure the return type for "value" is correct and not simply "string"
+  type Test = Expect<
+    Equal<
+      ResolvedValue,
+      'isEmpty' | 'isNotEmpty' | 'is' | 'not' | 'after' | 'onOrAfter' | 'before' | 'onOrBefore'
+    >
+  >;
+}

--- a/packages/grid/x-data-grid/src/tests/types/typesTestsUtils.ts
+++ b/packages/grid/x-data-grid/src/tests/types/typesTestsUtils.ts
@@ -1,0 +1,10 @@
+export type Expect<T extends true> = T;
+export type ExpectTrue<T extends true> = T;
+export type ExpectFalse<T extends false> = T;
+export type IsTrue<T extends true> = T;
+export type IsFalse<T extends false> = T;
+
+export type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+  ? true
+  : false;
+export type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true;


### PR DESCRIPTION
Hey 👋 

Currently, when we use col operator getters such as `getGridNumericOperators`, `getGridStringOperators`, etc the `value` field is inferred as a `string`. Normally this wouldn't be bad but as I understand it, it's part of the public api.

As such, there would be a benefit in having it properly inferred.

Before the PR:
<img width="964" alt="image" src="https://github.com/mui/mui-x/assets/22502084/2a3b457f-3f49-4a5f-9568-79c5900d449d">


After the PR:
<img width="916" alt="image" src="https://github.com/mui/mui-x/assets/22502084/b3d41c5a-8556-4f83-bf8a-53fc2b2392e6">

Since I didn't see any testing utils for types I made a few and used them for the tests.
There were also no tests for types to my knowledge, so I implemented a structure that might not be what you want.
**Either way, tests are validating that the functions are inferring the value properly.**

I'm willing to improve upon this or have it serve as a basis for a maintainer's PR.
Either way I'm happy since I just want the inference to work 😄 

**Issues:**
We've lost JSDOC. I was hoping you guys would know more about how to keep it but currently, I have no idea.
