### PR TITLE
[core] Generate `slot` API descriptions based on `slots` or `components`

### DIFF
--- a/docs/pages/x/api/charts/area-element.json
+++ b/docs/pages/x/api/charts/area-element.json
@@ -3,7 +3,14 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [
+    {
+      "class": null,
+      "name": "area",
+      "description": "The component that renders the root.",
+      "default": "AreaElementPath"
+    }
+  ],
   "name": "AreaElement",
   "imports": [
     "import { AreaElement } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/area-plot.json
+++ b/docs/pages/x/api/charts/area-plot.json
@@ -3,7 +3,14 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [
+    {
+      "class": null,
+      "name": "area",
+      "description": "The component that renders the root.",
+      "default": "AreaElementPath"
+    }
+  ],
   "name": "AreaPlot",
   "imports": [
     "import { AreaPlot } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -35,7 +35,17 @@
       "default": "null"
     }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "axisContent", "description": "" },
+    { "class": null, "name": "axisLabel", "description": "" },
+    { "class": null, "name": "axisLine", "description": "" },
+    { "class": null, "name": "axisTick", "description": "" },
+    { "class": null, "name": "axisTickLabel", "description": "" },
+    { "class": null, "name": "bar", "description": "" },
+    { "class": null, "name": "itemContent", "description": "" },
+    { "class": null, "name": "legend", "description": "" },
+    { "class": null, "name": "popper", "description": "" }
+  ],
   "name": "BarChart",
   "imports": [
     "import { BarChart } from '@mui/x-charts/BarChart';",

--- a/docs/pages/x/api/charts/bar-plot.json
+++ b/docs/pages/x/api/charts/bar-plot.json
@@ -4,7 +4,14 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [
+    {
+      "class": null,
+      "name": "bar",
+      "description": "The component that renders the root.",
+      "default": "BarElementPath"
+    }
+  ],
   "name": "BarPlot",
   "imports": [
     "import { BarPlot } from '@mui/x-charts/BarChart';",

--- a/docs/pages/x/api/charts/charts-axis.json
+++ b/docs/pages/x/api/charts/charts-axis.json
@@ -31,7 +31,12 @@
       "default": "null"
     }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "axisLabel", "description": "" },
+    { "class": null, "name": "axisLine", "description": "" },
+    { "class": null, "name": "axisTick", "description": "" },
+    { "class": null, "name": "axisTickLabel", "description": "" }
+  ],
   "name": "ChartsAxis",
   "imports": [
     "import { ChartsAxis } from '@mui/x-charts/ChartsAxis';",

--- a/docs/pages/x/api/charts/charts-tooltip.json
+++ b/docs/pages/x/api/charts/charts-tooltip.json
@@ -21,7 +21,11 @@
       "default": "'item'"
     }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "axisContent", "description": "" },
+    { "class": null, "name": "itemContent", "description": "" },
+    { "class": null, "name": "popper", "description": "" }
+  ],
   "name": "ChartsTooltip",
   "imports": [
     "import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';",

--- a/docs/pages/x/api/charts/charts-x-axis.json
+++ b/docs/pages/x/api/charts/charts-x-axis.json
@@ -37,7 +37,12 @@
     "tickNumber": { "type": { "name": "number" } },
     "tickSize": { "type": { "name": "number" }, "default": "6" }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "axisLabel", "description": "" },
+    { "class": null, "name": "axisLine", "description": "" },
+    { "class": null, "name": "axisTick", "description": "" },
+    { "class": null, "name": "axisTickLabel", "description": "" }
+  ],
   "name": "ChartsXAxis",
   "imports": [
     "import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';",

--- a/docs/pages/x/api/charts/charts-y-axis.json
+++ b/docs/pages/x/api/charts/charts-y-axis.json
@@ -37,7 +37,12 @@
     "tickNumber": { "type": { "name": "number" } },
     "tickSize": { "type": { "name": "number" }, "default": "6" }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "axisLabel", "description": "" },
+    { "class": null, "name": "axisLine", "description": "" },
+    { "class": null, "name": "axisTick", "description": "" },
+    { "class": null, "name": "axisTickLabel", "description": "" }
+  ],
   "name": "ChartsYAxis",
   "imports": [
     "import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';",

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -35,7 +35,20 @@
       "default": "null"
     }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "area", "description": "" },
