### PR TITLE
[charts] Fix typo between internal/external variable 

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -38,7 +38,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   const props = useThemeProps({ props: { ...defaultProps, ...inProps }, name: 'MuiChartsXAxis' });
   const {
     xAxis: {
-      [props.axisId]: { scale: xScale, ticksNumber, ...settings },
+      [props.axisId]: { scale: xScale, tickNumber, ...settings },
     },
   } = React.useContext(CartesianContext);
 
@@ -63,7 +63,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
 
   const tickSize = disableTicks ? 4 : tickSizeProp;
 
-  const xTicks = useTicks({ scale: xScale, ticksNumber, valueFormatter });
+  const xTicks = useTicks({ scale: xScale, tickNumber, valueFormatter });
   const positionSigne = position === 'bottom' ? 1 : -1;
 
   const labelRefPoint = {

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -38,7 +38,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
   const props = useThemeProps({ props: { ...defaultProps, ...inProps }, name: 'MuiChartsYAxis' });
   const {
     yAxis: {
-      [props.axisId]: { scale: yScale, ticksNumber, ...settings },
+      [props.axisId]: { scale: yScale, tickNumber, ...settings },
     },
   } = React.useContext(CartesianContext);
 
@@ -63,7 +63,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
 
   const tickSize = disableTicks ? 4 : tickSizeProp;
 
-  const yTicks = useTicks({ scale: yScale, ticksNumber, valueFormatter });
+  const yTicks = useTicks({ scale: yScale, tickNumber, valueFormatter });
 
   const positionSigne = position === 'right' ? 1 : -1;
 

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -26,7 +26,7 @@ import {
   ExtremumGetterResult,
 } from '../models/seriesType/config';
 import { MakeOptional } from '../models/helpers';
-import { getTicksNumber } from '../hooks/useTicks';
+import { getTickNumber } from '../hooks/useTicks';
 
 export type CartesianContextProviderProps = {
   xAxis?: MakeOptional<AxisConfig, 'id'>[];
@@ -183,14 +183,14 @@ function CartesianContextProvider({
           scale: scaleBand(axis.data!, range)
             .paddingInner(categoryGapRatio)
             .paddingOuter(categoryGapRatio / 2),
-          ticksNumber: axis.data!.length,
+          tickNumber: axis.data!.length,
         };
       }
       if (isPointScaleConfig(axis)) {
         completedXAxis[axis.id] = {
           ...axis,
           scale: scalePoint(axis.data!, range),
-          ticksNumber: axis.data!.length,
+          tickNumber: axis.data!.length,
         };
       }
       if (axis.scaleType === 'band' || axis.scaleType === 'point') {
@@ -201,9 +201,9 @@ function CartesianContextProvider({
       const scaleType = axis.scaleType ?? 'linear';
 
       const extremums = [axis.min ?? minData, axis.max ?? maxData];
-      const ticksNumber = getTicksNumber({ ...axis, range, domain: extremums });
+      const tickNumber = getTickNumber({ ...axis, range, domain: extremums });
 
-      const niceScale = getScale(scaleType, extremums, range).nice(ticksNumber);
+      const niceScale = getScale(scaleType, extremums, range).nice(tickNumber);
       const niceDomain = niceScale.domain();
       const domain = [axis.min ?? niceDomain[0], axis.max ?? niceDomain[1]];
 
@@ -211,7 +211,7 @@ function CartesianContextProvider({
         ...axis,
         scaleType,
         scale: niceScale.domain(domain),
-        ticksNumber,
+        tickNumber,
       } as AxisDefaultized<typeof scaleType>;
     });
 
@@ -237,14 +237,14 @@ function CartesianContextProvider({
           scale: scaleBand(axis.data!, [range[1], range[0]])
             .paddingInner(categoryGapRatio)
             .paddingOuter(categoryGapRatio / 2),
-          ticksNumber: axis.data!.length,
+          tickNumber: axis.data!.length,
         };
       }
       if (isPointScaleConfig(axis)) {
         completedYAxis[axis.id] = {
           ...axis,
           scale: scalePoint(axis.data!, [range[1], range[0]]),
-          ticksNumber: axis.data!.length,
+          tickNumber: axis.data!.length,
         };
       }
       if (axis.scaleType === 'band' || axis.scaleType === 'point') {
@@ -255,9 +255,9 @@ function CartesianContextProvider({
       const scaleType = axis.scaleType ?? 'linear';
 
       const extremums = [axis.min ?? minData, axis.max ?? maxData];
-      const ticksNumber = getTicksNumber({ ...axis, range, domain: extremums });
+      const tickNumber = getTickNumber({ ...axis, range, domain: extremums });
 
-      const niceScale = getScale(scaleType, extremums, range).nice(ticksNumber);
+      const niceScale = getScale(scaleType, extremums, range).nice(tickNumber);
       const niceDomain = niceScale.domain();
       const domain = [axis.min ?? niceDomain[0], axis.max ?? niceDomain[1]];
 
@@ -265,7 +265,7 @@ function CartesianContextProvider({
         ...axis,
         scaleType,
         scale: niceScale.domain(domain),
-        ticksNumber,
+        tickNumber,
       } as AxisDefaultized<typeof scaleType>;
     });
 

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -22,7 +22,7 @@ export interface TickParams {
   tickNumber?: number;
 }
 
-export function getTicksNumber(
+export function getTickNumber(
   params: TickParams & {
     range: any[];
     domain: any[];
@@ -40,12 +40,13 @@ export function getTicksNumber(
   return Math.min(maxTicks, Math.max(minTicks, defaultizedTickNumber));
 }
 
-function useTicks(options: {
-  scale: D3Scale;
-  ticksNumber?: number;
-  valueFormatter?: (value: any) => string;
-}) {
-  const { scale, ticksNumber, valueFormatter } = options;
+function useTicks(
+  options: {
+    scale: D3Scale;
+    valueFormatter?: (value: any) => string;
+  } & Pick<TickParams, 'tickNumber'>,
+) {
+  const { scale, tickNumber, valueFormatter } = options;
 
   return React.useMemo(() => {
     // band scale
@@ -77,12 +78,12 @@ function useTicks(options: {
       }));
     }
 
-    return scale.ticks(ticksNumber).map((value: any) => ({
-      formattedValue: valueFormatter?.(value) ?? scale.tickFormat(ticksNumber)(value),
+    return scale.ticks(tickNumber).map((value: any) => ({
+      formattedValue: valueFormatter?.(value) ?? scale.tickFormat(tickNumber)(value),
       offset: scale(value),
       labelOffset: 0,
     }));
-  }, [ticksNumber, scale, valueFormatter]);
+  }, [tickNumber, scale, valueFormatter]);
 }
 
 export default useTicks;

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -185,7 +185,7 @@ export type AxisDefaultized<S extends ScaleName = ScaleName, V = any> = Omit<
   'scaleType'
 > &
   AxisScaleConfig[S] & {
-    ticksNumber: number;
+    tickNumber: number;
   };
 
 export function isBandScaleConfig(


### PR DESCRIPTION
`tickNumber` was singular for the exposed interface and plural (`ticksNumber`) when computed internally