### PR TITLE
[docs] Improve chart SEO

### DIFF
--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Bars
+title: React Bar chart
 ---
 
 # Charts - Bars

--- a/docs/data/charts/funnel/funnel.md
+++ b/docs/data/charts/funnel/funnel.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Funnel
+title: React Funnel chart
 ---
 
 # Charts - Funnel 🚧

--- a/docs/data/charts/gantt/gantt.md
+++ b/docs/data/charts/gantt/gantt.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Gantt
+title: React Gantt chart
 ---
 
 # Charts - Gantt 🚧

--- a/docs/data/charts/heat-map/heat-map.md
+++ b/docs/data/charts/heat-map/heat-map.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Heat map
+title: React Heat map chart
 ---
 
 # Charts - Heat map 🚧

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Lines
+title: React Line chart
 ---
 
 # Charts - Lines

--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Pie
+title: React Pie chart
 ---
 
 # Charts - Pie

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Radar
+title: React Radar chart
 ---
 
 # Charts - Radar 🚧

--- a/docs/data/charts/sankey/sankey.md
+++ b/docs/data/charts/sankey/sankey.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Sankey
+title: React Sankey chart
 ---
 
 # Charts - Sankey 🚧

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Scatter
+title: React Scatter chart
 ---
 
 # Charts - Scatter

--- a/docs/data/charts/sparkline/sparkline.md
+++ b/docs/data/charts/sparkline/sparkline.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Sparkline
+title: React Sparkline chart
 ---
 
 # Charts - Sparkline

--- a/docs/data/charts/tree-map/tree-map.md
+++ b/docs/data/charts/tree-map/tree-map.md
@@ -1,5 +1,5 @@
 ---
-title: Charts - Tree map
+title: React Tree map chart
 ---
 
 # Charts - Tree map 🚧


### PR DESCRIPTION
Per the following search volume data, I think we should change the SEO title.

<img width="731" alt="Screenshot 2023-08-29 at 13 41 12" src="https://github.com/mui/mui-x/assets/3165635/7dd39c47-d6ef-46ec-843d-8f4f1ec640c7">

https://app.ahrefs.com/keywords-explorer/list/new/db2c322fa1f3891b3d2c32da458fe4a5/google/us/overview

on this pages, and the other chart pages.

Preview: https://deploy-preview-10170--material-ui-x.netlify.app/x/react-charts/gantt/