+    { "class": null, "name": "axisContent", "description": "" },
+    { "class": null, "name": "axisLabel", "description": "" },
+    { "class": null, "name": "axisLine", "description": "" },
+    { "class": null, "name": "axisTick", "description": "" },
+    { "class": null, "name": "axisTickLabel", "description": "" },
+    { "class": null, "name": "itemContent", "description": "" },
+    { "class": null, "name": "legend", "description": "" },
+    { "class": null, "name": "line", "description": "" },
+    { "class": null, "name": "lineHighlight", "description": "" },
+    { "class": null, "name": "mark", "description": "" },
+    { "class": null, "name": "popper", "description": "" }
+  ],
   "name": "LineChart",
   "imports": [
     "import { LineChart } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/line-element.json
+++ b/docs/pages/x/api/charts/line-element.json
@@ -3,7 +3,14 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [
+    {
+      "class": null,
+      "name": "line",
+      "description": "The component that renders the root.",
+      "default": "LineElementPath"
+    }
+  ],
   "name": "LineElement",
   "imports": [
     "import { LineElement } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/line-highlight-plot.json
+++ b/docs/pages/x/api/charts/line-highlight-plot.json
@@ -3,7 +3,7 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [{ "class": null, "name": "lineHighlight", "description": "" }],
   "name": "LineHighlightPlot",
   "imports": [
     "import { LineHighlightPlot } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/line-plot.json
+++ b/docs/pages/x/api/charts/line-plot.json
@@ -3,7 +3,14 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [
+    {
+      "class": null,
+      "name": "line",
+      "description": "The component that renders the root.",
+      "default": "LineElementPath"
+    }
+  ],
   "name": "LinePlot",
   "imports": [
     "import { LinePlot } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/mark-plot.json
+++ b/docs/pages/x/api/charts/mark-plot.json
@@ -3,7 +3,7 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [{ "class": null, "name": "mark", "description": "" }],
   "name": "MarkPlot",
   "imports": [
     "import { MarkPlot } from '@mui/x-charts/LineChart';",

--- a/docs/pages/x/api/charts/pie-plot.json
+++ b/docs/pages/x/api/charts/pie-plot.json
@@ -11,7 +11,10 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "pieArc", "description": "" },
+    { "class": null, "name": "pieArcLabel", "description": "" }
+  ],
   "name": "PiePlot",
   "imports": [
     "import { PiePlot } from '@mui/x-charts/PieChart';",

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -34,7 +34,17 @@
       "default": "null"
     }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "axisContent", "description": "" },
+    { "class": null, "name": "axisLabel", "description": "" },
+    { "class": null, "name": "axisLine", "description": "" },
+    { "class": null, "name": "axisTick", "description": "" },
+    { "class": null, "name": "axisTickLabel", "description": "" },
+    { "class": null, "name": "itemContent", "description": "" },
+    { "class": null, "name": "legend", "description": "" },
+    { "class": null, "name": "popper", "description": "" },
+    { "class": null, "name": "scatter", "description": "" }
+  ],
   "name": "ScatterChart",
   "imports": [
     "import { ScatterChart } from '@mui/x-charts/ScatterChart';",

--- a/docs/pages/x/api/charts/scatter-plot.json
+++ b/docs/pages/x/api/charts/scatter-plot.json
@@ -3,7 +3,7 @@
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },
-  "slots": [],
+  "slots": [{ "class": null, "name": "scatter", "description": "" }],
   "name": "ScatterPlot",
   "imports": [
     "import { ScatterPlot } from '@mui/x-charts/ScatterChart';",

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -31,7 +31,16 @@
       }
     }
   },
