### PR TITLE
[core] Update `no-response` workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -24,8 +24,8 @@ jobs:
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: 'status: needs more information'
+          responseRequiredLabel: 'status: waiting for follow-up'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
-            Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed.
-            If you wish to see the issue reopened, please provide the missing information.
+            The issue has been inactive for 7 days and is now automatically closed.
+            If you think that it has been incorectly closed, please reopen it and provide missing information (if any) or continue the last discussion.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -28,4 +28,4 @@ jobs:
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             The issue has been inactive for 7 days and has been automatically closed.
-            If you think that it has been incorectly closed, please reopen it and provide missing information (if any) or continue the last discussion.
+            If you think that it has been incorrectly closed, please reopen it and provide missing information (if any) or continue the last discussion.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -27,5 +27,5 @@ jobs:
           responseRequiredLabel: 'status: waiting for follow-up'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
-            The issue has been inactive for 7 days and is now automatically closed.
+            The issue has been inactive for 7 days and has been automatically closed.
             If you think that it has been incorectly closed, please reopen it and provide missing information (if any) or continue the last discussion.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Update the `no-response` workflow to use the new `status: waiting for follow-up` label.

PS: The label is not yet created. Once this PR is approved I will replace the existing `status: needs more information` label with `status: waiting for follow-up`