### PR TITLE
[DataGrid] Make `rowExpansionChange` event public

### DIFF
--- a/docs/data/data-grid/events/events.json
+++ b/docs/data/data-grid/events/events.json
@@ -325,6 +325,13 @@
     "componentProp": "onRowEditStop"
   },
   {
+    "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
+    "name": "rowExpansionChange",
+    "description": "Fired when the expansion of a row is changed. Called with a GridGroupNode object.",
+    "params": "GridGroupNode",
+    "event": "MuiEvent<{}>"
+  },
+  {
     "projects": ["x-data-grid-premium"],
     "name": "rowGroupingModelChange",
     "description": "Fired when the row grouping model changes.",

--- a/docs/data/data-grid/row-grouping/RowGroupingSetChildrenExpansion.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingSetChildrenExpansion.js
@@ -9,9 +9,15 @@ import { useMovieData } from '@mui/x-data-grid-generator';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 
+const debug = (params) => console.info('Row expansion changed for row ', params.id);
+
 export default function RowGroupingSetChildrenExpansion() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
+
+  React.useEffect(() => {
+    apiRef.current.subscribeEvent('rowExpansionChange', debug);
+  }, [apiRef]);
 
   const initialState = useKeepGroupedColumnsHidden({
     apiRef,

--- a/docs/data/data-grid/row-grouping/RowGroupingSetChildrenExpansion.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingSetChildrenExpansion.tsx
@@ -10,9 +10,16 @@ import { useMovieData } from '@mui/x-data-grid-generator';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 
+const debug = (params: GridGroupNode) =>
+  console.info('Row expansion changed for row ', params.id);
+
 export default function RowGroupingSetChildrenExpansion() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
+
+  React.useEffect(() => {
+    apiRef.current.subscribeEvent('rowExpansionChange', debug);
+  }, [apiRef]);
 
   const initialState = useKeepGroupedColumnsHidden({
     apiRef,

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -236,7 +236,7 @@ isGroupExpandedByDefault={
 
 {{"demo": "RowGroupingIsGroupExpandedByDefault.js", "bg": "inline", "defaultCodeOpen": false}}
 
-Use the `setRowChildrenExpansion` method on `apiRef` to programmatically set the expansion of a row.
+Use the `setRowChildrenExpansion` method on `apiRef` to programmatically set the expansion of a row. Changing the expansion of a row emits a `rowExpansionChange` event, listen to it to react to the expansion change.
 
 {{"demo": "RowGroupingSetChildrenExpansion.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/grid/x-data-grid/src/models/events/gridEventLookup.ts
@@ -441,7 +441,6 @@ export interface GridEventLookup
   sortedRowsSet: {};
   /**
    * Fired when the expansion of a row is changed. Called with a [[GridGroupNode]] object.
-   * @ignore - do not document.
    */
   rowExpansionChange: { params: GridGroupNode };
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #6335 

I wanted to add more things like `isExpanded` and `row` to the params of event as they could be useful in certain customizations, but this might be a breaking change for some users as the event is being used by some users and also used in [one](https://mui.com/x/react-data-grid/tree-data/#children-lazy-loading) of the demos. Recommendations are welcome.