### PR TITLE
MUIX-9797 - DataGrid: Strange behavior when width is undefined

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -8,7 +8,7 @@ import {
   GridColumnsInitialState,
 } from './gridColumnsInterfaces';
 import { GridColumnTypesRecord } from '../../../models';
-import { DEFAULT_GRID_COL_TYPE_KEY } from '../../../colDef';
+import { DEFAULT_GRID_COL_TYPE_KEY, GRID_STRING_COL_DEF } from '../../../colDef';
 import { GridStateCommunity } from '../../../models/gridStateCommunity';
 import { GridApiCommunity } from '../../../models/api/gridApiCommunity';
 import { GridColDef, GridStateColDef } from '../../../models/colDef/gridColDef';
@@ -177,7 +177,11 @@ export const hydrateColumnsWidth = (
         computedWidth = 0;
         flexColumns.push(newColumn);
       } else {
-        computedWidth = clamp(newColumn.width!, newColumn.minWidth!, newColumn.maxWidth!);
+        computedWidth = clamp(
+          newColumn.width || GRID_STRING_COL_DEF.width!,
+          newColumn.minWidth || GRID_STRING_COL_DEF.minWidth!,
+          newColumn.maxWidth || GRID_STRING_COL_DEF.maxWidth!,
+        );
       }
 
       widthAllocatedBeforeFlex += computedWidth;


### PR DESCRIPTION
### Description

This PR helps to fix column having a strange display when width is not set by setting default values to all properties that determine the width of the column.

closes https://github.com/mui/mui-x/issues/9797

https://github.com/GitStartHQ/client-mui-x/assets/32432927/b61b1bb9-b491-4249-82e2-9b6f76291e23


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
