### PR TITLE
[charts] Fix text position in Safari

### DIFF
--- a/packages/x-charts/src/internals/components/ChartsText.tsx
+++ b/packages/x-charts/src/internals/components/ChartsText.tsx
@@ -96,7 +96,7 @@ export function ChartsText(props: ChartsTextProps) {
         <tspan
           x={x}
           dy={`${index === 0 ? startDy : wordsByLines[0].height}px`}
-          dominantBaseline={dominantBaseline}
+          dominantBaseline={dominantBaseline} // Propagated to fix Safari issue: https://github.com/mui/mui-x/issues/10808
           key={index}
         >
           {line.text}

--- a/packages/x-charts/src/internals/components/ChartsText.tsx
+++ b/packages/x-charts/src/internals/components/ChartsText.tsx
@@ -93,7 +93,7 @@ export function ChartsText(props: ChartsTextProps) {
       style={style}
     >
       {wordsByLines.map((line, index) => (
-        <tspan x={x} dy={`${index === 0 ? startDy : wordsByLines[0].height}px`} key={index}>
+        <tspan x={x} dy={`${index === 0 ? startDy : wordsByLines[0].height}px`} dominantBaseline={dominantBaseline} key={index}>
           {line.text}
         </tspan>
       ))}

--- a/packages/x-charts/src/internals/components/ChartsText.tsx
+++ b/packages/x-charts/src/internals/components/ChartsText.tsx
@@ -93,7 +93,12 @@ export function ChartsText(props: ChartsTextProps) {
       style={style}
     >
       {wordsByLines.map((line, index) => (
-        <tspan x={x} dy={`${index === 0 ? startDy : wordsByLines[0].height}px`} dominantBaseline={dominantBaseline} key={index}>
+        <tspan
+          x={x}
+          dy={`${index === 0 ? startDy : wordsByLines[0].height}px`}
+          dominantBaseline={dominantBaseline}
+          key={index}
+        >
           {line.text}
         </tspan>
       ))}


### PR DESCRIPTION
Fixes #10808.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Thanks to @alexfauquette.

This fix can be reverted when Apple release a new Safari version with the fix mentioned at
[https://webkit.org/blog/14390/release-notes-for-safari-technology-preview-174/](https://webkit.org/blog/14390/release-notes-for-safari-technology-preview-174/).

> Fixed dominant-baseline CSS property to be inherited ([265525@main](https://commits.webkit.org/265525@main))

