### PR TITLE
[docs] Improve custom field input demos readability

### DIFF
--- a/docs/data/date-pickers/custom-field/PickerWithBrowserField.js
+++ b/docs/data/date-pickers/custom-field/PickerWithBrowserField.js
@@ -1,18 +1,9 @@
 import * as React from 'react';
 
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
-import { useSlotProps } from '@mui/base/utils';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
-import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
-import { DateRangeIcon } from '@mui/x-date-pickers/icons';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { unstable_useSingleInputDateRangeField as useSingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import { unstable_useMultiInputDateRangeField as useMultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
 
@@ -37,7 +28,7 @@ const BrowserField = React.forwardRef((props, ref) => {
 
   return (
     <Box
-      sx={{ ...(sx || {}), display: 'flex', alignItems: 'center', flexGrow: 1 }}
+      sx={{ ...(sx || {}), display: 'flex', alignItems: 'center' }}
       id={id}
       ref={handleRef}
     >
@@ -45,166 +36,6 @@ const BrowserField = React.forwardRef((props, ref) => {
       <input disabled={disabled} ref={inputRef} {...other} />
       {endAdornment}
     </Box>
-  );
-});
-
-const BrowserSingleInputDateRangeField = React.forwardRef((props, ref) => {
-  const { slots, slotProps, onAdornmentClick, ...other } = props;
-
-  const { inputRef: externalInputRef, ...textFieldProps } = useSlotProps({
-    elementType: 'input',
-    externalSlotProps: slotProps?.textField,
-    externalForwardedProps: other,
-    ownerState: props,
-  });
-
-  const {
-    ref: inputRef,
-    onClear,
-    clearable,
-    ...fieldProps
-  } = useSingleInputDateRangeField({
-    props: textFieldProps,
-    inputRef: externalInputRef,
-  });
-
-  /* If you don't need a clear button, you can skip the use of this hook */
-  const { InputProps: ProcessedInputProps, fieldProps: processedFieldProps } =
-    useClearableField({
-      onClear,
-      clearable,
-      fieldProps,
-      InputProps: {
-        ...fieldProps.InputProps,
-        endAdornment: (
-          <InputAdornment position="end">
-            <IconButton onClick={onAdornmentClick}>
-              <DateRangeIcon />
-            </IconButton>
-          </InputAdornment>
-        ),
-      },
-      slots,
-      slotProps,
-    });
-
-  return (
-    <BrowserField
-      {...processedFieldProps}
-      ref={ref}
-      style={{
-        minWidth: 300,
-      }}
-      inputRef={inputRef}
-      InputProps={{ ...ProcessedInputProps }}
-    />
-  );
-});
-
-BrowserSingleInputDateRangeField.fieldType = 'single-input';
-
-const BrowserSingleInputDateRangePicker = React.forwardRef((props, ref) => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const toggleOpen = () => setIsOpen((currentOpen) => !currentOpen);
-
-  const handleOpen = () => setIsOpen(true);
-
-  const handleClose = () => setIsOpen(false);
-
-  return (
-    <DateRangePicker
-      ref={ref}
-      {...props}
-      open={isOpen}
-      onClose={handleClose}
-      onOpen={handleOpen}
-      slots={{ field: BrowserSingleInputDateRangeField }}
-      slotProps={{
-        ...props?.slotProps,
-        field: {
-          onAdornmentClick: toggleOpen,
-          ...props?.slotProps?.field,
-        },
-      }}
-    />
-  );
-});
-
-const BrowserMultiInputDateRangeField = React.forwardRef((props, ref) => {
-  const {
-    slotProps,
-    value,
-    defaultValue,
-    format,
-    onChange,
-    readOnly,
-    disabled,
-    onError,
-    shouldDisableDate,
-    minDate,
-    maxDate,
-    disableFuture,
-    disablePast,
-    selectedSections,
-    onSelectedSectionsChange,
-    className,
-  } = props;
-
-  const { inputRef: startInputRef, ...startTextFieldProps } = useSlotProps({
-    elementType: 'input',
-    externalSlotProps: slotProps?.textField,
-    ownerState: { ...props, position: 'start' },
-  });
-
-  const { inputRef: endInputRef, ...endTextFieldProps } = useSlotProps({
-    elementType: 'input',
-    externalSlotProps: slotProps?.textField,
-    ownerState: { ...props, position: 'end' },
-  });
-
-  const {
-    startDate: { ref: startRef, ...startDateProps },
-    endDate: { ref: endRef, ...endDateProps },
-  } = useMultiInputDateRangeField({
-    sharedProps: {
-      value,
-      defaultValue,
-      format,
-      onChange,
-      readOnly,
-      disabled,
-      onError,
-      shouldDisableDate,
-      minDate,
-      maxDate,
-      disableFuture,
-      disablePast,
-      selectedSections,
-      onSelectedSectionsChange,
-    },
-    startTextFieldProps,
-    endTextFieldProps,
-    startInputRef,
-    endInputRef,
-  });
-
-  return (
-    <Stack ref={ref} spacing={2} direction="row" className={className}>
-      <BrowserField {...startDateProps} inputRef={startRef} />
-      <span> — </span>
-      <BrowserField {...endDateProps} inputRef={endRef} />
-    </Stack>
-  );
-});
-
-const BrowserDateRangePicker = React.forwardRef((props, ref) => {
-  return (
-    <DateRangePicker
-      ref={ref}
-      {...props}
-      slots={{ ...props?.slots, field: BrowserMultiInputDateRangeField }}
-    />
   );
 });
 
@@ -254,21 +85,11 @@ const BrowserDatePicker = React.forwardRef((props, ref) => {
 export default function PickerWithBrowserField() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer
-        components={['DatePicker', 'SingleInputDateRangeField', 'DateRangePicker']}
-      >
-        <BrowserDatePicker
-          slotProps={{
-            field: { clearable: true },
-          }}
-        />
-        <BrowserSingleInputDateRangePicker
-          slotProps={{
-            field: { clearable: true },
-          }}
-        />
-        <BrowserDateRangePicker />
-      </DemoContainer>
+      <BrowserDatePicker
+        slotProps={{
+          field: { clearable: true },
+        }}
+      />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/custom-field/PickerWithBrowserField.tsx
+++ b/docs/data/date-pickers/custom-field/PickerWithBrowserField.tsx
@@ -1,24 +1,9 @@
 import * as React from 'react';
 import { Dayjs } from 'dayjs';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
-import { useSlotProps } from '@mui/base/utils';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
-import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
-import { DateRangeIcon } from '@mui/x-date-pickers/icons';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import {
-  DateRangePicker,
-  DateRangePickerProps,
-} from '@mui/x-date-pickers-pro/DateRangePicker';
-import {
-  unstable_useSingleInputDateRangeField as useSingleInputDateRangeField,
-  SingleInputDateRangeFieldProps,
-} from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import { unstable_useMultiInputDateRangeField as useMultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { DatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
 import {
   unstable_useDateField as useDateField,
@@ -30,20 +15,10 @@ import {
 } from '@mui/x-date-pickers/DateField/DateField.types';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 import {
-  BaseMultiInputFieldProps,
-  DateRange,
-  DateRangeValidationError,
-  UseDateRangeFieldProps,
-  MultiInputFieldSlotTextFieldProps,
   BaseSingleInputFieldProps,
   DateValidationError,
-  RangeFieldSection,
   FieldSection,
 } from '@mui/x-date-pickers-pro';
-import type {
-  SingleInputDateRangeFieldSlotsComponent,
-  SingleInputDateRangeFieldSlotsComponentsProps,
-} from '@mui/x-date-pickers-pro/SingleInputDateRangeField/SingleInputDateRangeField.types';
 
 interface BrowserFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
@@ -84,7 +59,7 @@ const BrowserField = React.forwardRef(
 
     return (
       <Box
-        sx={{ ...(sx || {}), display: 'flex', alignItems: 'center', flexGrow: 1 }}
+        sx={{ ...(sx || {}), display: 'flex', alignItems: 'center' }}
         id={id}
         ref={handleRef}
       >
@@ -95,207 +70,6 @@ const BrowserField = React.forwardRef(
     );
   },
 ) as BrowserFieldComponent;
-
-interface BrowserSingleInputDateRangeFieldProps
-  extends SingleInputDateRangeFieldProps<
-    Dayjs,
-    Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>
-  > {
-  onAdornmentClick?: () => void;
-}
-
-type BrowserSingleInputDateRangeFieldComponent = ((
-  props: BrowserSingleInputDateRangeFieldProps & React.RefAttributes<HTMLDivElement>,
-) => React.JSX.Element) & { fieldType?: string };
-
-const BrowserSingleInputDateRangeField = React.forwardRef(
-  (props: BrowserSingleInputDateRangeFieldProps, ref: React.Ref<HTMLDivElement>) => {
-    const { slots, slotProps, onAdornmentClick, ...other } = props;
-
-    const {
-      inputRef: externalInputRef,
-      ...textFieldProps
-    }: SingleInputDateRangeFieldProps<Dayjs> = useSlotProps({
-      elementType: 'input',
-      externalSlotProps: slotProps?.textField,
-      externalForwardedProps: other,
-      ownerState: props as any,
-    });
-
-    const {
-      ref: inputRef,
-      onClear,
-      clearable,
-      ...fieldProps
-    } = useSingleInputDateRangeField<Dayjs, typeof textFieldProps>({
-      props: textFieldProps,
-      inputRef: externalInputRef,
-    });
-
-    /* If you don't need a clear button, you can skip the use of this hook */
-    const { InputProps: ProcessedInputProps, fieldProps: processedFieldProps } =
-      useClearableField<
-        {},
-        typeof textFieldProps.InputProps,
-        SingleInputDateRangeFieldSlotsComponent,
-        SingleInputDateRangeFieldSlotsComponentsProps<Dayjs>
-      >({
-        onClear,
-        clearable,
-        fieldProps,
-        InputProps: {
-          ...fieldProps.InputProps,
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton onClick={onAdornmentClick}>
-                <DateRangeIcon />
-              </IconButton>
-            </InputAdornment>
-          ),
-        },
-        slots,
-        slotProps,
-      });
-
-    return (
-      <BrowserField
-        {...processedFieldProps}
-        ref={ref}
-        style={{
-          minWidth: 300,
-        }}
-        inputRef={inputRef}
-        InputProps={{ ...ProcessedInputProps }}
-      />
-    );
-  },
-) as BrowserSingleInputDateRangeFieldComponent;
-
-BrowserSingleInputDateRangeField.fieldType = 'single-input';
-
-const BrowserSingleInputDateRangePicker = React.forwardRef(
-  (props: DateRangePickerProps<Dayjs>, ref: React.Ref<HTMLDivElement>) => {
-    const [isOpen, setIsOpen] = React.useState(false);
-
-    const toggleOpen = () => setIsOpen((currentOpen) => !currentOpen);
-
-    const handleOpen = () => setIsOpen(true);
-
-    const handleClose = () => setIsOpen(false);
-
-    return (
-      <DateRangePicker
-        ref={ref}
-        {...props}
-        open={isOpen}
-        onClose={handleClose}
-        onOpen={handleOpen}
-        slots={{ field: BrowserSingleInputDateRangeField }}
-        slotProps={{
-          ...props?.slotProps,
-          field: {
-            onAdornmentClick: toggleOpen,
-            ...props?.slotProps?.field,
-          } as any,
-        }}
-      />
-    );
-  },
-);
-
-interface BrowserMultiInputDateRangeFieldProps
-  extends UseDateRangeFieldProps<Dayjs>,
-    BaseMultiInputFieldProps<
-      DateRange<Dayjs>,
-      Dayjs,
-      RangeFieldSection,
-      DateRangeValidationError
-    > {}
-
-type BrowserMultiInputDateRangeFieldComponent = ((
-  props: BrowserMultiInputDateRangeFieldProps & React.RefAttributes<HTMLDivElement>,
-) => React.JSX.Element) & { propTypes?: any };
-
-const BrowserMultiInputDateRangeField = React.forwardRef(
-  (props: BrowserMultiInputDateRangeFieldProps, ref: React.Ref<HTMLDivElement>) => {
-    const {
-      slotProps,
-      value,
-      defaultValue,
-      format,
-      onChange,
-      readOnly,
-      disabled,
-      onError,
-      shouldDisableDate,
-      minDate,
-      maxDate,
-      disableFuture,
-      disablePast,
-      selectedSections,
-      onSelectedSectionsChange,
-      className,
-    } = props;
-
-    const { inputRef: startInputRef, ...startTextFieldProps } = useSlotProps({
-      elementType: 'input',
-      externalSlotProps: slotProps?.textField,
-      ownerState: { ...props, position: 'start' },
-    }) as MultiInputFieldSlotTextFieldProps;
-
-    const { inputRef: endInputRef, ...endTextFieldProps } = useSlotProps({
-      elementType: 'input',
-      externalSlotProps: slotProps?.textField,
-      ownerState: { ...props, position: 'end' },
-    }) as MultiInputFieldSlotTextFieldProps;
-
-    const {
-      startDate: { ref: startRef, ...startDateProps },
-      endDate: { ref: endRef, ...endDateProps },
-    } = useMultiInputDateRangeField<Dayjs, MultiInputFieldSlotTextFieldProps>({
-      sharedProps: {
-        value,
-        defaultValue,
-        format,
-        onChange,
-        readOnly,
-        disabled,
-        onError,
-        shouldDisableDate,
-        minDate,
-        maxDate,
-        disableFuture,
-        disablePast,
-        selectedSections,
-        onSelectedSectionsChange,
-      },
-      startTextFieldProps,
-      endTextFieldProps,
-      startInputRef,
-      endInputRef,
-    });
-
-    return (
-      <Stack ref={ref} spacing={2} direction="row" className={className}>
-        <BrowserField {...startDateProps} inputRef={startRef} />
-        <span> — </span>
-        <BrowserField {...endDateProps} inputRef={endRef} />
-      </Stack>
-    );
-  },
-) as BrowserMultiInputDateRangeFieldComponent;
-
-const BrowserDateRangePicker = React.forwardRef(
-  (props: DateRangePickerProps<Dayjs>, ref: React.Ref<HTMLDivElement>) => {
-    return (
-      <DateRangePicker
-        ref={ref}
-        {...props}
-        slots={{ ...props?.slots, field: BrowserMultiInputDateRangeField }}
-      />
-    );
-  },
-);
 
 interface BrowserDateFieldProps
   extends UseDateFieldProps<Dayjs>,
@@ -366,21 +140,11 @@ const BrowserDatePicker = React.forwardRef(
 export default function PickerWithBrowserField() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer
-        components={['DatePicker', 'SingleInputDateRangeField', 'DateRangePicker']}
-      >
-        <BrowserDatePicker
-          slotProps={{
-            field: { clearable: true },
-          }}
-        />
-        <BrowserSingleInputDateRangePicker
-          slotProps={{
-            field: { clearable: true },
-          }}
-        />
-        <BrowserDateRangePicker />
-      </DemoContainer>
+      <BrowserDatePicker
+        slotProps={{
+          field: { clearable: true },
+        }}
+      />
     </LocalizationProvider>
   );
 }

--- a/docs/data/date-pickers/custom-field/PickerWithJoyField.js
+++ b/docs/data/date-pickers/custom-field/PickerWithJoyField.js
@@ -127,7 +127,7 @@ const JoyDatePicker = React.forwardRef((props, ref) => {
 });
 
 /**
- * This component is for syncing the MUI docs's mode with this demo.
+ * This component is for syncing the theme mode of this demo with the MUI docs mode.
  * You might not need this component in your project.
  */
 function SyncThemeMode({ mode }) {

--- a/docs/data/date-pickers/custom-field/PickerWithJoyField.tsx
+++ b/docs/data/date-pickers/custom-field/PickerWithJoyField.tsx
@@ -177,7 +177,7 @@ const JoyDatePicker = React.forwardRef(
 );
 
 /**
- * This component is for syncing the MUI docs's mode with this demo.
+ * This component is for syncing the theme mode of this demo with the MUI docs mode.
  * You might not need this component in your project.
  */
 function SyncThemeMode({ mode }: { mode: 'light' | 'dark' }) {

--- a/docs/data/date-pickers/custom-field/PickerWithJoyField.tsx.preview
+++ b/docs/data/date-pickers/custom-field/PickerWithJoyField.tsx.preview
@@ -1,0 +1,12 @@
+<MaterialCssVarsProvider>
+  <CssVarsProvider theme={{ [THEME_ID]: joyTheme }}>
+    <SyncThemeMode mode={materialTheme.palette.mode} />
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <JoyDatePicker
+        slotProps={{
+          field: { clearable: true },
+        }}
+      />
+    </LocalizationProvider>
+  </CssVarsProvider>
+</MaterialCssVarsProvider>

--- a/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.js
@@ -1,0 +1,125 @@
+import * as React from 'react';
+
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { useSlotProps } from '@mui/base/utils';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { unstable_useMultiInputDateRangeField as useMultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
+
+const BrowserField = React.forwardRef((props, ref) => {
+  const {
+    disabled,
+    id,
+    label,
+    inputRef,
+    InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
+    // extracting `error`, 'focused', and `ownerState` as `input` does not support those props
+    error,
+    focused,
+    ownerState,
+    sx,
+    ...other
+  } = props;
+
+  const handleRef = useForkRef(containerRef, ref);
+
+  return (
+    <Box
+      sx={{ ...(sx || {}), display: 'flex', alignItems: 'center', flexGrow: 1 }}
+      id={id}
+      ref={handleRef}
+    >
+      {startAdornment}
+      <input disabled={disabled} ref={inputRef} {...other} />
+      {endAdornment}
+    </Box>
+  );
+});
+
+const BrowserMultiInputDateRangeField = React.forwardRef((props, ref) => {
+  const {
+    slotProps,
+    value,
+    defaultValue,
+    format,
+    onChange,
+    readOnly,
+    disabled,
+    onError,
+    shouldDisableDate,
+    minDate,
+    maxDate,
+    disableFuture,
+    disablePast,
+    selectedSections,
+    onSelectedSectionsChange,
+    className,
+  } = props;
+
+  const { inputRef: startInputRef, ...startTextFieldProps } = useSlotProps({
+    elementType: 'input',
+    externalSlotProps: slotProps?.textField,
+    ownerState: { ...props, position: 'start' },
+  });
+
+  const { inputRef: endInputRef, ...endTextFieldProps } = useSlotProps({
+    elementType: 'input',
+    externalSlotProps: slotProps?.textField,
+    ownerState: { ...props, position: 'end' },
+  });
+
+  const {
+    startDate: { ref: startRef, ...startDateProps },
+    endDate: { ref: endRef, ...endDateProps },
+  } = useMultiInputDateRangeField({
+    sharedProps: {
+      value,
+      defaultValue,
+      format,
+      onChange,
+      readOnly,
+      disabled,
+      onError,
+      shouldDisableDate,
+      minDate,
+      maxDate,
+      disableFuture,
+      disablePast,
+      selectedSections,
+      onSelectedSectionsChange,
+    },
+    startTextFieldProps,
+    endTextFieldProps,
+    startInputRef,
+    endInputRef,
+  });
+
+  return (
+    <Stack ref={ref} spacing={2} direction="row" className={className}>
+      <BrowserField {...startDateProps} inputRef={startRef} />
+      <span> — </span>
+      <BrowserField {...endDateProps} inputRef={endRef} />
+    </Stack>
+  );
+});
+
+const BrowserDateRangePicker = React.forwardRef((props, ref) => {
+  return (
+    <DateRangePicker
+      ref={ref}
+      {...props}
+      slots={{ ...props?.slots, field: BrowserMultiInputDateRangeField }}
+    />
+  );
+});
+
+export default function RangePickerWithBrowserField() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <BrowserDateRangePicker />
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.js
@@ -98,7 +98,13 @@ const BrowserMultiInputDateRangeField = React.forwardRef((props, ref) => {
   });
 
   return (
-    <Stack ref={ref} spacing={2} direction="row" className={className}>
+    <Stack
+      ref={ref}
+      spacing={2}
+      direction="row"
+      overflow="auto"
+      className={className}
+    >
       <BrowserField {...startDateProps} inputRef={startRef} />
       <span> — </span>
       <BrowserField {...endDateProps} inputRef={endRef} />

--- a/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.tsx
@@ -144,7 +144,13 @@ const BrowserMultiInputDateRangeField = React.forwardRef(
     });
 
     return (
-      <Stack ref={ref} spacing={2} direction="row" className={className}>
+      <Stack
+        ref={ref}
+        spacing={2}
+        direction="row"
+        overflow="auto"
+        className={className}
+      >
         <BrowserField {...startDateProps} inputRef={startRef} />
         <span> — </span>
         <BrowserField {...endDateProps} inputRef={endRef} />

--- a/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import { Dayjs } from 'dayjs';
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { useSlotProps } from '@mui/base/utils';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import {
+  DateRangePicker,
+  DateRangePickerProps,
+} from '@mui/x-date-pickers-pro/DateRangePicker';
+import { unstable_useMultiInputDateRangeField as useMultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
+import {
+  BaseMultiInputFieldProps,
+  DateRange,
+  DateRangeValidationError,
+  UseDateRangeFieldProps,
+  MultiInputFieldSlotTextFieldProps,
+  RangeFieldSection,
+} from '@mui/x-date-pickers-pro';
+
+interface BrowserFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  label?: React.ReactNode;
+  inputRef?: React.Ref<any>;
+  InputProps?: {
+    ref?: React.Ref<any>;
+    endAdornment?: React.ReactNode;
+    startAdornment?: React.ReactNode;
+  };
+  error?: boolean;
+  focused?: boolean;
+  ownerState?: any;
+  sx?: any;
+}
+
+type BrowserFieldComponent = ((
+  props: BrowserFieldProps & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { propTypes?: any };
+
+const BrowserField = React.forwardRef(
+  (props: BrowserFieldProps, ref: React.Ref<HTMLDivElement>) => {
+    const {
+      disabled,
+      id,
+      label,
+      inputRef,
+      InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
+      // extracting `error`, 'focused', and `ownerState` as `input` does not support those props
+      error,
+      focused,
+      ownerState,
+      sx,
+      ...other
+    } = props;
+
+    const handleRef = useForkRef(containerRef, ref);
+
+    return (
+      <Box
+        sx={{ ...(sx || {}), display: 'flex', alignItems: 'center', flexGrow: 1 }}
+        id={id}
+        ref={handleRef}
+      >
+        {startAdornment}
+        <input disabled={disabled} ref={inputRef} {...other} />
+        {endAdornment}
+      </Box>
+    );
+  },
+) as BrowserFieldComponent;
+
+interface BrowserMultiInputDateRangeFieldProps
+  extends UseDateRangeFieldProps<Dayjs>,
+    BaseMultiInputFieldProps<
+      DateRange<Dayjs>,
+      Dayjs,
+      RangeFieldSection,
+      DateRangeValidationError
+    > {}
+
+type BrowserMultiInputDateRangeFieldComponent = ((
+  props: BrowserMultiInputDateRangeFieldProps & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { propTypes?: any };
+
+const BrowserMultiInputDateRangeField = React.forwardRef(
+  (props: BrowserMultiInputDateRangeFieldProps, ref: React.Ref<HTMLDivElement>) => {
+    const {
+      slotProps,
+      value,
+      defaultValue,
+      format,
+      onChange,
+      readOnly,
+      disabled,
+      onError,
+      shouldDisableDate,
+      minDate,
+      maxDate,
+      disableFuture,
+      disablePast,
+      selectedSections,
+      onSelectedSectionsChange,
+      className,
+    } = props;
+
+    const { inputRef: startInputRef, ...startTextFieldProps } = useSlotProps({
+      elementType: 'input',
+      externalSlotProps: slotProps?.textField,
+      ownerState: { ...props, position: 'start' },
+    }) as MultiInputFieldSlotTextFieldProps;
+
+    const { inputRef: endInputRef, ...endTextFieldProps } = useSlotProps({
+      elementType: 'input',
+      externalSlotProps: slotProps?.textField,
+      ownerState: { ...props, position: 'end' },
+    }) as MultiInputFieldSlotTextFieldProps;
+
+    const {
+      startDate: { ref: startRef, ...startDateProps },
+      endDate: { ref: endRef, ...endDateProps },
+    } = useMultiInputDateRangeField<Dayjs, MultiInputFieldSlotTextFieldProps>({
+      sharedProps: {
+        value,
+        defaultValue,
+        format,
+        onChange,
+        readOnly,
+        disabled,
+        onError,
+        shouldDisableDate,
+        minDate,
+        maxDate,
+        disableFuture,
+        disablePast,
+        selectedSections,
+        onSelectedSectionsChange,
+      },
+      startTextFieldProps,
+      endTextFieldProps,
+      startInputRef,
+      endInputRef,
+    });
+
+    return (
+      <Stack ref={ref} spacing={2} direction="row" className={className}>
+        <BrowserField {...startDateProps} inputRef={startRef} />
+        <span> — </span>
+        <BrowserField {...endDateProps} inputRef={endRef} />
+      </Stack>
+    );
+  },
+) as BrowserMultiInputDateRangeFieldComponent;
+
+const BrowserDateRangePicker = React.forwardRef(
+  (props: DateRangePickerProps<Dayjs>, ref: React.Ref<HTMLDivElement>) => {
+    return (
+      <DateRangePicker
+        ref={ref}
+        {...props}
+        slots={{ ...props?.slots, field: BrowserMultiInputDateRangeField }}
+      />
+    );
+  },
+);
+
+export default function RangePickerWithBrowserField() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <BrowserDateRangePicker />
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.tsx.preview
+++ b/docs/data/date-pickers/custom-field/RangePickerWithBrowserField.tsx.preview
@@ -1,0 +1,1 @@
+<BrowserDateRangePicker />

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.js
@@ -190,7 +190,7 @@ const JoyDateRangePicker = React.forwardRef((props, ref) => {
 });
 
 /**
- * This component is for syncing the MUI docs's mode with this demo.
+ * This component is for syncing the theme mode of this demo with the MUI docs mode.
  * You might not need this component in your project.
  */
 function SyncThemeMode({ mode }) {

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.js
@@ -67,7 +67,14 @@ const JoyField = React.forwardRef((props, ref) => {
 
 const MultiInputJoyDateRangeFieldRoot = styled(
   React.forwardRef((props, ref) => (
-    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+    <Stack
+      ref={ref}
+      spacing={2}
+      direction="row"
+      alignItems="center"
+      overflow="auto"
+      {...props}
+    />
   )),
   {
     name: 'MuiMultiInputDateRangeField',

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.js
@@ -1,0 +1,211 @@
+import * as React from 'react';
+
+import {
+  useTheme as useMaterialTheme,
+  useColorScheme as useMaterialColorScheme,
+  Experimental_CssVarsProvider as MaterialCssVarsProvider,
+} from '@mui/material/styles';
+import {
+  extendTheme as extendJoyTheme,
+  useColorScheme,
+  styled,
+  CssVarsProvider,
+  THEME_ID,
+} from '@mui/joy/styles';
+import { useSlotProps } from '@mui/base/utils';
+import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import Typography from '@mui/joy/Typography';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { unstable_useMultiInputDateRangeField as useMultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
+
+const joyTheme = extendJoyTheme();
+
+const JoyField = React.forwardRef((props, ref) => {
+  const {
+    disabled,
+    id,
+    label,
+    InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
+    endDecorator,
+    startDecorator,
+    slotProps,
+    ...other
+  } = props;
+
+  return (
+    <FormControl disabled={disabled} id={id} ref={ref}>
+      <FormLabel>{label}</FormLabel>
+      <Input
+        ref={ref}
+        disabled={disabled}
+        startDecorator={
+          <React.Fragment>
+            {startAdornment}
+            {startDecorator}
+          </React.Fragment>
+        }
+        endDecorator={
+          <React.Fragment>
+            {endAdornment}
+            {endDecorator}
+          </React.Fragment>
+        }
+        slotProps={{
+          ...slotProps,
+          root: { ...slotProps?.root, ref: containerRef },
+        }}
+        {...other}
+      />
+    </FormControl>
+  );
+});
+
+const MultiInputJoyDateRangeFieldRoot = styled(
+  React.forwardRef((props, ref) => (
+    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+  )),
+  {
+    name: 'MuiMultiInputDateRangeField',
+    slot: 'Root',
+    overridesResolver: (props, styles) => styles.root,
+  },
+)({});
+
+const MultiInputJoyDateRangeFieldSeparator = styled(
+  (props) => (
+    <FormControl>
+      {/* Ensure that the separator is correctly aligned */}
+      <span />
+      <Typography {...props}>{props.children ?? ' — '}</Typography>
+    </FormControl>
+  ),
+  {
+    name: 'MuiMultiInputDateRangeField',
+    slot: 'Separator',
+    overridesResolver: (props, styles) => styles.separator,
+  },
+)({ marginTop: '25px' });
+
+const JoyMultiInputDateRangeField = React.forwardRef((props, ref) => {
+  const {
+    slotProps,
+    value,
+    defaultValue,
+    format,
+    onChange,
+    readOnly,
+    disabled,
+    onError,
+    shouldDisableDate,
+    minDate,
+    maxDate,
+    disableFuture,
+    disablePast,
+    selectedSections,
+    onSelectedSectionsChange,
+    className,
+  } = props;
+
+  const { inputRef: startInputRef, ...startTextFieldProps } = useSlotProps({
+    elementType: FormControl,
+    externalSlotProps: slotProps?.textField,
+    ownerState: { ...props, position: 'start' },
+  });
+
+  const { inputRef: endInputRef, ...endTextFieldProps } = useSlotProps({
+    elementType: FormControl,
+    externalSlotProps: slotProps?.textField,
+    ownerState: { ...props, position: 'end' },
+  });
+
+  const {
+    startDate: { ref: startRef, ...startDateProps },
+    endDate: { ref: endRef, ...endDateProps },
+  } = useMultiInputDateRangeField({
+    sharedProps: {
+      value,
+      defaultValue,
+      format,
+      onChange,
+      readOnly,
+      disabled,
+      onError,
+      shouldDisableDate,
+      minDate,
+      maxDate,
+      disableFuture,
+      disablePast,
+      selectedSections,
+      onSelectedSectionsChange,
+    },
+    startTextFieldProps,
+    endTextFieldProps,
+    startInputRef,
+    endInputRef,
+  });
+
+  return (
+    <MultiInputJoyDateRangeFieldRoot ref={ref} className={className}>
+      <JoyField
+        {...startDateProps}
+        slotProps={{
+          input: {
+            ref: startRef,
+          },
+        }}
+      />
+      <MultiInputJoyDateRangeFieldSeparator />
+      <JoyField
+        {...endDateProps}
+        slotProps={{
+          input: {
+            ref: endRef,
+          },
+        }}
+      />
+    </MultiInputJoyDateRangeFieldRoot>
+  );
+});
+
+const JoyDateRangePicker = React.forwardRef((props, ref) => {
+  return (
+    <DateRangePicker
+      ref={ref}
+      {...props}
+      slots={{ ...props?.slots, field: JoyMultiInputDateRangeField }}
+    />
+  );
+});
+
+/**
+ * This component is for syncing the MUI docs's mode with this demo.
+ * You might not need this component in your project.
+ */
+function SyncThemeMode({ mode }) {
+  const { setMode } = useColorScheme();
+  const { setMode: setMaterialMode } = useMaterialColorScheme();
+  React.useEffect(() => {
+    setMode(mode);
+    setMaterialMode(mode);
+  }, [mode, setMode, setMaterialMode]);
+  return null;
+}
+
+export default function RangePickerWithJoyField() {
+  const materialTheme = useMaterialTheme();
+  return (
+    <MaterialCssVarsProvider>
+      <CssVarsProvider theme={{ [THEME_ID]: joyTheme }}>
+        <SyncThemeMode mode={materialTheme.palette.mode} />
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <JoyDateRangePicker />
+        </LocalizationProvider>
+      </CssVarsProvider>
+    </MaterialCssVarsProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx
@@ -1,0 +1,254 @@
+import * as React from 'react';
+import { Dayjs } from 'dayjs';
+import {
+  useTheme as useMaterialTheme,
+  useColorScheme as useMaterialColorScheme,
+  Experimental_CssVarsProvider as MaterialCssVarsProvider,
+} from '@mui/material/styles';
+import {
+  extendTheme as extendJoyTheme,
+  useColorScheme,
+  styled,
+  CssVarsProvider,
+  THEME_ID,
+} from '@mui/joy/styles';
+import { useSlotProps } from '@mui/base/utils';
+import Input, { InputProps } from '@mui/joy/Input';
+import Stack, { StackProps } from '@mui/joy/Stack';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import Typography, { TypographyProps } from '@mui/joy/Typography';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import {
+  DateRangePicker,
+  DateRangePickerProps,
+} from '@mui/x-date-pickers-pro/DateRangePicker';
+import { unstable_useMultiInputDateRangeField as useMultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
+import {
+  BaseMultiInputFieldProps,
+  DateRange,
+  DateRangeValidationError,
+  UseDateRangeFieldProps,
+  MultiInputFieldSlotTextFieldProps,
+  RangeFieldSection,
+} from '@mui/x-date-pickers-pro';
+
+const joyTheme = extendJoyTheme();
+
+interface JoyFieldProps extends InputProps {
+  label?: React.ReactNode;
+  InputProps?: {
+    ref?: React.Ref<any>;
+    endAdornment?: React.ReactNode;
+    startAdornment?: React.ReactNode;
+  };
+}
+
+type JoyFieldComponent = ((
+  props: JoyFieldProps & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { propTypes?: any };
+
+const JoyField = React.forwardRef(
+  (props: JoyFieldProps, ref: React.Ref<HTMLDivElement>) => {
+    const {
+      disabled,
+      id,
+      label,
+      InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
+      endDecorator,
+      startDecorator,
+      slotProps,
+      ...other
+    } = props;
+
+    return (
+      <FormControl disabled={disabled} id={id} ref={ref}>
+        <FormLabel>{label}</FormLabel>
+        <Input
+          ref={ref}
+          disabled={disabled}
+          startDecorator={
+            <React.Fragment>
+              {startAdornment}
+              {startDecorator}
+            </React.Fragment>
+          }
+          endDecorator={
+            <React.Fragment>
+              {endAdornment}
+              {endDecorator}
+            </React.Fragment>
+          }
+          slotProps={{
+            ...slotProps,
+            root: { ...slotProps?.root, ref: containerRef },
+          }}
+          {...other}
+        />
+      </FormControl>
+    );
+  },
+) as JoyFieldComponent;
+
+const MultiInputJoyDateRangeFieldRoot = styled(
+  React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement>) => (
+    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+  )),
+  {
+    name: 'MuiMultiInputDateRangeField',
+    slot: 'Root',
+    overridesResolver: (props, styles) => styles.root,
+  },
+)({});
+
+const MultiInputJoyDateRangeFieldSeparator = styled(
+  (props: TypographyProps) => (
+    <FormControl>
+      {/* Ensure that the separator is correctly aligned */}
+      <span />
+      <Typography {...props}>{props.children ?? ' — '}</Typography>
+    </FormControl>
+  ),
+  {
+    name: 'MuiMultiInputDateRangeField',
+    slot: 'Separator',
+    overridesResolver: (props, styles) => styles.separator,
+  },
+)({ marginTop: '25px' });
+
+interface JoyMultiInputDateRangeFieldProps
+  extends UseDateRangeFieldProps<Dayjs>,
+    BaseMultiInputFieldProps<
+      DateRange<Dayjs>,
+      Dayjs,
+      RangeFieldSection,
+      DateRangeValidationError
+    > {}
+
+type JoyMultiInputDateRangeFieldComponent = ((
+  props: JoyMultiInputDateRangeFieldProps & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { propTypes?: any };
+
+const JoyMultiInputDateRangeField = React.forwardRef(
+  (props: JoyMultiInputDateRangeFieldProps, ref: React.Ref<HTMLDivElement>) => {
+    const {
+      slotProps,
+      value,
+      defaultValue,
+      format,
+      onChange,
+      readOnly,
+      disabled,
+      onError,
+      shouldDisableDate,
+      minDate,
+      maxDate,
+      disableFuture,
+      disablePast,
+      selectedSections,
+      onSelectedSectionsChange,
+      className,
+    } = props;
+
+    const { inputRef: startInputRef, ...startTextFieldProps } = useSlotProps({
+      elementType: FormControl,
+      externalSlotProps: slotProps?.textField,
+      ownerState: { ...props, position: 'start' },
+    }) as MultiInputFieldSlotTextFieldProps;
+
+    const { inputRef: endInputRef, ...endTextFieldProps } = useSlotProps({
+      elementType: FormControl,
+      externalSlotProps: slotProps?.textField,
+      ownerState: { ...props, position: 'end' },
+    }) as MultiInputFieldSlotTextFieldProps;
+
+    const {
+      startDate: { ref: startRef, ...startDateProps },
+      endDate: { ref: endRef, ...endDateProps },
+    } = useMultiInputDateRangeField<Dayjs, MultiInputFieldSlotTextFieldProps>({
+      sharedProps: {
+        value,
+        defaultValue,
+        format,
+        onChange,
+        readOnly,
+        disabled,
+        onError,
+        shouldDisableDate,
+        minDate,
+        maxDate,
+        disableFuture,
+        disablePast,
+        selectedSections,
+        onSelectedSectionsChange,
+      },
+      startTextFieldProps,
+      endTextFieldProps,
+      startInputRef,
+      endInputRef,
+    });
+
+    return (
+      <MultiInputJoyDateRangeFieldRoot ref={ref} className={className}>
+        <JoyField
+          {...startDateProps}
+          slotProps={{
+            input: {
+              ref: startRef,
+            },
+          }}
+        />
+        <MultiInputJoyDateRangeFieldSeparator />
+        <JoyField
+          {...endDateProps}
+          slotProps={{
+            input: {
+              ref: endRef,
+            },
+          }}
+        />
+      </MultiInputJoyDateRangeFieldRoot>
+    );
+  },
+) as JoyMultiInputDateRangeFieldComponent;
+
+const JoyDateRangePicker = React.forwardRef(
+  (props: DateRangePickerProps<Dayjs>, ref: React.Ref<HTMLDivElement>) => {
+    return (
+      <DateRangePicker
+        ref={ref}
+        {...props}
+        slots={{ ...props?.slots, field: JoyMultiInputDateRangeField }}
+      />
+    );
+  },
+);
+
+/**
+ * This component is for syncing the MUI docs's mode with this demo.
+ * You might not need this component in your project.
+ */
+function SyncThemeMode({ mode }: { mode: 'light' | 'dark' }) {
+  const { setMode } = useColorScheme();
+  const { setMode: setMaterialMode } = useMaterialColorScheme();
+  React.useEffect(() => {
+    setMode(mode);
+    setMaterialMode(mode);
+  }, [mode, setMode, setMaterialMode]);
+  return null;
+}
+
+export default function RangePickerWithJoyField() {
+  const materialTheme = useMaterialTheme();
+  return (
+    <MaterialCssVarsProvider>
+      <CssVarsProvider theme={{ [THEME_ID]: joyTheme }}>
+        <SyncThemeMode mode={materialTheme.palette.mode} />
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <JoyDateRangePicker />
+        </LocalizationProvider>
+      </CssVarsProvider>
+    </MaterialCssVarsProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx
@@ -93,7 +93,14 @@ const JoyField = React.forwardRef(
 
 const MultiInputJoyDateRangeFieldRoot = styled(
   React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement>) => (
-    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+    <Stack
+      ref={ref}
+      spacing={2}
+      direction="row"
+      alignItems="center"
+      overflow="auto"
+      {...props}
+    />
   )),
   {
     name: 'MuiMultiInputDateRangeField',

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx
@@ -233,7 +233,7 @@ const JoyDateRangePicker = React.forwardRef(
 );
 
 /**
- * This component is for syncing the MUI docs's mode with this demo.
+ * This component is for syncing the theme mode of this demo with the MUI docs mode.
  * You might not need this component in your project.
  */
 function SyncThemeMode({ mode }: { mode: 'light' | 'dark' }) {

--- a/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx.preview
+++ b/docs/data/date-pickers/custom-field/RangePickerWithJoyField.tsx.preview
@@ -1,0 +1,8 @@
+<MaterialCssVarsProvider>
+  <CssVarsProvider theme={{ [THEME_ID]: joyTheme }}>
+    <SyncThemeMode mode={materialTheme.palette.mode} />
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <JoyDateRangePicker />
+    </LocalizationProvider>
+  </CssVarsProvider>
+</MaterialCssVarsProvider>

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputBrowserField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputBrowserField.js
@@ -1,0 +1,138 @@
+import * as React from 'react';
+
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { useSlotProps } from '@mui/base/utils';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import { DateRangeIcon } from '@mui/x-date-pickers/icons';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { unstable_useSingleInputDateRangeField as useSingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
+import { useClearableField } from '@mui/x-date-pickers/hooks';
+
+const BrowserField = React.forwardRef((props, ref) => {
+  const {
+    disabled,
+    id,
+    label,
+    inputRef,
+    InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
+    // extracting `error`, 'focused', and `ownerState` as `input` does not support those props
+    error,
+    focused,
+    ownerState,
+    sx,
+    ...other
+  } = props;
+
+  const handleRef = useForkRef(containerRef, ref);
+
+  return (
+    <Box
+      sx={{ ...(sx || {}), display: 'flex', alignItems: 'center' }}
+      id={id}
+      ref={handleRef}
+    >
+      {startAdornment}
+      <input disabled={disabled} ref={inputRef} {...other} />
+      {endAdornment}
+    </Box>
+  );
+});
+
+const BrowserSingleInputDateRangeField = React.forwardRef((props, ref) => {
+  const { slots, slotProps, onAdornmentClick, ...other } = props;
+
+  const { inputRef: externalInputRef, ...textFieldProps } = useSlotProps({
+    elementType: 'input',
+    externalSlotProps: slotProps?.textField,
+    externalForwardedProps: other,
+    ownerState: props,
+  });
+
+  const {
+    ref: inputRef,
+    onClear,
+    clearable,
+    ...fieldProps
+  } = useSingleInputDateRangeField({
+    props: textFieldProps,
+    inputRef: externalInputRef,
+  });
+
+  /* If you don't need a clear button, you can skip the use of this hook */
+  const { InputProps: ProcessedInputProps, fieldProps: processedFieldProps } =
+    useClearableField({
+      onClear,
+      clearable,
+      fieldProps,
+      InputProps: {
+        ...fieldProps.InputProps,
+        endAdornment: (
+          <InputAdornment position="end">
+            <IconButton onClick={onAdornmentClick}>
+              <DateRangeIcon />
+            </IconButton>
+          </InputAdornment>
+        ),
+      },
+      slots,
+      slotProps,
+    });
+
+  return (
+    <BrowserField
+      {...processedFieldProps}
+      ref={ref}
+      style={{
+        minWidth: 300,
+      }}
+      inputRef={inputRef}
+      InputProps={{ ...ProcessedInputProps }}
+    />
+  );
+});
+
+BrowserSingleInputDateRangeField.fieldType = 'single-input';
+
+const BrowserSingleInputDateRangePicker = React.forwardRef((props, ref) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const toggleOpen = () => setIsOpen((currentOpen) => !currentOpen);
+
+  const handleOpen = () => setIsOpen(true);
+
+  const handleClose = () => setIsOpen(false);
+
+  return (
+    <DateRangePicker
+      ref={ref}
+      {...props}
+      open={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
+      slots={{ field: BrowserSingleInputDateRangeField }}
+      slotProps={{
+        ...props?.slotProps,
+        field: {
+          onAdornmentClick: toggleOpen,
+          ...props?.slotProps?.field,
+        },
+      }}
+    />
+  );
+});
+
+export default function RangePickerWithSingleInputBrowserField() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <BrowserSingleInputDateRangePicker
+        slotProps={{
+          field: { clearable: true },
+        }}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputBrowserField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputBrowserField.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+import { Dayjs } from 'dayjs';
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { useSlotProps } from '@mui/base/utils';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import { DateRangeIcon } from '@mui/x-date-pickers/icons';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import {
+  DateRangePicker,
+  DateRangePickerProps,
+} from '@mui/x-date-pickers-pro/DateRangePicker';
+import {
+  unstable_useSingleInputDateRangeField as useSingleInputDateRangeField,
+  SingleInputDateRangeFieldProps,
+} from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
+import { useClearableField } from '@mui/x-date-pickers/hooks';
+import type {
+  SingleInputDateRangeFieldSlotsComponent,
+  SingleInputDateRangeFieldSlotsComponentsProps,
+} from '@mui/x-date-pickers-pro/SingleInputDateRangeField/SingleInputDateRangeField.types';
+
+interface BrowserFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  label?: React.ReactNode;
+  inputRef?: React.Ref<any>;
+  InputProps?: {
+    ref?: React.Ref<any>;
+    endAdornment?: React.ReactNode;
+    startAdornment?: React.ReactNode;
+  };
+  error?: boolean;
+  focused?: boolean;
+  ownerState?: any;
+  sx?: any;
+}
+
+type BrowserFieldComponent = ((
+  props: BrowserFieldProps & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { propTypes?: any };
+
+const BrowserField = React.forwardRef(
+  (props: BrowserFieldProps, ref: React.Ref<HTMLDivElement>) => {
+    const {
+      disabled,
+      id,
+      label,
+      inputRef,
+      InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
+      // extracting `error`, 'focused', and `ownerState` as `input` does not support those props
+      error,
+      focused,
+      ownerState,
+      sx,
+      ...other
+    } = props;
+
+    const handleRef = useForkRef(containerRef, ref);
+
+    return (
+      <Box
+        sx={{ ...(sx || {}), display: 'flex', alignItems: 'center' }}
+        id={id}
+        ref={handleRef}
+      >
+        {startAdornment}
+        <input disabled={disabled} ref={inputRef} {...other} />
+        {endAdornment}
+      </Box>
+    );
+  },
+) as BrowserFieldComponent;
+
+interface BrowserSingleInputDateRangeFieldProps
+  extends SingleInputDateRangeFieldProps<
+    Dayjs,
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>
+  > {
+  onAdornmentClick?: () => void;
+}
+
+type BrowserSingleInputDateRangeFieldComponent = ((
+  props: BrowserSingleInputDateRangeFieldProps & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { fieldType?: string };
+
+const BrowserSingleInputDateRangeField = React.forwardRef(
+  (props: BrowserSingleInputDateRangeFieldProps, ref: React.Ref<HTMLDivElement>) => {
+    const { slots, slotProps, onAdornmentClick, ...other } = props;
+
+    const {
+      inputRef: externalInputRef,
+      ...textFieldProps
+    }: SingleInputDateRangeFieldProps<Dayjs> = useSlotProps({
+      elementType: 'input',
+      externalSlotProps: slotProps?.textField,
+      externalForwardedProps: other,
+      ownerState: props as any,
+    });
+
+    const {
+      ref: inputRef,
+      onClear,
+      clearable,
+      ...fieldProps
+    } = useSingleInputDateRangeField<Dayjs, typeof textFieldProps>({
+      props: textFieldProps,
+      inputRef: externalInputRef,
+    });
+
+    /* If you don't need a clear button, you can skip the use of this hook */
+    const { InputProps: ProcessedInputProps, fieldProps: processedFieldProps } =
+      useClearableField<
+        {},
+        typeof textFieldProps.InputProps,
+        SingleInputDateRangeFieldSlotsComponent,
+        SingleInputDateRangeFieldSlotsComponentsProps<Dayjs>
+      >({
+        onClear,
+        clearable,
+        fieldProps,
+        InputProps: {
+          ...fieldProps.InputProps,
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton onClick={onAdornmentClick}>
+                <DateRangeIcon />
+              </IconButton>
+            </InputAdornment>
+          ),
+        },
+        slots,
+        slotProps,
+      });
+
+    return (
+      <BrowserField
+        {...processedFieldProps}
+        ref={ref}
+        style={{
+          minWidth: 300,
+        }}
+        inputRef={inputRef}
+        InputProps={{ ...ProcessedInputProps }}
+      />
+    );
+  },
+) as BrowserSingleInputDateRangeFieldComponent;
+
+BrowserSingleInputDateRangeField.fieldType = 'single-input';
+
+const BrowserSingleInputDateRangePicker = React.forwardRef(
+  (props: DateRangePickerProps<Dayjs>, ref: React.Ref<HTMLDivElement>) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const toggleOpen = () => setIsOpen((currentOpen) => !currentOpen);
+
+    const handleOpen = () => setIsOpen(true);
+
+    const handleClose = () => setIsOpen(false);
+
+    return (
+      <DateRangePicker
+        ref={ref}
+        {...props}
+        open={isOpen}
+        onClose={handleClose}
+        onOpen={handleOpen}
+        slots={{ field: BrowserSingleInputDateRangeField }}
+        slotProps={{
+          ...props?.slotProps,
+          field: {
+            onAdornmentClick: toggleOpen,
+            ...props?.slotProps?.field,
+          } as any,
+        }}
+      />
+    );
+  },
+);
+
+export default function RangePickerWithSingleInputBrowserField() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <BrowserSingleInputDateRangePicker
+        slotProps={{
+          field: { clearable: true },
+        }}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputBrowserField.tsx.preview
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputBrowserField.tsx.preview
@@ -1,4 +1,4 @@
-<BrowserDatePicker
+<BrowserSingleInputDateRangePicker
   slotProps={{
     field: { clearable: true },
   }}

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.js
@@ -11,14 +11,16 @@ import {
   CssVarsProvider,
   THEME_ID,
 } from '@mui/joy/styles';
+import { useSlotProps } from '@mui/base/utils';
 import Input from '@mui/joy/Input';
 import FormControl from '@mui/joy/FormControl';
 import FormLabel from '@mui/joy/FormLabel';
+import IconButton from '@mui/joy/IconButton';
+import { DateRangeIcon } from '@mui/x-date-pickers/icons';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
-
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+import { unstable_useSingleInputDateRangeField as useSingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 
 const joyTheme = extendJoyTheme();
@@ -29,7 +31,6 @@ const JoyField = React.forwardRef((props, ref) => {
     id,
     label,
     InputProps: { ref: containerRef, startAdornment, endAdornment } = {},
-    formControlSx,
     endDecorator,
     startDecorator,
     slotProps,
@@ -37,12 +38,7 @@ const JoyField = React.forwardRef((props, ref) => {
   } = props;
 
   return (
-    <FormControl
-      disabled={disabled}
-      id={id}
-      sx={[...(Array.isArray(formControlSx) ? formControlSx : [formControlSx])]}
-      ref={ref}
-    >
+    <FormControl disabled={disabled} id={id} sx={{ minWidth: 350 }} ref={ref}>
       <FormLabel>{label}</FormLabel>
       <Input
         ref={ref}
@@ -69,15 +65,22 @@ const JoyField = React.forwardRef((props, ref) => {
   );
 });
 
-const JoyDateField = React.forwardRef((props, ref) => {
-  const { inputRef: externalInputRef, slots, slotProps, ...textFieldProps } = props;
+const JoySingleInputDateRangeField = React.forwardRef((props, ref) => {
+  const { slots, slotProps, onAdornmentClick, ...other } = props;
+
+  const { inputRef: externalInputRef, ...textFieldProps } = useSlotProps({
+    elementType: FormControl,
+    externalSlotProps: slotProps?.textField,
+    externalForwardedProps: other,
+    ownerState: props,
+  });
 
   const {
     onClear,
     clearable,
     ref: inputRef,
     ...fieldProps
-  } = useDateField({
+  } = useSingleInputDateRangeField({
     props: textFieldProps,
     inputRef: externalInputRef,
   });
@@ -89,37 +92,62 @@ const JoyDateField = React.forwardRef((props, ref) => {
       clearable,
       fieldProps,
       InputProps: fieldProps.InputProps,
-      slots,
-      slotProps,
+      slots: { ...slots, clearButton: IconButton },
+      slotProps: { ...slotProps, clearIcon: { color: 'action' } },
     });
 
   return (
     <JoyField
+      {...processedFieldProps}
       ref={ref}
       slotProps={{
         input: {
           ref: inputRef,
         },
       }}
-      {...processedFieldProps}
-      InputProps={ProcessedInputProps}
+      endDecorator={
+        <IconButton
+          onClick={onAdornmentClick}
+          variant="plain"
+          color="neutral"
+          sx={{ marginLeft: 2.5 }}
+        >
+          <DateRangeIcon color="action" />
+        </IconButton>
+      }
+      InputProps={{ ...ProcessedInputProps }}
     />
   );
 });
 
-const JoyDatePicker = React.forwardRef((props, ref) => {
+JoySingleInputDateRangeField.fieldType = 'single-input';
+
+const JoySingleInputDateRangePicker = React.forwardRef((props, ref) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const toggleOpen = (event) => {
+    // allows toggle behavior
+    event.stopPropagation();
+    setIsOpen((currentOpen) => !currentOpen);
+  };
+
+  const handleOpen = () => setIsOpen(true);
+
+  const handleClose = () => setIsOpen(false);
+
   return (
-    <DatePicker
-      ref={ref}
+    <DateRangePicker
       {...props}
-      slots={{ field: JoyDateField, ...props.slots }}
+      ref={ref}
+      open={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
+      slots={{ field: JoySingleInputDateRangeField }}
       slotProps={{
-        ...props.slotProps,
+        ...props?.slotProps,
         field: {
-          ...props.slotProps?.field,
-          formControlSx: {
-            flexDirection: 'row',
-          },
+          ...props?.slotProps?.field,
+          onAdornmentClick: toggleOpen,
         },
       }}
     />
@@ -140,14 +168,14 @@ function SyncThemeMode({ mode }) {
   return null;
 }
 
-export default function PickerWithJoyField() {
+export default function RangePickerWithSingleInputJoyField() {
   const materialTheme = useMaterialTheme();
   return (
     <MaterialCssVarsProvider>
       <CssVarsProvider theme={{ [THEME_ID]: joyTheme }}>
         <SyncThemeMode mode={materialTheme.palette.mode} />
         <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <JoyDatePicker
+          <JoySingleInputDateRangePicker
             slotProps={{
               field: { clearable: true },
             }}

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.js
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.js
@@ -155,7 +155,7 @@ const JoySingleInputDateRangePicker = React.forwardRef((props, ref) => {
 });
 
 /**
- * This component is for syncing the MUI docs's mode with this demo.
+ * This component is for syncing the theme mode of this demo with the MUI docs mode.
  * You might not need this component in your project.
  */
 function SyncThemeMode({ mode }) {

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.tsx
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.tsx
@@ -204,7 +204,7 @@ const JoySingleInputDateRangePicker = React.forwardRef(
 );
 
 /**
- * This component is for syncing the MUI docs's mode with this demo.
+ * This component is for syncing the theme mode of this demo with the MUI docs mode.
  * You might not need this component in your project.
  */
 function SyncThemeMode({ mode }: { mode: 'light' | 'dark' }) {

--- a/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.tsx.preview
+++ b/docs/data/date-pickers/custom-field/RangePickerWithSingleInputJoyField.tsx.preview
@@ -1,0 +1,12 @@
+<MaterialCssVarsProvider>
+  <CssVarsProvider theme={{ [THEME_ID]: joyTheme }}>
+    <SyncThemeMode mode={materialTheme.palette.mode} />
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <JoySingleInputDateRangePicker
+        slotProps={{
+          field: { clearable: true },
+        }}
+      />
+    </LocalizationProvider>
+  </CssVarsProvider>
+</MaterialCssVarsProvider>

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -69,6 +69,10 @@ A higher-level solution for _Joy UI_ will be provided in the near future for eve
 
 {{"demo": "PickerWithJoyField.js", "defaultCodeOpen": false}}
 
+{{"demo": "RangePickerWithSingleInputJoyField.js", "defaultCodeOpen": false}}
+
+{{"demo": "RangePickerWithJoyField.js", "defaultCodeOpen": false}}
+
 #### With the browser input
 
 You can also use any other input:

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -75,6 +75,10 @@ You can also use any other input:
 
 {{"demo": "PickerWithBrowserField.js", "defaultCodeOpen": false}}
 
+{{"demo": "RangePickerWithSingleInputBrowserField.js", "defaultCodeOpen": false}}
+
+{{"demo": "RangePickerWithBrowserField.js", "defaultCodeOpen": false}}
+
 :::warning
 You will need to use a component that supports the `sx` prop as a wrapper for your input, in order to be able to benefit from the **hover** and **focus** behavior of the clear button. You will have access to the `clearable` and `onClear` props using native HTML elements, but the on **focus** and **hover** behavior depends on styles applied via the `sx` prop.
 :::


### PR DESCRIPTION
Created from discussions on https://github.com/mui/mui-x/pull/10485
We agreed that if we split more complex demos on the linked PR, these complex ones should also be split.

I've removed the `DemoContainer` from the individual demos as it was causing more problems with layout. 🙈 