### PR TITLE
[docs] Fix image layout shift

### DIFF
--- a/docs/data/introduction/licensing/licensing.md
+++ b/docs/data/introduction/licensing/licensing.md
@@ -261,10 +261,10 @@ This error indicates that your license key is missing. You might not be allowed 
 The component will look something like this:
 
 <div class="only-light-mode">
-  <img src="/static/x/watermark-light.png" style="width: 653px; margin-bottom: 2rem;" alt="" loading="lazy">
+  <img src="/static/x/watermark-light.png" width="1306" height="536" style="width: 653px; margin-bottom: 2rem;" alt="" loading="lazy">
 </div>
 <div class="only-dark-mode">
-  <img src="/static/x/watermark-dark.png" style="width: 645px; margin-bottom: 2rem;" alt="" loading="lazy">
+  <img src="/static/x/watermark-dark.png" width="1290" height="548" style="width: 645px; margin-bottom: 2rem;" alt="" loading="lazy">
 </div>
 
 To solve the issue, you can check the [free trial conditions](#evaluation-trial-licenses), if you are eligible no actions are required.


### PR DESCRIPTION
Fix https://mui.com/x/introduction/licensing/#1-missing-license-key layout shift when loading.

---

**Off-topic** for @mui/docs-infra and @Janpot who worked a bit on the problem in the past.

We could likely solve this at the route by adding the width and height property right from the `parseMarkdown` file. It runs in a webpack loader. I mean, I guess we could use https://www.npmjs.com/package/image-size like Next.js does https://www.notion.so/mui-org/Docs-infra-Images-solution-30e78dbf24744ed5b570027656139092?pvs=4#ce8c7d593c9746e1aed59a5409f2a81b. I think this could also apply to `DocsImage.tsx` if we make it built-in. 

I would want to benchmark this though, I hope reading images in the filesystem isn't too slow. Because otherwise, we could do this in a script, so it gets cashed. But since we would want to run the script in the CI to make sure it's not out of date, I imagine it would slow the CI to, so there is no escape 😁