### PR TITLE
[docs] Polish page for SEO

### DIFF
--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -1,12 +1,12 @@
 ---
-title: React Chart components
+title: React Chart library
 githubLabel: 'component: charts'
 packageName: '@mui/x-charts'
 ---
 
-# Charts - Overview
+# Charts
 
-<p class="description">This page groups general topics that are common to multiple charts.</p>
+<p class="description">A fast and extendable library of react chart components for data visualization.</p>
 
 :::warning
 This library is in the alpha phase. This means it might receive some breaking changes if they are needed to improve the components.

--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -8,7 +8,7 @@ packageName: '@mui/x-date-pickers'
 
 # Date Calendar
 
-<p class="description">The Date Calendar component lets the user select a date without any input or popper / modal.</p>
+<p class="description">The Date Calendar component lets users select a date without any input or popper / modal.</p>
 
 ## Basic usage
 

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -8,7 +8,7 @@ packageName: '@mui/x-date-pickers'
 
 # Date Field
 
-<p class="description">The Date Field component lets the user select a date with the keyboard.</p>
+<p class="description">The Date Field component lets users select a date with the keyboard.</p>
 
 ## Basic usage
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -9,7 +9,7 @@ materialDesign: https://m2.material.io/components/date-pickers
 
 # Date Picker
 
-<p class="description">The Date Picker component lets the user select a date.</p>
+<p class="description">The Date Picker component lets users select a date.</p>
 
 ## Basic usage
 

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -8,7 +8,7 @@ packageName: '@mui/x-date-pickers'
 
 # Date Time Field
 
-<p class="description">The Date Time Field component lets the user select a date and a time with the keyboard.</p>
+<p class="description">The Date Time Field component lets users select a date and a time with the keyboard.</p>
 
 ## Basic usage
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -9,7 +9,7 @@ materialDesign: https://m2.material.io/components/date-pickers
 
 # Date Time Picker
 
-<p class="description">The Date Time Picker component lets the user select a date and time.</p>
+<p class="description">The Date Time Picker component lets users select a date and time.</p>
 
 ## Basic usage
 

--- a/docs/data/date-pickers/overview/overview.md
+++ b/docs/data/date-pickers/overview/overview.md
@@ -1,6 +1,6 @@
 ---
 productId: x-date-pickers
-title: Date and Time Picker React components
+title: React Date Picker and Time Picker components
 packageName: '@mui/x-date-pickers'
 githubLabel: 'component: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
@@ -9,7 +9,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Date and Time Pickers
 
-<p class="description">The Date and Time Pickers let the user select date and time values.</p>
+<p class="description">These react date picker and time picker components let users select date or time values.</p>
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
@@ -43,7 +43,7 @@ The Date and Time Pickers currently support the following date libraries:
 - [Moment.js](https://momentjs.com/)
 
 :::warning
-The Date and Time Pickers are not working well with Luxon macro-token (`D`, `DD`, `T`, `TT`, ...),
+The Date and Time Pickers are not working well with Luxon macro-token (`D`, `DD`, `T`, `TT`, …),
 because of [how they are expanded](https://github.com/mui/mui-x/issues/7615).
 
 If your application is using only a single locale, the easiest solution is to manually [provide a format](/x/react-date-pickers/adapters-locale/#custom-formats) that does not contain any macro-token
@@ -67,10 +67,10 @@ Here is the weight added to your gzipped bundle size by each of these libraries 
 
 | Library           | Gzipped size |
 | :---------------- | -----------: |
-| `dayjs@1.11.5`    |       6.77kB |
-| `date-fns@2.29.3` |      19.39kB |
-| `luxon@3.0.4`     |      23.26kB |
-| `moment@2.29.4`   |      20.78kB |
+| `dayjs@1.11.5`    |      6.77 kB |
+| `date-fns@2.29.3` |     19.39 kB |
+| `luxon@3.0.4`     |     23.26 kB |
+| `moment@2.29.4`   |     20.78 kB |
 
 :::info
 The results above were obtained in October 2022 with the latest version of each library.


### PR DESCRIPTION
## Charts

According to ahrefs, it seems that "react chart" is the main query developers uses to find a charting library. See https://app.ahrefs.com/keywords-explorer/google/us/overview?keyword=react%20charts vs. https://app.ahrefs.com/keywords-explorer/google/us/overview?keyword=react%20chart. I see more clicks for "react chart" than "react charts", we also see a blog post that compare chart libraries to rank first for "react chart". So it feels like the query to optimize for.

According to Moz, we have a couple of opportunities to make the page rank higher: https://analytics.moz.com/pro/research/page-grader?keyword=react%20chart&url=https%3A%2F%2Fmui.com%2Fx%2Freact-charts%2F. 

<img width="527" alt="Screenshot 2023-09-04 at 00 28 45" src="https://github.com/mui/mui-x/assets/3165635/dc8a391c-bc24-4695-abe2-8e7ab81e2289">

This PR acts on these opportunities.

## Pickers

I believe we have the wrong page ranking for the "react date picker" query. We want https://mui.com/x/react-data-grid/, not https://mui.com/x/react-date-pickers/date-picker/. I have updated a bit the page title and meta to have a higher change to rank.