### PR TITLE
[charts] Add TS definition to the exported elements

### DIFF
--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -68,21 +68,14 @@
   },
   "exports": {
     ".": {
-      "require": [
-        "./index.js",
-        "./index.d.ts"
-      ],
-      "import": [
-        "./esm/index.js",
-        "./index.d.ts"
-      ]
+      "types": "./index.d.ts",
+      "require": "./index.js",
+      "import": "./esm/index.js"
     },
     "./*": {
+      "types": "./*/index.d.ts",
       "require": "./*",
-      "import": [
-        "./esm/*",
-        "./index.d.ts"
-      ]
+      "import": "./esm/*"
     }
   },
   "setupFiles": [

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -68,12 +68,21 @@
   },
   "exports": {
     ".": {
-      "require": "./index.js",
-      "import": "./esm/index.js"
+      "require": [
+        "./index.js",
+        "./index.d.ts"
+      ],
+      "import": [
+        "./esm/index.js",
+        "./index.d.ts"
+      ]
     },
     "./*": {
       "require": "./*",
-      "import": "./esm/*"
+      "import": [
+        "./esm/*",
+        "./index.d.ts"
+      ]
     }
   },
   "setupFiles": [


### PR DESCRIPTION
I created a basic nextjs with charts to reproduce [this issue comment](https://github.com/mui/mui-x/issues/9556#issuecomment-1657232487). It failed to build because of missing TS definition.

https://github.com/alexfauquette/charts-next-test

The modification in this PR made directly in the `node_module` allowed to build