### PR TITLE
[DateTimePicker] Add support for `DigitalClock` view renderer

### DIFF
--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -188,6 +188,7 @@
       },
       "additionalInfo": { "sx": true }
     },
+    "thresholdToRenderTimeInASingleColumn": { "type": { "name": "number" }, "default": "24" },
     "timeSteps": {
       "type": {
         "name": "shape",
@@ -277,6 +278,12 @@
       "name": "dialog",
       "description": "Custom component for the dialog inside which the views are rendered on mobile.",
       "default": "PickersModalDialogRoot"
+    },
+    {
+      "class": null,
+      "name": "digitalClockItem",
+      "description": "Component responsible for rendering a single digital clock item.",
+      "default": "MenuItem from '@mui/material'"
     },
     {
       "class": null,

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -184,6 +184,7 @@
       },
       "additionalInfo": { "sx": true }
     },
+    "thresholdToRenderTimeInASingleColumn": { "type": { "name": "number" }, "default": "24" },
     "timeSteps": {
       "type": {
         "name": "shape",
@@ -267,6 +268,12 @@
       "name": "desktopTrapFocus",
       "description": "Custom component for trapping the focus inside the views on desktop.",
       "default": "FocusTrap from '@mui/base'."
+    },
+    {
+      "class": null,
+      "name": "digitalClockItem",
+      "description": "Component responsible for rendering a single digital clock item.",
+      "default": "MenuItem from '@mui/material'"
     },
     {
       "class": null,

--- a/docs/translations/api-docs/date-pickers/date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker.json
@@ -319,6 +319,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "thresholdToRenderTimeInASingleColumn": {
+      "description": "Amount of time options below or at which the single column time renderer is used.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "timeSteps": {
       "description": "The time steps between two time unit options. For example, if <code>timeStep.minutes = 8</code>, then the available minute options will be <code>[0, 8, 16, 24, 32, 40, 48, 56]</code>. When single column time renderer is used, only <code>timeStep.minutes</code> will be used.",
       "deprecated": "",
@@ -362,6 +367,7 @@
     "desktopTransition": "Custom component for the desktop popper <a href=\"https://mui.com/material-ui/transitions/\">Transition</a>.",
     "desktopTrapFocus": "Custom component for trapping the focus inside the views on desktop.",
     "dialog": "Custom component for the dialog inside which the views are rendered on mobile.",
+    "digitalClockItem": "Component responsible for rendering a single digital clock item.",
     "digitalClockSectionItem": "Component responsible for rendering a single multi section digital clock section item.",
     "field": "Component used to enter the date with the keyboard.",
     "inputAdornment": "Component displayed on the start or end input adornment used to open the picker on desktop.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-time-picker.json
@@ -314,6 +314,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "thresholdToRenderTimeInASingleColumn": {
+      "description": "Amount of time options below or at which the single column time renderer is used.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "timeSteps": {
       "description": "The time steps between two time unit options. For example, if <code>timeStep.minutes = 8</code>, then the available minute options will be <code>[0, 8, 16, 24, 32, 40, 48, 56]</code>. When single column time renderer is used, only <code>timeStep.minutes</code> will be used.",
       "deprecated": "",
@@ -356,6 +361,7 @@
     "desktopPaper": "Custom component for the paper rendered inside the desktop picker&#39;s Popper.",
     "desktopTransition": "Custom component for the desktop popper <a href=\"https://mui.com/material-ui/transitions/\">Transition</a>.",
     "desktopTrapFocus": "Custom component for trapping the focus inside the views on desktop.",
+    "digitalClockItem": "Component responsible for rendering a single digital clock item.",
     "digitalClockSectionItem": "Component responsible for rendering a single multi section digital clock section item.",
     "field": "Component used to enter the date with the keyboard.",
     "inputAdornment": "Component displayed on the start or end input adornment used to open the picker on desktop.",

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -393,6 +393,11 @@ DateTimePicker.propTypes = {
     PropTypes.object,
   ]),
   /**
+   * Amount of time options below or at which the single column time renderer is used.
+   * @default 24
+   */
+  thresholdToRenderTimeInASingleColumn: PropTypes.number,
+  /**
    * The time steps between two time unit options.
    * For example, if `timeStep.minutes = 8`, then the available minute options will be `[0, 8, 16, 24, 32, 40, 48, 56]`.
    * When single column time renderer is used, only `timeStep.minutes` will be used.

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -15,8 +15,9 @@ import { CalendarIcon } from '../icons';
 import { useDesktopPicker } from '../internals/hooks/useDesktopPicker';
 import { extractValidationProps } from '../internals/utils/validation/extractValidationProps';
 import { PickerViewRendererLookup } from '../internals/hooks/usePicker/usePickerViews';
-import { resolveDateTimeFormat } from '../internals/utils/date-time-utils';
+import { resolveDateTimeFormat, resolveViews } from '../internals/utils/date-time-utils';
 import { PickersActionBarAction } from '../PickersActionBar';
+import { resolveShouldRenderTimeInASingleColumn } from '../internals/utils/time-utils';
 
 type DesktopDateTimePickerComponent = (<TDate>(
   props: DesktopDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
@@ -36,9 +37,15 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
     DesktopDateTimePickerProps<TDate>
   >(inProps, 'MuiDesktopDateTimePicker');
 
+  const thresholdToRenderTimeInASingleColumn =
+    defaultizedProps.thresholdToRenderTimeInASingleColumn ?? 24;
   const timeSteps = { hours: 1, minutes: 5, seconds: 5, ...defaultizedProps.timeSteps };
   const shouldUseNewRenderer =
     !defaultizedProps.viewRenderers || Object.keys(defaultizedProps.viewRenderers).length === 0;
+  const shouldRenderTimeInASingleColumn = resolveShouldRenderTimeInASingleColumn(
+    timeSteps,
+    thresholdToRenderTimeInASingleColumn,
+  );
 
   const viewRenderers: PickerViewRendererLookup<TDate | null, DateOrTimeViewWithMeridiem, any, {}> =
     // we can only ensure the expected two-column layout if none of the renderers are overridden
@@ -71,12 +78,16 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
     ...defaultizedProps,
     viewRenderers,
     format: resolveDateTimeFormat(utils, defaultizedProps),
-    views: (defaultizedProps.ampm
-      ? [...defaultizedProps.views, 'meridiem']
-      : defaultizedProps.views) as DateOrTimeViewWithMeridiem[],
+    views: resolveViews(
+      defaultizedProps.ampm,
+      defaultizedProps.views,
+      shouldRenderTimeInASingleColumn,
+    ),
     yearsPerRow: defaultizedProps.yearsPerRow ?? 4,
     ampmInClock,
     timeSteps,
+    thresholdToRenderTimeInASingleColumn,
+    shouldRenderTimeInASingleColumn,
     slots: {
       field: DateTimeField,
       openPickerIcon: CalendarIcon,

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -486,6 +486,11 @@ DesktopDateTimePicker.propTypes = {
     PropTypes.object,
   ]),
   /**
+   * Amount of time options below or at which the single column time renderer is used.
+   * @default 24
+   */
+  thresholdToRenderTimeInASingleColumn: PropTypes.number,
+  /**
    * The time steps between two time unit options.
    * For example, if `timeStep.minutes = 8`, then the available minute options will be `[0, 8, 16, 24, 32, 40, 48, 56]`.
    * When single column time renderer is used, only `timeStep.minutes` will be used.

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.types.ts
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.types.ts
@@ -17,6 +17,7 @@ import {
   MultiSectionDigitalClockSlotsComponent,
   MultiSectionDigitalClockSlotsComponentsProps,
 } from '../MultiSectionDigitalClock';
+import { DigitalClockSlotsComponent, DigitalClockSlotsComponentsProps } from '../DigitalClock';
 
 export interface DesktopDateTimePickerSlotsComponent<TDate>
   extends BaseDateTimePickerSlotsComponent<TDate>,
@@ -24,17 +25,19 @@ export interface DesktopDateTimePickerSlotsComponent<TDate>
       UseDesktopPickerSlotsComponent<TDate, DateOrTimeViewWithMeridiem>,
       'Field' | 'OpenPickerIcon'
     >,
+    DigitalClockSlotsComponent,
     MultiSectionDigitalClockSlotsComponent {}
 
 export interface DesktopDateTimePickerSlotsComponentsProps<TDate>
   extends BaseDateTimePickerSlotsComponentsProps<TDate>,
     ExportedUseDesktopPickerSlotsComponentsProps<TDate, DateOrTimeViewWithMeridiem>,
+    DigitalClockSlotsComponentsProps,
     MultiSectionDigitalClockSlotsComponentsProps {}
 
 export interface DesktopDateTimePickerProps<TDate>
   extends BaseDateTimePickerProps<TDate, DateOrTimeViewWithMeridiem>,
     DesktopOnlyPickerProps<TDate>,
-    Omit<DesktopOnlyTimePickerProps<TDate>, 'thresholdToRenderTimeInASingleColumn'> {
+    DesktopOnlyTimePickerProps<TDate> {
   /**
    * Available views.
    */

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/DesktopDateTimePicker.test.tsx
@@ -63,4 +63,25 @@ describe('<DesktopDateTimePicker />', () => {
       expect(onClose.callCount).to.equal(1);
     });
   });
+
+  describe('prop: timeSteps', () => {
+    it('should use "DigitalClock" view renderer, when "timeSteps.minutes" = 60', () => {
+      const onChange = spy();
+      const onAccept = spy();
+      render(
+        <DesktopDateTimePicker
+          onChange={onChange}
+          onAccept={onAccept}
+          timeSteps={{ minutes: 60 }}
+        />,
+      );
+
+      userEvent.mousePress(screen.getByLabelText(/Choose date/));
+
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '1' }));
+      userEvent.mousePress(screen.getByRole('option', { name: '03:00 AM' }));
+      expect(onChange.lastCall.args[0]).toEqualDateTime(new Date(2018, 0, 1, 3, 0, 0));
+      expect(onAccept.callCount).to.equal(1);
+    });
+  });
 });

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -18,7 +18,10 @@ import {
 } from '../timeViewRenderers';
 import { PickersActionBarAction } from '../PickersActionBar';
 import { TimeViewWithMeridiem } from '../internals/models';
