### PR TITLE
bigint support for GridRowId

### DIFF
--- a/packages/grid/x-data-grid/src/models/gridRows.ts
+++ b/packages/grid/x-data-grid/src/models/gridRows.ts
@@ -182,7 +182,7 @@ export type GridRowTreeConfig = Record<GridRowId, GridTreeNode>;
 /**
  * The type of Id supported by the grid.
  */
-export type GridRowId = string | number;
+export type GridRowId = string | number | bigint;
 
 export interface GridRowEntry<R extends GridValidRowModel = GridValidRowModel> {
   /**


### PR DESCRIPTION
I am raising this for your attention. It seems like a simple fix, but not sure if I am missing anything. If you got an override option for temporary support, I'd appreciate it.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
