### PR TITLE
[Datagrid] on batching update the same id should not be used in multiple operation.

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -333,7 +333,7 @@ export const updateCacheWithNewRows = ({
     // Then add it to the "insert" update.
     // `actionAlreadyAppliedToRow` can't be equal to "modify", otherwise we would have an `oldRow` above.
     else if (actionAlreadyAppliedToRow == null) {
-      if (actionAlreadyAppliedToRow === 'remove') {
+      if (partialUpdates.actions.remove.includes(id)) {
         alreadyAppliedActionsToRemove.remove[id] = true;
         partialUpdates.actions.modify.push(id);
       } else {

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -336,7 +336,6 @@ export const updateCacheWithNewRows = ({
       if (partialUpdates.actions.remove.includes(id)) {
         partialUpdates.actions.remove = partialUpdates.actions.remove.filter(removeid => removeid !== id)
         partialUpdates.actions.modify.push(id);
-        partialUpdates.actions.insert = partialUpdates.actions.insert.filter(removeid => removeid !== id)
       } else {
         partialUpdates.actions.insert.push(id);
       }

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -334,7 +334,9 @@ export const updateCacheWithNewRows = ({
     // `actionAlreadyAppliedToRow` can't be equal to "modify", otherwise we would have an `oldRow` above.
     else if (actionAlreadyAppliedToRow == null) {
       if (partialUpdates.actions.remove.includes(id)) {
-        partialUpdates.actions.remove = partialUpdates.actions.remove.filter(removeid => removeid !== id)
+        partialUpdates.actions.remove = partialUpdates.actions.remove.filter(
+          (removeid) => removeid !== id,
+        );
         partialUpdates.actions.modify.push(id);
       } else {
         partialUpdates.actions.insert.push(id);

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -333,7 +333,7 @@ export const updateCacheWithNewRows = ({
     // Then add it to the "insert" update.
     // `actionAlreadyAppliedToRow` can't be equal to "modify", otherwise we would have an `oldRow` above.
     else if (actionAlreadyAppliedToRow == null) {
-      if (partialUpdates.actions.remove.includes(id)) {
+      if (actionAlreadyAppliedToRow === 'remove') {
         alreadyAppliedActionsToRemove.remove[id] = true;
         partialUpdates.actions.modify.push(id);
       } else {

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -333,7 +333,13 @@ export const updateCacheWithNewRows = ({
     // Then add it to the "insert" update.
     // `actionAlreadyAppliedToRow` can't be equal to "modify", otherwise we would have an `oldRow` above.
     else if (actionAlreadyAppliedToRow == null) {
-      partialUpdates.actions.insert.push(id);
+      if (partialUpdates.actions.remove.includes(id)) {
+        partialUpdates.actions.remove = partialUpdates.actions.remove.filter(removeid => removeid !== id)
+        partialUpdates.actions.modify.push(id);
+        partialUpdates.actions.insert = partialUpdates.actions.insert.filter(removeid => removeid !== id)
+      } else {
+        partialUpdates.actions.insert.push(id);
+      }
     }
 
     // Update the data row lookups.

--- a/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -334,9 +334,7 @@ export const updateCacheWithNewRows = ({
     // `actionAlreadyAppliedToRow` can't be equal to "modify", otherwise we would have an `oldRow` above.
     else if (actionAlreadyAppliedToRow == null) {
       if (partialUpdates.actions.remove.includes(id)) {
-        partialUpdates.actions.remove = partialUpdates.actions.remove.filter(
-          (removeid) => removeid !== id,
-        );
+        alreadyAppliedActionsToRemove.remove[id] = true;
         partialUpdates.actions.modify.push(id);
       } else {
         partialUpdates.actions.insert.push(id);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #9982

### Problem

while using `throttleRowsMs` if delete and insert update action batched together for the same id. it causes unpredictable behavior.

### Solution

If you delete and add items and if they are in the same batch, the delete action should not be executed in the first place and the insert operation should be modified.