### PR TITLE
[DataGrid] Fix: getRowId not defined

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -272,7 +272,7 @@ export const buildAggregatedFilterItemsApplier = (
 
   // We generate a new function with `eval()` to avoid expensive patterns for JS engines
   // such as a dynamic object assignment, e.g. `{ [dynamicKey]: value }`.
-  const filterItemTemplate = `(function filterItem$$(appliers, row, shouldApplyFilter) {
+  const filterItemTemplate = `(function filterItem$$(getRowId, appliers, row, shouldApplyFilter) {
       ${appliers
         .map(
           (applier, i) =>
@@ -305,7 +305,7 @@ export const buildAggregatedFilterItemsApplier = (
     filterItemTemplate.replaceAll('$$', String(filterItemsApplierId)),
   );
   const filterItem: GridFilterItemApplierNotAggregated = (row, shouldApplyItem) => {
-    return filterItemCore(appliers, row, shouldApplyItem);
+    return filterItemCore(getRowId, appliers, row, shouldApplyItem);
   };
   filterItemsApplierId += 1;
 


### PR DESCRIPTION
Closes #10598 
- Before: https://codesandbox.io/s/eager-minsky-wt7xxv?file=/src/demo.tsx
- After: https://codesandbox.io/s/cranky-sanne-c9fhnp?file=/package.json

Pass `getRowId` as a param rather than accessing it directly in `eval` code.