### PR TITLE
[DataGrid] Fix `RangeError` when flex columns have duplicated `field` property

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -42,6 +42,7 @@ export function computeFlexColumnsWidth({
     maxWidth?: number;
   }[];
 }) {
+  const uniqueFlexColumns = new Set<GridColDef['field']>(flexColumns.map((col) => col.field));
   const flexColumnsLookup: {
     all: Record<
       GridColDef['field'],
@@ -68,7 +69,7 @@ export function computeFlexColumnsWidth({
   // Step 5 of https://drafts.csswg.org/css-flexbox-1/#resolve-flexible-lengths
   function loopOverFlexItems() {
     // 5a: If all the flex items on the line are frozen, free space has been distributed.
-    if (flexColumnsLookup.frozenFields.length === flexColumns.length) {
+    if (flexColumnsLookup.frozenFields.length === uniqueFlexColumns.size) {
       return;
     }
 

--- a/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -109,7 +109,7 @@ export function useGridDimensions(
 
     if (props.autoHeight) {
       hasScrollY = false;
-      hasScrollX = columnsTotalWidth > rootDimensionsRef.current.width;
+      hasScrollX = Math.round(columnsTotalWidth) > Math.round(rootDimensionsRef.current.width);
 
       viewportOuterSize = {
         width: rootDimensionsRef.current.width,
@@ -122,9 +122,9 @@ export function useGridDimensions(
       };
 
       const scrollInformation = hasScroll({
-        content: { width: columnsTotalWidth, height: rowsMeta.currentPageTotalHeight },
+        content: { width: Math.round(columnsTotalWidth), height: rowsMeta.currentPageTotalHeight },
         container: {
-          width: viewportOuterSize.width,
+          width: Math.round(viewportOuterSize.width),
           height: viewportOuterSize.height - pinnedRowsHeight.top - pinnedRowsHeight.bottom,
         },
         scrollBarSize,

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1186,4 +1186,28 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       'Warning: Encountered two children with the same key, `id`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.',
     ]);
   });
+
+  // See https://github.com/mui/mui-x/issues/9550#issuecomment-1619020477
+  it('should not exceed maximum call stack size caused by floating point precision error', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // Need layouting
+      this.skip();
+    }
+
+    render(
+      <div style={{ height: 'auto', width: 1584 }}>
+        <DataGrid
+          rows={[{ id: 1 }]}
+          columns={[
+            { field: '1', flex: 1 },
+            { field: '2', flex: 1 },
+            { field: '3', flex: 1 },
+            { field: '4', flex: 1 },
+            { field: '5', flex: 1 },
+            { field: '6', flex: 1 },
+          ]}
+        />
+      </div>,
+    );
+  });
 });

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1161,4 +1161,29 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       </div>,
     );
   });
+
+  // See https://github.com/mui/mui-x/issues/9550
+  it('should not exceed maximum call stack size with duplicated flex fields', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // Need layouting
+      this.skip();
+    }
+
+    expect(() => {
+      render(
+        <div style={{ height: 200, width: 400 }}>
+          <DataGrid
+            rows={[{ id: 1 }]}
+            columns={[
+              { field: 'id', flex: 1 },
+              { field: 'id', flex: 1 },
+            ]}
+          />
+        </div>,
+      );
+    }).toErrorDev([
+      'Warning: Encountered two children with the same key, `id`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.',
+      'Warning: Encountered two children with the same key, `id`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.',
+    ]);
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/mui-x/issues/9550
Before: https://codesandbox.io/s/quiet-frost-3yn7ss
After: https://codesandbox.io/s/stoic-cherry-6nfdz7

Fixes https://github.com/mui/mui-x/pull/9516#issuecomment-1619996793
Before: https://codesandbox.io/s/maximum-call-stack-size-exceeded-zhz6dw
After: https://codesandbox.io/s/maximum-call-stack-size-exceeded-forked-wwvd53