### PR TITLE
[docs] Differentiate between packages in `slotProps` docs

### DIFF
--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -184,8 +184,10 @@ For example, for `columnMenu` slot, the interface name would be `ColumnMenuProps
 
 This [file](https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts) lists all the interfaces for each slot which could be used for augmentation.
 
-```tsx
-// augment the props for `toolbar` slot
+<codeblock storageKey="data-grid-pricing-plan">
+
+```tsx Community
+// augment the props for the toolbar slot
 declare module '@mui/x-data-grid' {
   interface ToolbarPropsOverrides {
     someCustomString: string;
@@ -195,18 +197,68 @@ declare module '@mui/x-data-grid' {
 
 <DataGrid
   slots={{
-    // custom component passed to the `toolbar` slot
+    // custom component passed to the toolbar slot
     toolbar: CustomGridToolbar,
   }}
   slotProps={{
     toolbar: {
-      // props required by `CustomGridToolbar`
+      // props required by CustomGridToolbar
       someCustomString: 'Hello',
       someCustomNumber: 42,
     },
   }}
 >
 ```
+
+```tsx Pro
+// augment the props for the toolbar slot
+declare module '@mui/x-data-grid-pro' {
+  interface ToolbarPropsOverrides {
+    someCustomString: string;
+    someCustomNumber: number;
+  }
+}
+
+<DataGridPro
+  slots={{
+    // custom component passed to the toolbar slot
+    toolbar: CustomGridToolbar,
+  }}
+  slotProps={{
+    toolbar: {
+      // props required by CustomGridToolbar
+      someCustomString: 'Hello',
+      someCustomNumber: 42,
+    },
+  }}
+>
+```
+
+```tsx Premium
+// augment the props for the toolbar slot
+declare module '@mui/x-data-grid-premium' {
+  interface ToolbarPropsOverrides {
+    someCustomString: string;
+    someCustomNumber: number;
+  }
+}
+
+<DataGridPremium
+  slots={{
+    // custom component passed to the toolbar slot
+    toolbar: CustomGridToolbar,
+  }}
+  slotProps={{
+    toolbar: {
+      // props required by CustomGridToolbar
+      someCustomString: 'Hello',
+      someCustomNumber: 42,
+    },
+  }}
+>
+```
+
+</codeblock>
 
 This demo below shows how to use the `slotProps` prop and module augmentation to pass a new prop `status` to the `footer` slot.
 

--- a/docs/data/data-grid/components/components.md
+++ b/docs/data/data-grid/components/components.md
@@ -184,7 +184,7 @@ For example, for `columnMenu` slot, the interface name would be `ColumnMenuProps
 
 This [file](https://github.com/mui/mui-x/blob/-/packages/grid/x-data-grid/src/models/gridSlotsComponentsProps.ts) lists all the interfaces for each slot which could be used for augmentation.
 
-<codeblock storageKey="data-grid-pricing-plan">
+<codeblock storageKey="pricing-plan">
 
 ```tsx Community
 // augment the props for the toolbar slot


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

We got this feedback recently:
>The code example isn't correct. You should add
>> import '@mui/x-data-grid-pro'
>
> to the augmentation file. It won't work otherwise.

While I couldn't reproduce the issue, it makes sense to augment the package that you actually use.

Preview: https://deploy-preview-9668--material-ui-x.netlify.app/x/react-data-grid/components/#custom-slot-props-with-typescript