### PR TITLE
[DataGrid] Fix `LazyLoading` demo crash

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/lazyLoader/useGridLazyLoader.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/lazyLoader/useGridLazyLoader.ts
@@ -36,9 +36,9 @@ function findSkeletonRowsSection({
 
   while (!isSkeletonSectionFound && firstRowIndex < lastRowIndex) {
     const isStartingWithASkeletonRow =
-      apiRef.current.getRowNode(visibleRowsSection[startIndex].id)!.type === 'skeletonRow';
+      apiRef.current.getRowNode(visibleRowsSection[startIndex].id)?.type === 'skeletonRow';
     const isEndingWithASkeletonRow =
-      apiRef.current.getRowNode(visibleRowsSection[endIndex].id)!.type === 'skeletonRow';
+      apiRef.current.getRowNode(visibleRowsSection[endIndex].id)?.type === 'skeletonRow';
 
     if (isStartingWithASkeletonRow && isEndingWithASkeletonRow) {
       isSkeletonSectionFound = true;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #10047 

A nasty one reported [twice](https://github.com/mui/material-ui/issues?q=is%3Aissue%20%5Bdocs%5D%20Demo%20LazyLoadingGrid%20crashes) in material-ui repo and [eight times](https://github.com/mui/mui-x/issues?q=is%3Aissue%20[docs]%20Demo%20LazyLoadingGrid%20crashes) in mui-x repo.