### PR TITLE
[docs] Fix Date Pickers usage to Title Case

### DIFF
--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - Date localization
+title: Date and Time Pickers - Date localization
 components: LocalizationProvider
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -9,7 +9,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Date and Time Pickers - Base concepts
 
-<p class="description">The Date and Time pickers expose a lot of components to fit your every need.</p>
+<p class="description">The Date and Time Pickers expose a lot of components to fit your every need.</p>
 
 ## Controlled value
 

--- a/docs/data/date-pickers/calendar-systems/calendar-systems.md
+++ b/docs/data/date-pickers/calendar-systems/calendar-systems.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - Calendar systems
+title: Date and Time Pickers - Calendar systems
 components: LocalizationProvider
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - Custom subcomponents
+title: Date and Time Pickers - Custom subcomponents
 components: DateTimePickerTabs
 ---
 

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - Custom field
+title: Date and Time Pickers - Custom field
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'
 ---

--- a/docs/data/date-pickers/custom-layout/custom-layout.md
+++ b/docs/data/date-pickers/custom-layout/custom-layout.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - Custom layout
+title: Date and Time Pickers - Custom layout
 components: PickersActionBar, PickersLayout
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -9,7 +9,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Date and Time Pickers - Getting Started
 
-<p class="description">Get started with the Date and Time pickers. Install the package, configure your application and start using the components.</p>
+<p class="description">Get started with the Date and Time Pickers. Install the package, configure your application and start using the components.</p>
 
 ## Installation
 

--- a/docs/data/date-pickers/overview/overview.md
+++ b/docs/data/date-pickers/overview/overview.md
@@ -9,7 +9,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Date and Time Pickers
 
-<p class="description">The Date and Time pickers let the user select date and time values.</p>
+<p class="description">The Date and Time Pickers let the user select date and time values.</p>
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 

--- a/docs/data/date-pickers/shortcuts/shortcuts.md
+++ b/docs/data/date-pickers/shortcuts/shortcuts.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - Shortcuts
+title: Date and Time Pickers - Shortcuts
 components: PickersShortcuts
 ---
 

--- a/docs/data/date-pickers/timezone/timezone.md
+++ b/docs/data/date-pickers/timezone/timezone.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time pickers - UTC and timezones
+title: Date and Time Pickers - UTC and timezones
 components: LocalizationProvider
 githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers'

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -34,7 +34,7 @@ You can either run it on a specific file, folder, or your entire codebase when c
 ```bash
 // Data Grid specific
 npx @mui/x-codemod v6.0.0/data-grid/preset-safe <path>
-// Target Date and Time pickers as well
+// Target Date and Time Pickers as well
 npx @mui/x-codemod v6.0.0/preset-safe <path>
 ```
 

--- a/docs/pages/x/api/date-pickers/index.md
+++ b/docs/pages/x/api/date-pickers/index.md
@@ -1,6 +1,6 @@
 # Date and Time Pickers - API Reference
 
-<p class="description">This page contains an index to the most important APIs of the date pickers.</p>
+<p class="description">This page contains an index to the most important APIs of the Date Pickers.</p>
 
 ## Components
 

--- a/docs/pages/x/api/date-pickers/index.md
+++ b/docs/pages/x/api/date-pickers/index.md
@@ -1,6 +1,6 @@
 # Date and Time Pickers - API Reference
 
-<p class="description">This page contains an index to the most important APIs of the Date Pickers.</p>
+<p class="description">This page contains an index to the most important APIs of the Date and Time Pickers.</p>
 
 ## Components
 


### PR DESCRIPTION
### What? 
Updating Date Picker usage to Title Case. 
For example, `Date picker` => `Date Picker`

Work on #9318