### PR TITLE
[license] Fix error terminology

### DIFF
--- a/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
@@ -13,6 +13,7 @@ describe('<DataGridPremium /> - License', () => {
       generateLicense({
         expiryDate: addYears(new Date(), 1),
         orderNumber: 'Test',
+        licensingModel: 'subscription',
         scope: 'pro',
       }),
     );

--- a/packages/x-license-pro/src/generateLicense/generateLicense.test.ts
+++ b/packages/x-license-pro/src/generateLicense/generateLicense.test.ts
@@ -2,19 +2,6 @@ import { expect } from 'chai';
 import { generateLicense } from './generateLicense';
 
 describe('License: generateLicense', () => {
-  // TODO: Remove
-  it('should generate pro license properly when "scope" is not provided', () => {
-    expect(
-      generateLicense({
-        expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
-        licensingModel: 'subscription',
-      }),
-    ).to.equal(
-      'b2b2ea9c6fd846e11770da3c795d6f63Tz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXBybyxMTT1zdWJzY3JpcHRpb24sS1Y9Mg==',
-    );
-  });
-
   it('should generate pro license properly when `scope: "pro"`', () => {
     expect(
       generateLicense({
@@ -41,20 +28,7 @@ describe('License: generateLicense', () => {
     );
   });
 
-  // TODO: Remove
-  it('should generate perpetual license when "licensingModel" is not provided', () => {
-    expect(
-      generateLicense({
-        expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
-        scope: 'pro',
-      }),
-    ).to.equal(
-      'b16edd8e6bc83293a723779a259f520cTz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXBybyxMTT1wZXJwZXR1YWwsS1Y9Mg==',
-    );
-  });
-
-  it('should generate subscription license when `licensingModel: "subscription"`', () => {
+  it('should generate annual license when `licensingModel: "subscription"`', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),

--- a/packages/x-license-pro/src/generateLicense/generateLicense.ts
+++ b/packages/x-license-pro/src/generateLicense/generateLicense.ts
@@ -20,7 +20,7 @@ function getClearLicenseString(details: LicenseDetails) {
   }
 
   if (details.licensingModel && !LICENSING_MODELS.includes(details.licensingModel)) {
-    throw new Error('MUI: Invalid sales model');
+    throw new Error('MUI: Invalid licensing model');
   }
 
   return `O=${details.orderNumber},E=${details.expiryDate.getTime()},S=${

--- a/packages/x-license-pro/src/generateLicense/generateLicense.ts
+++ b/packages/x-license-pro/src/generateLicense/generateLicense.ts
@@ -8,10 +8,8 @@ const licenseVersion = '2';
 export interface LicenseDetails {
   orderNumber: string;
   expiryDate: Date;
-  // TODO: to be made required once the store is updated
-  scope?: LicenseScope;
-  // TODO: to be made required once the store is updated
-  licensingModel?: LicensingModel;
+  scope: LicenseScope;
+  licensingModel: LicensingModel;
 }
 
 function getClearLicenseString(details: LicenseDetails) {
@@ -23,9 +21,9 @@ function getClearLicenseString(details: LicenseDetails) {
     throw new Error('MUI: Invalid licensing model');
   }
 
-  return `O=${details.orderNumber},E=${details.expiryDate.getTime()},S=${
-    details.scope ?? 'pro'
-  },LM=${details.licensingModel ?? 'perpetual'},KV=${licenseVersion}`;
+  return `O=${details.orderNumber},E=${details.expiryDate.getTime()},S=${details.scope},LM=${
+    details.licensingModel
+  },KV=${licenseVersion}`;
 }
 
 export function generateLicense(details: LicenseDetails) {

--- a/packages/x-license-pro/src/utils/licensingModel.ts
+++ b/packages/x-license-pro/src/utils/licensingModel.ts
@@ -8,6 +8,10 @@ export const LICENSING_MODELS = [
    * On development, a license is outdated if the expiry date has been reached
    * On production, a license is outdated if the current version of the software was released after the expiry date of the license (see "perpetual")
    */
+  'annual',
+  /**
+   * TODO 2025 remove, legacy name of annual.
+   */
   'subscription',
 ] as const;
 

--- a/packages/x-license-pro/src/verifyLicense/verifyLicense.test.ts
+++ b/packages/x-license-pro/src/verifyLicense/verifyLicense.test.ts
@@ -37,6 +37,8 @@ describe('License: verifyLicense', () => {
     it('should check expired license properly', () => {
       const expiredLicenseKey = generateLicense({
         expiryDate: new Date(releaseDate.getTime() - oneDayInMS),
+        scope: 'pro',
+        licensingModel: 'perpetual',
         orderNumber: 'MUI-123',
       });
 
@@ -129,6 +131,7 @@ describe('License: verifyLicense', () => {
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
           orderNumber: 'MUI-123',
+          scope: 'pro',
           licensingModel: 'subscription',
         });
 
@@ -146,6 +149,7 @@ describe('License: verifyLicense', () => {
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
           orderNumber: 'MUI-123',
+          scope: 'pro',
           licensingModel: 'subscription',
         });
 
@@ -163,6 +167,7 @@ describe('License: verifyLicense', () => {
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
           orderNumber: 'MUI-123',
+          scope: 'pro',
           licensingModel: 'perpetual',
         });
 
@@ -187,6 +192,26 @@ describe('License: verifyLicense', () => {
           isProduction: true,
         }),
       ).to.equal(LicenseStatus.Invalid);
+    });
+  });
+
+  describe('key version: 2.1', () => {
+    const licenseKeyPro = generateLicense({
+      expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
+      orderNumber: 'MUI-123',
+      scope: 'pro',
+      licensingModel: 'annual',
+    });
+
+    it('should accept licensingModel="annual"', () => {
+      expect(
+        verifyLicense({
+          releaseInfo: RELEASE_INFO,
+          licenseKey: licenseKeyPro,
+          acceptedScopes: ['pro', 'premium'],
+          isProduction: true,
+        }),
+      ).to.equal(LicenseStatus.Valid);
     });
   });
 });

--- a/packages/x-license-pro/src/verifyLicense/verifyLicense.ts
+++ b/packages/x-license-pro/src/verifyLicense/verifyLicense.ts
@@ -129,7 +129,7 @@ export function verifyLicense({
   }
 
   if (license.licensingModel == null || !LICENSING_MODELS.includes(license.licensingModel)) {
-    console.error('Error checking license. Sales model not found or invalid!');
+    console.error('Error checking license. Licensing model not found or invalid!');
     return LicenseStatus.Invalid;
   }
 
@@ -147,7 +147,7 @@ export function verifyLicense({
     if (license.expiryTimestamp < pkgTimestamp) {
       return LicenseStatus.ExpiredVersion;
     }
-  } else if (license.licensingModel === 'subscription') {
+  } else if (license.licensingModel === 'subscription' || license.licensingModel === 'annual') {
     if (license.expiryTimestamp < new Date().getTime()) {
       return LicenseStatus.ExpiredAnnual;
     }


### PR DESCRIPTION
`throw new Error('MUI: Invalid sales model');` doesn't make sense.

I have also used the opportunity to:

- remove dead code
- prepare the renaming from `subscription` to `annual`. We could use `subscription` in the future, but this would IMHO, also imply the need to have an active license in production