### PR TITLE
[docs] Fix demo using Pro while it's MIT

### DIFF
--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.js
@@ -8,11 +8,11 @@ import SaveIcon from '@mui/icons-material/Save';
 import CancelIcon from '@mui/icons-material/Close';
 import {
   GridRowModes,
-  DataGridPro,
+  DataGrid,
   GridToolbarContainer,
   GridActionsCellItem,
   GridRowEditStopReasons,
-} from '@mui/x-data-grid-pro';
+} from '@mui/x-data-grid';
 import {
   randomCreatedDate,
   randomTraderName,
@@ -215,7 +215,7 @@ export default function FullFeaturedCrudGrid() {
         },
       }}
     >
-      <DataGridPro
+      <DataGrid
         rows={rows}
         columns={columns}
         editMode="row"

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx
@@ -10,7 +10,7 @@ import {
   GridRowsProp,
   GridRowModesModel,
   GridRowModes,
-  DataGridPro,
+  DataGrid,
   GridColDef,
   GridToolbarContainer,
   GridActionsCellItem,
@@ -18,7 +18,7 @@ import {
   GridRowId,
   GridRowModel,
   GridRowEditStopReasons,
-} from '@mui/x-data-grid-pro';
+} from '@mui/x-data-grid';
 import {
   randomCreatedDate,
   randomTraderName,
@@ -228,7 +228,7 @@ export default function FullFeaturedCrudGrid() {
         },
       }}
     >
-      <DataGridPro
+      <DataGrid
         rows={rows}
         columns={columns}
         editMode="row"

--- a/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
+++ b/docs/data/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
@@ -1,4 +1,4 @@
-<DataGridPro
+<DataGrid
   rows={rows}
   columns={columns}
   editMode="row"

--- a/docs/data/data-grid/editing/ValidateServerNameGrid.js
+++ b/docs/data/data-grid/editing/ValidateServerNameGrid.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
-import { DataGridPro, GridEditInputCell } from '@mui/x-data-grid-pro';
+import { DataGrid, GridEditInputCell } from '@mui/x-data-grid';
 
 const StyledBox = styled(Box)(({ theme }) => ({
   height: 400,
@@ -79,7 +79,7 @@ export default function ValidateServerNameGrid() {
 
   return (
     <StyledBox>
-      <DataGridPro
+      <DataGrid
         rows={rows}
         columns={columns}
         isCellEditable={(params) => params.row.id === 5}

--- a/docs/data/data-grid/editing/ValidateServerNameGrid.tsx
+++ b/docs/data/data-grid/editing/ValidateServerNameGrid.tsx
@@ -5,11 +5,11 @@ import Tooltip, { tooltipClasses, TooltipProps } from '@mui/material/Tooltip';
 import {
   GridColDef,
   GridRowsProp,
-  DataGridPro,
+  DataGrid,
   GridPreProcessEditCellProps,
   GridEditInputCell,
   GridRenderEditCellParams,
-} from '@mui/x-data-grid-pro';
+} from '@mui/x-data-grid';
 
 const StyledBox = styled(Box)(({ theme }) => ({
   height: 400,
@@ -86,7 +86,7 @@ export default function ValidateServerNameGrid() {
 
   return (
     <StyledBox>
-      <DataGridPro
+      <DataGrid
         rows={rows}
         columns={columns}
         isCellEditable={(params) => params.row.id === 5}

--- a/docs/data/data-grid/editing/ValidateServerNameGrid.tsx.preview
+++ b/docs/data/data-grid/editing/ValidateServerNameGrid.tsx.preview
@@ -1,5 +1,5 @@
 <StyledBox>
-  <DataGridPro
+  <DataGrid
     rows={rows}
     columns={columns}
     isCellEditable={(params) => params.row.id === 5}

--- a/docs/data/data-grid/recipes-editing/MultilineEditing.js
+++ b/docs/data/data-grid/recipes-editing/MultilineEditing.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import {
-  DataGridPro,
+  DataGrid,
   useGridApiContext,
   GridCellEditStopReasons,
-} from '@mui/x-data-grid-pro';
+} from '@mui/x-data-grid';
 import InputBase from '@mui/material/InputBase';
 import Popper from '@mui/material/Popper';
 import Paper from '@mui/material/Paper';
@@ -130,7 +130,7 @@ for (let i = 0; i < 50; i += 1) {
 export default function MultilineEditing() {
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGridPro
+      <DataGrid
         rows={rows}
         columns={columns}
         onCellEditStop={(params, event) => {

--- a/docs/data/data-grid/recipes-editing/MultilineEditing.tsx
+++ b/docs/data/data-grid/recipes-editing/MultilineEditing.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import {
-  DataGridPro,
+  DataGrid,
   GridColDef,
   GridRowModel,
   GridRenderEditCellParams,
   useGridApiContext,
   GridColTypeDef,
   GridCellEditStopReasons,
-} from '@mui/x-data-grid-pro';
+} from '@mui/x-data-grid';
 import InputBase, { InputBaseProps } from '@mui/material/InputBase';
 import Popper from '@mui/material/Popper';
 import Paper from '@mui/material/Paper';
@@ -134,7 +134,7 @@ for (let i = 0; i < 50; i += 1) {
 export default function MultilineEditing() {
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGridPro
+      <DataGrid
         rows={rows}
         columns={columns}
         onCellEditStop={(params, event) => {

--- a/docs/data/data-grid/recipes-editing/MultilineEditing.tsx.preview
+++ b/docs/data/data-grid/recipes-editing/MultilineEditing.tsx.preview
@@ -1,4 +1,4 @@
-<DataGridPro
+<DataGrid
   rows={rows}
   columns={columns}
   onCellEditStop={(params, event) => {

--- a/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
+++ b/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
@@ -1,4 +1,8 @@
-# Data Grid - Row grouping recipes
+---
+title: Data Grid - Row grouping recipes
+---
+
+# Data Grid - Row grouping recipes [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
 
 <p class="description">Advanced grid customization recipes.</p>
 

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -104,6 +104,7 @@ const pages: MuiPage[] = [
       {
         pathname: '/x/react-data-grid-group-pivot',
         title: 'Group & Pivot',
+        plan: 'pro',
         children: [
           { pathname: '/x/react-data-grid/tree-data', plan: 'pro' },
           { pathname: '/x/react-data-grid/row-grouping', plan: 'premium' },
@@ -125,7 +126,11 @@ const pages: MuiPage[] = [
         pathname: '/x/react-data-grid/recipes',
         children: [
           { pathname: '/x/react-data-grid/recipes-editing', title: 'Editing' },
-          { pathname: '/x/react-data-grid/recipes-row-grouping', title: 'Row grouping' },
+          {
+            pathname: '/x/react-data-grid/recipes-row-grouping',
+            title: 'Row grouping',
+            plan: 'premium',
+          },
         ],
       },
       {


### PR DESCRIPTION
<img width="555" alt="Screenshot 2023-07-30 at 21 38 19" src="https://github.com/mui/mui-x/assets/3165635/6489a703-6b3b-439c-bf61-85fea7f92c6b">

https://mui-org.slack.com/archives/C04U3R2V9UK/p1690394764752449

These demos seem to still work correctly. Ok, there are warnings in the console to fix but it seems unrelated, only that we don't always use Material UI correctly.

I have found a few more instances where we are confusing users when it comes to MIT vs. Pro.