### PR TITLE
[fields] Use `numeric` `inputmode` instead of `tel`

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -472,7 +472,7 @@ export const useField = <
       return 'text';
     }
 
-    return 'tel';
+    return 'numeric';
   }, [selectedSectionIndexes, state.sections]);
 
   const inputHasFocus = inputRef.current && inputRef.current === getActiveElement(document);


### PR DESCRIPTION
Fixes #9912 

Change `tel` `inputmode` to `numeric` as it makes more sense in the given situation and solves the strange behavior on iOS.