### PR TITLE
[l10n] Improve Spanish (es-ES) locale

### DIFF
--- a/packages/x-date-pickers/src/locales/esES.ts
+++ b/packages/x-date-pickers/src/locales/esES.ts
@@ -74,7 +74,7 @@ const esESPickers: Partial<PickersLocaleText<any>> = {
   dateTableLabel: 'elige la hora',
 
   // Field section placeholders
-  fieldYearPlaceholder: (params) => 'Y'.repeat(params.digitAmount),
+  fieldYearPlaceholder: (params) => 'A'.repeat(params.digitAmount),
   fieldMonthPlaceholder: (params) => (params.contentType === 'letter' ? 'MMMM' : 'MM'),
   fieldDayPlaceholder: () => 'DD',
   fieldWeekDayPlaceholder: (params) => (params.contentType === 'letter' ? 'EEEE' : 'EE'),


### PR DESCRIPTION
Year in Spanish is 'año'. The first letter is 'A' not 'Y'

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
