### PR TITLE
[DataGrid] Add a recipe showing how to render components outside of the grid

### DIFF
--- a/docs/data/data-grid/filtering-recipes/QuickFilterOutsideOfGrid.js
+++ b/docs/data/data-grid/filtering-recipes/QuickFilterOutsideOfGrid.js
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import { DataGrid, GridToolbarQuickFilter, GridToolbar } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+function MyCustomToolbar(props) {
+  return (
+    <React.Fragment>
+      {ReactDOM.createPortal(
+        <GridToolbarQuickFilter />,
+        document.getElementById('filter-panel'),
+      )}
+      <GridToolbar {...props} />
+    </React.Fragment>
+  );
+}
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+export default function QuickFilterOutsideOfGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Employee',
+    rowLength: 1000,
+  });
+
+  // Otherwise filter will be applied on fields such as the hidden column id
+  const columns = React.useMemo(
+    () => data.columns.filter((column) => VISIBLE_FIELDS.includes(column.field)),
+    [data.columns],
+  );
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item>
+        <Box id="filter-panel" />
+      </Grid>
+      <Grid item style={{ height: 400, width: '100%' }}>
+        <DataGrid
+          {...data}
+          columns={columns}
+          slots={{
+            toolbar: MyCustomToolbar,
+          }}
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/docs/data/data-grid/filtering-recipes/QuickFilterOutsideOfGrid.tsx
+++ b/docs/data/data-grid/filtering-recipes/QuickFilterOutsideOfGrid.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import { DataGrid, GridToolbarQuickFilter, GridToolbar } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+function MyCustomToolbar(props: any) {
+  return (
+    <React.Fragment>
+      {ReactDOM.createPortal(
+        <GridToolbarQuickFilter />,
+        document.getElementById('filter-panel')!,
+      )}
+      <GridToolbar {...props} />
+    </React.Fragment>
+  );
+}
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+export default function QuickFilterOutsideOfGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Employee',
+    rowLength: 1000,
+  });
+
+  // Otherwise filter will be applied on fields such as the hidden column id
+  const columns = React.useMemo(
+    () => data.columns.filter((column) => VISIBLE_FIELDS.includes(column.field)),
+    [data.columns],
+  );
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item>
+        <Box id="filter-panel" />
+      </Grid>
+      <Grid item style={{ height: 400, width: '100%' }}>
+        <DataGrid
+          {...data}
+          columns={columns}
+          slots={{
+            toolbar: MyCustomToolbar,
+          }}
+        />
+      </Grid>
+    </Grid>
+  );
+}

--- a/docs/data/data-grid/filtering-recipes/QuickFilterOutsideOfGrid.tsx.preview
+++ b/docs/data/data-grid/filtering-recipes/QuickFilterOutsideOfGrid.tsx.preview
@@ -1,0 +1,14 @@
+<Grid container spacing={2}>
+  <Grid item>
+    <Box id="filter-panel" />
+  </Grid>
+  <Grid item style={{ height: 400, width: '100%' }}>
+    <DataGrid
+      {...data}
+      columns={columns}
+      slots={{
+        toolbar: MyCustomToolbar,
+      }}
+    />
+  </Grid>
+</Grid>

--- a/docs/data/data-grid/filtering-recipes/filtering-recipes.md
+++ b/docs/data/data-grid/filtering-recipes/filtering-recipes.md
@@ -1,0 +1,15 @@
+---
+title: Data Grid - Filtering customization recipes
+---
+
+# Data Grid - Filtering customization recipes
+
+<p class="description">Advanced filtering customization recipes.</p>
+
+## Quck filter outside of the grid
+
+Currently if you want to use the [Quick filter](/x/react-data-grid/filtering/quick-filter/) feature you need to use from the toolbar component slot.
+
+A common use case is to have certain components positioned outside of the grid. Because of the way the grid context works this might not be a straining forward thing to do. The example below illustrates how this use case can be achieved.
+
+{{"demo": "QuickFilterOutsideOfGrid.js", "bg": "inline", "defaultCodeOpen": false}}

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -78,6 +78,7 @@ const pages: MuiPage[] = [
             plan: 'pro',
             newFeature: true,
           },
+          { pathname: '/x/react-data-grid/filtering-recipes', title: 'Recipes' },
         ],
       },
       { pathname: '/x/react-data-grid/pagination' },

--- a/docs/pages/x/react-data-grid/filtering-recipes.js
+++ b/docs/pages/x/react-data-grid/filtering-recipes.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docsx/data/data-grid/filtering-recipes/filtering-recipes.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #2522

I opted for showing how to move the Quick filter outside of the grid as it seems like a common use case - having a "search" outside of the grid.

One thing to discuss is where to put that recipe - because it's related to the layout we can argue that it can be a separate page under the `Recipes` section.