### PR TITLE
[charts] Add reference links to shared/misc chart components 

### DIFF
--- a/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
+++ b/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
@@ -74,6 +74,15 @@ const mergeProps = (
     : { slots, slotProps };
 };
 
+/**
+ * Demos:
+ *
+ * - [Axis](https://mui.com/x/react-charts/axis/)
+ *
+ * API:
+ *
+ * - [ChartsAxis API](https://mui.com/x/api/charts/charts-axis/)
+ */
 function ChartsAxis(props: ChartsAxisProps) {
   const { topAxis, leftAxis, rightAxis, bottomAxis, slots, slotProps } = props;
   const { xAxis, xAxisIds, yAxis, yAxisIds } = React.useContext(CartesianContext);

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsAxisHighlight.tsx
@@ -12,6 +12,15 @@ export type ChartsAxisHighlightProps = {
   y?: AxisHighlight;
 };
 
+/**
+ * Demos:
+ *
+ * - [Custom components](https://mui.com/x/react-charts/components/)
+ *
+ * API:
+ *
+ * - [ChartsAxisHighlight API](https://mui.com/x/api/charts/charts-axis-highlight/)
+ */
 function ChartsAxisHighlight(props: ChartsAxisHighlightProps) {
   const { x: xAxisHighlight, y: yAxisHighlight } = props;
   const { xAxisIds, xAxis, yAxisIds, yAxis } = React.useContext(CartesianContext);

--- a/packages/x-charts/src/ChartsClipPath/ChartsClipPath.tsx
+++ b/packages/x-charts/src/ChartsClipPath/ChartsClipPath.tsx
@@ -7,6 +7,11 @@ export type ChartsClipPathProps = {
   offset?: { top?: number; right?: number; bottom?: number; left?: number };
 };
 
+/**
+ * API:
+ *
+ * - [ChartsClipPath API](https://mui.com/x/api/charts/charts-clip-path/)
+ */
 function ChartsClipPath(props: ChartsClipPathProps) {
   const { id, offset: offsetProps } = props;
   const { left, top, width, height } = React.useContext(DrawingContext);

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -85,6 +85,18 @@ const ChartsTooltipRoot = styled(Popper, {
   zIndex: theme.zIndex.modal,
 }));
 
+/**
+ * Demos:
+ *
+ * - [Bars demonstration](https://mui.com/x/react-charts/bar-demo/)
+ * - [Lines demonstration](https://mui.com/x/react-charts/line-demo/)
+ * - [Area demonstration](https://mui.com/x/react-charts/area-demo/)
+ * - [Pie demonstration](https://mui.com/x/react-charts/pie-demo/)
+ *
+ * API:
+ *
+ * - [ChartsTooltip API](https://mui.com/x/api/charts/charts-tool-tip/)
+ */
 function ChartsTooltip(props: ChartsTooltipProps) {
   const { trigger = 'axis', itemContent, axisContent, slots, slotProps } = props;
 

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -88,10 +88,7 @@ const ChartsTooltipRoot = styled(Popper, {
 /**
  * Demos:
  *
- * - [Bars demonstration](https://mui.com/x/react-charts/bar-demo/)
- * - [Lines demonstration](https://mui.com/x/react-charts/line-demo/)
- * - [Area demonstration](https://mui.com/x/react-charts/area-demo/)
- * - [Pie demonstration](https://mui.com/x/react-charts/pie-demo/)
+ * - [ChartsTooltip](https://mui.com/x/react-charts/tooltip/)
  *
  * API:
  *

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -34,6 +34,15 @@ const defaultProps = {
   tickSize: 6,
 } as const;
 
+/**
+ * Demos:
+ *
+ * - [Axis](https://mui.com/x/react-charts/axis/)
+ *
+ * API:
+ *
+ * - [ChartsXAxis API](https://mui.com/x/api/charts/charts-x-axis/)
+ */
 function ChartsXAxis(inProps: ChartsXAxisProps) {
   const props = useThemeProps({ props: { ...defaultProps, ...inProps }, name: 'MuiChartsXAxis' });
   const {

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -34,6 +34,15 @@ const defaultProps = {
   tickSize: 6,
 } as const;
 
+/**
+ * Demos:
+ *
+ * - [Axis](https://mui.com/x/react-charts/axis/)
+ *
+ * API:
+ *
+ * - [ChartsYAxis API](https://mui.com/x/api/charts/charts-y-axis/)
+ */
 function ChartsYAxis(inProps: ChartsYAxisProps) {
   const props = useThemeProps({ props: { ...defaultProps, ...inProps }, name: 'MuiChartsYAxis' });
   const {

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -70,6 +70,11 @@ export const CartesianContext = React.createContext<{
   // @ts-ignore
 }>({ xAxis: {}, yAxis: {}, xAxisIds: [], yAxisIds: [] });
 
+/**
+ * API:
+ *
+ * - [CartesianContextProvider API](https://mui.com/x/api/charts/cartesian-context-provider/)
+ */
 function CartesianContextProvider({
   xAxis: inXAxis,
   yAxis: inYAxis,

--- a/packages/x-charts/src/context/DrawingProvider.tsx
+++ b/packages/x-charts/src/context/DrawingProvider.tsx
@@ -30,6 +30,11 @@ export const DrawingContext = React.createContext<DrawingArea>({
 });
 export const SVGContext = React.createContext<React.RefObject<SVGSVGElement>>({ current: null });
 
+/**
+ * API:
+ *
+ * - [DrawingProvider API](https://mui.com/x/api/charts/drawing-provider/)
+ */
 function DrawingProvider({ width, height, margin, svgRef, children }: DrawingProviderProps) {
   const drawingArea = useChartDimensions(width, height, margin);
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

This adds Demo and API links to the component annotation for ...
- `CartesianContextProvider`
- `ChartsAxis`
- `ChartsXAxis`
- `ChartsYAxis`
- `DrawingProvider`
- `ChartsTooltip`
- `ChartsClipPath`
- `ChartsAxisHighlight`
... components

It's part of a series to solve #9226 