### PR TITLE
[core] Demonstrate import/no-cycle regression

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/filter/foo.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/foo.ts
@@ -1,0 +1,3 @@
+import { gridFilterModelSelector } from './gridFilterSelector';
+
+export const foo = gridFilterModelSelector;

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts
@@ -4,6 +4,11 @@ import { GridStateCommunity } from '../../../models/gridStateCommunity';
 import { gridSortedRowEntriesSelector } from '../sorting/gridSortingSelector';
 import { gridColumnLookupSelector } from '../columns/gridColumnsSelector';
 import { gridRowMaximumTreeDepthSelector, gridRowTreeSelector } from '../rows/gridRowsSelector';
+import { foo } from './foo';
+
+export const bar = () => {
+  foo({} as any);
+};
 
 /**
  * @category Filtering


### PR DESCRIPTION
A continuation of https://github.com/mui/material-ui/pull/37223#issuecomment-1555412817. `import/no-cycle` is not running in the grid's source. Partially because of the strange package structure for the grid (`grid/x-data-grid`).