### PR TITLE
[charts] Remove not functional component `styleOverrides`

### DIFF
--- a/packages/x-charts/src/themeAugmentation/components.d.ts
+++ b/packages/x-charts/src/themeAugmentation/components.d.ts
@@ -7,11 +7,9 @@ export interface ChartsComponents {
   };
   MuiChartsXAxis?: {
     defaultProps?: ComponentsProps['MuiChartsXAxis'];
-    styleOverrides?: ComponentsOverrides['MuiChartsXAxis'];
   };
   MuiChartsYAxis?: {
     defaultProps?: ComponentsProps['MuiChartsYAxis'];
-    styleOverrides?: ComponentsOverrides['MuiChartsYAxis'];
   };
   MuiChartsAxisHighlight?: {
     defaultProps?: ComponentsProps['MuiChartsAxisHighlight'];

--- a/packages/x-charts/src/themeAugmentation/components.d.ts
+++ b/packages/x-charts/src/themeAugmentation/components.d.ts
@@ -13,11 +13,9 @@ export interface ChartsComponents {
   };
   MuiChartsAxisHighlight?: {
     defaultProps?: ComponentsProps['MuiChartsAxisHighlight'];
-    styleOverrides?: never; // ComponentsOverrides['MuiChartsAxisHighlight'];
   };
   MuiChartsClipPath?: {
     defaultProps?: ComponentsProps['MuiChartsClipPath'];
-    styleOverrides?: never; // ComponentsOverrides['MuiChartsClipPath'];
   };
   MuiChartsLegend?: {
     defaultProps?: ComponentsProps['MuiChartsLegend'];
@@ -25,15 +23,12 @@ export interface ChartsComponents {
   };
   MuiChartsTooltip?: {
     defaultProps?: ComponentsProps['MuiChartsTooltip'];
-    styleOverrides?: never; // ComponentsOverrides['MuiChartsTooltip'];
   };
   MuiChartsSurface?: {
     defaultProps?: ComponentsProps['MuiChartsSurface'];
-    styleOverrides?: never; // ComponentsOverrides['MuiChartsSurface'];
   };
   MuiBarChart?: {
     defaultProps?: ComponentsProps['MuiBarChart'];
-    styleOverrides?: never; // ComponentsOverrides['MuiBarChart'];
   };
   MuiBarElement?: {
     defaultProps?: ComponentsProps['MuiBarElement'];
@@ -41,7 +36,6 @@ export interface ChartsComponents {
   };
   MuiLineChart?: {
     defaultProps?: ComponentsProps['MuiLineChart'];
-    styleOverrides?: never; // ComponentsOverrides['MuiLineChart'];
   };
   MuiAreaElement?: {
     defaultProps?: ComponentsProps['MuiAreaElement'];
@@ -57,11 +51,9 @@ export interface ChartsComponents {
   };
   MuiScatterChart?: {
     defaultProps?: ComponentsProps['MuiScatterChart'];
-    styleOverrides?: never; // ComponentsOverrides['MuiScatterChart'];
   };
   MuiScatter?: {
     defaultProps?: ComponentsProps['MuiScatter'];
-    styleOverrides?: never; // ComponentsOverrides['MuiScatter'];
   };
 }
 

--- a/packages/x-charts/src/themeAugmentation/overrides.d.ts
+++ b/packages/x-charts/src/themeAugmentation/overrides.d.ts
@@ -6,8 +6,6 @@ import { AreaElementClassKey, LineElementClassKey, MarkElementClassKey } from '.
 // prettier-ignore
 export interface PickersComponentNameToClassKey {
   MuiChartsAxis: ChartsAxisClassKey;
-  MuiChartsXAxis:  ChartsAxisClassKey;
-  MuiChartsYAxis:  ChartsAxisClassKey;
   MuiChartsLegend: ChartsLegendClassKey;
 
   // BarChart components

--- a/packages/x-charts/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-charts/src/themeAugmentation/themeAugmentation.spec.ts
@@ -20,22 +20,12 @@ createTheme({
         // @ts-expect-error invalid MuiChartsXAxis prop
         someRandomProp: true,
       },
-      styleOverrides: {
-        root: { backgroundColor: 'red' },
-        // @ts-expect-error invalid MuiChartsXAxis class key
-        constent: { color: 'red' },
-      },
     },
     MuiChartsYAxis: {
       defaultProps: {
         axisId: 'test',
         // @ts-expect-error invalid MuiChartsYAxis prop
         someRandomProp: true,
-      },
-      styleOverrides: {
-        root: { backgroundColor: 'red' },
-        // @ts-expect-error invalid MuiChartsYAxis class key
-        constent: { color: 'red' },
       },
     },
     MuiChartsAxisHighlight: {


### PR DESCRIPTION
Created from: https://github.com/mui/mui-x/pull/9994#discussion_r1290246220
- Remove `ChartsXAxis` and `ChartsYAxis` `styleOverrides` as they are not used. Only the `ChartsAxis` is used globally.
- Remove `never` entries (same change as in https://github.com/mui/mui-x/pull/9978/files#diff-099ff841d1bc7939194814f7348976c6c1eb34f250eb792e93ef4bd2781851f8) 