### PR TITLE
[docs] Fix RTL data grid demo

### DIFF
--- a/docs/data/data-grid/localization/DataGridRTL.js
+++ b/docs/data/data-grid/localization/DataGridRTL.js
@@ -1,6 +1,16 @@
 import * as React from 'react';
+import { prefixer } from 'stylis';
+import rtlPlugin from 'stylis-plugin-rtl';
 import { DataGrid, arSD } from '@mui/x-data-grid';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
 import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
+
+// Create rtl cache
+const cacheRtl = createCache({
+  key: 'data-grid-rtl-demo',
+  stylisPlugins: [prefixer, rtlPlugin],
+});
 
 const columns = [
   {
@@ -40,7 +50,9 @@ const rows = [
 ];
 
 export default function DataGridRTL() {
+  // Inherit the theme from the docs site (dark/light mode)
   const existingTheme = useTheme();
+
   const theme = React.useMemo(
     () =>
       createTheme({}, arSD, existingTheme, {
@@ -49,10 +61,12 @@ export default function DataGridRTL() {
     [existingTheme],
   );
   return (
-    <ThemeProvider theme={theme}>
-      <div dir="rtl" style={{ height: 400, width: '100%' }}>
-        <DataGrid rows={rows} columns={columns} />
-      </div>
-    </ThemeProvider>
+    <CacheProvider value={cacheRtl}>
+      <ThemeProvider theme={theme}>
+        <div dir="rtl" style={{ height: 400, width: '100%' }}>
+          <DataGrid rows={rows} columns={columns} />
+        </div>
+      </ThemeProvider>
+    </CacheProvider>
   );
 }

--- a/docs/data/data-grid/localization/DataGridRTL.tsx
+++ b/docs/data/data-grid/localization/DataGridRTL.tsx
@@ -1,6 +1,16 @@
 import * as React from 'react';
+import { prefixer } from 'stylis';
+import rtlPlugin from 'stylis-plugin-rtl';
 import { DataGrid, GridColDef, arSD } from '@mui/x-data-grid';
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
 import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
+
+// Create rtl cache
+const cacheRtl = createCache({
+  key: 'data-grid-rtl-demo',
+  stylisPlugins: [prefixer, rtlPlugin],
+});
 
 const columns: GridColDef[] = [
   {
@@ -40,7 +50,9 @@ const rows = [
 ];
 
 export default function DataGridRTL() {
+  // Inherit the theme from the docs site (dark/light mode)
   const existingTheme = useTheme();
+
   const theme = React.useMemo(
     () =>
       createTheme({}, arSD, existingTheme, {
@@ -49,10 +61,12 @@ export default function DataGridRTL() {
     [existingTheme],
   );
   return (
-    <ThemeProvider theme={theme}>
-      <div dir="rtl" style={{ height: 400, width: '100%' }}>
-        <DataGrid rows={rows} columns={columns} />
-      </div>
-    </ThemeProvider>
+    <CacheProvider value={cacheRtl}>
+      <ThemeProvider theme={theme}>
+        <div dir="rtl" style={{ height: 400, width: '100%' }}>
+          <DataGrid rows={rows} columns={columns} />
+        </div>
+      </ThemeProvider>
+    </CacheProvider>
   );
 }

--- a/docs/data/data-grid/localization/DataGridRTL.tsx.preview
+++ b/docs/data/data-grid/localization/DataGridRTL.tsx.preview
@@ -1,5 +1,7 @@
-<ThemeProvider theme={theme}>
-  <div dir="rtl" style={{ height: 400, width: '100%' }}>
-    <DataGrid rows={rows} columns={columns} />
-  </div>
-</ThemeProvider>
+<CacheProvider value={cacheRtl}>
+  <ThemeProvider theme={theme}>
+    <div dir="rtl" style={{ height: 400, width: '100%' }}>
+      <DataGrid rows={rows} columns={columns} />
+    </div>
+  </ThemeProvider>
+</CacheProvider>

--- a/docs/package.json
+++ b/docs/package.json
@@ -93,6 +93,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.22.5",
     "@babel/preset-typescript": "^7.23.2",
     "@types/doctrine": "^0.0.7",
+    "@types/stylis": "^4.2.0",
     "cpy-cli": "^5.0.0",
     "gm": "^1.25.0",
     "typescript-to-proptypes": "^2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,7 +3070,7 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
   integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
-"@types/stylis@^4.0.2":
+"@types/stylis@^4.0.2", "@types/stylis@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.2.tgz#baabb6b3aa6787e90a6bd6cd75cd8fb9a4f256a3"
   integrity sha512-Rm17MsTpQQP5Jq4BF7CdrxJsDufoiL/q5IbJZYZmOZAJALyijgF7BzLgobXUqraNcQdqFYLYGeglDp6QzaxPpg==


### PR DESCRIPTION
Related to #8665 and a continuation of #10561. I landed here by chance, I was looking at https://github.com/mui/material-ui/pull/31847 (I'm in Morroco right now, an Arabic / RTL country, so why not empathize with them 😄) and noticed that the style of the demo was broken.

Before https://deploy-preview-10721--material-ui-x.netlify.app/x/react-data-grid/localization/#rtl-support
<img width="776" alt="Screenshot 2023-10-19 at 18 12 00" src="https://github.com/mui/mui-x/assets/3165635/c19bcb82-9192-4d3e-af58-fa0a221552bb">

After https://deploy-preview-10728--material-ui-x.netlify.app/x/react-data-grid/localization/#rtl-support
<img width="782" alt="Screenshot 2023-10-19 at 18 11 52" src="https://github.com/mui/mui-x/assets/3165635/39167f34-7554-4e67-91f2-b74ba7dca5a2">