### PR TITLE
[DataGridPremium] Fix `sum` aggregation to ignore non-numeric values

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
@@ -2,12 +2,12 @@ import { GridValueFormatterParams } from '@mui/x-data-grid-pro';
 import { isNumber } from '@mui/x-data-grid-pro/internals';
 import { GridAggregationFunction } from './gridAggregationInterfaces';
 
-const sumAgg: GridAggregationFunction<number> = {
+const sumAgg: GridAggregationFunction<unknown, number> = {
   apply: ({ values }) => {
     let sum = 0;
     for (let i = 0; i < values.length; i += 1) {
       const value = values[i];
-      if (value != null) {
+      if (isNumber(value)) {
         sum += value;
       }
     }

--- a/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -765,4 +765,28 @@ describe('<DataGridPremium /> - Aggregation', () => {
       ]);
     });
   });
+
+  describe('built-in aggregation functions', () => {
+    describe('`sum`', () => {
+      it('should work with numbers', () => {
+        expect(
+          GRID_AGGREGATION_FUNCTIONS.sum.apply({
+            values: [0, 10, 12, 23],
+            field: 'value',
+            groupId: 0,
+          }),
+        ).to.equal(45);
+      });
+
+      it('should ignore non-numbers', () => {
+        expect(
+          GRID_AGGREGATION_FUNCTIONS.sum.apply({
+            values: [0, 10, 12, 23, 'a', '', undefined, null, NaN, {}, true],
+            field: 'value',
+            groupId: 0,
+          }),
+        ).to.equal(45);
+      });
+    });
+  });
 });

--- a/packages/grid/x-data-grid/src/utils/utils.ts
+++ b/packages/grid/x-data-grid/src/utils/utils.ts
@@ -1,5 +1,5 @@
-export function isNumber(value: any): value is number {
-  return typeof value === 'number';
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
 }
 
 export function isFunction(value: any): value is Function {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/10717
- Before: https://codesandbox.io/s/datagridpremium-basic-forked-4pcq56?file=/src/App.tsx
- After: https://codesandbox.io/s/datagridpremium-basic-forked-hg9v2c?file=/src/App.tsx