### PR TITLE
[license] Correctly throw errors

### DIFF
--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.test.tsx
@@ -19,17 +19,26 @@ function TestComponent() {
   return <div data-testid="status">Status: {licesenStatus.status}</div>;
 }
 
-describe('useLicenseVerifier', () => {
+describe('useLicenseVerifier', function test() {
+  // Can't change the process.env.NODE_ENV in Karma
+  if (!/jsdom/.test(window.navigator.userAgent)) {
+    return;
+  }
+
   const { render } = createRenderer();
 
   let env: any;
   beforeEach(() => {
     env = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'test';
+    // Avoid Karma "Invalid left-hand side in assignment" SyntaxError
+    // eslint-disable-next-line no-useless-concat
+    process.env['NODE_' + 'ENV'] = 'test';
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = env;
+    // Avoid Karma "Invalid left-hand side in assignment" SyntaxError
+    // eslint-disable-next-line no-useless-concat
+    process.env['NODE_' + 'ENV'] = env;
   });
 
   describe('error', () => {
@@ -69,7 +78,9 @@ describe('useLicenseVerifier', () => {
     });
 
     it('should throw if the license is expired by more than a 30 days', () => {
-      process.env.NODE_ENV = 'development';
+      // Avoid Karma "Invalid left-hand side in assignment" SyntaxError
+      // eslint-disable-next-line no-useless-concat
+      process.env['NODE_' + 'ENV'] = 'development';
 
       const expiredLicenseKey = generateLicense({
         expiryDate: new Date(new Date().getTime() - oneDayInMS * 30),

--- a/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.ts
+++ b/packages/x-license-pro/src/useLicenseVerifier/useLicenseVerifier.ts
@@ -56,7 +56,6 @@ export function useLicenseVerifier(
       acceptedScopes,
     });
 
-    sharedLicenseStatuses[packageName] = { key: licenseKey, licenseVerifier: licenseStatus };
     const fullPackageName = `@mui/${packageName}`;
 
     if (licenseStatus.status === LICENSE_STATUS.Valid) {
@@ -77,6 +76,7 @@ export function useLicenseVerifier(
       throw new Error('missing status handler');
     }
 
+    sharedLicenseStatuses[packageName] = { key: licenseKey, licenseVerifier: licenseStatus };
     return licenseStatus;
   }, [packageName, releaseInfo, contextKey]);
 }


### PR DESCRIPTION
This is a continuation of #9701. The cache for the output of `useLicenseVerifier()` wasn't set at the right location. It would lead to a strange behavior where the exception would log, but not break the rendering flow, at least, not always. It would only break when using server-side rendering.

Now, the behavior is consistent, it breaks server-side and client-side (new).