### PR TITLE
[charts] Remove require condition from package.json exports

### DIFF
--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -70,13 +70,11 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./esm/index.js",
-      "default": "./esm/index.js"
+      "import": "./esm/index.js"
     },
     "./*": {
       "types": "./*/index.d.ts",
-      "import": "./esm/*/index.js",
-      "default": "./esm/*/index.js"
+      "import": "./esm/*/index.js"
     }
   },
   "setupFiles": [

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -70,13 +70,13 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "require": "./index.js",
-      "import": "./esm/index.js"
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
     },
     "./*": {
       "types": "./*/index.d.ts",
-      "require": "./*/index.js",
-      "import": "./esm/*/index.js"
+      "import": "./esm/*/index.js",
+      "default": "./esm/*/index.js"
     }
   },
   "setupFiles": [

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -70,11 +70,13 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "import": "./esm/index.js"
+      "import": "./esm/index.js",
+      "default": "./esm/index.js"
     },
     "./*": {
       "types": "./*/index.d.ts",
-      "import": "./esm/*/index.js"
+      "import": "./esm/*/index.js",
+      "default": "./esm/*/index.js"
     }
   },
   "setupFiles": [


### PR DESCRIPTION
At the moment we don't have a working commonjs export for `@mui/x-charts`. We're using this alpha package to test the waters in the community about support for ESM modules. As such it makes sense to remove the non-working `require` condition, and supply a `default` condition as a fallback. Alternatively we could opt for removing the `import` condition altogether and just keeping `default`.

Closes https://github.com/mui/mui-x/issues/10257
Closes #10195

* https://deploy-preview-10272--material-ui-x.netlify.app/x/react-charts/bars/
* https://codesandbox.io/s/jsttrw?file=/Demo.tsx