### PR TITLE
[docs] Fix mobile scrollbar column resize

### DIFF
--- a/docs/data/data-grid/column-dimensions/ColumnAutosizing.js
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizing.js
@@ -70,10 +70,12 @@ export default function ColumnAutosizing() {
   return (
     <div style={{ width: '100%' }}>
       <Stack
-        spacing={2}
+        spacing={1}
         direction="row"
         alignItems="center"
-        sx={{ marginBottom: '1em' }}
+        sx={{ mb: 1 }}
+        useFlexGap
+        flexWrap="wrap"
       >
         <Button
           variant="outlined"
@@ -82,6 +84,7 @@ export default function ColumnAutosizing() {
           Autosize columns
         </Button>
         <FormControlLabel
+          sx={{ ml: 0 }}
           control={
             <Checkbox
               checked={includeHeaders}
@@ -91,6 +94,7 @@ export default function ColumnAutosizing() {
           label="Include headers"
         />
         <FormControlLabel
+          sx={{ ml: 0 }}
           control={
             <Checkbox
               checked={includeOutliers}
@@ -107,6 +111,7 @@ export default function ColumnAutosizing() {
           sx={{ width: '12ch' }}
         />
         <FormControlLabel
+          sx={{ ml: 0 }}
           control={
             <Checkbox
               checked={expand}

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizing.tsx
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizing.tsx
@@ -73,10 +73,12 @@ export default function ColumnAutosizing() {
   return (
     <div style={{ width: '100%' }}>
       <Stack
-        spacing={2}
+        spacing={1}
         direction="row"
         alignItems="center"
-        sx={{ marginBottom: '1em' }}
+        sx={{ mb: 1 }}
+        useFlexGap
+        flexWrap="wrap"
       >
         <Button
           variant="outlined"
@@ -85,6 +87,7 @@ export default function ColumnAutosizing() {
           Autosize columns
         </Button>
         <FormControlLabel
+          sx={{ ml: 0 }}
           control={
             <Checkbox
               checked={includeHeaders}
@@ -94,6 +97,7 @@ export default function ColumnAutosizing() {
           label="Include headers"
         />
         <FormControlLabel
+          sx={{ ml: 0 }}
           control={
             <Checkbox
               checked={includeOutliers}
@@ -110,6 +114,7 @@ export default function ColumnAutosizing() {
           sx={{ width: '12ch' }}
         />
         <FormControlLabel
+          sx={{ ml: 0 }}
           control={
             <Checkbox
               checked={expand}


### PR DESCRIPTION
A quick follow-up on #10180. Fix a scrollbar on the page on mobile.

before https://deploy-preview-10180--material-ui-x.netlify.app/x/react-data-grid/column-dimensions/#autosizing

<img width="400" alt="Screenshot 2023-09-24 at 16 47 35" src="https://github.com/mui/mui-x/assets/3165635/25320906-6b04-46ed-b48e-2ed173ee046b">

after https://deploy-preview-10455--material-ui-x.netlify.app/x/react-data-grid/column-dimensions/#autosizing

<img width="400" alt="Screenshot 2023-09-24 at 16 48 16" src="https://github.com/mui/mui-x/assets/3165635/6c13a830-bf41-427e-b6b9-aa7912c7de21">
