### PR TITLE
[docs] Fix wrong chart tooltip reference

### DIFF
--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -9,7 +9,7 @@ packageName: '@mui/x-charts'
 <p class="description">This page groups general topics that are common to multiple charts.</p>
 
 :::warning
-⚠️ This library is in the alpha phase. This means it might receive some breaking changes if they are needed to improve the components.
+This library is in the alpha phase. This means it might receive some breaking changes if they are needed to improve the components.
 :::
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}

--- a/docs/data/charts/tooltip/BandHighlight.js
+++ b/docs/data/charts/tooltip/BandHighlight.js
@@ -5,7 +5,6 @@ import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Radio from '@mui/material/Radio';
 import Stack from '@mui/material/Stack';
-
 import { BarChart } from '@mui/x-charts/BarChart';
 import { legendClasses } from '@mui/x-charts/ChartsLegend';
 

--- a/docs/data/charts/tooltip/BandHighlight.tsx
+++ b/docs/data/charts/tooltip/BandHighlight.tsx
@@ -5,7 +5,6 @@ import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Radio from '@mui/material/Radio';
 import Stack from '@mui/material/Stack';
-
 import { BarChart } from '@mui/x-charts/BarChart';
 import { legendClasses } from '@mui/x-charts/ChartsLegend';
 

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -7,7 +7,7 @@ title: Charts - Tooltip
 <p class="description">Tooltip provides extra data on charts item.</p>
 
 In all charts components, you can pass props to the tooltip by using `tooltip={{...}}`.
-If you are using composition, you can add the `<Tooltip />` component and pass props directly.
+If you are using composition, you can add the `<ChartTooltip />` component and pass props directly.
 
 ## Interactions
 


### PR DESCRIPTION
I have tried `import { Tooltip } from '@mui/x-charts/Tooltip';` but it didn't work. ChartTooltip is what works, and also what feels "right" in a global namespace.

Change tested with:

```diff
diff --git a/docs/data/charts/overview/Combining.tsx b/docs/data/charts/overview/Combining.tsx
index 5f2a25250..060bbfd15 100644
--- a/docs/data/charts/overview/Combining.tsx
+++ b/docs/data/charts/overview/Combining.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { BarPlot } from '@mui/x-charts/BarChart';
 import { LinePlot } from '@mui/x-charts/LineChart';
+import { ChartsTooltip } from "@mui/x-charts/ChartsTooltip";
+import { ChartsAxisHighlight } from "@mui/x-charts/ChartsAxisHighlight";
 import { ChartContainer } from '@mui/x-charts/ChartContainer';
 import { AllSeriesType } from '@mui/x-charts/models';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
@@ -57,6 +59,8 @@ export default function Combining() {
       <ChartsXAxis label="Years" position="bottom" axisId="years" />
       <ChartsYAxis label="Results" position="left" axisId="eco" />
       <ChartsYAxis label="PIB" position="right" axisId="pib" />
+      <ChartsTooltip />
+      <ChartsAxisHighlight x="line" />
     </ChartContainer>
   );
 }
```