-  "slots": [],
+  "slots": [
+    { "class": null, "name": "area", "description": "" },
+    { "class": null, "name": "axisContent", "description": "" },
+    { "class": null, "name": "bar", "description": "" },
+    { "class": null, "name": "itemContent", "description": "" },
+    { "class": null, "name": "line", "description": "" },
+    { "class": null, "name": "lineHighlight", "description": "" },
+    { "class": null, "name": "mark", "description": "" },
+    { "class": null, "name": "popper", "description": "" }
+  ],
   "name": "SparkLineChart",
   "imports": [
     "import { SparkLineChart } from '@mui/x-charts/SparkLineChart';",

--- a/docs/pages/x/api/date-pickers/pickers-calendar-header.json
+++ b/docs/pages/x/api/date-pickers/pickers-calendar-header.json
@@ -2,6 +2,18 @@
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "className": { "type": { "name": "string" } },
+    "components": {
+      "type": { "name": "object" },
+      "default": "{}",
+      "deprecated": true,
+      "deprecationInfo": "Please use <code>slots</code>."
+    },
+    "componentsProps": {
+      "type": { "name": "object" },
+      "default": "{}",
+      "deprecated": true,
+      "deprecationInfo": "Please use <code>slotProps</code>."
+    },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/pickers-calendar-header.json
+++ b/docs/pages/x/api/date-pickers/pickers-calendar-header.json
@@ -12,7 +12,44 @@
       "additionalInfo": { "sx": true }
     }
   },
