### PR TITLE
[core] Update React renovate group with `@types`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,14 @@
     },
     {
       "groupName": "React",
-      "matchPackageNames": ["react", "react-dom", "react-is", "react-test-renderer"]
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "react-is",
+        "react-test-renderer",
+        "@types/react",
+        "@types/react-dom"
+      ]
     },
     {
       "groupName": "React router",


### PR DESCRIPTION
Noticed that the `@types/react` and `@types/react-dom` dependency bumping happens via separate PRs and almost always causes conflicts after merging one or the other. 🙈 
Bumping all relevant React dependencies in a single Renovate PR should avoid such cases.