### PR TITLE
[DataGrid] Fix custom column docs, remove legacy `extendType`

### DIFF
--- a/docs/data/data-grid/filtering/customization.md
+++ b/docs/data/data-grid/filtering/customization.md
@@ -136,7 +136,7 @@ The filter operators can then be edited just like on a regular column.
 
 ```ts
 const ratingColumnType: GridColTypeDef = {
-  extendType: 'number',
+  type: 'number',
   filterOperators: getGridNumericOperators().filter(
     (operator) => operator.value === '>' || operator.value === '<',
   ),

--- a/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
@@ -13,7 +13,7 @@ import {
 } from '../params/gridCellParams';
 import { GridColumnHeaderParams } from '../params/gridColumnHeaderParams';
 import { GridComparatorFn, GridSortDirection } from '../gridSortModel';
-import { GridColType, GridNativeColTypes } from './gridColType';
+import { GridColType } from './gridColType';
 import { GridRowParams } from '../params/gridRowParams';
 import { GridValueOptionsParams } from '../params/gridValueOptionsParams';
 import { GridActionsCellItemProps } from '../../components/cell/GridActionsCellItem';

--- a/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/grid/x-data-grid/src/models/colDef/gridColDef.ts
@@ -327,9 +327,7 @@ export type GridColDef<R extends GridValidRowModel = any, V = any, F = V> =
   | GridActionsColDef<R, V, F>
   | GridSingleSelectColDef<R, V, F>;
 
-export type GridColTypeDef<V = any, F = V> = Omit<GridBaseColDef<any, V, F>, 'field'> & {
-  extendType?: GridNativeColTypes;
-};
+export type GridColTypeDef<V = any, F = V> = Omit<GridBaseColDef<any, V, F>, 'field'>;
 
 export type GridStateColDef<R extends GridValidRowModel = any, V = any, F = V> = GridColDef<
   R,


### PR DESCRIPTION
As I understand it, this property has no effect since #7309. I have noticed the issue looking at a date formatting issue with Toolpad: https://github.com/mui/mui-toolpad/blob/32d14b33cd296b204a1ce9b3199035524bd751db/packages/toolpad-components/src/DataGrid.tsx#L285

But the docs look wrong too: https://mui.com/x/react-data-grid/filtering/customization/#custom-column-types.