-  "slots": [],
+  "slots": [
+    {
+      "class": null,
+      "name": "leftArrowIcon",
+      "description": "Icon displayed in the left view switch button.",
+      "default": "ArrowLeft"
+    },
+    {
+      "class": null,
+      "name": "nextIconButton",
+      "description": "Button allowing to switch to the right view.",
+      "default": "IconButton"
+    },
+    {
+      "class": null,
+      "name": "previousIconButton",
+      "description": "Button allowing to switch to the left view.",
+      "default": "IconButton"
+    },
+    {
+      "class": null,
+      "name": "rightArrowIcon",
+      "description": "Icon displayed in the right view switch button.",
+      "default": "ArrowRight"
+    },
+    {
+      "class": null,
+      "name": "switchViewButton",
+      "description": "Button displayed to switch between different calendar views.",
+      "default": "IconButton"
+    },
+    {
+      "class": null,
+      "name": "switchViewIcon",
+      "description": "Icon displayed in the SwitchViewButton. Rotated by 180° when the open view is &#39;year&#39;.",
+      "default": "ArrowDropDown"
+    }
+  ],
   "name": "PickersCalendarHeader",
   "imports": [
     "import { PickersCalendarHeader } from '@mui/x-date-pickers/PickersCalendarHeader';",

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -83,10 +83,12 @@ function extractSlots(options: {
     project,
     checkDeclarations: true,
     shouldResolveObject: ({ name }) => {
+      // TODO v7: Remove the `components` fallback once `slots` is used everywhere
       return name === 'slots' || name === 'components';
     },
     shouldInclude: ({ name, depth }) => {
       // The keys allowed in the `components` prop have depth=2
+      // TODO v7: Remove the `components` fallback once `slots` is used everywhere
       return name === 'slots' || name === 'components' || depth === 2;
     },
   });
@@ -97,6 +99,7 @@ function extractSlots(options: {
   }
 
   const componentsProps = props.types.find(
+    // TODO v7: Remove the `components` fallback once `slots` is used everywhere
     (type) => type.name === 'slots' || type.name === 'components',
   )!;
   if (!componentsProps) {
@@ -483,6 +486,7 @@ const buildComponentDocumentation = async (options: {
   /**
    * Slot descriptions.
    */
+  // TODO v7: Remove the `components` fallback once `slots` is used everywhere
   if (componentApi.propDescriptions.slots || componentApi.propDescriptions.components) {
     const slots = extractSlots({
       filename,

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -83,11 +83,11 @@ function extractSlots(options: {
     project,
     checkDeclarations: true,
     shouldResolveObject: ({ name }) => {
-      return name === 'components';
+      return name === 'slots' || name === 'components';
     },
     shouldInclude: ({ name, depth }) => {
       // The keys allowed in the `components` prop have depth=2
-      return name === 'components' || depth === 2;
+      return name === 'slots' || name === 'components' || depth === 2;
     },
   });
 
@@ -96,7 +96,9 @@ function extractSlots(options: {
     throw new Error(`No proptypes found for \`${displayName}\``);
   }
 
-  const componentsProps = props.types.find((type) => type.name === 'components')!;
+  const componentsProps = props.types.find(
+    (type) => type.name === 'slots' || type.name === 'components',
+  )!;
   if (!componentsProps) {
     return slots;
   }
@@ -481,7 +483,7 @@ const buildComponentDocumentation = async (options: {
   /**
    * Slot descriptions.
    */
-  if (componentApi.propDescriptions.components) {
+  if (componentApi.propDescriptions.slots || componentApi.propDescriptions.components) {
     const slots = extractSlots({
       filename,
       name: reactApi.name, // e.g. DataGrid

--- a/docs/translations/api-docs/charts/area-element.json
+++ b/docs/translations/api-docs/charts/area-element.json
@@ -25,5 +25,5 @@
       "conditions": "faded"
     }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": { "area": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/charts/area-plot.json
+++ b/docs/translations/api-docs/charts/area-plot.json
@@ -13,5 +13,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "area": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/charts/bar-chart.json
+++ b/docs/translations/api-docs/charts/bar-chart.json
@@ -43,5 +43,15 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": {
+    "axisContent": "",
+    "axisLabel": "",
+    "axisLine": "",
+    "axisTick": "",
+    "axisTickLabel": "",
+    "bar": "",
+    "itemContent": "",
+    "legend": "",
+    "popper": ""
+  }
 }

--- a/docs/translations/api-docs/charts/bar-plot.json
+++ b/docs/translations/api-docs/charts/bar-plot.json
@@ -18,5 +18,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "bar": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/charts/charts-axis.json
+++ b/docs/translations/api-docs/charts/charts-axis.json
@@ -55,5 +55,5 @@
     "left": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the left axis" },
     "right": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the right axis" }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": { "axisLabel": "", "axisLine": "", "axisTick": "", "axisTickLabel": "" }
 }

--- a/docs/translations/api-docs/charts/charts-tooltip.json
+++ b/docs/translations/api-docs/charts/charts-tooltip.json
@@ -47,5 +47,5 @@
       "nodeName": "the valueCell element"
     }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": { "axisContent": "", "itemContent": "", "popper": "" }
 }

--- a/docs/translations/api-docs/charts/charts-x-axis.json
+++ b/docs/translations/api-docs/charts/charts-x-axis.json
@@ -121,5 +121,5 @@
     "left": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the left axis" },
     "right": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the right axis" }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": { "axisLabel": "", "axisLine": "", "axisTick": "", "axisTickLabel": "" }
 }

--- a/docs/translations/api-docs/charts/charts-y-axis.json
+++ b/docs/translations/api-docs/charts/charts-y-axis.json
@@ -121,5 +121,5 @@
     "left": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the left axis" },
     "right": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the right axis" }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": { "axisLabel": "", "axisLine": "", "axisTick": "", "axisTickLabel": "" }
 }

--- a/docs/translations/api-docs/charts/line-chart.json
+++ b/docs/translations/api-docs/charts/line-chart.json
@@ -43,5 +43,18 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": {
+    "area": "",
+    "axisContent": "",
+    "axisLabel": "",
+    "axisLine": "",
+    "axisTick": "",
+    "axisTickLabel": "",
+    "itemContent": "",
+    "legend": "",
+    "line": "",
+    "lineHighlight": "",
+    "mark": "",
+    "popper": ""
+  }
 }

--- a/docs/translations/api-docs/charts/line-element.json
+++ b/docs/translations/api-docs/charts/line-element.json
@@ -25,5 +25,5 @@
       "conditions": "faded"
     }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": { "line": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/charts/line-highlight-plot.json
+++ b/docs/translations/api-docs/charts/line-highlight-plot.json
@@ -13,5 +13,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "lineHighlight": "" }
 }

--- a/docs/translations/api-docs/charts/line-plot.json
+++ b/docs/translations/api-docs/charts/line-plot.json
@@ -13,5 +13,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "line": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/charts/mark-plot.json
+++ b/docs/translations/api-docs/charts/mark-plot.json
@@ -13,5 +13,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "mark": "" }
 }

--- a/docs/translations/api-docs/charts/pie-plot.json
+++ b/docs/translations/api-docs/charts/pie-plot.json
@@ -27,5 +27,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "pieArc": "", "pieArcLabel": "" }
 }

--- a/docs/translations/api-docs/charts/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart.json
@@ -38,5 +38,15 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": {
+    "axisContent": "",
+    "axisLabel": "",
+    "axisLine": "",
+    "axisTick": "",
+    "axisTickLabel": "",
+    "itemContent": "",
+    "legend": "",
+    "popper": "",
+    "scatter": ""
+  }
 }

