### PR TITLE
[docs] Make overview demo work in codesandbox

### DIFF
--- a/docs/data/date-pickers/base-concepts/ComponentFamilies.js
+++ b/docs/data/date-pickers/base-concepts/ComponentFamilies.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
+import { styled } from '@mui/material/styles';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -12,12 +13,24 @@ import { MultiInputDateTimeRangeField } from '@mui/x-date-pickers-pro/MultiInput
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 
+const ProSpan = styled('span')({
+  display: 'inline-block',
+  height: '1em',
+  width: '1em',
+  verticalAlign: 'middle',
+  marginLeft: '0.3em',
+  marginBottom: '0.08em',
+  backgroundSize: 'contain',
+  backgroundRepeat: 'no-repeat',
+  backgroundImage: 'url(https://mui.com/static/x/pro.svg)',
+});
+
 function ProLabel({ children }) {
   return (
     <Stack direction="row" spacing={0.5} component="span">
       <Tooltip title="Included in Pro package">
         <a href="https://mui.com/x/introduction/licensing/#pro-plan">
-          <span className="plan-pro" />
+          <ProSpan />
         </a>
       </Tooltip>
       <span>{children}</span>

--- a/docs/data/date-pickers/base-concepts/ComponentFamilies.tsx
+++ b/docs/data/date-pickers/base-concepts/ComponentFamilies.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
+import { styled } from '@mui/material/styles';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -12,12 +13,24 @@ import { MultiInputDateTimeRangeField } from '@mui/x-date-pickers-pro/MultiInput
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 
+const ProSpan = styled('span')({
+  display: 'inline-block',
+  height: '1em',
+  width: '1em',
+  verticalAlign: 'middle',
+  marginLeft: '0.3em',
+  marginBottom: '0.08em',
+  backgroundSize: 'contain',
+  backgroundRepeat: 'no-repeat',
+  backgroundImage: 'url(https://mui.com/static/x/pro.svg)',
+});
+
 function ProLabel({ children }: { children: React.ReactNode }) {
   return (
     <Stack direction="row" spacing={0.5} component="span">
       <Tooltip title="Included in Pro package">
         <a href="https://mui.com/x/introduction/licensing/#pro-plan">
-          <span className="plan-pro" />
+          <ProSpan />
         </a>
       </Tooltip>
       <span>{children}</span>

--- a/docs/data/date-pickers/overview/CommonlyUsedComponents.js
+++ b/docs/data/date-pickers/overview/CommonlyUsedComponents.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Tooltip from '@mui/material/Tooltip';
 import Stack from '@mui/material/Stack';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
@@ -8,6 +9,18 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+
+const ProSpan = styled('span')({
+  display: 'inline-block',
+  height: '1em',
+  width: '1em',
+  verticalAlign: 'middle',
+  marginLeft: '0.3em',
+  marginBottom: '0.08em',
+  backgroundSize: 'contain',
+  backgroundRepeat: 'no-repeat',
+  backgroundImage: 'url(https://mui.com/static/x/pro.svg)',
+});
 
 function Label({ componentName, valueType, isProOnly }) {
   const content = (
@@ -21,7 +34,7 @@ function Label({ componentName, valueType, isProOnly }) {
       <Stack direction="row" spacing={0.5} component="span">
         <Tooltip title="Included on Pro package">
           <a href="https://mui.com/x/introduction/licensing/#pro-plan">
-            <span className="plan-pro" />
+            <ProSpan />
           </a>
         </Tooltip>
         {content}

--- a/docs/data/date-pickers/overview/CommonlyUsedComponents.tsx
+++ b/docs/data/date-pickers/overview/CommonlyUsedComponents.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import Tooltip from '@mui/material/Tooltip';
 import Stack from '@mui/material/Stack';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
@@ -8,6 +9,18 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
+
+const ProSpan = styled('span')({
+  display: 'inline-block',
+  height: '1em',
+  width: '1em',
+  verticalAlign: 'middle',
+  marginLeft: '0.3em',
+  marginBottom: '0.08em',
+  backgroundSize: 'contain',
+  backgroundRepeat: 'no-repeat',
+  backgroundImage: 'url(https://mui.com/static/x/pro.svg)',
+});
 
 function Label({
   componentName,
@@ -29,7 +42,7 @@ function Label({
       <Stack direction="row" spacing={0.5} component="span">
         <Tooltip title="Included on Pro package">
           <a href="https://mui.com/x/introduction/licensing/#pro-plan">
-            <span className="plan-pro" />
+            <ProSpan />
           </a>
         </Tooltip>
         {content}


### PR DESCRIPTION
Follow up of #10619

Preview: https://deploy-preview-10661--material-ui-x.netlify.app/x/react-date-pickers/