-import { resolveTimeFormat } from '../internals/utils/time-utils';
+import {
+  resolveShouldRenderTimeInASingleColumn,
+  resolveTimeFormat,
+} from '../internals/utils/time-utils';
 
 type DesktopTimePickerComponent = (<TDate>(
   props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
@@ -41,8 +44,10 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   const thresholdToRenderTimeInASingleColumn =
     defaultizedProps.thresholdToRenderTimeInASingleColumn ?? 24;
   const timeSteps = { hours: 1, minutes: 5, seconds: 5, ...defaultizedProps.timeSteps };
-  const shouldRenderTimeInASingleColumn =
-    (24 * 60) / (timeSteps.hours * timeSteps.minutes) <= thresholdToRenderTimeInASingleColumn;
+  const shouldRenderTimeInASingleColumn = resolveShouldRenderTimeInASingleColumn(
+    timeSteps,
+    thresholdToRenderTimeInASingleColumn,
+  );
 
   const renderTimeView = shouldRenderTimeInASingleColumn
     ? renderDigitalClockTimeView

--- a/packages/x-date-pickers/src/dateTimeViewRenderers/dateTimeViewRenderers.tsx
+++ b/packages/x-date-pickers/src/dateTimeViewRenderers/dateTimeViewRenderers.tsx
@@ -4,7 +4,6 @@ import { resolveComponentProps } from '@mui/base/utils';
 import { DateCalendar, DateCalendarProps } from '../DateCalendar';
 import { DateOrTimeViewWithMeridiem } from '../internals/models';
 import {
-  MultiSectionDigitalClock,
   MultiSectionDigitalClockProps,
   multiSectionDigitalClockSectionClasses,
 } from '../MultiSectionDigitalClock';
@@ -12,6 +11,12 @@ import { DateTimeViewWrapper } from '../internals/components/DateTimeViewWrapper
 import { isInternalTimeView } from '../internals/utils/time-utils';
 import { isDatePickerView } from '../internals/utils/date-utils';
 import type { DateTimePickerProps } from '../DateTimePicker/DateTimePicker.types';
+import {
+  renderDigitalClockTimeView,
+  renderMultiSectionDigitalClockTimeView,
+} from '../timeViewRenderers';
+import { digitalClockClasses } from '../DigitalClock';
+import { VIEW_HEIGHT } from '../internals/constants/dimensions';
 
 export interface DateTimeViewRendererProps<TDate>
   extends Omit<
@@ -32,6 +37,7 @@ export interface DateTimeViewRendererProps<TDate>
   views: readonly DateOrTimeViewWithMeridiem[];
   focusedView: DateOrTimeViewWithMeridiem | null;
   timeViewsCount: number;
+  shouldRenderTimeInASingleColumn: boolean;
 }
 
 export const renderDesktopDateTimeView = <TDate extends unknown>({
@@ -85,11 +91,44 @@ export const renderDesktopDateTimeView = <TDate extends unknown>({
   timeSteps,
   skipDisabled,
   timeViewsCount,
+  shouldRenderTimeInASingleColumn,
 }: DateTimeViewRendererProps<TDate>) => {
   const isActionBarVisible = !!resolveComponentProps(
     slotProps?.actionBar ?? componentsProps?.actionBar,
     {} as any,
   )?.actions?.length;
+  const commonTimeProps = {
+    view: isInternalTimeView(view) ? view : 'hours',
+    onViewChange,
+    focusedView: focusedView && isInternalTimeView(focusedView) ? focusedView : null,
+    onFocusedViewChange,
+    views: views.filter(isInternalTimeView),
+    value,
+    defaultValue,
+    referenceDate,
+    onChange,
+    className,
+    classes,
+    disableFuture,
+    disablePast,
+    minTime,
+    maxTime,
+    shouldDisableTime,
+    shouldDisableClock,
+    minutesStep,
+    ampm,
+    components,
+    componentsProps,
+    slots,
+    slotProps,
+    readOnly,
+    disabled,
+    autoFocus,
+    disableIgnoringDatePartForTimeValidation,
+    timeSteps,
+    skipDisabled,
+    timezone,
+  };
   return (
     <React.Fragment>
       <DateTimeViewWrapper>
@@ -138,46 +177,34 @@ export const renderDesktopDateTimeView = <TDate extends unknown>({
         {timeViewsCount > 0 && (
           <React.Fragment>
             <Divider orientation="vertical" />
-            <MultiSectionDigitalClock
-              view={isInternalTimeView(view) ? view : 'hours'}
-              onViewChange={onViewChange}
-              focusedView={focusedView && isInternalTimeView(focusedView) ? focusedView : null}
-              onFocusedViewChange={onFocusedViewChange}
-              views={views.filter(isInternalTimeView)}
-              value={value}
-              defaultValue={defaultValue}
-              referenceDate={referenceDate}
-              onChange={onChange}
-              className={className}
-              classes={classes}
-              disableFuture={disableFuture}
-              disablePast={disablePast}
-              minTime={minTime}
-              maxTime={maxTime}
-              shouldDisableTime={shouldDisableTime}
-              shouldDisableClock={shouldDisableClock}
-              minutesStep={minutesStep}
-              ampm={ampm}
-              components={components}
-              componentsProps={componentsProps}
-              slots={slots}
-              slotProps={slotProps}
-              readOnly={readOnly}
-              disabled={disabled}
-              sx={{
-                borderBottom: 0,
-                width: 'auto',
-                [`.${multiSectionDigitalClockSectionClasses.root}`]: {
-                  maxHeight: '100%',
-                },
-                ...(Array.isArray(sx) ? sx : [sx]),
-              }}
-              autoFocus={autoFocus}
-              disableIgnoringDatePartForTimeValidation={disableIgnoringDatePartForTimeValidation}
-              timeSteps={timeSteps}
-              skipDisabled={skipDisabled}
-              timezone={timezone}
-            />
+            {shouldRenderTimeInASingleColumn
+              ? renderDigitalClockTimeView({
+                  ...commonTimeProps,
+                  view: 'hours',
+                  views: ['hours'],
+                  focusedView: focusedView && isInternalTimeView(focusedView) ? 'hours' : null,
+                  sx: {
+                    width: 'auto',
+                    [`&.${digitalClockClasses.root}`]: {
+                      maxHeight: VIEW_HEIGHT,
+                    },
+                    ...(Array.isArray(sx) ? sx : [sx]),
+                  },
+                })
+              : renderMultiSectionDigitalClockTimeView({
+                  ...commonTimeProps,
+                  view: isInternalTimeView(view) ? view : 'hours',
+                  views: views.filter(isInternalTimeView),
+                  focusedView: focusedView && isInternalTimeView(focusedView) ? focusedView : null,
+                  sx: {
+                    borderBottom: 0,
+                    width: 'auto',
+                    [`.${multiSectionDigitalClockSectionClasses.root}`]: {
+                      maxHeight: '100%',
+                    },
+                    ...(Array.isArray(sx) ? sx : [sx]),
+                  },
+                })}
           </React.Fragment>
         )}
       </DateTimeViewWrapper>

--- a/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
@@ -1,6 +1,7 @@
 import { DateOrTimeView, DateView, MuiPickersAdapter, TimeView } from '../../models';
-import { resolveTimeFormat, isTimeView } from './time-utils';
+import { resolveTimeFormat, isTimeView, isInternalTimeView } from './time-utils';
 import { resolveDateFormat } from './date-utils';
+import { DateOrTimeViewWithMeridiem } from '../models';
 
 export const resolveDateTimeFormat = (
   utils: MuiPickersAdapter<any>,
@@ -33,4 +34,15 @@ export const resolveDateTimeFormat = (
   const dateFormat = resolveDateFormat(utils, { views: dateViews, ...other }, false);
 
   return `${dateFormat} ${timeFormat}`;
+};
+
+export const resolveViews = (
+  ampm: boolean,
+  views: readonly DateOrTimeView[],
+  shouldUseSingleColumn: boolean,
+): DateOrTimeViewWithMeridiem[] => {
+  if (shouldUseSingleColumn) {
+    return views.filter((view) => !isInternalTimeView(view) || view === 'hours');
+  }
+  return (ampm ? [...views, 'meridiem'] : views) as DateOrTimeViewWithMeridiem[];
 };

--- a/packages/x-date-pickers/src/internals/utils/time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/time-utils.ts
@@ -1,4 +1,4 @@
-import { MuiPickersAdapter, TimeView } from '../../models';
+import { MuiPickersAdapter, TimeStepOptions, TimeView } from '../../models';
 import { DateOrTimeViewWithMeridiem, TimeViewWithMeridiem } from '../models';
 import { areViewsEqual } from './views';
 
@@ -92,3 +92,8 @@ export const resolveTimeFormat = (
     ? `${formats.hours12h}:${formats.minutes} ${formats.meridiem}`
     : `${formats.hours24h}:${formats.minutes}`;
 };
+
+export const resolveShouldRenderTimeInASingleColumn = (
+  timeSteps: TimeStepOptions,
+  threshold: number,
+) => (24 * 60) / ((timeSteps.hours ?? 1) * (timeSteps.minutes ?? 5)) <= threshold;


### PR DESCRIPTION
Closes #9207 

- Add the option to `DesktopDateTimePicker` to render a `DigitalClock` instead of `MultiSectionDigitalClock`
- The `DigitalClock` component is chosen when the same criteria is met as for the `DesktopTimePicker`