### PR TITLE
[datagrid] Fix typing of GridActionsCellItem

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -8,6 +8,7 @@ import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 export type GridActionsCellItemProps = {
   label: string;
   icon?: React.ReactElement;
+  /** from https://mui.com/material-ui/api/button-base/#ButtonBase-prop-component */
   component?: React.ElementType;
 } & (
   | ({ showInMenu?: false; icon: React.ReactElement } & IconButtonProps)

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -8,6 +8,7 @@ import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 export type GridActionsCellItemProps = {
   label: string;
   icon?: React.ReactElement;
+  component?: React.ElementType;
 } & (
   | ({ showInMenu?: false; icon: React.ReactElement } & IconButtonProps)
   | ({ showInMenu: true } & MenuItemProps)


### PR DESCRIPTION
Fixes #4654

Fix typing, add `component`.

https://github.com/mui/mui-x/issues/4654#issuecomment-1119956263