### PR TITLE
[docs] Improve recipe with `useLayoutEffect` and `beforeunload` event-listener

### DIFF
--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
@@ -21,7 +21,7 @@ export default function SaveAndRestoreStateInitialState() {
     }
   }, [apiRef]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const stateFromLocalStorage = localStorage?.getItem('dataGridState');
     setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
 

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.js
@@ -14,17 +14,26 @@ export default function SaveAndRestoreStateInitialState() {
 
   const [initialState, setInitialState] = React.useState();
 
-  React.useEffect(() => {
-    const stateFromLocalStorage = localStorage?.getItem('dataGridState');
-    setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
-  }, []);
-
   const saveSnapshot = React.useCallback(() => {
-    if (apiRef?.current && localStorage) {
+    if (apiRef?.current?.exportState && localStorage) {
       const currentState = apiRef.current.exportState();
       localStorage.setItem('dataGridState', JSON.stringify(currentState));
     }
   }, [apiRef]);
+
+  React.useEffect(() => {
+    const stateFromLocalStorage = localStorage?.getItem('dataGridState');
+    setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
+
+    // handle refresh and navigating away/refreshing
+    window.addEventListener('beforeunload', saveSnapshot);
+
+    return () => {
+      // in case of an SPA remove the event-listener
+      window.removeEventListener('beforeunload', saveSnapshot);
+      saveSnapshot();
+    };
+  }, [saveSnapshot]);
 
   if (!initialState) {
     return <CircularProgress />;
@@ -36,7 +45,6 @@ export default function SaveAndRestoreStateInitialState() {
         {...data}
         apiRef={apiRef}
         loading={loading}
-        onStateChange={saveSnapshot}
         initialState={{
           ...data.initialState,
           ...initialState,

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
@@ -15,17 +15,26 @@ export default function SaveAndRestoreStateInitialState() {
 
   const [initialState, setInitialState] = React.useState<GridInitialStatePremium>();
 
-  React.useEffect(() => {
-    const stateFromLocalStorage = localStorage?.getItem('dataGridState');
-    setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
-  }, []);
-
   const saveSnapshot = React.useCallback(() => {
-    if (apiRef?.current && localStorage) {
+    if (apiRef?.current?.exportState && localStorage) {
       const currentState = apiRef.current.exportState();
       localStorage.setItem('dataGridState', JSON.stringify(currentState));
     }
   }, [apiRef]);
+
+  React.useEffect(() => {
+    const stateFromLocalStorage = localStorage?.getItem('dataGridState');
+    setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
+
+    // handle refresh and navigating away/refreshing
+    window.addEventListener('beforeunload', saveSnapshot);
+
+    return () => {
+      // in case of an SPA remove the event-listener
+      window.removeEventListener('beforeunload', saveSnapshot);
+      saveSnapshot();
+    };
+  }, []);
 
   if (!initialState) {
     return <CircularProgress />;
@@ -37,7 +46,6 @@ export default function SaveAndRestoreStateInitialState() {
         {...data}
         apiRef={apiRef}
         loading={loading}
-        onStateChange={saveSnapshot}
         initialState={{
           ...data.initialState,
           ...initialState,

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
@@ -22,7 +22,7 @@ export default function SaveAndRestoreStateInitialState() {
     }
   }, [apiRef]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const stateFromLocalStorage = localStorage?.getItem('dataGridState');
     setInitialState(stateFromLocalStorage ? JSON.parse(stateFromLocalStorage) : {});
 

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx
@@ -34,7 +34,7 @@ export default function SaveAndRestoreStateInitialState() {
       window.removeEventListener('beforeunload', saveSnapshot);
       saveSnapshot();
     };
-  }, []);
+  }, [saveSnapshot]);
 
   if (!initialState) {
     return <CircularProgress />;

--- a/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
+++ b/docs/data/data-grid/state/SaveAndRestoreStateInitialState.tsx.preview
@@ -2,7 +2,6 @@
   {...data}
   apiRef={apiRef}
   loading={loading}
-  onStateChange={saveSnapshot}
   initialState={{
     ...data.initialState,
     ...initialState,

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -97,7 +97,7 @@ If you restore the page using `initialState` before the data is fetched, the Dat
 
 You can use `apiRef.current.exportState()` to save a snapshot of the state to an external storage (e.g. using `localStorage` or `redux`).
 This way the state can be persisted on refresh or navigating to another page. This is done by listening on the `beforeunload` event.
-When used in an SPA the `useLayoutEffect` cleanup function is being used instead.
+When the component is unmounted, the `useLayoutEffect` cleanup function is being used instead.
 
 {{"demo": "SaveAndRestoreStateInitialState.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -96,7 +96,8 @@ If you restore the page using `initialState` before the data is fetched, the Dat
 ### Save and restore the state from external storage
 
 You can use `apiRef.current.exportState()` to save a snapshot of the state to an external storage (e.g. using `localStorage` or `redux`).
-This way the state can be persisted when refreshing the page or navigating to another page.
+This way the state can be persisted on refresh or navigating to another page. This is done by listening on the `beforeunload` event.
+When used in an SPA the `useLayoutEffect` cleanup function is being used instead.
 
 {{"demo": "SaveAndRestoreStateInitialState.js", "bg": "inline", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

This implements the suggested changes from @lauri865 (many thanks for pointing that out 🙇🏼).

Now we do save the state on either one of 2 routes:
1. when unmounting with the `useLayoutEffect` cleanup function
2. on navigating away or refreshing (when client session gets reset) by listening on the `beforeunload` event

Fixes #10770 