### PR TITLE
[DataGrid] Fix autosize missing a few pixels

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -1070,6 +1070,7 @@
       "aggregationColumnHeader--alignRight",
       "aggregationColumnHeaderLabel",
       "autoHeight",
+      "autosizing",
       "booleanCell",
       "cell--editable",
       "cell--editing",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -991,6 +991,7 @@
       "aggregationColumnHeader--alignRight",
       "aggregationColumnHeaderLabel",
       "autoHeight",
+      "autosizing",
       "booleanCell",
       "cell--editable",
       "cell--editing",

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -840,6 +840,7 @@
       "aggregationColumnHeader--alignRight",
       "aggregationColumnHeaderLabel",
       "autoHeight",
+      "autosizing",
       "booleanCell",
       "cell--editable",
       "cell--editing",

--- a/docs/translations/api-docs/data-grid/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium.json
@@ -987,6 +987,10 @@
       "nodeName": "the root element",
       "conditions": "<code>autoHeight={true}</code>"
     },
+    "autosizing": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the root element while it is being autosized"
+    },
     "booleanCell": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the icon of the boolean cell"

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -885,6 +885,10 @@
       "nodeName": "the root element",
       "conditions": "<code>autoHeight={true}</code>"
     },
+    "autosizing": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the root element while it is being autosized"
+    },
     "booleanCell": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the icon of the boolean cell"

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -670,6 +670,10 @@
       "nodeName": "the root element",
       "conditions": "<code>autoHeight={true}</code>"
     },
+    "autosizing": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the root element while it is being autosized"
+    },
     "booleanCell": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the icon of the boolean cell"

--- a/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -203,6 +203,9 @@ function extractColumnWidths(
 ) {
   const widthByField = {} as Record<string, number>;
 
+  const root = apiRef.current.rootElementRef!.current!;
+  root.classList.add(gridClasses.autosizing);
+
   columns.forEach((column) => {
     const cells = findGridCells(apiRef.current, column.field);
 
@@ -214,7 +217,7 @@ function extractColumnWidths(
       }
       const style = window.getComputedStyle(cell, null);
       const paddingWidth = parseInt(style.paddingLeft, 10) + parseInt(style.paddingRight, 10);
-      const contentWidth = (cell.firstElementChild?.scrollWidth ?? -1) + 1;
+      const contentWidth = cell.firstElementChild?.getBoundingClientRect().width ?? 0;
       return paddingWidth + contentWidth;
     });
 
@@ -247,6 +250,8 @@ function extractColumnWidths(
 
     widthByField[column.field] = clamp(maxContent, min, max);
   });
+
+  root.classList.remove(gridClasses.autosizing);
 
   return widthByField;
 }

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -485,13 +485,13 @@ describe('<DataGridPro /> - Columns', () => {
         await autosize({ includeHeaders: true }, [155, 177]);
       });
       it('.includeOutliers works', async () => {
-        await autosize({ includeOutliers: true }, [50, 145]);
+        await autosize({ includeOutliers: true }, [50, 144]);
       });
       it('.outliersFactor works', async () => {
-        await autosize({ outliersFactor: 40 }, [50, 145]);
+        await autosize({ outliersFactor: 40 }, [50, 144]);
       });
       it('.expand works', async () => {
-        await autosize({ expand: true }, [134, 149]);
+        await autosize({ expand: true }, [134, 148]);
       });
     });
   });

--- a/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/grid/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -56,6 +56,7 @@ export const GridRootStyles = styled('div', {
       [`&.${gridClasses['root--disableUserSelection']} .${gridClasses.cell}`]:
         styles['root--disableUserSelection'],
     },
+    { [`&.${gridClasses.autosizing}`]: styles.autosizing },
     { [`& .${gridClasses.editBooleanCell}`]: styles.editBooleanCell },
     { [`& .${gridClasses['cell--editing']}`]: styles['cell--editing'] },
     { [`& .${gridClasses['cell--textCenter']}`]: styles['cell--textCenter'] },
@@ -148,6 +149,14 @@ export const GridRootStyles = styled('div', {
       height: 'auto',
       [`& .${gridClasses['row--lastVisible']} .${gridClasses.cell}`]: {
         borderBottomColor: 'transparent',
+      },
+    },
+    [`&.${gridClasses.autosizing}`]: {
+      [`& .${gridClasses.columnHeaderTitleContainerContent} > *`]: {
+        overflow: 'visible !important',
+      },
+      [`& .${gridClasses.cell} > *`]: {
+        overflow: 'visible !important',
       },
     },
     [`& .${gridClasses['virtualScrollerContent--overflowed']} .${gridClasses['row--lastVisible']} .${gridClasses.cell}`]:

--- a/packages/grid/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/grid/x-data-grid/src/constants/gridClasses.ts
@@ -33,6 +33,10 @@ export interface GridClasses {
    */
   autoHeight: string;
   /**
+   * Styles applied to the root element while it is being autosized.
+   */
+  autosizing: string;
+  /**
    * Styles applied to the icon of the boolean cell.
    */
   booleanCell: string;
@@ -546,6 +550,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'aggregationColumnHeader--alignRight',
   'aggregationColumnHeaderLabel',
   'autoHeight',
+  'autosizing',
   'booleanCell',
   'cell--editable',
   'cell--editing',


### PR DESCRIPTION
Closes_ sidenote in https://github.com/mui/mui-x/issues/10456

Use `.getBoundingClientRect` to calculate widths.