### PR TITLE
[docs] Fix DataGrid[Pro/Premium] reference links

### DIFF
--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -60,6 +60,16 @@ interface DataGridPremiumComponent {
   propTypes?: any;
 }
 
+/**
+ *
+ * Demos:
+ *
+ * - [DataGridPremium](https://mui.com/x/react-data-grid/demo/)
+ *
+ * API:
+ *
+ * - [DataGridPremium API](https://mui.com/x/api/data-grid/data-grid-premium/)
+ */
 export const DataGridPremium = React.memo(DataGridPremiumRaw) as DataGridPremiumComponent;
 
 DataGridPremiumRaw.propTypes = {

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -61,13 +61,10 @@ interface DataGridPremiumComponent {
 }
 
 /**
- *
  * Demos:
- *
  * - [DataGridPremium](https://mui.com/x/react-data-grid/demo/)
  *
  * API:
- *
  * - [DataGridPremium API](https://mui.com/x/api/data-grid/data-grid-premium/)
  */
 export const DataGridPremium = React.memo(DataGridPremiumRaw) as DataGridPremiumComponent;

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -59,6 +59,16 @@ interface DataGridProComponent {
   propTypes?: any;
 }
 
+/**
+ *
+ * Demos:
+ *
+ * - [DataGridPro](https://mui.com/x/react-data-grid/demo/)
+ *
+ * API:
+ *
+ * - [DataGridPro API](https://mui.com/x/api/data-grid/data-grid-pro/)
+ */
 export const DataGridPro = React.memo(DataGridProRaw) as DataGridProComponent;
 
 DataGridProRaw.propTypes = {

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -60,13 +60,10 @@ interface DataGridProComponent {
 }
 
 /**
- *
  * Demos:
- *
  * - [DataGridPro](https://mui.com/x/react-data-grid/demo/)
  *
  * API:
- *
  * - [DataGridPro API](https://mui.com/x/api/data-grid/data-grid-pro/)
  */
 export const DataGridPro = React.memo(DataGridProRaw) as DataGridProComponent;

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -33,16 +33,6 @@ const DataGridRaw = React.forwardRef(function DataGrid<R extends GridValidRowMod
   );
 });
 
-/**
- *
- * Demos:
- *
- * - [DataGrid](https://mui.com/x/react-data-grid/demo/)
- *
- * API:
- *
- * - [DataGrid API](https://mui.com/x/api/data-grid/data-grid/)
- */
 interface DataGridComponent {
   <R extends GridValidRowModel = any>(
     props: DataGridProps<R> & React.RefAttributes<HTMLDivElement>,
@@ -50,6 +40,13 @@ interface DataGridComponent {
   propTypes?: any;
 }
 
+/**
+ * Demos:
+ * - [DataGrid](https://mui.com/x/react-data-grid/demo/)
+ *
+ * API:
+ * - [DataGrid API](https://mui.com/x/api/data-grid/data-grid/)
+ */
 export const DataGrid = React.memo(DataGridRaw) as DataGridComponent;
 
 /**

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -33,6 +33,16 @@ const DataGridRaw = React.forwardRef(function DataGrid<R extends GridValidRowMod
   );
 });
 
+/**
+ *
+ * Demos:
+ *
+ * - [DataGrid](https://mui.com/x/react-data-grid/demo/)
+ *
+ * API:
+ *
+ * - [DataGrid API](https://mui.com/x/api/data-grid/data-grid/)
+ */
 interface DataGridComponent {
   <R extends GridValidRowModel = any>(
     props: DataGridProps<R> & React.RefAttributes<HTMLDivElement>,

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -652,15 +652,10 @@ GridFilterForm.propTypes = {
 } as any;
 
 /**
- *
  * Demos:
- *
- * - [DataGrid](https://mui.com/x/react-data-grid/)
- * - [DataGridPro](https://mui.com/x/react-data-grid/#pro-plan)
- * - [DataGridPremium](https://mui.com/x/react-data-grid/#premium-plan)
+ * - [Filtering - overview](https://mui.com/x/react-data-grid/filtering/)
  *
  * API:
- *
  * - [GridFilterForm API](https://mui.com/x/api/data-grid/grid-filter-form/)
  */
 export { GridFilterForm };

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -651,4 +651,16 @@ GridFilterForm.propTypes = {
   valueInputProps: PropTypes.any,
 } as any;
 
+/**
+ *
+ * Demos:
+ *
+ * - [DataGrid](https://mui.com/x/react-data-grid/)
+ * - [DataGridPro](https://mui.com/x/react-data-grid/#pro-plan)
+ * - [DataGridPremium](https://mui.com/x/react-data-grid/#premium-plan)
+ *
+ * API:
+ *
+ * - [GridFilterForm API](https://mui.com/x/api/data-grid/grid-filter-form/)
+ */
 export { GridFilterForm };

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
@@ -317,4 +317,11 @@ GridFilterPanel.propTypes = {
   ]),
 } as any;
 
+/**
+ * Demos:
+ * - [Filtering - overview](https://mui.com/x/react-data-grid/filtering/)
+ *
+ * API:
+ * - [GridFilterPanel API](https://mui.com/x/api/data-grid/grid-filter-panel/)
+ */
 export { GridFilterPanel, getGridFilter };

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -182,4 +182,11 @@ GridToolbarQuickFilter.propTypes = {
   quickFilterParser: PropTypes.func,
 } as any;
 
+/**
+ * Demos:
+ * - [Filtering - overview](https://mui.com/x/react-data-grid/filtering/)
+ *
+ * API:
+ * - [GridToolbarQuickFilter API](https://mui.com/x/api/data-grid/grid-toolbar-quick-filter/)
+ */
 export { GridToolbarQuickFilter };

--- a/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
+++ b/packages/grid/x-data-grid/src/components/toolbar/GridToolbarQuickFilter.tsx
@@ -185,6 +185,7 @@ GridToolbarQuickFilter.propTypes = {
 /**
  * Demos:
  * - [Filtering - overview](https://mui.com/x/react-data-grid/filtering/)
+ * - [Filtering - quick filter](https://mui.com/x/react-data-grid/filtering/quick-filter/)
  *
  * API:
  * - [GridToolbarQuickFilter API](https://mui.com/x/api/data-grid/grid-toolbar-quick-filter/)


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

--- 

This adds Demo and API links to the export for `DataGrid`, `DataGridPro` and `DataGridPremium`

It's part of a series to solve #9226 