### PR TITLE
[DataGrid] Fix CSV export for values containing double quotes

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
@@ -146,14 +146,8 @@ describe('<DataGridPro /> - Export', () => {
               apiRef={apiRef}
               columns={columns}
               rows={[
-                {
-                  id: 0,
-                  brand: 'Nike',
-                },
-                {
-                  id: 1,
-                  brand: 'Samsung 24" (inches)',
-                },
+                { id: 0, brand: 'Nike' },
+                { id: 1, brand: 'Samsung 24" (inches)' },
               ]}
             />
           </div>
@@ -162,7 +156,7 @@ describe('<DataGridPro /> - Export', () => {
 
       render(<TestCaseCSVExport />);
       expect(apiRef.current.getDataAsCsv()).to.equal(
-        ['id,Brand', '0,Nike', '1,Samsung 24"" (inches)'].join('\r\n'),
+        ['id,Brand', '0,Nike', '1,"Samsung 24"" (inches)"'].join('\r\n'),
       );
     });
 

--- a/packages/grid/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -7,14 +7,12 @@ import { buildWarning } from '../../../../utils/warning';
 
 function sanitizeCellValue(value: any, delimiterCharacter: string) {
   if (typeof value === 'string') {
-    const formattedValue = value.replace(/"/g, '""');
-
     // Make sure value containing delimiter or line break won't be split into multiple rows
-    if ([delimiterCharacter, '\n', '\r'].some((delimiter) => formattedValue.includes(delimiter))) {
-      return `"${formattedValue}"`;
+    if ([delimiterCharacter, '\n', '\r', '"'].some((delimiter) => value.includes(delimiter))) {
+      return `"${value.replace(/"/g, '""')}"`;
     }
 
-    return formattedValue;
+    return value;
   }
 
   return value;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/mui-x/issues/9322