### PR TITLE
[docs] Customization Playground - fix DesktopDatePicker sx props examples

### DIFF
--- a/docs/data/date-pickers/date-picker/examplesConfig.ts
+++ b/docs/data/date-pickers/date-picker/examplesConfig.ts
@@ -129,9 +129,11 @@ export const datePickerExamples: PickersSubcomponentType = {
         type: 'success',
       },
       sxProp: {
-        type: 'success',
+        type: 'warning',
+        parentSlot: 'desktopPaper',
+        comments:
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
       },
-
       styledComponents: {
         type: 'warning',
         comments:
@@ -147,9 +149,11 @@ export const datePickerExamples: PickersSubcomponentType = {
         type: 'success',
       },
       sxProp: {
-        type: 'success',
+        type: 'warning',
+        parentSlot: 'desktopPaper',
+        comments:
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
       },
-
       styledComponents: {
         type: 'warning',
         comments:
@@ -165,9 +169,11 @@ export const datePickerExamples: PickersSubcomponentType = {
         type: 'success',
       },
       sxProp: {
-        type: 'success',
+        type: 'warning',
+        parentSlot: 'desktopPaper',
+        comments:
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
       },
-
       styledComponents: {
         type: 'warning',
         comments:
@@ -183,9 +189,11 @@ export const datePickerExamples: PickersSubcomponentType = {
         type: 'success',
       },
       sxProp: {
-        type: 'success',
+        type: 'warning',
+        parentSlot: 'desktopPaper',
+        comments:
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
       },
-
       styledComponents: {
         type: 'warning',
         comments:
@@ -194,6 +202,44 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
     },
     slots: ['root', 'today'],
+  },
+  PickersMonth: {
+    examples: {
+      customTheme: {
+        type: 'success',
+        componentProps: { views: ['month'] },
+      },
+      sxProp: {
+        type: 'warning',
+        parentSlot: 'desktopPaper',
+        comments:
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
+        componentProps: { views: ['month'] },
+      },
+
+      styledComponents: {
+        type: 'warning',
+        comments:
+          'You will need to specify the `disablePortal` prop for the popper in order to be able to use `DesktopDatePicker` as a styled component ',
+        componentProps: { views: ['month'] },
+      },
+    },
+    slots: ['root', 'monthButton'],
+  },
+  InputBase: {
+    examples: {
+      customTheme: {
+        type: 'success',
+      },
+      sxProp: {
+        type: 'success',
+      },
+
+      styledComponents: {
+        type: 'success',
+      },
+    },
+    slots: ['root'],
   },
 };
 

--- a/docs/data/date-pickers/date-picker/examplesConfig.ts
+++ b/docs/data/date-pickers/date-picker/examplesConfig.ts
@@ -136,9 +136,10 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       styledComponents: {
         type: 'warning',
+        parentSlot: 'layout',
+        parentComponent: 'PickersLayout',
         comments:
-          'You will need to specify the `disablePortal` prop for the popper in order to be able to use `DesktopDatePicker` as a styled component ',
-        componentProps: { slotProps: { popper: { disablePortal: true } } },
+          'Because of the structure of the DesktopDatePicker and the way the popper renders, the `layout` slot will need to be replaced with a wtyled component',
       },
     },
     slots: ['root'],
@@ -156,9 +157,10 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       styledComponents: {
         type: 'warning',
+        parentSlot: 'layout',
+        parentComponent: 'PickersLayout',
         comments:
-          'You will need to specify the `disablePortal` prop for the popper in order to be able to use `DesktopDatePicker` as a styled component ',
-        componentProps: { slotProps: { popper: { disablePortal: true } } },
+          'Because of the structure of the DesktopDatePicker and the way the popper renders, the `layout` slot will need to be replaced with a wtyled component',
       },
     },
     slots: ['root', 'label', 'labelContainer', 'switchViewButton', 'switchViewIcon'],
@@ -176,9 +178,10 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       styledComponents: {
         type: 'warning',
+        parentSlot: 'layout',
+        parentComponent: 'PickersLayout',
         comments:
-          'You will need to specify the `disablePortal` prop for the popper in order to be able to use `DesktopDatePicker` as a styled component ',
-        componentProps: { slotProps: { popper: { disablePortal: true } } },
+          'Because of the structure of the DesktopDatePicker and the way the popper renders, the `layout` slot will need to be replaced with a wtyled component',
       },
     },
     slots: ['root', 'weekDayLabel', 'weekContainer', 'weekNumberLabel', 'weekNumber'],
