### PR TITLE
[docs] Improve the UI for pickers introduction

### DIFF
--- a/docs/src/modules/components/InstallationInstructions.tsx
+++ b/docs/src/modules/components/InstallationInstructions.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
 // @ts-expect-error
-import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+import HighlightedCodeWithTabs from 'docs/src/modules/components/HighlightedCodeWithTabs';
 import Stack from '@mui/material/Stack';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
-import MenuItem from '@mui/material/MenuItem';
-import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import ToggleOptions from './ToggleOptions';
 
 const defaultPackageManagers: Record<string, string> = {
-  yarn: 'yarn add',
   npm: 'npm install',
+  yarn: 'yarn add',
 };
 
 export default function InstallationInstructions(props: {
@@ -23,88 +21,50 @@ export default function InstallationInstructions(props: {
 }) {
   const { packages, packageManagers = defaultPackageManagers, peerDependency = null } = props;
   const packagesTypes = Object.keys(packages);
-  const packageManagersNames = Object.keys(packageManagers);
 
-  const [licenseType, setLicenseType] = React.useState(packagesTypes[0]);
-  const [packageManger, setPackageManger] = React.useState(packageManagersNames[0]);
+  const [licenceType, setLicenceType] = React.useState(packagesTypes[0]);
   const [libraryUsed, setLibraryUsed] = React.useState(
-    peerDependency ? peerDependency.packages[0] : null,
+    peerDependency ? peerDependency.packages[0] : '',
   );
 
-  const handlePackageMangerChange = (
-    event: React.MouseEvent<HTMLElement>,
-    nextPackageManager: string,
-  ) => {
-    if (nextPackageManager !== null) {
-      setPackageManger(nextPackageManager);
-    }
-  };
+  const tabs = Object.entries(packageManagers).map(([packageManger, installInstruction]) => {
+    const code = [`${installInstruction} ${packages[licenceType]}`];
 
-  const handleLicenseTypeChange = (
-    event: React.MouseEvent<HTMLElement>,
-    nextLicenseType: string,
-  ) => {
-    if (nextLicenseType !== null) {
-      setLicenseType(nextLicenseType);
+    if (peerDependency) {
+      code.push('');
+      if (peerDependency.installationComment) {
+        code.push(peerDependency.installationComment);
+      }
+      code.push(`${installInstruction} ${libraryUsed}`);
     }
-  };
-
-  const commands = [`${packageManagers[packageManger]} ${packages[licenseType]}`];
-
-  if (peerDependency) {
-    commands.push('');
-    if (peerDependency.installationComment) {
-      commands.push(peerDependency.installationComment);
-    }
-    commands.push(`${packageManagers[packageManger]} ${libraryUsed}`);
-  }
+    return {
+      code: code.join('\n'),
+      language: 'bash',
+      tab: packageManger,
+    };
+  });
 
   return (
     <Stack sx={{ width: '100%' }} px={{ xs: 3, sm: 0 }}>
-      <Stack direction="row" spacing={2}>
-        <ToggleButtonGroup
-          value={packageManger}
-          exclusive
-          onChange={handlePackageMangerChange}
-          size="small"
-        >
-          {packageManagersNames.map((key) => (
-            <ToggleButton value={key} key={key}>
-              {key}
-            </ToggleButton>
-          ))}
-        </ToggleButtonGroup>
-        <ToggleButtonGroup
-          value={licenseType}
-          exclusive
-          onChange={handleLicenseTypeChange}
-          size="small"
-        >
-          {packagesTypes.map((key) => (
-            <ToggleButton value={key} key={key}>
-              {key}
-            </ToggleButton>
-          ))}
-        </ToggleButtonGroup>
-        {peerDependency ? (
-          <TextField
-            size="small"
-            label={peerDependency.label}
-            value={libraryUsed}
-            onChange={(event) => {
-              setLibraryUsed(event.target.value);
-            }}
-            select
-          >
-            {peerDependency.packages.map((packageName) => (
-              <MenuItem key={packageName} value={packageName}>
-                {packageName}
-              </MenuItem>
-            ))}
-          </TextField>
-        ) : null}
-      </Stack>
-      <HighlightedCode sx={{ width: '100%' }} code={commands.join('\n')} language="bash" />
+      <Box sx={{ display: 'flex', gap: 3, width: 'max-content', py: 1, pb: 1.5 }}>
+        <ToggleOptions
+          value={licenceType}
+          setValue={setLicenceType}
+          options={packagesTypes}
+          label="Plan"
+        />
+        {peerDependency && (
+          <ToggleOptions
+            label="Date Library"
+            value={libraryUsed!}
+            setValue={setLibraryUsed}
+            options={peerDependency.packages}
+            autoColapse
+          />
+        )}
+      </Box>
+
+      <HighlightedCodeWithTabs tabs={tabs} storageKey="codeblock-package-manager" />
     </Stack>
   );
 }

--- a/docs/src/modules/components/PickersRenderingInstructions.js
+++ b/docs/src/modules/components/PickersRenderingInstructions.js
@@ -1,4 +1,3 @@
-/* eslint-disable material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import Stack from '@mui/material/Stack';

--- a/docs/src/modules/components/PickersRenderingInstructions.js
+++ b/docs/src/modules/components/PickersRenderingInstructions.js
@@ -2,10 +2,7 @@
 import * as React from 'react';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
-import MenuItem from '@mui/material/MenuItem';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import ToggleButton from '@mui/material/ToggleButton';
+import ToggleOptions from './ToggleOptions';
 
 const libraries = {
   dayjs: 'AdapterDayjs',
@@ -17,16 +14,6 @@ const libraries = {
 export default function PickersRenderingInstructions() {
   const [licenceType, setLicenceType] = React.useState('community');
   const [libraryUsed, setLibraryUsed] = React.useState('dayjs');
-
-  const handleLicenceTypeChange = (event, nextLicenseType) => {
-    if (nextLicenseType !== null) {
-      setLicenceType(nextLicenseType);
-    }
-  };
-
-  const handleLibraryUsedChange = (event) => {
-    setLibraryUsed(event.target.value);
-  };
 
   const componentPackage =
     licenceType === 'pro' ? '@mui/x-date-pickers-pro' : '@mui/x-date-pickers';
@@ -49,28 +36,20 @@ export default function PickersRenderingInstructions() {
   return (
     <Stack sx={{ width: '100%' }} px={{ xs: 3, sm: 0 }}>
       <Stack direction="row" spacing={2}>
-        <ToggleButtonGroup
+        <ToggleOptions
           value={licenceType}
-          exclusive
-          onChange={handleLicenceTypeChange}
-          size="small"
-        >
-          <ToggleButton value="community">community</ToggleButton>
-          <ToggleButton value="pro">pro</ToggleButton>
-        </ToggleButtonGroup>
-        <TextField
-          size="small"
-          label="Date library"
+          setValue={setLicenceType}
+          options={['community', 'pro']}
+          label="Plan"
+        />
+
+        <ToggleOptions
           value={libraryUsed}
-          onChange={handleLibraryUsedChange}
-          select
-        >
-          {Object.keys(libraries).map((lib) => (
-            <MenuItem key={lib} value={lib}>
-              {lib}
-            </MenuItem>
-          ))}
-        </TextField>
+          setValue={setLibraryUsed}
+          options={Object.keys(libraries)}
+          label="Date library"
+          autoColapse
+        />
       </Stack>
       <HighlightedCode sx={{ width: '100%' }} code={commandLines} language="tsx" />
     </Stack>

--- a/docs/src/modules/components/ToggleOptions.tsx
+++ b/docs/src/modules/components/ToggleOptions.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+export default function ToggleOptions(props: {
+  options: string[];
+  label: string;
+  value: string;
+  setValue: (arg: React.SetStateAction<string>) => void;
+  autoColapse?: boolean;
+}) {
+  const { options, label, value, setValue, autoColapse } = props;
+
+  return (
+    <Box>
+      <Typography
+        role="presentation"
+        sx={{
+          fontWeight: 600,
+          fontSize: '0.75rem',
+          mb: '2px',
+          color: 'text.secondary',
+        }}
+      >
+        {label}
+      </Typography>
+      <ToggleButtonGroup
+        sx={(theme) => (autoColapse ? { [theme.breakpoints.down('md')]: { display: 'none' } } : {})}
+        size="small"
+        fullWidth
+        color="primary"
+        value={value}
+        exclusive
+        onChange={(event, newValue) => {
+          if (newValue) {
+            setValue(newValue);
+          }
+        }}
+        aria-label={label}
+      >
+        {options.map((option) => {
+          return (
+            <ToggleButton
+              key={option}
+              value={option}
+              sx={{
+                width: 'max-content',
+                minWidth: 64,
+                py: 0.5,
+                px: 1,
+              }}
+            >
+              {option}
+            </ToggleButton>
+          );
+        })}
+      </ToggleButtonGroup>
+      <Select
+        sx={(theme) =>
+          autoColapse
+            ? {
+                [theme.breakpoints.up('md')]: { display: 'none' },
+
+                fontSize: '0.8125rem',
+                lineHeight: 1.75,
+                '& .MuiSelect-select': {
+                  fontSize: theme.typography.pxToRem(13),
+                  px: 1,
+                  py: 0.5,
+                },
+              }
+            : { display: 'none' }
+        }
+        size="small"
+        fullWidth
+        variant="outlined"
+        color="primary"
+        value={value}
+        onChange={(event) => {
+          if (event.target.value) {
+            setValue(event.target.value);
+          }
+        }}
+        aria-label={label}
+      >
+        {options.map((option) => {
+          return (
+            <MenuItem key={option} value={option}>
+              {option}
+            </MenuItem>
+          );
+        })}
+      </Select>
+    </Box>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1877,7 +1877,7 @@
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
   version "5.13.7"
-  resolved "https://github.com/mui/material-ui.git#ab2cb8cf9614ccab02b62a22de5129a1c2774d96"
+  resolved "https://github.com/mui/material-ui.git#a4afa9ff2442589deb73a4b08c299913983967bd"
 
 "@mui/private-theming@^5.13.1":
   version "5.13.1"


### PR DESCRIPTION
This PR uses the remaining codes from https://github.com/mui/material-ui/pull/36766 to improve the installation instruction

When the screen get too small the toggle button groups transform into a select to have best of desktop and mobile experience

![image](https://github.com/mui/mui-x/assets/45398769/fc8f3a5e-4e82-4a03-b1fd-280f4550f79c)
![image](https://github.com/mui/mui-x/assets/45398769/1327522e-b224-4332-911a-fbd3d0bb3b70)
