### PR TITLE
[DataGrid] Experiment: Remove layout jump when start editing

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridEditInputCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridEditInputCell.tsx
@@ -32,7 +32,7 @@ const GridEditInputCellRoot = styled(InputBase, {
   ...theme.typography.body2,
   padding: '1px 0',
   '& input': {
-    padding: '0 16px',
+    padding: '0 9px',
     height: '100%',
   },
 }));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #5513 

Preview: https://deploy-preview-9612--material-ui-x.netlify.app/x/react-data-grid/