### PR TITLE
[docs] Fix a11y issue on plan links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [l10n] Improve Chinese (zh-CN) and Chinese(traditional) (zh-TW) locales (#9999) @MyNameIsTakenOMG
 - [l10n] Improve Spanish (es-ES) locale (#10037) @Macampu420
 
-#### `@mui/x-data-grid-pro@v6.11.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@v6.11.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@v6.11.2`.
 
-#### `@mui/x-data-grid-premium@v6.11.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@v6.11.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@v6.11.2`.
 
@@ -43,7 +43,7 @@ Same changes as in `@mui/x-data-grid-pro@v6.11.2`.
 - [pickers] Pass the shortcut information in the `onChange` context (#9985) @flaviendelangle
 - [pickers] Replace `Grid` toolbar component with a styled `div` (#10052) @LukasTy
 
-#### `@mui/x-date-pickers-pro@v6.11.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@v6.11.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@v6.11.2`.
 
@@ -77,11 +77,11 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 - [DataGrid] `getCellAggregationResult`: Handle `null` `rowNode` case (#9915) @romgrk
 
-#### `@mui/x-data-grid-pro@6.11.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.11.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.11.1`.
 
-#### `@mui/x-data-grid-premium@6.11.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.11.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.11.1`.
 
@@ -96,7 +96,7 @@ Same changes as in `@mui/x-data-grid-pro@6.11.1`.
 - [l10n] Improve Finnish (fi-FI) locale (#9795) @kurkle
 - [l10n] Improve Icelandic (is-IS) locale (#9639) @magnimarels
 
-#### `@mui/x-date-pickers-pro@6.11.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.11.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.11.1`.
 
@@ -146,11 +146,11 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [l10n] Improve Finnish (fi-FI) locale (#9848) @sambbaahh
 - [l10n] Improve Italian (it-IT) locale (#9627) @fabio-rizzello-omnia
 
-#### `@mui/x-data-grid-pro@v6.11.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@v6.11.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@v6.11.0`.
 
-#### `@mui/x-data-grid-premium@v6.11.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@v6.11.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@v6.11.0`.
 
@@ -169,7 +169,7 @@ Same changes as in `@mui/x-data-grid-pro@v6.11.0`.
 - [pickers] Fix offset management on dayjs adapter (#9884) @flaviendelangle
 - [pickers] Use device motion reduction preference (#9823) @LukasTy
 
-#### `@mui/x-date-pickers-pro@v6.11.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@v6.11.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@v6.11.0`.
 
@@ -232,11 +232,11 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [DataGrid] Keep focused cell in the DOM (#7357) @yaredtsy
 - [l10n] Improve Finnish (fi-FI) locale (#9746) @sambbaahh
 
-#### `@mui/x-data-grid-pro@v6.10.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@v6.10.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@v6.10.2`.
 
-#### `@mui/x-data-grid-premium@v6.10.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@v6.10.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@v6.10.2`, plus:
 
@@ -248,7 +248,7 @@ Same changes as in `@mui/x-data-grid-pro@v6.10.2`, plus:
 
 - [pickers] Remove the `endOfDate` from `DigitalClock` timeOptions (#9800) @noraleonte
 
-#### `@mui/x-date-pickers-pro@v6.10.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@v6.10.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@v6.10.2`.
 
@@ -300,14 +300,14 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [DataGrid] Update focused cell on page change via keyboard (#9203) @m4theushw
 - [DataGrid] Wait for remote stylesheets to load before print (#9665) @cherniavskii
 
-#### `@mui/x-data-grid-pro@v6.10.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@v6.10.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@v6.10.1`, plus:
 
 - [DataGridPro] Improve tree data performance (#9682) @cherniavskii
 - [DataGridPro] Prevent affecting cells from child DataGrid when resizing a column (#9670) @m4theushw
 
-#### `@mui/x-data-grid-premium@v6.10.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@v6.10.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@v6.10.1`.
 
@@ -318,7 +318,7 @@ Same changes as in `@mui/x-data-grid-pro@v6.10.1`.
 - [fields] Fix `format` and `value` update order (#9715) @LukasTy
 - [pickers] Remove `require` usage in comment (#9675) @LukasTy
 
-#### `@mui/x-date-pickers-pro@v6.10.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@v6.10.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@v6.10.1`.
 
@@ -369,11 +369,11 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGrid] Make `rowExpansionChange` event public (#9611) @MBilalShafi
 - [l10n] Improve Polish (pl-PL) locale (#9625) @ch1llysense
 
-#### `@mui/x-data-grid-pro@6.10.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.10.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.10.0`.
 
-#### `@mui/x-data-grid-premium@6.10.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.10.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.10.0`.
 
@@ -384,7 +384,7 @@ Same changes as in `@mui/x-data-grid-pro@6.10.0`.
 - [pickers] Fix date calendar issues (#9652) @LukasTy
 - [l10n] Improve Norwegian (nb-NO) locale (#9608) @JosteinBrevik
 
-#### `@mui/x-date-pickers-pro@6.10.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.10.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.10.0`.
 
@@ -437,11 +437,11 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [DataGrid] Correctly reflect `TablePagination`'s `rowsPerPageOptions` shape to `pageSizeOptions` (#9438) @burakkgunduzz
 - [l10n] Improve Spanish (es-ES) locale (#9500) @fufex
 
-#### `@mui/x-data-grid-pro@6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.9.2`.
 
-#### `@mui/x-data-grid-premium@6.9.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.2` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.9.2`, plus:
 
@@ -454,7 +454,7 @@ Same changes as in `@mui/x-data-grid-pro@6.9.2`, plus:
 - [pickers] Forward digital clock classes (#9555) @YoonjiJang
 - [pickers] Rename `internal` folder to `internals` on `@mui/x-date-picker-pro` (#9571) @flaviendelangle
 
-#### `@mui/x-date-pickers-pro@6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.9.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.9.2`.
 
@@ -502,14 +502,14 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [DataGrid] Fix `Maximum call stack size exceeded` error when using fractional width (#9516) @cherniavskii
 - [l10n] Improve Romanian (ro-RO) and Hungarian (hu-HU) translations (#9436) @noraleonte
 
-#### `@mui/x-data-grid-pro@6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.9.1`, plus:
 
 - [DataGridPro] Don't throw error in column pinning (#9507) @romgrk
 - [DataGridPro] Fix bug with `checkboxSelection` and treeData/grouping (#9418) @romgrk
 
-#### `@mui/x-data-grid-premium@6.9.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.1` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.9.1`.
 
@@ -523,7 +523,7 @@ Same changes as in `@mui/x-data-grid-pro@6.9.1`.
 - [l10n] Add Chinese (Hong Kong) (zh-HK) locale (#9468) @samchiu90
 - [l10n] Improve Romanian (ro-RO) translations (#9436) @noraleonte
 
-#### `@mui/x-date-pickers-pro@6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.9.1` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.9.1`.
 
@@ -587,11 +587,11 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [DataGrid] Use container dimensions from `getComputedStyle` (#9236) @m4theushw
 - [l10n] Improve Brazilian Portuguese (pt-BR) locale (#9404) @julioAz
 
-#### `@mui/x-data-grid-pro@6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.9.0`.
 
-#### `@mui/x-data-grid-premium@6.9.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.9.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.9.0`.
 
@@ -607,7 +607,7 @@ Same changes as in `@mui/x-data-grid-pro@6.9.0`.
 - [pickers] Reduce date range calendar vertical border width (#9368) @oliviertassinari
 - [pickers] Reset fields internal state when pasting value (#9385) @alexfauquette
 
-#### `@mui/x-date-pickers-pro@6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.9.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.9.0`.
 
@@ -663,11 +663,11 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [DataGrid] Scroll performance improvements (#9037) @romgrk
 - [l10n] Improve Greek (el-GR) locale (#9292) @clytras
 
-#### `@mui/x-data-grid-pro@6.8.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.8.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.8.0`.
 
-#### `@mui/x-data-grid-premium@6.8.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.8.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.8.0`.
 
@@ -680,7 +680,7 @@ Same changes as in `@mui/x-data-grid-pro@6.8.0`.
 - [pickers] Close the calendar when a shortcut is selected (#9080) @flaviendelangle
 - [pickers] Fix disabling for digital clock (#9300) @alexfauquette
 
-#### `@mui/x-date-pickers-pro@6.8.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.8.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.8.0`.
 
@@ -756,13 +756,13 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [l10n] Improve German (de-DE) locale (#9259) @ximex
 - [l10n] Improve Turkish (tr-TR) locale (#9237) @MCErtan
 
-#### `@mui/x-data-grid-pro@6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-data-grid-pro@6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-data-grid@6.7.0`, plus:
 
 - [DataGridPro] Improve header filter menu visuals (#9181) @MBilalShafi
 
-#### `@mui/x-data-grid-premium@6.7.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### `@mui/x-data-grid-premium@6.7.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in `@mui/x-data-grid-pro@6.7.0`, plus:
 
@@ -776,7 +776,7 @@ Same changes as in `@mui/x-data-grid-pro@6.7.0`, plus:
 - [l10n] Improve German (de-DE) locale (#9258) @ximex
 - [pickers] Apply dynamic default format depending on views for all desktop and mobile pickers (#9126) @flaviendelangle
 
-#### `@mui/x-date-pickers-pro@6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### `@mui/x-date-pickers-pro@6.7.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in `@mui/x-date-pickers@6.7.0`, plus:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Pro packages:
 - [`@mui/x-data-grid-pro`](https://www.npmjs.com/package/@mui/x-data-grid-pro)
 - [`@mui/x-date-pickers-pro`](https://www.npmjs.com/package/@mui/x-date-pickers-pro)
 
-### Premium Plan
+### Premium plan
 
 The Premium version of MUI X covers the most advanced features of the data grid, such as row grouping, Excel export, and aggregation, in addition to everything that's included in the Pro Plan.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See the [Pricing](https://mui.com/pricing/) page for a detailed feature comparis
 
 ## Plans
 
-### Community Plan
+### Community plan
 
 The free version of MUI X is [published under an MIT license](https://www.tldrlegal.com/license/mit-license) and is [free forever](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd#20f609acab4441cf9346614119fbbac1).
 This version contains features that we believe are maintainable by contributions from the open-source community.
@@ -59,7 +59,7 @@ MIT licensed packages:
 - [`@mui/x-date-pickers`](https://www.npmjs.com/package/@mui/x-date-pickers)
 - [`@mui/x-charts`](https://www.npmjs.com/package/@mui/x-charts)
 
-### Pro Plan
+### Pro plan
 
 The Pro version of MUI X expands on the features of the free version with more advanced capabilities such as multi-filtering, multi-sorting, column resizing and column pinning for the data grid; as well as the date range picker component.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Pro packages:
 
 ### Premium plan
 
-The Premium version of MUI X covers the most advanced features of the data grid, such as row grouping, Excel export, and aggregation, in addition to everything that's included in the Pro Plan.
+The Premium version of MUI X covers the most advanced features of the data grid, such as row grouping, Excel export, and aggregation, in addition to everything that's included in the Pro plan.
 
 The Premium version is available under a commercial license—visit [the Pricing page](https://mui.com/pricing/) for details.
 

--- a/docs/data/data-grid/aggregation/aggregation.md
+++ b/docs/data/data-grid/aggregation/aggregation.md
@@ -2,7 +2,7 @@
 title: Data Grid - Aggregation
 ---
 
-# Data Grid - Aggregation [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Aggregation <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 <p class="description">Add aggregation functions to the Data Grid so users can combine row values.</p>
 

--- a/docs/data/data-grid/aggregation/aggregation.md
+++ b/docs/data/data-grid/aggregation/aggregation.md
@@ -2,7 +2,7 @@
 title: Data Grid - Aggregation
 ---
 
-# Data Grid - Aggregation <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+# Data Grid - Aggregation [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 <p class="description">Add aggregation functions to the Data Grid so users can combine row values.</p>
 

--- a/docs/data/data-grid/cell-selection/cell-selection.md
+++ b/docs/data/data-grid/cell-selection/cell-selection.md
@@ -2,7 +2,7 @@
 title: Data Grid - Cell selection
 ---
 
-# Data Grid - Cell selection <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+# Data Grid - Cell selection [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 <p class="description">Cell selection allows the user to select individual cells or a range of cells.</p>
 

--- a/docs/data/data-grid/cell-selection/cell-selection.md
+++ b/docs/data/data-grid/cell-selection/cell-selection.md
@@ -2,7 +2,7 @@
 title: Data Grid - Cell selection
 ---
 
-# Data Grid - Cell selection [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Cell selection <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 <p class="description">Cell selection allows the user to select individual cells or a range of cells.</p>
 

--- a/docs/data/data-grid/clipboard/clipboard.md
+++ b/docs/data/data-grid/clipboard/clipboard.md
@@ -15,7 +15,7 @@ The priority of the data copied to the clipboard is the following, from highest 
 
 {{"demo": "ClipboardCopy.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Clipboard paste [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+## Clipboard paste <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 :::info
 

--- a/docs/data/data-grid/clipboard/clipboard.md
+++ b/docs/data/data-grid/clipboard/clipboard.md
@@ -15,7 +15,7 @@ The priority of the data copied to the clipboard is the following, from highest 
 
 {{"demo": "ClipboardCopy.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Clipboard paste <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+## Clipboard paste [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 :::info
 

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -40,7 +40,7 @@ Before using fluid width, note that:
 
 {{"demo": "ColumnFluidWidthGrid.js", "bg": "inline"}}
 
-## Resizing <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Resizing [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 By default, `DataGridPro` allows all columns to be resized by dragging the right portion of the column separator.
 

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -40,7 +40,7 @@ Before using fluid width, note that:
 
 {{"demo": "ColumnFluidWidthGrid.js", "bg": "inline"}}
 
-## Resizing [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Resizing <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 By default, `DataGridPro` allows all columns to be resized by dragging the right portion of the column separator.
 

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -66,7 +66,7 @@ In addition to the required `groupId` and `children`, you can use the following 
 
 {{"demo": "CustomizationDemo.js", "bg": "inline"}}
 
-## Column reordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Column reordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 By default, the columns that are part of a group cannot be dragged to outside their group.
 You can customize this behavior on specific groups by setting `freeReordering: true` in a column group object.
@@ -87,7 +87,7 @@ This feature isn't implemented yet. It's coming.
 Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
-## Column group ordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>🚧
+## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
 Users could drag and drop group header to move all the group children at once, [like they can already do it with normal columns](/x/react-data-grid/column-ordering/).
 

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -66,7 +66,7 @@ In addition to the required `groupId` and `children`, you can use the following 
 
 {{"demo": "CustomizationDemo.js", "bg": "inline"}}
 
-## Column reordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Column reordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 By default, the columns that are part of a group cannot be dragged to outside their group.
 You can customize this behavior on specific groups by setting `freeReordering: true` in a column group object.
@@ -87,7 +87,7 @@ This feature isn't implemented yet. It's coming.
 Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
 :::
 
-## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)🚧
+## Column group ordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>🚧
 
 Users could drag and drop group header to move all the group children at once, [like they can already do it with normal columns](/x/react-data-grid/column-ordering/).
 

--- a/docs/data/data-grid/column-menu/column-menu.md
+++ b/docs/data/data-grid/column-menu/column-menu.md
@@ -140,7 +140,7 @@ By default, each column header has the column menu enabled. To disable the colum
 
 {{"demo": "DisabledColumnMenuGrid.js", "bg": "inline"}}
 
-## Column menu with Pro/Premium features [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)[<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+## Column menu with Pro/Premium features <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a><a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 In the following demo, in addition to Data Grid MIT features, you can see commercial features like [grouping](/x/react-data-grid/row-grouping/), and [aggregation](/x/react-data-grid/aggregation/) in action. Try tweaking the values from respective column menu items.
 

--- a/docs/data/data-grid/column-menu/column-menu.md
+++ b/docs/data/data-grid/column-menu/column-menu.md
@@ -140,7 +140,7 @@ By default, each column header has the column menu enabled. To disable the colum
 
 {{"demo": "DisabledColumnMenuGrid.js", "bg": "inline"}}
 
-## Column menu with Pro/Premium features <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a><a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+## Column menu with Pro/Premium features [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')[<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 In the following demo, in addition to Data Grid MIT features, you can see commercial features like [grouping](/x/react-data-grid/row-grouping/), and [aggregation](/x/react-data-grid/aggregation/) in action. Try tweaking the values from respective column menu items.
 

--- a/docs/data/data-grid/column-ordering/column-ordering.md
+++ b/docs/data/data-grid/column-ordering/column-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column ordering
 ---
 
-# Data Grid - Column ordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Column ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Drag and drop your columns to reorder them.</p>
 

--- a/docs/data/data-grid/column-ordering/column-ordering.md
+++ b/docs/data/data-grid/column-ordering/column-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column ordering
 ---
 
-# Data Grid - Column ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Column ordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Drag and drop your columns to reorder them.</p>
 

--- a/docs/data/data-grid/column-pinning/column-pinning.md
+++ b/docs/data/data-grid/column-pinning/column-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column pinning
 ---
 
-# Data Grid - Column pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Column pinning <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Pin columns to keep them visible at all time.</p>
 

--- a/docs/data/data-grid/column-pinning/column-pinning.md
+++ b/docs/data/data-grid/column-pinning/column-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Column pinning
 ---
 
-# Data Grid - Column pinning <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Column pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Pin columns to keep them visible at all time.</p>
 

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -32,8 +32,8 @@ By default, the export menu displays all the available export formats, according
 
 - [Print](#print-export)
 - [CSV](#csv-export)
-- [Excel](#excel-export) [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
-- [Clipboard](#clipboard) [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan) (🚧 Not delivered yet)
+- [Excel](#excel-export) <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+- [Clipboard](#clipboard) <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a> (🚧 Not delivered yet)
 
 You can customize their respective behavior by passing an options object either to the `GridToolbar` or to the `GridToolbarExport` as a prop.
 
@@ -219,7 +219,7 @@ The demo below shows how to add a JSON export.
 
 {{"demo": "CustomExport.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Excel export [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+## Excel export <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 This feature relies on [exceljs](https://github.com/exceljs/exceljs).
 The Excel export allows translating columns' type and tree structure of a DataGrid to an Excel file.
@@ -409,7 +409,7 @@ Only use this API as the last option. Give preference to the props to control th
 
 {{"demo": "PrintExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
-### Excel [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+### Excel <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 {{"demo": "ExcelExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 

--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -32,8 +32,8 @@ By default, the export menu displays all the available export formats, according
 
 - [Print](#print-export)
 - [CSV](#csv-export)
-- [Excel](#excel-export) <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
-- [Clipboard](#clipboard) <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a> (🚧 Not delivered yet)
+- [Excel](#excel-export) [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
+- [Clipboard](#clipboard) [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') (🚧 Not delivered yet)
 
 You can customize their respective behavior by passing an options object either to the `GridToolbar` or to the `GridToolbarExport` as a prop.
 
@@ -219,7 +219,7 @@ The demo below shows how to add a JSON export.
 
 {{"demo": "CustomExport.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Excel export <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+## Excel export [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 This feature relies on [exceljs](https://github.com/exceljs/exceljs).
 The Excel export allows translating columns' type and tree structure of a DataGrid to an Excel file.
@@ -409,7 +409,7 @@ Only use this API as the last option. Give preference to the props to control th
 
 {{"demo": "PrintExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 
-### Excel <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+### Excel [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 {{"demo": "ExcelExportApiNoSnap.js", "bg": "inline", "hideToolbar": true}}
 

--- a/docs/data/data-grid/filtering/header-filters.md
+++ b/docs/data/data-grid/filtering/header-filters.md
@@ -2,7 +2,7 @@
 title: Data Grid - Header filters
 ---
 
-# Data Grid - Header filters <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Header filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Quickly accessible per-column filters on grid header.</p>
 

--- a/docs/data/data-grid/filtering/header-filters.md
+++ b/docs/data/data-grid/filtering/header-filters.md
@@ -2,7 +2,7 @@
 title: Data Grid - Header filters
 ---
 
-# Data Grid - Header filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Header filters <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Quickly accessible per-column filters on grid header.</p>
 

--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -37,13 +37,13 @@ A filter item represents a filtering rule and is composed of several elements:
 - `filterItem.field`: the field on which the rule applies.
 - `filterItem.value`: the value to look for.
 - `filterItem.operator`: name of the operator method to use (e.g. _contains_), matches the `value` key of the operator object.
-- `filterItem.id` ([<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)): required when multiple filter items are used.
+- `filterItem.id` (<a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>): required when multiple filter items are used.
 
 :::info
 Some operators do not need any value (for instance the `isEmpty` operator of the `string` column).
 :::
 
-#### The `logicOperator` [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+#### The `logicOperator` <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 The `logicOperator` tells the data grid if a row should satisfy all (`AND`) filter items or at least one (`OR`) in order to be considered valid.
 

--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -37,13 +37,13 @@ A filter item represents a filtering rule and is composed of several elements:
 - `filterItem.field`: the field on which the rule applies.
 - `filterItem.value`: the value to look for.
 - `filterItem.operator`: name of the operator method to use (e.g. _contains_), matches the `value` key of the operator object.
-- `filterItem.id` (<a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>): required when multiple filter items are used.
+- `filterItem.id` ([<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')): required when multiple filter items are used.
 
 :::info
 Some operators do not need any value (for instance the `isEmpty` operator of the `string` column).
 :::
 
-#### The `logicOperator` <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+#### The `logicOperator` [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 The `logicOperator` tells the data grid if a row should satisfy all (`AND`) filter items or at least one (`OR`) in order to be considered valid.
 

--- a/docs/data/data-grid/filtering/multi-filters.md
+++ b/docs/data/data-grid/filtering/multi-filters.md
@@ -2,7 +2,7 @@
 title: Data Grid - Multi filters
 ---
 
-# Data Grid - Multi filters <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Multi filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Apply multiple filters at the same time.</p>
 

--- a/docs/data/data-grid/filtering/multi-filters.md
+++ b/docs/data/data-grid/filtering/multi-filters.md
@@ -2,7 +2,7 @@
 title: Data Grid - Multi filters
 ---
 
-# Data Grid - Multi filters [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Multi filters <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Apply multiple filters at the same time.</p>
 

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -2,7 +2,7 @@
 title: Data Grid - Master detail
 ---
 
-# Data Grid - Master detail [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Master detail <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Expand your rows to display additional information.</p>
 

--- a/docs/data/data-grid/master-detail/master-detail.md
+++ b/docs/data/data-grid/master-detail/master-detail.md
@@ -2,7 +2,7 @@
 title: Data Grid - Master detail
 ---
 
-# Data Grid - Master detail <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Master detail [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Expand your rows to display additional information.</p>
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -37,7 +37,7 @@ import { DataGrid } from '@mui/x-data-grid';
 
 The commercial versions are available in the form of two plans: Pro and Premium.
 
-### Pro Plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+### Pro plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 The Pro version includes and extends the features available in the MIT version to support more complex use cases. It adds new features like advanced filtering, column pinning, column and row reordering, support for tree data, and virtualization to handle bigger datasets.
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -23,7 +23,7 @@ The `DataGrid` presents information in a structured format of rows and columns. 
 
 The component comes in three different versions. One available under MIT license and two available under commercial license.
 
-### MIT version (Free forever)
+## MIT version (Free forever)
 
 The first version is meant as a stronger alternative to [data tables](/material-ui/react-table/#sorting-amp-selecting). It's a clean abstraction with basic features like editing, pagination, sorting and filtering single columns, and column groups.
 
@@ -33,11 +33,11 @@ import { DataGrid } from '@mui/x-data-grid';
 
 {{"demo": "DataGridDemo.js", "defaultCodeOpen": false, "bg": "inline"}}
 
-### Commercial versions
+## Commercial versions
 
 The commercial versions are available in the form of two plans: Pro and Premium.
 
-#### Pro Plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+### Pro Plan <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 The Pro version includes and extends the features available in the MIT version to support more complex use cases. It adds new features like advanced filtering, column pinning, column and row reordering, support for tree data, and virtualization to handle bigger datasets.
 
@@ -49,7 +49,7 @@ import { DataGridPro } from '@mui/x-data-grid-pro';
 
 {{"demo": "DataGridProDemo.js", "defaultCodeOpen": false, "disableAd": true, "bg": "inline"}}
 
-#### Premium Plan [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+### Premium Plan <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 The Premium version includes everything from Pro, as well as advanced features for data analysis and large datasets management, like row grouping with aggregation functions (e.g., Sum) and the ability to export to Excel files.
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -37,7 +37,7 @@ import { DataGrid } from '@mui/x-data-grid';
 
 The commercial versions are available in the form of two plans: Pro and Premium.
 
-### Pro Plan <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+### Pro Plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 The Pro version includes and extends the features available in the MIT version to support more complex use cases. It adds new features like advanced filtering, column pinning, column and row reordering, support for tree data, and virtualization to handle bigger datasets.
 
@@ -49,7 +49,7 @@ import { DataGridPro } from '@mui/x-data-grid-pro';
 
 {{"demo": "DataGridProDemo.js", "defaultCodeOpen": false, "disableAd": true, "bg": "inline"}}
 
-### Premium Plan <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+### Premium plan [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 The Premium version includes everything from Pro, as well as advanced features for data analysis and large datasets management, like row grouping with aggregation functions (e.g., Sum) and the ability to export to Excel files.
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -2,7 +2,7 @@
 title: Data Grid - Pivoting
 ---
 
-# Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)🚧
+# Data Grid - Pivoting <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>🚧
 
 <p class="description">Turn a column values into columns.</p>
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -2,7 +2,7 @@
 title: Data Grid - Pivoting
 ---
 
-# Data Grid - Pivoting <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>🚧
+# Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🚧
 
 <p class="description">Turn a column values into columns.</p>
 

--- a/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
+++ b/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row grouping recipes
 ---
 
-# Data Grid - Row grouping recipes <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+# Data Grid - Row grouping recipes [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 <p class="description">Advanced grid customization recipes.</p>
 

--- a/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
+++ b/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row grouping recipes
 ---
 
-# Data Grid - Row grouping recipes [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Row grouping recipes <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 <p class="description">Advanced grid customization recipes.</p>
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row grouping
 ---
 
-# Data Grid - Row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan)
+# Data Grid - Row grouping <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
 
 <p class="description">Group your rows according to some column values.</p>
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row grouping
 ---
 
-# Data Grid - Row grouping <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a>
+# Data Grid - Row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 <p class="description">Group your rows according to some column values.</p>
 

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row ordering
 ---
 
-# Data Grid - Row ordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Row ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Drag and drop your rows to reorder them.</p>
 

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row ordering
 ---
 
-# Data Grid - Row ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Row ordering <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Drag and drop your rows to reorder them.</p>
 

--- a/docs/data/data-grid/row-pinning/row-pinning.md
+++ b/docs/data/data-grid/row-pinning/row-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row pinning
 ---
 
-# Data Grid - Row pinning <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Row pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Pin rows to keep them visible at all times.</p>
 

--- a/docs/data/data-grid/row-pinning/row-pinning.md
+++ b/docs/data/data-grid/row-pinning/row-pinning.md
@@ -2,7 +2,7 @@
 title: Data Grid - Row pinning
 ---
 
-# Data Grid - Row pinning [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Row pinning <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Pin rows to keep them visible at all times.</p>
 

--- a/docs/data/data-grid/row-selection/row-selection.md
+++ b/docs/data/data-grid/row-selection/row-selection.md
@@ -10,7 +10,7 @@ To unselect a row, hold the <kbd class="key">Ctrl</kbd> key and click on it.
 
 {{"demo": "SingleRowSelectionGrid.js", "bg": "inline"}}
 
-## Multiple row selection <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Multiple row selection [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 On the `DataGridPro` component, you can select multiple rows in two ways:
 

--- a/docs/data/data-grid/row-selection/row-selection.md
+++ b/docs/data/data-grid/row-selection/row-selection.md
@@ -10,7 +10,7 @@ To unselect a row, hold the <kbd class="key">Ctrl</kbd> key and click on it.
 
 {{"demo": "SingleRowSelectionGrid.js", "bg": "inline"}}
 
-## Multiple row selection [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Multiple row selection <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 On the `DataGridPro` component, you can select multiple rows in two ways:
 

--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -30,7 +30,7 @@ apiRef.current.updateRows([{ id: 1, _action: 'delete' }]);
 > The free version of the `DataGrid` is limited to a single row update per `apiRef.current.updateRows` call.
 > Multiple row updates at a time are supported in [Pro](/x/introduction/licensing/#pro-plan) and [Premium](/x/introduction/licensing/#premium-plan) plans.
 
-## Infinite loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Infinite loading <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 The grid provides a `onRowsScrollEnd` prop that can be used to load additional rows when the scroll reaches the bottom of the viewport area.
 
@@ -38,7 +38,7 @@ In addition, the area in which `onRowsScrollEnd` is called can be changed using 
 
 {{"demo": "InfiniteLoadingGrid.js", "bg": "inline", "disableAd": true}}
 
-## Lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Lazy loading <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 :::warning
 This feature is experimental, it needs to be explicitly activated using the `lazyLoading` experimental feature flag.
@@ -76,7 +76,7 @@ In order for filtering and sorting to work you need to set their modes to `serve
 You can find out more information about how to do that on the [server-side filter page](/x/react-data-grid/filtering/server-side/) and on the [server-side sorting page](/x/react-data-grid/sorting/#server-side-sorting).
 :::
 
-## High frequency [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## High frequency <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 Whenever the rows are updated, the data grid has to apply the sorting and filters. This can be a problem if you have high frequency updates. To maintain good performances, the data grid allows to batch the updates and only apply them after a period of time. The `throttleRowsMs` prop can be used to define the frequency (in milliseconds) at which rows updates are applied.
 

--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -30,7 +30,7 @@ apiRef.current.updateRows([{ id: 1, _action: 'delete' }]);
 > The free version of the `DataGrid` is limited to a single row update per `apiRef.current.updateRows` call.
 > Multiple row updates at a time are supported in [Pro](/x/introduction/licensing/#pro-plan) and [Premium](/x/introduction/licensing/#premium-plan) plans.
 
-## Infinite loading <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Infinite loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 The grid provides a `onRowsScrollEnd` prop that can be used to load additional rows when the scroll reaches the bottom of the viewport area.
 
@@ -38,7 +38,7 @@ In addition, the area in which `onRowsScrollEnd` is called can be changed using 
 
 {{"demo": "InfiniteLoadingGrid.js", "bg": "inline", "disableAd": true}}
 
-## Lazy loading <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 :::warning
 This feature is experimental, it needs to be explicitly activated using the `lazyLoading` experimental feature flag.
@@ -76,7 +76,7 @@ In order for filtering and sorting to work you need to set their modes to `serve
 You can find out more information about how to do that on the [server-side filter page](/x/react-data-grid/filtering/server-side/) and on the [server-side sorting page](/x/react-data-grid/sorting/#server-side-sorting).
 :::
 
-## High frequency <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## High frequency [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 Whenever the rows are updated, the data grid has to apply the sorting and filters. This can be a problem if you have high frequency updates. To maintain good performances, the data grid allows to batch the updates and only apply them after a period of time. The `throttleRowsMs` prop can be used to define the frequency (in milliseconds) at which rows updates are applied.
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -16,7 +16,7 @@ The `DataGrid` can only sort the rows according to one criterion at a time.
 To use multi-sorting, you need to upgrade to [Pro plan](/x/introduction/licensing/#pro-plan) or above.
 :::
 
-## Multi-sorting <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Multi-sorting [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 The following demo lets you sort the rows according to several criteria at the same time.
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -16,7 +16,7 @@ The `DataGrid` can only sort the rows according to one criterion at a time.
 To use multi-sorting, you need to upgrade to [Pro plan](/x/introduction/licensing/#pro-plan) or above.
 :::
 
-## Multi-sorting [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Multi-sorting <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 The following demo lets you sort the rows according to several criteria at the same time.
 

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -2,7 +2,7 @@
 title: Data Grid - Tree data
 ---
 
-# Data Grid - Tree data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Data Grid - Tree data <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">Use Tree data to handle rows with parent / child relationship.</p>
 

--- a/docs/data/data-grid/tree-data/tree-data.md
+++ b/docs/data/data-grid/tree-data/tree-data.md
@@ -2,7 +2,7 @@
 title: Data Grid - Tree data
 ---
 
-# Data Grid - Tree data <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Data Grid - Tree data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">Use Tree data to handle rows with parent / child relationship.</p>
 

--- a/docs/data/data-grid/virtualization/virtualization.md
+++ b/docs/data/data-grid/virtualization/virtualization.md
@@ -7,7 +7,7 @@ This is a built-in feature of the rendering engine and greatly improves renderin
 
 _\*unlimited: Browsers set a limit on the number of pixels a scroll container can host: 17.5 million pixels on Firefox, 33.5 million pixels on Chrome, Edge, and Safari. A [reproduction](https://codesandbox.io/s/beautiful-silence-1yifo?file=/src/App.js)._
 
-## Row virtualization [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Row virtualization <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 Row virtualization is the insertion and removal of rows as the data grid scrolls vertically.
 

--- a/docs/data/data-grid/virtualization/virtualization.md
+++ b/docs/data/data-grid/virtualization/virtualization.md
@@ -7,7 +7,7 @@ This is a built-in feature of the rendering engine and greatly improves renderin
 
 _\*unlimited: Browsers set a limit on the number of pixels a scroll container can host: 17.5 million pixels on Firefox, 33.5 million pixels on Chrome, Edge, and Safari. A [reproduction](https://codesandbox.io/s/beautiful-silence-1yifo?file=/src/App.js)._
 
-## Row virtualization <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Row virtualization [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 Row virtualization is the insertion and removal of rows as the data grid scrolls vertically.
 

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -17,13 +17,13 @@ You can use the `textField` slot to pass custom props to the `TextField`:
 
 {{"demo": "TextFieldSlotProps.js"}}
 
-### Customize the separator of multi input fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+### Customize the separator of multi input fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 You can use the `fieldSeparator` slot to pass custom props to the `Typography` rendered between the two `TextField`:
 
 {{"demo": "MultiInputFieldSeparatorSlotProps.js"}}
 
-### Use single input fields on range pickers <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+### Use single input fields on range pickers [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 You can pass the single input fields to the range picker to use it for keyboard editing:
 

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -17,13 +17,13 @@ You can use the `textField` slot to pass custom props to the `TextField`:
 
 {{"demo": "TextFieldSlotProps.js"}}
 
-### Customize the separator of multi input fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+### Customize the separator of multi input fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 You can use the `fieldSeparator` slot to pass custom props to the `Typography` rendered between the two `TextField`:
 
 {{"demo": "MultiInputFieldSeparatorSlotProps.js"}}
 
-### Use single input fields on range pickers [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+### Use single input fields on range pickers <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 You can pass the single input fields to the range picker to use it for keyboard editing:
 

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -6,7 +6,7 @@ githubLabel: 'component: DateRangePicker'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Range Calendar <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Date Range Calendar [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">The Date Range Calendar lets the user select a range of dates without any input or popper / modal.</p>
 

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -6,7 +6,7 @@ githubLabel: 'component: DateRangePicker'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Range Calendar [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Date Range Calendar <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">The Date Range Calendar lets the user select a range of dates without any input or popper / modal.</p>
 

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Range Field <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Date Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">The Date Range Field components let the user select a date range with the keyboard.</p>
 

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Date Range Field <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">The Date Range Field components let the user select a date range with the keyboard.</p>
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Date Range Picker <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Date Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">The Date Range Picker let the user select a range of dates.</p>
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Date Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Date Range Picker <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">The Date Range Picker let the user select a range of dates.</p>
 

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Time Range Field <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Date Time Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">The Date Time Range Field let the user select a range of dates with an explicit starting and ending time with the keyboard.</p>
 

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Date Time Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Date Time Range Field <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">The Date Time Range Field let the user select a range of dates with an explicit starting and ending time with the keyboard.</p>
 

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -6,7 +6,7 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Date Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)🚧
+# Date Time Range Picker <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>🚧
 
 <p class="description">The Date Time Range Picker let the user select a range of dates with an explicit starting and ending time.</p>
 

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -6,7 +6,7 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Date Time Range Picker <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>🚧
+# Date Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
 <p class="description">The Date Time Range Picker let the user select a range of dates with an explicit starting and ending time.</p>
 

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -19,7 +19,7 @@ They provide refined navigation through arrow keys and support advanced behavior
 
 {{"demo": "SingleDateFieldExamples.js", "defaultCodeOpen": false}}
 
-### Fields to edit a range <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+### Fields to edit a range [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 All fields to edit a range are available in a single input version and in a multi input version.
 
@@ -56,14 +56,14 @@ You need to make sure the input is focused before imperatively updating the sele
 
 {{"demo": "ControlledSelectedSections.js", "defaultCodeOpen": false }}
 
-#### Usage with multi input range fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+#### Usage with multi input range fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 For multi input range fields, you just have to make sure that the right input is focused before updating the selected section(s).
 Otherwise, the section(s) might be selected on the wrong input.
 
 {{"demo": "ControlledSelectedSectionsMultiInputRangeField.js", "defaultCodeOpen": false }}
 
-#### Usage with single input range fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+#### Usage with single input range fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 For single input range fields, you won't be able to use the section name to select a single section because each section is present both in the start and in the end date.
 Instead, you can pass the index of the section using the `unstableFieldRef` prop to access the full list of sections:

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -19,7 +19,7 @@ They provide refined navigation through arrow keys and support advanced behavior
 
 {{"demo": "SingleDateFieldExamples.js", "defaultCodeOpen": false}}
 
-### Fields to edit a range [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+### Fields to edit a range <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 All fields to edit a range are available in a single input version and in a multi input version.
 
@@ -56,14 +56,14 @@ You need to make sure the input is focused before imperatively updating the sele
 
 {{"demo": "ControlledSelectedSections.js", "defaultCodeOpen": false }}
 
-#### Usage with multi input range fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+#### Usage with multi input range fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 For multi input range fields, you just have to make sure that the right input is focused before updating the selected section(s).
 Otherwise, the section(s) might be selected on the wrong input.
 
 {{"demo": "ControlledSelectedSectionsMultiInputRangeField.js", "defaultCodeOpen": false }}
 
-#### Usage with single input range fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+#### Usage with single input range fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 For single input range fields, you won't be able to use the section name to select a single section because each section is present both in the start and in the end date.
 Instead, you can pass the index of the section using the `unstableFieldRef` prop to access the full list of sections:

--- a/docs/data/date-pickers/lifecycle/lifecycle.md
+++ b/docs/data/date-pickers/lifecycle/lifecycle.md
@@ -31,7 +31,7 @@ The example below shows the last value received by `onChange`.
 
 {{"demo": "LifeCycleDateFieldEmpty.js", "defaultCodeOpen": false}}
 
-### On range fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+### On range fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 On range fields (`SingleInputDateRangeField` / `MultiInputDateRangeField` / ... ),
 `onChange` is called if the date you are modifying is matching one of the conditions above,

--- a/docs/data/date-pickers/lifecycle/lifecycle.md
+++ b/docs/data/date-pickers/lifecycle/lifecycle.md
@@ -31,7 +31,7 @@ The example below shows the last value received by `onChange`.
 
 {{"demo": "LifeCycleDateFieldEmpty.js", "defaultCodeOpen": false}}
 
-### On range fields [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+### On range fields <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 On range fields (`SingleInputDateRangeField` / `MultiInputDateRangeField` / ... ),
 `onChange` is called if the date you are modifying is matching one of the conditions above,

--- a/docs/data/date-pickers/overview/overview.md
+++ b/docs/data/date-pickers/overview/overview.md
@@ -17,7 +17,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 {{"demo": "CommonlyUsedComponents.js"}}
 
-## Community or Pro Plan?
+## Community or Pro plan?
 
 The Date and Time Pickers are available in two packages:
 

--- a/docs/data/date-pickers/shortcuts/shortcuts.md
+++ b/docs/data/date-pickers/shortcuts/shortcuts.md
@@ -45,7 +45,7 @@ Here is an example where `minDate` is set to the middle of the year.
 
 {{"demo": "DisabledDatesShortcuts.js", "bg": "inline"}}
 
-## Range shortcuts [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+## Range shortcuts <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 Shortcuts on range pickers require `getValue` property to return an array with two values.
 

--- a/docs/data/date-pickers/shortcuts/shortcuts.md
+++ b/docs/data/date-pickers/shortcuts/shortcuts.md
@@ -45,7 +45,7 @@ Here is an example where `minDate` is set to the middle of the year.
 
 {{"demo": "DisabledDatesShortcuts.js", "bg": "inline"}}
 
-## Range shortcuts <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+## Range shortcuts [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 Shortcuts on range pickers require `getValue` property to return an array with two values.
 

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Time Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+# Time Range Field <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
 
 <p class="description">The Time Range Field let the user select a range of time with the keyboard.</p>
 

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -6,7 +6,7 @@ githubLabel: 'component: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 
-# Time Range Field <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>
+# Time Range Field [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 <p class="description">The Time Range Field let the user select a range of time with the keyboard.</p>
 

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -6,7 +6,7 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Time Range Picker <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>🚧
+# Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
 <p class="description">The Time Range Picker let the user select a range of time.</p>
 

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -6,7 +6,7 @@ packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---
 
-# Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)🚧
+# Time Range Picker <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a>🚧
 
 <p class="description">The Time Range Picker let the user select a range of time.</p>
 

--- a/docs/data/introduction/installation/installation.md
+++ b/docs/data/introduction/installation/installation.md
@@ -2,7 +2,7 @@
 
 <p class="description">Install the necessary packages to start building with MUI X components.</p>
 
-MUI X packages are available through the free MIT-licensed Community Plan, or the commercially-licensed Pro and Premium plans.
+MUI X packages are available through the free MIT-licensed Community plan, or the commercially-licensed Pro and Premium plans.
 See [the licensing page](/x/introduction/licensing/) for complete details.
 
 ## Peer dependencies

--- a/docs/data/introduction/installation/installation.md
+++ b/docs/data/introduction/installation/installation.md
@@ -2,7 +2,7 @@
 
 <p class="description">Install the necessary packages to start building with MUI X components.</p>
 
-MUI X packages are available through the free MIT-licensed Community Plan, or the commercially-licensed Pro and Premium Plans.
+MUI X packages are available through the free MIT-licensed Community Plan, or the commercially-licensed Pro and Premium plans.
 See [the licensing page](/x/introduction/licensing/) for complete details.
 
 ## Peer dependencies

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -18,7 +18,7 @@ See the [Pricing](https://mui.com/r/x-get-license/) page for a detailed feature 
 
 ## Plans
 
-### Community Plan
+### Community plan
 
 The community version of MUI X is [published under an MIT license](https://www.tldrlegal.com/license/mit-license) and is [free forever](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd#20f609acab4441cf9346614119fbbac1).
 This version contains features that we believe are maintainable by contributions from the open-source community.
@@ -28,7 +28,7 @@ MIT licensed npm packages:
 - [`@mui/x-data-grid`](https://www.npmjs.com/package/@mui/x-data-grid)
 - [`@mui/x-date-pickers`](https://www.npmjs.com/package/@mui/x-date-pickers)
 
-### Pro Plan <span class="plan-pro"></span>
+### Pro plan <span class="plan-pro"></span>
 
 The Pro version of MUI X expands on the features of the community version with more advanced capabilities such as multi-filtering, multi-sorting, column resizing and column pinning for the data grid; as well as the date range picker component.
 
@@ -45,7 +45,7 @@ The features exclusive to the Pro version are marked with the <span class="plan-
 
 ### Premium plan <span class="plan-premium"></span>
 
-The Premium version of MUI X covers the most advanced features of the data grid, such as row grouping, Excel export, and aggregation, in addition to everything that's included in the Pro Plan.
+The Premium version of MUI X covers the most advanced features of the data grid, such as row grouping, Excel export, and aggregation, in addition to everything that's included in the Pro plan.
 
 The Premium version is available under a commercial license—visit [the Pricing page](https://mui.com/r/x-get-license/) for details.
 

--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -43,7 +43,7 @@ Pro npm packages:
 The features exclusive to the Pro version are marked with the <span class="plan-pro"></span> icon throughout the documentation.
 :::
 
-### Premium Plan <span class="plan-premium"></span>
+### Premium plan <span class="plan-premium"></span>
 
 The Premium version of MUI X covers the most advanced features of the data grid, such as row grouping, Excel export, and aggregation, in addition to everything that's included in the Pro Plan.
 

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -21,7 +21,7 @@ They feature advanced functionality for data-rich applications and a wide range 
 MUI X is **open core**—base components are MIT-licensed, while more advanced features require a Pro or Premium commercial license.
 See [Licensing](/x/introduction/licensing/) for details.
 
-Throughout the documentation, Pro- and Premium-only features are denoted with the [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan) and [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan) icons, respectively.
+Throughout the documentation, Pro- and Premium-only features are denoted with the <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a> and <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a> icons, respectively.
 :::
 
 ## Advantages of MUI X

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -21,7 +21,7 @@ They feature advanced functionality for data-rich applications and a wide range 
 MUI X is **open core**—base components are MIT-licensed, while more advanced features require a Pro or Premium commercial license.
 See [Licensing](/x/introduction/licensing/) for details.
 
-Throughout the documentation, Pro- and Premium-only features are denoted with the <a title="Pro plan" href="/x/introduction/licensing/#pro-plan"><span class="plan-pro"></span></a> and <a title="Premium plan" href="/x/introduction/licensing/#premium-plan"><span class="plan-premium"></span></a> icons, respectively.
+Throughout the documentation, Pro- and Premium-only features are denoted with the [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan') and [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') icons, respectively.
 :::
 
 ## Advantages of MUI X

--- a/docs/data/migration/migration-pickers-lab/migration-pickers-lab.md
+++ b/docs/data/migration/migration-pickers-lab/migration-pickers-lab.md
@@ -29,7 +29,7 @@ If you already have a license for `@mui/x-data-grid-pro`, you can use the same o
 
 ### 1. Install MUI X packages
 
-#### Community Plan
+#### Community plan
 
 <codeblock storageKey="package-manager">
 ```bash npm
@@ -46,7 +46,7 @@ pnpm add @mui/x-date-pickers
 
 </codeblock>
 
-#### Pro Plan
+#### Pro plan
 
 <codeblock storageKey="package-manager">
 
@@ -99,7 +99,7 @@ Which will transform the imports like this:
 +import { DateRangePicker } from '@mui/x-date-pickers-pro';
 ```
 
-Components of the Community Plan such as `<DatePicker />` can be imported from both `@mui/x-date-pickers-pro` and `@mui/x-date-pickers`.
+Components of the Community plan such as `<DatePicker />` can be imported from both `@mui/x-date-pickers-pro` and `@mui/x-date-pickers`.
 [Date adapters](/x/react-date-pickers/getting-started/#installation) such as `AdapterDayjs` can only be imported from `@mui/x-date-pickers/[adapterName]`.
 
 ### 3. Handle breaking changes introduced in alpha

--- a/docs/pages/x/api/date-pickers/date-range-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.json
@@ -162,6 +162,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-calendar/\">Date Range Calendar </a></li>\n<li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-calendar/\">Date Range Calendar <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker <span class=\"plan-pro\"></span></a></li></ul>",
   "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangeCalendar" }]
 }

--- a/docs/pages/x/api/date-pickers/date-range-picker-day.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-day.json
@@ -79,6 +79,6 @@
   "forwardsRefTo": "HTMLButtonElement",
   "filename": "/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker <span class=\"plan-pro\"></span></a></li></ul>",
   "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePickerDay" }]
 }

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -287,6 +287,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [{ "packageName": "@mui/x-date-pickers-pro", "componentName": "DateRangePicker" }]
 }

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -265,7 +265,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "DesktopDateRangePicker" }
   ]

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -259,7 +259,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MobileDateRangePicker" }
   ]

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
@@ -127,7 +127,7 @@
     "name": "MuiMultiInputDateRangeField"
   },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MultiInputDateRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
@@ -152,7 +152,7 @@
     "name": "MuiMultiInputDateTimeRangeField"
   },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MultiInputDateTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
@@ -140,7 +140,7 @@
     "name": "MuiMultiInputTimeRangeField"
   },
   "filename": "/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx",
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field <span class=\"plan-pro\"></span></a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "MultiInputTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -138,7 +138,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-field/\">Date Range Field <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "SingleInputDateRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -167,7 +167,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field </a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-time-range-field/\">Date Time Range Field <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "SingleInputDateTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -151,7 +151,7 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field </a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/fields/\">Fields component</a></li>\n<li><a href=\"/x/react-date-pickers/time-range-field/\">Time Range Field <span class=\"plan-pro\"></span></a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "SingleInputTimeRangeField" }
   ]

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -203,7 +203,7 @@
   "forwardsRefTo": "undefined",
   "filename": "/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker </a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-date-pickers/date-range-picker/\">Date Range Picker <span class=\"plan-pro\"></span></a></li>\n<li><a href=\"/x/react-date-pickers/validation/\">Validation</a></li></ul>",
   "packages": [
     { "packageName": "@mui/x-date-pickers-pro", "componentName": "StaticDateRangePicker" }
   ]

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -203,9 +203,12 @@ function findXDemos(
   return pagesMarkdown
     .filter((page) => page.components.includes(componentName))
     .map((page) => {
+      // Remove link if it exists as the demo title will already be rendered inside a link.
+      // A link can be present when the Pro or Premium icon is added to the h1 of the demo page.
+      let demoPageTitle = page.title.replace(/<a\b[^>]*>/i, '').replace(/<\/a>/i, '');
+
       if (page.pathname.includes('date-pickers')) {
-        let demoPageTitle = /^Date and Time Pickers - (.*)$/.exec(page.title)?.[1] ?? page.title;
-        demoPageTitle = demoPageTitle.replace(/\[(.*)]\((.*)\)/g, '');
+        demoPageTitle = /^Date and Time Pickers - (.*)$/.exec(demoPageTitle)?.[1] ?? demoPageTitle;
 
         const pathnameMatches = /\/date-pickers\/([^/]+)\/([^/]+)/.exec(page.pathname);
 

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -203,7 +203,8 @@ function findXDemos(
   return pagesMarkdown
     .filter((page) => page.components.includes(componentName))
     .map((page) => {
-      // Remove link if it exists as the demo title will already be rendered inside a link.
+      // Titles for paid packages have the structure "Page title <a><span/></a>"
+      // Next line remove the <a/> to avoid nested links and keep the <span/> to show the plan level.
       // A link can be present when the Pro or Premium icon is added to the h1 of the demo page.
       let demoPageTitle = page.title.replace(/<a\b[^>]*>/i, '').replace(/<\/a>/i, '');
 

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -206,7 +206,10 @@ function findXDemos(
       // Titles for paid packages have the structure "Page title <a><span/></a>"
       // Next line remove the <a/> to avoid nested links and keep the <span/> to show the plan level.
       // A link can be present when the Pro or Premium icon is added to the h1 of the demo page.
-      let demoPageTitle = page.title.replace(/<a\b[^>]*>/i, '').replace(/<\/a>/i, '');
+      let demoPageTitle = page.title
+        .replace(/<a\b[^>]*>/i, '')
+        .replace(/<\/a>/i, '')
+        .replace(/\[(.*)]\((.*)\)/g, '$1');
 
       if (page.pathname.includes('date-pickers')) {
         demoPageTitle = /^Date and Time Pickers - (.*)$/.exec(demoPageTitle)?.[1] ?? demoPageTitle;

--- a/packages/grid/x-data-grid-pro/README.md
+++ b/packages/grid/x-data-grid-pro/README.md
@@ -1,6 +1,6 @@
 # @mui/x-data-grid-pro
 
-This package is the Pro Plan edition of the data grid component.
+This package is the Pro plan edition of the data grid component.
 It's part of MUI X, an open core extension of MUI, with advanced components.
 
 ## Installation

--- a/packages/grid/x-data-grid/README.md
+++ b/packages/grid/x-data-grid/README.md
@@ -1,6 +1,6 @@
 # @mui/x-data-grid
 
-This package is the Community Plan edition of the data grid component.
+This package is the Community plan edition of the data grid component.
 It's part of MUI X, an open core extension of MUI, with advanced components.
 
 ## Installation

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -233,14 +233,14 @@ ${changeLogMessages.length > 0 ? '\n\n' : ''}${changeLogMessages.join('\n')}
 
 ${logChangelogSection(dataGridCommits)}
 
-#### \`@mui/x-data-grid-pro@v__VERSION__\` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### \`@mui/x-data-grid-pro@v__VERSION__\` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in \`@mui/x-data-grid@v__VERSION__\`${
     dataGridProCommits.length > 0 ? ', plus:' : '.'
   }
 ${logChangelogSection(dataGridProCommits)}
 
-#### \`@mui/x-data-grid-premium@v__VERSION__\` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link)
+#### \`@mui/x-data-grid-premium@v__VERSION__\` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
 Same changes as in \`@mui/x-data-grid-pro@v__VERSION__\`${
     dataGridPremiumCommits.length > 0 ? ', plus:' : '.'
@@ -252,7 +252,7 @@ ${logChangelogSection(dataGridPremiumCommits)}
 
 ${logChangelogSection(pickersCommits)}
 
-#### \`@mui/x-date-pickers-pro@v__VERSION__\` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link)
+#### \`@mui/x-date-pickers-pro@v__VERSION__\` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
 Same changes as in \`@mui/x-date-pickers@v__VERSION__\`${
     pickersProCommits.length > 0 ? ', plus:' : '.'


### PR DESCRIPTION
You can reproduce the issue on:

https://pagespeed.web.dev/analysis/https-mui-com-x-react-data-grid/smqgr9b748?form_factor=mobile

<img width="937" alt="Screenshot 2023-08-13 at 17 38 45" src="https://github.com/mui/mui-x/assets/3165635/e2dc099c-9558-42dd-b8c2-c8bfd8cb7572">

or with WAVE

<img width="297" alt="Screenshot 2023-08-13 at 17 40 52" src="https://github.com/mui/mui-x/assets/3165635/3fa2c0fe-9ec6-4bbc-8b2b-ab0817a488d4">

I think this brings two values:

1. It helps maintainers have a higher signal-noise ratio, signal is the errors on the components we expose, and noise is what the docs-infra raises.
2. It can increase trust developers with not a lot of time can place in our a11y work & care. If they use Lighthouse to get a quick feel about our a11y compliance, a not-so-high score could be a flag.

I found this in https://github.com/mui/material-ui/pull/38241, testing for something else.

Preview: https://deploy-preview-10026--material-ui-x.netlify.app/x/react-data-grid/

---

The fix will truly only works once https://github.com/mui/material-ui/pull/38579 is merged and deployed in MUI X.