### PR TITLE
[TreeView] Fix box-sizing dependency

### DIFF
--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -60,6 +60,7 @@ const StyledTreeItemContent = styled(TreeItemContent, {
 })<{ ownerState: TreeItemOwnerState }>(({ theme }) => ({
   padding: '0 8px',
   width: '100%',
+  boxSizing: 'border-box', // prevent width + padding to overflow
   display: 'flex',
   alignItems: 'center',
   cursor: 'pointer',
@@ -116,10 +117,11 @@ const StyledTreeItemContent = styled(TreeItemContent, {
     },
   },
   [`& .${treeItemClasses.label}`]: {
+    paddingLeft: 4,
     width: '100%',
+    boxSizing: 'border-box', // prevent width + padding to overflow
     // fixes overflow - see https://github.com/mui/material-ui/issues/27372
     minWidth: 0,
-    paddingLeft: 4,
     position: 'relative',
     ...theme.typography.body1,
   },


### PR DESCRIPTION
##  The problem

1. Open https://mui.com/x/react-tree-view/
2. Open the first demo in codesandbox https://codesandbox.io/s/confident-sammet-2m3vhd

<img width="445" alt="Screenshot 2023-09-06 at 20 23 17" src="https://github.com/mui/mui-x/assets/3165635/a6d39ac4-9dba-407f-863a-dd66a12197f7">

Only `CssBaseline` changes the box-sizing globally https://mui.com/material-ui/react-css-baseline/#layout (I imagine only used by evergreen projects). So depending on how your app is configured the component will break.

https://tailwindcss.com/docs/box-sizing talks a bit about the concept as well.

## The solution

We use the same trick in all the other Material UI components where it's needed.

## Context

I found this by pure luck, I wanted to test the playground http://0.0.0.0:3000/playground/.