### PR TITLE
[charts] Fix label and tick alignment

### DIFF
--- a/docs/data/charts/axis/AxisWithComposition.js
+++ b/docs/data/charts/axis/AxisWithComposition.js
@@ -57,7 +57,7 @@ export default function AxisWithComposition() {
         <LinePlot />
         <ChartsXAxis axisId="quarters" label="2021 quarters" labelFontSize={18} />
         <ChartsYAxis axisId="quantities" label="# units sold" />
-        <ChartsYAxis axisId="money" position="right" label="revenu" />
+        <ChartsYAxis axisId="money" position="right" label="revenue" />
       </ResponsiveChartContainer>
     </Box>
   );

--- a/docs/data/charts/axis/AxisWithComposition.tsx
+++ b/docs/data/charts/axis/AxisWithComposition.tsx
@@ -57,7 +57,7 @@ export default function AxisWithComposition() {
         <LinePlot />
         <ChartsXAxis axisId="quarters" label="2021 quarters" labelFontSize={18} />
         <ChartsYAxis axisId="quantities" label="# units sold" />
-        <ChartsYAxis axisId="money" position="right" label="revenu" />
+        <ChartsYAxis axisId="money" position="right" label="revenue" />
       </ResponsiveChartContainer>
     </Box>
   );

--- a/docs/data/charts/components/BasicScaleDemo.js
+++ b/docs/data/charts/components/BasicScaleDemo.js
@@ -29,7 +29,7 @@ function DrawingAreaBox() {
         x={left}
         y={top}
         textAnchor="start"
-        alignmentBaseline="text-after-edge"
+        dominantBaseline="text-after-edge"
       >
         ({left},{top})
       </StyledText>
@@ -37,7 +37,7 @@ function DrawingAreaBox() {
         x={left + width}
         y={top + height}
         textAnchor="end"
-        alignmentBaseline="text-before-edge"
+        dominantBaseline="text-before-edge"
       >
         ({left + width},{top + height})
       </StyledText>

--- a/docs/data/charts/components/BasicScaleDemo.tsx
+++ b/docs/data/charts/components/BasicScaleDemo.tsx
@@ -29,7 +29,7 @@ function DrawingAreaBox() {
         x={left}
         y={top}
         textAnchor="start"
-        alignmentBaseline="text-after-edge"
+        dominantBaseline="text-after-edge"
       >
         ({left},{top})
       </StyledText>
@@ -37,7 +37,7 @@ function DrawingAreaBox() {
         x={left + width}
         y={top + height}
         textAnchor="end"
-        alignmentBaseline="text-before-edge"
+        dominantBaseline="text-before-edge"
       >
         ({left + width},{top + height})
       </StyledText>

--- a/docs/data/charts/components/ScaleDemo.js
+++ b/docs/data/charts/components/ScaleDemo.js
@@ -79,7 +79,7 @@ function ValueHighlight(props) {
         x={left + 5}
         y={mouseY}
         textAnchor="start"
-        alignmentBaseline="text-after-edge"
+        dominantBaseline="text-after-edge"
       >
         {leftAxisScale.invert(mouseY).toFixed(0)}
       </StyledText>
@@ -88,7 +88,7 @@ function ValueHighlight(props) {
         x={left + width - 5}
         y={mouseY}
         textAnchor="end"
-        alignmentBaseline="text-after-edge"
+        dominantBaseline="text-after-edge"
       >
         {rightAxisScale.invert(mouseY).toFixed(0)}
       </StyledText>

--- a/docs/data/charts/components/ScaleDemo.tsx
+++ b/docs/data/charts/components/ScaleDemo.tsx
@@ -79,7 +79,7 @@ function ValueHighlight(props: { svgRef: React.RefObject<SVGSVGElement> }) {
         x={left + 5}
         y={mouseY}
         textAnchor="start"
-        alignmentBaseline="text-after-edge"
+        dominantBaseline="text-after-edge"
       >
         {leftAxisScale.invert(mouseY).toFixed(0)}
       </StyledText>
@@ -88,7 +88,7 @@ function ValueHighlight(props: { svgRef: React.RefObject<SVGSVGElement> }) {
         x={left + width - 5}
         y={mouseY}
         textAnchor="end"
-        alignmentBaseline="text-after-edge"
+        dominantBaseline="text-after-edge"
       >
         {rightAxisScale.invert(mouseY).toFixed(0)}
       </StyledText>

--- a/docs/data/charts/stacking/StackOrderDemo.js
+++ b/docs/data/charts/stacking/StackOrderDemo.js
@@ -120,7 +120,7 @@ export default function StackOrderDemo() {
           [`.${axisClasses.bottom}`]: {
             [`.${axisClasses.tickLabel}`]: {
               transform: 'rotate(45deg)',
-              alignmentBaseline: 'hanging',
+              dominantBaseline: 'hanging',
               textAnchor: 'start',
             },
             [`.${axisClasses.label}`]: {

--- a/docs/data/charts/stacking/StackOrderDemo.tsx
+++ b/docs/data/charts/stacking/StackOrderDemo.tsx
@@ -115,7 +115,7 @@ export default function StackOrderDemo() {
           [`.${axisClasses.bottom}`]: {
             [`.${axisClasses.tickLabel}`]: {
               transform: 'rotate(45deg)',
-              alignmentBaseline: 'hanging',
+              dominantBaseline: 'hanging',
               textAnchor: 'start',
             },
             [`.${axisClasses.label}`]: {

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -171,7 +171,7 @@ export const ChartsLegendLabel = styled('text', {
       calc(0.5 * var(--ChartsLegend-itemMarkSize))
       )`,
   fill: theme.palette.text.primary,
-  alignmentBaseline: 'central',
+  dominantBaseline: 'central',
 }));
 
 const defaultProps = {

--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -55,7 +55,6 @@ const PieArcLabelRoot = styled('text', {
   overridesResolver: (_, styles) => styles.root,
 })(({ theme }) => ({
   fill: theme.palette.text.primary,
-  alignmentBaseline: 'baseline',
   textAnchor: 'middle',
 }));
 

--- a/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
+++ b/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
@@ -7,24 +7,24 @@ export const AxisRoot = styled('g', {
   overridesResolver: (props, styles) => styles.root,
 })({
   [`&.${axisClasses.directionY}`]: {
-    [`.${axisClasses.tickLabel}`]: { alignmentBaseline: 'middle' },
-    [`.${axisClasses.label}`]: { alignmentBaseline: 'baseline', textAnchor: 'middle' },
+    [`.${axisClasses.tickLabel}`]: { dominantBaseline: 'middle' },
+    [`.${axisClasses.label}`]: { dominantBaseline: 'auto', textAnchor: 'middle' },
   },
   [`&.${axisClasses.left}`]: {
-    [`.${axisClasses.tickLabel}`]: { alignmentBaseline: 'central', textAnchor: 'end' },
+    [`.${axisClasses.tickLabel}`]: { dominantBaseline: 'central', textAnchor: 'end' },
   },
   [`&.${axisClasses.right}`]: {
-    [`.${axisClasses.tickLabel}`]: { alignmentBaseline: 'central', textAnchor: 'start' },
+    [`.${axisClasses.tickLabel}`]: { dominantBaseline: 'central', textAnchor: 'start' },
   },
   [`&.${axisClasses.bottom}`]: {
     [`.${axisClasses.tickLabel}, .${axisClasses.label}`]: {
-      alignmentBaseline: 'hanging',
+      dominantBaseline: 'hanging',
       textAnchor: 'middle',
     },
   },
   [`&.${axisClasses.top}`]: {
     [`.${axisClasses.tickLabel}, .${axisClasses.label}`]: {
-      alignmentBaseline: 'baseline',
+      dominantBaseline: 'baseline',
       textAnchor: 'middle',
     },
   },


### PR DESCRIPTION
Fixes #9929 

- Use `dominantBaseline` instead of `alignmentBaseline`. The `alignmentBaseline` shouldn't work on `text` elements as per the spec.
- Remove explicit `PieArcLabel` alignment as it didn't seem to do anything
- Fix typo