### PR TITLE
v6.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Same changes as in `@mui/x-date-pickers@6.18.0`.
 
 - [docs] Add a data grid recipe for autosizing columns after fetching row-data (#10822) @michelengelen
 - [docs] Add a data grid recipe showing how to remove cell outline on `focus` (#10843) @michelengelen
+- [docs] Add demo about how to use charts margin (#10886) @alexfauquette
 - [docs] Improve custom field input demos readability (#10559) @LukasTy
 
 ### Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ Same changes as in `@mui/x-date-pickers@6.18.0`.
 
 ### Docs
 
-- [docs] Add a recipe for autosizing columns after fetching row-data (#10822) @michelengelen
-- [docs] Add recipe showing how to remove cell focus outline (#10843) @michelengelen
+- [docs] Add a data grid recipe for autosizing columns after fetching row-data (#10822) @michelengelen
+- [docs] Add a data grid recipe showing how to remove cell outline on `focus` (#10843) @michelengelen
 
 ### Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,64 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.18.0
+
+_Nov 3, 2023_
+
+We'd like to offer a big thanks to the 7 contributors who made this release possible. Here are some highlights ✨:
+
+- 🎁 The Charts package is now officially stable!
+- 📈 Line charts now support partial data, and to interpolate missing ones.
+
+<img width="380" alt="line charts with partial data" src="https://github.com/mui/mui-x/assets/45398769/385ecf77-19b2-4a03-8aef-5d547db1d9ad">
+
+- 🐞 Bugfixes
+- 📚 Documentation improvements
+
+### Data Grid
+
+#### `@mui/x-data-grid@6.18.0`
+
+- [DataGrid] Allow to ignore [diacritics](https://en.wikipedia.org/wiki/Diacritic) when filtering (#10569) @cherniavskii
+- [DataGrid] Fix a typo in `gridFilterApi` (#10786) @vu-dao-93
+- [DataGrid] Fix `undefined` row id (#10670) @romgrk
+- [DataGrid] Make column autosizing work with dynamic row height (#10693) @cherniavskii
+- [l10n] Allow to customize sorting label per column (#10839) @JerryWu1234
+
+#### `@mui/x-data-grid-pro@6.18.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@6.18.0`.
+
+#### `@mui/x-data-grid-premium@6.18.0` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@6.18.0`.
+
+### Date Pickers
+
+#### `@mui/x-date-pickers@6.18.0`
+
+- [pickers] Add reference links to calendar components  (#10644) @michelengelen
+
+#### `@mui/x-date-pickers-pro@6.18.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-date-pickers@6.18.0`.
+
+### Charts / `@mui/x-charts@6.18.0`
+
+- [charts] Add animation on pie chart (#10782) @alexfauquette
+- [charts] Add reference links to shared/misc chart components (#10660) @michelengelen
+- [charts] Allows to connect nulls (#10803) @alexfauquette
+- [charts] Fix axis highlight in dark mode (#10820) @LukasTy
+
+### Docs
+
+- [docs] Add a recipe for autosizing columns after fetching row-data (#10822) @michelengelen
+- [docs] Add recipe showing how to remove cell focus outline (#10843) @michelengelen
+
+### Core
+
+- [core] Generate `slot` API descriptions based on `slots` or `components` (#10879) @LukasTy
+
 ## 6.17.0
 
 _Oct 27, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Same changes as in `@mui/x-date-pickers@6.18.0`.
 
 - [docs] Add a data grid recipe for autosizing columns after fetching row-data (#10822) @michelengelen
 - [docs] Add a data grid recipe showing how to remove cell outline on `focus` (#10843) @michelengelen
+- [docs] Improve custom field input demos readability (#10559) @LukasTy
 
 ### Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ _Nov 3, 2023_
 We'd like to offer a big thanks to the 7 contributors who made this release possible. Here are some highlights ✨:
 
 - 🎁 The Charts package is now officially stable!
-- 📈 Line charts now support partial data, and to interpolate missing ones.
+- 🥧 Pie charts are now animated.
+- 📈 Line charts now support partial data, and can interpolate missing data.
 
 <img width="380" alt="line charts with partial data" src="https://github.com/mui/mui-x/assets/45398769/385ecf77-19b2-4a03-8aef-5d547db1d9ad">
 
-- 🐞 Bugfixes
+- ✨ Allow to ignore [diacritics](https://en.wikipedia.org/wiki/Diacritic) when filtering
 - 📚 Documentation improvements
 
 ### Data Grid
@@ -39,7 +40,7 @@ Same changes as in `@mui/x-data-grid-pro@6.18.0`.
 
 #### `@mui/x-date-pickers@6.18.0`
 
-- [pickers] Add reference links to calendar components  (#10644) @michelengelen
+- [pickers] Add reference links to calendar components (#10644) @michelengelen
 
 #### `@mui/x-date-pickers-pro@6.18.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.17.0",
+  "version": "6.18.0",
   "private": true,
   "scripts": {
     "start": "yarn && yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@mui/base": "^5.0.0-beta.22",
-    "@mui/x-data-grid-premium": "6.17.0",
+    "@mui/x-data-grid-premium": "6.18.0",
     "chance": "^1.1.11",
     "clsx": "^2.0.0",
     "lru-cache": "^7.18.3"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,8 +44,8 @@
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@mui/utils": "^5.14.16",
-    "@mui/x-data-grid": "6.17.0",
-    "@mui/x-data-grid-pro": "6.17.0",
+    "@mui/x-data-grid": "6.18.0",
+    "@mui/x-data-grid-pro": "6.18.0",
     "@mui/x-license-pro": "6.10.2",
     "@types/format-util": "^1.0.3",
     "clsx": "^2.0.0",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@mui/utils": "^5.14.16",
-    "@mui/x-data-grid": "6.17.0",
+    "@mui/x-data-grid": "6.18.0",
     "@mui/x-license-pro": "6.10.2",
     "@types/format-util": "^1.0.3",
     "clsx": "^2.0.0",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-charts",
-  "version": "6.0.0-alpha.17",
+  "version": "6.18.0",
   "description": "The community edition of the charts components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -44,7 +44,7 @@
     "@babel/runtime": "^7.23.2",
     "@mui/base": "^5.0.0-beta.22",
     "@mui/utils": "^5.14.16",
-    "@mui/x-date-pickers": "6.17.0",
+    "@mui/x-date-pickers": "6.18.0",
     "@mui/x-license-pro": "6.10.2",
     "clsx": "^2.0.0",
     "prop-types": "^15.8.1",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -259,11 +259,11 @@ Same changes as in \`@mui/x-date-pickers@__VERSION__\`${
   }
 ${logChangelogSection(pickersProCommits)}
 
-### Charts / \`@mui/x-charts@__CHARTS_VERSION__\`
+### Charts / \`@mui/x-charts@__VERSION__\`
 
 ${logChangelogSection(chartsCommits)}
 
-### Tree View / \`@mui/x-tree-view@__TREE_VIEW_VERSION__\`
+### Tree View / \`@mui/x-tree-view@__VERSION__\`
 
 ${logChangelogSection(treeViewCommits)}
 ${logChangelogSection(codemodCommits, `### \`@mui/x-codemod@__VERSION__\``)}


### PR DESCRIPTION
Noticeable element:

- minor version due to charts becoming stable
- Since no PR refers to the tree view, I removed the section header, and reverteded the version bump proposed by `yarn release:version`.
- Same I revert the proposal of bumping the `@mui/x-license-pro` version proposed by `yarn release:version`