### PR TITLE
[DateRangePicker] Fix touch based range dragging

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
@@ -166,12 +166,13 @@ const useDragRangeEvents = <TDate>({
   });
 
   const handleTouchMove = useEventCallback((event: React.TouchEvent<HTMLButtonElement>) => {
+    // on mobile we should only initialize dragging state after move is detected
+    setIsDragging(true);
     const target = resolveElementFromTouch(event);
     if (!target) {
       return;
     }
 
-    event.stopPropagation();
     setIsDragging(true);
 
     const button = event.target as HTMLButtonElement;

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
@@ -152,12 +152,6 @@ const useDragRangeEvents = <TDate>({
     }
 
     setRangeDragDay(newDate);
-    setIsDragging(true);
-    const button = event.target as HTMLButtonElement;
-    const buttonDataset = button.dataset;
-    if (buttonDataset.position) {
-      onDatePositionChange(buttonDataset.position as DateRangePosition);
-    }
   });
 
   const handleDragEnter = useEventCallback((event: React.DragEvent<HTMLButtonElement>) => {
@@ -173,8 +167,17 @@ const useDragRangeEvents = <TDate>({
 
   const handleTouchMove = useEventCallback((event: React.TouchEvent<HTMLButtonElement>) => {
     const target = resolveElementFromTouch(event);
-    if (!isDragging || !target) {
+    if (!target) {
       return;
+    }
+
+    event.stopPropagation();
+    setIsDragging(true);
+
+    const button = event.target as HTMLButtonElement;
+    const buttonDataset = button.dataset;
+    if (buttonDataset.position) {
+      onDatePositionChange(buttonDataset.position as DateRangePosition);
     }
 
     const newDate = resolveDateFromTarget(target, utils, timezone);

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
@@ -166,24 +166,29 @@ const useDragRangeEvents = <TDate>({
   });
 
   const handleTouchMove = useEventCallback((event: React.TouchEvent<HTMLButtonElement>) => {
-    // on mobile we should only initialize dragging state after move is detected
-    setIsDragging(true);
     const target = resolveElementFromTouch(event);
     if (!target) {
       return;
     }
 
+    const newDate = resolveDateFromTarget(target, utils, timezone);
+    if (newDate) {
+      setRangeDragDay(newDate);
+    }
+
+    // this prevents initiating drag when user starts touchmove outside and then moves over a draggable element
+    const targetsAreIdentical = target === event.changedTouches[0].target;
+    if (!(targetsAreIdentical && isElementDraggable(newDate))) {
+      return;
+    }
+
+    // on mobile we should only initialize dragging state after move is detected
     setIsDragging(true);
 
     const button = event.target as HTMLButtonElement;
     const buttonDataset = button.dataset;
     if (buttonDataset.position) {
       onDatePositionChange(buttonDataset.position as DateRangePosition);
-    }
-
-    const newDate = resolveDateFromTarget(target, utils, timezone);
-    if (newDate) {
-      setRangeDragDay(newDate);
     }
   });
 

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/useDragRange.ts
@@ -178,7 +178,7 @@ const useDragRangeEvents = <TDate>({
 
     // this prevents initiating drag when user starts touchmove outside and then moves over a draggable element
     const targetsAreIdentical = target === event.changedTouches[0].target;
-    if (!(targetsAreIdentical && isElementDraggable(newDate))) {
+    if (!targetsAreIdentical || !isElementDraggable(newDate)) {
       return;
     }
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

~~⚠️ This PR is a replacement for #10403 since the commit history got corrupted and included changes not related to this change.~~ (did not notice that those changes came from @LukasTy .. Sry 🙇🏼 )

### Description
Touch based range dragging was preventing the selection of a date, when a range was set already. With this change it is possible to select a single date from the range, even if it is the start-date.

Fixes #10332 

### Video
https://github.com/mui/mui-x/assets/32863416/05fca116-18eb-40c4-93bf-27158544bc48
