### PR TITLE
[renovate] Monthly schedule for lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -99,5 +99,9 @@
   "prHourlyLimit": 0,
   "rangeStrategy": "bump",
   "schedule": "on sunday before 6:00am",
-  "timezone": "UTC"
+  "timezone": "UTC",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": "before 6:00am on the first day of the month"
+  }
 }


### PR DESCRIPTION
This rule is enabled on MUI core and Toolpad repositories. I'm proposing to bring X in line. This adds a monthly [renovatebot PR with recreated lockfile](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance). The goal is to regularly bring all transitive dependencies up to date. It will be especially intersting around the docs to keep transitive dependencies relatively up to date as many of them are implicitly shared between the repositories.

Note for reviewers: The maintenance burden of closing the resulting PRs will stay with the X team, not the code infra team.