### PR TITLE
[DataGrid] Add debug mode

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -51,6 +51,7 @@
       "deprecated": true,
       "deprecationInfo": "Use the <code>slotProps</code> prop instead."
     },
+    "debug": { "type": { "name": "bool" } },
     "defaultGroupingExpansionDepth": { "type": { "name": "number" }, "default": "0" },
     "density": {
       "type": {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -42,6 +42,7 @@
       "deprecated": true,
       "deprecationInfo": "Use the <code>slotProps</code> prop instead."
     },
+    "debug": { "type": { "name": "bool" } },
     "defaultGroupingExpansionDepth": { "type": { "name": "number" }, "default": "0" },
     "density": {
       "type": {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -28,6 +28,7 @@
       "deprecated": true,
       "deprecationInfo": "Use the <code>slotProps</code> prop instead."
     },
+    "debug": { "type": { "name": "bool" } },
     "density": {
       "type": {
         "name": "enum",

--- a/docs/translations/api-docs/data-grid/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium.json
@@ -111,6 +111,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "debug": {
+      "description": "If <code>true</code>, the data grid will attach the <code>apiRef</code> to the root HTML element. Usage: - Set the <code>debug</code> prop to <code>true</code>. - In the dev tools, select the root HTML element (<code>.MuiDataGrid-root</code>). - Type <code>$0.apiRef</code> in the console to access the <code>apiRef</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "defaultGroupingExpansionDepth": {
       "description": "If above 0, the row children will be expanded up to this depth. If equal to -1, all the row children will be expanded.",
       "deprecated": "",

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -96,6 +96,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "debug": {
+      "description": "If <code>true</code>, the data grid will attach the <code>apiRef</code> to the root HTML element. Usage: - Set the <code>debug</code> prop to <code>true</code>. - In the dev tools, select the root HTML element (<code>.MuiDataGrid-root</code>). - Type <code>$0.apiRef</code> in the console to access the <code>apiRef</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "defaultGroupingExpansionDepth": {
       "description": "If above 0, the row children will be expanded up to this depth. If equal to -1, all the row children will be expanded.",
       "deprecated": "",

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -81,6 +81,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "debug": {
+      "description": "If <code>true</code>, the data grid will attach the <code>apiRef</code> to the root HTML element. Usage: - Set the <code>debug</code> prop to <code>true</code>. - In the dev tools, select the root HTML element (<code>.MuiDataGrid-root</code>). - Type <code>$0.apiRef</code> in the console to access the <code>apiRef</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "density": {
       "description": "Set the density of the grid.",
       "deprecated": "",

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -196,6 +196,15 @@ DataGridPremiumRaw.propTypes = {
    */
   componentsProps: PropTypes.object,
   /**
+   * If `true`, the data grid will attach the `apiRef` to the root HTML element.
+   * Usage:
+   * - Set the `debug` prop to `true`.
+   * - In the dev tools, select the root HTML element (`.MuiDataGrid-root`).
+   * - Type `$0.apiRef` in the console to access the `apiRef`.
+   * @default false
+   */
+  debug: PropTypes.bool,
+  /**
    * If above 0, the row children will be expanded up to this depth.
    * If equal to -1, all the row children will be expanded.
    * @default 0

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -179,6 +179,15 @@ DataGridProRaw.propTypes = {
    */
   componentsProps: PropTypes.object,
   /**
+   * If `true`, the data grid will attach the `apiRef` to the root HTML element.
+   * Usage:
+   * - Set the `debug` prop to `true`.
+   * - In the dev tools, select the root HTML element (`.MuiDataGrid-root`).
+   * - Type `$0.apiRef` in the console to access the `apiRef`.
+   * @default false
+   */
+  debug: PropTypes.bool,
+  /**
    * If above 0, the row children will be expanded up to this depth.
    * If equal to -1, all the row children will be expanded.
    * @default 0

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -157,6 +157,15 @@ DataGridRaw.propTypes = {
    */
   componentsProps: PropTypes.object,
   /**
+   * If `true`, the data grid will attach the `apiRef` to the root HTML element.
+   * Usage:
+   * - Set the `debug` prop to `true`.
+   * - In the dev tools, select the root HTML element (`.MuiDataGrid-root`).
+   * - Type `$0.apiRef` in the console to access the `apiRef`.
+   * @default false
+   */
+  debug: PropTypes.bool,
+  /**
    * Set the density of the grid.
    * @default "standard"
    */

--- a/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/grid/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -80,6 +80,7 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
   keepColumnPositionIfDraggedOutside: false,
   unstable_ignoreValueFormatterDuringExport: false,
   clipboardCopyCellDelimiter: '\t',
+  debug: false,
 };
 
 const defaultSlots = uncapitalizeObjectKeys(DATA_GRID_DEFAULT_SLOTS_COMPONENTS)!;

--- a/packages/grid/x-data-grid/src/components/containers/GridRoot.tsx
+++ b/packages/grid/x-data-grid/src/components/containers/GridRoot.tsx
@@ -19,6 +19,7 @@ import { gridDensityValueSelector } from '../../hooks/features/density/densitySe
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { GridDensity } from '../../models/gridDensity';
 import { useGridAriaAttributes } from '../../hooks/utils/useGridAriaAttributes';
+import { useDebugMode } from '../../hooks/utils/useDebugMode';
 
 export interface GridRootProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -73,6 +74,15 @@ const GridRoot = React.forwardRef<HTMLDivElement, GridRootProps>(function GridRo
   useEnhancedEffect(() => {
     setMountedState(true);
   }, []);
+
+  useDebugMode({
+    rootContainerEl: rootContainerRef.current,
+    apiRef,
+    enabled:
+      mountedState &&
+      // @ts-ignore
+      (rootProps.debug as unknown as boolean),
+  });
 
   if (!mountedState) {
     return null;

--- a/packages/grid/x-data-grid/src/hooks/utils/useDebugMode.tsx
+++ b/packages/grid/x-data-grid/src/hooks/utils/useDebugMode.tsx
@@ -3,8 +3,8 @@ import type { GridPrivateApiCommunity } from '../../models/api/gridApiCommunity'
 
 /**
  * Usage:
- * - Set `debug` prop to `true`
- * - Find the root HTML element (`.MuiDataGrid-root`) in dev tools and select it.
+ * - Set the `debug` prop to `true`.
+ * - In the dev tools, select the root HTML element (`.MuiDataGrid-root`).
  * - Type `$0.apiRef` in the console to access the `apiRef`.
  */
 export const useDebugMode = ({
@@ -19,7 +19,9 @@ export const useDebugMode = ({
   React.useEffect(() => {
     if (enabled && rootContainerEl) {
       // @ts-ignore
-      rootContainerEl.apiRef = apiRef;
+      rootContainerEl.apiRef = {
+        current: apiRef.current.getPublicApi(),
+      };
     }
   }, [
     rootContainerEl,

--- a/packages/grid/x-data-grid/src/hooks/utils/useDebugMode.tsx
+++ b/packages/grid/x-data-grid/src/hooks/utils/useDebugMode.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import type { GridPrivateApiCommunity } from '../../models/api/gridApiCommunity';
+
+/**
+ * Usage:
+ * - Set `debug` prop to `true`
+ * - Find the root HTML element (`.MuiDataGrid-root`) in dev tools and select it.
+ * - Type `$0.apiRef` in the console to access the `apiRef`.
+ */
+export const useDebugMode = ({
+  rootContainerEl,
+  apiRef,
+  enabled,
+}: {
+  rootContainerEl?: HTMLElement | null;
+  apiRef: React.MutableRefObject<GridPrivateApiCommunity>;
+  enabled: boolean;
+}) => {
+  React.useEffect(() => {
+    if (enabled && rootContainerEl) {
+      // @ts-ignore
+      rootContainerEl.apiRef = apiRef;
+    }
+  }, [
+    rootContainerEl,
+    apiRef,
+    // @ts-ignore
+    enabled,
+  ]);
+};

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -371,6 +371,15 @@ export interface DataGridPropsWithDefaultValues {
    * @default '\t'
    */
   clipboardCopyCellDelimiter: string;
+  /**
+   * If `true`, the data grid will attach the `apiRef` to the root HTML element.
+   * Usage:
+   * - Set the `debug` prop to `true`.
+   * - In the dev tools, select the root HTML element (`.MuiDataGrid-root`).
+   * - Type `$0.apiRef` in the console to access the `apiRef`.
+   * @default false
+   */
+  debug: boolean;
 }
 
 /**


### PR DESCRIPTION
This makes access to `apiRef` easier, quite a useful thing for debugging.
What do you think?

<img width="550" src="https://github.com/mui/mui-x/assets/13808724/4d352c55-71f2-41d2-8cae-91c25de9ac4a">