--- a/docs/translations/api-docs/charts/scatter-plot.json
+++ b/docs/translations/api-docs/charts/scatter-plot.json
@@ -13,5 +13,5 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": { "scatter": "" }
 }

--- a/docs/translations/api-docs/charts/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart.json
@@ -45,5 +45,14 @@
     }
   },
   "classDescriptions": {},
-  "slotDescriptions": {}
+  "slotDescriptions": {
+    "area": "",
+    "axisContent": "",
+    "bar": "",
+    "itemContent": "",
+    "line": "",
+    "lineHighlight": "",
+    "mark": "",
+    "popper": ""
+  }
 }

--- a/docs/translations/api-docs/date-pickers/pickers-calendar-header.json
+++ b/docs/translations/api-docs/date-pickers/pickers-calendar-header.json
@@ -11,6 +11,16 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "components": {
+      "description": "Overridable components.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "componentsProps": {
+      "description": "The props used for each component slot.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "slotProps": {
       "description": "The props used for each component slot.",
       "deprecated": "",

--- a/docs/translations/api-docs/date-pickers/pickers-calendar-header.json
+++ b/docs/translations/api-docs/date-pickers/pickers-calendar-header.json
@@ -43,5 +43,12 @@
       "nodeName": "the switch view icon element"
     }
   },
