### PR TITLE
[DataGrid] Rename `global` to `globalScope` due to Jest issue

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -26,8 +26,8 @@ import {
 } from '../columns';
 
 // Fixes https://github.com/mui/mui-x/issues/10056
-const global = (typeof window === 'undefined' ? globalThis : window) as any;
-const evalCode = global[atob('ZXZhbA==')] as <T>(source: string) => T;
+const globalScope = (typeof window === 'undefined' ? globalThis : window) as any;
+const evalCode = globalScope[atob('ZXZhbA==')] as <T>(source: string) => T;
 
 let hasEval: boolean;
 try {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/10056#issuecomment-1734121108

Jest already has a variable named `global` in scope in their build process and it prevents code from reusing that name.

NOTE: AUTO-MERGE ENABLED