### PR TITLE
[docs] Add demo about how to use charts margin

### DIFF
--- a/docs/data/charts/styling/MarginNoSnap.js
+++ b/docs/data/charts/styling/MarginNoSnap.js
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import ChartsUsageDemo from 'docsx/src/modules/components/ChartsUsageDemo';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '@mui/x-charts/constants';
+
+const data = ['left', 'right', 'top', 'bottom'].map((propName) => ({
+  propName,
+  knob: 'number',
+  defaultValue: 80,
+  step: 1,
+  min: 0,
+  max: 200,
+}));
+export default function MarginNoSnap() {
+  return (
+    <ChartsUsageDemo
+      componentName="Margin demos"
+      data={data}
+      renderDemo={(props) => (
+        <BarChart
+          series={[{ data: [6, 18, 12] }]}
+          width={500}
+          height={300}
+          margin={{
+            left: props.left,
+            right: props.right,
+            top: props.top,
+            bottom: props.bottom,
+          }}
+          xAxis={[
+            {
+              id: DEFAULT_X_AXIS_KEY,
+              scaleType: 'band',
+              data: ['Page 1', 'Page 2', 'Page 3'],
+            },
+          ]}
+          topAxis={DEFAULT_X_AXIS_KEY}
+          rightAxis={DEFAULT_Y_AXIS_KEY}
+        />
+      )}
+      getCode={({ props }) => {
+        return [
+          `import { BarChart } from '@mui/x-charts/BarChart';`,
+          '',
+          `<BarChart`,
+          `  // ...`,
+          `  margin={{`,
+          `    left: ${props.left},`,
+          `    right: ${props.right},`,
+          `    top: ${props.top},`,
+          `    bottom: ${props.bottom},`,
+          `  }}`,
+          '/>',
+        ].join('\n');
+      }}
+    />
+  );
+}

--- a/docs/data/charts/styling/styling.md
+++ b/docs/data/charts/styling/styling.md
@@ -52,16 +52,18 @@ Those will fix the chart's size to the given value (in px).
 
 ### Placement
 
-At the core of charts layout is the drawing area which corresponds to the space available to represent data.
+At the core of chart layout is the drawing area which corresponds to the space available to represent data.
 
-This space can be fined with the `margin` prop and its properties `top`, `bottom`, `left`, and `right`.
+This space can be defined with the `margin` prop and its properties `top`, `bottom`, `left`, and `right`.
 Those values define the space between the SVG border and the drawing area.
 
-You might want to modify those values to let more space for your axis ticks or reduce them to provide more space for the data.
+You might want to modify those values to leave more space for your axis ticks or reduce them to provide more space for the data.
+
+{{"demo": "MarginNoSnap.js"}}
 
 ### CSS
 
 Since the library relies on SVG for rendering, you can customize them as you do with other MUI components with CSS overriding.
 
 Chart components accept the `sx` props.
-And you can target any sub elements with its class name.
+From here, you can target any subcomponents with its class name.


### PR DESCRIPTION
> New comment :-1:
> I find MUI X docs to be very confusing compared to Material-UI docs.
> 
> I'm trying to apply margin right now (as mentioned above). It won't take 'inherit' as a value, seems to only accept a number.
> 
> So I want to look at the definition of the margin prop: what are its default values?
> Well I can't find the margin prop. It's not in the API reference under BarChart (which is what I'm using).
> sent from https://mui.com/x/react-charts/styling/

https://mui-org.slack.com/archives/C04U3R2V9UK/p1698962389920629