### PR TITLE
[DataGridPro] Fix useGridRows not giving error on reversed data

### DIFF
--- a/packages/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/lazyLoader.DataGridPro.test.tsx
@@ -171,4 +171,26 @@ describe('<DataGridPro /> - Lazy loader', () => {
     expect(apiRef.current.getRowNode(4)).to.not.equal(null);
     expect(apiRef.current.getRowNode(5)).to.not.equal(null);
   });
+
+  it('should update rows when `apiRef.current.updateRows` with data reversed', () => {
+    render(<TestLazyLoader rowCount={5} autoHeight={isJSDOM} />);
+
+    const newRows: GridRowModel[] = [
+      {
+        id: 3,
+        first: 'Jim',
+      },
+      {
+        id: 2,
+        first: 'Jack',
+      },
+      {
+        id: 1,
+        first: 'Mike',
+      },
+    ];
+
+    act(() => apiRef.current.unstable_replaceRows(0, newRows));
+    expect(getColumnValues(1)).to.deep.equal(['Jim', 'Jack', 'Mike']);
+  });
 });

--- a/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -410,6 +410,7 @@ export const useGridRows = (
       const dataRowIdToIdLookup = { ...gridRowsDataRowIdToIdLookupSelector(apiRef) };
       const rootGroup = tree[GRID_ROOT_GROUP_ID] as GridGroupNode;
       const rootGroupChildren = [...rootGroup.children];
+      const seenIds: GridRowId[] = [];
 
       for (let i = 0; i < newRows.length; i += 1) {
         const rowModel = newRows[i];
@@ -421,9 +422,11 @@ export const useGridRows = (
 
         const [replacedRowId] = rootGroupChildren.splice(firstRowToRender + i, 1, rowId);
 
-        delete dataRowIdToModelLookup[replacedRowId];
-        delete dataRowIdToIdLookup[replacedRowId];
-        delete tree[replacedRowId];
+        if (!seenIds.includes(replacedRowId)) {
+          delete dataRowIdToModelLookup[replacedRowId];
+          delete dataRowIdToIdLookup[replacedRowId];
+          delete tree[replacedRowId];
+        }
 
         const rowTreeNodeConfig: GridLeafNode = {
           id: rowId,
@@ -435,6 +438,8 @@ export const useGridRows = (
         dataRowIdToModelLookup[rowId] = rowModel;
         dataRowIdToIdLookup[rowId] = rowId;
         tree[rowId] = rowTreeNodeConfig;
+
+        seenIds.push(rowId);
       }
 
       tree[GRID_ROOT_GROUP_ID] = { ...rootGroup, children: rootGroupChildren };

--- a/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -410,7 +410,7 @@ export const useGridRows = (
       const dataRowIdToIdLookup = { ...gridRowsDataRowIdToIdLookupSelector(apiRef) };
       const rootGroup = tree[GRID_ROOT_GROUP_ID] as GridGroupNode;
       const rootGroupChildren = [...rootGroup.children];
-      const seenIds: GridRowId[] = [];
+      const seenIds = new Set<GridRowId>();
 
       for (let i = 0; i < newRows.length; i += 1) {
         const rowModel = newRows[i];
@@ -420,12 +420,12 @@ export const useGridRows = (
           'A row was provided without id when calling replaceRows().',
         );
 
-        const [replacedRowId] = rootGroupChildren.splice(firstRowToRender + i, 1, rowId);
+        const [removedRowId] = rootGroupChildren.splice(firstRowToRender + i, 1, rowId);
 
-        if (!seenIds.includes(replacedRowId)) {
-          delete dataRowIdToModelLookup[replacedRowId];
-          delete dataRowIdToIdLookup[replacedRowId];
-          delete tree[replacedRowId];
+        if (!seenIds.has(removedRowId)) {
+          delete dataRowIdToModelLookup[removedRowId];
+          delete dataRowIdToIdLookup[removedRowId];
+          delete tree[removedRowId];
         }
 
         const rowTreeNodeConfig: GridLeafNode = {
@@ -439,7 +439,7 @@ export const useGridRows = (
         dataRowIdToIdLookup[rowId] = rowId;
         tree[rowId] = rowTreeNodeConfig;
 
-        seenIds.push(rowId);
+        seenIds.add(rowId);
       }
 
       tree[GRID_ROOT_GROUP_ID] = { ...rootGroup, children: rootGroupChildren };


### PR DESCRIPTION
It seems there a sorting issue in combination with the lazy loader. When `unstable_replaceRows` is called having existing rows in a different order, `useGridRows` gives an error because it can't find rows because they have been deleted before. 

This behavior can be seen in the following demo. This is a fork of the lazy loading example from the documentation with rowLength adjusted to 10. To trigger the error simply change the order of the Name column.
https://codesandbox.io/s/nifty-pike-slzjmd?file=/src/Demo.tsx

This PR includes a suggested fix and test. Let me know if any change is needed and we're happy to update it.