### PR TITLE
[DataGrid] Experiment with sticky column headers

### DIFF
--- a/packages/grid/x-data-grid/src/components/DataGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/components/DataGridVirtualScroller.tsx
@@ -5,6 +5,30 @@ import { GridVirtualScrollerRenderZone } from './virtualization/GridVirtualScrol
 import { useGridVirtualScroller } from '../hooks/features/virtualization/useGridVirtualScroller';
 import { GridOverlays } from './base/GridOverlays';
 
+import { useGridPrivateApiContext } from '../hooks/utils/useGridPrivateApiContext';
+import { useGridSelector } from '../hooks/utils/useGridSelector';
+import { useGridRootProps } from '../hooks/utils/useGridRootProps';
+import {
+  gridColumnPositionsSelector,
+  gridColumnVisibilityModelSelector,
+  gridVisibleColumnDefinitionsSelector,
+} from '../hooks/features/columns/gridColumnsSelector';
+import { gridFilterActiveItemsLookupSelector } from '../hooks/features/filter/gridFilterSelector';
+import { gridSortColumnLookupSelector } from '../hooks/features/sorting/gridSortingSelector';
+import {
+  gridTabIndexColumnHeaderSelector,
+  gridTabIndexCellSelector,
+  gridFocusColumnHeaderSelector,
+  unstable_gridTabIndexColumnGroupHeaderSelector,
+  unstable_gridFocusColumnGroupHeaderSelector,
+} from '../hooks/features/focus/gridFocusStateSelector';
+import { gridDensityFactorSelector } from '../hooks/features/density/densitySelector';
+import {
+  gridColumnGroupsHeaderMaxDepthSelector,
+  gridColumnGroupsHeaderStructureSelector,
+} from '../hooks/features/columnGrouping/gridColumnGroupsSelector';
+import { gridColumnMenuSelector } from '../hooks/features/columnMenu/columnMenuSelector';
+
 interface DataGridVirtualScrollerProps extends React.HTMLAttributes<HTMLDivElement> {
   disableVirtualization?: boolean;
 }
@@ -18,8 +42,71 @@ const DataGridVirtualScroller = React.forwardRef<HTMLDivElement, DataGridVirtual
       disableVirtualization,
     });
 