@@ -196,9 +199,10 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       styledComponents: {
         type: 'warning',
+        parentSlot: 'layout',
+        parentComponent: 'PickersLayout',
         comments:
-          'You will need to specify the `disablePortal` prop for the popper in order to be able to use `DesktopDatePicker` as a styled component ',
-        componentProps: { slotProps: { popper: { disablePortal: true } } },
+          'Because of the structure of the DesktopDatePicker and the way the popper renders, the `layout` slot will need to be replaced with a wtyled component',
       },
     },
     slots: ['root', 'today'],
@@ -219,8 +223,10 @@ export const datePickerExamples: PickersSubcomponentType = {
 
       styledComponents: {
         type: 'warning',
+        parentSlot: 'layout',
+        parentComponent: 'PickersLayout',
         comments:
-          'You will need to specify the `disablePortal` prop for the popper in order to be able to use `DesktopDatePicker` as a styled component ',
+          'Because of the structure of the DesktopDatePicker and the way the popper renders, the `layout` slot will need to be replaced with a wtyled component',
         componentProps: { views: ['month'] },
       },
     },

--- a/docs/data/date-pickers/date-picker/examplesConfig.ts
+++ b/docs/data/date-pickers/date-picker/examplesConfig.ts
@@ -130,9 +130,9 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       sxProp: {
         type: 'warning',
-        parentSlot: 'desktopPaper',
+        parentSlot: 'layout',
         comments:
-          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `layout` slot',
       },
       styledComponents: {
         type: 'warning',
@@ -150,9 +150,9 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       sxProp: {
         type: 'warning',
-        parentSlot: 'desktopPaper',
+        parentSlot: 'layout',
         comments:
-          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `layout` slot',
       },
       styledComponents: {
         type: 'warning',
@@ -170,9 +170,9 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       sxProp: {
         type: 'warning',
-        parentSlot: 'desktopPaper',
+        parentSlot: 'layout',
         comments:
-          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `layout` slot',
       },
       styledComponents: {
         type: 'warning',
@@ -190,9 +190,9 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       sxProp: {
         type: 'warning',
-        parentSlot: 'desktopPaper',
+        parentSlot: 'layout',
         comments:
-          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `layout` slot',
       },
       styledComponents: {
         type: 'warning',
@@ -211,9 +211,9 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
       sxProp: {
         type: 'warning',
-        parentSlot: 'desktopPaper',
+        parentSlot: 'layout',
         comments:
-          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `desktopPaper` slot',
+          'Because of the structure of the DesktopDatePicker, the `sx` prop needs to be applied to the `layout` slot',
         componentProps: { views: ['month'] },
       },
 
@@ -225,21 +225,6 @@ export const datePickerExamples: PickersSubcomponentType = {
       },
     },
     slots: ['root', 'monthButton'],
-  },
-  InputBase: {
-    examples: {
-      customTheme: {
-        type: 'success',
-      },
-      sxProp: {
-        type: 'success',
-      },
-
-      styledComponents: {
-        type: 'success',
-      },
-    },
-    slots: ['root'],
   },
 };
 

--- a/docs/src/modules/components/CustomizationPlayground.tsx
+++ b/docs/src/modules/components/CustomizationPlayground.tsx
@@ -90,7 +90,7 @@ const ConfigItemLabel = styled(Typography)(({ theme }) => ({
 
 const SlotItemsWrapper = styled(Box)(({ theme }) => ({
   display: 'flex',
-  gap: theme.spacing(1),
+  gap: theme.spacing(0.5),
   flexWrap: 'wrap',
 }));
 

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -254,7 +254,7 @@ const getCodeExample = ({
         slotProps: {
           ...examples.componentProps?.slotProps,
           [selectedExample?.parentSlot]: {
-            sx: { [`'& .Mui${selectedDemo}-${selectedSlot}'`]: tokens },
+            sx: { [`'.Mui${selectedDemo}-${selectedSlot}'`]: tokens },
           },
         },
       };

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -95,7 +95,7 @@ export function withStyles(
 
     if (selectedCustomizationOption === 'sxProp') {
       const sxProp = {
-        [`& .Mui${selectedDemo}-${selectedSlot}`]: { ...tokens },
+        [`.Mui${selectedDemo}-${selectedSlot}`]: { ...tokens },
       };
 
       return <Component {...props} sx={{ ...sxProp, ...props?.sx }} />;
@@ -118,7 +118,7 @@ export function withStyles(
 
     if (selectedCustomizationOption === 'styledComponents') {
       const StyledComponent = styled(Component as React.JSXElementConstructor<any>)(() => ({
-        [`& .Mui${selectedDemo}-${selectedSlot}`]: { ...tokens },
+        [`.Mui${selectedDemo}-${selectedSlot}`]: { ...tokens },
       }));
       return <StyledComponent {...props} />;
     }
@@ -296,7 +296,7 @@ const newTheme = (theme) => createTheme({
       };
       return `import { styled } from '@mui/material/styles'\n${code}
 const Styled${selectedExample?.parentComponent} = styled(${selectedExample?.parentComponent})({
-  '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
+  '.Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
   }
 })
 
@@ -309,7 +309,7 @@ export default function StyledPickerContainer() {
     }
     return `import { styled } from '@mui/material/styles'\n${code}
 const Styled${componentName} = styled(${componentName})({
-  '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
+  '.Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
   }
 })
 

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -263,7 +263,7 @@ const getCodeExample = ({
     } else {
       code = `${code}\n<${componentName}${formatComponentProps(examples.componentProps, 1)}
   sx={{
-    '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(3)}
+    '.Mui${selectedDemo}-${selectedSlot}': {${getTokensString(3)}
     },
   }}
 />`;

--- a/docs/src/modules/utils/useCustomizationPlayground.tsx
+++ b/docs/src/modules/utils/useCustomizationPlayground.tsx
@@ -13,6 +13,7 @@ type CustomizationItemType = {
   comments?: string;
   componentProps?: any;
   parentSlot?: string;
+  parentComponent?: string;
 };
 export type CustomizationItemsType = Partial<{
   [k in keyof CustomizationLabelType]: CustomizationItemType;
@@ -145,7 +146,7 @@ function formatComponentProps(componentProps?: Object, spacing: number = 1) {
     return (Object.keys(obj) as Array<keyof typeof obj>)
       .map((key) => {
         const getValue = (val: any) => {
-          if (typeof val === 'string') {
+          if (typeof val === 'string' && !val.includes('Styled')) {
             return `'${val}'`;
           }
           if (separator === '=' && typeof val !== 'object') {
@@ -285,11 +286,32 @@ const newTheme = (theme) => createTheme({
   <${componentName}${formatComponentProps(examples.componentProps, 2)} />
 </ThemeProvider>`;
   } else if (selectedCustomizationOption === 'styledComponents') {
+    if (selectedExample?.parentSlot && selectedExample?.parentComponent) {
+      const componentProps = {
+        ...examples.componentProps,
+        slots: {
+          ...examples.componentProps?.slots,
+          [selectedExample?.parentSlot]: `Styled${selectedExample?.parentComponent}`,
+        },
+      };
+      return `import { styled } from '@mui/material/styles'\n${code}
+const Styled${selectedExample?.parentComponent} = styled(${selectedExample?.parentComponent})({
+  '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
+  }
+})
+
+export default function StyledPickerContainer() {
+  return (
+    <${componentName} ${formatComponentProps(componentProps, 3)}
+    />
+  );
+}`;
+    }
     return `import { styled } from '@mui/material/styles'\n${code}
 const Styled${componentName} = styled(${componentName})({
   '& .Mui${selectedDemo}-${selectedSlot}': {${getTokensString(2)}
   }
-}))
+})
 
 export default function StyledPickerContainer() {
   return (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

related to https://github.com/mui/mui-x/issues/10657 

When styling the elements within the popper of `DesktopDatePicker` with the `sx` prop, this needs to be passed to one of the parents of the styled element in order for it to be targeted. I updated the code examples for this. However, it is a workaround-ish solution, so I flagged it with 'warning' and left a comment in the code.