### PR TITLE
[license] Throw in dev mode after 30 days

### DIFF
--- a/packages/x-license-pro/src/Watermark/Watermark.tsx
+++ b/packages/x-license-pro/src/Watermark/Watermark.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { MuiCommercialPackageName, useLicenseVerifier } from '../useLicenseVerifier';
-import { LicenseStatus } from '../utils/licenseStatus';
+import { LICENSE_STATUS, LicenseStatus } from '../utils/licenseStatus';
 
 function getLicenseErrorMessage(licenseStatus: LicenseStatus) {
   switch (licenseStatus) {
-    case LicenseStatus.ExpiredAnnualGrace:
-    case LicenseStatus.ExpiredAnnual:
+    case LICENSE_STATUS.ExpiredAnnualGrace:
+    case LICENSE_STATUS.ExpiredAnnual:
       return 'MUI X Expired license key';
-    case LicenseStatus.ExpiredVersion:
+    case LICENSE_STATUS.ExpiredVersion:
       return 'MUI X Expired package version';
-    case LicenseStatus.Invalid:
+    case LICENSE_STATUS.Invalid:
       return 'MUI X Invalid license key';
-    case LicenseStatus.OutOfScope:
+    case LICENSE_STATUS.OutOfScope:
       return 'MUI X License key plan mismatch';
-    case LicenseStatus.NotFound:
+    case LICENSE_STATUS.NotFound:
       return 'MUI X Missing license key';
     default:
       throw new Error('MUI: Unhandled MUI X license status.');
@@ -29,7 +29,7 @@ export function Watermark(props: WatermarkProps) {
   const { packageName, releaseInfo } = props;
   const licenseStatus = useLicenseVerifier(packageName, releaseInfo);
 
-  if (licenseStatus === LicenseStatus.Valid) {
+  if (licenseStatus.status === LICENSE_STATUS.Valid) {
     return null;
   }
 
@@ -48,7 +48,7 @@ export function Watermark(props: WatermarkProps) {
         fontSize: 24,
       }}
     >
-      {getLicenseErrorMessage(licenseStatus)}
+      {getLicenseErrorMessage(licenseStatus.status)}
     </div>
   );
 }

--- a/packages/x-license-pro/src/Watermark/Watermark.tsx
+++ b/packages/x-license-pro/src/Watermark/Watermark.tsx
@@ -4,6 +4,7 @@ import { LicenseStatus } from '../utils/licenseStatus';
 
 function getLicenseErrorMessage(licenseStatus: LicenseStatus) {
   switch (licenseStatus) {
+    case LicenseStatus.ExpiredAnnualGrace:
     case LicenseStatus.ExpiredAnnual:
       return 'MUI X Expired license key';
     case LicenseStatus.ExpiredVersion:

--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
@@ -14,8 +14,8 @@ const releaseDate = new Date(3000, 0, 0, 0, 0, 0, 0);
 const releaseInfo = generateReleaseInfo(releaseDate);
 
 function TestComponent() {
-  const status = useLicenseVerifier('x-date-pickers-pro', releaseInfo);
-  return <div data-testid="status">Status: {status}</div>;
+  const licesenStatus = useLicenseVerifier('x-date-pickers-pro', releaseInfo);
+  return <div data-testid="status">Status: {licesenStatus.status}</div>;
 }
 
 describe('useLicenseVerifier', () => {

--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.ts
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { verifyLicense } from '../verifyLicense/verifyLicense';
 import { LicenseInfo } from '../utils/licenseInfo';
 import {
+  showExpiredAnnualGraceLicenseKeyError,
   showExpiredAnnualLicenseKeyError,
   showInvalidLicenseKeyError,
   showMissingLicenseKeyError,
@@ -28,6 +29,8 @@ export function useLicenseVerifier(
   const { key: contextKey } = React.useContext(LicenseInfoContext);
   return React.useMemo(() => {
     const licenseKey = contextKey ?? LicenseInfo.getLicenseKey();
+
+    // Cache the response to not trigger the error twice.
     if (
       sharedLicenseStatuses[packageName] &&
       sharedLicenseStatuses[packageName]!.key === licenseKey
@@ -56,6 +59,8 @@ export function useLicenseVerifier(
       showLicenseKeyPlanMismatchError();
     } else if (licenseStatus === LicenseStatus.NotFound) {
       showMissingLicenseKeyError({ plan, packageName: fullPackageName });
+    } else if (licenseStatus === LicenseStatus.ExpiredAnnualGrace) {
+      showExpiredAnnualGraceLicenseKeyError({ plan });
     } else if (licenseStatus === LicenseStatus.ExpiredAnnual) {
       showExpiredAnnualLicenseKeyError({ plan });
     } else if (licenseStatus === LicenseStatus.ExpiredVersion) {

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -59,7 +59,15 @@ export function showExpiredPackageVersionError({ packageName }: { packageName: s
   ]);
 }
 
-export function showExpiredAnnualGraceLicenseKeyError({ plan }: { plan: string }) {
+export function showExpiredAnnualGraceLicenseKeyError({
+  plan,
+  licenseKey,
+  expiryTimestamp,
+}: {
+  plan: string;
+  licenseKey: string;
+  expiryTimestamp: number;
+}) {
   showError([
     'MUI: Expired license key.',
     '',
@@ -71,10 +79,22 @@ export function showExpiredAnnualGraceLicenseKeyError({ plan }: { plan: string }
     `- Stop making changes to code depending directly or indirectly on MUI X ${plan}'s APIs`,
     '',
     'Note that your license is perpetual in production environments with any version released before your license term ends.',
+    '',
+    `- License key expiry timestamp: ${new Date(expiryTimestamp)}`,
+    `- Installed license key: ${licenseKey}`,
+    '',
   ]);
 }
 
-export function showExpiredAnnualLicenseKeyError({ plan }: { plan: string }) {
+export function showExpiredAnnualLicenseKeyError({
+  plan,
+  licenseKey,
+  expiryTimestamp,
+}: {
+  plan: string;
+  licenseKey: string;
+  expiryTimestamp: number;
+}) {
   throw new Error(
     [
       'MUI: Expired license key.',
@@ -87,6 +107,10 @@ export function showExpiredAnnualLicenseKeyError({ plan }: { plan: string }) {
       `- Stop making changes to code depending directly or indirectly on MUI X ${plan}'s APIs`,
       '',
       'Note that your license is perpetual in production environments with any version released before your license term ends.',
+      '',
+      `- License key expiry timestamp: ${new Date(expiryTimestamp)}`,
+      `- Installed license key: ${licenseKey}`,
+      '',
     ].join('\n'),
   );
 }

--- a/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license-pro/src/utils/licenseErrorMessageUtils.ts
@@ -59,7 +59,7 @@ export function showExpiredPackageVersionError({ packageName }: { packageName: s
   ]);
 }
 
-export function showExpiredAnnualLicenseKeyError({ plan }: { plan: string }) {
+export function showExpiredAnnualGraceLicenseKeyError({ plan }: { plan: string }) {
   showError([
     'MUI: Expired license key.',
     '',
@@ -72,4 +72,21 @@ export function showExpiredAnnualLicenseKeyError({ plan }: { plan: string }) {
     '',
     'Note that your license is perpetual in production environments with any version released before your license term ends.',
   ]);
+}
+
+export function showExpiredAnnualLicenseKeyError({ plan }: { plan: string }) {
+  throw new Error(
+    [
+      'MUI: Expired license key.',
+      '',
+      `Your annual license key to use MUI X ${plan}'s on non-production environments is expired. If you are seeing this development console message, you might be close to breach the license terms by making direct or indirect changes to the frontend of an app that render a MUI X ${plan} component (more details in https://mui.com/r/x-license-annual).`,
+      '',
+      'To solve the problem you can either:',
+      '',
+      '- Renew your license https://mui.com/r/x-get-license and use the new key',
+      `- Stop making changes to code depending directly or indirectly on MUI X ${plan}'s APIs`,
+      '',
+      'Note that your license is perpetual in production environments with any version released before your license term ends.',
+    ].join('\n'),
+  );
 }

--- a/packages/x-license-pro/src/utils/licenseStatus.ts
+++ b/packages/x-license-pro/src/utils/licenseStatus.ts
@@ -1,4 +1,5 @@
-enum LicenseStatus {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export enum LICENSE_STATUS {
   NotFound = 'NotFound',
   Invalid = 'Invalid',
   ExpiredAnnual = 'ExpiredAnnual',
@@ -8,4 +9,4 @@ enum LicenseStatus {
   OutOfScope = 'OutOfScope',
 }
 
-export { LicenseStatus };
+export type LicenseStatus = keyof typeof LICENSE_STATUS;

--- a/packages/x-license-pro/src/utils/licenseStatus.ts
+++ b/packages/x-license-pro/src/utils/licenseStatus.ts
@@ -2,6 +2,7 @@ enum LicenseStatus {
   NotFound = 'NotFound',
   Invalid = 'Invalid',
   ExpiredAnnual = 'ExpiredAnnual',
+  ExpiredAnnualGrace = 'ExpiredAnnualGrace',
   ExpiredVersion = 'ExpiredVersion',
   Valid = 'Valid',
   OutOfScope = 'OutOfScope',

--- a/packages/x-license-pro/src/verifyLicense/verifyLicense.test.ts
+++ b/packages/x-license-pro/src/verifyLicense/verifyLicense.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { generateLicense } from '../generateLicense/generateLicense';
 import { generateReleaseInfo, verifyLicense } from './verifyLicense';
-import { LicenseStatus } from '../utils/licenseStatus';
+import { LICENSE_STATUS } from '../utils/licenseStatus';
 
 const oneDayInMS = 1000 * 60 * 60 * 24;
 const releaseDate = new Date(2018, 0, 0, 0, 0, 0, 0);
@@ -13,13 +13,14 @@ describe('License: verifyLicense', () => {
       '0f94d8b65161817ca5d7f7af8ac2f042T1JERVI6TVVJLVN0b3J5Ym9vayxFWFBJUlk9MTY1NDg1ODc1MzU1MCxLRVlWRVJTSU9OPTE=';
 
     it('should log an error when ReleaseInfo is not valid', () => {
-      expect(() =>
-        verifyLicense({
-          releaseInfo: '__RELEASE_INFO__',
-          licenseKey,
-          acceptedScopes: ['pro', 'premium'],
-          isProduction: true,
-        }),
+      expect(
+        () =>
+          verifyLicense({
+            releaseInfo: '__RELEASE_INFO__',
+            licenseKey,
+            acceptedScopes: ['pro', 'premium'],
+            isProduction: true,
+          }).status,
       ).to.throw('MUI: The release information is invalid. Not able to validate license.');
     });
 
@@ -30,8 +31,8 @@ describe('License: verifyLicense', () => {
           licenseKey,
           acceptedScopes: ['pro', 'premium'],
           isProduction: true,
-        }),
-      ).to.equal(LicenseStatus.Valid);
+        }).status,
+      ).to.equal(LICENSE_STATUS.Valid);
     });
 
     it('should check expired license properly', () => {
@@ -48,8 +49,8 @@ describe('License: verifyLicense', () => {
           licenseKey: expiredLicenseKey,
           acceptedScopes: ['pro', 'premium'],
           isProduction: true,
-        }),
-      ).to.equal(LicenseStatus.ExpiredVersion);
+        }).status,
+      ).to.equal(LICENSE_STATUS.ExpiredVersion);
     });
 
     it('should return Invalid for invalid license', () => {
@@ -60,8 +61,8 @@ describe('License: verifyLicense', () => {
             'b43ff5f9ac93f021855ff59ff0ba5220TkFNRTpNYC1VSSBTQVMsREVWRUxPUEVSX0NPVU5UPTEwLEVYUElSWT0xNTkxNzIzMDY3MDQyLFZFUlNJT049MS4yLjM',
           acceptedScopes: ['pro', 'premium'],
           isProduction: true,
-        }),
-      ).to.equal(LicenseStatus.Invalid);
+        }).status,
+      ).to.equal(LICENSE_STATUS.Invalid);
     });
   });
 
@@ -81,13 +82,14 @@ describe('License: verifyLicense', () => {
     });
 
     it('should log an error when ReleaseInfo is not valid', () => {
-      expect(() =>
-        verifyLicense({
-          releaseInfo: '__RELEASE_INFO__',
-          licenseKey: licenseKeyPro,
-          acceptedScopes: ['pro', 'premium'],
-          isProduction: true,
-        }),
+      expect(
+        () =>
+          verifyLicense({
+            releaseInfo: '__RELEASE_INFO__',
+            licenseKey: licenseKeyPro,
+            acceptedScopes: ['pro', 'premium'],
+            isProduction: true,
+          }).status,
       ).to.throw('MUI: The release information is invalid. Not able to validate license.');
     });
 
@@ -99,8 +101,8 @@ describe('License: verifyLicense', () => {
             licenseKey: licenseKeyPro,
             acceptedScopes: ['pro', 'premium'],
             isProduction: true,
-          }),
-        ).to.equal(LicenseStatus.Valid);
+          }).status,
+        ).to.equal(LICENSE_STATUS.Valid);
       });
 
       it('should accept premium license for premium features', () => {
@@ -110,8 +112,8 @@ describe('License: verifyLicense', () => {
             licenseKey: licenseKeyPremium,
             acceptedScopes: ['premium'],
             isProduction: true,
-          }),
-        ).to.equal(LicenseStatus.Valid);
+          }).status,
+        ).to.equal(LICENSE_STATUS.Valid);
       });
 
       it('should not accept pro license for premium feature', () => {
@@ -121,8 +123,8 @@ describe('License: verifyLicense', () => {
             licenseKey: licenseKeyPro,
             acceptedScopes: ['premium'],
             isProduction: true,
-          }),
-        ).to.equal(LicenseStatus.OutOfScope);
+          }).status,
+        ).to.equal(LICENSE_STATUS.OutOfScope);
       });
     });
 
