### PR TITLE
[pickers] Improve customization playground examples

### DIFF
--- a/docs/src/modules/components/CustomizationPlayground.tsx
+++ b/docs/src/modules/components/CustomizationPlayground.tsx
@@ -50,9 +50,9 @@ const PlaygroundDemoArea = styled(Box)(() => ({
 
 const PlaygroundConfigArea = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2),
-  backgroundColor: alpha(theme.palette.primary.main, 0.1),
-  borderRadius: theme.shape.borderRadius,
-  boxShadow: theme.shadows[3],
+  backgroundColor: alpha(theme.palette.primary.light, 0.05),
+  border: `1px solid ${grey[200]}`,
+  borderRadius: '4px',
   [theme.breakpoints.down('lg')]: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -299,8 +299,8 @@ const CustomizationPlayground = function CustomizationPlayground({
 
   return (
     <Box sx={{ flexGrow: 1 }}>
-      <BrandingProvider>
-        {selectedDemo && customizationOptions && selectedCustomizationOption && (
+      {selectedDemo && customizationOptions && selectedCustomizationOption && (
+        <BrandingProvider>
           <TabsWrapper>
             <StylingApproachTabs
               onChange={(_e, newValue) => {
@@ -310,28 +310,30 @@ const CustomizationPlayground = function CustomizationPlayground({
               options={customizationOptions}
             />
             {selectedExample && <StylingRecommendation type={selectedExample.type} />}
-          </TabsWrapper>
-        )}
-        <PlaygroundWrapper>
-          <PlaygroundDemoArea>
-            <StyledChild sx={{ width: 'fit-content' }}>
-              {React.Children.map(
-                children,
-                (child) =>
-                  React.isValidElement(child) &&
-                  React.cloneElement(
-                    child,
-                    selectedDemo && selectedCustomizationOption
-                      ? {
-                          ...examples[selectedDemo]?.examples[selectedCustomizationOption]
-                            ?.componentProps,
-                        }
-                      : {},
-                  ),
-              )}
-            </StyledChild>
-          </PlaygroundDemoArea>
-          {shouldBeInteractive && (
+          </TabsWrapper>{' '}
+        </BrandingProvider>
+      )}
+      <PlaygroundWrapper>
+        <PlaygroundDemoArea>
+          <StyledChild sx={{ width: 'fit-content' }}>
+            {React.Children.map(
+              children,
+              (child) =>
+                React.isValidElement(child) &&
+                React.cloneElement(
+                  child,
+                  selectedDemo && selectedCustomizationOption
+                    ? {
+                        ...examples[selectedDemo]?.examples[selectedCustomizationOption]
+                          ?.componentProps,
+                      }
+                    : {},
+                ),
+            )}
+          </StyledChild>
+        </PlaygroundDemoArea>
+        {shouldBeInteractive && (
+          <BrandingProvider>
             <PlaygroundConfigArea>
               <ConfigSectionWrapper>
                 <ConfigLabel gutterBottom>Components</ConfigLabel>
@@ -380,13 +382,13 @@ const CustomizationPlayground = function CustomizationPlayground({
                 </Stack>
               </ConfigSectionWrapper>
             </PlaygroundConfigArea>
-          )}
-        </PlaygroundWrapper>
-
-        {shouldBeInteractive && (
-          <HighlightedCode code={codeExample} language="js" sx={{ overflowX: 'hidden' }} />
+          </BrandingProvider>
         )}
-      </BrandingProvider>
+      </PlaygroundWrapper>
+
+      {shouldBeInteractive && (
+        <HighlightedCode code={codeExample} language="js" sx={{ overflowX: 'hidden' }} />
+      )}
     </Box>
   );
 };

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -270,6 +270,7 @@ const newTheme = (theme) => createTheme({
     return `import { styled } from '@mui/material/styles'\n${code}
 const Styled${componentName} = styled(${componentName})({
   '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
+  }
 }))
 
 export default function StyledPickerContainer() {

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -78,7 +78,7 @@ export function withStyles(
     const defaultTheme = useTheme();
 
     const tokens = {
-      borderRadius: selectedTokens.borderRadius,
+      borderRadius: `${selectedTokens.borderRadius}px`,
       borderColor: DEFAULT_COLORS[selectedTokens.color][500],
       border: `${selectedTokens.borderWidth}px solid`,
       backgroundColor:
@@ -252,19 +252,17 @@ const getCodeExample = ({
 />`;
   } else if (selectedCustomizationOption === 'customTheme') {
     code = `import { createTheme } from '@mui/material/styles'\n${code}
-<ThemeProvider
-  theme={
-    createTheme({
-      components: {
-        Mui${selectedDemo}: {
-          styleOverrides: {
-            ${selectedSlot}: {${getTokensString(7)}
-            }
-          }
+const newTheme = (theme) => createTheme({
+  ...theme,
+  components: {
+    Mui${selectedDemo}: {
+      styleOverrides: {
+        ${selectedSlot}: {${getTokensString(5)}
         }
-    })
-  }
->
+      }
+    }
+})
+<ThemeProvider theme={newTheme}>
   <${componentName}${formatComponentProps(examples.componentProps, 2)} />
 </ThemeProvider>`;
   } else if (selectedCustomizationOption === 'styledComponents') {

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -246,7 +246,7 @@ const getCodeExample = ({
   if (selectedCustomizationOption === 'sxProp') {
     code = `${code}\n<${componentName}${formatComponentProps(examples.componentProps, 1)}
   sx={{
-    '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
+    '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(3)}
     },
   }}
 />`;
@@ -261,6 +261,7 @@ const newTheme = (theme) => createTheme({
         }
       }
     }
+  }
 })
 <ThemeProvider theme={newTheme}>
   <${componentName}${formatComponentProps(examples.componentProps, 2)} />
@@ -268,7 +269,7 @@ const newTheme = (theme) => createTheme({
   } else if (selectedCustomizationOption === 'styledComponents') {
     return `import { styled } from '@mui/material/styles'\n${code}
 const Styled${componentName} = styled(${componentName})({
-  '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(3)}
+  '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
 }))
 
 export default function StyledPickerContainer() {

--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -159,7 +159,7 @@ const PickersCalendarWeekDayLabel = styled(Typography, {
 }));
 
 const PickersCalendarWeekNumberLabel = styled(Typography, {
-  name: 'MuiDayPicker',
+  name: 'MuiDayCalendar',
   slot: 'WeekNumberLabel',
   overridesResolver: (_, styles) => styles.weekNumberLabel,
 })(({ theme }) => ({
@@ -174,7 +174,7 @@ const PickersCalendarWeekNumberLabel = styled(Typography, {
 }));
 
 const PickersCalendarWeekNumber = styled(Typography, {
-  name: 'MuiDayPicker',
+  name: 'MuiDayCalendar',
   slot: 'WeekNumber',
   overridesResolver: (_, styles) => styles.weekNumber,
 })(({ theme }) => ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #10514 

- Fix `weekNumber` and `weekNumberLabel` bug:


https://github.com/mui/mui-x/assets/72460825/49115c87-b008-422a-9ba3-d9b335802854

- Improve custom theme examples to init new theme outside of the `ThemeProvider`
<img width="677" alt="image" src="https://github.com/mui/mui-x/assets/72460825/33bc02f8-4a92-4d3a-abeb-eeb34853ae44">