-  "slotDescriptions": {}
+  "slotDescriptions": {
+    "leftArrowIcon": "Icon displayed in the left view switch button.",
+    "nextIconButton": "Button allowing to switch to the right view.",
+    "previousIconButton": "Button allowing to switch to the left view.",
+    "rightArrowIcon": "Icon displayed in the right view switch button.",
+    "switchViewButton": "Button displayed to switch between different calendar views.",
+    "switchViewIcon": "Icon displayed in the SwitchViewButton. Rotated by 180° when the open view is &#39;year&#39;."
+  }
 }

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -276,6 +276,18 @@ PickersCalendarHeader.propTypes = {
    * className applied to the root element.
    */
   className: PropTypes.string,
+  /**
+   * Overridable components.
+   * @default {}
+   * @deprecated Please use `slots`.
+   */
+  components: PropTypes.object,
+  /**
+   * The props used for each component slot.
+   * @default {}
+   * @deprecated Please use `slotProps`.
+   */
+  componentsProps: PropTypes.object,
   currentMonth: PropTypes.any.isRequired,
   disabled: PropTypes.bool,
   disableFuture: PropTypes.bool,

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -2,106 +2,26 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Fade from '@mui/material/Fade';
-import { styled, SxProps, Theme, useThemeProps } from '@mui/material/styles';
-import { SlotComponentProps, useSlotProps } from '@mui/base/utils';
+import { styled, useThemeProps } from '@mui/material/styles';
+import { useSlotProps } from '@mui/base/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/utils';
 import IconButton from '@mui/material/IconButton';
-import SvgIcon from '@mui/material/SvgIcon';
-import { SlideDirection } from '../DateCalendar/PickersSlideTransition';
 import { useLocaleText, useUtils } from '../internals/hooks/useUtils';
 import { PickersFadeTransitionGroup } from '../DateCalendar/PickersFadeTransitionGroup';
 import { ArrowDropDownIcon } from '../icons';
-import {
-  PickersArrowSwitcher,
-  ExportedPickersArrowSwitcherProps,
-  PickersArrowSwitcherSlotsComponent,
-  PickersArrowSwitcherSlotsComponentsProps,
-} from '../internals/components/PickersArrowSwitcher';
+import { PickersArrowSwitcher } from '../internals/components/PickersArrowSwitcher';
 import {
   usePreviousMonthDisabled,
   useNextMonthDisabled,
-  MonthValidationOptions,
 } from '../internals/hooks/date-helpers-hooks';
-import { DateView } from '../models';
 import {
   getPickersCalendarHeaderUtilityClass,
   pickersCalendarHeaderClasses,
-  PickersCalendarHeaderClasses,
 } from './pickersCalendarHeaderClasses';
-import { UncapitalizeObjectKeys } from '../internals/utils/slots-migration';
-
-export type ExportedPickersCalendarHeaderProps<TDate> = Pick<
-  PickersCalendarHeaderProps<TDate>,
-  'classes' | 'slots' | 'slotProps'
->;
-
-export interface PickersCalendarHeaderSlotsComponent extends PickersArrowSwitcherSlotsComponent {
-  /**
-   * Button displayed to switch between different calendar views.
-   * @default IconButton
-   */
-  SwitchViewButton?: React.ElementType;
-  /**
-   * Icon displayed in the SwitchViewButton. Rotated by 180° when the open view is 'year'.
-   * @default ArrowDropDown
-   */
-  SwitchViewIcon?: React.ElementType;
-}
-
-// We keep the interface to allow module augmentation
-export interface PickersCalendarHeaderComponentsPropsOverrides {}
-
-type PickersCalendarHeaderOwnerState<TDate> = PickersCalendarHeaderProps<TDate>;
-
-export interface PickersCalendarHeaderSlotsComponentsProps<TDate>
-  extends PickersArrowSwitcherSlotsComponentsProps {
-  switchViewButton?: SlotComponentProps<
-    typeof IconButton,
-    PickersCalendarHeaderComponentsPropsOverrides,
-    PickersCalendarHeaderOwnerState<TDate>
-  >;
-
-  switchViewIcon?: SlotComponentProps<
-    typeof SvgIcon,
-    PickersCalendarHeaderComponentsPropsOverrides,
-    undefined
-  >;
-}
-
-export interface PickersCalendarHeaderProps<TDate>
-  extends ExportedPickersArrowSwitcherProps,
-    MonthValidationOptions<TDate> {
-  /**
-   * Overridable component slots.
-   * @default {}
-   */
-  slots?: UncapitalizeObjectKeys<PickersCalendarHeaderSlotsComponent>;
-  /**
-   * The props used for each component slot.
-   * @default {}
-   */
-  slotProps?: PickersCalendarHeaderSlotsComponentsProps<TDate>;
-  currentMonth: TDate;
-  disabled?: boolean;
-  views: readonly DateView[];
-  onMonthChange: (date: TDate, slideDirection: SlideDirection) => void;
-  view: DateView;
-  reduceAnimations: boolean;
-  onViewChange?: (view: DateView) => void;
-  labelId?: string;
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<PickersCalendarHeaderClasses>;
-  /**
-   * className applied to the root element.
-   */
-  className?: string;
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx?: SxProps<Theme>;
-}
+import {
+  PickersCalendarHeaderOwnerState,
+  PickersCalendarHeaderProps,
+} from './PickersCalendarHeader.types';
 
 const useUtilityClasses = (ownerState: PickersCalendarHeaderOwnerState<any>) => {
   const { classes } = ownerState;
@@ -212,6 +132,8 @@ const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TD
   const {
     slots,
     slotProps,
+    components,
+    componentsProps,
     currentMonth: month,
     disabled,
     disableFuture,
@@ -233,7 +155,10 @@ const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TD
 
   const classes = useUtilityClasses(props);
 
-  const SwitchViewButton = slots?.switchViewButton ?? PickersCalendarHeaderSwitchViewButton;
+  const SwitchViewButton =
+    slots?.switchViewButton ??
+    components?.SwitchViewButton ??
+    PickersCalendarHeaderSwitchViewButton;
   const switchViewButtonProps = useSlotProps({
     elementType: SwitchViewButton,
     externalSlotProps: slotProps?.switchViewButton,
@@ -245,7 +170,8 @@ const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TD
     className: classes.switchViewButton,
   });
 
-  const SwitchViewIcon = slots?.switchViewIcon ?? PickersCalendarHeaderSwitchViewIcon;
+  const SwitchViewIcon =
+    slots?.switchViewIcon ?? components?.SwitchViewIcon ?? PickersCalendarHeaderSwitchViewIcon;
   // The spread is here to avoid this bug mui/material-ui#34056
   const { ownerState: switchViewIconOwnerState, ...switchViewIconProps } = useSlotProps({
     elementType: SwitchViewIcon,

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.types.ts
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.types.ts
@@ -1,0 +1,99 @@
+import { SlotComponentProps } from '@mui/base/utils';
+import IconButton from '@mui/material/IconButton';
+import SvgIcon from '@mui/material/SvgIcon';
+import { SxProps, Theme } from '@mui/material/styles';
+import {
+  ExportedPickersArrowSwitcherProps,
+  PickersArrowSwitcherSlotsComponent,
+  PickersArrowSwitcherSlotsComponentsProps,
+} from '../internals/components/PickersArrowSwitcher';
+import { MonthValidationOptions } from '../internals/hooks/date-helpers-hooks';
+import { UncapitalizeObjectKeys } from '../internals/utils/slots-migration';
+import { DateView } from '../models/views';
+import { SlideDirection } from '../DateCalendar/PickersSlideTransition';
+import { PickersCalendarHeaderClasses } from './pickersCalendarHeaderClasses';
+
+export interface PickersCalendarHeaderSlotsComponent extends PickersArrowSwitcherSlotsComponent {
+  /**
+   * Button displayed to switch between different calendar views.
+   * @default IconButton
+   */
+  SwitchViewButton?: React.ElementType;
+  /**
+   * Icon displayed in the SwitchViewButton. Rotated by 180° when the open view is 'year'.
+   * @default ArrowDropDown
+   */
+  SwitchViewIcon?: React.ElementType;
+}
+
+// We keep the interface to allow module augmentation
+export interface PickersCalendarHeaderComponentsPropsOverrides {}
+
+export type PickersCalendarHeaderOwnerState<TDate> = PickersCalendarHeaderProps<TDate>;
+
+export interface PickersCalendarHeaderSlotsComponentsProps<TDate>
+  extends PickersArrowSwitcherSlotsComponentsProps {
+  switchViewButton?: SlotComponentProps<
+    typeof IconButton,
+    PickersCalendarHeaderComponentsPropsOverrides,
+    PickersCalendarHeaderOwnerState<TDate>
+  >;
+
+  switchViewIcon?: SlotComponentProps<
+    typeof SvgIcon,
+    PickersCalendarHeaderComponentsPropsOverrides,
+    undefined
+  >;
+}
+
+export interface PickersCalendarHeaderProps<TDate>
+  extends ExportedPickersArrowSwitcherProps,
+    MonthValidationOptions<TDate> {
+  /**
+   * Overridable components.
+   * @default {}
+   * @deprecated Please use `slots`.
+   */
+  components?: PickersCalendarHeaderSlotsComponent;
+  /**
+   * The props used for each component slot.
+   * @default {}
+   * @deprecated Please use `slotProps`.
+   */
+  componentsProps?: PickersCalendarHeaderSlotsComponentsProps<TDate>;
+  /**
+   * Overridable component slots.
+   * @default {}
+   */
+  slots?: UncapitalizeObjectKeys<PickersCalendarHeaderSlotsComponent>;
+  /**
+   * The props used for each component slot.
+   * @default {}
+   */
+  slotProps?: PickersCalendarHeaderSlotsComponentsProps<TDate>;
+  currentMonth: TDate;
+  disabled?: boolean;
+  views: readonly DateView[];
+  onMonthChange: (date: TDate, slideDirection: SlideDirection) => void;
+  view: DateView;
+  reduceAnimations: boolean;
+  onViewChange?: (view: DateView) => void;
+  labelId?: string;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<PickersCalendarHeaderClasses>;
+  /**
+   * className applied to the root element.
+   */
+  className?: string;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+}
+
+export type ExportedPickersCalendarHeaderProps<TDate> = Pick<
+  PickersCalendarHeaderProps<TDate>,
+  'classes' | 'slots' | 'slotProps'
+>;

--- a/packages/x-date-pickers/src/PickersCalendarHeader/index.ts
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/index.ts
@@ -9,4 +9,4 @@ export type {
   PickersCalendarHeaderSlotsComponent,
   PickersCalendarHeaderSlotsComponentsProps,
   ExportedPickersCalendarHeaderProps,
-} from './PickersCalendarHeader';
+} from './PickersCalendarHeader.types';


### PR DESCRIPTION
I've noticed that all of the charts API pages lack a `slots` section.

The existing `docs:api` pipeline was generating slots documentation only for components that have the `components` prop.
I've updated the generation to look for `slots` or `components` to avoid this discrepancy.

Making this change revealed that `PickersCalendarHeader` had no described `slots`. I've added the `components` prop to this component to correctly generate the `slots` descriptions.

This is also relevant for https://github.com/mui/mui-x/pull/10700, where currently the `slots` descriptions are nuked. 💥 

## Note for charts
This change reveals that most of the `x-charts` slots lack a description. 🙈 