### PR TITLE
[pickers] Always respect locale when formatting meridiem

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -15,6 +15,7 @@ import {
 import { DateOrTimeViewWithMeridiem, WrapperVariant } from '../internals/models';
 import { useMeridiemMode } from '../internals/hooks/date-helpers-hooks';
 import { MULTI_SECTION_CLOCK_SECTION_WIDTH } from '../internals/constants/dimensions';
+import { formatMeridiem } from '../internals/utils/date-utils';
 
 export interface ExportedDateTimePickerToolbarProps extends ExportedBaseToolbarProps {
   ampm?: boolean;
@@ -322,7 +323,7 @@ function DateTimePickerToolbar<TDate extends unknown>(inProps: DateTimePickerToo
               variant="subtitle2"
               selected={meridiemMode === 'am'}
               typographyClassName={classes.ampmLabel}
-              value={utils.getMeridiemText('am')}
+              value={formatMeridiem(utils, 'am')}
               onClick={readOnly ? undefined : () => handleMeridiemChange('am')}
               disabled={disabled}
             />
@@ -330,7 +331,7 @@ function DateTimePickerToolbar<TDate extends unknown>(inProps: DateTimePickerToo
               variant="subtitle2"
               selected={meridiemMode === 'pm'}
               typographyClassName={classes.ampmLabel}
-              value={utils.getMeridiemText('pm')}
+              value={formatMeridiem(utils, 'pm')}
               onClick={readOnly ? undefined : () => handleMeridiemChange('pm')}
               disabled={disabled}
             />
@@ -343,7 +344,7 @@ function DateTimePickerToolbar<TDate extends unknown>(inProps: DateTimePickerToo
             data-mui-test="am-pm-view-button"
             onClick={() => onViewChange('meridiem')}
             selected={view === 'meridiem'}
-            value={value && meridiemMode ? utils.getMeridiemText(meridiemMode) : '--'}
+            value={value && meridiemMode ? formatMeridiem(utils, meridiemMode) : '--'}
             width={MULTI_SECTION_CLOCK_SECTION_WIDTH}
           />
         )}

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
@@ -22,6 +22,7 @@ import { TimeViewWithMeridiem } from '../internals/models';
 import { useControlledValueWithTimezone } from '../internals/hooks/useValueWithTimezone';
 import { singleItemValueManager } from '../internals/utils/valueManagers';
 import { useClockReferenceDate } from '../internals/hooks/useClockReferenceDate';
+import { formatMeridiem } from '../internals/utils/date-utils';
 
 const useUtilityClasses = (ownerState: MultiSectionDigitalClockProps<any>) => {
   const { classes } = ownerState;
@@ -330,8 +331,8 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
         }
 
         case 'meridiem': {
-          const amLabel = utils.getMeridiemText('am');
-          const pmLabel = utils.getMeridiemText('pm');
+          const amLabel = formatMeridiem(utils, 'am');
+          const pmLabel = formatMeridiem(utils, 'pm');
           return {
             onChange: handleMeridiemChange,
             items: [

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
@@ -6,6 +6,7 @@ import { createPickerRenderer, adapterToUse, wrapPickerMount } from 'test/utils/
 import { MultiSectionDigitalClock } from '@mui/x-date-pickers/MultiSectionDigitalClock';
 import { expect } from 'chai';
 import { multiSectionDigitalClockHandler } from 'test/utils/pickers/viewHandlers';
+import { formatMeridiem } from '@mui/x-date-pickers/internals/utils/date-utils';
 
 describe('<MultiSectionDigitalClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });
@@ -63,7 +64,7 @@ describe('<MultiSectionDigitalClock /> - Describes', () => {
         expect(selectedItems[1]).to.have.text(minutesLabel);
         if (hasMeridiem) {
           expect(selectedItems[2]).to.have.text(
-            adapterToUse.getMeridiemText(adapterToUse.getHours(expectedValue) >= 12 ? 'pm' : 'am'),
+            formatMeridiem(adapterToUse, adapterToUse.getHours(expectedValue) >= 12 ? 'pm' : 'am'),
           );
         }
       }

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -15,6 +15,7 @@ import {
   TimePickerToolbarClasses,
 } from './timePickerToolbarClasses';
 import { TimeViewWithMeridiem } from '../internals/models';
+import { formatMeridiem } from '../internals/utils/date-utils';
 
 export interface TimePickerToolbarProps<TDate>
   extends BaseToolbarProps<TDate | null, TimeViewWithMeridiem> {
@@ -232,7 +233,7 @@ function TimePickerToolbar<TDate extends unknown>(inProps: TimePickerToolbarProp
             data-mui-test="toolbar-am-btn"
             selected={meridiemMode === 'am'}
             typographyClassName={classes.ampmLabel}
-            value={utils.getMeridiemText('am')}
+            value={formatMeridiem(utils, 'am')}
             onClick={readOnly ? undefined : () => handleMeridiemChange('am')}
             disabled={disabled}
           />
@@ -242,7 +243,7 @@ function TimePickerToolbar<TDate extends unknown>(inProps: TimePickerToolbarProp
             data-mui-test="toolbar-pm-btn"
             selected={meridiemMode === 'pm'}
             typographyClassName={classes.ampmLabel}
-            value={utils.getMeridiemText('pm')}
+            value={formatMeridiem(utils, 'pm')}
             onClick={readOnly ? undefined : () => handleMeridiemChange('pm')}
             disabled={disabled}
           />

--- a/packages/x-date-pickers/src/internals/utils/date-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.ts
@@ -133,6 +133,11 @@ export const getTodayDate = <TDate>(
     ? utils.startOfDay(utils.dateWithTimezone(undefined, timezone)!)
     : utils.dateWithTimezone(undefined, timezone)!;
 
+export const formatMeridiem = <TDate>(utils: MuiPickersAdapter<TDate>, meridiem: 'am' | 'pm') => {
+  const date = utils.setHours(utils.date()!, meridiem === 'am' ? 2 : 14);
+  return utils.format(date, 'meridiem');
+};
+
 const dateViews = ['year', 'month', 'day'];
 export const isDatePickerView = (view: DateOrTimeViewWithMeridiem): view is DateView =>
   dateViews.includes(view);

--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -742,6 +742,7 @@ export interface MuiPickersAdapter<TDate, TLocale = any> {
   getYearRange(start: TDate, end: TDate): TDate[];
   /**
    * Allow to customize how the "am"` and "pm" strings are rendered.
+   * @deprecated Use `utils.format(utils.setHours(utils.date()!, meridiem === 'am' ? 2 : 14), 'meridiem')` instead.
    * @param {"am" | "pm"} meridiem The string to render.
    * @return {string} The formatted string.
    */

--- a/test/utils/pickers/viewHandlers.ts
+++ b/test/utils/pickers/viewHandlers.ts
@@ -1,6 +1,7 @@
 import { fireTouchChangedEvent, userEvent, screen } from '@mui/monorepo/test/utils';
 import { getClockTouchEvent } from 'test/utils/pickers-utils';
 import { MuiPickersAdapter, TimeView } from '@mui/x-date-pickers/models';
+import { formatMeridiem } from '@mui/x-date-pickers/internals/utils/date-utils';
 
 type TDate = any;
 
@@ -50,7 +51,7 @@ export const multiSectionDigitalClockHandler: ViewHandler<TimeView> = {
     if (hasMeridiem) {
       userEvent.mousePress(
         screen.getByRole('option', {
-          name: adapter.getMeridiemText(adapter.getHours(value) >= 12 ? 'pm' : 'am'),
+          name: formatMeridiem(adapter, adapter.getHours(value) >= 12 ? 'pm' : 'am'),
         }),
       );
     }


### PR DESCRIPTION
Fixes #9977

The `getMeridiemText` did not have the same behavior across adapters.
It can be replaced by an adapter-agnostic method.