### PR TITLE
[DataGridPro] Fix `undefined` values passed to `valueFormatter` for tree leaf nodes

### DIFF
--- a/packages/grid/x-data-grid-pro/src/hooks/features/treeData/gridTreeDataGroupColDef.ts
+++ b/packages/grid/x-data-grid-pro/src/hooks/features/treeData/gridTreeDataGroupColDef.ts
@@ -13,7 +13,9 @@ export const GRID_TREE_DATA_GROUPING_COL_DEF: Omit<GridColDef, 'field' | 'editab
   align: 'left',
   width: 200,
   valueGetter: (params) =>
-    params.rowNode.type === 'group' ? params.rowNode.groupingKey : undefined,
+    params.rowNode.type === 'group' || params.rowNode.type === 'leaf'
+      ? params.rowNode.groupingKey
+      : undefined,
 };
 
 export const GRID_TREE_DATA_GROUPING_FIELD = '__tree_data_group__';

--- a/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -336,6 +336,27 @@ describe('<DataGridPro /> - Tree data', () => {
       );
       expect(getColumnValues(0)).to.deep.equal(['A', 'A', 'B', 'B', 'A', 'B', 'A', 'A', 'C']);
     });
+
+    // https://github.com/mui/mui-x/issues/9344
+    it('should support valueFormatter', () => {
+      render(
+        <Test
+          groupingColDef={{ valueFormatter: ({ value }) => `> ${value}` }}
+          defaultGroupingExpansionDepth={-1}
+        />,
+      );
+      expect(getColumnValues(0)).to.deep.equal([
+        '> A (2)',
+        '> A',
+        '> B',
+        '> B (4)',
+        '> A',
+        '> B (2)',
+        '> A (1)',
+        '> A',
+        '> C',
+      ]);
+    });
   });
 
   describe('row grouping column', () => {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/9344
Fixes https://github.com/mui/mui-x/issues/8571