### PR TITLE
[DataGrid] Fix `valueFormatter` being persisted on column type change

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -349,7 +349,6 @@ export const createColumnsState = ({
     // If the column type has changed - merge the existing state with the default column type definition
     if (existingState && existingState.type !== newColumn.type) {
       existingState = {
-        ...existingState,
         ...getDefaultColTypeDef(columnTypes, newColumn.type),
         field,
       };

--- a/packages/grid/x-data-grid/src/tests/columns.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columns.DataGrid.test.tsx
@@ -72,6 +72,19 @@ describe('<DataGrid /> - Columns', () => {
     expect(getColumnHeaderCell(0)).to.have.class('MuiDataGrid-columnHeader--numeric');
   });
 
+  it('should not persist valueFormatter on column type change', () => {
+    const { setProps } = render(
+      <TestDataGrid
+        columns={[{ field: 'price', type: 'price', valueFormatter: ({ value }) => `$${value}` }]}
+        rows={[{ id: 0, price: 1 }]}
+      />,
+    );
+    expect(getCell(0, 0).textContent).to.equal('$1');
+
+    setProps({ columns: [{ field: 'price' }] });
+    expect(getCell(0, 0).textContent).to.equal('1');
+  });
+
   it('should not override column properties when changing column type', () => {
     const { setProps } = render(
       <TestDataGrid


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/5970#issuecomment-1679498700