### PR TITLE
[DataGridPremium] Fix `avg` aggregation to ignore non-numeric values

### DIFF
--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
@@ -17,14 +17,23 @@ const sumAgg: GridAggregationFunction<unknown, number> = {
   columnTypes: ['number'],
 };
 
-const avgAgg: GridAggregationFunction<number> = {
-  apply: (params) => {
-    if (params.values.length === 0) {
+const avgAgg: GridAggregationFunction<unknown, number> = {
+  apply: ({ values }) => {
+    if (values.length === 0) {
       return null;
     }
 
-    const sum = sumAgg.apply(params) as number;
-    return sum / params.values.length;
+    let sum = 0;
+    let valuesCount = 0;
+    for (let i = 0; i < values.length; i += 1) {
+      const value = values[i];
+      if (isNumber(value)) {
+        valuesCount += 1;
+        sum += value;
+      }
+    }
+
+    return sum / valuesCount;
   },
   columnTypes: ['number'],
 };

--- a/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -789,6 +789,28 @@ describe('<DataGridPremium /> - Aggregation', () => {
       });
     });
 
+    describe('`avg`', () => {
+      it('should work with numbers', () => {
+        expect(
+          GRID_AGGREGATION_FUNCTIONS.avg.apply({
+            values: [0, 10, 12, 23],
+            field: 'value',
+            groupId: 0,
+          }),
+        ).to.equal(11.25);
+      });
+
+      it('should ignore non-numbers', () => {
+        expect(
+          GRID_AGGREGATION_FUNCTIONS.avg.apply({
+            values: [0, 10, 12, 23, 'a', '', undefined, null, NaN, {}, true],
+            field: 'value',
+            groupId: 0,
+          }),
+        ).to.equal(11.25);
+      });
+    });
+
     describe('`size`', () => {
       it('should work with any value types', () => {
         expect(


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/10743