@@ -141,8 +143,8 @@ describe('License: verifyLicense', () => {
             licenseKey: expiredLicenseKey,
             acceptedScopes: ['pro', 'premium'],
             isProduction: true,
-          }),
-        ).to.equal(LicenseStatus.Valid);
+          }).status,
+        ).to.equal(LICENSE_STATUS.Valid);
       });
 
       it('should not validate subscription license in dev if current date is after expiry date but release date is before expiry date', () => {
@@ -159,8 +161,8 @@ describe('License: verifyLicense', () => {
             licenseKey: expiredLicenseKey,
             acceptedScopes: ['pro', 'premium'],
             isProduction: false,
-          }),
-        ).to.equal(LicenseStatus.ExpiredAnnualGrace);
+          }).status,
+        ).to.equal(LICENSE_STATUS.ExpiredAnnualGrace);
       });
 
       it('should throw if the license is expired by more than a 30 days', () => {
@@ -177,8 +179,8 @@ describe('License: verifyLicense', () => {
             licenseKey: expiredLicenseKey,
             acceptedScopes: ['pro', 'premium'],
             isProduction: false,
-          }),
-        ).to.equal(LicenseStatus.ExpiredAnnual);
+          }).status,
+        ).to.equal(LICENSE_STATUS.ExpiredAnnual);
       });
 
       it('should validate perpetual license in dev if current date is after expiry date but release date is before expiry date', () => {
@@ -195,8 +197,8 @@ describe('License: verifyLicense', () => {
             licenseKey: expiredLicenseKey,
             acceptedScopes: ['pro', 'premium'],
             isProduction: false,
-          }),
-        ).to.equal(LicenseStatus.Valid);
+          }).status,
+        ).to.equal(LICENSE_STATUS.Valid);
       });
     });
 
