### PR TITLE
[docs] Add link to `custom layout` page

### DIFF
--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -251,4 +251,4 @@ You can avoid this by customizing the popper height. This will not produce any v
 ## Shortcuts
 
 You can add shortcuts to every pickers.
-For more information, check the [dedicated page](/x/react-date-pickers/shortcuts/)
+For more information, check the [dedicated page](/x/react-date-pickers/shortcuts/).

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -96,6 +96,10 @@ You can force a specific orientation using the `orientation` prop:
 
 {{"demo": "StaticDatePickerLandscape.js", "bg": true}}
 
+:::info
+You can find more information about the layout customization in the [custom layout page](/x/react-date-pickers/custom-layout/).
+:::
+
 ## Helper text
 
 You can show a helper text with the date format accepted:

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -99,7 +99,7 @@ To simplify range selection, you can add [shortcuts](/x/react-date-pickers/short
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/)
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
 
 ## Month Range Picker 🚧
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -112,7 +112,7 @@ You might be interested in using the [Time Clock](/x/react-date-pickers/time-clo
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/)
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
 
 ## Localization
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -99,6 +99,10 @@ You can force a specific orientation using the `orientation` prop.
 
 {{"demo": "StaticDateTimePickerLandscape.js", "bg": true}}
 
+:::info
+You can find more information about the layout customization in the [custom layout page](/x/react-date-pickers/custom-layout/).
+:::
+
 ## Choose time view renderer
 
 You can use the `viewRenderers` prop to change the view that is used for rendering a view.

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -97,6 +97,10 @@ You can force a specific orientation using the `orientation` prop.
 
 {{"demo": "StaticTimePickerLandscape.js", "bg": true}}
 
+:::info
+You can find more information about the layout customization in the [custom layout page](/x/react-date-pickers/custom-layout/).
+:::
+
 ## Choose time view renderer
 
 You can use the `viewRenderers` prop to change the view that is used for rendering a view.

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -110,4 +110,4 @@ You might be interested in using the [Time Clock](/x/react-date-pickers/time-clo
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/)
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).


### PR DESCRIPTION
Address idea discussed in https://mui-org.slack.com/archives/C04U3R2V9UK/p1693305205544659?thread_ts=1693304702.501099&cid=C04U3R2V9UK

Add some missing ending dots (`.`) that I noticed.