### PR TITLE
[DataGrid] Allow print export for more than 100 rows

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -15,6 +15,7 @@ import { gridClasses } from '../../../constants/gridClasses';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { gridRowsMetaSelector } from '../rows/gridRowsMetaSelector';
 import { getColumnsToExport } from './utils';
+import { mergeStateWithPaginationModel } from '../pagination/useGridPagination';
 import { GridPipeProcessor, useGridRegisterPipeProcessor } from '../../core/pipeProcessing';
 import {
   GridExportDisplayOptions,
@@ -55,7 +56,7 @@ function buildPrintWindow(title?: string): HTMLIFrameElement {
  */
 export const useGridPrintExport = (
   apiRef: React.MutableRefObject<GridPrivateApiCommunity>,
-  props: Pick<DataGridProcessedProps, 'pagination' | 'columnHeaderHeight'>,
+  props: Pick<DataGridProcessedProps, 'pagination' | 'columnHeaderHeight' | 'rowCount'>,
 ): void => {
   const logger = useGridLogger(apiRef, 'useGridPrintExport');
   const doc = React.useRef<Document | null>(null);
@@ -272,7 +273,15 @@ export const useGridPrintExport = (
 
       if (props.pagination) {
         const visibleRowCount = gridExpandedRowCountSelector(apiRef);
-        apiRef.current.setPageSize(visibleRowCount);
+        const paginationModel = {
+          page: 0,
+          pageSize: visibleRowCount,
+        };
+        apiRef.current.updateControlState(
+          'pagination',
+          mergeStateWithPaginationModel(visibleRowCount, 'DataGridPro', paginationModel),
+        );
+        apiRef.current.forceUpdate();
       }
 
       await updateGridColumnsForPrint(options?.fields, options?.allColumns);

--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -56,7 +56,7 @@ function buildPrintWindow(title?: string): HTMLIFrameElement {
  */
 export const useGridPrintExport = (
   apiRef: React.MutableRefObject<GridPrivateApiCommunity>,
-  props: Pick<DataGridProcessedProps, 'pagination' | 'columnHeaderHeight' | 'rowCount'>,
+  props: Pick<DataGridProcessedProps, 'pagination' | 'columnHeaderHeight'>,
 ): void => {
   const logger = useGridLogger(apiRef, 'useGridPrintExport');
   const doc = React.useRef<Document | null>(null);

--- a/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/grid/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -279,6 +279,7 @@ export const useGridPrintExport = (
         };
         apiRef.current.updateControlState(
           'pagination',
+          // Using signature `DataGridPro` to allow more than 100 rows in the print export
           mergeStateWithPaginationModel(visibleRowCount, 'DataGridPro', paginationModel),
         );
         apiRef.current.forceUpdate();

--- a/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPagination.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/pagination/useGridPagination.ts
@@ -46,7 +46,7 @@ export const paginationStateInitializer: GridStateInitializer<
   };
 };
 
-const mergeStateWithPaginationModel =
+export const mergeStateWithPaginationModel =
   (
     rowCount: number,
     signature: DataGridProcessedProps['signature'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #3154 
  - Before: https://codesandbox.io/s/unruffled-bird-hn429h?file=/Demo.tsx
  - After: https://codesandbox.io/s/confident-kalam-52944q?file=/Demo.tsx

**Options that were available:**
1. Limit print export to 100 rows and add an explicit warning (would not work great with "Free Forever" MIT licensing, or would it? 🤔 CC @joserodolfofreitas)
2. ✅ Make Grid think during the export that it doesn't have 100 rows per page restriction (by modifying the signature prop manually, isn't very clean, but works)

Let me know if you have other ideas in mind.