### PR TITLE
[DataGridPro] Make default filter items have stable references in header filters

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -42,6 +42,8 @@ const GridHeaderFilterRow = styled('div', {
   display: 'flex',
 }));
 
+const filterItemsCache: Record<GridStateColDef['field'], GridFilterItem> = Object.create(null);
+
 export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   const apiRef = useGridPrivateApiContext();
   const { headerGroupingMaxDepth, hasOtherElementInTabSequence } = props;
@@ -55,7 +57,6 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
       hasOtherElementInTabSequence || columnHeaderFilterTabIndexState !== null,
   });
   const headerFiltersRef = React.useRef<HTMLDivElement>(null);
-  const filterItemsRef = React.useRef<Map<GridStateColDef['field'], GridFilterItem>>(new Map());
   apiRef.current.register('private', {
     headerFiltersElementRef: headerFiltersRef,
   });
@@ -83,14 +84,14 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         // there's a valid `filterModelItem` for this column
         return filterModelItem;
       }
-      const defaultCachedItem = filterItemsRef.current.get(colDef.field);
+      const defaultCachedItem = filterItemsCache[colDef.field];
       if (defaultCachedItem != null) {
         // there's a cached `defaultItem` for this column
         return defaultCachedItem;
       }
       // there's no cached `defaultItem` for this column, let's generate one and cache it
       const defaultItem = getGridFilter(colDef);
-      filterItemsRef.current.set(colDef.field, defaultItem);
+      filterItemsCache[colDef.field] = defaultItem;
       return defaultItem;
     },
     [filterModel],


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #10325 
- Before: https://codesandbox.io/s/musing-lake-9ltjdm?file=/Demo.tsx
- After: https://codesandbox.io/s/trusting-ellis-rlqrm3

The bug surfaced after https://github.com/mui/mui-x/pull/9712, the reason is the same as in https://github.com/mui/mui-x/issues/8119, i.e. till a valid filter item is defined for a column, a new default filter item is being generated on every render which is causing the [useEffect](https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx#L58) in the GridFilterItemValue to be called unnecessarily hence removing the first typed character from the header filter.

**Test:** I didn't manage to reproduce the issue, probably it's not re-rendering that often in test env 🤔 