### PR TITLE
[pickers] Fix `YearCalendar` and `MonthCalendar` a11y

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -307,6 +307,7 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
     readOnly,
     disabled,
     timezone,
+    gridLabelId,
   };
 
   const prevOpenViewRef = React.useRef(view);
@@ -384,7 +385,6 @@ export const DateCalendar = React.forwardRef(function DateCalendar<TDate>(
               shouldDisableYear={shouldDisableYear}
               hasFocus={hasFocus}
               onFocusedViewChange={(isViewFocused) => setFocusedView('day', isViewFocused)}
-              gridLabelId={gridLabelId}
               showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
               fixedWeekNumber={fixedWeekNumber}
               dayOfWeekFormatter={dayOfWeekFormatter}

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -220,7 +220,7 @@ describe('<DesktopDatePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
 
       // Select year
-      userEvent.mousePress(screen.getByRole('button', { name: '2025' }));
+      userEvent.mousePress(screen.getByRole('radio', { name: '2025' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2025, 0, 1));
       expect(onAccept.callCount).to.equal(0);

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
@@ -41,7 +41,7 @@ describe('<DesktopDateTimePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
 
       // Select year
-      userEvent.mousePress(screen.getByRole('button', { name: '2025' }));
+      userEvent.mousePress(screen.getByRole('radio', { name: '2025' }));
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2025, 0, 1, 11, 55));
       expect(onAccept.callCount).to.equal(0);

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -92,6 +92,7 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
     onFocusedViewChange,
     monthsPerRow = 3,
     timezone: timezoneProp,
+    gridLabelId,
     ...other
   } = props;
 
@@ -253,11 +254,14 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
       ref={ref}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
+      role="radiogroup"
+      aria-labelledby={gridLabelId}
       {...other}
     >
       {getMonthsInYear(utils, value ?? referenceDate).map((month) => {
         const monthNumber = utils.getMonth(month);
         const monthText = utils.format(month, 'monthShort');
+        const monthLabel = utils.format(month, 'month');
         const isSelected = monthNumber === selectedMonth;
         const isDisabled = disabled || isMonthDisabled(month);
 
@@ -274,6 +278,7 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
             onFocus={handleMonthFocus}
             onBlur={handleMonthBlur}
             aria-current={todayMonth === monthNumber ? 'date' : undefined}
+            aria-label={monthLabel}
             monthsPerRow={monthsPerRow}
           >
             {monthText}

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -327,6 +327,7 @@ MonthCalendar.propTypes = {
    * @default false
    */
   disablePast: PropTypes.bool,
+  gridLabelId: PropTypes.string,
   hasFocus: PropTypes.bool,
   /**
    * Maximal selectable date.

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.types.ts
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.types.ts
@@ -62,4 +62,5 @@ export interface MonthCalendarProps<TDate>
   onMonthFocus?: (month: number) => void;
   hasFocus?: boolean;
   onFocusedViewChange?: (hasFocus: boolean) => void;
+  gridLabelId?: string;
 }

--- a/packages/x-date-pickers/src/MonthCalendar/PickersMonth.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/PickersMonth.tsx
@@ -16,6 +16,7 @@ export interface ExportedPickersMonthProps {
 
 export interface PickersMonthProps extends ExportedPickersMonthProps {
   'aria-current'?: React.AriaAttributes['aria-current'];
+  'aria-label'?: React.AriaAttributes['aria-label'];
   autoFocus: boolean;
   children: React.ReactNode;
   disabled?: boolean;
@@ -120,6 +121,7 @@ export const PickersMonth = React.memo(function PickersMonth(inProps: PickersMon
     onFocus,
     onBlur,
     'aria-current': ariaCurrent,
+    'aria-label': ariaLabel,
     // We don't want to forward this prop to the root element
     monthsPerRow,
     ...other
@@ -140,8 +142,11 @@ export const PickersMonth = React.memo(function PickersMonth(inProps: PickersMon
         ref={ref}
         disabled={disabled}
         type="button"
+        role="radio"
         tabIndex={disabled ? -1 : tabIndex}
         aria-current={ariaCurrent}
+        aria-checked={selected}
+        aria-label={ariaLabel}
         onClick={(event) => onClick(event, value)}
         onKeyDown={(event) => onKeyDown(event, value)}
         onFocus={(event) => onFocus(event, value)}

--- a/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
@@ -11,7 +11,7 @@ describe('<MonthCalendar />', () => {
   it('should allow to pick month standalone by click, `Enter` and `Space`', () => {
     const onChange = spy();
     render(<MonthCalendar value={adapterToUse.date(new Date(2019, 1, 2))} onChange={onChange} />);
-    const targetMonth = screen.getByRole('button', { name: 'Feb' });
+    const targetMonth = screen.getByRole('radio', { name: 'February' });
 
     // A native button implies Enter and Space keydown behavior
     // These keydown events only trigger click behavior if they're trusted (programmatically dispatched events aren't trusted).
@@ -30,7 +30,7 @@ describe('<MonthCalendar />', () => {
     const onChange = spy();
     render(<MonthCalendar onChange={onChange} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Feb' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'February' }));
 
     expect(onChange.callCount).to.equal(1);
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2019, 1, 1, 0, 0, 0));
@@ -79,7 +79,7 @@ describe('<MonthCalendar />', () => {
         />,
       );
 
-      screen.getAllByRole('button').forEach((monthButton) => {
+      screen.getAllByRole('radio').forEach((monthButton) => {
         expect(monthButton).to.have.attribute('disabled');
         fireEvent.click(monthButton);
         expect(onChange.callCount).to.equal(0);

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
@@ -55,7 +55,7 @@ describe('<MonthCalendar /> - Describes', () => {
       const newValue = adapterToUse.addMonths(value, 1);
 
       userEvent.mousePress(
-        screen.getByRole('button', { name: adapterToUse.format(newValue, 'monthShort') }),
+        screen.getByRole('radio', { name: adapterToUse.format(newValue, 'month') }),
       );
 
       return newValue;

--- a/packages/x-date-pickers/src/YearCalendar/PickersYear.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/PickersYear.tsx
@@ -143,8 +143,10 @@ export const PickersYear = React.memo(function PickersYear(inProps: PickersYearP
         ref={ref}
         disabled={disabled}
         type="button"
+        role="radio"
         tabIndex={disabled ? -1 : tabIndex}
         aria-current={ariaCurrent}
+        aria-checked={selected}
         onClick={(event) => onClick(event, value)}
         onKeyDown={(event) => onKeyDown(event, value)}
         onFocus={(event) => onFocus(event, value)}

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -99,6 +99,7 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
     onFocusedViewChange,
     yearsPerRow = 3,
     timezone: timezoneProp,
+    gridLabelId,
     ...other
   } = props;
 
@@ -275,6 +276,8 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
       ref={handleRef}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
+      role="radiogroup"
+      aria-labelledby={gridLabelId}
       {...other}
     >
       {utils.getYearRange(minDate, maxDate).map((year) => {

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -346,6 +346,7 @@ YearCalendar.propTypes = {
    * @default false
    */
   disablePast: PropTypes.bool,
+  gridLabelId: PropTypes.string,
   hasFocus: PropTypes.bool,
   /**
    * Maximal selectable date.

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.types.ts
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.types.ts
@@ -63,4 +63,5 @@ export interface YearCalendarProps<TDate>
   onYearFocus?: (year: number) => void;
   hasFocus?: boolean;
   onFocusedViewChange?: (hasFocus: boolean) => void;
+  gridLabelId?: string;
 }

--- a/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
@@ -11,7 +11,7 @@ describe('<YearCalendar />', () => {
   it('allows to pick year standalone by click, `Enter` and `Space`', () => {
     const onChange = spy();
     render(<YearCalendar value={adapterToUse.date(new Date(2019, 1, 2))} onChange={onChange} />);
-    const targetYear = screen.getByRole('button', { name: '2025' });
+    const targetYear = screen.getByRole('radio', { name: '2025' });
 
     // A native button implies Enter and Space keydown behavior
     // These keydown events only trigger click behavior if they're trusted (programmatically dispatched events aren't trusted).
@@ -30,7 +30,7 @@ describe('<YearCalendar />', () => {
     const onChange = spy();
     render(<YearCalendar onChange={onChange} />);
 
-    fireEvent.click(screen.getByRole('button', { name: '2025' }));
+    fireEvent.click(screen.getByRole('radio', { name: '2025' }));
 
     expect(onChange.callCount).to.equal(1);
     expect(onChange.args[0][0]).toEqualDateTime(new Date(2025, 0, 1, 0, 0, 0, 0));
@@ -45,7 +45,7 @@ describe('<YearCalendar />', () => {
         readOnly
       />,
     );
-    const targetYear = screen.getByRole('button', { name: '2025' });
+    const targetYear = screen.getByRole('radio', { name: '2025' });
     expect(targetYear.tagName).to.equal('BUTTON');
 
     fireEvent.click(targetYear);
@@ -64,7 +64,7 @@ describe('<YearCalendar />', () => {
         />,
       );
 
-      screen.getAllByRole('button').forEach((monthButton) => {
+      screen.getAllByRole('radio').forEach((monthButton) => {
         expect(monthButton).to.have.attribute('disabled');
         fireEvent.click(monthButton);
         expect(onChange.callCount).to.equal(0);
@@ -144,7 +144,7 @@ describe('<YearCalendar />', () => {
       />,
     );
 
-    const button2019 = screen.getByRole('button', { name: '2019' });
+    const button2019 = screen.getByRole('radio', { name: '2019' });
 
     act(() => button2019.focus());
     fireEvent.keyDown(button2019, { key: 'ArrowLeft' });

--- a/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
@@ -52,7 +52,7 @@ describe('<YearCalendar /> - Describes', () => {
     setNewValue: (value) => {
       const newValue = adapterToUse.addYears(value, 1);
       userEvent.mousePress(
-        screen.getByRole('button', { name: adapterToUse.getYear(newValue).toString() }),
+        screen.getByRole('radio', { name: adapterToUse.getYear(newValue).toString() }),
       );
 
       return newValue;


### PR DESCRIPTION
Fixes #9916 
Fixes #10141

I've looked into replicating the role structure that the DayCalendar has and it seems that it's not really possible without a breaking change.
The structure needs to include a `grid -> row -> cell` structure to work properly.
We can't introduce such a structure without a breaking change, because that would change the DOM structure and possibly impact someone depending on the current structure.

The simplest and still logical solution seemed to use `radiogroup` role as the behavior of the `YearCalendar` and `MonthCalendar` components is essentially just that - a group of radio buttons from which only one can be selected at a time.

## Important note
I've looked into all possible solutions I could think of that would avoid a **breaking change** (not changing the role) but to no avail.
Essentially, our existing structure and given roles are incorrect and impossible to fix without any breaking change.
IMHO, this **breaking change** is the least we could do. The other change would also involve changing the DOM structure, which could end up being a more annoying change as compared to just a role change.
What do you think, is it a justifiable compromise for shipping within a minor release?

# Changelog
The `YearCalendar` and `MonthCalendar` items role has been changed from `button` to `radio` in order to improve the component's a11y support.
If you were relying on the mentioned components having a `button` role for items, you will need to update your usage to expect a `radio` role instead.