### PR TITLE
[fields] Bootstrap the multi-HTML input component

### DIFF
--- a/packages/x-date-pickers/src/internals/components/FakeTextField/FakeTextField.tsx
+++ b/packages/x-date-pickers/src/internals/components/FakeTextField/FakeTextField.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import { FieldSection } from '../../../models';
+
+interface FakeTextFieldProps {
+  sections: FieldSection[];
+}
+
+export function FakeTextField(props: FakeTextFieldProps) {
+  const { sections } = props;
+
+  return (
+    <Stack direction="row" spacing={1}>
+      {sections.map((section) => (
+        <React.Fragment>
+          {section.startSeparator}
+          <input value={section.value} onChange={() => {}} />
+          {section.endSeparator}
+        </React.Fragment>
+      ))}
+    </Stack>
+  );
+}

--- a/packages/x-date-pickers/src/internals/components/FakeTextField/index.ts
+++ b/packages/x-date-pickers/src/internals/components/FakeTextField/index.ts
@@ -1,0 +1,1 @@
+export { FakeTextField } from './FakeTextField';


### PR DESCRIPTION
Code to play with a concrete example:

```tsx
import * as React from 'react';
import dayjs from 'dayjs';
import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
import { FakeTextField } from '@mui/x-date-pickers/internals/components/FakeTextField';
import {
  addPositionPropertiesToSections,
  splitFormatIntoSections,
} from '@mui/x-date-pickers/internals/hooks/useField';
import { useLocaleText, useUtils } from '@mui/x-date-pickers/internals';

const date = dayjs('2022-04-17');
const timezone = 'default';
const format = 'MM-DD-YYYY';
const formatDensity = 'spacious';
const shouldRespectLeadingZeros = false;
const isRTL = false;

const AppContent = () => {
  const utils = useUtils();
  const localeText = useLocaleText();

  const sections = React.useMemo(
    () =>
      addPositionPropertiesToSections(
        splitFormatIntoSections(
          utils,
          timezone,
          localeText,
          format,
          date,
          formatDensity,
          shouldRespectLeadingZeros,
          isRTL,
        ),
        isRTL,
      ),
    [utils, localeText],
  );

  return <FakeTextField sections={sections} />;
};

export default function App() {
  return (
    <LocalizationProvider dateAdapter={AdapterDayjs}>
      <AppContent />
    </LocalizationProvider>
  );
}
```