### PR TITLE
[pickers] Remove `require` usage in comment

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -23,7 +23,7 @@ type Constructor = (...args: Parameters<typeof defaultDayjs>) => Dayjs;
 const localeNotFoundWarning = buildWarning([
   'Your locale has not been found.',
   'Either the locale key is not a supported one. Locales supported by dayjs are available here: https://github.com/iamkun/dayjs/tree/dev/src/locale',
-  "Or you forget to import the locale with `require('dayjs/locale/{localeUsed}')`",
+  "Or you forget to import the locale from 'dayjs/locale/{localeUsed}'",
   'fallback on English locale',
 ]);
 


### PR DESCRIPTION
Fixes #9642 

Update the comment to avoid using `require` and thus avoid an issue on the "Vite land".
