### PR TITLE
[pickers] Fix `sx` and `className` props on `MobileDateRangePicker`

### DIFF
--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -20,7 +20,7 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
   ref: React.Ref<HTMLDivElement>,
 ) {
   // Props with the default values common to all date time pickers
-  const { className, sx, ...defaultizedProps } = useDateRangePickerDefaultizedProps<
+  const defaultizedProps = useDateRangePickerDefaultizedProps<
     TDate,
     MobileDateRangePickerProps<TDate>
   >(inProps, 'MuiMobileDateRangePicker');


### PR DESCRIPTION
Fixes #9851

I probably forgot to remove this spreading when the `sx` and `className` management was moved inside the shared files.