### PR TITLE
[pickers] Fix timezone `UTC` false positive

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -326,15 +326,17 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
   };
 
   public getTimezone = (value: Dayjs): string => {
-    if (this.hasUTCPlugin() && value.isUTC()) {
-      return 'UTC';
-    }
-
     if (this.hasTimezonePlugin()) {
       // @ts-ignore
       const zone = value.$x?.$timezone;
 
-      return zone ?? 'system';
+      if (zone) {
+        return zone;
+      }
+    }
+
+    if (this.hasUTCPlugin() && value.isUTC()) {
+      return 'UTC';
     }
 
     return 'system';

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -239,16 +239,13 @@ export class AdapterMoment implements MuiPickersAdapter<Moment, string> {
   };
 
   public getTimezone = (value: Moment): string => {
-    if (value.isUTC()) {
-      return 'UTC';
-    }
-
     // @ts-ignore
     // eslint-disable-next-line no-underscore-dangle
     const zone = value._z?.name;
+    const defaultZone = value.isUTC() ? 'UTC' : 'system';
 
     // @ts-ignore
-    return zone ?? this.moment.defaultZone?.name ?? 'system';
+    return zone ?? this.moment.defaultZone?.name ?? defaultZone;
   };
 
   public setTimezone = (value: Moment, timezone: PickersTimezone): Moment => {

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -169,6 +169,14 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
     setDefaultTimezone(undefined);
   });
 
+  it.only('should not mix Europe/London and UTC in winter', () => {
+    if (!adapter.isTimezoneCompatible) {
+      return;
+    }
+    const dateWithZone = adapter.dateWithTimezone('2023-10-30T11:44:00.000Z', 'Europe/London');
+    expect(adapter.getTimezone(dateWithZone)).to.equal('Europe/London');
+  });
+
   it('Method: setTimezone', () => {
     if (adapter.isTimezoneCompatible) {
       const test = (timezone: PickersTimezone) => {

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -169,7 +169,7 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
     setDefaultTimezone(undefined);
   });
 
-  it.only('should not mix Europe/London and UTC in winter', () => {
+  it('should not mix Europe/London and UTC in winter', () => {
     if (!adapter.isTimezoneCompatible) {
       return;
     }


### PR DESCRIPTION
Fix #10579


The issue seems to be that `Europe/London` is `+01:00` in summer and `+00:00` during the winter. And for the latter, the `isUTC()` returns true which moves the internal timeZone from `Europe/London` to `UTC`

Here is a codesandbox to reproduce the bug: https://codesandbox.io/s/vibrant-zhukovsky-rcz9f4?file=/Demo.tsx (click on 30th or 31th of October)
Here is the same with a fix https://codesandbox.io/s/mystifying-lewin-v2tzj2?file=/Demo.tsx

The duplicate day for dayjs example is another issue #10584