### PR TITLE
6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.15.0",
+  "version": "6.16.0",
   "private": true,
   "scripts": {
     "start": "yarn && yarn docs:dev",


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

--- 

It seems during closing #10503 and reopening as #10504 the version change in the root package.json got lost.

This is to fix that