### PR TITLE
[datagrid] Hide `eval` from bundlers

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -25,6 +25,7 @@ import {
   gridVisibleColumnFieldsSelector,
 } from '../columns';
 
+// Fixes https://github.com/mui/mui-x/issues/10056
 const global = (typeof window === 'undefined' ? globalThis : window) as any;
 const evalCode = global[atob('ZXZhbA==')] as <T>(source: string) => T;
 

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -306,7 +306,7 @@ export const buildAggregatedFilterItemsApplier = (
   );
   const filterItem: GridFilterItemApplierNotAggregated = (row, shouldApplyItem) => {
     return filterItemCore(appliers, row, shouldApplyItem);
-  }
+  };
   filterItemsApplierId += 1;
 
   return filterItem;


### PR DESCRIPTION
Fixes #10056 

Hide `eval` calls so bundlers can minify.

| Before | After |
| --- | --- |
| ![Screenshot from 2023-09-13 07-20-32](https://github.com/mui/mui-x/assets/1423607/4ffa4e2e-2f42-44e0-94dc-330f06537eae) | ![Screenshot from 2023-09-13 07-19-44](https://github.com/mui/mui-x/assets/1423607/2696a019-e0b4-47bc-8dc8-4d3521c4832f) |