### PR TITLE
[data grid] Fix keyboard navigation for actions cell with disabled buttons

### DIFF
--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -97,11 +97,13 @@ function GridActionsCell(props: GridActionsCellProps) {
       focus() {
         // If ignoreCallToFocus is true, then one of the buttons was clicked and the focus is already set
         if (!ignoreCallToFocus.current) {
-          setFocusedButtonIndex(0);
+          // find the first focusable button and pass the index to the state
+          const focusableButtonIndex = options.findIndex((o) => !o.props.disabled);
+          setFocusedButtonIndex(focusableButtonIndex);
         }
       },
     }),
-    [],
+    [options],
   );
 
   React.useEffect(() => {

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -143,19 +143,24 @@ function GridActionsCell(props: GridActionsCellProps) {
       return;
     }
 
+    const getNewIndex = (index: number, direction: 'left' | 'right'): number => {
+      if (index < 0 || index > options.length) {
+        return index;
+      }
+      if (direction === 'left') {
+        return options[index - 1]?.props.disabled ? getNewIndex(index - 1, 'left') : index - 1;
+      }
+      if (direction === 'right') {
+        return options[index + 1]?.props.disabled ? getNewIndex(index + 1, 'right') : index + 1;
+      }
+      return index;
+    };
+
     let newIndex: number = focusedButtonIndex;
     if (event.key === 'ArrowRight') {
-      if (theme.direction === 'rtl') {
-        newIndex -= 1;
-      } else {
-        newIndex += 1;
-      }
+      newIndex = getNewIndex(focusedButtonIndex, theme.direction === 'rtl' ? 'left' : 'right');
     } else if (event.key === 'ArrowLeft') {
-      if (theme.direction === 'rtl') {
-        newIndex += 1;
-      } else {
-        newIndex -= 1;
-      }
+      newIndex = getNewIndex(focusedButtonIndex, theme.direction === 'rtl' ? 'right' : 'left');
     }
 
     if (newIndex < 0 || newIndex >= numberOfButtons) {

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -147,13 +147,10 @@ function GridActionsCell(props: GridActionsCellProps) {
       if (index < 0 || index > options.length) {
         return index;
       }
-      if (direction === 'left') {
-        return options[index - 1]?.props.disabled ? getNewIndex(index - 1, 'left') : index - 1;
-      }
-      if (direction === 'right') {
-        return options[index + 1]?.props.disabled ? getNewIndex(index + 1, 'right') : index + 1;
-      }
-      return index;
+      const indexMod = direction === 'left' ? -1 : 1;
+      return options[index + indexMod]?.props.disabled
+        ? getNewIndex(index + indexMod, direction)
+        : index + indexMod;
     };
 
     let newIndex: number = focusedButtonIndex;

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -147,7 +147,12 @@ function GridActionsCell(props: GridActionsCellProps) {
       if (index < 0 || index > options.length) {
         return index;
       }
-      const indexMod = direction === 'left' ? -1 : 1;
+
+      // for rtl mode we need to reverse the direction
+      const rtlMod = theme.direction === 'rtl' ? -1 : 1;
+      const indexMod = (direction === 'left' ? -1 : 1) * rtlMod;
+
+      // if the button that should receive focus is disabled go one more step
       return options[index + indexMod]?.props.disabled
         ? getNewIndex(index + indexMod, direction)
         : index + indexMod;
@@ -155,9 +160,9 @@ function GridActionsCell(props: GridActionsCellProps) {
 
     let newIndex: number = focusedButtonIndex;
     if (event.key === 'ArrowRight') {
-      newIndex = getNewIndex(focusedButtonIndex, theme.direction === 'rtl' ? 'left' : 'right');
+      newIndex = getNewIndex(focusedButtonIndex, 'right');
     } else if (event.key === 'ArrowLeft') {
-      newIndex = getNewIndex(focusedButtonIndex, theme.direction === 'rtl' ? 'right' : 'left');
+      newIndex = getNewIndex(focusedButtonIndex, 'left');
     }
 
     if (newIndex < 0 || newIndex >= numberOfButtons) {

--- a/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridCell.tsx
@@ -18,6 +18,7 @@ import {
   GridRowId,
   GridCellMode,
   GridEditCellProps,
+  GridActionsColDef,
 } from '../../models';
 import {
   GridRenderEditCellParams,
@@ -585,9 +586,13 @@ const GridCellV7 = React.forwardRef<HTMLDivElement, GridCellV7Props>((props, ref
 
   const { cellMode, hasFocus, isEditable, value, formattedValue } = cellParamsWithAPI;
 
-  const managesOwnFocus = column.type === 'actions';
+  const canManageOwnFocus =
+    column.type === 'actions' &&
+    (column as GridActionsColDef)
+      .getActions?.(apiRef.current.getRowParams(rowId))
+      .some((action) => !action.props.disabled);
   const tabIndex =
-    (cellMode === 'view' || !isEditable) && !managesOwnFocus ? cellParamsWithAPI.tabIndex : -1;
+    (cellMode === 'view' || !isEditable) && !canManageOwnFocus ? cellParamsWithAPI.tabIndex : -1;
 
   const { classes: rootClasses, getCellClassName } = rootProps;
 
@@ -772,7 +777,7 @@ const GridCellV7 = React.forwardRef<HTMLDivElement, GridCellV7Props>((props, ref
     );
   }
 
-  if (React.isValidElement(children) && managesOwnFocus) {
+  if (React.isValidElement(children) && canManageOwnFocus) {
     children = React.cloneElement<any>(children, { focusElementRef });
   }
 

--- a/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -10,8 +10,9 @@ import {
   getColumnValues,
   getRow,
 } from 'test/utils/helperFn';
-import { DataGrid, DataGridProps, GridColDef } from '@mui/x-data-grid';
+import { DataGrid, DataGridProps, GridActionsCellItem, GridColDef } from '@mui/x-data-grid';
 import { useBasicDemoData, getBasicGridData } from '@mui/x-data-grid-generator';
+import RestoreIcon from '@mui/icons-material/Restore';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -714,6 +715,116 @@ describe('<DataGrid /> - Keyboard', () => {
 
     fireEvent.keyDown(firstCell, { key: 'ArrowDown' });
     expect(virtualScroller.scrollLeft).to.equal(0);
+  });
+
+  it('should focus actions cell with one disabled item', () => {
+    const columns = [
+      {
+        field: 'actions',
+        type: 'actions',
+        getActions: () => [
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_1'} disabled />,
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_2'} />,
+        ],
+      },
+      { field: 'id', width: 400 },
+      { field: 'name' },
+    ];
+    const rows = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Doe' },
+    ];
+
+    render(
+      <div style={{ width: 300, height: 300 }}>
+        <DataGrid rows={rows} columns={columns} />
+      </div>,
+    );
+
+    const cell = getCell(0, 1);
+    userEvent.mousePress(cell);
+
+    fireEvent.keyDown(cell, { key: 'ArrowLeft' });
+    expect(getActiveCell()).to.equal(`0-0`);
+
+    // expect the only focusable button to be the active element
+    expect(document.activeElement?.id).to.equal('action_2');
+  });
+
+  it('should focus actions cell with all items disabled', () => {
+    const columns = [
+      {
+        field: 'actions',
+        type: 'actions',
+        getActions: () => [
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_1'} disabled />,
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_2'} disabled />,
+        ],
+      },
+      { field: 'id', width: 400 },
+      { field: 'name' },
+    ];
+    const rows = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Doe' },
+    ];
+
+    render(
+      <div style={{ width: 300, height: 300 }}>
+        <DataGrid rows={rows} columns={columns} />
+      </div>,
+    );
+
+    const cell = getCell(0, 1);
+    userEvent.mousePress(cell);
+
+    fireEvent.keyDown(cell, { key: 'ArrowLeft' });
+    expect(getActiveCell()).to.equal(`0-0`);
+
+    // expect the cell to be active, not a button inside
+    expect(document.activeElement?.role).to.equal('cell');
+  });
+
+  it('should be able to navigate the actions', () => {
+    const columns = [
+      {
+        field: 'actions',
+        type: 'actions',
+        getActions: () => [
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_1'} disabled />,
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_2'} />,
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_3'} disabled />,
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_4'} disabled />,
+          <GridActionsCellItem label="Test" icon={<RestoreIcon />} id={'action_5'} />,
+        ],
+      },
+      { field: 'id', width: 400 },
+      { field: 'name' },
+    ];
+    const rows = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Doe' },
+    ];
+
+    render(
+      <div style={{ width: 300, height: 300 }}>
+        <DataGrid rows={rows} columns={columns} />
+      </div>,
+    );
+
+    const cell = getCell(0, 1);
+    userEvent.mousePress(cell);
+
+    fireEvent.keyDown(cell, { key: 'ArrowLeft' });
+    expect(getActiveCell()).to.equal(`0-0`);
+
+    // expect the only focusable button to be the active element
+    expect(document.activeElement?.id).to.equal('action_2');
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
+
+    // expect the only focusable button to be the active element
+    expect(document.activeElement?.id).to.equal('action_5');
   });
 
   it('should not throw when moving into an empty grid', async () => {

--- a/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -780,9 +780,6 @@ describe('<DataGrid /> - Keyboard', () => {
 
     fireEvent.keyDown(cell, { key: 'ArrowLeft' });
     expect(getActiveCell()).to.equal(`0-0`);
-
-    // expect the cell to be active, not a button inside
-    expect(document.activeElement?.role).to.equal('cell');
   });
 
   it('should be able to navigate the actions', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

This fixes the keyboard navigation for the actions cell when the first (or all) button is disabled.
It does also introduce a new check for the `managesOwnFocus` and renames it to `canManageOwnFocus`


https://github.com/mui/mui-x/assets/32863416/0eab6c81-5dfd-43e6-b367-225df359352a



Fixes #10696 