### PR TITLE
[docs] Add a Getting Started page for the Tree View

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See the [Licensing page](https://mui.com/x/introduction/licensing/) for details.
 - [Data Grid](https://mui.com/x/react-data-grid/)
 - [Date and Time Pickers](https://mui.com/x/react-date-pickers/getting-started/)
 - [Charts](https://mui.com/x/react-charts/)
+- [Tree View](https://mui.com/x/react-tree-view/)
 
 ## Installation
 
@@ -32,6 +33,10 @@ Read the Date and Time Pickers [Installation instructions](https://mui.com/x/rea
 ### Charts
 
 Read the Charts [Installation instructions](https://mui.com/x/react-charts/#getting-started) in the MUI X docs.
+
+### Tree View
+
+Read the Charts [Installation instructions](https://mui.com/x/react-tree-view/getting-started/#installation) in the MUI X docs.
 
 ## MIT vs. commercial licenses
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Read the Charts [Installation instructions](https://mui.com/x/react-charts/#gett
 
 ### Tree View
 
-Read the Charts [Installation instructions](https://mui.com/x/react-tree-view/getting-started/#installation) in the MUI X docs.
+Read the Tree View [Installation instructions](https://mui.com/x/react-tree-view/getting-started/#installation) in the MUI X docs.
 
 ## MIT vs. commercial licenses
 
@@ -63,6 +63,7 @@ MIT licensed packages:
 - [`@mui/x-data-grid`](https://www.npmjs.com/package/@mui/x-data-grid)
 - [`@mui/x-date-pickers`](https://www.npmjs.com/package/@mui/x-date-pickers)
 - [`@mui/x-charts`](https://www.npmjs.com/package/@mui/x-charts)
+- [`@mui/x-tree-view`](https://www.npmjs.com/package/@mui/x-tree-view)
 
 ### Pro plan
 

--- a/docs/data/introduction/installation/installation.md
+++ b/docs/data/introduction/installation/installation.md
@@ -27,4 +27,4 @@ The installation [instructions](/x/react-charts/#getting-started).
 
 ### Tree View
 
-The installation [instructions](/x/react-tree-view/#getting-started).
+The installation [instructions](/x/react-tree-view/getting-started/#installation).

--- a/docs/data/introduction/installation/installation.md
+++ b/docs/data/introduction/installation/installation.md
@@ -24,3 +24,7 @@ The installation [instructions](/x/react-date-pickers/getting-started/#installat
 ### Charts
 
 The installation [instructions](/x/react-charts/#getting-started).
+
+### Tree View
+
+The installation [instructions](/x/react-tree-view/#getting-started).

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -13,6 +13,7 @@ MUI X is a collection of advanced UI components, including:
 - [Data Grid](/x/react-data-grid/)
 - [Date and Time Pickers](/x/react-date-pickers/)
 - [Charts](/x/react-charts/)
+- [Tree View](/x/react-tree-view/)
 
 These components are significantly more complex than the ones found in the MUI Core libraries.
 They feature advanced functionality for data-rich applications and a wide range of other use cases.

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -418,6 +418,7 @@ const pages: MuiPage[] = [
     title: 'Tree View',
     newFeature: true,
     children: [
+      { pathname: '/x/react-tree-view/getting-started' },
       { pathname: '/x/react-tree-view', title: 'Overview' },
       {
         pathname: '/x/api/tree-view-group',

--- a/docs/data/tree-view/getting-started/FirstComponent.js
+++ b/docs/data/tree-view/getting-started/FirstComponent.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { TreeView } from '@mui/x-tree-view/TreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+
+export default function FirstComponent() {
+  return (
+    <TreeView
+      aria-label="file system navigator"
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
+    >
+      <TreeItem nodeId="1" label="Applications">
+        <TreeItem nodeId="2" label="Calendar" />
+      </TreeItem>
+      <TreeItem nodeId="5" label="Documents">
+        <TreeItem nodeId="10" label="OSS" />
+        <TreeItem nodeId="6" label="MUI">
+          <TreeItem nodeId="8" label="index.js" />
+        </TreeItem>
+      </TreeItem>
+    </TreeView>
+  );
+}

--- a/docs/data/tree-view/getting-started/FirstComponent.tsx
+++ b/docs/data/tree-view/getting-started/FirstComponent.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { TreeView } from '@mui/x-tree-view/TreeView';
+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+
+export default function FirstComponent() {
+  return (
+    <TreeView
+      aria-label="file system navigator"
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
+    >
+      <TreeItem nodeId="1" label="Applications">
+        <TreeItem nodeId="2" label="Calendar" />
+      </TreeItem>
+      <TreeItem nodeId="5" label="Documents">
+        <TreeItem nodeId="10" label="OSS" />
+        <TreeItem nodeId="6" label="MUI">
+          <TreeItem nodeId="8" label="index.js" />
+        </TreeItem>
+      </TreeItem>
+    </TreeView>
+  );
+}

--- a/docs/data/tree-view/getting-started/FirstComponent.tsx.preview
+++ b/docs/data/tree-view/getting-started/FirstComponent.tsx.preview
@@ -1,0 +1,16 @@
+<TreeView
+    aria-label="file system navigator"
+    defaultCollapseIcon={<ExpandMoreIcon />}
+    defaultExpandIcon={<ChevronRightIcon />}
+    sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
+>
+    <TreeItem nodeId="1" label="Applications">
+        <TreeItem nodeId="2" label="Calendar" />
+    </TreeItem>
+    <TreeItem nodeId="5" label="Documents">
+        <TreeItem nodeId="10" label="OSS" />
+        <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="8" label="index.js" />
+        </TreeItem>
+    </TreeItem>
+</TreeView>

--- a/docs/data/tree-view/getting-started/FirstComponent.tsx.preview
+++ b/docs/data/tree-view/getting-started/FirstComponent.tsx.preview
@@ -1,16 +1,16 @@
 <TreeView
-    aria-label="file system navigator"
-    defaultCollapseIcon={<ExpandMoreIcon />}
-    defaultExpandIcon={<ChevronRightIcon />}
-    sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
+  aria-label="file system navigator"
+  defaultCollapseIcon={<ExpandMoreIcon />}
+  defaultExpandIcon={<ChevronRightIcon />}
+  sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
 >
-    <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" />
+  <TreeItem nodeId="1" label="Applications">
+    <TreeItem nodeId="2" label="Calendar" />
+  </TreeItem>
+  <TreeItem nodeId="5" label="Documents">
+    <TreeItem nodeId="10" label="OSS" />
+    <TreeItem nodeId="6" label="MUI">
+      <TreeItem nodeId="8" label="index.js" />
     </TreeItem>
-    <TreeItem nodeId="5" label="Documents">
-        <TreeItem nodeId="10" label="OSS" />
-        <TreeItem nodeId="6" label="MUI">
-            <TreeItem nodeId="8" label="index.js" />
-        </TreeItem>
-    </TreeItem>
+  </TreeItem>
 </TreeView>

--- a/docs/data/tree-view/getting-started/getting-started.md
+++ b/docs/data/tree-view/getting-started/getting-started.md
@@ -78,6 +78,6 @@ Take a look at the [Styled engine guide](/material-ui/guides/styled-engine/) for
 
 ## Render your first component
 
-To make sure that everything is set up correctly, try rendering a simple `DatePicker` component:
+To make sure that everything is set up correctly, try rendering a simple `TreeView` component:
 
 {{"demo": "FirstComponent.js"}}

--- a/docs/data/tree-view/getting-started/getting-started.md
+++ b/docs/data/tree-view/getting-started/getting-started.md
@@ -1,0 +1,83 @@
+---
+productId: x-tree-view
+title: Tree View - Getting started
+packageName: '@mui/x-tree-view'
+githubLabel: 'component: tree view'
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+---
+
+# Tree View - Getting Started
+
+<p class="description">Get started with the Tree View. Install the package, configure your application and start using the components.</p>
+
+## Installation
+
+Using your favorite package manager, install `@mui/x-tree-view`:
+
+<codeblock storageKey="package-manager">
+```bash npm
+npm install @mui/x-tree-view
+```
+
+```bash yarn
+yarn add @mui/x-tree-view
+```
+
+```bash pnpm
+pnpm add @mui/x-tree-view
+```
+
+</codeblock>
+
+The Tree View package has a peer dependency on `@mui/material`.
+If you are not already using it in your project, you can install it with:
+
+<codeblock storageKey="package-manager">
+```bash npm
+npm install @mui/material @emotion/react @emotion/styled
+```
+```bash yarn
+yarn add @mui/material @emotion/react @emotion/styled
+```
+```bash pnpm
+pnpm add @mui/material @emotion/react @emotion/styled
+```
+</codeblock>
+
+<!-- #react-peer-version -->
+
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
+
+```json
+"peerDependencies": {
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
+},
+```
+
+### Style engine
+
+Material UI is using [Emotion](https://emotion.sh/docs/introduction) as a styling engine by default. If you want to use [`styled-components`](https://styled-components.com/) instead, run:
+
+<codeblock storageKey="package-manager">
+```bash npm
+npm install @mui/styled-engine-sc styled-components
+```
+
+```bash yarn
+yarn add @mui/styled-engine-sc styled-components
+```
+
+```bash pnpm
+pnpm add @mui/styled-engine-sc styled-components
+```
+
+</codeblock>
+
+Take a look at the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.
+
+## Render your first component
+
+To make sure that everything is set up correctly, try rendering a simple `DatePicker` component:
+
+{{"demo": "FirstComponent.js"}}

--- a/docs/pages/x/react-tree-view/getting-started.js
+++ b/docs/pages/x/react-tree-view/getting-started.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docsx/data/tree-view/getting-started/getting-started.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}


### PR DESCRIPTION
I am moving "Getting Started" above "Overview" in the nav bar because for now "Overview contains all the doc of the Tree View and should be read after "Getting Started".

But once we move this doc to new pages and we build an actual "Overview" page that only introduces the component, I will move it back in 1st position.

I think it's worth creating the "Getting Started" page now to have a clear installation guide just like we have on other components