### PR TITLE
[fields] Fix section clearing with timezone

### DIFF
--- a/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
@@ -55,8 +55,10 @@ export const rangeValueManager: RangePickerValueManager = {
   hasError: (error) => error[0] != null || error[1] != null,
   defaultErrorState: [null, null],
   getTimezone: (utils, value) => {
-    const timezoneStart = value[0] == null ? null : utils.getTimezone(value[0]);
-    const timezoneEnd = value[1] == null ? null : utils.getTimezone(value[1]);
+    const timezoneStart =
+      value[0] == null || !utils.isValid(value[0]) ? null : utils.getTimezone(value[0]);
+    const timezoneEnd =
+      value[1] == null || !utils.isValid(value[1]) ? null : utils.getTimezone(value[1]);
 
     if (timezoneStart != null && timezoneEnd != null && timezoneStart !== timezoneEnd) {
       throw new Error('MUI: The timezone of the start and the end date should be the same');

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -59,7 +59,7 @@ describe('<DesktopDatePicker /> - Field', () => {
   });
 
   describeAdapters('Timezone', DesktopDatePicker, ({ adapter, render, clickOnInput }) => {
-    it.only('should clear the selected section when all sections are completed when using timezones', () => {
+    it('should clear the selected section when all sections are completed when using timezones', () => {
       function WrappedDesktopDatePicker() {
         const [value, setValue] = React.useState(adapter.date()!);
         return (

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -9,42 +9,76 @@ import {
   expectInputValue,
   buildFieldInteractions,
 } from 'test/utils/pickers-utils';
+import { describeAdapters } from '@mui/x-date-pickers/tests/describeAdapters';
 
 describe('<DesktopDatePicker /> - Field', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
-  const { clickOnInput } = buildFieldInteractions({ clock, render, Component: DesktopDatePicker });
+  describe('Basic behaviors', () => {
+    const { render, clock } = createPickerRenderer({
+      clock: 'fake',
+      clockConfig: new Date('2018-01-01T10:05:05.000'),
+    });
+    const { clickOnInput } = buildFieldInteractions({
+      clock,
+      render,
+      Component: DesktopDatePicker,
+    });
 
-  it('should be able to reset a single section', () => {
-    render(<DesktopDatePicker format={adapterToUse.formats.monthAndDate} />);
+    it('should be able to reset a single section', () => {
+      render(<DesktopDatePicker format={adapterToUse.formats.monthAndDate} />);
 
-    const input = getTextbox();
-    expectInputPlaceholder(input, 'MMMM DD');
-    clickOnInput(input, 1);
+      const input = getTextbox();
+      expectInputPlaceholder(input, 'MMMM DD');
+      clickOnInput(input, 1);
 
-    fireEvent.change(input, { target: { value: 'N DD' } }); // Press "1"
-    expectInputValue(input, 'November DD');
+      fireEvent.change(input, { target: { value: 'N DD' } }); // Press "1"
+      expectInputValue(input, 'November DD');
 
-    fireEvent.change(input, { target: { value: 'November 4' } }); // Press "1"
-    expectInputValue(input, 'November 04');
+      fireEvent.change(input, { target: { value: 'November 4' } }); // Press "1"
+      expectInputValue(input, 'November 04');
 
-    userEvent.keyPress(input, { key: 'Backspace' });
-    expectInputValue(input, 'November DD');
+      userEvent.keyPress(input, { key: 'Backspace' });
+      expectInputValue(input, 'November DD');
+    });
+
+    it('should adapt the default field format based on the props of the picker', () => {
+      const testFormat = (props: DesktopDatePickerProps<any>, expectedFormat: string) => {
+        const { unmount } = render(<DesktopDatePicker {...props} />);
+        const input = getTextbox();
+        expectInputPlaceholder(input, expectedFormat);
+        unmount();
+      };
+
+      testFormat({ views: ['year'] }, 'YYYY');
+      testFormat({ views: ['month'] }, 'MMMM');
+      testFormat({ views: ['day'] }, 'DD');
+      testFormat({ views: ['month', 'day'] }, 'MMMM DD');
+      testFormat({ views: ['year', 'month'] }, 'MMMM YYYY');
+      testFormat({ views: ['year', 'month', 'day'] }, 'MM/DD/YYYY');
+      testFormat({ views: ['year', 'day'] }, 'MM/DD/YYYY');
+    });
   });
 
-  it('should adapt the default field format based on the props of the picker', () => {
-    const testFormat = (props: DesktopDatePickerProps<any>, expectedFormat: string) => {
-      const { unmount } = render(<DesktopDatePicker {...props} />);
-      const input = getTextbox();
-      expectInputPlaceholder(input, expectedFormat);
-      unmount();
-    };
+  describeAdapters('Timezone', DesktopDatePicker, ({ adapter, render, clickOnInput }) => {
+    it.only('should clear the selected section when all sections are completed when using timezones', () => {
+      function WrappedDesktopDatePicker() {
+        const [value, setValue] = React.useState(adapter.date()!);
+        return (
+          <DesktopDatePicker
+            value={value}
+            onChange={setValue}
+            format={adapter.formats.monthAndYear}
+            timezone="America/Chicago"
+          />
+        );
+      }
+      render(<WrappedDesktopDatePicker />);
 
-    testFormat({ views: ['year'] }, 'YYYY');
-    testFormat({ views: ['month'] }, 'MMMM');
-    testFormat({ views: ['day'] }, 'DD');
-    testFormat({ views: ['month', 'day'] }, 'MMMM DD');
-    testFormat({ views: ['year', 'month'] }, 'MMMM YYYY');
-    testFormat({ views: ['year', 'month', 'day'] }, 'MM/DD/YYYY');
-    testFormat({ views: ['year', 'day'] }, 'MM/DD/YYYY');
+      const input = getTextbox();
+      expectInputValue(input, 'June 2022');
+      clickOnInput(input, 0);
+
+      userEvent.keyPress(input, { key: 'Backspace' });
+      expectInputValue(input, 'MMMM 2022');
+    });
   });
 });

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -38,7 +38,8 @@ export const singleItemValueManager: SingleItemPickerValueManager = {
   isSameError: (a, b) => a === b,
   hasError: (error) => error != null,
   defaultErrorState: null,
-  getTimezone: (utils, value) => (value == null ? null : utils.getTimezone(value)),
+  getTimezone: (utils, value) =>
+    value == null || !utils.isValid(value) ? null : utils.getTimezone(value),
   setTimezone: (utils, timezone, value) =>
     value == null ? null : utils.setTimezone(value, timezone),
 };


### PR DESCRIPTION
Fixes #9818

When clearing a section, the value passed to `onChange` is an invalid date.
For these date, we can't reliably set the timezone, so I'd suggest treating them as `null` and ignore there timezone.