### PR TITLE
[pickers] Always use up-to-date `defaultView`

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -16,7 +16,7 @@ import {
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DesktopDatePicker />', () => {
-  const { render } = createPickerRenderer({ clock: 'fake' });
+  const { render, clock } = createPickerRenderer({ clock: 'fake' });
 
   it('allows to change selected date from the field according to `format`', () => {
     const handleChange = spy();
@@ -98,6 +98,29 @@ describe('<DesktopDatePicker />', () => {
       openPicker({ type: 'date', variant: 'desktop' });
       expect(handleViewChange.callCount).to.equal(2);
       expect(handleViewChange.lastCall.firstArg).to.equal('month');
+    });
+
+    it('should go to the relevant `view` when `views` prop changes', () => {
+      const { setProps } = render(
+        <DesktopDatePicker
+          defaultValue={adapterToUse.date(new Date(2018, 0, 1))}
+          views={['year']}
+        />,
+      );
+
+      openPicker({ type: 'date', variant: 'desktop' });
+
+      expect(screen.getByRole('radio', { checked: true, name: '2018' })).to.not.equal(null);
+
+      // Dismiss the picker
+      userEvent.keyPress(document.activeElement!, { key: 'Escape' });
+      setProps({ views: ['month', 'year'] });
+      openPicker({ type: 'date', variant: 'desktop' });
+      // wait for all pending changes to be flushed
+      clock.runToLast();
+
+      // should have changed the open view
+      expect(screen.getByRole('radio', { checked: true, name: 'January' })).to.not.equal(null);
     });
 
     it('should move the focus to the newly opened views', function test() {

--- a/packages/x-date-pickers/src/internals/hooks/useViews.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useViews.tsx
@@ -214,7 +214,8 @@ export function useViews<TValue, TView extends DateOrTimeViewWithMeridiem>({
     setFocusedView: handleFocusedViewChange,
     nextView,
     previousView,
-    defaultView: defaultView.current,
+    // Always return up to date default view instead of the initial one (i.e. defaultView.current)
+    defaultView: views.includes(openTo!) ? openTo! : views[0],
     goToNextView,
     setValueAndGoToNextView,
     setValueAndGoToView,


### PR DESCRIPTION
Fixes #10878

This snippet was correctly updating the `view`:
https://github.com/mui/mui-x/blob/6c749a8b73435b387d2f5d7c92563271e0f07745/packages/x-date-pickers/src/internals/hooks/useViews.tsx#L140

and after that, this snippet was reverting the `view` back to the original `defaultView` 🙈 
https://github.com/mui/mui-x/blob/6c749a8b73435b387d2f5d7c92563271e0f07745/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts#L259

After this change, having the up-to-date `defaultView` avoids the problem of incorrectly reverting the `view`.