### PR TITLE
[core] Update `no-response` workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -24,9 +24,9 @@ jobs:
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: "status: waiting for author's response"
+          responseRequiredLabel: "status: waiting for author"
           # Label to add back when required label is removed
-          optionalFollowupLabel: "status: waiting for maintainer's response"
+          optionalFollowupLabel: "status: waiting for maintainer"
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             The issue has been inactive for 7 days and has been automatically closed.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -18,13 +18,15 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb # v0.5.0
+      - uses: MBilalShafi/no-response-add-label@9657b5bc1e09373e571df54429c3c167edaad556
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: 'status: waiting for follow-up'
+          responseRequiredLabel: "status: waiting for author's response"
+          # Label to add back when required label is removed
+          optionalFollowupLabel: "status: waiting for maintainer's response"
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             The issue has been inactive for 7 days and has been automatically closed.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -24,9 +24,9 @@ jobs:
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: "status: waiting for author"
+          responseRequiredLabel: 'status: waiting for author'
           # Label to add back when required label is removed
-          optionalFollowupLabel: "status: waiting for maintainer"
+          optionalFollowupLabel: 'status: waiting for maintainer'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             The issue has been inactive for 7 days and has been automatically closed.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

A follow-up to the https://github.com/mui/mui-x/pull/10102 as per discussion in https://www.notion.so/mui-org/Improve-support-automation-workflow-c491041115fa4a8e97ef483c8df5bf97?pvs=4
(Currently following approach A as mentioned in the document)

New GitHub action tested on this test repo: https://github.com/MBilalShafi/test-github-action/issues/2

TODOs after PR merge:
- [ ] Rename label `status: waiting for follow-up` -> `status: waiting for author`
- [ ] Rename label `status: needs triage` -> `status: waiting for maintainer`