### PR TITLE
[core] Move @mui/base from peer dependency to dependency

### DIFF
--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.11",
+    "@mui/base": "^5.0.0-alpha.87",
     "clsx": "^2.0.0",
     "d3-color": "^3.1.0",
     "d3-scale": "^4.0.2",

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import composeClasses from '@mui/utils/composeClasses';
-import { SlotComponentProps } from '@mui/base';
+import type { SlotComponentProps } from '@mui/base';
 import { useSlotProps } from '@mui/base/utils';
 import generateUtilityClass from '@mui/utils/generateUtilityClass';
 import { styled } from '@mui/material/styles';

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
-import { SlotComponentProps } from '@mui/base';
+import type { SlotComponentProps } from '@mui/base';
 import { useSlotProps } from '@mui/base/utils';
 import generateUtilityClass from '@mui/utils/generateUtilityClass';
 import { styled } from '@mui/material/styles';

--- a/packages/x-charts/src/LineChart/LineElement.tsx
+++ b/packages/x-charts/src/LineChart/LineElement.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { color as d3Color } from 'd3-color';
 import composeClasses from '@mui/utils/composeClasses';
-import { SlotComponentProps } from '@mui/base';
+import type { SlotComponentProps } from '@mui/base';
 import { useSlotProps } from '@mui/base/utils';
 import generateUtilityClass from '@mui/utils/generateUtilityClass';
 import { styled } from '@mui/material/styles';

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -34,7 +34,6 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
   "react": "^17.0.0 || ^18.0.0",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.11",
+    "@mui/base": "^5.0.0-alpha.87",
     "@mui/utils": "^5.14.7",
     "@mui/x-date-pickers": "6.12.1",
     "@mui/x-license-pro": "6.10.2",
@@ -52,7 +53,6 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/base": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.6",
     "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -34,7 +34,6 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
   "react": "^17.0.0 || ^18.0.0",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.11",
+    "@mui/base": "^5.0.0-alpha.87",
     "@mui/utils": "^5.14.7",
     "@types/react-transition-group": "^4.4.6",
     "clsx": "^2.0.0",
@@ -54,7 +55,6 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/base": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.6",
     "@mui/system": "^5.8.0",
     "date-fns": "^2.25.0",

--- a/packages/x-tree-view/README.md
+++ b/packages/x-tree-view/README.md
@@ -21,7 +21,6 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/base": "^5.0.0-alpha.87",
   "@mui/material": "^5.8.6",
   "@mui/system": "^5.8.0",
   "react": "^17.0.0 || ^18.0.0",

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.11",
+    "@mui/base": "^5.0.0-alpha.87",
     "@mui/utils": "^5.14.7",
     "@types/react-transition-group": "^4.4.6",
     "clsx": "^2.0.0",
@@ -52,7 +53,6 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/base": "^5.0.0-alpha.87",
     "@mui/material": "^5.8.6",
     "@mui/system": "^5.8.0",
     "react": "^17.0.0 || ^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,7 +1789,7 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
-"@mui/base@5.0.0-beta.13", "@mui/base@^5.0.0-beta.13":
+"@mui/base@5.0.0-beta.13", "@mui/base@^5.0.0-alpha.87", "@mui/base@^5.0.0-beta.13":
   version "5.0.0-beta.13"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.13.tgz#3bae94c39752546d84a67d4ca73486b7c4923a89"
   integrity sha512-uC0l97pBspfDAp+iz2cJq8YZ8Sd9i73V77+WzUiOAckIVEyCm5dyVDZCCO2/phmzckVEeZCGcytybkjMQuhPQw==


### PR DESCRIPTION
There is no singleton in @mui/base, no need to have it as a peer dependency. Along the way, I added a missing dependency for the charts.

I have noticed the issue installing Toolpad:

<img width="1003" alt="Screenshot 2023-09-03 at 20 51 47" src="https://github.com/mui/mui-x/assets/3165635/a66167bf-0f25-4645-9b14-2a48f1fcae99">

See https://github.com/mui/mui-x/pull/8590#issuecomment-1511226153 for a previous discussion on this. I have seen the change listed in #7902 but I don't see how it could be a breaking change.

---

Side note:

- `import X from '@mui/base'` should be banned, it pulls in everything. It should be imported from the lower level.
- `import X from '@mui/utils'` should be banned in MUI X (unless there is a really good reason). It's a private npm repository for Base UI and MUI System. Developers who would look at how to add their own components should be able to do such with public packages. They might check MUI X to see how its done, so we should set the example.