### PR TITLE
[DataGrid] Restore focus after `GridMenu` closes

### DIFF
--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -73,7 +73,8 @@ function GridMenu(props: GridMenuProps) {
   const savedFocusRef = React.useRef<HTMLElement | null>(null);
   React.useEffect(() => {
     if (open) {
-      savedFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      savedFocusRef.current =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
     } else {
       savedFocusRef.current?.focus?.();
       savedFocusRef.current = null;

--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import ClickAwayListener, { ClickAwayListenerProps } from '@mui/material/ClickAwayListener';
-import { unstable_composeClasses as composeClasses, HTMLElementType } from '@mui/utils';
+import {
+  unstable_composeClasses as composeClasses,
+  unstable_useEnhancedEffect as useEnhancedEffect,
+  HTMLElementType,
+} from '@mui/utils';
 import Grow, { GrowProps } from '@mui/material/Grow';
 import Paper from '@mui/material/Paper';
 import Popper, { PopperProps } from '@mui/material/Popper';
@@ -71,7 +75,7 @@ function GridMenu(props: GridMenuProps) {
   const classes = useUtilityClasses(rootProps);
 
   const savedFocusRef = React.useRef<HTMLElement | null>(null);
-  React.useEffect(() => {
+  useEnhancedEffect(() => {
     if (open) {
       savedFocusRef.current =
         document.activeElement instanceof HTMLElement ? document.activeElement : null;

--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -70,6 +70,19 @@ function GridMenu(props: GridMenuProps) {
   const rootProps = useGridRootProps();
   const classes = useUtilityClasses(rootProps);
 
+  const previousOpenRef = React.useRef(open);
+  const savedFocusRef = React.useRef<HTMLElement | null>(null);
+
+  if (previousOpenRef.current !== open) {
+    previousOpenRef.current = open;
+    if (open) {
+      savedFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    } else {
+      savedFocusRef.current?.focus?.();
+      savedFocusRef.current = null;
+    }
+  }
+
   React.useEffect(() => {
     // Emit menuOpen or menuClose events
     const eventName = open ? 'menuOpen' : 'menuClose';

--- a/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/grid/x-data-grid/src/components/menu/GridMenu.tsx
@@ -70,18 +70,15 @@ function GridMenu(props: GridMenuProps) {
   const rootProps = useGridRootProps();
   const classes = useUtilityClasses(rootProps);
 
-  const previousOpenRef = React.useRef(open);
   const savedFocusRef = React.useRef<HTMLElement | null>(null);
-
-  if (previousOpenRef.current !== open) {
-    previousOpenRef.current = open;
+  React.useEffect(() => {
     if (open) {
       savedFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     } else {
       savedFocusRef.current?.focus?.();
       savedFocusRef.current = null;
     }
-  }
+  }, [open]);
 
   React.useEffect(() => {
     // Emit menuOpen or menuClose events


### PR DESCRIPTION
Closes #10241

Restore focus after the grid menu closes. Not sure about this implementation, read the comment below & the issue above.