+    const apiRef = useGridPrivateApiContext();
+    const rootProps = useGridRootProps();
+
+    const visibleColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
+    const filterColumnLookup = useGridSelector(apiRef, gridFilterActiveItemsLookupSelector);
+    const sortColumnLookup = useGridSelector(apiRef, gridSortColumnLookupSelector);
+    const columnPositions = useGridSelector(apiRef, gridColumnPositionsSelector);
+    const columnHeaderTabIndexState = useGridSelector(apiRef, gridTabIndexColumnHeaderSelector);
+    const cellTabIndexState = useGridSelector(apiRef, gridTabIndexCellSelector);
+    const columnGroupHeaderTabIndexState = useGridSelector(
+      apiRef,
+      unstable_gridTabIndexColumnGroupHeaderSelector,
+    );
+
+    const columnHeaderFocus = useGridSelector(apiRef, gridFocusColumnHeaderSelector);
+    const columnGroupHeaderFocus = useGridSelector(
+      apiRef,
+      unstable_gridFocusColumnGroupHeaderSelector,
+    );
+
+    const densityFactor = useGridSelector(apiRef, gridDensityFactorSelector);
+    const headerGroupingMaxDepth = useGridSelector(apiRef, gridColumnGroupsHeaderMaxDepthSelector);
+
+    const columnMenuState = useGridSelector(apiRef, gridColumnMenuSelector);
+    const columnVisibility = useGridSelector(apiRef, gridColumnVisibilityModelSelector);
+    const columnGroupsHeaderStructure = useGridSelector(
+      apiRef,
+      gridColumnGroupsHeaderStructureSelector,
+    );
+
+    const hasOtherElementInTabSequence = !(
+      columnGroupHeaderTabIndexState === null &&
+      columnHeaderTabIndexState === null &&
+      cellTabIndexState === null
+    );
+
+    const columnHeadersRef = React.useRef<HTMLDivElement>(null);
+    const columnsContainerRef = React.useRef<HTMLDivElement>(null);
+
+    apiRef.current.register('private', {
+      columnHeadersContainerElementRef: columnsContainerRef,
+      columnHeadersElementRef: columnHeadersRef,
+    });
+
     return (
       <GridVirtualScroller className={className} {...getRootProps(other)}>
+        <rootProps.slots.columnHeaders
+          ref={columnsContainerRef}
+          innerRef={columnHeadersRef}
+          visibleColumns={visibleColumns}
+          filterColumnLookup={filterColumnLookup}
+          sortColumnLookup={sortColumnLookup}
+          columnPositions={columnPositions}
+          columnHeaderTabIndexState={columnHeaderTabIndexState}
+          columnGroupHeaderTabIndexState={columnGroupHeaderTabIndexState}
+          columnHeaderFocus={columnHeaderFocus}
+          columnGroupHeaderFocus={columnGroupHeaderFocus}
+          densityFactor={densityFactor}
+          headerGroupingMaxDepth={headerGroupingMaxDepth}
+          columnMenuState={columnMenuState}
+          columnVisibility={columnVisibility}
+          columnGroupsHeaderStructure={columnGroupsHeaderStructure}
+          hasOtherElementInTabSequence={hasOtherElementInTabSequence}
+          // {...ColumnHeadersProps}
+        />
         <GridOverlays />
         <GridVirtualScrollerContent {...getContentProps()}>
           <GridVirtualScrollerRenderZone {...getRenderZoneProps()}>

--- a/packages/grid/x-data-grid/src/components/DataGridVirtualScroller.tsx
+++ b/packages/grid/x-data-grid/src/components/DataGridVirtualScroller.tsx
@@ -86,6 +86,14 @@ const DataGridVirtualScroller = React.forwardRef<HTMLDivElement, DataGridVirtual
       columnHeadersElementRef: columnHeadersRef,
     });
 
