### PR TITLE
[charts] Add reference links to line chart + sparkline components

### DIFF
--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -75,6 +75,17 @@ export interface LineChartProps
    */
   slotProps?: LineChartSlotComponentProps;
 }
+
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [LineChart API](https://mui.com/x/api/charts/line-chart/)
+ */
 const LineChart = React.forwardRef(function LineChart(props: LineChartProps, ref) {
   const {
     xAxis,

--- a/packages/x-charts/src/LineChart/LineElement.tsx
+++ b/packages/x-charts/src/LineChart/LineElement.tsx
@@ -110,6 +110,16 @@ export type LineElementProps = Omit<LineElementOwnerState, 'isFaded' | 'isHighli
     };
   };
 
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [LineElement API](https://mui.com/x/api/charts/line-element/)
+ */
 function LineElement(props: LineElementProps) {
   const { id, classes: innerClasses, color, highlightScope, slots, slotProps, ...other } = props;
 

--- a/packages/x-charts/src/LineChart/LineHighlightElement.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightElement.tsx
@@ -51,6 +51,16 @@ const HighlightElement = styled('circle', {
 export type LineHighlightElementProps = LineHighlightElementOwnerState &
   React.ComponentPropsWithoutRef<'circle'> & {};
 
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [LineHighlightElement API](https://mui.com/x/api/charts/line-highlight-element/)
+ */
 function LineHighlightElement(props: LineHighlightElementProps) {
   const { x, y, id, classes: innerClasses, color, ...other } = props;
 

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -27,6 +27,16 @@ export interface LineHighlightPlotProps extends React.SVGAttributes<SVGSVGElemen
   slotProps?: LineHighlightPlotSlotComponentProps;
 }
 
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [LineHighlightPlot API](https://mui.com/x/api/charts/line-highlight-plot/)
+ */
 function LineHighlightPlot(props: LineHighlightPlotProps) {
   const { slots, slotProps, ...other } = props;
 

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -19,6 +19,16 @@ export interface LinePlotProps
   extends React.SVGAttributes<SVGSVGElement>,
     Pick<LineElementProps, 'slots' | 'slotProps'> {}
 
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [LinePlot API](https://mui.com/x/api/charts/line-plot/)
+ */
 function LinePlot(props: LinePlotProps) {
   const { slots, slotProps, ...other } = props;
   const seriesData = React.useContext(SeriesContext).line;

--- a/packages/x-charts/src/LineChart/MarkElement.tsx
+++ b/packages/x-charts/src/LineChart/MarkElement.tsx
@@ -101,6 +101,16 @@ export type MarkElementProps = Omit<MarkElementOwnerState, 'isFaded' | 'isHighli
     highlightScope?: Partial<HighlightScope>;
   };
 
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [MarkElement API](https://mui.com/x/api/charts/mark-element/)
+ */
 function MarkElement(props: MarkElementProps) {
   const {
     x,

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -26,6 +26,16 @@ export interface MarkPlotProps extends React.SVGAttributes<SVGSVGElement> {
   slotProps?: MarkPlotSlotComponentProps;
 }
 
+/**
+ * Demos:
+ *
+ * - [Lines](https://mui.com/x/react-charts/lines/)
+ * - [Line demonstration](https://mui.com/x/react-charts/line-demo/)
+ *
+ * API:
+ *
+ * - [MarkPlot API](https://mui.com/x/api/charts/mark-plot/)
+ */
 function MarkPlot(props: MarkPlotProps) {
   const { slots, slotProps, ...other } = props;
 

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -106,6 +106,15 @@ const SPARKLINE_DEFAULT_MARGIN = {
   right: 5,
 };
 
+/**
+ * Demos:
+ *
+ * - [SparkLine](https://mui.com/x/react-charts/sparkline/)
+ *
+ * API:
+ *
+ * - [SparkLineChart API](https://mui.com/x/api/charts/spark-line-chart/)
+ */
 const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLineChartProps, ref) {
   const {
     xAxis,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

This adds Demo and API links to the component annotation for ...
- `LineChart`
- `LineElement`
- `LineHighlightElement`
- `LineHighlightPlot`
- `LinePlot`
- `MarkElement`
- `MarkPlot`
- `SparkLineChart` (although technically not 100%in the linechart group)
... components

It's part of a series to solve #9226 