### PR TITLE
[core] Use PR charts version in preview

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -57,6 +57,7 @@ ponyfillGlobal.muiDocConfig = {
       '@mui/x-data-grid-generator': getMuiPackageVersion('x-data-grid-generator', muiCommitRef),
       '@mui/x-date-pickers': getMuiPackageVersion('x-date-pickers', muiCommitRef),
       '@mui/x-date-pickers-pro': getMuiPackageVersion('x-date-pickers-pro', muiCommitRef),
+      '@mui/x-charts': getMuiPackageVersion('x-charts', muiCommitRef),
       'date-fns': 'latest',
       dayjs: 'latest',
       exceljs: 'latest',


### PR DESCRIPTION
The codesandbox generated by preview were not using the code from the PR but the latest release

From https://github.com/mui/mui-x/pull/9744#pullrequestreview-1544784552

### Result

![image](https://github.com/mui/mui-x/assets/45398769/f0bfff02-d815-4ba8-8400-58ca857310fb)

https://codesandbox.io/s/lyqllr?file=/demo.tsx