### PR TITLE
[docs] Add a recipe for saving and restoring `state` externally

### DIFF
--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
@@ -37,7 +37,10 @@ export default function SaveAndRestoreStateInitialState() {
         apiRef={apiRef}
         loading={loading}
         onStateChange={saveSnapshot}
-        initialState={initialState}
+        initialState={{
+          ...data.initialState,
+          ...initialState,
+        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
@@ -1,26 +1,8 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import { DataGridPremium, useGridApiRef } from '@mui/x-data-grid-premium';
-
-import { CircularProgress } from '@mui/material';
-import Box from '@mui/material/Box';
-
-function saveDataGridStateToLocalStorage(stateSnapshot) {
-  console.info('State update: Update the state snap in localStorage', stateSnapshot);
-  localStorage.setItem('dataGridState', JSON.stringify(stateSnapshot));
-}
-
-function getInitialStateFromLocalStorage() {
-  const stateFromLocalStorage = localStorage.getItem('dataGridState');
-  return new Promise((resolve) => {
-    if (!stateFromLocalStorage) {
-      resolve({});
-      return;
-    }
-    const state = JSON.parse(stateFromLocalStorage);
-    resolve(state);
-  });
-}
 
 export default function SaveAndRestoreStateInitialState() {
   const apiRef = useGridApiRef();
@@ -33,20 +15,14 @@ export default function SaveAndRestoreStateInitialState() {
   const [initialState, setInitialState] = React.useState();
 
   React.useEffect(() => {
-    const getSnapshot = async () => {
-      const snapshotFromLocalStorage = await getInitialStateFromLocalStorage();
-      setInitialState(snapshotFromLocalStorage);
-    };
-    getSnapshot().catch(() => {
-      // fallback to no state when state retrieval fails
-      setInitialState({});
-    });
+    const stateFromLocalStorage = localStorage?.getItem('dataGridState');
+    setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
   }, []);
 
   const saveSnapshot = React.useCallback(() => {
-    if (apiRef?.current) {
+    if (apiRef?.current && localStorage) {
       const currentState = apiRef.current.exportState();
-      saveDataGridStateToLocalStorage(currentState);
+      localStorage.setItem('dataGridState', JSON.stringify(currentState));
     }
   }, [apiRef]);
 
@@ -61,9 +37,7 @@ export default function SaveAndRestoreStateInitialState() {
         apiRef={apiRef}
         loading={loading}
         onStateChange={saveSnapshot}
-        initialState={{
-          ...initialState,
-        }}
+        initialState={initialState}
       />
     </Box>
   );

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { useDemoData } from '@mui/x-data-grid-generator';
+import { DataGridPremium, useGridApiRef } from '@mui/x-data-grid-premium';
+
+import { CircularProgress } from '@mui/material';
+import Box from '@mui/material/Box';
+
+function saveDataGridStateToLocalStorage(stateSnapshot) {
+  console.info('State update: Update the state snap in localStorage', stateSnapshot);
+  localStorage.setItem('dataGridState', JSON.stringify(stateSnapshot));
+}
+
+function getInitialStateFromLocalStorage() {
+  const stateFromLocalStorage = localStorage.getItem('dataGridState');
+  return new Promise((resolve) => {
+    if (!stateFromLocalStorage) {
+      resolve({});
+      return;
+    }
+    const state = JSON.parse(stateFromLocalStorage);
+    resolve(state);
+  });
+}
+
+export default function SaveAndRestoreStateInitialState() {
+  const apiRef = useGridApiRef();
+  const { data, loading } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 10,
+  });
+
+  const [initialState, setInitialState] = React.useState();
+
+  React.useEffect(() => {
+    const getSnapshot = async () => {
+      const snapshotFromLocalStorage = await getInitialStateFromLocalStorage();
+      setInitialState(snapshotFromLocalStorage);
+    };
+    getSnapshot().catch(() => {
+      // fallback to no state when state retrieval fails
+      setInitialState({});
+    });
+  }, []);
+
+  const saveSnapshot = React.useCallback(() => {
+    if (apiRef?.current) {
+      const currentState = apiRef.current.exportState();
+      saveDataGridStateToLocalStorage(currentState);
+    }
+  }, [apiRef]);
+
+  if (!initialState) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <Box sx={{ height: 300, width: '100%' }}>
+      <DataGridPremium
+        {...data}
+        apiRef={apiRef}
+        loading={loading}
+        onStateChange={saveSnapshot}
+        initialState={{
+          ...initialState,
+        }}
+      />
+    </Box>
+  );
+}

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { useDemoData } from '@mui/x-data-grid-generator';
+import { DataGridPremium, useGridApiRef } from '@mui/x-data-grid-premium';
+import { GridInitialStatePremium } from '@mui/x-data-grid-premium/models/gridStatePremium';
+import { CircularProgress } from '@mui/material';
+import Box from '@mui/material/Box';
+
+function saveDataGridStateToLocalStorage(stateSnapshot: GridInitialStatePremium) {
+  console.info('State update: Update the state snap in localStorage', stateSnapshot);
+  localStorage.setItem('dataGridState', JSON.stringify(stateSnapshot));
+}
+
+function getInitialStateFromLocalStorage(): Promise<GridInitialStatePremium> {
+  const stateFromLocalStorage = localStorage.getItem('dataGridState');
+  return new Promise((resolve) => {
+    if (!stateFromLocalStorage) {
+      resolve({});
+      return;
+    }
+    const state = JSON.parse(stateFromLocalStorage);
+    resolve(state);
+  });
+}
+
+export default function SaveAndRestoreStateInitialState() {
+  const apiRef = useGridApiRef();
+  const { data, loading } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 10,
+  });
+
+  const [initialState, setInitialState] = React.useState<GridInitialStatePremium>();
+
+  React.useEffect(() => {
+    const getSnapshot = async () => {
+      const snapshotFromLocalStorage = await getInitialStateFromLocalStorage();
+      setInitialState(snapshotFromLocalStorage);
+    };
+    getSnapshot().catch(() => {
+      // fallback to no state when state retrieval fails
+      setInitialState({});
+    });
+  }, []);
+
+  const saveSnapshot = React.useCallback(() => {
+    if (apiRef?.current) {
+      const currentState = apiRef.current.exportState();
+      saveDataGridStateToLocalStorage(currentState);
+    }
+  }, [apiRef]);
+
+  if (!initialState) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <Box sx={{ height: 300, width: '100%' }}>
+      <DataGridPremium
+        {...data}
+        apiRef={apiRef}
+        loading={loading}
+        onStateChange={saveSnapshot}
+        initialState={{
+          ...initialState,
+        }}
+      />
+    </Box>
+  );
+}

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
@@ -38,7 +38,10 @@ export default function SaveAndRestoreStateInitialState() {
         apiRef={apiRef}
         loading={loading}
         onStateChange={saveSnapshot}
-        initialState={initialState}
+        initialState={{
+          ...data.initialState,
+          ...initialState,
+        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
@@ -1,26 +1,9 @@
 import * as React from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import { useDemoData } from '@mui/x-data-grid-generator';
 import { DataGridPremium, useGridApiRef } from '@mui/x-data-grid-premium';
 import { GridInitialStatePremium } from '@mui/x-data-grid-premium/models/gridStatePremium';
-import { CircularProgress } from '@mui/material';
-import Box from '@mui/material/Box';
-
-function saveDataGridStateToLocalStorage(stateSnapshot: GridInitialStatePremium) {
-  console.info('State update: Update the state snap in localStorage', stateSnapshot);
-  localStorage.setItem('dataGridState', JSON.stringify(stateSnapshot));
-}
-
-function getInitialStateFromLocalStorage(): Promise<GridInitialStatePremium> {
-  const stateFromLocalStorage = localStorage.getItem('dataGridState');
-  return new Promise((resolve) => {
-    if (!stateFromLocalStorage) {
-      resolve({});
-      return;
-    }
-    const state = JSON.parse(stateFromLocalStorage);
-    resolve(state);
-  });
-}
 
 export default function SaveAndRestoreStateInitialState() {
   const apiRef = useGridApiRef();
@@ -33,20 +16,14 @@ export default function SaveAndRestoreStateInitialState() {
   const [initialState, setInitialState] = React.useState<GridInitialStatePremium>();
 
   React.useEffect(() => {
-    const getSnapshot = async () => {
-      const snapshotFromLocalStorage = await getInitialStateFromLocalStorage();
-      setInitialState(snapshotFromLocalStorage);
-    };
-    getSnapshot().catch(() => {
-      // fallback to no state when state retrieval fails
-      setInitialState({});
-    });
+    const stateFromLocalStorage = localStorage?.getItem('dataGridState');
+    setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
   }, []);
 
   const saveSnapshot = React.useCallback(() => {
-    if (apiRef?.current) {
+    if (apiRef?.current && localStorage) {
       const currentState = apiRef.current.exportState();
-      saveDataGridStateToLocalStorage(currentState);
+      localStorage.setItem('dataGridState', JSON.stringify(currentState));
     }
   }, [apiRef]);
 
@@ -61,9 +38,7 @@ export default function SaveAndRestoreStateInitialState() {
         apiRef={apiRef}
         loading={loading}
         onStateChange={saveSnapshot}
-        initialState={{
-          ...initialState,
-        }}
+        initialState={initialState}
       />
     </Box>
   );

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
@@ -3,7 +3,5 @@
   apiRef={apiRef}
   loading={loading}
   onStateChange={saveSnapshot}
-  initialState={{
-    ...initialState,
-  }}
+  initialState={initialState}
 />

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
@@ -3,5 +3,8 @@
   apiRef={apiRef}
   loading={loading}
   onStateChange={saveSnapshot}
-  initialState={initialState}
+  initialState={{
+    ...data.initialState,
+    ...initialState,
+  }}
 />

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
@@ -1,0 +1,9 @@
+<DataGridPremium
+  {...data}
+  apiRef={apiRef}
+  loading={loading}
+  onStateChange={saveSnapshot}
+  initialState={{
+    ...initialState,
+  }}
+/>

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -96,7 +96,7 @@ If you restore the page using `initialState` before the data is fetched, the Dat
 ### Save and restore the state from external storage
 
 You can use `apiRef.current.exportState()` to save a snapshot of the state to an external storage (e.g. using `LocalStorage` or `redux`).
-This way the state can be persisted even when refreshing the page.
+This way the state can be persisted when refreshing the page or navigating to another page.
 
 {{"demo": "SaveAndRestoreStateInitialState.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -93,6 +93,13 @@ If you restore the page using `initialState` before the data is fetched, the Dat
 
 {{"demo": "RestoreStateInitialState.js", "bg": "inline", "defaultCodeOpen": false}}
 
+### Save and restore the state from external storage
+
+You can use `apiRef.current.exportState()` to save a snapshot of the state to an external storage (e.g. using `LocalStorage` or `redux`).
+This way the state can be persisted even when refreshing the page.
+
+{{"demo": "SaveAndRestoreStateInitialState.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ### Restore the state with apiRef
 
 You can pass the state returned by `apiRef.current.exportState()` to the `apiRef.current.restoreState` method.

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -95,7 +95,7 @@ If you restore the page using `initialState` before the data is fetched, the Dat
 
 ### Save and restore the state from external storage
 
-You can use `apiRef.current.exportState()` to save a snapshot of the state to an external storage (e.g. using `LocalStorage` or `redux`).
+You can use `apiRef.current.exportState()` to save a snapshot of the state to an external storage (e.g. using `localStorage` or `redux`).
 This way the state can be persisted when refreshing the page or navigating to another page.
 
 {{"demo": "SaveAndRestoreStateInitialState.js", "bg": "inline", "defaultCodeOpen": false}}

--- a/docs/scripts/pages/playground/index.tsx
+++ b/docs/scripts/pages/playground/index.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export default function Playground() {
+  return (
+    <div>A playground for a fast iteration development cycle in isolation outside of git.</div>
+  );
+}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

Adds a new recipe to the `DataGrid` docs pages showing how to save and restore `state` externally using `LocalStorage`.

Fixes #10508 

Preview: https://deploy-preview-10722--material-ui-x.netlify.app/x/react-data-grid/state/#save-and-restore-the-state-from-external-storage