### PR TITLE
[pickers] Add reference links to misc picker components

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -523,10 +523,9 @@ DateRangePickerDayRaw.propTypes = {
 } as any;
 
 /**
- *
  * Demos:
  *
- * - [Date Range Picker](https://mui.com/x/react-date-pickers/date-range-picker/)
+ * - [DateRangePicker](https://mui.com/x/react-date-pickers/date-range-picker/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -83,6 +83,15 @@ const DateTimePickerTabsRoot = styled(Tabs, {
   },
 }));
 
+/**
+ * Demos:
+ *
+ * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
+ *
+ * API:
+ *
+ * - [DateTimePickerTabs API](https://mui.com/x/api/date-pickers/date-time-picker-tabs/)
+ */
 const DateTimePickerTabs = function DateTimePickerTabs(inProps: DateTimePickerTabsProps) {
   const props = useThemeProps({ props: inProps, name: 'MuiDateTimePickerTabs' });
   const {

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -86,7 +86,7 @@ const DateTimePickerTabsRoot = styled(Tabs, {
 /**
  * Demos:
  *
- * - [DateTimePicker](https://mui.com/x/react-date-pickers/date-time-picker/) 
+ * - [DateTimePicker](https://mui.com/x/react-date-pickers/date-time-picker/)
  * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
  *
  * API:

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -86,6 +86,7 @@ const DateTimePickerTabsRoot = styled(Tabs, {
 /**
  * Demos:
  *
+ * - [DateTimePicker](https://mui.com/x/react-date-pickers/date-time-picker/) 
  * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
  *
  * API:

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
@@ -86,7 +86,6 @@ const monthMap = [
 /**
  * Demos:
  *
- * - [DatePicker](https://mui.com/x/react-date-pickers/date-picker/)
  * - [DateCalendar](https://mui.com/x/react-date-pickers/date-calendar/)
  *
  * API:

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
@@ -84,10 +84,10 @@ const monthMap = [
 ];
 
 /**
- *
  * Demos:
  *
- * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
+ * - [DatePicker](https://mui.com/x/react-date-pickers/date-picker/)
+ * - [DateCalendar](https://mui.com/x/react-date-pickers/date-calendar/)
  *
  * API:
  *

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -55,6 +55,18 @@ type LocalizationProviderComponent = (<TDate, TLocale>(
   props: LocalizationProviderProps<TDate, TLocale>,
 ) => React.JSX.Element) & { propTypes?: any };
 
+/**
+ * Demos:
+ *
+ * - [Date format and localization](https://mui.com/x/react-date-pickers/adapters-locale/)
+ * - [Calendar systems](https://mui.com/x/react-date-pickers/calendar-systems/)
+ * - [Translated components](https://mui.com/x/react-date-pickers/localization/)
+ * - [UTC and timezones](https://mui.com/x/react-date-pickers/timezone/)
+ *
+ * API:
+ *
+ * - [LocalizationProvider API](https://mui.com/x/api/date-pickers/localization-provider/)
+ */
 export const LocalizationProvider = function LocalizationProvider<TDate, TLocale>(
   inProps: LocalizationProviderProps<TDate, TLocale>,
 ) {

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -19,6 +19,16 @@ export interface PickersActionBarProps extends DialogActionsProps {
   onSetToday: () => void;
 }
 
+/**
+ * Demos:
+ *
+ * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
+ * - [Custom layout](https://mui.com/x/react-date-pickers/custom-layout/)
+ *
+ * API:
+ *
+ * - [PickersActionBar API](https://mui.com/x/api/date-pickers/pickers-action-bar/)
+ */
 function PickersActionBar(props: PickersActionBarProps) {
   const { onAccept, onClear, onCancel, onSetToday, actions, ...other } = props;
 

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -192,6 +192,8 @@ type PickersCalendarHeaderComponent = (<TDate>(
 /**
  * Demos:
  *
+ * - [DateCalendar](https://mui.com/x/react-date-pickers/date-calendar/)
+ * - [DateRangeCalendar](https://mui.com/x/react-date-pickers/date-range-calendar/)
  * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
  *
  * API:

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -189,6 +189,15 @@ type PickersCalendarHeaderComponent = (<TDate>(
   props: PickersCalendarHeaderProps<TDate> & React.RefAttributes<HTMLButtonElement>,
 ) => React.JSX.Element) & { propTypes?: any };
 
+/**
+ * Demos:
+ *
+ * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
+ *
+ * API:
+ *
+ * - [PickersCalendarHeader API](https://mui.com/x/api/date-pickers/pickers-calendar-header/)
+ */
 const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TDate>(
   inProps: PickersCalendarHeaderProps<TDate>,
   ref: React.Ref<HTMLDivElement>,

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -497,7 +497,6 @@ PickersDayRaw.propTypes = {
 /**
  * Demos:
  *
- * - [DatePicker](https://mui.com/x/react-date-pickers/date-picker/)
  * - [DateCalendar](https://mui.com/x/react-date-pickers/date-calendar/)
  * API:
  *

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.tsx
@@ -495,11 +495,10 @@ PickersDayRaw.propTypes = {
 } as any;
 
 /**
- *
  * Demos:
  *
- * - [Date Picker](https://mui.com/x/react-date-pickers/date-picker/)
- *
+ * - [DatePicker](https://mui.com/x/react-date-pickers/date-picker/)
+ * - [DateCalendar](https://mui.com/x/react-date-pickers/date-calendar/)
  * API:
  *
  * - [PickersDay API](https://mui.com/x/api/date-pickers/pickers-day/)

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -70,6 +70,15 @@ export const PickersLayoutContentWrapper = styled('div', {
   flexDirection: 'column',
 });
 
+/**
+ * Demos:
+ *
+ * - [Custom layout](https://mui.com/x/react-date-pickers/custom-layout/)
+ *
+ * API:
+ *
+ * - [PickersLayout API](https://mui.com/x/api/date-pickers/pickers-layout/)
+ */
 const PickersLayout = function PickersLayout<
   TValue,
   TDate,

--- a/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
+++ b/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
@@ -45,6 +45,16 @@ export interface PickersShortcutsProps<TValue> extends ExportedPickersShortcutPr
   isValid: (value: TValue) => boolean;
 }
 
+/**
+ * Demos:
+ *
+ * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
+ * - [Shortcuts](https://mui.com/x/react-date-pickers/shortcuts/)
+ *
+ * API:
+ *
+ * - [PickersShortcuts API](https://mui.com/x/api/date-pickers/pickers-shortcuts/)
+ */
 function PickersShortcuts<TValue>(props: PickersShortcutsProps<TValue>) {
   const { items, changeImportance, isLandscape, onChange, isValid, ...other } = props;
 

--- a/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
+++ b/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
@@ -48,7 +48,6 @@ export interface PickersShortcutsProps<TValue> extends ExportedPickersShortcutPr
 /**
  * Demos:
  *
- * - [Custom slots and subcomponents](https://mui.com/x/react-date-pickers/custom-components/)
  * - [Shortcuts](https://mui.com/x/react-date-pickers/shortcuts/)
  *
  * API:


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

This adds Demo and API links to the component annotation for ...
- `DateTimePickerTabs`
- `DateRangePickerDay`
- `DayCalendarSkeleton`
- `LocalizationProvider`
- `PickersCalendarHeader`
- `PickersDay`
- `PickersActionBar`
- `PickersLayout`
- `PickersShortcuts`
... components

It's part of a series to solve #9226 