### PR TITLE
[pickers] Use device motion reduction preference

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -14,7 +14,7 @@ import {
   DayCalendar,
   DayCalendarSlotsComponent,
   DayCalendarSlotsComponentsProps,
-  defaultReduceAnimations,
+  useDefaultReduceAnimations,
   PickersArrowSwitcher,
   PickersCalendarHeader,
   useCalendarState,
@@ -119,6 +119,7 @@ function useDateRangeCalendarDefaultizedProps<TDate>(
 ): DateRangeCalendarDefaultizedProps<TDate> {
   const utils = useUtils<TDate>();
   const defaultDates = useDefaultDates<TDate>();
+  const defaultReduceAnimations = useDefaultReduceAnimations();
   const themeProps = useThemeProps({
     props,
     name,

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -22,7 +22,7 @@ import {
   mergeDateAndTime,
 } from '../internals/utils/date-utils';
 import { PickerViewRoot } from '../internals/components/PickerViewRoot';
-import { defaultReduceAnimations } from '../internals/utils/defaultReduceAnimations';
+import { useDefaultReduceAnimations } from '../internals/hooks/useDefaultReduceAnimations';
 import { getDateCalendarUtilityClass } from './dateCalendarClasses';
 import { BaseDateValidationProps } from '../internals/models/validation';
 import { useControlledValueWithTimezone } from '../internals/hooks/useValueWithTimezone';
@@ -44,20 +44,22 @@ function useDateCalendarDefaultizedProps<TDate>(
 ): DateCalendarDefaultizedProps<TDate> {
   const utils = useUtils<TDate>();
   const defaultDates = useDefaultDates<TDate>();
+  const defaultReduceAnimations = useDefaultReduceAnimations();
   const themeProps = useThemeProps({
     props,
     name,
   });
 
   return {
-    loading: false,
-    disablePast: false,
-    disableFuture: false,
-    openTo: 'day',
-    views: ['year', 'day'],
-    reduceAnimations: defaultReduceAnimations,
-    renderLoading: () => <span data-mui-test="loading-progress">...</span>,
     ...themeProps,
+    loading: themeProps.loading ?? false,
+    disablePast: themeProps.disablePast ?? false,
+    disableFuture: themeProps.disableFuture ?? false,
+    openTo: themeProps.openTo ?? 'day',
+    views: themeProps.views ?? ['year', 'day'],
+    reduceAnimations: themeProps.reduceAnimations ?? defaultReduceAnimations,
+    renderLoading:
+      themeProps.renderLoading ?? (() => <span data-mui-test="loading-progress">...</span>),
     minDate: applyDefaultDate(utils, themeProps.minDate, defaultDates.minDate),
     maxDate: applyDefaultDate(utils, themeProps.maxDate, defaultDates.maxDate),
   };

--- a/packages/x-date-pickers/src/internals/hooks/useDefaultReduceAnimations.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useDefaultReduceAnimations.ts
@@ -1,0 +1,11 @@
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+const PREFERS_REDUCED_MOTION = '@media (prefers-reduced-motion: reduce)';
+
+export const defaultReduceAnimations =
+  typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent);
+
+export const useDefaultReduceAnimations = () => {
+  const prefersReduced = useMediaQuery(PREFERS_REDUCED_MOTION, { defaultMatches: false });
+  return prefersReduced || defaultReduceAnimations;
+};

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -131,7 +131,7 @@ export {
   onSpaceOrEnter,
   DEFAULT_DESKTOP_MODE_MEDIA_QUERY,
 } from './utils/utils';
-export { defaultReduceAnimations } from './utils/defaultReduceAnimations';
+export { useDefaultReduceAnimations } from './hooks/useDefaultReduceAnimations';
 export { extractValidationProps } from './utils/validation/extractValidationProps';
 export { validateDate } from './utils/validation/validateDate';
 export { validateDateTime } from './utils/validation/validateDateTime';

--- a/packages/x-date-pickers/src/internals/utils/defaultReduceAnimations.ts
+++ b/packages/x-date-pickers/src/internals/utils/defaultReduceAnimations.ts
@@ -1,2 +1,0 @@
-export const defaultReduceAnimations =
-  typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent);


### PR DESCRIPTION
Fixes #9740

- Add media query detection for reduced motion when resolving the default `reduceAnimations` prop value
- Fix `DateCalendar` props defaulting order