### PR TITLE
[DataGrid] Fix for error thrown when removing skeleton rows, after sorting is applied

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -440,7 +440,7 @@ export const useGridRows = (
       tree[GRID_ROOT_GROUP_ID] = { ...rootGroup, children: rootGroupChildren };
 
       // Removes potential remaining skeleton rows from the dataRowIds.
-      const dataRowIds = rootGroupChildren.filter((childId) => tree[childId].type === 'leaf');
+      const dataRowIds = rootGroupChildren.filter((childId) => tree[childId]?.type === 'leaf');
 
       apiRef.current.caches.rows.dataRowIdToModelLookup = dataRowIdToModelLookup;
       apiRef.current.caches.rows.dataRowIdToIdLookup = dataRowIdToIdLookup;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This fixes an issue that arises when sorting is applied to a filtered, lazy loaded DataGrid instance. An error is thrown when the sort method is changed. 

The stack trace thrown on my app is as follows:

<img width="629" alt="Screen Shot 2023-10-26 at 5 35 43 pm" src="https://github.com/mui/mui-x/assets/84322007/ce167646-b733-433f-afd5-602f8ef61092">

Which leads you into the line of code that I changed:
<img width="678" alt="Screen Shot 2023-10-26 at 5 35 53 pm" src="https://github.com/mui/mui-x/assets/84322007/ba2ce310-81fe-4c1d-86ef-5accb18e5a9a">

This fixes the issue, where a child row doesn't appear in the tree.