+    const contentProps = getContentProps();
+
+    React.useEffect(() => {
+      if (columnsContainerRef.current) {
+        columnsContainerRef.current.style.width = `${contentProps.style.width}px`;
+      }
+    }, [contentProps.style.width]);
+
     return (
       <GridVirtualScroller className={className} {...getRootProps(other)}>
         <rootProps.slots.columnHeaders
@@ -105,10 +113,11 @@ const DataGridVirtualScroller = React.forwardRef<HTMLDivElement, DataGridVirtual
           columnVisibility={columnVisibility}
           columnGroupsHeaderStructure={columnGroupsHeaderStructure}
           hasOtherElementInTabSequence={hasOtherElementInTabSequence}
+          // style={{ width: contentProps.style.width }}
           // {...ColumnHeadersProps}
         />
         <GridOverlays />
-        <GridVirtualScrollerContent {...getContentProps()}>
+        <GridVirtualScrollerContent {...contentProps}>
           <GridVirtualScrollerRenderZone {...getRenderZoneProps()}>
             {getRows()}
           </GridVirtualScrollerRenderZone>

--- a/packages/grid/x-data-grid/src/components/base/GridBody.tsx
+++ b/packages/grid/x-data-grid/src/components/base/GridBody.tsx
@@ -2,29 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiContext';
-import { useGridSelector } from '../../hooks/utils/useGridSelector';
 import { GridMainContainer } from '../containers/GridMainContainer';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
-import {
-  gridColumnPositionsSelector,
-  gridColumnVisibilityModelSelector,
-  gridVisibleColumnDefinitionsSelector,
-} from '../../hooks/features/columns/gridColumnsSelector';
-import { gridFilterActiveItemsLookupSelector } from '../../hooks/features/filter/gridFilterSelector';
-import { gridSortColumnLookupSelector } from '../../hooks/features/sorting/gridSortingSelector';
-import {
-  gridTabIndexColumnHeaderSelector,
-  gridTabIndexCellSelector,
-  gridFocusColumnHeaderSelector,
-  unstable_gridTabIndexColumnGroupHeaderSelector,
-  unstable_gridFocusColumnGroupHeaderSelector,
-} from '../../hooks/features/focus/gridFocusStateSelector';
-import { gridDensityFactorSelector } from '../../hooks/features/density/densitySelector';
-import {
-  gridColumnGroupsHeaderMaxDepthSelector,
-  gridColumnGroupsHeaderStructureSelector,
-} from '../../hooks/features/columnGrouping/gridColumnGroupsSelector';
-import { gridColumnMenuSelector } from '../../hooks/features/columnMenu/columnMenuSelector';
 
 interface GridBodyProps {
   children?: React.ReactNode;
@@ -42,39 +21,6 @@ function GridBody(props: GridBodyProps) {
   const apiRef = useGridPrivateApiContext();
   const rootProps = useGridRootProps();
   const rootRef = React.useRef<HTMLDivElement>(null);
-
-  const visibleColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
-  const filterColumnLookup = useGridSelector(apiRef, gridFilterActiveItemsLookupSelector);
-  const sortColumnLookup = useGridSelector(apiRef, gridSortColumnLookupSelector);
-  const columnPositions = useGridSelector(apiRef, gridColumnPositionsSelector);
-  const columnHeaderTabIndexState = useGridSelector(apiRef, gridTabIndexColumnHeaderSelector);
-  const cellTabIndexState = useGridSelector(apiRef, gridTabIndexCellSelector);
-  const columnGroupHeaderTabIndexState = useGridSelector(
-    apiRef,
-    unstable_gridTabIndexColumnGroupHeaderSelector,
-  );
-
-  const columnHeaderFocus = useGridSelector(apiRef, gridFocusColumnHeaderSelector);
-  const columnGroupHeaderFocus = useGridSelector(
-    apiRef,
-    unstable_gridFocusColumnGroupHeaderSelector,
-  );
-
-  const densityFactor = useGridSelector(apiRef, gridDensityFactorSelector);
-  const headerGroupingMaxDepth = useGridSelector(apiRef, gridColumnGroupsHeaderMaxDepthSelector);
-
-  const columnMenuState = useGridSelector(apiRef, gridColumnMenuSelector);
-  const columnVisibility = useGridSelector(apiRef, gridColumnVisibilityModelSelector);
-  const columnGroupsHeaderStructure = useGridSelector(
-    apiRef,
-    gridColumnGroupsHeaderStructureSelector,
-  );
-
-  const hasOtherElementInTabSequence = !(
-    columnGroupHeaderTabIndexState === null &&
-    columnHeaderTabIndexState === null &&
-    cellTabIndexState === null
-  );
 
   const [isVirtualizationDisabled, setIsVirtualizationDisabled] = React.useState(
     rootProps.disableVirtualization,
@@ -132,40 +78,17 @@ function GridBody(props: GridBodyProps) {
   apiRef.current.unstable_disableVirtualization = disableVirtualization;
   apiRef.current.unstable_enableVirtualization = enableVirtualization;
 
-  const columnHeadersRef = React.useRef<HTMLDivElement>(null);
-  const columnsContainerRef = React.useRef<HTMLDivElement>(null);
+  const hasDimensions = !!apiRef.current.getRootDimensions();
+
   const virtualScrollerRef = React.useRef<HTMLDivElement>(null);
 
   apiRef.current.register('private', {
-    columnHeadersContainerElementRef: columnsContainerRef,
-    columnHeadersElementRef: columnHeadersRef,
     virtualScrollerRef,
     mainElementRef: rootRef,
   });
 
-  const hasDimensions = !!apiRef.current.getRootDimensions();
-
   return (
     <GridMainContainer ref={rootRef}>
-      <rootProps.slots.columnHeaders
-        ref={columnsContainerRef}
-        innerRef={columnHeadersRef}
-        visibleColumns={visibleColumns}
-        filterColumnLookup={filterColumnLookup}
-        sortColumnLookup={sortColumnLookup}
-        columnPositions={columnPositions}
-        columnHeaderTabIndexState={columnHeaderTabIndexState}
-        columnGroupHeaderTabIndexState={columnGroupHeaderTabIndexState}
-        columnHeaderFocus={columnHeaderFocus}
-        columnGroupHeaderFocus={columnGroupHeaderFocus}
-        densityFactor={densityFactor}
-        headerGroupingMaxDepth={headerGroupingMaxDepth}
-        columnMenuState={columnMenuState}
-        columnVisibility={columnVisibility}
-        columnGroupsHeaderStructure={columnGroupsHeaderStructure}
-        hasOtherElementInTabSequence={hasOtherElementInTabSequence}
-        {...ColumnHeadersProps}
-      />
       {hasDimensions && (
         <VirtualScrollerComponent
           // The content is only rendered after dimensions are computed because

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridBaseColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridBaseColumnHeaders.tsx
@@ -23,8 +23,9 @@ const GridColumnHeadersRoot = styled('div', {
   slot: 'ColumnHeaders',
   overridesResolver: (props, styles) => styles.columnHeaders,
 })<{ ownerState: OwnerState }>({
-  position: 'relative',
-  overflow: 'hidden',
+  position: 'sticky',
+  top: 0,
+  zIndex: 2,
   display: 'flex',
   alignItems: 'center',
   boxSizing: 'border-box',

--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -1,20 +1,13 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
-import { styled, useTheme } from '@mui/system';
-import { defaultMemoize } from 'reselect';
+import { styled } from '@mui/system';
 import { useGridPrivateApiContext } from '../../utils/useGridPrivateApiContext';
 import { useGridRootProps } from '../../utils/useGridRootProps';
 import { GridRenderContext } from '../../../models/params/gridScrollParams';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridEventListener } from '../../../models/events';
 import { GridColumnHeaderItem } from '../../../components/columnHeaders/GridColumnHeaderItem';
-import { getFirstColumnIndexToRender, getTotalHeaderHeight } from '../columns/gridColumnsUtils';
-import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
-import {
-  areRenderContextsEqual,
-  getRenderableIndexes,
-} from '../virtualization/useGridVirtualScroller';
+import { getTotalHeaderHeight } from '../columns/gridColumnsUtils';
 import { GridColumnGroupHeader } from '../../../components/columnHeaders/GridColumnGroupHeader';
 import { GridColumnGroup } from '../../../models/gridColumnGrouping';
 import { GridStateColDef } from '../../../models/colDef/gridColDef';
@@ -71,10 +64,6 @@ export interface GetHeadersParams {
   maxLastColumn?: number;
 }
 
-function isUIEvent(event: any): event is React.UIEvent {
-  return !!event.target;
-}
-
 export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   const {
     innerRef: innerRefProp,
@@ -82,7 +71,6 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
     visibleColumns,
     sortColumnLookup,
     filterColumnLookup,
-    columnPositions,
     columnHeaderTabIndexState,
     columnGroupHeaderTabIndexState,
     columnHeaderFocus,
@@ -94,7 +82,6 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
     columnGroupsHeaderStructure,
     hasOtherElementInTabSequence,
   } = props;
-  const theme = useTheme();
 
   const [dragCol, setDragCol] = React.useState('');
   const [resizeCol, setResizeCol] = React.useState('');
@@ -104,135 +91,8 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   const rootProps = useGridRootProps();
   const innerRef = React.useRef<HTMLDivElement>(null);
   const handleInnerRef = useForkRef(innerRefProp, innerRef);
-  const [renderContext, setRenderContextRaw] = React.useState<GridRenderContext | null>(null);
-  const prevRenderContext = React.useRef<GridRenderContext | null>(renderContext);
-  const prevScrollLeft = React.useRef(0);
-  const currentPage = useGridVisibleRows(apiRef, rootProps);
   const totalHeaderHeight = getTotalHeaderHeight(apiRef, rootProps.columnHeaderHeight);
   const headerHeight = Math.floor(rootProps.columnHeaderHeight * densityFactor);
-
-  const setRenderContext = React.useCallback(
-    (nextRenderContext: GridRenderContext | null) => {
-      if (
-        renderContext &&
-        nextRenderContext &&
-        areRenderContextsEqual(renderContext, nextRenderContext)
-      ) {
-        return;
-      }
-      setRenderContextRaw(nextRenderContext);
-    },
-    [renderContext],
-  );
-
-  React.useEffect(() => {
-    apiRef.current.columnHeadersContainerElementRef!.current!.scrollLeft = 0;
-  }, [apiRef]);
-
-  // memoize `getFirstColumnIndexToRender`, since it's called on scroll
-  const getFirstColumnIndexToRenderRef = React.useRef<typeof getFirstColumnIndexToRender>(
-    defaultMemoize(getFirstColumnIndexToRender, {
-      equalityCheck: (a, b) =>
-        ['firstColumnIndex', 'minColumnIndex', 'columnBuffer'].every((key) => a[key] === b[key]),
-    }),
-  );
-
-  const updateInnerPosition = React.useCallback(
-    (nextRenderContext: GridRenderContext) => {
-      if (1 === 1) {
-        return;
-      }
-
-      const [firstRowToRender, lastRowToRender] = getRenderableIndexes({
-        firstIndex: nextRenderContext.firstRowIndex,
-        lastIndex: nextRenderContext.lastRowIndex,
-        minFirstIndex: 0,
-        maxLastIndex: currentPage.rows.length,
-        buffer: rootProps.rowBuffer,
-      });
-
-      const firstColumnToRender = getFirstColumnIndexToRenderRef.current({
-        firstColumnIndex: nextRenderContext!.firstColumnIndex,
-        minColumnIndex,
-        columnBuffer: rootProps.columnBuffer,
-        firstRowToRender,
-        lastRowToRender,
-        apiRef,
-        visibleRows: currentPage.rows,
-      });
-
-      const direction = theme.direction === 'ltr' ? 1 : -1;
-
-      const offset =
-        firstColumnToRender > 0
-          ? prevScrollLeft.current - direction * columnPositions[firstColumnToRender]
-          : prevScrollLeft.current;
-
-      innerRef!.current!.style.transform = `translate3d(${-offset}px, 0px, 0px)`;
-    },
-    [
-      columnPositions,
-      minColumnIndex,
-      rootProps.columnBuffer,
-      apiRef,
-      currentPage.rows,
-      rootProps.rowBuffer,
-      theme.direction,
-    ],
-  );
-
-  React.useLayoutEffect(() => {
-    if (renderContext) {
-      updateInnerPosition(renderContext);
-    }
-  }, [renderContext, updateInnerPosition]);
-
-  const handleScroll = React.useCallback<GridEventListener<'scrollPositionChange'>>(
-    ({ left, renderContext: nextRenderContext = null }, event) => {
-      if (!innerRef.current) {
-        return;
-      }
-
-      // Ignore vertical scroll.
-      // Excepts the first event which sets the previous render context.
-      if (
-        prevScrollLeft.current === left &&
-        prevRenderContext.current?.firstColumnIndex === nextRenderContext?.firstColumnIndex &&
-        prevRenderContext.current?.lastColumnIndex === nextRenderContext?.lastColumnIndex
-      ) {
-        return;
-      }
-      prevScrollLeft.current = left;
-
-      // We can only update the position when we guarantee that the render context has been
-      // rendered. This is achieved using ReactDOM.flushSync or when the context doesn't change.
-      let canUpdateInnerPosition = false;
-
-      if (nextRenderContext !== prevRenderContext.current || !prevRenderContext.current) {
-        // ReactDOM.flushSync cannot be called on `scroll` events fired inside effects
-        if (isUIEvent(event)) {
-          // To prevent flickering, the inner position can only be updated after the new context has
-          // been rendered. ReactDOM.flushSync ensures that the state changes will happen before
-          // updating the position.
-          ReactDOM.flushSync(() => {
-            setRenderContext(nextRenderContext);
-          });
-          canUpdateInnerPosition = true;
-        } else {
-          setRenderContext(nextRenderContext);
-        }
-        prevRenderContext.current = nextRenderContext;
-      } else {
-        canUpdateInnerPosition = true;
-      }
-
-      // Pass directly the render context to avoid waiting for the next render
-      if (nextRenderContext && canUpdateInnerPosition) {
-        updateInnerPosition(nextRenderContext);
-      }
-    },
-    [updateInnerPosition, setRenderContext],
-  );
 
   const handleColumnResizeStart = React.useCallback<GridEventListener<'columnResizeStart'>>(
     (params) => setResizeCol(params.field),
@@ -258,50 +118,16 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   useGridApiEventHandler(apiRef, 'columnHeaderDragStart', handleColumnReorderStart);
   useGridApiEventHandler(apiRef, 'columnHeaderDragEnd', handleColumnReorderStop);
 
-  useGridApiEventHandler(apiRef, 'scrollPositionChange', handleScroll);
-
   // Helper for computation common between getColumnHeaders and getColumnGroupHeaders
   const getColumnsToRender = (params?: GetHeadersParams) => {
-    const {
-      renderContext: nextRenderContext = renderContext,
-      minFirstColumn = minColumnIndex,
-      maxLastColumn = visibleColumns.length,
-    } = params || {};
+    const { minFirstColumn = minColumnIndex, maxLastColumn = visibleColumns.length } = params || {};
 
-    if (!nextRenderContext) {
-      return null;
-    }
-
-    const [firstRowToRender, lastRowToRender] = getRenderableIndexes({
-      firstIndex: nextRenderContext.firstRowIndex,
-      lastIndex: nextRenderContext.lastRowIndex,
-      minFirstIndex: 0,
-      maxLastIndex: currentPage.rows.length,
-      buffer: rootProps.rowBuffer,
-    });
-
-    const firstColumnToRender = getFirstColumnIndexToRenderRef.current({
-      firstColumnIndex: nextRenderContext!.firstColumnIndex,
-      minColumnIndex: minFirstColumn,
-      columnBuffer: rootProps.columnBuffer,
-      apiRef,
-      firstRowToRender,
-      lastRowToRender,
-      visibleRows: currentPage.rows,
-    });
-
-    const lastColumnToRender = Math.min(
-      nextRenderContext.lastColumnIndex! + rootProps.columnBuffer,
-      maxLastColumn,
-    );
-
-    // const renderedColumns = visibleColumns.slice(firstColumnToRender, lastColumnToRender);
     const renderedColumns = visibleColumns;
 
     return {
       renderedColumns,
-      firstColumnToRender,
-      lastColumnToRender,
+      firstColumnToRender: 0,
+      lastColumnToRender: renderedColumns.length - 1,
       minFirstColumn,
       maxLastColumn,
     };
@@ -498,7 +324,6 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   };
 
   return {
-    renderContext,
     getColumnHeaders,
     getColumnsToRender,
     getColumnGroupHeaders,

--- a/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -139,6 +139,10 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
 
   const updateInnerPosition = React.useCallback(
     (nextRenderContext: GridRenderContext) => {
+      if (1 === 1) {
+        return;
+      }
+
       const [firstRowToRender, lastRowToRender] = getRenderableIndexes({
         firstIndex: nextRenderContext.firstRowIndex,
         lastIndex: nextRenderContext.lastRowIndex,
@@ -291,7 +295,8 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
       maxLastColumn,
     );
 
-    const renderedColumns = visibleColumns.slice(firstColumnToRender, lastColumnToRender);
+    // const renderedColumns = visibleColumns.slice(firstColumnToRender, lastColumnToRender);
+    const renderedColumns = visibleColumns;
 
     return {
       renderedColumns,
@@ -455,7 +460,6 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         <GridColumnHeaderRow
           style={{
             height: `${headerHeight}px`,
-            transform: `translateX(-${depthInfo.leftOverflow}px)`,
           }}
           key={depthIndex}
           role="row"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This is a sticky column headers idea borrowed from https://github.com/mui/mui-x/pull/9171 and applied to our current virtualization engine.

Demo: https://deploy-preview-9589--material-ui-x.netlify.app/x/react-data-grid/virtualization/#column-virtualization