### PR TITLE
[docs] Align pickers `uncontrolled vs controlled` sections

### DIFF
--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -14,6 +14,8 @@ packageName: '@mui/x-date-pickers'
 
 {{"demo": "BasicDateCalendar.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateCalendarValue.js"}}

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -14,6 +14,8 @@ packageName: '@mui/x-date-pickers'
 
 {{"demo": "BasicDateField.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateFieldValue.js"}}

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -14,6 +14,8 @@ packageName: '@mui/x-date-pickers-pro'
 
 {{"demo": "BasicDateRangeCalendar.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateRangeCalendarValue.js"}}

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -21,6 +21,8 @@ All the topics covered below are applicable to both `SingleInputDateRangeField` 
 
 {{"demo": "BasicDateRangeField.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateRangeFieldValue.js"}}

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -25,6 +25,8 @@ Check-out their documentation page for more information:
 - [Date Range Field](/x/react-date-pickers/date-range-field/)
 - [Date Range Calendar](/x/react-date-pickers/date-range-calendar/)
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateRangePickerValue.js"}}

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -14,6 +14,8 @@ packageName: '@mui/x-date-pickers'
 
 {{"demo": "BasicDateTimeField.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateTimeFieldValue.js"}}

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -27,6 +27,8 @@ Check-out their documentation page for more information:
 - [Digital Clock](/x/react-date-pickers/digital-clock/)
 - [Time Clock](/x/react-date-pickers/time-clock/)
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateTimePickerValue.js"}}

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -21,6 +21,8 @@ or two inputs using `MultiInputDateTimeRangeField` as show below.
 
 {{"demo": "BasicDateTimeRangeField.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DateTimeRangeFieldValue.js"}}

--- a/docs/data/date-pickers/digital-clock/digital-clock.md
+++ b/docs/data/date-pickers/digital-clock/digital-clock.md
@@ -20,6 +20,8 @@ The `DigitalClock` is more appropriate when there is a limited amount of time op
 
 {{"demo": "DigitalClockBasic.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "DigitalClockValue.js"}}

--- a/docs/data/date-pickers/time-clock/time-clock.md
+++ b/docs/data/date-pickers/time-clock/time-clock.md
@@ -14,6 +14,8 @@ packageName: '@mui/x-date-pickers'
 
 {{"demo": "BasicTimeClock.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "TimeClockValue.js"}}

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -14,6 +14,8 @@ packageName: '@mui/x-date-pickers'
 
 {{"demo": "BasicTimeField.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "TimeFieldValue.js"}}

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -26,6 +26,8 @@ Check-out their documentation page for more information:
 - [Digital Clock](/x/react-date-pickers/digital-clock/)
 - [Time Clock](/x/react-date-pickers/time-clock/)
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "TimePickerValue.js"}}

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -21,6 +21,8 @@ or two inputs using `MultiInputTimeRangeField` as show below.
 
 {{"demo": "BasicTimeRangeField.js"}}
 
+## Uncontrolled vs. controlled value
+
 The value of the component can be uncontrolled or controlled.
 
 {{"demo": "TimeRangeFieldValue.js"}}


### PR DESCRIPTION
Only the [Date Picker](https://mui.com/x/react-date-pickers/date-picker/#uncontrolled-vs-controlled-value) page seems to currently have a separate `uncontrolled vs controlled` section (heading).

Applied the same section (heading) approach to all the picker component pages.