### PR TITLE
[pickers] Remove the `endOfDate` from `DigitalClock` timeOptions

### DIFF
--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
@@ -268,7 +268,6 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
       ...Array.from({ length: Math.ceil((24 * 60) / timeStep) - 1 }, (_, index) =>
         utils.addMinutes(startOfDay, timeStep * (index + 1)),
       ),
-      utils.endOfDay(valueOrReferenceDate),
     ];
   }, [valueOrReferenceDate, timeStep, utils]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #9794 

Removing the `endOfDate` from the `timeOptions` array, as it introduces invalid values for different `timeSteps`. 

- if `timeStep={60}`: https://mui.com/x/react-date-pickers/digital-clock/#skip-rendering-disabled-options
- if `timeStep={1}`:
![image](https://github.com/mui/mui-x/assets/72460825/408a505f-d984-41f0-ac8b-695fbce1516e)

