### PR TITLE
[docs] Add a recipe for autosizing columns after fetching row-data

### DIFF
--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.js
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.js
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Rating from '@mui/material/Rating';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { useGridApiRef } from '@mui/x-data-grid';
+import { DataGridPro, DEFAULT_GRID_AUTOSIZE_OPTIONS } from '@mui/x-data-grid-pro';
+import { randomRating, randomTraderName } from '@mui/x-data-grid-generator';
+import * as ReactDOM from 'react-dom';
+
+const columns = [
+  { field: 'id', headerName: 'Brand ID' },
+  { field: 'brand', headerName: 'Brand name' },
+  { field: 'rep', headerName: 'Representative' },
+  { field: 'rating', headerName: 'Rating', renderCell: renderRating },
+];
+
+function renderRating(params) {
+  return <Rating readOnly value={params.value} />;
+}
+
+function getFakeData(length) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const names = [
+        'Nike',
+        'Adidas',
+        'Puma',
+        'Reebok',
+        'Fila',
+        'Lululemon Athletica Clothing',
+        'Varley',
+      ];
+
+      const rows = Array.from({ length }).map((_, id) => ({
+        id,
+        brand: names[id % names.length],
+        rep: randomTraderName(),
+        rating: randomRating(),
+      }));
+
+      resolve({ rows });
+    }, 1000);
+  });
+}
+
+export default function ColumnAutosizingAsync() {
+  const apiRef = useGridApiRef();
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [rows] = React.useState([]);
+
+  const [includeHeaders, setIncludeHeaders] = React.useState(
+    DEFAULT_GRID_AUTOSIZE_OPTIONS.includeHeaders,
+  );
+  const [includeOutliers, setExcludeOutliers] = React.useState(
+    DEFAULT_GRID_AUTOSIZE_OPTIONS.includeOutliers,
+  );
+  const [outliersFactor, setOutliersFactor] = React.useState(
+    String(DEFAULT_GRID_AUTOSIZE_OPTIONS.outliersFactor),
+  );
+  const [expand, setExpand] = React.useState(DEFAULT_GRID_AUTOSIZE_OPTIONS.expand);
+
+  const autosizeOptions = React.useMemo(
+    () => ({
+      includeHeaders,
+      includeOutliers,
+      outliersFactor: Number.isNaN(parseFloat(outliersFactor))
+        ? 1
+        : parseFloat(outliersFactor),
+      expand,
+    }),
+    [expand, includeHeaders, includeOutliers, outliersFactor],
+  );
+
+  const fetchData = React.useCallback(() => {
+    setIsLoading(true);
+    getFakeData(100)
+      .then((data) => {
+        return ReactDOM.flushSync(() => {
+          setIsLoading(false);
+          apiRef.current.updateRows(data.rows);
+        });
+      })
+      .then(() => apiRef.current.autosizeColumns(autosizeOptions));
+  }, [apiRef, autosizeOptions]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return (
+    <div style={{ width: '100%' }}>
+      <Stack
+        spacing={1}
+        direction="row"
+        alignItems="center"
+        sx={{ mb: 1 }}
+        useFlexGap
+        flexWrap="wrap"
+      >
+        <Button variant="outlined" onClick={fetchData}>
+          Refetch data
+        </Button>
+        <FormControlLabel
+          sx={{ ml: 0 }}
+          control={
+            <Checkbox
+              checked={includeHeaders}
+              onChange={(ev) => setIncludeHeaders(ev.target.checked)}
+            />
+          }
+          label="Include headers"
+        />
+        <FormControlLabel
+          sx={{ ml: 0 }}
+          control={
+            <Checkbox
+              checked={includeOutliers}
+              onChange={(event) => setExcludeOutliers(event.target.checked)}
+            />
+          }
+          label="Include outliers"
+        />
+        <TextField
+          size="small"
+          label="Outliers factor"
+          value={outliersFactor}
+          onChange={(ev) => setOutliersFactor(ev.target.value)}
+          sx={{ width: '12ch' }}
+        />
+        <FormControlLabel
+          sx={{ ml: 0 }}
+          control={
+            <Checkbox
+              checked={expand}
+              onChange={(ev) => setExpand(ev.target.checked)}
+            />
+          }
+          label="Expand"
+        />
+      </Stack>
+      <div style={{ height: 400, width: '100%' }}>
+        <DataGridPro
+          apiRef={apiRef}
+          density="compact"
+          columns={columns}
+          rows={rows}
+          loading={isLoading}
+          autosizeOptions={autosizeOptions}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.js
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import Button from '@mui/material/Button';
-import Checkbox from '@mui/material/Checkbox';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import Rating from '@mui/material/Rating';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
 import { useGridApiRef } from '@mui/x-data-grid';
-import { DataGridPro, DEFAULT_GRID_AUTOSIZE_OPTIONS } from '@mui/x-data-grid-pro';
-import { randomRating, randomTraderName } from '@mui/x-data-grid-generator';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+import {
+  randomInt,
+  randomRating,
+  randomTraderName,
+} from '@mui/x-data-grid-generator';
 import * as ReactDOM from 'react-dom';
 
 const columns = [
@@ -36,7 +37,7 @@ function getFakeData(length) {
 
       const rows = Array.from({ length }).map((_, id) => ({
         id,
-        brand: names[id % names.length],
+        brand: names[randomInt(0, names.length - 1)],
         rep: randomTraderName(),
         rating: randomRating(),
       }));
@@ -51,46 +52,25 @@ export default function ColumnAutosizingAsync() {
   const [isLoading, setIsLoading] = React.useState(false);
   const [rows] = React.useState([]);
 
-  const [includeHeaders, setIncludeHeaders] = React.useState(
-    DEFAULT_GRID_AUTOSIZE_OPTIONS.includeHeaders,
-  );
-  const [includeOutliers, setExcludeOutliers] = React.useState(
-    DEFAULT_GRID_AUTOSIZE_OPTIONS.includeOutliers,
-  );
-  const [outliersFactor, setOutliersFactor] = React.useState(
-    String(DEFAULT_GRID_AUTOSIZE_OPTIONS.outliersFactor),
-  );
-  const [expand, setExpand] = React.useState(DEFAULT_GRID_AUTOSIZE_OPTIONS.expand);
-
-  const autosizeOptions = React.useMemo(
-    () => ({
-      includeHeaders,
-      includeOutliers,
-      outliersFactor: Number.isNaN(parseFloat(outliersFactor))
-        ? 1
-        : parseFloat(outliersFactor),
-      expand,
-    }),
-    [expand, includeHeaders, includeOutliers, outliersFactor],
-  );
-
-  const fetchData = React.useCallback(
-    (options) => {
-      setIsLoading(true);
-      getFakeData(100)
-        .then((data) => {
-          return ReactDOM.flushSync(() => {
-            setIsLoading(false);
-            apiRef.current.updateRows(data.rows);
-          });
-        })
-        .then(() => apiRef.current.autosizeColumns(options));
-    },
-    [apiRef],
-  );
+  const fetchData = React.useCallback(() => {
+    setIsLoading(true);
+    getFakeData(100)
+      .then((data) => {
+        return ReactDOM.flushSync(() => {
+          setIsLoading(false);
+          apiRef.current.updateRows(data.rows);
+        });
+      })
+      .then(() =>
+        apiRef.current.autosizeColumns({
+          includeHeaders: true,
+          includeOutliers: true,
+        }),
+      );
+  }, [apiRef]);
 
   React.useEffect(() => {
-    fetchData(DEFAULT_GRID_AUTOSIZE_OPTIONS);
+    fetchData();
   }, [fetchData]);
 
   return (
@@ -103,46 +83,9 @@ export default function ColumnAutosizingAsync() {
         useFlexGap
         flexWrap="wrap"
       >
-        <Button variant="outlined" onClick={() => fetchData(autosizeOptions)}>
+        <Button variant="outlined" onClick={fetchData}>
           Refetch data
         </Button>
-        <FormControlLabel
-          sx={{ ml: 0 }}
-          control={
-            <Checkbox
-              checked={includeHeaders}
-              onChange={(ev) => setIncludeHeaders(ev.target.checked)}
-            />
-          }
-          label="Include headers"
-        />
-        <FormControlLabel
-          sx={{ ml: 0 }}
-          control={
-            <Checkbox
-              checked={includeOutliers}
-              onChange={(event) => setExcludeOutliers(event.target.checked)}
-            />
-          }
-          label="Include outliers"
-        />
-        <TextField
-          size="small"
-          label="Outliers factor"
-          value={outliersFactor}
-          onChange={(ev) => setOutliersFactor(ev.target.value)}
-          sx={{ width: '12ch' }}
-        />
-        <FormControlLabel
-          sx={{ ml: 0 }}
-          control={
-            <Checkbox
-              checked={expand}
-              onChange={(ev) => setExpand(ev.target.checked)}
-            />
-          }
-          label="Expand"
-        />
       </Stack>
       <div style={{ height: 400, width: '100%' }}>
         <DataGridPro
@@ -151,7 +94,6 @@ export default function ColumnAutosizingAsync() {
           columns={columns}
           rows={rows}
           loading={isLoading}
-          autosizeOptions={autosizeOptions}
         />
       </div>
     </div>

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.js
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.js
@@ -74,20 +74,23 @@ export default function ColumnAutosizingAsync() {
     [expand, includeHeaders, includeOutliers, outliersFactor],
   );
 
-  const fetchData = React.useCallback(() => {
-    setIsLoading(true);
-    getFakeData(100)
-      .then((data) => {
-        return ReactDOM.flushSync(() => {
-          setIsLoading(false);
-          apiRef.current.updateRows(data.rows);
-        });
-      })
-      .then(() => apiRef.current.autosizeColumns(autosizeOptions));
-  }, [apiRef, autosizeOptions]);
+  const fetchData = React.useCallback(
+    (options) => {
+      setIsLoading(true);
+      getFakeData(100)
+        .then((data) => {
+          return ReactDOM.flushSync(() => {
+            setIsLoading(false);
+            apiRef.current.updateRows(data.rows);
+          });
+        })
+        .then(() => apiRef.current.autosizeColumns(options));
+    },
+    [apiRef],
+  );
 
   React.useEffect(() => {
-    fetchData();
+    fetchData(DEFAULT_GRID_AUTOSIZE_OPTIONS);
   }, [fetchData]);
 
   return (
@@ -100,7 +103,7 @@ export default function ColumnAutosizingAsync() {
         useFlexGap
         flexWrap="wrap"
       >
-        <Button variant="outlined" onClick={fetchData}>
+        <Button variant="outlined" onClick={() => fetchData(autosizeOptions)}>
           Refetch data
         </Button>
         <FormControlLabel

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.tsx
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Rating from '@mui/material/Rating';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import { useGridApiRef } from '@mui/x-data-grid';
+import {
+  DataGridPro,
+  GridApiPro,
+  DEFAULT_GRID_AUTOSIZE_OPTIONS,
+} from '@mui/x-data-grid-pro';
+import { randomRating, randomTraderName } from '@mui/x-data-grid-generator';
+import * as ReactDOM from 'react-dom';
+import { GridData } from 'docsx/data/data-grid/virtualization/ColumnVirtualizationGrid';
+
+const columns = [
+  { field: 'id', headerName: 'Brand ID' },
+  { field: 'brand', headerName: 'Brand name' },
+  { field: 'rep', headerName: 'Representative' },
+  { field: 'rating', headerName: 'Rating', renderCell: renderRating },
+];
+
+function renderRating(params: any) {
+  return <Rating readOnly value={params.value} />;
+}
+
+function getFakeData(length: number): Promise<{ rows: GridData['rows'] }> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const names = [
+        'Nike',
+        'Adidas',
+        'Puma',
+        'Reebok',
+        'Fila',
+        'Lululemon Athletica Clothing',
+        'Varley',
+      ];
+      const rows = Array.from({ length }).map((_, id) => ({
+        id,
+        brand: names[id % names.length],
+        rep: randomTraderName(),
+        rating: randomRating(),
+      }));
+
+      resolve({ rows });
+    }, 1000);
+  });
+}
+
+export default function ColumnAutosizingAsync() {
+  const apiRef = useGridApiRef<GridApiPro>();
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [rows] = React.useState([]);
+
+  const [includeHeaders, setIncludeHeaders] = React.useState(
+    DEFAULT_GRID_AUTOSIZE_OPTIONS.includeHeaders,
+  );
+  const [includeOutliers, setExcludeOutliers] = React.useState(
+    DEFAULT_GRID_AUTOSIZE_OPTIONS.includeOutliers,
+  );
+  const [outliersFactor, setOutliersFactor] = React.useState(
+    String(DEFAULT_GRID_AUTOSIZE_OPTIONS.outliersFactor),
+  );
+  const [expand, setExpand] = React.useState(DEFAULT_GRID_AUTOSIZE_OPTIONS.expand);
+
+  const autosizeOptions = React.useMemo(
+    () => ({
+      includeHeaders,
+      includeOutliers,
+      outliersFactor: Number.isNaN(parseFloat(outliersFactor))
+        ? 1
+        : parseFloat(outliersFactor),
+      expand,
+    }),
+    [expand, includeHeaders, includeOutliers, outliersFactor],
+  );
+
+  const fetchData = React.useCallback(() => {
+    setIsLoading(true);
+    getFakeData(100)
+      .then((data) => {
+        return ReactDOM.flushSync(() => {
+          setIsLoading(false);
+          apiRef.current.updateRows(data.rows);
+        });
+      })
+      .then(() => apiRef.current.autosizeColumns(autosizeOptions));
+  }, [apiRef, autosizeOptions]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return (
+    <div style={{ width: '100%' }}>
+      <Stack
+        spacing={1}
+        direction="row"
+        alignItems="center"
+        sx={{ mb: 1 }}
+        useFlexGap
+        flexWrap="wrap"
+      >
+        <Button variant="outlined" onClick={fetchData}>
+          Refetch data
+        </Button>
+        <FormControlLabel
+          sx={{ ml: 0 }}
+          control={
+            <Checkbox
+              checked={includeHeaders}
+              onChange={(ev) => setIncludeHeaders(ev.target.checked)}
+            />
+          }
+          label="Include headers"
+        />
+        <FormControlLabel
+          sx={{ ml: 0 }}
+          control={
+            <Checkbox
+              checked={includeOutliers}
+              onChange={(event) => setExcludeOutliers(event.target.checked)}
+            />
+          }
+          label="Include outliers"
+        />
+        <TextField
+          size="small"
+          label="Outliers factor"
+          value={outliersFactor}
+          onChange={(ev) => setOutliersFactor(ev.target.value)}
+          sx={{ width: '12ch' }}
+        />
+        <FormControlLabel
+          sx={{ ml: 0 }}
+          control={
+            <Checkbox
+              checked={expand}
+              onChange={(ev) => setExpand(ev.target.checked)}
+            />
+          }
+          label="Expand"
+        />
+      </Stack>
+      <div style={{ height: 400, width: '100%' }}>
+        <DataGridPro
+          apiRef={apiRef}
+          density="compact"
+          columns={columns}
+          rows={rows}
+          loading={isLoading}
+          autosizeOptions={autosizeOptions}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.tsx
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingAsync.tsx
@@ -78,20 +78,23 @@ export default function ColumnAutosizingAsync() {
     [expand, includeHeaders, includeOutliers, outliersFactor],
   );
 
-  const fetchData = React.useCallback(() => {
-    setIsLoading(true);
-    getFakeData(100)
-      .then((data) => {
-        return ReactDOM.flushSync(() => {
-          setIsLoading(false);
-          apiRef.current.updateRows(data.rows);
-        });
-      })
-      .then(() => apiRef.current.autosizeColumns(autosizeOptions));
-  }, [apiRef, autosizeOptions]);
+  const fetchData = React.useCallback(
+    (options: typeof autosizeOptions) => {
+      setIsLoading(true);
+      getFakeData(100)
+        .then((data) => {
+          return ReactDOM.flushSync(() => {
+            setIsLoading(false);
+            apiRef.current.updateRows(data.rows);
+          });
+        })
+        .then(() => apiRef.current.autosizeColumns(options));
+    },
+    [apiRef],
+  );
 
   React.useEffect(() => {
-    fetchData();
+    fetchData(DEFAULT_GRID_AUTOSIZE_OPTIONS);
   }, [fetchData]);
 
   return (
@@ -104,7 +107,7 @@ export default function ColumnAutosizingAsync() {
         useFlexGap
         flexWrap="wrap"
       >
-        <Button variant="outlined" onClick={fetchData}>
+        <Button variant="outlined" onClick={() => fetchData(autosizeOptions)}>
           Refetch data
         </Button>
         <FormControlLabel

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -99,7 +99,7 @@ DOM access is required to accurately calculate dimensions, so unmounted cells (w
 
 ### Autosizing asynchronously [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
-The `autosizeColumns` method from the `apiRef` can be used as well to adjust the column size on specified events, for example when receiving row-data from an endpoint.
+The `autosizeColumns` method from the `apiRef` can be used as well to adjust the column size on specified events, for example when receiving row data from the server.
 
 {{"demo": "ColumnAutosizingAsync.js", "disableAd": true, "bg": "inline"}}
 

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -97,6 +97,16 @@ The data grid can only autosize based on the currently rendered cells.
 DOM access is required to accurately calculate dimensions, so unmounted cells (when [virtualization](/x/react-data-grid/virtualization/) is on) cannot be sized. If you need a bigger row sample, [open an issue](https://github.com/mui/mui-x/issues) to discuss it further.
 :::
 
+## Autosizing asynchronously [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+
+The `autosizeColumns` method from the `apiRef` can be used as well to adjust the column size on specified events, for example when receiving row-data from an endpoint.
+
+{{"demo": "ColumnAutosizingAsync.js", "disableAd": true, "bg": "inline"}}
+
+:::warning
+This example uses `ReactDOM.flushSync`. If used incorrectly it can hurt the performance of your application. Please refer to the official [React docs](https://react.dev/reference/react-dom/flushSync) for further information.
+:::
+
 ## API
 
 - [DataGrid](/x/api/data-grid/data-grid/)

--- a/docs/data/data-grid/column-dimensions/column-dimensions.md
+++ b/docs/data/data-grid/column-dimensions/column-dimensions.md
@@ -97,7 +97,7 @@ The data grid can only autosize based on the currently rendered cells.
 DOM access is required to accurately calculate dimensions, so unmounted cells (when [virtualization](/x/react-data-grid/virtualization/) is on) cannot be sized. If you need a bigger row sample, [open an issue](https://github.com/mui/mui-x/issues) to discuss it further.
 :::
 
-## Autosizing asynchronously [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+### Autosizing asynchronously [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 The `autosizeColumns` method from the `apiRef` can be used as well to adjust the column size on specified events, for example when receiving row-data from an endpoint.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

This adds a recipe for the autosizing functionality of the DataGrid using the `apiRef.current.autosizeColumns()` and `apiRef.current.updateRows()` methods.

I did take the example provided by @cherniavskii (option 3 described in #10578) and refactored the `useData` function a bit to fake an API call.

Fixes #10578 