### PR TITLE
[pickers] Add warning to `shouldDisableDate` validation

### DIFF
--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -108,6 +108,10 @@ If you know that all days of some months are disabled—you can provide the [`sh
 Same with the [`shouldDisableYear`](#disable-specific-years) prop for the `year` view.
 :::
 
+:::info
+Please note that `shouldDisableDate` will execute on every date rendered in the `day` view. Expensive computations in this validation function can impact performance.
+:::
+
 #### Disable specific dates in range components [<span class="pro-premium"></span>](/x/introduction/licensing/#pro-plan)
 
 For components supporting date range edition (`DateRangePicker`, `DateTimeRangePicker` 🚧)—the `shouldDisableDate` prop receives a second argument to differentiate the start and the end date.

--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -108,7 +108,7 @@ If you know that all days of some months are disabled—you can provide the [`sh
 Same with the [`shouldDisableYear`](#disable-specific-years) prop for the `year` view.
 :::
 
-:::info
+:::success
 Please note that `shouldDisableDate` will execute on every date rendered in the `day` view. Expensive computations in this validation function can impact performance.
 :::
 

--- a/docs/translations/api-docs/date-pickers/date-calendar.json
+++ b/docs/translations/api-docs/date-pickers/date-calendar.json
@@ -146,7 +146,7 @@
       "typeDescriptions": { "React.ReactNode": "The node to render when loading." }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-field.json
+++ b/docs/translations/api-docs/date-pickers/date-field.json
@@ -164,7 +164,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-picker.json
@@ -212,7 +212,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-range-calendar.json
+++ b/docs/translations/api-docs/date-pickers/date-range-calendar.json
@@ -148,7 +148,7 @@
       "typeDescriptions": { "React.ReactNode": "The node to render when loading." }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-range-calendar.json
+++ b/docs/translations/api-docs/date-pickers/date-range-calendar.json
@@ -148,7 +148,7 @@
       "typeDescriptions": { "React.ReactNode": "The node to render when loading." }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker.json
@@ -226,7 +226,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker.json
@@ -226,7 +226,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-time-field.json
+++ b/docs/translations/api-docs/date-pickers/date-time-field.json
@@ -208,7 +208,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker.json
@@ -261,7 +261,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-picker.json
@@ -207,7 +207,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
@@ -221,7 +221,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
@@ -221,7 +221,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-time-picker.json
@@ -256,7 +256,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-picker.json
@@ -207,7 +207,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
@@ -221,7 +221,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
@@ -221,7 +221,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-time-picker.json
@@ -256,7 +256,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/multi-input-date-range-field.json
+++ b/docs/translations/api-docs/date-pickers/multi-input-date-range-field.json
@@ -103,7 +103,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/multi-input-date-range-field.json
+++ b/docs/translations/api-docs/date-pickers/multi-input-date-range-field.json
@@ -103,7 +103,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/multi-input-date-time-range-field.json
@@ -147,7 +147,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/multi-input-date-time-range-field.json
@@ -147,7 +147,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/single-input-date-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-range-field.json
@@ -164,7 +164,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/single-input-date-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-range-field.json
@@ -164,7 +164,7 @@
       "typeDescriptions": {}
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/single-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-time-range-field.json
@@ -208,7 +208,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/single-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-time-range-field.json
@@ -208,7 +208,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/static-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-picker.json
@@ -166,7 +166,7 @@
       "typeDescriptions": { "React.ReactNode": "The node to render when loading." }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker.json
@@ -176,7 +176,7 @@
       "typeDescriptions": { "React.ReactNode": "The node to render when loading." }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker.json
@@ -176,7 +176,7 @@
       "typeDescriptions": { "React.ReactNode": "The node to render when loading." }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.<br>Warning: This validation will run on every rendered date. Expensive computations can impact performance.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/docs/translations/api-docs/date-pickers/static-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-time-picker.json
@@ -215,7 +215,7 @@
       }
     },
     "shouldDisableDate": {
-      "description": "Disable specific date.",
+      "description": "Disable specific date.<br>Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.",
       "deprecated": "",
       "typeDescriptions": {
         "day": "The date to test.",

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -749,7 +749,8 @@ DateRangeCalendar.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -748,6 +748,8 @@ DateRangeCalendar.propTypes = {
   renderLoading: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -295,6 +295,8 @@ DateRangePicker.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -296,7 +296,8 @@ DateRangePicker.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -326,7 +326,8 @@ DesktopDateRangePicker.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -325,6 +325,8 @@ DesktopDateRangePicker.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -325,6 +325,8 @@ MobileDateRangePicker.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -326,7 +326,8 @@ MobileDateRangePicker.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
@@ -328,6 +328,8 @@ MultiInputDateRangeField.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
@@ -329,7 +329,8 @@ MultiInputDateRangeField.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
@@ -367,6 +367,8 @@ MultiInputDateTimeRangeField.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
@@ -368,7 +368,8 @@ MultiInputDateTimeRangeField.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -265,6 +265,8 @@ SingleInputDateRangeField.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -266,7 +266,8 @@ SingleInputDateRangeField.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -307,6 +307,8 @@ SingleInputDateTimeRangeField.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -308,7 +308,8 @@ SingleInputDateTimeRangeField.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -246,6 +246,8 @@ StaticDateRangePicker.propTypes = {
   renderLoading: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -247,7 +247,8 @@ StaticDateRangePicker.propTypes = {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/internals/models/dateRange.ts
+++ b/packages/x-date-pickers-pro/src/internals/models/dateRange.ts
@@ -14,6 +14,7 @@ import { RangeFieldSection } from './fields';
 export interface DayRangeValidationProps<TDate> {
   /**
    * Disable specific date.
+   * Warning: This validation will run on every render. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/internals/models/dateRange.ts
+++ b/packages/x-date-pickers-pro/src/internals/models/dateRange.ts
@@ -14,7 +14,8 @@ import { RangeFieldSection } from './fields';
 export interface DayRangeValidationProps<TDate> {
   /**
    * Disable specific date.
-   * Warning: This validation will run on every render. Expensive computations can impact performance.
+   *
+   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers-pro/src/internals/models/dateRange.ts
+++ b/packages/x-date-pickers-pro/src/internals/models/dateRange.ts
@@ -15,7 +15,8 @@ export interface DayRangeValidationProps<TDate> {
   /**
    * Disable specific date.
    *
-   * Warning: This validation will run on every rendered date. Expensive computations can impact performance.
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @param {string} position The date to test, 'start' or 'end'.

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -559,6 +559,9 @@ DateCalendar.propTypes = {
   renderLoading: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/DateField/DateField.tsx
+++ b/packages/x-date-pickers/src/DateField/DateField.tsx
@@ -262,6 +262,9 @@ DateField.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -285,6 +285,9 @@ DatePicker.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
@@ -305,6 +305,9 @@ DateTimeField.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -331,6 +331,9 @@ DateTimePicker.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -325,6 +325,9 @@ DesktopDatePicker.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -413,6 +413,9 @@ DesktopDateTimePicker.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -321,6 +321,9 @@ MobileDatePicker.propTypes = {
   ]),
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -381,6 +381,9 @@ MobileDateTimePicker.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -237,6 +237,9 @@ StaticDatePicker.propTypes = {
   renderLoading: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -295,6 +295,9 @@ StaticDateTimePicker.propTypes = {
   shouldDisableClock: PropTypes.func,
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.

--- a/packages/x-date-pickers/src/internals/models/validation.ts
+++ b/packages/x-date-pickers/src/internals/models/validation.ts
@@ -82,6 +82,9 @@ export interface BaseDateValidationProps<TDate> extends FutureAndPastValidationP
 export interface DayValidationProps<TDate> {
   /**
    * Disable specific date.
+   *
+   * Warning: This function can be called multiple times (e.g. when rendering date calendar, checking if focus can be moved to a certain date, etc.). Expensive computations can impact performance.
+   *
    * @template TDate
    * @param {TDate} day The date to test.
    * @returns {boolean} If `true` the date will be disabled.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Added a line with a warning to the `shouldDisableDate` validation.

Fixes #6787 