### PR TITLE
[pickers] Fix month switcher RTL

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.tsx
@@ -98,21 +98,19 @@ export const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitch
     label: previousLabel,
   };
 
-  const [leftProps, rightProps] = isRTL ? [nextProps, previousProps] : [previousProps, nextProps];
-
   const PreviousIconButton = slots?.previousIconButton ?? PickersArrowSwitcherButton;
   const previousIconButtonProps = useSlotProps({
     elementType: PreviousIconButton,
     externalSlotProps: slotProps?.previousIconButton,
     additionalProps: {
       size: 'medium',
-      title: leftProps.label,
-      'aria-label': leftProps.label,
-      disabled: leftProps.isDisabled,
+      title: previousProps.label,
+      'aria-label': previousProps.label,
+      disabled: previousProps.isDisabled,
       edge: 'end',
-      onClick: leftProps.goTo,
+      onClick: previousProps.goTo,
     },
-    ownerState: { ...ownerState, hidden: leftProps.isHidden },
+    ownerState: { ...ownerState, hidden: previousProps.isHidden },
     className: classes.button,
   });
 
@@ -122,13 +120,13 @@ export const PickersArrowSwitcher = React.forwardRef(function PickersArrowSwitch
     externalSlotProps: slotProps?.nextIconButton,
     additionalProps: {
       size: 'medium',
-      title: rightProps.label,
-      'aria-label': rightProps.label,
-      disabled: rightProps.isDisabled,
+      title: nextProps.label,
+      'aria-label': nextProps.label,
+      disabled: nextProps.isDisabled,
       edge: 'start',
-      onClick: rightProps.goTo,
+      onClick: nextProps.goTo,
     },
-    ownerState: { ...ownerState, hidden: rightProps.isHidden },
+    ownerState: { ...ownerState, hidden: nextProps.isHidden },
     className: classes.button,
   });
 


### PR DESCRIPTION
Fix #9989

I don't know why but the property inversion was not working. But it seems useless so I just removed it


```jsx
const [leftProps, rightProps] = isRTL ? [nextProps, previousProps] : [previousProps, nextProps];
```