### PR TITLE
[core] Bump monorepo

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,6 +19,9 @@ const defaultAlias = {
   '@mui/markdown': '@mui/monorepo/packages/markdown',
   '@mui-internal/api-docs-builder': '@mui/monorepo/packages/api-docs-builder',
   '@mui-internal/docs-utilities': '@mui/monorepo/packages/docs-utilities',
+  '@mui-internal/test-utils': resolveAliasPath(
+    './node_modules/@mui/monorepo/packages/test-utils/src',
+  ),
   'typescript-to-proptypes': '@mui/monorepo/packages/typescript-to-proptypes/src',
   docs: resolveAliasPath('./node_modules/@mui/monorepo/docs'),
   test: resolveAliasPath('./test'),

--- a/docs/data/date-pickers/base-concepts/ComponentFamilies.js
+++ b/docs/data/date-pickers/base-concepts/ComponentFamilies.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Link from 'next/link';
 import dayjs from 'dayjs';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -16,9 +17,9 @@ function ProLabel({ children }) {
   return (
     <Stack direction="row" spacing={0.5} component="span">
       <Tooltip title="Included in Pro package">
-        <a href="/x/introduction/licensing/#pro-plan">
+        <Link href="/x/introduction/licensing/#pro-plan">
           <span className="plan-pro" />
-        </a>
+        </Link>
       </Tooltip>
       <span>{children}</span>
     </Stack>

--- a/docs/data/date-pickers/base-concepts/ComponentFamilies.tsx
+++ b/docs/data/date-pickers/base-concepts/ComponentFamilies.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Link from 'next/link';
 import dayjs from 'dayjs';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -16,9 +17,9 @@ function ProLabel({ children }: { children: React.ReactNode }) {
   return (
     <Stack direction="row" spacing={0.5} component="span">
       <Tooltip title="Included in Pro package">
-        <a href="/x/introduction/licensing/#pro-plan">
+        <Link href="/x/introduction/licensing/#pro-plan">
           <span className="plan-pro" />
-        </a>
+        </Link>
       </Tooltip>
       <span>{children}</span>
     </Stack>

--- a/docs/data/date-pickers/overview/CommonlyUsedComponents.js
+++ b/docs/data/date-pickers/overview/CommonlyUsedComponents.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Link from 'next/link';
 import Tooltip from '@mui/material/Tooltip';
 import Stack from '@mui/material/Stack';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
@@ -20,9 +21,9 @@ function Label({ componentName, valueType, isProOnly }) {
     return (
       <Stack direction="row" spacing={0.5} component="span">
         <Tooltip title="Included on Pro package">
-          <a href="/x/introduction/licensing/#pro-plan">
+          <Link href="/x/introduction/licensing/#pro-plan">
             <span className="plan-pro" />
-          </a>
+          </Link>
         </Tooltip>
         {content}
       </Stack>

--- a/docs/data/date-pickers/overview/CommonlyUsedComponents.tsx
+++ b/docs/data/date-pickers/overview/CommonlyUsedComponents.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Link from 'next/link';
 import Tooltip from '@mui/material/Tooltip';
 import Stack from '@mui/material/Stack';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
@@ -28,9 +29,9 @@ function Label({
     return (
       <Stack direction="row" spacing={0.5} component="span">
         <Tooltip title="Included on Pro package">
-          <a href="/x/introduction/licensing/#pro-plan">
+          <Link href="/x/introduction/licensing/#pro-plan">
             <span className="plan-pro" />
-          </a>
+          </Link>
         </Tooltip>
         {content}
       </Stack>

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@mui/material": "^5.14.11",
     "@mui/monorepo": "https://github.com/mui/material-ui.git#master",
     "@mui/utils": "^5.14.11",
+    "@next/eslint-plugin-next": "^13.5.4",
     "@octokit/plugin-retry": "^6.0.1",
     "@octokit/rest": "^20.0.2",
     "@playwright/test": "1.38.1",

--- a/packages/grid/x-data-grid-premium/src/tests/DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/DataGridPremium.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, act } from '@mui/monorepo/test/utils';
+import { createRenderer, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import {
   DataGridPremium as DataGrid,

--- a/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, userEvent, within, act } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, userEvent, within, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
 import { SinonSpy, spy } from 'sinon';

--- a/packages/grid/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { stub, SinonStub } from 'sinon';
 import { expect } from 'chai';
 import { spyApi, getCell } from 'test/utils/helperFn';
-import { createRenderer, fireEvent, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act, userEvent } from '@mui-internal/test-utils';
 import {
   DataGridPremium,
   DataGridPremiumProps,

--- a/packages/grid/x-data-grid-premium/src/tests/clipboard.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/clipboard.DataGridPremium.test.tsx
@@ -7,7 +7,7 @@ import {
   GridColDef,
 } from '@mui/x-data-grid-premium';
 // @ts-ignore Remove once the test utils are typed
-import { createRenderer, fireEvent, userEvent, waitFor } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, userEvent, waitFor } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { stub, SinonStub, spy } from 'sinon';
 import { getCell, getColumnValues, sleep } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid-premium/src/tests/columns.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/columns.DataGridPremium.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, createRenderer, fireEvent } from '@mui/monorepo/test/utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGridPremium, gridClasses } from '@mui/x-data-grid-premium';
 import { getCell, getColumnHeaderCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/exportExcel.DataGridPremium.test.tsx
@@ -8,7 +8,7 @@ import {
   DataGridPremiumProps,
   GridActionsCellItem,
 } from '@mui/x-data-grid-premium';
-import { createRenderer, screen, fireEvent, act } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, fireEvent, act } from '@mui-internal/test-utils';
 import { spy, SinonSpy } from 'sinon';
 import { expect } from 'chai';
 import Excel from 'exceljs';

--- a/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import addYears from 'date-fns/addYears';
 import { expect } from 'chai';
-import { createRenderer, screen, waitFor } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, waitFor } from '@mui-internal/test-utils';
 import { DataGridPremium } from '@mui/x-data-grid-premium';
 import { generateLicense, LicenseInfo } from '@mui/x-license-pro';
 

--- a/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
@@ -6,7 +6,7 @@ import {
   act,
   userEvent,
   waitFor,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import {
   microtasks,
   getColumnHeaderCell,

--- a/packages/grid/x-data-grid-premium/src/tests/rowPinning.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowPinning.DataGridPremium.test.tsx
@@ -1,4 +1,4 @@
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import * as React from 'react';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid-premium/src/tests/statePersistence.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/statePersistence.DataGridPremium.test.tsx
@@ -8,7 +8,7 @@ import {
   GridRowsProp,
   useGridApiRef,
 } from '@mui/x-data-grid-premium';
-import { createRenderer, act } from '@mui/monorepo/test/utils';
+import { createRenderer, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { getColumnValues } from 'test/utils/helperFn';
 

--- a/packages/grid/x-data-grid-premium/tsconfig.json
+++ b/packages/grid/x-data-grid-premium/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/grid/x-data-grid-premium/tsconfig.json
+++ b/packages/grid/x-data-grid-premium/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/grid/x-data-grid-pro/src/tests/accessibility.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/accessibility.DataGridPro.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import axe from 'axe-core';
 import { DataGridPro } from '@mui/x-data-grid-pro';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer } from '@mui-internal/test-utils';
 
 function logViolations(violations: any) {
   if (violations.length !== 0) {

--- a/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
@@ -13,7 +13,7 @@ import {
   GridCellModes,
 } from '@mui/x-data-grid-pro';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
-import { createRenderer, fireEvent, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act, userEvent } from '@mui-internal/test-utils';
 import { getCell, spyApi } from 'test/utils/helperFn';
 
 describe('<DataGridPro /> - Cell editing', () => {

--- a/packages/grid/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { GridApi, useGridApiRef, DataGridPro, DataGridProProps } from '@mui/x-data-grid-pro';
-import { createRenderer, fireEvent, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { stub, SinonStub } from 'sinon';
 import { getCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnHeaders.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { gridClasses, DataGridPro, DataGridProProps } from '@mui/x-data-grid-pro';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -18,7 +18,7 @@ import {
   createEvent,
   act,
   userEvent,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import { getCell, getColumnHeaderCell, getColumnHeadersTextContent } from 'test/utils/helperFn';
 
 // TODO Move to utils

--- a/packages/grid/x-data-grid-pro/src/tests/columnReorder.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnReorder.DataGridPro.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, fireEvent, createEvent, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, createEvent, act } from '@mui-internal/test-utils';
 import {
   getColumnHeadersTextContent,
   getColumnHeaderCell,

--- a/packages/grid/x-data-grid-pro/src/tests/columnSpanning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnSpanning.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGridPro, GridApi, useGridApiRef, GridColDef, gridClasses } from '@mui/x-data-grid-pro';
 import { getActiveCell, getCell, getColumnHeaderCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {

--- a/packages/grid/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { createRenderer, fireEvent, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act } from '@mui-internal/test-utils';
 import {
   DataGridPro,
   DataGridProProps,

--- a/packages/grid/x-data-grid-pro/src/tests/components.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/components.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, EventType, fireEvent, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, EventType, fireEvent, userEvent } from '@mui-internal/test-utils';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
@@ -18,7 +18,7 @@ import {
   waitFor,
   act,
   userEvent,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import { getRow, getCell, getColumnValues, getRows } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);

--- a/packages/grid/x-data-grid-pro/src/tests/editComponents.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/editComponents.DataGridPro.test.tsx
@@ -10,7 +10,7 @@ import {
   renderEditInputCell,
   renderEditSingleSelectCell,
 } from '@mui/x-data-grid-pro';
-import { act, createRenderer, fireEvent, screen, userEvent } from '@mui/monorepo/test/utils';
+import { act, createRenderer, fireEvent, screen, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { getCell, spyApi } from 'test/utils/helperFn';
 import { spy, SinonSpy } from 'sinon';

--- a/packages/grid/x-data-grid-pro/src/tests/events.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/events.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import {
   DataGridPro,

--- a/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
@@ -5,7 +5,7 @@ import {
   GridApi,
   DataGridProProps,
 } from '@mui/x-data-grid-pro';
-import { createRenderer, act } from '@mui/monorepo/test/utils';
+import { createRenderer, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 

--- a/packages/grid/x-data-grid-pro/src/tests/filterPanel.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filterPanel.DataGridPro.test.tsx
@@ -7,7 +7,7 @@ import {
   GridApi,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import { createRenderer, act } from '@mui/monorepo/test/utils';
+import { createRenderer, act } from '@mui-internal/test-utils';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 

--- a/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
@@ -15,7 +15,7 @@ import {
   gridExpandedSortedRowEntriesSelector,
   gridClasses,
 } from '@mui/x-data-grid-pro';
-import { createRenderer, fireEvent, screen, act, within } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act, within } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { spy } from 'sinon';

--- a/packages/grid/x-data-grid-pro/src/tests/layout.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/layout.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { GridApi, useGridApiRef, DataGridPro, ptBR, DataGridProProps } from '@mui/x-data-grid-pro';

--- a/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act } from '@mui-internal/test-utils';
 import { getColumnHeaderCell, getColumnValues, getRow } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid-pro/src/tests/license.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/license.DataGridPro.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen, waitFor } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, waitFor } from '@mui-internal/test-utils';
 import { DataGridPro } from '@mui/x-data-grid-pro';
 import { LicenseInfo } from '@mui/x-license-pro';
 

--- a/packages/grid/x-data-grid-pro/src/tests/pagination.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/pagination.DataGridPro.test.tsx
@@ -1,4 +1,4 @@
-import { createRenderer, act } from '@mui/monorepo/test/utils';
+import { createRenderer, act } from '@mui-internal/test-utils';
 import { getColumnValues } from 'test/utils/helperFn';
 import * as React from 'react';
 import { expect } from 'chai';

--- a/packages/grid/x-data-grid-pro/src/tests/printExport.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/printExport.DataGrid.test.tsx
@@ -9,7 +9,7 @@ import {
   DataGridProProps,
 } from '@mui/x-data-grid-pro';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
-import { createRenderer, screen, fireEvent, act } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, fireEvent, act } from '@mui-internal/test-utils';
 
 describe('<DataGridPro /> - Print export', () => {
   const { render, clock } = createRenderer();

--- a/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowEditing.DataGridPro.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/x-data-grid-pro';
 import Portal from '@mui/material/Portal';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
-import { createRenderer, fireEvent, act, userEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act, userEvent, screen } from '@mui-internal/test-utils';
 import { getCell, getRow, spyApi } from 'test/utils/helperFn';
 
 describe('<DataGridPro /> - Row editing', () => {

--- a/packages/grid/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowPinning.DataGridPro.test.tsx
@@ -18,7 +18,7 @@ import {
   act,
   userEvent,
   waitFor,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import {
   getActiveCell,
   getActiveColumnHeader,

--- a/packages/grid/x-data-grid-pro/src/tests/rowReorder.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowReorder.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, fireEvent, createEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, createEvent } from '@mui-internal/test-utils';
 import { getCell, getRowsFieldContent } from 'test/utils/helperFn';
 import { useGridApiRef, DataGridPro, gridClasses, GridApi } from '@mui/x-data-grid-pro';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';

--- a/packages/grid/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getCell, getColumnValues, getRows } from 'test/utils/helperFn';
-import { createRenderer, fireEvent, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act } from '@mui-internal/test-utils';
 import {
   GridApi,
   useGridApiRef,

--- a/packages/grid/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act, userEvent } from '@mui-internal/test-utils';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid-pro/src/tests/sorting.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/sorting.DataGridPro.test.tsx
@@ -7,7 +7,7 @@ import {
   useGridApiRef,
   GridColDef,
 } from '@mui/x-data-grid-pro';
-import { createRenderer, fireEvent, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { getColumnValues, getCell, getColumnHeaderCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid-pro/src/tests/state.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/state.DataGridPro.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { getColumnValues } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import { DataGridPro, useGridApiRef, GridApi, DataGridProProps } from '@mui/x-data-grid-pro';

--- a/packages/grid/x-data-grid-pro/src/tests/statePersistence.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/statePersistence.DataGridPro.test.tsx
@@ -10,7 +10,7 @@ import {
   GridRowsProp,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import { createRenderer, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import {
   getColumnHeaderCell,

--- a/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -1,4 +1,4 @@
-import { createRenderer, fireEvent, screen, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act, userEvent } from '@mui-internal/test-utils';
 import {
   getCell,
   getColumnHeaderCell,

--- a/packages/grid/x-data-grid-pro/tsconfig.json
+++ b/packages/grid/x-data-grid-pro/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/grid/x-data-grid-pro/tsconfig.json
+++ b/packages/grid/x-data-grid-pro/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/grid/x-data-grid/src/components/panel/GridPanel.test.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/GridPanel.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui/monorepo/test/utils';
+import { createRenderer, describeConformance } from '@mui-internal/test-utils';
 import {
   GridPanel,
   gridPanelClasses as classes,

--- a/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -94,7 +94,6 @@ export function computeFlexColumnsWidth({
         flexColumnsLookup.all[column.field] &&
         flexColumnsLookup.all[column.field].frozen === true
       ) {
-        // eslint-disable-next-line no-continue
         continue;
       }
 

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -374,7 +374,7 @@ export const buildAggregatedQuickFilterApplier = (
     const result = {} as GridQuickFilterValueResult;
     const usedCellParams = {} as { [field: string]: GridCellParams };
 
-    /* eslint-disable no-restricted-syntax, no-labels, no-continue */
+    /* eslint-disable no-restricted-syntax, no-labels */
     outer: for (let v = 0; v < quickFilterValues.length; v += 1) {
       const filterValue = quickFilterValues[v];
 
@@ -415,7 +415,7 @@ export const buildAggregatedQuickFilterApplier = (
 
       result[filterValue] = false;
     }
-    /* eslint-enable no-restricted-syntax, no-labels, no-continue */
+    /* eslint-enable no-restricted-syntax, no-labels */
 
     return result;
   };

--- a/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.test.tsx
+++ b/packages/grid/x-data-grid/src/hooks/utils/useGridApiEventHandler.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { sleep } from 'test/utils/helperFn';
 import { createUseGridApiEventHandler } from './useGridApiEventHandler';
 import { FinalizationRegistryBasedCleanupTracking } from '../../utils/cleanupTracking/FinalizationRegistryBasedCleanupTracking';

--- a/packages/grid/x-data-grid/src/locales/roRO.ts
+++ b/packages/grid/x-data-grid/src/locales/roRO.ts
@@ -86,7 +86,7 @@ const roROGrid: Partial<GridLocaleText> = {
   headerFilterOperatorIs: 'Este',
   headerFilterOperatorNot: 'Nu este',
   headerFilterOperatorAfter: 'Este după',
-  headerFilterOperatorOnOrAfter: 'Este la sau „după”',
+  headerFilterOperatorOnOrAfter: 'Este la sau după',
   headerFilterOperatorBefore: 'Este înainte de',
   headerFilterOperatorOnOrBefore: 'este la sau înainte de',
   headerFilterOperatorIsEmpty: 'Este gol',

--- a/packages/grid/x-data-grid/src/tests/DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGrid } from '@mui/x-data-grid';
 

--- a/packages/grid/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { createRenderer, fireEvent, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGrid } from '@mui/x-data-grid';
 import { getCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid/src/tests/columnHeaders.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnHeaders.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, within, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, within, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGrid } from '@mui/x-data-grid';
 import { getColumnHeaderCell, getColumnHeadersTextContent } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, within, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, within, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGrid, gridClasses, GridColDef } from '@mui/x-data-grid';
 import { getCell, getActiveCell, getColumnHeaderCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid/src/tests/columns.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columns.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { DataGrid, DataGridProps, GridRowsProp, GridColDef } from '@mui/x-data-grid';
 import { getCell, getColumnHeaderCell, getColumnHeadersTextContent } from 'test/utils/helperFn';
 

--- a/packages/grid/x-data-grid/src/tests/columnsGrouping.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnsGrouping.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, ErrorBoundary, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, ErrorBoundary, screen } from '@mui-internal/test-utils';
 import { DataGrid, DataGridProps, GridRowModel, GridColDef } from '@mui/x-data-grid';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);

--- a/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/columnsVisibility.DataGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { DataGrid, DataGridProps, GridRowsProp, GridColDef, GridToolbar } from '@mui/x-data-grid';
 import { getColumnHeadersTextContent } from 'test/utils/helperFn';
 

--- a/packages/grid/x-data-grid/src/tests/components.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/components.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, ErrorBoundary, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, ErrorBoundary, fireEvent, screen } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { DataGrid, GridOverlay } from '@mui/x-data-grid';

--- a/packages/grid/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy, SinonSpy } from 'sinon';
 import { DataGrid, DataGridProps, GridToolbar, GridToolbarExport } from '@mui/x-data-grid';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
-import { createRenderer, screen, fireEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
 
 describe('<DataGrid /> - Export', () => {
   const { render, clock } = createRenderer({ clock: 'fake' });

--- a/packages/grid/x-data-grid/src/tests/filterPanel.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filterPanel.DataGrid.test.tsx
@@ -9,7 +9,7 @@ import {
   GridFilterInputValueProps,
   GridPreferencePanelsValue,
 } from '@mui/x-data-grid';
-import { createRenderer, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
 
 function setColumnValue(columnValue: string) {

--- a/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import {
   DataGrid,

--- a/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act, userEvent } from '@mui-internal/test-utils';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, ErrorBoundary, waitFor } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, ErrorBoundary, waitFor } from '@mui-internal/test-utils';
 import { stub, spy } from 'sinon';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy, stub, SinonStub, SinonSpy } from 'sinon';
 import { expect } from 'chai';
-import { createRenderer, fireEvent, screen, userEvent, waitFor } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, userEvent, waitFor } from '@mui-internal/test-utils';
 import {
   DataGrid,
   DataGridProps,

--- a/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, fireEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {

--- a/packages/grid/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, fireEvent, screen, act, userEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act, userEvent } from '@mui-internal/test-utils';
 import {
   DataGrid,
   DataGridProps,

--- a/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -7,7 +7,7 @@ import {
   userEvent,
   ErrorBoundary,
   waitFor,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import clsx from 'clsx';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';

--- a/packages/grid/x-data-grid/src/tests/sorting.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/sorting.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, act, waitFor } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act, waitFor } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { DataGrid, DataGridProps, GridSortModel, useGridApiRef, GridApi } from '@mui/x-data-grid';
 import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';

--- a/packages/grid/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, act } from '@mui/monorepo/test/utils';
+import { createRenderer, fireEvent, screen, act } from '@mui-internal/test-utils';
 import { getColumnHeadersTextContent } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import {

--- a/packages/grid/x-data-grid/tsconfig.json
+++ b/packages/grid/x-data-grid/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/grid/x-data-grid/tsconfig.json
+++ b/packages/grid/x-data-grid/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/x-charts/tsconfig.json
+++ b/packages/x-charts/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/x-charts/tsconfig.json
+++ b/packages/x-charts/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/x-codemod/tsconfig.json
+++ b/packages/x-codemod/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "include": [
     "src/**/*",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation",
     "../../node_modules/date-fns",
     "../../node_modules/dayjs/plugin/utc.d.ts",

--- a/packages/x-codemod/tsconfig.json
+++ b/packages/x-codemod/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "include": [
     "src/**/*",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation",
     "../../node_modules/date-fns",
     "../../node_modules/dayjs/plugin/utc.d.ts",

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -8,7 +8,7 @@ import {
   describeConformance,
   fireTouchChangedEvent,
   userEvent,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import {
   adapterToUse,
   buildPickerDragInteractions,

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { fireEvent, screen } from '@mui/monorepo/test/utils/createRenderer';
+import { fireEvent, screen } from '@mui-internal/test-utils/createRenderer';
 import { expect } from 'chai';
 import { createPickerRenderer, stubMatchMedia } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/DateRangePicker/describes.DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/describes.DateRangePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import {
   DateRangePickerDay,
   dateRangePickerDayClasses as classes,

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, fireEvent, userEvent, act, getByRole } from '@mui/monorepo/test/utils';
+import { screen, fireEvent, userEvent, act, getByRole } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 import { DateRange, LocalizationProvider } from '@mui/x-date-pickers-pro';

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describes.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describes.DesktopDateRangePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance, screen, userEvent } from '@mui/monorepo/test/utils';
+import { describeConformance, screen, userEvent } from '@mui-internal/test-utils';
 import {
   adapterToUse,
   createPickerRenderer,

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { screen, userEvent, fireEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent, fireEvent } from '@mui-internal/test-utils';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import { createPickerRenderer, adapterToUse, openPicker } from 'test/utils/pickers';
 import { DateRange } from '@mui/x-date-pickers-pro';

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describes.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describes.MobileDateRangePicker.test.tsx
@@ -4,7 +4,7 @@ import {
   screen,
   userEvent,
   fireDiscreteEvent,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import {
   adapterToUse,

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.conformance.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.validation.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.validation.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@mui/monorepo/test/utils';
-import { fireEvent } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils';
+import { fireEvent } from '@mui-internal/test-utils/createRenderer';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { createPickerRenderer, adapterToUse, describeRangeValidation } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.conformance.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { MultiInputDateTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputDateTimeRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.validation.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.validation.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@mui/monorepo/test/utils';
-import { fireEvent } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils';
+import { fireEvent } from '@mui-internal/test-utils/createRenderer';
 import { MultiInputDateTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputDateTimeRangeField';
 import { createPickerRenderer, adapterToUse, describeRangeValidation } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.conformance.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { MultiInputTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputTimeRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.validation.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.validation.test.tsx
@@ -1,5 +1,5 @@
-import { screen } from '@mui/monorepo/test/utils';
-import { fireEvent } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils';
+import { fireEvent } from '@mui-internal/test-utils/createRenderer';
 import { MultiInputTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputTimeRangeField';
 import { createPickerRenderer, adapterToUse, describeRangeValidation } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/editing.SingleInputDateRangeField.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import { userEvent, fireEvent } from '@mui/monorepo/test/utils';
+import { userEvent, fireEvent } from '@mui-internal/test-utils';
 import { expectInputValue, describeAdapters } from 'test/utils/pickers';
 
 describe('<SingleInputDateRangeField /> - Editing', () => {

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import { act, userEvent } from '@mui/monorepo/test/utils';
+import { act, userEvent } from '@mui-internal/test-utils';
 import {
   adapterToUse,
   buildFieldInteractions,

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describes.SingleInputDateTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describes.SingleInputDateTimeRangeField.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { SingleInputDateTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputDateTimeRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describes.SingleInputTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describes.SingleInputTimeRangeField.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import { SingleInputTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputTimeRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { isWeekend } from 'date-fns';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
-import { describeConformance, screen } from '@mui/monorepo/test/utils';
+import { describeConformance, screen } from '@mui-internal/test-utils';
 import {
   wrapPickerMount,
   createPickerRenderer,

--- a/packages/x-date-pickers-pro/tsconfig.json
+++ b/packages/x-date-pickers-pro/tsconfig.json
@@ -7,7 +7,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation",
     "../../node_modules/dayjs/plugin/utc.d.ts",
     "../../node_modules/dayjs/plugin/timezone.d.ts",

--- a/packages/x-date-pickers-pro/tsconfig.json
+++ b/packages/x-date-pickers-pro/tsconfig.json
@@ -7,7 +7,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation",
     "../../node_modules/dayjs/plugin/utc.d.ts",
     "../../node_modules/dayjs/plugin/timezone.d.ts",

--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import { expect } from 'chai';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import {
   createPickerRenderer,
   expectInputPlaceholder,

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -5,7 +5,7 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import {
   buildPickerDragInteractions,

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
@@ -4,7 +4,7 @@ import { DateTime, Settings } from 'luxon';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import {
   cleanText,
   createPickerRenderer,

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
@@ -4,7 +4,7 @@ import momentTZ from 'moment-timezone';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { AdapterMomentHijri } from '@mui/x-date-pickers/AdapterMomentHijri';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import {
   createPickerRenderer,
   expectInputPlaceholder,

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.test.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import jMoment from 'moment-jalaali';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { AdapterMomentJalaali } from '@mui/x-date-pickers/AdapterMomentJalaali';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import {
   createPickerRenderer,
   expectInputPlaceholder,

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { fireEvent, userEvent, screen } from '@mui/monorepo/test/utils';
+import { fireEvent, userEvent, screen } from '@mui-internal/test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { PickersDay } from '@mui/x-date-pickers/PickersDay';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';

--- a/packages/x-date-pickers/src/DateCalendar/tests/describes.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/describes.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, screen, userEvent } from '@mui/monorepo/test/utils';
+import { describeConformance, screen, userEvent } from '@mui-internal/test-utils';
 import { DateCalendar, dateCalendarClasses as classes } from '@mui/x-date-pickers/DateCalendar';
 import { pickersDayClasses } from '@mui/x-date-pickers/PickersDay';
 import {

--- a/packages/x-date-pickers/src/DateCalendar/tests/keyboard.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/keyboard.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { act, fireEvent, screen } from '@mui-internal/test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { adapterToUse, createPickerRenderer } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/DateCalendar/tests/timezone.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/timezone.DateCalendar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { userEvent, screen } from '@mui/monorepo/test/utils';
+import { userEvent, screen } from '@mui-internal/test-utils';
 import { describeAdapters } from 'test/utils/pickers';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 

--- a/packages/x-date-pickers/src/DateCalendar/tests/validation.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/validation.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, fireEvent } from '@mui/monorepo/test/utils';
+import { screen, fireEvent } from '@mui-internal/test-utils';
 import { DateCalendar, DateCalendarProps } from '@mui/x-date-pickers/DateCalendar';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance, userEvent } from '@mui/monorepo/test/utils';
+import { describeConformance, userEvent } from '@mui-internal/test-utils';
 import TextField from '@mui/material/TextField';
 import { DateField } from '@mui/x-date-pickers/DateField';
 import {

--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { DateField } from '@mui/x-date-pickers/DateField';
-import { act, userEvent, fireEvent } from '@mui/monorepo/test/utils';
+import { act, userEvent, fireEvent } from '@mui-internal/test-utils';
 import { expectInputValue, getTextbox, describeAdapters } from 'test/utils/pickers';
 
 describe('<DateField /> - Editing', () => {

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { DateField } from '@mui/x-date-pickers/DateField';
-import { act, userEvent } from '@mui/monorepo/test/utils';
+import { act, userEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   expectInputValue,

--- a/packages/x-date-pickers/src/DatePicker/tests/DatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DatePicker/tests/DatePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import { createPickerRenderer, stubMatchMedia } from 'test/utils/pickers';
 
 describe('<DatePicker />', () => {

--- a/packages/x-date-pickers/src/DateTimeField/tests/describes.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/describes.DateTimeField.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
-import { describeConformance, userEvent } from '@mui/monorepo/test/utils';
+import { describeConformance, userEvent } from '@mui-internal/test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import {
   adapterToUse,

--- a/packages/x-date-pickers/src/DateTimeField/tests/editing.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/editing.DateTimeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { userEvent, screen } from '@mui/monorepo/test/utils';
+import { userEvent, screen } from '@mui-internal/test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { adapterToUse, buildFieldInteractions, createPickerRenderer } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { userEvent } from '@mui/monorepo/test/utils';
+import { userEvent } from '@mui-internal/test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/DateTimePicker/tests/DateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/tests/DateTimePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import { createPickerRenderer, stubMatchMedia } from 'test/utils/pickers';
 
 describe('<DateTimePicker />', () => {

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.test.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance } from '@mui/monorepo/test/utils';
+import { describeConformance } from '@mui-internal/test-utils';
 import {
   DayCalendarSkeleton,
   dayCalendarSkeletonClasses as classes,

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { TransitionProps } from '@mui/material/transitions';
 import { inputBaseClasses } from '@mui/material/InputBase';
-import { fireEvent, screen, userEvent } from '@mui/monorepo/test/utils';
+import { fireEvent, screen, userEvent } from '@mui-internal/test-utils';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/describes.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/describes.DesktopDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   adapterToUse,

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, userEvent } from '@mui/monorepo/test/utils';
+import { fireEvent, userEvent } from '@mui-internal/test-utils';
 import { DesktopDatePicker, DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePicker';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { DesktopDateTimePicker } from '@mui/x-date-pickers/DesktopDateTimePicker';
 import { adapterToUse, createPickerRenderer, openPicker } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describes.DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describes.DesktopDateTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   adapterToUse,

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/DesktopTimePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
 import { createPickerRenderer, openPicker } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { screen, userEvent, describeConformance } from '@mui/monorepo/test/utils';
+import { screen, userEvent, describeConformance } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,

--- a/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, describeConformance } from '@mui/monorepo/test/utils';
+import { screen, describeConformance } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,

--- a/packages/x-date-pickers/src/DigitalClock/tests/timezone.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/timezone.DigitalClock.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
 import { getDateOffset, describeAdapters } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.test.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer } from '@mui/monorepo/test/utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { useLocalizationContext } from '@mui/x-date-pickers/internals';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { fireEvent, screen, userEvent } from '@mui/monorepo/test/utils';
+import { fireEvent, screen, userEvent } from '@mui-internal/test-utils';
 import { PickersDay } from '@mui/x-date-pickers/PickersDay';
 import { DayCalendarSkeleton } from '@mui/x-date-pickers/DayCalendarSkeleton';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/describes.MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/describes.MobileDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   adapterToUse,

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/MobileDateTimePicker.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { fireTouchChangedEvent, screen, userEvent } from '@mui/monorepo/test/utils';
+import { fireTouchChangedEvent, screen, userEvent } from '@mui-internal/test-utils';
 import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker';
 import {
   adapterToUse,

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/describes.MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/describes.MobileDateTimePicker.test.tsx
@@ -1,4 +1,4 @@
-import { screen, userEvent, fireTouchChangedEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent, fireTouchChangedEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   adapterToUse,

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/MobileTimePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { fireTouchChangedEvent, screen, userEvent, act } from '@mui/monorepo/test/utils';
+import { fireTouchChangedEvent, screen, userEvent, act } from '@mui-internal/test-utils';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
@@ -4,7 +4,7 @@ import {
   screen,
   userEvent,
   fireTouchChangedEvent,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,

--- a/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { fireEvent, screen } from '@mui/monorepo/test/utils';
+import { fireEvent, screen } from '@mui-internal/test-utils';
 import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, userEvent, screen } from '@mui/monorepo/test/utils';
+import { describeConformance, userEvent, screen } from '@mui-internal/test-utils';
 import {
   wrapPickerMount,
   createPickerRenderer,

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, describeConformance } from '@mui/monorepo/test/utils';
+import { screen, describeConformance } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.test.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { PickersActionBar } from '@mui/x-date-pickers/PickersActionBar';
 import { createPickerRenderer } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { describeConformance, fireEvent, screen } from '@mui-internal/test-utils';
 import ButtonBase from '@mui/material/ButtonBase';
 import { PickersDay, pickersDayClasses as classes } from '@mui/x-date-pickers/PickersDay';
 import { adapterToUse, wrapPickerMount, createPickerRenderer } from 'test/utils/pickers';

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { fireEvent, screen } from '@mui/monorepo/test/utils';
+import { fireEvent, screen } from '@mui-internal/test-utils';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePickerKeyboard.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/StaticDatePickerKeyboard.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { act, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { act, fireEvent, screen } from '@mui-internal/test-utils';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { DateView } from '@mui/x-date-pickers/models';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';

--- a/packages/x-date-pickers/src/StaticDateTimePicker/tests/StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/tests/StaticDateTimePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { fireEvent, screen } from '@mui/monorepo/test/utils';
+import { fireEvent, screen } from '@mui-internal/test-utils';
 import { StaticDateTimePicker } from '@mui/x-date-pickers/StaticDateTimePicker';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 import { DateTimePickerTabs, DateTimePickerTabsProps } from '../../DateTimePicker';

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   getAllByRole,
   fireEvent,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import {
   adapterToUse,
   wrapPickerMount,

--- a/packages/x-date-pickers/src/TimeClock/tests/TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/TimeClock.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   within,
   getAllByRole,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import { TimeClock } from '@mui/x-date-pickers/TimeClock';
 import { createPickerRenderer, adapterToUse, timeClockHandler } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/TimeClock/tests/describes.TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/describes.TimeClock.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, screen } from '@mui/monorepo/test/utils';
+import { describeConformance, screen } from '@mui-internal/test-utils';
 import {
   clockPointerClasses,
   TimeClock,

--- a/packages/x-date-pickers/src/TimeClock/tests/timezone.TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/timezone.TimeClock.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { screen, fireTouchChangedEvent } from '@mui/monorepo/test/utils';
+import { screen, fireTouchChangedEvent } from '@mui-internal/test-utils';
 import { TimeClock } from '@mui/x-date-pickers/TimeClock';
 import {
   getClockTouchEvent,

--- a/packages/x-date-pickers/src/TimeField/tests/describes.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/describes.TimeField.test.tsx
@@ -1,4 +1,4 @@
-import { userEvent } from '@mui/monorepo/test/utils';
+import { userEvent } from '@mui-internal/test-utils';
 import {
   adapterToUse,
   createPickerRenderer,

--- a/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/editing.TimeField.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
-import { userEvent, fireEvent } from '@mui/monorepo/test/utils';
+import { userEvent, fireEvent } from '@mui-internal/test-utils';
 import { expectInputValue, getCleanedSelectedContent, describeAdapters } from 'test/utils/pickers';
 
 describe('<TimeField /> - Editing', () => {

--- a/packages/x-date-pickers/src/TimePicker/tests/TimePicker.test.tsx
+++ b/packages/x-date-pickers/src/TimePicker/tests/TimePicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { screen } from '@mui/monorepo/test/utils/createRenderer';
+import { screen } from '@mui-internal/test-utils/createRenderer';
 import { expect } from 'chai';
 import { createPickerRenderer, stubMatchMedia } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import { act, fireEvent, screen } from '@mui/monorepo/test/utils';
+import { act, fireEvent, screen } from '@mui-internal/test-utils';
 import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 

--- a/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { userEvent, screen, describeConformance } from '@mui/monorepo/test/utils';
+import { userEvent, screen, describeConformance } from '@mui-internal/test-utils';
 import {
   pickersYearClasses,
   YearCalendar,

--- a/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
+++ b/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import moment from 'moment/moment';
 import jMoment from 'moment-jalaali';
-import { userEvent } from '@mui/monorepo/test/utils';
+import { userEvent } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import {
   buildFieldInteractions,

--- a/packages/x-date-pickers/tsconfig.json
+++ b/packages/x-date-pickers/tsconfig.json
@@ -7,7 +7,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation",
     "../../node_modules/dayjs/plugin/utc.d.ts",
     "../../node_modules/dayjs/plugin/timezone.d.ts",

--- a/packages/x-date-pickers/tsconfig.json
+++ b/packages/x-date-pickers/tsconfig.json
@@ -7,7 +7,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation",
     "../../node_modules/dayjs/plugin/utc.d.ts",
     "../../node_modules/dayjs/plugin/timezone.d.ts",

--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, screen } from '@mui/monorepo/test/utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import {
   useLicenseVerifier,
   LicenseInfo,

--- a/packages/x-license-pro/tsconfig.json
+++ b/packages/x-license-pro/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/x-license-pro/tsconfig.json
+++ b/packages/x-license-pro/tsconfig.json
@@ -6,7 +6,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -9,7 +9,7 @@ import {
   createRenderer,
   fireEvent,
   screen,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import { TreeView } from '@mui/x-tree-view/TreeView';
 import { TreeItem, treeItemClasses as classes } from '@mui/x-tree-view/TreeItem';
 

--- a/packages/x-tree-view/src/TreeView/TreeView.test.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.test.tsx
@@ -8,7 +8,7 @@ import {
   fireEvent,
   screen,
   describeConformance,
-} from '@mui/monorepo/test/utils';
+} from '@mui-internal/test-utils';
 import Portal from '@mui/material/Portal';
 import { TreeView, treeViewClasses as classes } from '@mui/x-tree-view/TreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';

--- a/packages/x-tree-view/tsconfig.json
+++ b/packages/x-tree-view/tsconfig.json
@@ -7,7 +7,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui/monorepo/test/utils/initMatchers.ts",
+    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/packages/x-tree-view/tsconfig.json
+++ b/packages/x-tree-view/tsconfig.json
@@ -7,7 +7,7 @@
   "include": [
     "src/**/*",
     "../../test/utils/addChaiAssertions.ts",
-    "../../node_modules/@mui-internal/test-utils/initMatchers.ts",
+    "../../node_modules/@mui/monorepo/packages/test-utils/src/initMatchers.ts",
     "../../node_modules/@mui/material/themeCssVarsAugmentation"
   ]
 }

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import '@mui/monorepo/test/utils/setupKarma';
+import '@mui-internal/test-utils/setupKarma';
 
 import './utils/init';
 import { createXMochaHooks } from './utils/mochaHooks';

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { act } from '@mui/monorepo/test/utils';
+import { act } from '@mui-internal/test-utils';
 import { unwrapPrivateAPI } from '@mui/x-data-grid/internals';
 import type { GridApiCommon } from '@mui/x-data-grid/models/api/gridApiCommon';
 

--- a/test/utils/init.ts
+++ b/test/utils/init.ts
@@ -1,4 +1,4 @@
-import '@mui/monorepo/test/utils/init';
+import '@mui-internal/test-utils/init';
 import './licenseRelease';
 import './addChaiAssertions';
 import './setupPickers';

--- a/test/utils/pickers/calendar.ts
+++ b/test/utils/pickers/calendar.ts
@@ -1,4 +1,4 @@
-import { fireEvent, createEvent } from '@mui/monorepo/test/utils';
+import { fireEvent, createEvent } from '@mui-internal/test-utils';
 
 export const rangeCalendarDayTouches = {
   '2018-01-01': {

--- a/test/utils/pickers/clock.ts
+++ b/test/utils/pickers/clock.ts
@@ -1,6 +1,6 @@
 import { CLOCK_WIDTH } from '@mui/x-date-pickers/TimeClock/shared';
 import { clockPointerClasses } from '@mui/x-date-pickers/TimeClock';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 
 export const getClockTouchEvent = (
   value: number | string,

--- a/test/utils/pickers/createPickerRenderer.tsx
+++ b/test/utils/pickers/createPickerRenderer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { createRenderer, CreateRendererOptions, RenderOptions } from '@mui/monorepo/test/utils';
+import { createRenderer, CreateRendererOptions, RenderOptions } from '@mui-internal/test-utils';
 import { AdapterClassToUse, AdapterName, adapterToUse, availableAdapters } from './adapters';
 
 interface CreatePickerRendererOptions extends CreateRendererOptions {

--- a/test/utils/pickers/describeAdapters/describeAdapters.ts
+++ b/test/utils/pickers/describeAdapters/describeAdapters.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import moment from 'moment';
 import momentTZ from 'moment-timezone';
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import {
   AdapterName,
   buildFieldInteractions,

--- a/test/utils/pickers/describeGregorianAdapter/describeGregorianAdapter.ts
+++ b/test/utils/pickers/describeGregorianAdapter/describeGregorianAdapter.ts
@@ -1,4 +1,4 @@
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import { MuiPickersAdapter } from '@mui/x-date-pickers';
 import { testCalculations } from './testCalculations';
 import { testLocalization } from './testLocalization';

--- a/test/utils/pickers/describeHijriAdapter/describeHijriAdapter.ts
+++ b/test/utils/pickers/describeHijriAdapter/describeHijriAdapter.ts
@@ -1,4 +1,4 @@
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import { MuiPickersAdapter } from '@mui/x-date-pickers';
 import { testCalculations } from './testCalculations';
 import { testLocalization } from './testLocalization';

--- a/test/utils/pickers/describeJalaliAdapter/describeJalaliAdapter.ts
+++ b/test/utils/pickers/describeJalaliAdapter/describeJalaliAdapter.ts
@@ -1,4 +1,4 @@
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import { MuiPickersAdapter } from '@mui/x-date-pickers';
 import { testCalculations } from './testCalculations';
 import { testLocalization } from './testLocalization';

--- a/test/utils/pickers/describePicker/describePicker.tsx
+++ b/test/utils/pickers/describePicker/describePicker.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, fireEvent, createDescribe } from '@mui/monorepo/test/utils';
+import { screen, fireEvent, createDescribe } from '@mui-internal/test-utils';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import { DescribePickerOptions } from './describePicker.types';
 

--- a/test/utils/pickers/describePicker/describePicker.types.ts
+++ b/test/utils/pickers/describePicker/describePicker.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MuiRenderResult } from '@mui/monorepo/test/utils/createRenderer';
+import { MuiRenderResult } from '@mui-internal/test-utils/createRenderer';
 
 export interface DescribePickerOptions {
   fieldType: 'single-input' | 'multi-input';

--- a/test/utils/pickers/describeRangeValidation/describeRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/describeRangeValidation.tsx
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import * as React from 'react';
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import { testDayViewRangeValidation } from './testDayViewRangeValidation';
 import { testTextFieldRangeValidation } from './testTextFieldRangeValidation';
 import { DescribeRangeValidationInputOptions } from './describeRangeValidation.types';

--- a/test/utils/pickers/describeRangeValidation/testDayViewRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/testDayViewRangeValidation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 
 const isDisable = (el: HTMLElement) => el.getAttribute('disabled') !== null;

--- a/test/utils/pickers/describeRangeValidation/testTextFieldKeyboardRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/testTextFieldKeyboardRangeValidation.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
-import { act } from '@mui/monorepo/test/utils/createRenderer';
+import { act } from '@mui-internal/test-utils/createRenderer';
 import { DescribeRangeValidationTestSuite } from './describeRangeValidation.types';
 
 const testInvalidStatus = (expectedAnswer: boolean[], isSingleInput?: boolean) => {

--- a/test/utils/pickers/describeRangeValidation/testTextFieldRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/testTextFieldRangeValidation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 import { DescribeRangeValidationTestSuite } from './describeRangeValidation.types';
 

--- a/test/utils/pickers/describeValidation/describeValidation.ts
+++ b/test/utils/pickers/describeValidation/describeValidation.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import * as React from 'react';
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import { testDayViewValidation } from './testDayViewValidation';
 import { testMonthViewValidation } from './testMonthViewValidation';
 import { testTextFieldValidation } from './testTextFieldValidation';

--- a/test/utils/pickers/describeValidation/describeValidation.types.ts
+++ b/test/utils/pickers/describeValidation/describeValidation.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MuiRenderResult, createRenderer } from '@mui/monorepo/test/utils/createRenderer';
+import { MuiRenderResult, createRenderer } from '@mui-internal/test-utils/createRenderer';
 import { DateOrTimeView } from '@mui/x-date-pickers/models';
 import { PickerComponentFamily } from '../describe.types';
 

--- a/test/utils/pickers/describeValidation/testDayViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testDayViewValidation.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 

--- a/test/utils/pickers/describeValidation/testMinutesViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testMinutesViewValidation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 

--- a/test/utils/pickers/describeValidation/testMonthViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testMonthViewValidation.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 

--- a/test/utils/pickers/describeValidation/testTextFieldValidation.tsx
+++ b/test/utils/pickers/describeValidation/testTextFieldValidation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { TimeView } from '@mui/x-date-pickers/models';
 import { adapterToUse } from 'test/utils/pickers';
 import { DescribeValidationTestSuite } from './describeValidation.types';

--- a/test/utils/pickers/describeValidation/testYearViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testYearViewValidation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen } from '@mui/monorepo/test/utils';
+import { screen } from '@mui-internal/test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 

--- a/test/utils/pickers/describeValue/describeValue.tsx
+++ b/test/utils/pickers/describeValue/describeValue.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import createDescribe from '@mui/monorepo/test/utils/createDescribe';
+import createDescribe from '@mui-internal/test-utils/createDescribe';
 import { BasePickerInputProps, UsePickerValueNonStaticProps } from '@mui/x-date-pickers/internals';
 import { FieldSection } from '@mui/x-date-pickers/models';
 import { buildFieldInteractions, BuildFieldInteractionsResponse } from 'test/utils/pickers';

--- a/test/utils/pickers/describeValue/describeValue.types.ts
+++ b/test/utils/pickers/describeValue/describeValue.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, MuiRenderResult } from '@mui/monorepo/test/utils/createRenderer';
+import { createRenderer, MuiRenderResult } from '@mui-internal/test-utils/createRenderer';
 import {
   BuildFieldInteractionsResponse,
   FieldSectionSelector,

--- a/test/utils/pickers/describeValue/testControlledUnControlled.tsx
+++ b/test/utils/pickers/describeValue/testControlledUnControlled.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, act, userEvent } from '@mui/monorepo/test/utils';
+import { screen, act, userEvent } from '@mui-internal/test-utils';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import { getExpectedOnChangeCount } from 'test/utils/pickers';
 import { DescribeValueOptions, DescribeValueTestSuite } from './describeValue.types';

--- a/test/utils/pickers/describeValue/testPickerActionBar.tsx
+++ b/test/utils/pickers/describeValue/testPickerActionBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import {
   adapterToUse,
   getExpectedOnChangeCount,

--- a/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
+++ b/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { getExpectedOnChangeCount, getTextbox, openPicker } from 'test/utils/pickers';
 import { DescribeValueTestSuite } from './describeValue.types';
 

--- a/test/utils/pickers/describeValue/testShortcuts.tsx
+++ b/test/utils/pickers/describeValue/testShortcuts.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { expectPickerChangeHandlerValue } from 'test/utils/pickers';
-import { userEvent, screen } from '@mui/monorepo/test/utils';
+import { userEvent, screen } from '@mui-internal/test-utils';
 import { DescribeValueTestSuite } from './describeValue.types';
 
 export const testShortcuts: DescribeValueTestSuite<any, 'picker'> = (ElementToTest, options) => {

--- a/test/utils/pickers/fields.tsx
+++ b/test/utils/pickers/fields.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, userEvent, act, fireEvent } from '@mui/monorepo/test/utils';
+import { createRenderer, screen, userEvent, act, fireEvent } from '@mui-internal/test-utils';
 import { FieldRef, FieldSection, FieldSectionType } from '@mui/x-date-pickers/models';
 import { expectInputValue } from './assertions';
 

--- a/test/utils/pickers/openPicker.ts
+++ b/test/utils/pickers/openPicker.ts
@@ -1,4 +1,4 @@
-import { screen, userEvent } from '@mui/monorepo/test/utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 
 export type OpenPickerParams =
   | {

--- a/test/utils/pickers/viewHandlers.ts
+++ b/test/utils/pickers/viewHandlers.ts
@@ -1,4 +1,4 @@
-import { fireTouchChangedEvent, userEvent, screen } from '@mui/monorepo/test/utils';
+import { fireTouchChangedEvent, userEvent, screen } from '@mui-internal/test-utils';
 import { getClockTouchEvent } from 'test/utils/pickers';
 import { MuiPickersAdapter, TimeView } from '@mui/x-date-pickers/models';
 import { formatMeridiem } from '@mui/x-date-pickers/internals/utils/date-utils';

--- a/test/utils/setupJSDOM.js
+++ b/test/utils/setupJSDOM.js
@@ -1,4 +1,5 @@
-const coreExports = require('@mui/monorepo/test/utils/setupJSDOM');
+const coreExports = require('@mui-internal/test-utils/setupJSDOM');
+
 require('./licenseRelease');
 require('./addChaiAssertions');
 require('./setupPickers');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,8 @@
       "@mui/x-tree-view/*": ["./packages/x-tree-view/src/*"],
       "@mui/x-license-pro": ["./packages/x-license-pro/src"],
       "@mui/x-license-pro/*": ["./packages/x-license-pro/src/*"],
+      "@mui-internal/test-utils": ["./node_modules/@mui/monorepo/packages/test-utils/src"],
+      "@mui-internal/test-utils/*": ["./node_modules/@mui/monorepo/packages/test-utils/src/*"],
       "test/*": ["./test/*"],
       "docs/*": ["./node_modules/@mui/monorepo/docs"],
       "docsx/*": ["./docs/*"]

--- a/webpackBaseConfig.js
+++ b/webpackBaseConfig.js
@@ -23,6 +23,10 @@ module.exports = {
       '@mui/x-tree-view': path.resolve(__dirname, './packages/x-tree-view/src'),
       '@mui/x-license-pro': path.resolve(__dirname, './packages/x-license-pro/src'),
       '@mui/markdown': path.resolve(__dirname, './node_modules/@mui/monorepo/packages/markdown'),
+      '@mui-internal/test-utils': path.resolve(
+        __dirname,
+        './node_modules/@mui/monorepo/packages/test-utils/src',
+      ),
       docs: path.resolve(__dirname, './node_modules/@mui/monorepo/docs'),
       docsx: path.resolve(__dirname, './docs'),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,6 +1929,13 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.19.tgz#46905b4e6f62da825b040343cbc233144e9578d3"
   integrity sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ==
 
+"@next/eslint-plugin-next@^13.5.4":
+  version "13.5.4"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.4.tgz#ec70af509f07dc4e545df25834ac94d2c341c36a"
+  integrity sha512-vI94U+D7RNgX6XypSyjeFrOzxGlZyxOplU0dVE5norIfZGn/LDjJYPHdvdsR5vN1eRtl6PDAsOHmycFEOljK5A==
+  dependencies:
+    glob "7.1.7"
+
 "@next/swc-darwin-arm64@13.4.19":
   version "13.4.19"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz#77ad462b5ced4efdc26cb5a0053968d2c7dac1b6"
@@ -7431,6 +7438,18 @@ glob@7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,7 +1851,7 @@
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
   version "5.14.11"
-  resolved "https://github.com/mui/material-ui.git#ba2b0c524ab9aeac88bc73c17cca4fe7a8cd71d5"
+  resolved "https://github.com/mui/material-ui.git#7f9c09fea69759f0f621cbe3eb0f738d51c8201e"
 
 "@mui/private-theming@^5.14.11":
   version "5.14.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,8 +1850,8 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.14.10"
-  resolved "https://github.com/mui/material-ui.git#f1401844507519e09814bf8ea3ac338ec8011044"
+  version "5.14.11"
+  resolved "https://github.com/mui/material-ui.git#ba2b0c524ab9aeac88bc73c17cca4fe7a8cd71d5"
 
 "@mui/private-theming@^5.14.11":
   version "5.14.11"


### PR DESCRIPTION
Monorepo was in v5.14.10 but the new [feedback function](https://github.com/mui/material-ui/pull/39075) is in v5.14.11