### PR TITLE
[DataGrid] Refactor `GridMenu` prop `onClickAway` to `onClose`

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,6 +3,8 @@ const fse = require('fs-extra');
 const path = require('path');
 const prettier = require('prettier');
 
+const dangerCommand = process.env.DANGER_COMMAND;
+
 async function reportBundleSize() {
   const snapshotPath = path.join(__dirname, './performance-snapshot.json');
   const prettierConfigPath = path.join(__dirname, './prettier.config.js');
@@ -110,6 +112,14 @@ function addL10nHelpMessage() {
 async function run() {
   addL10nHelpMessage();
   addDeployPreviewUrls();
+
+  switch (dangerCommand) {
+    case 'reportPerformance':
+      await reportBundleSize();
+      break;
+    default:
+      throw new TypeError(`Unrecognized danger command '${dangerCommand}'`);
+  }
 }
 
 run().catch((error) => {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,8 +3,6 @@ const fse = require('fs-extra');
 const path = require('path');
 const prettier = require('prettier');
 
-const dangerCommand = process.env.DANGER_COMMAND;
-
 async function reportBundleSize() {
   const snapshotPath = path.join(__dirname, './performance-snapshot.json');
   const prettierConfigPath = path.join(__dirname, './prettier.config.js');
@@ -112,14 +110,6 @@ function addL10nHelpMessage() {
 async function run() {
   addL10nHelpMessage();
   addDeployPreviewUrls();
-
-  switch (dangerCommand) {
-    case 'reportPerformance':
-      await reportBundleSize();
-      break;
-    default:
-      throw new TypeError(`Unrecognized danger command '${dangerCommand}'`);
-  }
 }
 
 run().catch((error) => {

--- a/packages/grid/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenu.tsx
+++ b/packages/grid/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenu.tsx
@@ -59,7 +59,7 @@ function GridHeaderFilterMenu({
       placement="bottom-end"
       open={open}
       target={target}
-      onClickAway={hideMenu}
+      onClose={hideMenu}
       onExited={hideMenu}
     >
       <MenuList aria-labelledby={labelledBy} id={id} onKeyDown={handleListKeyDown}>

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -215,11 +215,11 @@ function GridActionsCell(props: GridActionsCellProps) {
 
       {menuButtons.length > 0 && (
         <GridMenu
-          onClickAway={hideMenu}
-          onClick={hideMenu}
           open={open}
           target={buttonRef.current}
           position={position}
+          onClose={hideMenu}
+          onClick={hideMenu}
         >
           <MenuList
             id={menuId}

--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -53,7 +53,7 @@ const GridMenuRoot = styled(Popper, {
 export interface GridMenuProps extends Omit<PopperProps, 'onKeyDown' | 'children'> {
   open: boolean;
   target: HTMLElement | null;
-  onClickAway: ClickAwayListenerProps['onClickAway'];
+  onClose: (event?: Event) => void;
   position?: MenuPosition;
   onExited?: GrowProps['onExited'];
   children: React.ReactNode;
@@ -65,7 +65,7 @@ const transformOrigin = {
 };
 
 function GridMenu(props: GridMenuProps) {
-  const { open, target, onClickAway, children, position, className, onExited, ...other } = props;
+  const { open, target, onClose, children, position, className, onExited, ...other } = props;
   const apiRef = useGridApiContext();
   const rootProps = useGridRootProps();
   const classes = useUtilityClasses(rootProps);
@@ -86,6 +86,13 @@ function GridMenu(props: GridMenuProps) {
     }
   };
 
+  const handleClickAway: ClickAwayListenerProps['onClickAway'] = (event) => {
+    if (event.target && (target === event.target || target?.contains(event.target as Node))) {
+      return;
+    }
+    onClose(event);
+  };
+
   return (
     <GridMenuRoot
       as={rootProps.slots.basePopper}
@@ -99,7 +106,7 @@ function GridMenu(props: GridMenuProps) {
       {...rootProps.slotProps?.basePopper}
     >
       {({ TransitionProps, placement }) => (
-        <ClickAwayListener onClickAway={onClickAway} mouseEvent="onMouseDown">
+        <ClickAwayListener onClickAway={handleClickAway} mouseEvent="onMouseDown">
           <Grow
             {...TransitionProps}
             style={{ transformOrigin: transformOrigin[placement as keyof typeof transformOrigin] }}
@@ -119,7 +126,7 @@ GridMenu.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   children: PropTypes.node,
-  onClickAway: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   onExited: PropTypes.func,
   /**
    * If `true`, the component is shown.

--- a/packages/grid/x-data-grid/src/components/menu/columnMenu/GridColumnHeaderMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/columnMenu/GridColumnHeaderMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { HTMLElementType } from '@mui/utils';
+import { unstable_useEventCallback as useEventCallback, HTMLElementType } from '@mui/utils';
 import { useGridApiContext } from '../../../hooks/utils/useGridApiContext';
 import { GridMenu, GridMenuProps } from '../GridMenu';
 
@@ -28,17 +28,17 @@ function GridColumnHeaderMenu({
   const apiRef = useGridApiContext();
   const colDef = apiRef.current.getColumn(field);
 
-  const hideMenu = React.useCallback(
-    (event: MouseEvent | TouchEvent) => {
+  const hideMenu = useEventCallback((event?: Event) => {
+    if (event) {
       // Prevent triggering the sorting
       event.stopPropagation();
 
-      if (!target?.contains(event.target as HTMLElement)) {
-        apiRef.current.hideColumnMenu();
+      if (target?.contains(event.target as HTMLElement)) {
+        return;
       }
-    },
-    [apiRef, target],
-  );
+    }
+    apiRef.current.hideColumnMenu();
+  });
 
   if (!target || !colDef) {
     return null;
@@ -49,7 +49,7 @@ function GridColumnHeaderMenu({
       placement={`bottom-${colDef!.align === 'right' ? 'start' : 'end'}` as any}
       open={open}
       target={target}
-      onClickAway={hideMenu}
+      onClose={hideMenu}
       onExited={onExited}
     >
       <ContentComponent

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
@@ -10,7 +10,7 @@ import { isHideMenuKey, isTabKey } from '../../utils/keyboardUtils';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridSelector } from '../../hooks/utils/useGridSelector';
 import { GridDensityOption } from '../../models/api/gridDensityApi';
-import { GridMenu, GridMenuProps } from '../menu/GridMenu';
+import { GridMenu } from '../menu/GridMenu';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { gridClasses } from '../../constants/gridClasses';
 
@@ -60,14 +60,7 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
       setOpen((prevOpen) => !prevOpen);
       onClick?.(event);
     };
-    const handleDensitySelectorClickAway: GridMenuProps['onClickAway'] = (event) => {
-      if (
-        buttonRef.current === event.target ||
-        // if user clicked on the icon
-        buttonRef.current?.contains(event.target as Element)
-      ) {
-        return;
-      }
+    const handleDensitySelectorClose = () => {
       setOpen(false);
     };
     const handleDensityUpdate = (newDensity: GridDensity) => {
@@ -120,7 +113,7 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
         <GridMenu
           open={open}
           target={buttonRef.current}
-          onClickAway={handleDensitySelectorClickAway}
+          onClose={handleDensitySelectorClose}
           position="bottom-start"
         >
           <MenuList

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -4,7 +4,7 @@ import MenuList from '@mui/material/MenuList';
 import { ButtonProps } from '@mui/material/Button';
 import { isHideMenuKey, isTabKey } from '../../utils/keyboardUtils';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
-import { GridMenu, GridMenuProps } from '../menu/GridMenu';
+import { GridMenu } from '../menu/GridMenu';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { gridClasses } from '../../constants/gridClasses';
 
@@ -37,17 +37,6 @@ export const GridToolbarExportContainer = React.forwardRef<HTMLButtonElement, Bu
       }
     };
 
-    const handleMenuClickAway: GridMenuProps['onClickAway'] = (event) => {
-      if (
-        buttonRef.current === event.target ||
-        // if user clicked on the icon
-        buttonRef.current?.contains(event.target as Element)
-      ) {
-        return;
-      }
-      setOpen(false);
-    };
-
     if (children == null) {
       return null;
     }
@@ -72,7 +61,7 @@ export const GridToolbarExportContainer = React.forwardRef<HTMLButtonElement, Bu
         <GridMenu
           open={open}
           target={buttonRef.current}
-          onClickAway={handleMenuClickAway}
+          onClose={handleMenuClose}
           position="bottom-start"
         >
           <MenuList


### PR DESCRIPTION
I noticed all our usages of `GridMenu` use the same logic, so it's easier to centralize.

Following an exploration done for #10241 but unrelated.
