### PR TITLE
[pickers] Refine `referenceDate` behavior in views

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -185,14 +185,11 @@ describe('<DateCalendar />', () => {
           onChange={onChange}
           referenceDate={adapterToUse.date(new Date(2022, 3, 17, 12, 30))}
           view="day"
-          autoFocus
         />,
       );
 
-      // should focus the reference day
-      expect(
-        screen.getByRole('gridcell', { name: '17' }).classList.contains('Mui-focusVisible'),
-      ).to.equal(true);
+      // should make the reference day firstly focusable
+      expect(screen.getByRole('gridcell', { name: '17' })).to.have.attribute('tabindex', '0');
 
       userEvent.mousePress(screen.getByRole('gridcell', { name: '2' }));
       expect(onChange.callCount).to.equal(1);

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -183,14 +183,20 @@ describe('<DateCalendar />', () => {
       render(
         <DateCalendar
           onChange={onChange}
-          referenceDate={adapterToUse.date(new Date(2018, 0, 1, 12, 30))}
+          referenceDate={adapterToUse.date(new Date(2022, 3, 17, 12, 30))}
           view="day"
+          autoFocus
         />,
       );
 
+      // should focus the reference day
+      expect(
+        screen.getByRole('gridcell', { name: '17' }).classList.contains('Mui-focusVisible'),
+      ).to.equal(true);
+
       userEvent.mousePress(screen.getByRole('gridcell', { name: '2' }));
       expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2018, 0, 2, 12, 30));
+      expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2022, 3, 2, 12, 30));
     });
 
     it('should not use `referenceDate` when a value is defined', () => {

--- a/packages/x-date-pickers/src/DateCalendar/useCalendarState.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/useCalendarState.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import { SlideDirection } from './PickersSlideTransition';
 import { useIsDateDisabled } from './useIsDateDisabled';
-import { useUtils, useNow } from '../internals/hooks/useUtils';
+import { useUtils } from '../internals/hooks/useUtils';
 import { MuiPickersAdapter, PickersTimezone } from '../models';
 import { DateCalendarDefaultizedProps } from './DateCalendar.types';
 import { singleItemValueManager } from '../internals/utils/valueManagers';
@@ -127,7 +127,6 @@ export const useCalendarState = <TDate extends unknown>(params: UseCalendarState
     timezone,
   } = params;
 
-  const now = useNow<TDate>(timezone);
   const utils = useUtils<TDate>();
 
   const reducerFn = React.useRef(
@@ -162,7 +161,7 @@ export const useCalendarState = <TDate extends unknown>(params: UseCalendarState
 
   const [calendarState, dispatch] = React.useReducer(reducerFn, {
     isMonthSwitchingAnimating: false,
-    focusedDay: value || now,
+    focusedDay: referenceDate,
     currentMonth: utils.startOfMonth(referenceDate),
     slideDirection: 'left',
   });

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
@@ -10,6 +10,7 @@ import {
   describeValidation,
   describeValue,
   describePicker,
+  formatFullTimeValue,
 } from 'test/utils/pickers';
 import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
 
@@ -68,9 +69,7 @@ describe('<DesktopTimePicker /> - Describes', () => {
       }
       expectInputValue(
         input,
-        expectedValue
-          ? adapterToUse.format(expectedValue, hasMeridiem ? 'fullTime12h' : 'fullTime24h')
-          : '',
+        expectedValue ? formatFullTimeValue(adapterToUse, expectedValue) : '',
       );
     },
     setNewValue: (value, { isOpened, applySameValue, selectSection }) => {

--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
@@ -283,6 +283,10 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
     ];
   }, [valueOrReferenceDate, timeStep, utils]);
 
+  const focusedOptionIndex = timeOptions.findIndex((option) =>
+    utils.isEqual(option, valueOrReferenceDate),
+  );
+
   return (
     <DigitalClockRoot
       ref={handleRef}
@@ -296,11 +300,13 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
         aria-label={localeText.timePickerToolbarTitle}
         className={classes.list}
       >
-        {timeOptions.map((option) => {
+        {timeOptions.map((option, index) => {
           if (skipDisabled && isTimeDisabled(option)) {
             return null;
           }
           const isSelected = utils.isEqual(option, value);
+          const tabIndex =
+            focusedOptionIndex === index || (focusedOptionIndex === -1 && index === 0) ? 0 : -1;
           return (
             <ClockItem
               key={utils.toISO(option)}
@@ -312,6 +318,7 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
               // aria-readonly is not supported here and does not have any effect
               aria-disabled={readOnly}
               aria-selected={isSelected}
+              tabIndex={tabIndex}
               {...clockItemProps}
             >
               {utils.format(option, ampm ? 'fullTime12h' : 'fullTime24h')}

--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
@@ -205,7 +205,7 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
       return;
     }
     const activeItem = containerRef.current.querySelector<HTMLElement>(
-      '[role="listbox"] [role="option"][tabindex="0"]',
+      '[role="listbox"] [role="option"][tabindex="0"], [role="listbox"] [role="option"][aria-selected="true"]',
     );
 
     if (!activeItem) {

--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
@@ -204,14 +204,17 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
     if (containerRef.current === null) {
       return;
     }
-    const selectedItem = containerRef.current.querySelector<HTMLElement>(
-      '[role="listbox"] [role="option"][aria-selected="true"]',
+    const activeItem = containerRef.current.querySelector<HTMLElement>(
+      '[role="listbox"] [role="option"][tabindex="0"]',
     );
 
-    if (!selectedItem) {
+    if (!activeItem) {
       return;
     }
-    const offsetTop = selectedItem.offsetTop;
+    const offsetTop = activeItem.offsetTop;
+    if (autoFocus || !!focusedView) {
+      activeItem.focus();
+    }
 
     // Subtracting the 4px of extra margin intended for the first visible section item
     containerRef.current.scrollTop = offsetTop - 4;
@@ -295,7 +298,6 @@ export const DigitalClock = React.forwardRef(function DigitalClock<TDate extends
       {...other}
     >
       <DigitalClockList
-        autoFocusItem={autoFocus || !!focusedView}
         role="listbox"
         aria-label={localeText.timePickerToolbarTitle}
         className={classes.list}

--- a/packages/x-date-pickers/src/DigitalClock/tests/DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/DigitalClock.test.tsx
@@ -2,7 +2,13 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
-import { adapterToUse, createPickerRenderer, digitalClockHandler } from 'test/utils/pickers';
+import {
+  adapterToUse,
+  createPickerRenderer,
+  digitalClockHandler,
+  formatFullTimeValue,
+} from 'test/utils/pickers';
+import { screen } from '@mui-internal/test-utils';
 
 describe('<DigitalClock />', () => {
   const { render } = createPickerRenderer();
@@ -10,13 +16,22 @@ describe('<DigitalClock />', () => {
   describe('Reference date', () => {
     it('should use `referenceDate` when no value defined', () => {
       const onChange = spy();
+      const referenceDate = new Date(2018, 0, 1, 12, 30);
 
-      render(
-        <DigitalClock
-          onChange={onChange}
-          referenceDate={adapterToUse.date(new Date(2018, 0, 1, 12, 30))}
-        />,
-      );
+      render(<DigitalClock onChange={onChange} referenceDate={adapterToUse.date(referenceDate)} />);
+
+      // the first item should not be initially focusable when `referenceDate` is defined
+      expect(
+        screen.getByRole('option', {
+          name: formatFullTimeValue(adapterToUse, new Date(2018, 0, 1, 0, 0, 0)),
+        }),
+      ).to.have.attribute('tabindex', '-1');
+      // check that the relevant time based on the `referenceDate` is focusable
+      expect(
+        screen.getByRole('option', {
+          name: formatFullTimeValue(adapterToUse, referenceDate),
+        }),
+      ).to.have.attribute('tabindex', '0');
 
       digitalClockHandler.setViewValue(
         adapterToUse,
@@ -24,6 +39,18 @@ describe('<DigitalClock />', () => {
       );
       expect(onChange.callCount).to.equal(1);
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2018, 0, 1, 15, 30));
+    });
+
+    it('should fallback to making the first entry focusable when `referenceDate` does not map to any option', () => {
+      const referenceDate = new Date(2018, 0, 1, 12, 33);
+
+      render(<DigitalClock referenceDate={adapterToUse.date(referenceDate)} />);
+
+      expect(
+        screen.getByRole('option', {
+          name: formatFullTimeValue(adapterToUse, new Date(2018, 0, 1, 0, 0, 0)),
+        }),
+      ).to.have.attribute('tabindex', '0');
     });
 
     it('should not use `referenceDate` when a value is defined', () => {

--- a/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
@@ -8,6 +8,7 @@ import {
   digitalClockHandler,
   describeValidation,
   describeValue,
+  formatFullTimeValue,
 } from 'test/utils/pickers';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
 
@@ -56,14 +57,11 @@ describe('<DigitalClock /> - Describes', () => {
     emptyValue: null,
     clock,
     assertRenderedValue: (expectedValue: any) => {
-      const hasMeridiem = adapterToUse.is12HourCycleInCurrentLocale();
       const selectedItem = screen.queryByRole('option', { selected: true });
       if (!expectedValue) {
         expect(selectedItem).to.equal(null);
       } else {
-        expect(selectedItem).to.have.text(
-          adapterToUse.format(expectedValue, hasMeridiem ? 'fullTime12h' : 'fullTime24h'),
-        );
+        expect(selectedItem).to.have.text(formatFullTimeValue(adapterToUse, expectedValue));
       }
     },
     setNewValue: (value) => {

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
@@ -17,6 +17,7 @@ import {
   describeValidation,
   describeValue,
   describePicker,
+  formatFullTimeValue,
 } from 'test/utils/pickers';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 
@@ -73,7 +74,7 @@ describe('<MobileTimePicker /> - Describes', () => {
         expectInputPlaceholder(input, hasMeridiem ? 'hh:mm aa' : 'hh:mm');
       }
       const expectedValueStr = expectedValue
-        ? adapterToUse.format(expectedValue, hasMeridiem ? 'fullTime12h' : 'fullTime24h')
+        ? formatFullTimeValue(adapterToUse, expectedValue)
         : '';
 
       expectInputValue(input, expectedValueStr);

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -135,13 +135,11 @@ export const MonthCalendar = React.forwardRef(function MonthCalendar<TDate>(
       return utils.getMonth(value);
     }
 
-    if (disableHighlightToday) {
-      return null;
-    }
-
-    return utils.getMonth(referenceDate);
-  }, [value, utils, disableHighlightToday, referenceDate]);
-  const [focusedMonth, setFocusedMonth] = React.useState(() => selectedMonth || todayMonth);
+    return null;
+  }, [value, utils]);
+  const [focusedMonth, setFocusedMonth] = React.useState(
+    () => selectedMonth || utils.getMonth(referenceDate),
+  );
 
   const [internalHasFocus, setInternalHasFocus] = useControlled({
     name: 'MonthCalendar',

--- a/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/MonthCalendar.test.tsx
@@ -169,5 +169,11 @@ describe('<MonthCalendar />', () => {
       expect(january).not.to.have.attribute('disabled');
       expect(february).to.have.attribute('disabled');
     });
+
+    it('should not mark the `referenceDate` month as selected', () => {
+      render(<MonthCalendar referenceDate={adapterToUse.date(new Date(2018, 1, 2))} />);
+
+      expect(screen.getByRole('radio', { name: 'February', checked: false })).to.not.equal(null);
+    });
   });
 });

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
@@ -8,11 +8,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
-import {
-  MonthCalendar,
-  monthCalendarClasses as classes,
-  pickersMonthClasses,
-} from '@mui/x-date-pickers/MonthCalendar';
+import { MonthCalendar, monthCalendarClasses as classes } from '@mui/x-date-pickers/MonthCalendar';
 
 describe('<MonthCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });
@@ -42,17 +38,19 @@ describe('<MonthCalendar /> - Describes', () => {
     emptyValue: null,
     clock,
     assertRenderedValue: (expectedValue: any) => {
-      const selectedCells = document.querySelectorAll(`.${pickersMonthClasses.selected}`);
+      const activeMonth = screen
+        .queryAllByRole('radio')
+        .find((cell) => cell.getAttribute('tabindex') === '0');
+      expect(activeMonth).not.to.equal(null);
       if (expectedValue == null) {
-        expect(selectedCells).to.have.length(1);
-        expect(selectedCells[0]).to.have.text(
+        expect(activeMonth).to.have.text(
           adapterToUse.format(adapterToUse.date(), 'monthShort').toString(),
         );
       } else {
-        expect(selectedCells).to.have.length(1);
-        expect(selectedCells[0]).to.have.text(
+        expect(activeMonth).to.have.text(
           adapterToUse.format(expectedValue, 'monthShort').toString(),
         );
+        expect(activeMonth).to.have.attribute('aria-checked', 'true');
       }
     },
     setNewValue: (value) => {

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
@@ -304,6 +304,7 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
               isDisabled: (hours) => disabled || isTimeDisabled(hours, 'hours'),
               timeStep: timeSteps.hours,
               resolveAriaLabel: localeText.hoursClockNumberText,
+              valueOrReferenceDate,
             }),
           };
         }
@@ -350,12 +351,14 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
                 value: 'am',
                 label: amLabel,
                 isSelected: () => !!value && meridiemMode === 'am',
+                isFocused: () => !!valueOrReferenceDate && meridiemMode === 'am',
                 ariaLabel: amLabel,
               },
               {
                 value: 'pm',
                 label: pmLabel,
                 isSelected: () => !!value && meridiemMode === 'pm',
+                isFocused: () => !!valueOrReferenceDate && meridiemMode === 'pm',
                 ariaLabel: pmLabel,
               },
             ],

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.types.ts
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.types.ts
@@ -13,6 +13,7 @@ import { TimeViewWithMeridiem } from '../internals/models';
 export interface MultiSectionDigitalClockOption<TValue> {
   isDisabled?: (value: TValue) => boolean;
   isSelected: (value: TValue) => boolean;
+  isFocused: (value: TValue) => boolean;
   label: string;
   value: TValue;
   ariaLabel: string;

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.utils.ts
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.utils.ts
@@ -9,6 +9,7 @@ interface IGetHoursSectionOptions<TDate> {
   isDisabled: (value: number) => boolean;
   timeStep: number;
   resolveAriaLabel: (value: string) => string;
+  valueOrReferenceDate: TDate;
 }
 
 export const getHourSectionOptions = <TDate>({
@@ -19,25 +20,31 @@ export const getHourSectionOptions = <TDate>({
   isDisabled,
   resolveAriaLabel,
   timeStep,
+  valueOrReferenceDate,
 }: IGetHoursSectionOptions<TDate>): MultiSectionDigitalClockOption<number>[] => {
   const currentHours = value ? utils.getHours(value) : null;
 
   const result: MultiSectionDigitalClockOption<number>[] = [];
 
-  const isSelected = (hour: number) => {
-    if (currentHours === null) {
+  const isSelected = (hour: number, overriddenCurrentHours?: number) => {
+    const resolvedCurrentHours = overriddenCurrentHours ?? currentHours;
+    if (resolvedCurrentHours === null) {
       return false;
     }
 
     if (ampm) {
       if (hour === 12) {
-        return currentHours === 12 || currentHours === 0;
+        return resolvedCurrentHours === 12 || resolvedCurrentHours === 0;
       }
 
-      return currentHours === hour || currentHours - 12 === hour;
+      return resolvedCurrentHours === hour || resolvedCurrentHours - 12 === hour;
     }
 
-    return currentHours === hour;
+    return resolvedCurrentHours === hour;
+  };
+
+  const isFocused = (hour: number) => {
+    return isSelected(hour, utils.getHours(valueOrReferenceDate));
   };
 
   const endHour = ampm ? 11 : 23;
@@ -52,6 +59,7 @@ export const getHourSectionOptions = <TDate>({
       label,
       isSelected,
       isDisabled,
+      isFocused,
       ariaLabel,
     });
   }
@@ -83,6 +91,10 @@ export const getTimeSectionOptions = ({
     return hasValue && value === timeValue;
   };
 
+  const isFocused = (timeValue: number) => {
+    return value === timeValue;
+  };
+
   return [
     ...Array.from({ length: Math.ceil(60 / timeStep) }, (_, index) => {
       const timeValue = timeStep * index;
@@ -91,6 +103,7 @@ export const getTimeSectionOptions = ({
         label: resolveLabel(timeValue),
         isDisabled,
         isSelected,
+        isFocused,
         ariaLabel: resolveAriaLabel(timeValue.toString()),
       };
     }),

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -156,7 +156,7 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
         return;
       }
       const activeItem = containerRef.current.querySelector<HTMLElement>(
-        '[role="option"][tabindex="0"]',
+        '[role="option"][tabindex="0"], [role="option"][aria-selected="true"]',
       );
       if (!activeItem || previousActive.current === activeItem) {
         // Handle setting the ref to null if the selected item is ever reset via UI

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -175,6 +175,8 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
       containerRef.current.scrollTop = offsetTop - 4;
     });
 
+    const focusedOptionIndex = items.findIndex((item) => item.isFocused(item.value));
+
     return (
       <MultiSectionDigitalClockSectionRoot
         ref={handleRef}
@@ -184,11 +186,13 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
         role="listbox"
         {...other}
       >
-        {items.map((option) => {
+        {items.map((option, index) => {
           if (skipDisabled && option.isDisabled?.(option.value)) {
             return null;
           }
           const isSelected = option.isSelected(option.value);
+          const tabIndex =
+            focusedOptionIndex === index || (focusedOptionIndex === -1 && index === 0) ? 0 : -1;
           return (
             <DigitalClockSectionItem
               key={option.label}
@@ -201,6 +205,7 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
               aria-disabled={readOnly}
               aria-label={option.ariaLabel}
               aria-selected={isSelected}
+              tabIndex={tabIndex}
               {...slotProps?.digitalClockSectionItem}
             >
               {option.label}

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -122,7 +122,7 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
   ) {
     const containerRef = React.useRef<HTMLUListElement>(null);
     const handleRef = useForkRef(ref, containerRef);
-    const previousSelected = React.useRef<HTMLElement | null>(null);
+    const previousActive = React.useRef<HTMLElement | null>(null);
 
     const props = useThemeProps({
       props: inProps,
@@ -155,21 +155,21 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
       if (containerRef.current === null) {
         return;
       }
-      const selectedItem = containerRef.current.querySelector<HTMLElement>(
-        '[role="option"][aria-selected="true"]',
+      const activeItem = containerRef.current.querySelector<HTMLElement>(
+        '[role="option"][tabindex="0"]',
       );
-      if (!selectedItem || previousSelected.current === selectedItem) {
+      if (!activeItem || previousActive.current === activeItem) {
         // Handle setting the ref to null if the selected item is ever reset via UI
-        if (previousSelected.current !== selectedItem) {
-          previousSelected.current = selectedItem;
+        if (previousActive.current !== activeItem) {
+          previousActive.current = activeItem;
         }
         return;
       }
-      previousSelected.current = selectedItem;
+      previousActive.current = activeItem;
       if (active && autoFocus) {
-        selectedItem.focus();
+        activeItem.focus();
       }
-      const offsetTop = selectedItem.offsetTop;
+      const offsetTop = activeItem.offsetTop;
 
       // Subtracting the 4px of extra margin intended for the first visible section item
       containerRef.current.scrollTop = offsetTop - 4;

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/MultiSectionDigitalClock.test.tsx
@@ -10,6 +10,7 @@ import {
   adapterToUse,
   multiSectionDigitalClockHandler,
 } from 'test/utils/pickers';
+import { screen } from '@mui-internal/test-utils';
 
 describe('<MultiSectionDigitalClock />', () => {
   const { render } = createPickerRenderer();
@@ -17,13 +18,23 @@ describe('<MultiSectionDigitalClock />', () => {
   describe('Reference date', () => {
     it('should use `referenceDate` when no value defined', () => {
       const onChange = spy();
+      const referenceDate = new Date(2018, 0, 1, 13, 30);
 
       render(
         <MultiSectionDigitalClock
           onChange={onChange}
-          referenceDate={adapterToUse.date(new Date(2018, 0, 1, 12, 30))}
+          referenceDate={adapterToUse.date(referenceDate)}
         />,
       );
+
+      // the first section items should not be initially focusable when `referenceDate` is defined
+      expect(screen.getByRole('option', { name: '12 hours' })).to.have.attribute('tabindex', '-1');
+      expect(screen.getByRole('option', { name: '0 minutes' })).to.have.attribute('tabindex', '-1');
+      expect(screen.getByRole('option', { name: 'AM' })).to.have.attribute('tabindex', '-1');
+      // check that the relevant time based on the `referenceDate` is focusable
+      expect(screen.getByRole('option', { name: '1 hours' })).to.have.attribute('tabindex', '0');
+      expect(screen.getByRole('option', { name: '30 minutes' })).to.have.attribute('tabindex', '0');
+      expect(screen.getByRole('option', { name: 'PM' })).to.have.attribute('tabindex', '0');
 
       multiSectionDigitalClockHandler.setViewValue(
         adapterToUse,
@@ -31,6 +42,14 @@ describe('<MultiSectionDigitalClock />', () => {
       );
       expect(onChange.callCount).to.equal(3);
       expect(onChange.lastCall.firstArg).toEqualDateTime(new Date(2018, 0, 1, 15, 30));
+    });
+
+    it('should fallback to making the first entry focusable when `referenceDate` does not map to an option', () => {
+      const referenceDate = new Date(2018, 0, 1, 13, 33);
+
+      render(<MultiSectionDigitalClock referenceDate={adapterToUse.date(referenceDate)} />);
+
+      expect(screen.getByRole('option', { name: '0 minutes' })).to.have.attribute('tabindex', '0');
     });
 
     it('should not use `referenceDate` when a value is defined', () => {

--- a/packages/x-date-pickers/src/TimeField/tests/describes.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/describes.TimeField.test.tsx
@@ -7,6 +7,7 @@ import {
   getTextbox,
   describeValidation,
   describeValue,
+  formatFullTimeValue,
 } from 'test/utils/pickers';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
 
@@ -33,7 +34,7 @@ describe('<TimeField /> - Describes', () => {
         expectInputPlaceholder(input, hasMeridiem ? 'hh:mm aa' : 'hh:mm');
       }
       const expectedValueStr = expectedValue
-        ? adapterToUse.format(expectedValue, hasMeridiem ? 'fullTime12h' : 'fullTime24h')
+        ? formatFullTimeValue(adapterToUse, expectedValue)
         : '';
       expectInputValue(input, expectedValueStr);
     },

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -139,15 +139,12 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
     if (value != null) {
       return utils.getYear(value);
     }
+    return null;
+  }, [value, utils]);
 
-    if (disableHighlightToday) {
-      return null;
-    }
-
-    return utils.getYear(referenceDate);
-  }, [value, utils, disableHighlightToday, referenceDate]);
-
-  const [focusedYear, setFocusedYear] = React.useState(() => selectedYear || todayYear);
+  const [focusedYear, setFocusedYear] = React.useState(
+    () => selectedYear || utils.getYear(referenceDate),
+  );
 
   const [internalHasFocus, setInternalHasFocus] = useControlled({
     name: 'YearCalendar',

--- a/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/YearCalendar.test.tsx
@@ -169,4 +169,10 @@ describe('<YearCalendar />', () => {
     expect(year2019).not.to.have.attribute('disabled');
     expect(year2020).to.have.attribute('disabled');
   });
+
+  it('should not mark the `referenceDate` year as selected', () => {
+    render(<YearCalendar referenceDate={adapterToUse.date(new Date(2018, 1, 2))} />);
+
+    expect(screen.getByRole('radio', { name: '2018', checked: false })).to.not.equal(null);
+  });
 });

--- a/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { userEvent, screen, describeConformance } from '@mui-internal/test-utils';
-import {
-  pickersYearClasses,
-  YearCalendar,
-  yearCalendarClasses as classes,
-} from '@mui/x-date-pickers/YearCalendar';
+import { YearCalendar, yearCalendarClasses as classes } from '@mui/x-date-pickers/YearCalendar';
 import {
   wrapPickerMount,
   createPickerRenderer,
@@ -44,13 +40,15 @@ describe('<YearCalendar /> - Describes', () => {
     emptyValue: null,
     clock,
     assertRenderedValue: (expectedValue: any) => {
-      const selectedCells = document.querySelectorAll(`.${pickersYearClasses.selected}`);
+      const activeYear = screen
+        .queryAllByRole('radio')
+        .find((cell) => cell.getAttribute('tabindex') === '0');
+      expect(activeYear).not.to.equal(null);
       if (expectedValue == null) {
-        expect(selectedCells).to.have.length(1);
-        expect(selectedCells[0]).to.have.text(adapterToUse.getYear(adapterToUse.date()).toString());
+        expect(activeYear).to.have.text(adapterToUse.getYear(adapterToUse.date()).toString());
       } else {
-        expect(selectedCells).to.have.length(1);
-        expect(selectedCells[0]).to.have.text(adapterToUse.getYear(expectedValue).toString());
+        expect(activeYear).to.have.text(adapterToUse.getYear(expectedValue).toString());
+        expect(activeYear).to.have.attribute('aria-checked', 'true');
       }
     },
     setNewValue: (value) => {

--- a/test/utils/pickers/misc.ts
+++ b/test/utils/pickers/misc.ts
@@ -56,3 +56,11 @@ export const getDateOffset = <TDate extends unknown>(
   const cleanUtcHour = utcHour > 12 ? 24 - utcHour : -utcHour;
   return cleanUtcHour * 60;
 };
+
+export const formatFullTimeValue = <TDate extends unknown>(
+  adapter: MuiPickersAdapter<TDate>,
+  value: TDate,
+) => {
+  const hasMeridiem = adapter.is12HourCycleInCurrentLocale();
+  return adapter.format(value, hasMeridiem ? 'fullTime12h' : 'fullTime24h');
+};

--- a/test/utils/pickers/viewHandlers.ts
+++ b/test/utils/pickers/viewHandlers.ts
@@ -1,5 +1,5 @@
 import { fireTouchChangedEvent, userEvent, screen } from '@mui-internal/test-utils';
-import { getClockTouchEvent } from 'test/utils/pickers';
+import { getClockTouchEvent, formatFullTimeValue } from 'test/utils/pickers';
 import { MuiPickersAdapter, TimeView } from '@mui/x-date-pickers/models';
 import { formatMeridiem } from '@mui/x-date-pickers/internals/utils/date-utils';
 
@@ -35,9 +35,7 @@ export const timeClockHandler: ViewHandler<TimeView> = {
 
 export const digitalClockHandler: ViewHandler<TimeView> = {
   setViewValue: (adapter, value) => {
-    const hasMeridiem = adapter.is12HourCycleInCurrentLocale();
-    const formattedLabel = adapter.format(value, hasMeridiem ? 'fullTime12h' : 'fullTime24h');
-    userEvent.mousePress(screen.getByRole('option', { name: formattedLabel }));
+    userEvent.mousePress(screen.getByRole('option', { name: formatFullTimeValue(adapter, value) }));
   },
 };
 


### PR DESCRIPTION
Part of #10747 

Align the behavior of `referenceDate` on the views (`DateCalendar`, `DigitalClock`, and `MultiSectionDigitalClock`).
The behavior on `TimeClock` already makes sense.

- Make the `referenceDate` day focusable (tabindex="0") if no value is present in `DateCalendar` instead of today's day
- Make the `referenceDate` time focusable (tabindex="0") and scroll the options list to it if no value is present and the date maps to an available option in `DigitalClock`
- Make the `referenceDate` time sections focusable (tabindex="0") and scroll the options lists to them if no value is present and the date maps to an available option in `MultiSectionDigitalClock`

~~WDYT about `MonthCalendar` and `YearCalendar`, should we align it to also not mark the `reference` month and day as selected, but only focus it?~~ 🤔 

## Update
I've also updated the behavior of `YearCalendar` and `MonthCalendar`.
P.S. The Argos diff is expected if we go with the proposal, because `YearCalendar` and `MonthCalendar` do not have the `autoFocus` prop set to `true` when used outside of `DateCalendar`.

### Before
<img width="299" alt="Screenshot 2023-11-06 at 17 54 17" src="https://github.com/mui/mui-x/assets/4941090/6c0728d1-456f-4dbd-8ab1-6739c792d8e5">
<img width="348" alt="Screenshot 2023-11-06 at 17 55 10" src="https://github.com/mui/mui-x/assets/4941090/9430cd35-4afd-4fe2-8ebd-077cffb98596">

### After
<img width="349" alt="Screenshot 2023-11-06 at 17 54 47" src="https://github.com/mui/mui-x/assets/4941090/4e2779fd-08b6-4f27-a7bd-ba7a2b4ff482">
<img width="316" alt="Screenshot 2023-11-06 at 17 54 51" src="https://github.com/mui/mui-x/assets/4941090/9e2595c9-76a9-4c89-90ec-a97e1ddcf791">
