### PR TITLE
[DataGrid][l10n] Improve Finnish (fi-FI) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -67,7 +67,7 @@
     "languageTag": "fi-FI",
     "importName": "fiFI",
     "localeName": "Finnish",
-    "missingKeysCount": 27,
+    "missingKeysCount": 26,
     "totalKeysCount": 119,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/fiFI.ts"
   },

--- a/packages/grid/x-data-grid/src/locales/fiFI.ts
+++ b/packages/grid/x-data-grid/src/locales/fiFI.ts
@@ -107,7 +107,7 @@ const fiFIGrid: Partial<GridLocaleText> = {
   // Column menu text
   columnMenuLabel: 'Valikko',
   columnMenuShowColumns: 'Näytä sarakkeet',
-  // columnMenuManageColumns: 'Manage columns',
+  columnMenuManageColumns: 'Hallitse sarakkeita',
   columnMenuFilter: 'Suodata',
   columnMenuHideColumn: 'Piilota',
   columnMenuUnsort: 'Poista järjestys',


### PR DESCRIPTION
Added Finnish translation for columnMenuManageColumns

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
