### PR TITLE
[test] Fix dev mode warning

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -53,7 +53,7 @@ function excludeTest(suite, name) {
 }
 
 // Also use some of the demos to avoid code duplication.
-const requireDocs = require.context('docsx/data', true, /js$/);
+const requireDocs = require.context('docsx/data', true, /\.js$/);
 const tests = requireDocs.keys().reduce((res, path) => {
   const [name, ...suiteArray] = path.replace('./', '').replace('.js', '').split('/').reverse();
   const suite = `docs-${suiteArray.reverse().join('-')}`;

--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -44,6 +44,14 @@ module.exports = {
   },
   resolve: {
     ...webpackBaseConfig.resolve,
+    fallback: {
+      // Exclude polyfill and treat 'fs' as an empty module since it is not required. next -> gzip-size relies on it.
+      fs: false,
+      // needed by enzyme > cheerio
+      stream: false,
+      // Exclude polyfill and treat 'zlib' as an empty module since it is not required. next -> gzip-size relies on it.
+      zlib: false,
+    },
     alias: {
       ...webpackBaseConfig.resolve.alias,
       docs: false, // Disable this alias as it creates a circular resolution loop with the docsx alias


### PR DESCRIPTION
A small issue I noticed in #10609, cleaning things up so the next person has a better experience.

<img width="610" alt="Screenshot 2023-10-08 at 18 46 16" src="https://github.com/mui/mui-x/assets/3165635/d23869f7-4640-41ba-8e75-00ed26a88ae8">

To reproduce, you can run `yarn test:regressions:dev`

The rest of the codebase already does it correctly, the only instance that I could find that is wrong.

---

Same goes for, fixed using Material UI solution

<img width="1155" alt="Screenshot 2023-10-08 at 19 03 51" src="https://github.com/mui/mui-x/assets/3165635/3bf74a48-e257-47e3-9d6b-e80275122e7d">
