### PR TITLE
[docs] Improve Tree View demos

### DIFF
--- a/docs/data/tree-view/overview/BarTreeView.js
+++ b/docs/data/tree-view/overview/BarTreeView.js
@@ -6,57 +6,58 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeItem, useTreeItem } from '@mui/x-tree-view/TreeItem';
 import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
 
 const CustomContentRoot = styled('div')(({ theme }) => ({
   WebkitTapHighlightColor: 'transparent',
-  '&:hover, &.Mui-disabled, &.Mui-focused, &.Mui-selected, &.Mui-selected.Mui-focused, &.Mui-selected:hover':
+  '&&:hover, &&.Mui-disabled, &&.Mui-focused, &&.Mui-selected, &&.Mui-selected.Mui-focused, &&.Mui-selected:hover':
     {
       backgroundColor: 'transparent',
     },
-  [`& .MuiTreeItem-contentBar`]: {
+  '.MuiTreeItem-contentBar': {
     position: 'absolute',
     width: '100%',
     height: 24,
     left: 0,
-    '&:hover &': {
-      backgroundColor: theme.palette.action.hover,
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: 'transparent',
-      },
-    },
-    '&.Mui-disabled &': {
-      opacity: theme.palette.action.disabledOpacity,
+  },
+  '&:hover .MuiTreeItem-contentBar': {
+    backgroundColor: theme.palette.action.hover,
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
       backgroundColor: 'transparent',
     },
-    '&.Mui-focused &': {
-      backgroundColor: theme.palette.action.focus,
-    },
-    '&.Mui-selected &': {
+  },
+  '&.Mui-disabled .MuiTreeItem-contentBar': {
+    opacity: theme.palette.action.disabledOpacity,
+    backgroundColor: 'transparent',
+  },
+  '&.Mui-focused .MuiTreeItem-contentBar': {
+    backgroundColor: theme.palette.action.focus,
+  },
+  '&.Mui-selected .MuiTreeItem-contentBar': {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.selectedOpacity,
+    ),
+  },
+  '&.Mui-selected:hover .MuiTreeItem-contentBar': {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+    ),
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
       backgroundColor: alpha(
         theme.palette.primary.main,
         theme.palette.action.selectedOpacity,
       ),
     },
-    '&.Mui-selected:hover &': {
-      backgroundColor: alpha(
-        theme.palette.primary.main,
-        theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
-      ),
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.selectedOpacity,
-        ),
-      },
-    },
-    '&.Mui-selected.Mui-focused &': {
-      backgroundColor: alpha(
-        theme.palette.primary.main,
-        theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
-      ),
-    },
+  },
+  '&.Mui-selected.Mui-focused .MuiTreeItem-contentBar': {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+    ),
   },
 }));
 
