### PR TITLE
[DataGrid] `getCellAggregationResult`: handle null rowNode case

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/wrapColumnWithAggregation.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/wrapColumnWithAggregation.tsx
@@ -203,7 +203,10 @@ export const wrapColumnWithAggregationValue = ({
     field: string,
   ): GridAggregationLookup[GridRowId][string] | null => {
     let cellAggregationPosition: GridAggregationPosition | null = null;
-    const rowNode = apiRef.current.getRowNode(id)!;
+    const rowNode = apiRef.current.getRowNode(id);
+    if (!rowNode) {
+      return null;
+    }
 
     if (rowNode.type === 'group') {
       cellAggregationPosition = 'inline';


### PR DESCRIPTION
Closes #9876

Remove a `!` and handle the null case.

I find that `!` often ends up causing bugs down the line. I wonder if there is a set of rules we could enfore for its usage that would protect us more from bugs.

Before: https://codesandbox.io/s/frosty-burnell-smdsgs?file=/Demo.tsx
After: https://codesandbox.io/s/vibrant-wu-c9gjj7?file=/Demo.tsx