### PR TITLE
[docs] Add pnpm installation instructions for MUI X

### DIFF
--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -40,6 +40,10 @@ npm install @mui/x-charts
 yarn add @mui/x-charts
 ```
 
+```bash pnpm
+pnpm add @mui/x-charts
+```
+
 </codeblock>
 
 ## Display charts

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -20,6 +20,10 @@ npm install @mui/material @emotion/react @emotion/styled
 yarn add @mui/material @emotion/react @emotion/styled
 ```
 
+```bash pnpm
+pnpm add @mui/material @emotion/react @emotion/styled
+```
+
 </codeblock>
 
 <!-- #react-peer-version -->
@@ -44,6 +48,10 @@ npm install @mui/styled-engine-sc styled-components
 
 ```bash yarn
 yarn add @mui/styled-engine-sc styled-components
+```
+
+```bash pnpm
+pnpm add @mui/styled-engine-sc styled-components
 ```
 
 </codeblock>

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -32,8 +32,13 @@ If you are not already using it in your project, you can install it with:
 ```bash npm
 npm install @mui/material @emotion/react @emotion/styled
 ```
+
 ```bash yarn
 yarn add @mui/material @emotion/react @emotion/styled
+```
+
+```bash pnpm
+pnpm add @mui/material @emotion/react @emotion/styled
 ```
 </codeblock>
 
@@ -59,6 +64,10 @@ npm install @mui/styled-engine-sc styled-components
 
 ```bash yarn
 yarn add @mui/styled-engine-sc styled-components
+```
+
+```bash pnpm
+pnpm add @mui/styled-engine-sc styled-components
 ```
 
 </codeblock>

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -67,6 +67,7 @@ yarn add @mui/styled-engine-sc styled-components
 ```bash pnpm
 pnpm add @mui/styled-engine-sc styled-components
 ```
+
 </codeblock>
 
 Take a look at the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.

--- a/docs/data/date-pickers/getting-started/getting-started.md
+++ b/docs/data/date-pickers/getting-started/getting-started.md
@@ -32,11 +32,9 @@ If you are not already using it in your project, you can install it with:
 ```bash npm
 npm install @mui/material @emotion/react @emotion/styled
 ```
-
 ```bash yarn
 yarn add @mui/material @emotion/react @emotion/styled
 ```
-
 ```bash pnpm
 pnpm add @mui/material @emotion/react @emotion/styled
 ```
@@ -69,7 +67,6 @@ yarn add @mui/styled-engine-sc styled-components
 ```bash pnpm
 pnpm add @mui/styled-engine-sc styled-components
 ```
-
 </codeblock>
 
 Take a look at the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.

--- a/docs/src/modules/components/InstallationInstructions.tsx
+++ b/docs/src/modules/components/InstallationInstructions.tsx
@@ -8,6 +8,7 @@ import ToggleOptions from './ToggleOptions';
 const defaultPackageManagers: Record<string, string> = {
   npm: 'npm install',
   yarn: 'yarn add',
+  pnpm: 'pnpm add'
 };
 
 export default function InstallationInstructions(props: {

--- a/docs/src/modules/components/InstallationInstructions.tsx
+++ b/docs/src/modules/components/InstallationInstructions.tsx
@@ -8,7 +8,7 @@ import ToggleOptions from './ToggleOptions';
 const defaultPackageManagers: Record<string, string> = {
   npm: 'npm install',
   yarn: 'yarn add',
-  pnpm: 'pnpm add'
+  pnpm: 'pnpm add',
 };
 
 export default function InstallationInstructions(props: {


### PR DESCRIPTION
Adding the support of pnpm in MUI X 

Fix #9699 

<img width="859" alt="image" src="https://github.com/mui/mui-x/assets/92274722/f7a5034c-f670-4e93-b293-fed183a0d48b">

https://deploy-preview-9707--material-ui-x.netlify.app/x/react-data-grid/getting-started/