@@ -119,26 +120,23 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(props, ref) {
 
 export default function BarTreeView() {
   return (
-    <TreeView
-      aria-label="icon expansion"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, position: 'relative' }}
-    >
-      <CustomTreeItem nodeId="1" label="Applications">
-        <CustomTreeItem nodeId="2" label="Calendar" />
-        <CustomTreeItem nodeId="3" label="Chrome" />
-        <CustomTreeItem nodeId="4" label="Webstorm" />
-      </CustomTreeItem>
-      <CustomTreeItem nodeId="5" label="Documents">
-        <CustomTreeItem nodeId="10" label="OSS" />
-        <CustomTreeItem nodeId="6" label="MUI">
-          <CustomTreeItem nodeId="7" label="src">
+    <Box sx={{ minHeight: 180, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="icon expansion"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+        sx={{ position: 'relative' }}
+      >
+        <CustomTreeItem nodeId="1" label="Applications">
+          <CustomTreeItem nodeId="2" label="Calendar" />
+        </CustomTreeItem>
+        <CustomTreeItem nodeId="5" label="Documents">
+          <CustomTreeItem nodeId="10" label="OSS" />
+          <CustomTreeItem nodeId="6" label="MUI">
             <CustomTreeItem nodeId="8" label="index.js" />
-            <CustomTreeItem nodeId="9" label="tree-view.js" />
           </CustomTreeItem>
         </CustomTreeItem>
-      </CustomTreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/BarTreeView.tsx
+++ b/docs/data/tree-view/overview/BarTreeView.tsx
@@ -11,57 +11,58 @@ import {
 } from '@mui/x-tree-view/TreeItem';
 import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
 
 const CustomContentRoot = styled('div')(({ theme }) => ({
   WebkitTapHighlightColor: 'transparent',
-  '&:hover, &.Mui-disabled, &.Mui-focused, &.Mui-selected, &.Mui-selected.Mui-focused, &.Mui-selected:hover':
+  '&&:hover, &&.Mui-disabled, &&.Mui-focused, &&.Mui-selected, &&.Mui-selected.Mui-focused, &&.Mui-selected:hover':
     {
       backgroundColor: 'transparent',
     },
-  [`& .MuiTreeItem-contentBar`]: {
+  '.MuiTreeItem-contentBar': {
     position: 'absolute',
     width: '100%',
     height: 24,
     left: 0,
-    '&:hover &': {
-      backgroundColor: theme.palette.action.hover,
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: 'transparent',
-      },
-    },
-    '&.Mui-disabled &': {
-      opacity: theme.palette.action.disabledOpacity,
+  },
+  '&:hover .MuiTreeItem-contentBar': {
+    backgroundColor: theme.palette.action.hover,
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
       backgroundColor: 'transparent',
     },
-    '&.Mui-focused &': {
-      backgroundColor: theme.palette.action.focus,
-    },
-    '&.Mui-selected &': {
+  },
+  '&.Mui-disabled .MuiTreeItem-contentBar': {
+    opacity: theme.palette.action.disabledOpacity,
+    backgroundColor: 'transparent',
+  },
+  '&.Mui-focused .MuiTreeItem-contentBar': {
+    backgroundColor: theme.palette.action.focus,
+  },
+  '&.Mui-selected .MuiTreeItem-contentBar': {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.selectedOpacity,
+    ),
+  },
+  '&.Mui-selected:hover .MuiTreeItem-contentBar': {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+    ),
+    // Reset on touch devices, it doesn't add specificity
+    '@media (hover: none)': {
       backgroundColor: alpha(
         theme.palette.primary.main,
         theme.palette.action.selectedOpacity,
       ),
     },
-    '&.Mui-selected:hover &': {
-      backgroundColor: alpha(
-        theme.palette.primary.main,
-        theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
-      ),
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: alpha(
-          theme.palette.primary.main,
-          theme.palette.action.selectedOpacity,
-        ),
-      },
-    },
-    '&.Mui-selected.Mui-focused &': {
-      backgroundColor: alpha(
-        theme.palette.primary.main,
-        theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
-      ),
-    },
+  },
+  '&.Mui-selected.Mui-focused .MuiTreeItem-contentBar': {
+    backgroundColor: alpha(
+      theme.palette.primary.main,
+      theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+    ),
   },
 }));
 
@@ -130,26 +131,23 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(
 
 export default function BarTreeView() {
   return (
-    <TreeView
-      aria-label="icon expansion"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, position: 'relative' }}
-    >
-      <CustomTreeItem nodeId="1" label="Applications">
-        <CustomTreeItem nodeId="2" label="Calendar" />
-        <CustomTreeItem nodeId="3" label="Chrome" />
-        <CustomTreeItem nodeId="4" label="Webstorm" />
-      </CustomTreeItem>
-      <CustomTreeItem nodeId="5" label="Documents">
-        <CustomTreeItem nodeId="10" label="OSS" />
-        <CustomTreeItem nodeId="6" label="MUI">
-          <CustomTreeItem nodeId="7" label="src">
+    <Box sx={{ minHeight: 180, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="icon expansion"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+        sx={{ position: 'relative' }}
+      >
+        <CustomTreeItem nodeId="1" label="Applications">
+          <CustomTreeItem nodeId="2" label="Calendar" />
+        </CustomTreeItem>
+        <CustomTreeItem nodeId="5" label="Documents">
+          <CustomTreeItem nodeId="10" label="OSS" />
+          <CustomTreeItem nodeId="6" label="MUI">
             <CustomTreeItem nodeId="8" label="index.js" />
-            <CustomTreeItem nodeId="9" label="tree-view.js" />
           </CustomTreeItem>
         </CustomTreeItem>
-      </CustomTreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/BarTreeView.tsx.preview
+++ b/docs/data/tree-view/overview/BarTreeView.tsx.preview
@@ -1,0 +1,16 @@
+<TreeView
+  aria-label="icon expansion"
+  defaultCollapseIcon={<ExpandMoreIcon />}
+  defaultExpandIcon={<ChevronRightIcon />}
+  sx={{ position: 'relative' }}
+>
+  <CustomTreeItem nodeId="1" label="Applications">
+    <CustomTreeItem nodeId="2" label="Calendar" />
+  </CustomTreeItem>
+  <CustomTreeItem nodeId="5" label="Documents">
+    <CustomTreeItem nodeId="10" label="OSS" />
+    <CustomTreeItem nodeId="6" label="MUI">
+      <CustomTreeItem nodeId="8" label="index.js" />
+    </CustomTreeItem>
+  </CustomTreeItem>
+</TreeView>

--- a/docs/data/tree-view/overview/ControlledTreeView.js
+++ b/docs/data/tree-view/overview/ControlledTreeView.js
@@ -31,7 +31,7 @@ export default function ControlledTreeView() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}>
+    <Box sx={{ minHeight: 270, flexGrow: 1, maxWidth: 300 }}>
       <Box sx={{ mb: 1 }}>
         <Button onClick={handleExpandClick}>
           {expanded.length === 0 ? 'Expand all' : 'Collapse all'}

--- a/docs/data/tree-view/overview/ControlledTreeView.tsx
+++ b/docs/data/tree-view/overview/ControlledTreeView.tsx
@@ -31,7 +31,7 @@ export default function ControlledTreeView() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}>
+    <Box sx={{ minHeight: 270, flexGrow: 1, maxWidth: 300 }}>
       <Box sx={{ mb: 1 }}>
         <Button onClick={handleExpandClick}>
           {expanded.length === 0 ? 'Expand all' : 'Collapse all'}

--- a/docs/data/tree-view/overview/CustomizedTreeView.js
+++ b/docs/data/tree-view/overview/CustomizedTreeView.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import { useSpring, animated } from '@react-spring/web';
 import SvgIcon from '@mui/material/SvgIcon';
 
@@ -41,10 +42,6 @@ function CloseSquare(props) {
 
 function TransitionComponent(props) {
   const style = useSpring({
-    from: {
-      opacity: 0,
-      transform: 'translate3d(20px,0,0)',
-    },
     to: {
       opacity: props.in ? 1 : 0,
       transform: `translate3d(${props.in ? 0 : 20}px,0,0)`,
@@ -77,28 +74,30 @@ const StyledTreeItem = styled(CustomTreeItem)(({ theme }) => ({
 
 export default function CustomizedTreeView() {
   return (
-    <TreeView
-      aria-label="customized"
-      defaultExpanded={['1']}
-      defaultCollapseIcon={<MinusSquare />}
-      defaultExpandIcon={<PlusSquare />}
-      defaultEndIcon={<CloseSquare />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <StyledTreeItem nodeId="1" label="Main">
-        <StyledTreeItem nodeId="2" label="Hello" />
-        <StyledTreeItem nodeId="3" label="Subtree with children">
-          <StyledTreeItem nodeId="6" label="Hello" />
-          <StyledTreeItem nodeId="7" label="Sub-subtree with children">
-            <StyledTreeItem nodeId="9" label="Child 1" />
-            <StyledTreeItem nodeId="10" label="Child 2" />
-            <StyledTreeItem nodeId="11" label="Child 3" />
+    <Box sx={{ minHeight: 270, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="customized"
+        defaultExpanded={['1']}
+        defaultCollapseIcon={<MinusSquare />}
+        defaultExpandIcon={<PlusSquare />}
+        defaultEndIcon={<CloseSquare />}
+        sx={{ overflowX: 'hidden' }}
+      >
+        <StyledTreeItem nodeId="1" label="Main">
+          <StyledTreeItem nodeId="2" label="Hello" />
+          <StyledTreeItem nodeId="3" label="Subtree with children">
+            <StyledTreeItem nodeId="6" label="Hello" />
+            <StyledTreeItem nodeId="7" label="Sub-subtree with children">
+              <StyledTreeItem nodeId="9" label="Child 1" />
+              <StyledTreeItem nodeId="10" label="Child 2" />
+              <StyledTreeItem nodeId="11" label="Child 3" />
+            </StyledTreeItem>
+            <StyledTreeItem nodeId="8" label="Hello" />
           </StyledTreeItem>
-          <StyledTreeItem nodeId="8" label="Hello" />
+          <StyledTreeItem nodeId="4" label="World" />
+          <StyledTreeItem nodeId="5" label="Something something" />
         </StyledTreeItem>
-        <StyledTreeItem nodeId="4" label="World" />
-        <StyledTreeItem nodeId="5" label="Something something" />
-      </StyledTreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/CustomizedTreeView.tsx
+++ b/docs/data/tree-view/overview/CustomizedTreeView.tsx
@@ -76,7 +76,7 @@ const StyledTreeItem = styled(CustomTreeItem)(({ theme }) => ({
 
 export default function CustomizedTreeView() {
   return (
-    <Box sx={{ flexGrow: 1, maxWidth: 300 }}>
+    <Box sx={{ minHeight: 270, flexGrow: 1, maxWidth: 300 }}>
       <TreeView
         aria-label="customized"
         defaultExpanded={['1']}

--- a/docs/data/tree-view/overview/CustomizedTreeView.tsx
+++ b/docs/data/tree-view/overview/CustomizedTreeView.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import { useSpring, animated } from '@react-spring/web';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import { TransitionProps } from '@mui/material/transitions';
@@ -41,10 +42,6 @@ function CloseSquare(props: SvgIconProps) {
 
 function TransitionComponent(props: TransitionProps) {
   const style = useSpring({
-    from: {
-      opacity: 0,
-      transform: 'translate3d(20px,0,0)',
-    },
     to: {
       opacity: props.in ? 1 : 0,
       transform: `translate3d(${props.in ? 0 : 20}px,0,0)`,
@@ -79,28 +76,30 @@ const StyledTreeItem = styled(CustomTreeItem)(({ theme }) => ({
 
 export default function CustomizedTreeView() {
   return (
-    <TreeView
-      aria-label="customized"
-      defaultExpanded={['1']}
-      defaultCollapseIcon={<MinusSquare />}
-      defaultExpandIcon={<PlusSquare />}
-      defaultEndIcon={<CloseSquare />}
-      sx={{ height: 264, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <StyledTreeItem nodeId="1" label="Main">
-        <StyledTreeItem nodeId="2" label="Hello" />
-        <StyledTreeItem nodeId="3" label="Subtree with children">
-          <StyledTreeItem nodeId="6" label="Hello" />
-          <StyledTreeItem nodeId="7" label="Sub-subtree with children">
-            <StyledTreeItem nodeId="9" label="Child 1" />
-            <StyledTreeItem nodeId="10" label="Child 2" />
-            <StyledTreeItem nodeId="11" label="Child 3" />
+    <Box sx={{ flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="customized"
+        defaultExpanded={['1']}
+        defaultCollapseIcon={<MinusSquare />}
+        defaultExpandIcon={<PlusSquare />}
+        defaultEndIcon={<CloseSquare />}
+        sx={{ overflowX: 'hidden' }}
+      >
+        <StyledTreeItem nodeId="1" label="Main">
+          <StyledTreeItem nodeId="2" label="Hello" />
+          <StyledTreeItem nodeId="3" label="Subtree with children">
+            <StyledTreeItem nodeId="6" label="Hello" />
+            <StyledTreeItem nodeId="7" label="Sub-subtree with children">
+              <StyledTreeItem nodeId="9" label="Child 1" />
+              <StyledTreeItem nodeId="10" label="Child 2" />
+              <StyledTreeItem nodeId="11" label="Child 3" />
+            </StyledTreeItem>
+            <StyledTreeItem nodeId="8" label="Hello" />
           </StyledTreeItem>
-          <StyledTreeItem nodeId="8" label="Hello" />
+          <StyledTreeItem nodeId="4" label="World" />
+          <StyledTreeItem nodeId="5" label="Something something" />
         </StyledTreeItem>
-        <StyledTreeItem nodeId="4" label="World" />
-        <StyledTreeItem nodeId="5" label="Something something" />
-      </StyledTreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/DisabledTreeItems.js
+++ b/docs/data/tree-view/overview/DisabledTreeItems.js
@@ -14,7 +14,7 @@ export default function DisabledTreeItems() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }} px={2}>
+    <Box sx={{ minHeight: 220, flexGrow: 1, maxWidth: 300 }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
           control={
@@ -34,21 +34,14 @@ export default function DisabledTreeItems() {
         disabledItemsFocusable={focusDisabledItems}
         multiSelect
       >
-        <TreeItem nodeId="1" label="One">
-          <TreeItem nodeId="2" label="Two" />
-          <TreeItem nodeId="3" label="Three" />
-          <TreeItem nodeId="4" label="Four" />
+        <TreeItem nodeId="1" label="Applications">
+          <TreeItem nodeId="2" label="Calendar" />
         </TreeItem>
-        <TreeItem nodeId="5" label="Five" disabled>
-          <TreeItem nodeId="6" label="Six" />
-        </TreeItem>
-        <TreeItem nodeId="7" label="Seven">
-          <TreeItem nodeId="8" label="Eight" />
-          <TreeItem nodeId="9" label="Nine">
-            <TreeItem nodeId="10" label="Ten">
-              <TreeItem nodeId="11" label="Eleven" />
-              <TreeItem nodeId="12" label="Twelve" />
-            </TreeItem>
+        <TreeItem nodeId="11" label="Blog" disabled />
+        <TreeItem nodeId="5" label="Documents">
+          <TreeItem nodeId="10" label="OSS" />
+          <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="8" label="index.js" />
           </TreeItem>
         </TreeItem>
       </TreeView>

--- a/docs/data/tree-view/overview/DisabledTreeItems.tsx
+++ b/docs/data/tree-view/overview/DisabledTreeItems.tsx
@@ -14,7 +14,7 @@ export default function DisabledTreeItems() {
   };
 
   return (
-    <Box sx={{ height: 270, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }} px={2}>
+    <Box sx={{ minHeight: 220, flexGrow: 1, maxWidth: 300 }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
           control={
@@ -34,21 +34,14 @@ export default function DisabledTreeItems() {
         disabledItemsFocusable={focusDisabledItems}
         multiSelect
       >
-        <TreeItem nodeId="1" label="One">
-          <TreeItem nodeId="2" label="Two" />
-          <TreeItem nodeId="3" label="Three" />
-          <TreeItem nodeId="4" label="Four" />
+        <TreeItem nodeId="1" label="Applications">
+          <TreeItem nodeId="2" label="Calendar" />
         </TreeItem>
-        <TreeItem nodeId="5" label="Five" disabled>
-          <TreeItem nodeId="6" label="Six" />
-        </TreeItem>
-        <TreeItem nodeId="7" label="Seven">
-          <TreeItem nodeId="8" label="Eight" />
-          <TreeItem nodeId="9" label="Nine">
-            <TreeItem nodeId="10" label="Ten">
-              <TreeItem nodeId="11" label="Eleven" />
-              <TreeItem nodeId="12" label="Twelve" />
-            </TreeItem>
+        <TreeItem nodeId="11" label="Blog" disabled />
+        <TreeItem nodeId="5" label="Documents">
+          <TreeItem nodeId="10" label="OSS" />
+          <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="8" label="index.js" />
           </TreeItem>
         </TreeItem>
       </TreeView>

--- a/docs/data/tree-view/overview/FileSystemNavigator.js
+++ b/docs/data/tree-view/overview/FileSystemNavigator.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -6,21 +7,22 @@ import { TreeItem } from '@mui/x-tree-view/TreeItem';
 
 export default function FileSystemNavigator() {
   return (
-    <TreeView
-      aria-label="file system navigator"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" />
-      </TreeItem>
-      <TreeItem nodeId="5" label="Documents">
-        <TreeItem nodeId="10" label="OSS" />
-        <TreeItem nodeId="6" label="MUI">
-          <TreeItem nodeId="8" label="index.js" />
+    <Box sx={{ minHeight: 180, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="file system navigator"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        <TreeItem nodeId="1" label="Applications">
+          <TreeItem nodeId="2" label="Calendar" />
         </TreeItem>
-      </TreeItem>
-    </TreeView>
+        <TreeItem nodeId="5" label="Documents">
+          <TreeItem nodeId="10" label="OSS" />
+          <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="8" label="index.js" />
+          </TreeItem>
+        </TreeItem>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/FileSystemNavigator.tsx
+++ b/docs/data/tree-view/overview/FileSystemNavigator.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -6,21 +7,22 @@ import { TreeItem } from '@mui/x-tree-view/TreeItem';
 
 export default function FileSystemNavigator() {
   return (
-    <TreeView
-      aria-label="file system navigator"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" />
-      </TreeItem>
-      <TreeItem nodeId="5" label="Documents">
-        <TreeItem nodeId="10" label="OSS" />
-        <TreeItem nodeId="6" label="MUI">
-          <TreeItem nodeId="8" label="index.js" />
+    <Box sx={{ minHeight: 180, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="file system navigator"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        <TreeItem nodeId="1" label="Applications">
+          <TreeItem nodeId="2" label="Calendar" />
         </TreeItem>
-      </TreeItem>
-    </TreeView>
+        <TreeItem nodeId="5" label="Documents">
+          <TreeItem nodeId="10" label="OSS" />
+          <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="8" label="index.js" />
+          </TreeItem>
+        </TreeItem>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/FileSystemNavigator.tsx.preview
+++ b/docs/data/tree-view/overview/FileSystemNavigator.tsx.preview
@@ -2,7 +2,6 @@
   aria-label="file system navigator"
   defaultCollapseIcon={<ExpandMoreIcon />}
   defaultExpandIcon={<ChevronRightIcon />}
-  sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
 >
   <TreeItem nodeId="1" label="Applications">
     <TreeItem nodeId="2" label="Calendar" />

--- a/docs/data/tree-view/overview/IconExpansionTreeView.js
+++ b/docs/data/tree-view/overview/IconExpansionTreeView.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -74,26 +75,22 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(props, ref) {
 
 export default function IconExpansionTreeView() {
   return (
-    <TreeView
-      aria-label="icon expansion"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <CustomTreeItem nodeId="1" label="Applications">
-        <CustomTreeItem nodeId="2" label="Calendar" />
-        <CustomTreeItem nodeId="3" label="Chrome" />
-        <CustomTreeItem nodeId="4" label="Webstorm" />
-      </CustomTreeItem>
-      <CustomTreeItem nodeId="5" label="Documents">
-        <CustomTreeItem nodeId="10" label="OSS" />
-        <CustomTreeItem nodeId="6" label="MUI">
-          <CustomTreeItem nodeId="7" label="src">
+    <Box sx={{ minHeight: 180, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="icon expansion"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        <CustomTreeItem nodeId="1" label="Applications">
+          <CustomTreeItem nodeId="2" label="Calendar" />
+        </CustomTreeItem>
+        <CustomTreeItem nodeId="5" label="Documents">
+          <CustomTreeItem nodeId="10" label="OSS" />
+          <CustomTreeItem nodeId="6" label="MUI">
             <CustomTreeItem nodeId="8" label="index.js" />
-            <CustomTreeItem nodeId="9" label="tree-view.js" />
           </CustomTreeItem>
         </CustomTreeItem>
-      </CustomTreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/IconExpansionTreeView.tsx
+++ b/docs/data/tree-view/overview/IconExpansionTreeView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -89,26 +90,22 @@ const CustomTreeItem = React.forwardRef(function CustomTreeItem(
 
 export default function IconExpansionTreeView() {
   return (
-    <TreeView
-      aria-label="icon expansion"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 240, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <CustomTreeItem nodeId="1" label="Applications">
-        <CustomTreeItem nodeId="2" label="Calendar" />
-        <CustomTreeItem nodeId="3" label="Chrome" />
-        <CustomTreeItem nodeId="4" label="Webstorm" />
-      </CustomTreeItem>
-      <CustomTreeItem nodeId="5" label="Documents">
-        <CustomTreeItem nodeId="10" label="OSS" />
-        <CustomTreeItem nodeId="6" label="MUI">
-          <CustomTreeItem nodeId="7" label="src">
+    <Box sx={{ minHeight: 180, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="icon expansion"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        <CustomTreeItem nodeId="1" label="Applications">
+          <CustomTreeItem nodeId="2" label="Calendar" />
+        </CustomTreeItem>
+        <CustomTreeItem nodeId="5" label="Documents">
+          <CustomTreeItem nodeId="10" label="OSS" />
+          <CustomTreeItem nodeId="6" label="MUI">
             <CustomTreeItem nodeId="8" label="index.js" />
-            <CustomTreeItem nodeId="9" label="tree-view.js" />
           </CustomTreeItem>
         </CustomTreeItem>
-      </CustomTreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/IconExpansionTreeView.tsx.preview
+++ b/docs/data/tree-view/overview/IconExpansionTreeView.tsx.preview
@@ -1,0 +1,15 @@
+<TreeView
+  aria-label="icon expansion"
+  defaultCollapseIcon={<ExpandMoreIcon />}
+  defaultExpandIcon={<ChevronRightIcon />}
+>
+  <CustomTreeItem nodeId="1" label="Applications">
+    <CustomTreeItem nodeId="2" label="Calendar" />
+  </CustomTreeItem>
+  <CustomTreeItem nodeId="5" label="Documents">
+    <CustomTreeItem nodeId="10" label="OSS" />
+    <CustomTreeItem nodeId="6" label="MUI">
+      <CustomTreeItem nodeId="8" label="index.js" />
+    </CustomTreeItem>
+  </CustomTreeItem>
+</TreeView>

--- a/docs/data/tree-view/overview/MultiSelectTreeView.js
+++ b/docs/data/tree-view/overview/MultiSelectTreeView.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -6,26 +7,27 @@ import { TreeItem } from '@mui/x-tree-view/TreeItem';
 
 export default function MultiSelectTreeView() {
   return (
-    <TreeView
-      aria-label="multi-select"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      multiSelect
-      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" />
-        <TreeItem nodeId="3" label="Chrome" />
-        <TreeItem nodeId="4" label="Webstorm" />
-      </TreeItem>
-      <TreeItem nodeId="5" label="Documents">
-        <TreeItem nodeId="6" label="MUI">
-          <TreeItem nodeId="7" label="src">
-            <TreeItem nodeId="8" label="index.js" />
-            <TreeItem nodeId="9" label="tree-view.js" />
+    <Box sx={{ minHeight: 220, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="multi-select"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+        multiSelect
+      >
+        <TreeItem nodeId="1" label="Applications">
+          <TreeItem nodeId="2" label="Calendar" />
+          <TreeItem nodeId="3" label="Chrome" />
+          <TreeItem nodeId="4" label="Webstorm" />
+        </TreeItem>
+        <TreeItem nodeId="5" label="Documents">
+          <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="7" label="src">
+              <TreeItem nodeId="8" label="index.js" />
+              <TreeItem nodeId="9" label="tree-view.js" />
+            </TreeItem>
           </TreeItem>
         </TreeItem>
-      </TreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/MultiSelectTreeView.tsx
+++ b/docs/data/tree-view/overview/MultiSelectTreeView.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -6,26 +7,27 @@ import { TreeItem } from '@mui/x-tree-view/TreeItem';
 
 export default function MultiSelectTreeView() {
   return (
-    <TreeView
-      aria-label="multi-select"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
-      multiSelect
-      sx={{ height: 216, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" />
-        <TreeItem nodeId="3" label="Chrome" />
-        <TreeItem nodeId="4" label="Webstorm" />
-      </TreeItem>
-      <TreeItem nodeId="5" label="Documents">
-        <TreeItem nodeId="6" label="MUI">
-          <TreeItem nodeId="7" label="src">
-            <TreeItem nodeId="8" label="index.js" />
-            <TreeItem nodeId="9" label="tree-view.js" />
+    <Box sx={{ minHeight: 220, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="multi-select"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpandIcon={<ChevronRightIcon />}
+        multiSelect
+      >
+        <TreeItem nodeId="1" label="Applications">
+          <TreeItem nodeId="2" label="Calendar" />
+          <TreeItem nodeId="3" label="Chrome" />
+          <TreeItem nodeId="4" label="Webstorm" />
+        </TreeItem>
+        <TreeItem nodeId="5" label="Documents">
+          <TreeItem nodeId="6" label="MUI">
+            <TreeItem nodeId="7" label="src">
+              <TreeItem nodeId="8" label="index.js" />
+              <TreeItem nodeId="9" label="tree-view.js" />
+            </TreeItem>
           </TreeItem>
         </TreeItem>
-      </TreeItem>
-    </TreeView>
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/RichObjectTreeView.js
+++ b/docs/data/tree-view/overview/RichObjectTreeView.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -35,14 +36,15 @@ export default function RichObjectTreeView() {
   );
 
   return (
-    <TreeView
-      aria-label="rich object"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpanded={['root']}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      {renderTree(data)}
-    </TreeView>
+    <Box sx={{ minHeight: 110, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="rich object"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpanded={['root']}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        {renderTree(data)}
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/RichObjectTreeView.tsx
+++ b/docs/data/tree-view/overview/RichObjectTreeView.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { TreeView } from '@mui/x-tree-view/TreeView';
@@ -41,14 +42,15 @@ export default function RichObjectTreeView() {
   );
 
   return (
-    <TreeView
-      aria-label="rich object"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpanded={['root']}
-      defaultExpandIcon={<ChevronRightIcon />}
-      sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
-    >
-      {renderTree(data)}
-    </TreeView>
+    <Box sx={{ minHeight: 110, flexGrow: 1, maxWidth: 300 }}>
+      <TreeView
+        aria-label="rich object"
+        defaultCollapseIcon={<ExpandMoreIcon />}
+        defaultExpanded={['root']}
+        defaultExpandIcon={<ChevronRightIcon />}
+      >
+        {renderTree(data)}
+      </TreeView>
+    </Box>
   );
 }

--- a/docs/data/tree-view/overview/RichObjectTreeView.tsx.preview
+++ b/docs/data/tree-view/overview/RichObjectTreeView.tsx.preview
@@ -3,7 +3,6 @@
   defaultCollapseIcon={<ExpandMoreIcon />}
   defaultExpanded={['root']}
   defaultExpandIcon={<ChevronRightIcon />}
-  sx={{ height: 110, flexGrow: 1, maxWidth: 400, overflowY: 'auto' }}
 >
   {renderTree(data)}
 </TreeView>

--- a/docs/data/tree-view/overview/overview.md
+++ b/docs/data/tree-view/overview/overview.md
@@ -59,17 +59,17 @@ const data = {
 };
 ```
 
-{{"demo": "RichObjectTreeView.js", "defaultCodeOpen": false}}
+{{"demo": "RichObjectTreeView.js"}}
 
 ## ContentComponent prop
 
 You can use the `ContentComponent` prop and the `useTreeItem` hook to further customize the behavior of the TreeItem.
 
-Such as limiting expansion to clicking the icon:
+Such as limiting expansion to clicking the expand icon:
 
 {{"demo": "IconExpansionTreeView.js", "defaultCodeOpen": false}}
 
-Or increasing the width of the state indicator:
+Or increasing the width of the item state indicator to be full-width:
 
 {{"demo": "BarTreeView.js", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
I notice on #10255 that https://mui.com/x/react-tree-view/#custom-icons-border-and-animation demos is broken:

https://github.com/mui/mui-x/assets/3165635/36c97bcc-e8be-4a58-98ca-78d032942d51

1. It animates on load while it shouldn't. It can be solved like this https://github.com/pmndrs/react-spring/issues/485#issuecomment-460409296.
2. It creates an overflow scrollbar. It can be solved with `overflowX: hidden`, see how even with an overflow y, it continues to work:

https://github.com/mui/mui-x/assets/3165635/680cde4e-6de8-44b9-b3cb-8598129951fb

---

Along the way, I improved a bit in the other demos:

- Use less vertical space when possible
- Use minHeight over height in the case we add more items in the demos and forgot about this property (same for developer who copy the demos)
- Use smaller tree when the demos doesn't need the larger one
- Fix the second demo of https://mui.com/x/react-tree-view/#contentcomponent-prop. I assume JSS migration to Emotion broke it.
- Move the sx style outside of the TreeView node when they are supposed to simulate the side nav container the tree view will be rendered into but not relevant for the children.

Preview: https://deploy-preview-10268--material-ui-x.netlify.app/x/react-tree-view/