### PR TITLE
[pickers] Replace `Grid` toolbar component with a styled `div`

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/utils';
@@ -48,17 +47,20 @@ const PickersToolbarRoot = styled('div', {
   }),
 }));
 
-const PickersToolbarContent = styled(Grid, {
+const PickersToolbarContent = styled('div', {
   name: 'MuiPickersToolbar',
   slot: 'Content',
   overridesResolver: (props, styles) => styles.content,
 })<{
   ownerState: PickersToolbarProps<any, any>;
 }>(({ ownerState }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  width: '100%',
+  justifyContent: ownerState.isLandscape ? 'flex-start' : 'space-between',
+  flexDirection: ownerState.isLandscape ? ownerState.landscapeDirection ?? 'column' : 'row',
   flex: 1,
-  ...(!ownerState.isLandscape && {
-    alignItems: 'center',
-  }),
+  alignItems: ownerState.isLandscape ? 'flex-start' : 'center',
 }));
 
 type PickersToolbarComponent = (<TValue, TView extends DateOrTimeViewWithMeridiem>(
@@ -74,15 +76,7 @@ export const PickersToolbar = React.forwardRef(function PickersToolbar<
   ref: React.Ref<HTMLDivElement>,
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiPickersToolbar' });
-  const {
-    children,
-    className,
-    isLandscape,
-    landscapeDirection = 'column',
-    toolbarTitle,
-    hidden,
-    titleId,
-  } = props;
+  const { children, className, toolbarTitle, hidden, titleId } = props;
 
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
@@ -106,14 +100,7 @@ export const PickersToolbar = React.forwardRef(function PickersToolbar<
       >
         {toolbarTitle}
       </Typography>
-      <PickersToolbarContent
-        container
-        justifyContent={isLandscape ? 'flex-start' : 'space-between'}
-        className={classes.content}
-        ownerState={ownerState}
-        direction={isLandscape ? landscapeDirection : 'row'}
-        alignItems={isLandscape ? 'flex-start' : 'flex-end'}
-      >
+      <PickersToolbarContent className={classes.content} ownerState={ownerState}>
         {children}
       </PickersToolbarContent>
     </PickersToolbarRoot>


### PR DESCRIPTION
Fixes #9990 

The content wrapping `Grid` container parent seems useless and error-prone, because it requires the children to be `Grid` items for correct layout.
Styling needs seem to be easily achievable with just some extra CSS.