@@ -208,8 +210,8 @@ describe('License: verifyLicense', () => {
             'b43ff5f9ac93f021855ff59ff0ba5220TkFNRTpNYC1VSSBTQVMsREVWRUxPUEVSX0NPVU5UPTEwLEVYUElSWT0xNTkxNzIzMDY3MDQyLFZFUlNJT049MS4yLjM',
           acceptedScopes: ['pro', 'premium'],
           isProduction: true,
-        }),
-      ).to.equal(LicenseStatus.Invalid);
+        }).status,
+      ).to.equal(LICENSE_STATUS.Invalid);
     });
   });
 
@@ -228,8 +230,8 @@ describe('License: verifyLicense', () => {
           licenseKey: licenseKeyPro,
           acceptedScopes: ['pro', 'premium'],
           isProduction: true,
-        }),
-      ).to.equal(LicenseStatus.Valid);
+        }).status,
+      ).to.equal(LICENSE_STATUS.Valid);
     });
   });
 });

--- a/packages/x-license-pro/src/verifyLicense/verifyLicense.test.ts
+++ b/packages/x-license-pro/src/verifyLicense/verifyLicense.test.ts
@@ -147,7 +147,25 @@ describe('License: verifyLicense', () => {
 
       it('should not validate subscription license in dev if current date is after expiry date but release date is before expiry date', () => {
         const expiredLicenseKey = generateLicense({
-          expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
+          expiryDate: new Date(new Date().getTime() - oneDayInMS),
+          orderNumber: 'MUI-123',
+          scope: 'pro',
+          licensingModel: 'subscription',
+        });
+
+        expect(
+          verifyLicense({
+            releaseInfo: RELEASE_INFO,
+            licenseKey: expiredLicenseKey,
+            acceptedScopes: ['pro', 'premium'],
+            isProduction: false,
+          }),
+        ).to.equal(LicenseStatus.ExpiredAnnualGrace);
+      });
+
+      it('should throw if the license is expired by more than a 30 days', () => {
+        const expiredLicenseKey = generateLicense({
+          expiryDate: new Date(new Date().getTime() - oneDayInMS * 30),
           orderNumber: 'MUI-123',
           scope: 'pro',
           licensingModel: 'subscription',

--- a/packages/x-license-pro/src/verifyLicense/verifyLicense.ts
+++ b/packages/x-license-pro/src/verifyLicense/verifyLicense.ts
@@ -1,6 +1,6 @@
 import { base64Decode, base64Encode } from '../encoding/base64';
 import { md5 } from '../encoding/md5';
-import { LicenseStatus } from '../utils/licenseStatus';
+import { LICENSE_STATUS, LicenseStatus } from '../utils/licenseStatus';
 import { LicenseScope, LICENSE_SCOPES } from '../utils/licenseScope';
 import { LicensingModel, LICENSING_MODELS } from '../utils/licensingModel';
 
@@ -105,37 +105,37 @@ export function verifyLicense({
   licenseKey: string | undefined;
   acceptedScopes: LicenseScope[];
   isProduction: boolean;
-}) {
+}): { status: LicenseStatus; meta?: any } {
   if (!releaseInfo) {
     throw new Error('MUI: The release information is missing. Not able to validate license.');
   }
 
   if (!licenseKey) {
-    return LicenseStatus.NotFound;
+    return { status: LICENSE_STATUS.NotFound };
   }
 
   const hash = licenseKey.substr(0, 32);
   const encoded = licenseKey.substr(32);
 
   if (hash !== md5(encoded)) {
-    return LicenseStatus.Invalid;
+    return { status: LICENSE_STATUS.Invalid };
   }
 
   const license = decodeLicense(encoded);
 
   if (license == null) {
     console.error('Error checking license. Key version not found!');
-    return LicenseStatus.Invalid;
+    return { status: LICENSE_STATUS.Invalid };
   }
 
   if (license.licensingModel == null || !LICENSING_MODELS.includes(license.licensingModel)) {
     console.error('Error checking license. Licensing model not found or invalid!');
-    return LicenseStatus.Invalid;
+    return { status: LICENSE_STATUS.Invalid };
   }
 
   if (license.expiryTimestamp == null) {
     console.error('Error checking license. Expiry timestamp not found or invalid!');
-    return LicenseStatus.Invalid;
+    return { status: LICENSE_STATUS.Invalid };
   }
 
   if (license.licensingModel === 'perpetual' || isProduction) {
@@ -145,26 +145,32 @@ export function verifyLicense({
     }
 
     if (license.expiryTimestamp < pkgTimestamp) {
-      return LicenseStatus.ExpiredVersion;
+      return { status: LICENSE_STATUS.ExpiredVersion };
     }
   } else if (license.licensingModel === 'subscription' || license.licensingModel === 'annual') {
     if (new Date().getTime() > license.expiryTimestamp) {
       // 30 days grace
       if (new Date().getTime() < license.expiryTimestamp + 1000 * 3600 * 24 * 30) {
-        return LicenseStatus.ExpiredAnnualGrace;
+        return {
+          status: LICENSE_STATUS.ExpiredAnnualGrace,
+          meta: { expiryTimestamp: license.expiryTimestamp, licenseKey },
+        };
       }
-      return LicenseStatus.ExpiredAnnual;
+      return {
+        status: LICENSE_STATUS.ExpiredAnnual,
+        meta: { expiryTimestamp: license.expiryTimestamp, licenseKey },
+      };
     }
   }
 
   if (license.scope == null || !LICENSE_SCOPES.includes(license.scope)) {
     console.error('Error checking license. scope not found or invalid!');
-    return LicenseStatus.Invalid;
+    return { status: LICENSE_STATUS.Invalid };
   }
 
   if (!acceptedScopes.includes(license.scope)) {
-    return LicenseStatus.OutOfScope;
+    return { status: LICENSE_STATUS.OutOfScope };
   }
 
-  return LicenseStatus.Valid;
+  return { status: LICENSE_STATUS.Valid };
 }

--- a/packages/x-license-pro/src/verifyLicense/verifyLicense.ts
+++ b/packages/x-license-pro/src/verifyLicense/verifyLicense.ts
@@ -148,7 +148,11 @@ export function verifyLicense({
       return LicenseStatus.ExpiredVersion;
     }
   } else if (license.licensingModel === 'subscription' || license.licensingModel === 'annual') {
-    if (license.expiryTimestamp < new Date().getTime()) {
+    if (new Date().getTime() > license.expiryTimestamp) {
+      // 30 days grace
+      if (new Date().getTime() < license.expiryTimestamp + 1000 * 3600 * 24 * 30) {
+        return LicenseStatus.ExpiredAnnualGrace;
+      }
       return LicenseStatus.ExpiredAnnual;
     }
   }

--- a/scripts/x-license-pro.exports.json
+++ b/scripts/x-license-pro.exports.json
@@ -1,10 +1,11 @@
 [
   { "name": "generateLicense", "kind": "Function" },
   { "name": "generateReleaseInfo", "kind": "Function" },
+  { "name": "LICENSE_STATUS", "kind": "Enum" },
   { "name": "LicenseDetails", "kind": "Interface" },
   { "name": "LicenseInfo", "kind": "Class" },
   { "name": "LicenseScope", "kind": "TypeAlias" },
-  { "name": "LicenseStatus", "kind": "Enum" },
+  { "name": "LicenseStatus", "kind": "TypeAlias" },
   { "name": "LicensingModel", "kind": "TypeAlias" },
   { "name": "MuiCommercialPackageName", "kind": "TypeAlias" },
   { "name": "MuiLicenseInfo", "kind": "Interface" },

--- a/scripts/x-license-pro.exports.json
+++ b/scripts/x-license-pro.exports.json
@@ -8,6 +8,7 @@
   { "name": "LicensingModel", "kind": "TypeAlias" },
   { "name": "MuiCommercialPackageName", "kind": "TypeAlias" },
   { "name": "MuiLicenseInfo", "kind": "Interface" },
+  { "name": "showExpiredAnnualGraceLicenseKeyError", "kind": "Function" },
   { "name": "showExpiredAnnualLicenseKeyError", "kind": "Function" },
   { "name": "showExpiredPackageVersionError", "kind": "Function" },
   { "name": "showInvalidLicenseKeyError", "kind": "Function" },


### PR DESCRIPTION
A continutation of #9135.

- During the first 30 days, you only get a console.error, as before.
- After 30 days, you get this:

<img width="1004" alt="Screenshot 2023-07-16 at 19 53 37" src="https://github.com/mui/mui-x/assets/3165635/273bae57-3a34-4405-92d7-d65298766afd">

Effectively, if you are doing SSR, you can't build anymore, you would need to remove the license key. I think that the timing for this makes sense now. Developers can opt into the perpetual plan if they prefer this license model.

I worked a bit on #1364 at the same time.