### PR TITLE
[charts] Add default `barGapRatio` and increase `categoryGapRatio`

### DIFF
--- a/docs/data/charts/bar-demo/PositiveAndNegativeBarChart.js
+++ b/docs/data/charts/bar-demo/PositiveAndNegativeBarChart.js
@@ -33,8 +33,6 @@ export default function PositiveAndNegativeBarChart() {
         {
           data: xLabels,
           scaleType: 'band',
-          categoryGapRatio: 0.2,
-          barGapRatio: 0.1,
         },
       ]}
       yAxis={[{ max: 10000 }]}

--- a/docs/data/charts/bar-demo/PositiveAndNegativeBarChart.tsx
+++ b/docs/data/charts/bar-demo/PositiveAndNegativeBarChart.tsx
@@ -34,8 +34,6 @@ export default function PositiveAndNegativeBarChart() {
         {
           data: xLabels,
           scaleType: 'band',
-          categoryGapRatio: 0.2,
-          barGapRatio: 0.1,
         } as Omit<AxisConfig, 'id'>,
       ]}
       yAxis={[{ max: 10000 }]}

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -35,7 +35,8 @@ export type CartesianContextProviderProps = {
   children: React.ReactNode;
 };
 
-const DEFAULT_CATEGORY_GAP_RATIO = 0.1;
+const DEFAULT_CATEGORY_GAP_RATIO = 0.2;
+const DEFAULT_BAR_GAP_RATIO = 0.1;
 
 // TODO: those might be better placed in a distinct file
 const xExtremumGetters: { [T in CartesianChartSeriesType]: ExtremumGetter<T> } = {
@@ -174,9 +175,10 @@ function CartesianContextProvider({
 
       if (isBandScaleConfig(axis)) {
         const categoryGapRatio = axis.categoryGapRatio ?? DEFAULT_CATEGORY_GAP_RATIO;
+        const barGapRatio = axis.barGapRatio ?? DEFAULT_BAR_GAP_RATIO;
         completedXAxis[axis.id] = {
           categoryGapRatio,
-          barGapRatio: 0,
+          barGapRatio,
           ...axis,
           scale: scaleBand(axis.data!, range)
             .paddingInner(categoryGapRatio)

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -121,13 +121,13 @@ interface AxisScaleConfig {
     /**
      * The ratio between the space allocated for padding between two categories and the category width.
      * 0 means no gap, and 1 no data.
-     * @default 0.1
+     * @default 0.2
      */
     categoryGapRatio: number;
     /**
      * The ratio between the width of a bar, and the gap between two bars.
      * 0 means no gap, and 1 no bar.
-     * @default 0
+     * @default 0.1
      */
     barGapRatio: number;
   };


### PR DESCRIPTION
Fixes #10196 

Also, increase the `categoryGapRatio` to `0.2` from `0.1` as the current default seems somewhat cramped. 🤷

Preview: https://deploy-preview-10317--material-ui-x.netlify.app/x/react-charts/bars/#basics 