### PR TITLE
[core] Use turborepo to run the `typescript` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "sinon": "^15.2.0",
     "stream-browserify": "^3.0.0",
     "string-replace-loader": "^3.1.0",
+    "turbo": "^1.10.12",
     "typescript": "^5.1.6",
     "util": "^0.12.5",
     "webpack": "^5.88.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:performance:build": "webpack --config test/performance/webpack.config.js",
     "test:performance:server": "serve test/performance -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
-    "typescript": "lerna run --no-bail --parallel typescript",
+    "typescript": "turbo run --parallel --continue typescript",
     "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.json"],
+  "pipeline": {
+    "typescript": {
+      "dependsOn": ["^typescript"],
+      "outputs": []
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13252,6 +13252,48 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbo-darwin-64@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.10.12.tgz#a3d9d6bd3436e795254865bc3d76a9c79aff8085"
+  integrity sha512-vmDfGVPl5/aFenAbOj3eOx3ePNcWVUyZwYr7taRl0ZBbmv2TzjRiFotO4vrKCiTVnbqjQqAFQWY2ugbqCI1kOQ==
+
+turbo-darwin-arm64@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.12.tgz#ff1d9466935687ca68c0dee88a909c34cc654357"
+  integrity sha512-3JliEESLNX2s7g54SOBqqkqJ7UhcOGkS0ywMr5SNuvF6kWVTbuUq7uBU/sVbGq8RwvK1ONlhPvJne5MUqBCTCQ==
+
+turbo-linux-64@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.10.12.tgz#d184a491cc67c07672d339e36427378d0fc6b82e"
+  integrity sha512-siYhgeX0DidIfHSgCR95b8xPee9enKSOjCzx7EjTLmPqPaCiVebRYvbOIYdQWRqiaKh9yfhUtFmtMOMScUf1gg==
+
+turbo-linux-arm64@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.10.12.tgz#44e6ca10b20fd4c59f8c85acf8366c7c09ebca81"
+  integrity sha512-K/ZhvD9l4SslclaMkTiIrnfcACgos79YcAo4kwc8bnMQaKuUeRpM15sxLpZp3xDjDg8EY93vsKyjaOhdFG2UbA==
+
+turbo-windows-64@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.10.12.tgz#36380eca8e7b0505d08b87a084efab1500b2a80e"
+  integrity sha512-7FSgSwvktWDNOqV65l9AbZwcoueAILeE4L7JvjauNASAjjbuzXGCEq5uN8AQU3U5BOFj4TdXrVmO2dX+lLu8Zg==
+
+turbo-windows-arm64@1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.10.12.tgz#757ad59b9abf1949f22280bee6e8aad253743ba5"
+  integrity sha512-gCNXF52dwom1HLY9ry/cneBPOKTBHhzpqhMylcyvJP0vp9zeMQQkt6yjYv+6QdnmELC92CtKNp2FsNZo+z0pyw==
+
+turbo@^1.10.12:
+  version "1.10.12"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.10.12.tgz#cd6f56b92da0600dae9fd94230483556a5c83187"
+  integrity sha512-WM3+jTfQWnB9W208pmP4oeehZcC6JQNlydb/ZHMRrhmQa+htGhWLCzd6Q9rLe0MwZLPpSPFV2/bN5egCLyoKjQ==
+  optionalDependencies:
+    turbo-darwin-64 "1.10.12"
+    turbo-darwin-arm64 "1.10.12"
+    turbo-linux-64 "1.10.12"
+    turbo-linux-arm64 "1.10.12"
+    turbo-windows-64 "1.10.12"
+    turbo-windows-arm64 "1.10.12"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"


### PR DESCRIPTION
We have a lot of packages and two independent teams in MUI X, it's time to start optimizing our workflow a bit 🙂

I gave [Turborepo](https://turbo.build/) a try and started using it for the `typescript` task.
The main goal is to avoid compiling packages that have not changed. For example, when working on the data grid, the other packages will not be compiled unless their files change.

If it works well, we can use it for other tasks. I believe I can integrate it with the `test:karma` task (I usually use it to test everything locally).

We don't use [Remote caching](https://turbo.build/repo/docs/core-concepts/remote-caching) yet, which means that each team member will have their own local cache. We can look into adding the remote cache later to speed up our CI.

---

For comparison, after I change a file in the data grid package, `yarn typescript` takes ~8s 🚀:

```sh
yarn typescript
yarn run v1.22.17
$ turbo run --parallel --continue typescript
• Packages in scope: @mui/x-charts, @mui/x-codemod, @mui/x-data-grid, @mui/x-data-grid-generator, @mui/x-data-grid-premium, @mui/x-data-grid-pro, @mui/x-date-pickers, @mui/x-date-pickers-pro, @mui/x-license-pro, @mui/x-tree-view, docs, eslint-plugin-material-ui
• Running typescript in 12 packages
• Remote caching disabled
docs:typescript: cache hit (outputs already on disk), replaying logs 750b65f6100baa8c
@mui/x-tree-view:typescript: cache hit (outputs already on disk), replaying logs 9db66a35e783e5d3
@mui/x-codemod:typescript: cache hit (outputs already on disk), replaying logs d16ab5fdc4cda081
@mui/x-date-pickers:typescript: cache hit (outputs already on disk), replaying logs b43dc4375c0637c3
@mui/x-data-grid-premium:typescript: cache hit (outputs already on disk), replaying logs 4c690cb12e94a213
@mui/x-data-grid-generator:typescript: cache hit (outputs already on disk), replaying logs a5a5b89a02f84db0
@mui/x-license-pro:typescript: cache hit (outputs already on disk), replaying logs b48cef00597aa62d
@mui/x-data-grid:typescript: cache miss, executing 7afa33b1c652eb9d
docs:typescript: $ tsc -p tsconfig.json
@mui/x-date-pickers:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-premium:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-generator:typescript: $ tsc -p tsconfig.json
@mui/x-license-pro:typescript: $ tsc -p tsconfig.json
@mui/x-codemod:typescript: $ tsc -p tsconfig.json
@mui/x-tree-view:typescript: $ tsc -p tsconfig.json
@mui/x-date-pickers-pro:typescript: cache hit (outputs already on disk), replaying logs 99b340f6eb0dec4f
@mui/x-data-grid-pro:typescript: cache hit (outputs already on disk), replaying logs 09760b702dee4d3c
@mui/x-charts:typescript: cache hit (outputs already on disk), replaying logs a585dd3aef2f65af
@mui/x-data-grid-pro:typescript: $ tsc -p tsconfig.json
@mui/x-date-pickers-pro:typescript: $ tsc -p tsconfig.json
@mui/x-charts:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid:typescript: $ tsc -p tsconfig.json

 Tasks:    11 successful, 11 total
Cached:    10 cached, 11 total
  Time:    7.862s 

✨  Done in 8.55s.
```

When bypassing the cache, it takes ~42s:

```sh
yarn typescript        
yarn run v1.22.17
$ turbo run --parallel --continue typescript
• Packages in scope: @mui/x-charts, @mui/x-codemod, @mui/x-data-grid, @mui/x-data-grid-generator, @mui/x-data-grid-premium, @mui/x-data-grid-pro, @mui/x-date-pickers, @mui/x-date-pickers-pro, @mui/x-license-pro, @mui/x-tree-view, docs, eslint-plugin-material-ui
• Running typescript in 12 packages
• Remote caching disabled
@mui/x-license-pro:typescript: cache hit (outputs already on disk), replaying logs b48cef00597aa62d
docs:typescript: cache hit (outputs already on disk), replaying logs 750b65f6100baa8c
@mui/x-date-pickers:typescript: cache hit (outputs already on disk), replaying logs b43dc4375c0637c3
@mui/x-date-pickers:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid:typescript: cache hit (outputs already on disk), replaying logs 7a62fe8f89574c44
@mui/x-data-grid-premium:typescript: cache hit (outputs already on disk), replaying logs 4c690cb12e94a213
@mui/x-data-grid:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-pro:typescript: cache hit (outputs already on disk), replaying logs 09760b702dee4d3c
docs:typescript: $ tsc -p tsconfig.json
@mui/x-charts:typescript: cache hit (outputs already on disk), replaying logs a585dd3aef2f65af
@mui/x-data-grid-pro:typescript: $ tsc -p tsconfig.json
@mui/x-license-pro:typescript: $ tsc -p tsconfig.json
@mui/x-date-pickers-pro:typescript: cache hit (outputs already on disk), replaying logs 99b340f6eb0dec4f
@mui/x-date-pickers-pro:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-premium:typescript: $ tsc -p tsconfig.json
@mui/x-charts:typescript: $ tsc -p tsconfig.json
@mui/x-codemod:typescript: cache hit, replaying logs d16ab5fdc4cda081
@mui/x-tree-view:typescript: cache hit, replaying logs 9db66a35e783e5d3
@mui/x-tree-view:typescript: $ tsc -p tsconfig.json
@mui/x-codemod:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-generator:typescript: cache hit, replaying logs a5a5b89a02f84db0
@mui/x-data-grid-generator:typescript: $ tsc -p tsconfig.json

 Tasks:    11 successful, 11 total
Cached:    11 cached, 11 total
  Time:    228ms >>> FULL TURBO

✨  Done in 0.73s.
➜  mui-x git:(turborepo) yarn typescript --force
yarn run v1.22.17
$ turbo run --parallel --continue typescript --force
• Packages in scope: @mui/x-charts, @mui/x-codemod, @mui/x-data-grid, @mui/x-data-grid-generator, @mui/x-data-grid-premium, @mui/x-data-grid-pro, @mui/x-date-pickers, @mui/x-date-pickers-pro, @mui/x-license-pro, @mui/x-tree-view, docs, eslint-plugin-material-ui
• Running typescript in 12 packages
• Remote caching disabled
@mui/x-data-grid-premium:typescript: cache bypass, force executing 4c690cb12e94a213
@mui/x-date-pickers-pro:typescript: cache bypass, force executing 99b340f6eb0dec4f
@mui/x-data-grid:typescript: cache bypass, force executing 7a62fe8f89574c44
@mui/x-data-grid-generator:typescript: cache bypass, force executing a5a5b89a02f84db0
@mui/x-tree-view:typescript: cache bypass, force executing 9db66a35e783e5d3
@mui/x-codemod:typescript: cache bypass, force executing d16ab5fdc4cda081
@mui/x-data-grid-pro:typescript: cache bypass, force executing 09760b702dee4d3c
@mui/x-license-pro:typescript: cache bypass, force executing b48cef00597aa62d
@mui/x-charts:typescript: cache bypass, force executing a585dd3aef2f65af
docs:typescript: cache bypass, force executing 750b65f6100baa8c
@mui/x-date-pickers:typescript: cache bypass, force executing b43dc4375c0637c3
docs:typescript: $ tsc -p tsconfig.json
@mui/x-codemod:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-generator:typescript: $ tsc -p tsconfig.json
@mui/x-charts:typescript: $ tsc -p tsconfig.json
@mui/x-date-pickers-pro:typescript: $ tsc -p tsconfig.json
@mui/x-date-pickers:typescript: $ tsc -p tsconfig.json
@mui/x-license-pro:typescript: $ tsc -p tsconfig.json
@mui/x-tree-view:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-premium:typescript: $ tsc -p tsconfig.json
@mui/x-data-grid-pro:typescript: $ tsc -p tsconfig.json

 Tasks:    11 successful, 11 total
Cached:    0 cached, 11 total
  Time:    41.861s 

✨  Done in 42.38s.
```