### PR TITLE
[charts] Improve properties JSDoc

### DIFF
--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -1,5 +1,11 @@
 {
   "props": {
+    "axisHighlight": {
+      "type": {
+        "name": "shape",
+        "description": "{ x?: 'band'<br>&#124;&nbsp;'line'<br>&#124;&nbsp;'none', y?: 'band'<br>&#124;&nbsp;'line'<br>&#124;&nbsp;'none' }"
+      }
+    },
     "bottomAxis": {
       "type": {
         "name": "union",
@@ -10,12 +16,22 @@
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
+    "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
+    "disableAxisListener": { "type": { "name": "bool" } },
+    "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {
         "name": "union",
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'left'<br>&#124;&nbsp;'right', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "yAxisIds[0] The id of the first provided axis"
+    },
+    "margin": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "object depends on the charts type."
     },
     "rightAxis": {
       "type": {
@@ -33,6 +49,19 @@
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'bottom'<br>&#124;&nbsp;'top', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "null"
+    },
+    "width": { "type": { "name": "number" }, "default": "undefined" },
+    "xAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
+    },
+    "yAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
     }
   },
   "slots": [

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -31,7 +31,7 @@
         "name": "shape",
         "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
       },
-      "default": "object depends on the charts type."
+      "default": "object Depends on the charts type."
     },
     "rightAxis": {
       "type": {

--- a/docs/pages/x/api/charts/cartesian-context-provider.json
+++ b/docs/pages/x/api/charts/cartesian-context-provider.json
@@ -1,5 +1,19 @@
 {
-  "props": {},
+  "props": {
+    "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
+    "xAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
+    },
+    "yAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
+    }
+  },
   "slots": [],
   "name": "CartesianContextProvider",
   "imports": [

--- a/docs/pages/x/api/charts/drawing-provider.json
+++ b/docs/pages/x/api/charts/drawing-provider.json
@@ -5,7 +5,7 @@
         "name": "shape",
         "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
       },
-      "default": "object depends on the charts type."
+      "default": "object Depends on the charts type."
     }
   },
   "slots": [],

--- a/docs/pages/x/api/charts/drawing-provider.json
+++ b/docs/pages/x/api/charts/drawing-provider.json
@@ -1,5 +1,13 @@
 {
-  "props": {},
+  "props": {
+    "margin": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "object depends on the charts type."
+    }
+  },
   "slots": [],
   "name": "DrawingProvider",
   "imports": [

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -1,5 +1,11 @@
 {
   "props": {
+    "axisHighlight": {
+      "type": {
+        "name": "shape",
+        "description": "{ x?: 'band'<br>&#124;&nbsp;'line'<br>&#124;&nbsp;'none', y?: 'band'<br>&#124;&nbsp;'line'<br>&#124;&nbsp;'none' }"
+      }
+    },
     "bottomAxis": {
       "type": {
         "name": "union",
@@ -10,13 +16,23 @@
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
+    "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
+    "disableAxisListener": { "type": { "name": "bool" } },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
+    "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {
         "name": "union",
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'left'<br>&#124;&nbsp;'right', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "yAxisIds[0] The id of the first provided axis"
+    },
+    "margin": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "object depends on the charts type."
     },
     "rightAxis": {
       "type": {
@@ -33,6 +49,19 @@
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'bottom'<br>&#124;&nbsp;'top', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "null"
+    },
+    "width": { "type": { "name": "number" }, "default": "undefined" },
+    "xAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
+    },
+    "yAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
     }
   },
   "slots": [

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -32,7 +32,7 @@
         "name": "shape",
         "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
       },
-      "default": "object depends on the charts type."
+      "default": "object Depends on the charts type."
     },
     "rightAxis": {
       "type": {

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -10,12 +10,22 @@
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
+    "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
+    "disableAxisListener": { "type": { "name": "bool" } },
+    "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {
         "name": "union",
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'left'<br>&#124;&nbsp;'right', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "yAxisIds[0] The id of the first provided axis"
+    },
+    "margin": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "object depends on the charts type."
     },
     "rightAxis": {
       "type": {
@@ -32,6 +42,19 @@
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'bottom'<br>&#124;&nbsp;'top', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "null"
+    },
+    "width": { "type": { "name": "number" }, "default": "undefined" },
+    "xAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
+    },
+    "yAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
     }
   },
   "slots": [],

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -25,7 +25,7 @@
         "name": "shape",
         "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
       },
-      "default": "object depends on the charts type."
+      "default": "object Depends on the charts type."
     },
     "rightAxis": {
       "type": {

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -25,7 +25,7 @@
         "name": "shape",
         "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
       },
-      "default": "object depends on the charts type."
+      "default": "object Depends on the charts type."
     },
     "rightAxis": {
       "type": {

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -10,12 +10,22 @@
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
+    "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
+    "disableAxisListener": { "type": { "name": "bool" } },
+    "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {
         "name": "union",
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'left'<br>&#124;&nbsp;'right', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "yAxisIds[0] The id of the first provided axis"
+    },
+    "margin": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "object depends on the charts type."
     },
     "rightAxis": {
       "type": {
@@ -32,6 +42,19 @@
         "description": "{ axisId: string, classes?: object, disableLine?: bool, disableTicks?: bool, fill?: string, label?: string, labelFontSize?: number, labelStyle?: object, position?: 'bottom'<br>&#124;&nbsp;'top', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number }<br>&#124;&nbsp;string"
       },
       "default": "null"
+    },
+    "width": { "type": { "name": "number" }, "default": "undefined" },
+    "xAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
+    },
+    "yAxis": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;{ axisId?: string, classes?: object, data?: array, dataKey?: string, disableLine?: bool, disableTicks?: bool, fill?: string, hideTooltip?: bool, id?: string, label?: string, labelFontSize?: number, labelStyle?: object, max?: Date<br>&#124;&nbsp;number, min?: Date<br>&#124;&nbsp;number, position?: 'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top', scaleType?: 'band'<br>&#124;&nbsp;'linear'<br>&#124;&nbsp;'log'<br>&#124;&nbsp;'point'<br>&#124;&nbsp;'pow'<br>&#124;&nbsp;'sqrt'<br>&#124;&nbsp;'time'<br>&#124;&nbsp;'utc', slotProps?: object, slots?: object, stroke?: string, tickFontSize?: number, tickInterval?: 'auto'<br>&#124;&nbsp;array<br>&#124;&nbsp;func, tickLabelInterval?: 'auto'<br>&#124;&nbsp;func, tickLabelStyle?: object, tickMaxStep?: number, tickMinStep?: number, tickNumber?: number, tickSize?: number, valueFormatter?: func }&gt;"
+      }
     }
   },
   "slots": [

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -8,6 +8,16 @@
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
+    "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
+    "disableAxisListener": { "type": { "name": "bool" } },
+    "height": { "type": { "name": "number" }, "default": "undefined" },
+    "margin": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "object depends on the charts type."
+    },
     "plotType": {
       "type": { "name": "enum", "description": "'bar'<br>&#124;&nbsp;'line'" },
       "default": "'line'"
@@ -24,6 +34,7 @@
         "returned": "string"
       }
     },
+    "width": { "type": { "name": "number" }, "default": "undefined" },
     "xAxis": {
       "type": {
         "name": "shape",

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -16,7 +16,7 @@
         "name": "shape",
         "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
       },
-      "default": "object depends on the charts type."
+      "default": "object Depends on the charts type."
     },
     "plotType": {
       "type": { "name": "enum", "description": "'bar'<br>&#124;&nbsp;'line'" },

--- a/docs/translations/api-docs/charts/bar-chart.json
+++ b/docs/translations/api-docs/charts/bar-chart.json
@@ -1,6 +1,11 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "axisHighlight": {
+      "description": "Object <code>{ x, y }</code> that defines how the charts highlight the mouse position along x and y axes. The two proerties accept the next values: - &#39;none&#39;: display nothing. - &#39;line&#39;: display a line at the current mouse position. - &#39;band&#39;: display a band at the current mouse position. Only available  with band scale.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "bottomAxis": {
       "description": "Indicate which axis to display the bottom of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>.",
       "deprecated": "",
@@ -11,8 +16,28 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "dataset": {
+      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "disableAxisListener": {
+      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "height": {
+      "description": "The height of the chart in px. If not defined, it takes the height of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "leftAxis": {
       "description": "Indicate which axis to display the left of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "margin": {
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -38,6 +63,21 @@
     },
     "topAxis": {
       "description": "Indicate which axis to display the top of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "width": {
+      "description": "The width of the chart in px. If not defined, it takes the width of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "xAxis": {
+      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "yAxis": {
+      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/bar-chart.json
+++ b/docs/translations/api-docs/charts/bar-chart.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "axisHighlight": {
-      "description": "Object <code>{ x, y }</code> that defines how the charts highlight the mouse position along x and y axes. The two proerties accept the next values: - &#39;none&#39;: display nothing. - &#39;line&#39;: display a line at the current mouse position. - &#39;band&#39;: display a band at the current mouse position. Only available  with band scale.",
+      "description": "Object <code>{ x, y }</code> that defines how the charts highlight the mouse position along the x- and y-axes. The two properties accept the following values: - &#39;none&#39;: display nothing. - &#39;line&#39;: display a line at the current mouse position. - &#39;band&#39;: display a band at the current mouse position. Only available with band scale.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -17,12 +17,12 @@
       "typeDescriptions": {}
     },
     "dataset": {
-      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "disableAxisListener": {
-      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "description": "If <code>true</code>, the charts will not listen to the mouse move event. It might break interactive features, but will improve performance.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -37,7 +37,7 @@
       "typeDescriptions": {}
     },
     "margin": {
-      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -72,12 +72,12 @@
       "typeDescriptions": {}
     },
     "xAxis": {
-      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "description": "The configuration of the x-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_X_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "yAxis": {
-      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
+      "description": "The configuration of the y-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/cartesian-context-provider.json
+++ b/docs/translations/api-docs/charts/cartesian-context-provider.json
@@ -2,17 +2,17 @@
   "componentDescription": "",
   "propDescriptions": {
     "dataset": {
-      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "xAxis": {
-      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "description": "The configuration of the x-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_X_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "yAxis": {
-      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
+      "description": "The configuration of the y-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/cartesian-context-provider.json
+++ b/docs/translations/api-docs/charts/cartesian-context-provider.json
@@ -1,6 +1,22 @@
 {
   "componentDescription": "",
-  "propDescriptions": {},
+  "propDescriptions": {
+    "dataset": {
+      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "xAxis": {
+      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "yAxis": {
+      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    }
+  },
   "classDescriptions": {},
   "slotDescriptions": {}
 }

--- a/docs/translations/api-docs/charts/charts-axis.json
+++ b/docs/translations/api-docs/charts/charts-axis.json
@@ -48,8 +48,8 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group containing the axis label"
     },
-    "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x axes" },
-    "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y axes" },
+    "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x-axes" },
+    "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y-axes" },
     "top": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the top axis" },
     "bottom": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the bottom axis" },
     "left": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the left axis" },

--- a/docs/translations/api-docs/charts/charts-x-axis.json
+++ b/docs/translations/api-docs/charts/charts-x-axis.json
@@ -114,8 +114,8 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group containing the axis label"
     },
-    "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x axes" },
-    "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y axes" },
+    "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x-axes" },
+    "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y-axes" },
     "top": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the top axis" },
     "bottom": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the bottom axis" },
     "left": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the left axis" },

--- a/docs/translations/api-docs/charts/charts-y-axis.json
+++ b/docs/translations/api-docs/charts/charts-y-axis.json
@@ -114,8 +114,8 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group containing the axis label"
     },
-    "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x axes" },
-    "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y axes" },
+    "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x-axes" },
+    "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y-axes" },
     "top": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the top axis" },
     "bottom": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the bottom axis" },
     "left": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the left axis" },

--- a/docs/translations/api-docs/charts/drawing-provider.json
+++ b/docs/translations/api-docs/charts/drawing-provider.json
@@ -1,6 +1,12 @@
 {
   "componentDescription": "",
-  "propDescriptions": {},
+  "propDescriptions": {
+    "margin": {
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    }
+  },
   "classDescriptions": {},
   "slotDescriptions": {}
 }

--- a/docs/translations/api-docs/charts/drawing-provider.json
+++ b/docs/translations/api-docs/charts/drawing-provider.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "margin": {
-      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/line-chart.json
+++ b/docs/translations/api-docs/charts/line-chart.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "axisHighlight": {
-      "description": "Object <code>{ x, y }</code> that defines how the charts highlight the mouse position along x and y axes. The two proerties accept the next values: - &#39;none&#39;: display nothing. - &#39;line&#39;: display a line at the current mouse position. - &#39;band&#39;: display a band at the current mouse position. Only available  with band scale.",
+      "description": "Object <code>{ x, y }</code> that defines how the charts highlight the mouse position along the x- and y-axes. The two properties accept the following values: - &#39;none&#39;: display nothing. - &#39;line&#39;: display a line at the current mouse position. - &#39;band&#39;: display a band at the current mouse position. Only available with band scale.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -17,12 +17,12 @@
       "typeDescriptions": {}
     },
     "dataset": {
-      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "disableAxisListener": {
-      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "description": "If <code>true</code>, the charts will not listen to the mouse move event. It might break interactive features, but will improve performance.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -42,7 +42,7 @@
       "typeDescriptions": {}
     },
     "margin": {
-      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -72,12 +72,12 @@
       "typeDescriptions": {}
     },
     "xAxis": {
-      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "description": "The configuration of the x-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_X_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "yAxis": {
-      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
+      "description": "The configuration of the y-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/line-chart.json
+++ b/docs/translations/api-docs/charts/line-chart.json
@@ -1,6 +1,11 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "axisHighlight": {
+      "description": "Object <code>{ x, y }</code> that defines how the charts highlight the mouse position along x and y axes. The two proerties accept the next values: - &#39;none&#39;: display nothing. - &#39;line&#39;: display a line at the current mouse position. - &#39;band&#39;: display a band at the current mouse position. Only available  with band scale.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "bottomAxis": {
       "description": "Indicate which axis to display the bottom of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>.",
       "deprecated": "",
@@ -11,13 +16,33 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "dataset": {
+      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "disableAxisListener": {
+      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "disableLineItemHighlight": {
       "description": "If <code>true</code>, render the line highlight item.",
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "height": {
+      "description": "The height of the chart in px. If not defined, it takes the height of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "leftAxis": {
       "description": "Indicate which axis to display the left of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "margin": {
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -38,6 +63,21 @@
     },
     "topAxis": {
       "description": "Indicate which axis to display the top of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "width": {
+      "description": "The width of the chart in px. If not defined, it takes the width of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "xAxis": {
+      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "yAxis": {
+      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/pie-chart.json
+++ b/docs/translations/api-docs/charts/pie-chart.json
@@ -11,8 +11,28 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "dataset": {
+      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "disableAxisListener": {
+      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "height": {
+      "description": "The height of the chart in px. If not defined, it takes the height of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "leftAxis": {
       "description": "Indicate which axis to display the left of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "margin": {
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -33,6 +53,21 @@
     },
     "topAxis": {
       "description": "Indicate which axis to display the top of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "width": {
+      "description": "The width of the chart in px. If not defined, it takes the width of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "xAxis": {
+      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "yAxis": {
+      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/pie-chart.json
+++ b/docs/translations/api-docs/charts/pie-chart.json
@@ -12,12 +12,12 @@
       "typeDescriptions": {}
     },
     "dataset": {
-      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "disableAxisListener": {
-      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "description": "If <code>true</code>, the charts will not listen to the mouse move event. It might break interactive features, but will improve performance.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -32,7 +32,7 @@
       "typeDescriptions": {}
     },
     "margin": {
-      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -62,12 +62,12 @@
       "typeDescriptions": {}
     },
     "xAxis": {
-      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "description": "The configuration of the x-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_X_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "yAxis": {
-      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
+      "description": "The configuration of the y-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart.json
@@ -11,8 +11,28 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "dataset": {
+      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "disableAxisListener": {
+      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "height": {
+      "description": "The height of the chart in px. If not defined, it takes the height of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "leftAxis": {
       "description": "Indicate which axis to display the left of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "margin": {
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -33,6 +53,21 @@
     },
     "topAxis": {
       "description": "Indicate which axis to display the top of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "width": {
+      "description": "The width of the chart in px. If not defined, it takes the width of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "xAxis": {
+      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "yAxis": {
+      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart.json
@@ -12,12 +12,12 @@
       "typeDescriptions": {}
     },
     "dataset": {
-      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "disableAxisListener": {
-      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "description": "If <code>true</code>, the charts will not listen to the mouse move event. It might break interactive features, but will improve performance.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -32,7 +32,7 @@
       "typeDescriptions": {}
     },
     "margin": {
-      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -62,12 +62,12 @@
       "typeDescriptions": {}
     },
     "xAxis": {
-      "description": "The configuration of the x axes. If not provided, a default axis config is used with id <code>DEFAULT_X_AXIS_KEY</code>.",
+      "description": "The configuration of the x-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_X_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "yAxis": {
-      "description": "The configuration of the y axes. If not provided, a default axis config is used with id <code>DEFAULT_Y_AXIS_KEY</code>.",
+      "description": "The configuration of the y-axes. If not provided, a default axis config is used with id set to <code>DEFAULT_Y_AXIS_KEY</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     }

--- a/docs/translations/api-docs/charts/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart.json
@@ -13,12 +13,12 @@
     },
     "data": { "description": "Data to plot.", "deprecated": "", "typeDescriptions": {} },
     "dataset": {
-      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property.",
       "deprecated": "",
       "typeDescriptions": {}
     },
     "disableAxisListener": {
-      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "description": "If <code>true</code>, the charts will not listen to the mouse move event. It might break interactive features, but will improve performance.",
       "deprecated": "",
       "typeDescriptions": {}
     },
@@ -28,7 +28,7 @@
       "typeDescriptions": {}
     },
     "margin": {
-      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
       "deprecated": "",
       "typeDescriptions": {}
     },

--- a/docs/translations/api-docs/charts/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart.json
@@ -12,6 +12,26 @@
       "typeDescriptions": {}
     },
     "data": { "description": "Data to plot.", "deprecated": "", "typeDescriptions": {} },
+    "dataset": {
+      "description": "An array of object that can be used to populate series and axis data using there <code>dataKey</code> property.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "disableAxisListener": {
+      "description": "If true, the charts will not listen to the mouse move event. It might breaks interactive features, but save some computation power.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "height": {
+      "description": "The height of the chart in px. If not defined, it takes the height of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
+    "margin": {
+      "description": "The margin between the SVG and the drawing area. It&#39;s used for leving space for extra information wuch as axes, or legend. Accept and object with some of the next properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "plotType": { "description": "Type of plot used.", "deprecated": "", "typeDescriptions": {} },
     "showHighlight": {
       "description": "Set to <code>true</code> to highlight the value. With line, it shows a point. With bar, it shows a highlight band.",
@@ -37,6 +57,11 @@
       "description": "Formatter used by the tooltip.",
       "deprecated": "",
       "typeDescriptions": { "value": "The value to format.", "string": "the formatted value." }
+    },
+    "width": {
+      "description": "The width of the chart in px. If not defined, it takes the width of the parent element.",
+      "deprecated": "",
+      "typeDescriptions": {}
     },
     "xAxis": {
       "description": "The xAxis configuration. Notice it is a single configuration object, not an array of configuration.",

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -43,6 +43,13 @@ export interface BarChartProps
     Pick<BarPlotProps, 'skipAnimation'> {
   series: MakeOptional<BarSeriesType, 'type'>[];
   tooltip?: ChartsTooltipProps;
+  /**
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
+   * The two proerties accept the next values:
+   * - 'none': display nothing.
+   * - 'line': display a line at the current mouse position.
+   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   */
   axisHighlight?: ChartsAxisHighlightProps;
   /**
    * @deprecated Consider using `slotProps.legend` instead.

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -174,6 +174,13 @@ BarChart.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
+   * The two proerties accept the next values:
+   * - 'none': display nothing.
+   * - 'line': display a line at the current mouse position.
+   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   */
   axisHighlight: PropTypes.shape({
     x: PropTypes.oneOf(['band', 'line', 'none']),
     y: PropTypes.oneOf(['band', 'line', 'none']),
@@ -218,9 +225,21 @@ BarChart.propTypes = {
    * Color palette used to colorize multiple series.
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
+  /**
+   * If true, the charts will not listen to the mouse move event.
+   * It might breaks interactive features, but save some computation power.
+   * @default false
+   */
   disableAxisListener: PropTypes.bool,
+  /**
+   * The height of the chart in px. If not defined, it takes the height of the parent element.
+   * @default undefined
+   */
   height: PropTypes.number,
   layout: PropTypes.oneOf(['horizontal', 'vertical']),
   /**
@@ -271,6 +290,12 @@ BarChart.propTypes = {
     slotProps: PropTypes.object,
     slots: PropTypes.object,
   }),
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,
@@ -408,7 +433,15 @@ BarChart.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   }),
+  /**
+   * The width of the chart in px. If not defined, it takes the width of the parent element.
+   * @default undefined
+   */
   width: PropTypes.number,
+  /**
+   * The configuration of the x axes.
+   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,
@@ -445,6 +478,10 @@ BarChart.propTypes = {
       valueFormatter: PropTypes.func,
     }),
   ),
+  /**
+   * The configuration of the y axes.
+   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -44,11 +44,11 @@ export interface BarChartProps
   series: MakeOptional<BarSeriesType, 'type'>[];
   tooltip?: ChartsTooltipProps;
   /**
-   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
-   * The two proerties accept the next values:
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along the x- and y-axes.
+   * The two properties accept the following values:
    * - 'none': display nothing.
    * - 'line': display a line at the current mouse position.
-   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   * - 'band': display a band at the current mouse position. Only available with band scale.
    */
   axisHighlight?: ChartsAxisHighlightProps;
   /**
@@ -175,11 +175,11 @@ BarChart.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
-   * The two proerties accept the next values:
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along the x- and y-axes.
+   * The two properties accept the following values:
    * - 'none': display nothing.
    * - 'line': display a line at the current mouse position.
-   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   * - 'band': display a band at the current mouse position. Only available with band scale.
    */
   axisHighlight: PropTypes.shape({
     x: PropTypes.oneOf(['band', 'line', 'none']),
@@ -226,13 +226,13 @@ BarChart.propTypes = {
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
   /**
-   * If true, the charts will not listen to the mouse move event.
-   * It might breaks interactive features, but save some computation power.
+   * If `true`, the charts will not listen to the mouse move event.
+   * It might break interactive features, but will improve performance.
    * @default false
    */
   disableAxisListener: PropTypes.bool,
@@ -292,9 +292,9 @@ BarChart.propTypes = {
   }),
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
@@ -439,8 +439,8 @@ BarChart.propTypes = {
    */
   width: PropTypes.number,
   /**
-   * The configuration of the x axes.
-   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   * The configuration of the x-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_X_AXIS_KEY`.
    */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
@@ -479,8 +479,8 @@ BarChart.propTypes = {
     }),
   ),
   /**
-   * The configuration of the y axes.
-   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   * The configuration of the y-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_Y_AXIS_KEY`.
    */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/x-charts/src/ChartsAxis/axisClasses.ts
+++ b/packages/x-charts/src/ChartsAxis/axisClasses.ts
@@ -16,9 +16,9 @@ export interface ChartsAxisClasses {
   tickLabel: string;
   /** Styles applied to the group containing the axis label. */
   label: string;
-  /** Styles applied to x axes. */
+  /** Styles applied to x-axes. */
   directionX: string;
-  /** Styles applied to y axes. */
+  /** Styles applied to y-axes. */
   directionY: string;
   /** Styles applied to the top axis. */
   top: string;

--- a/packages/x-charts/src/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface.tsx
@@ -24,8 +24,8 @@ export interface ChartsSurfaceProps {
   sx?: SxProps<Theme>;
   children?: React.ReactNode;
   /**
-   * If true, the charts will not listen to the mouse move event.
-   * It might breaks interactive features, but save some computation power.
+   * If `true`, the charts will not listen to the mouse move event.
+   * It might break interactive features, but will improve performance.
    * @default false
    */
   disableAxisListener?: boolean;

--- a/packages/x-charts/src/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface.tsx
@@ -9,7 +9,13 @@ type ViewBox = {
   height?: number;
 };
 export interface ChartsSurfaceProps {
+  /**
+   * The width of the chart in px.
+   */
   width: number;
+  /**
+   * The height of the chart in px.
+   */
   height: number;
   viewBox?: ViewBox;
   className?: string;
@@ -17,6 +23,11 @@ export interface ChartsSurfaceProps {
   desc?: string;
   sx?: SxProps<Theme>;
   children?: React.ReactNode;
+  /**
+   * If true, the charts will not listen to the mouse move event.
+   * It might breaks interactive features, but save some computation power.
+   * @default false
+   */
   disableAxisListener?: boolean;
 }
 

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -179,6 +179,13 @@ LineChart.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
+   * The two proerties accept the next values:
+   * - 'none': display nothing.
+   * - 'line': display a line at the current mouse position.
+   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   */
   axisHighlight: PropTypes.shape({
     x: PropTypes.oneOf(['band', 'line', 'none']),
     y: PropTypes.oneOf(['band', 'line', 'none']),
@@ -223,13 +230,25 @@ LineChart.propTypes = {
    * Color palette used to colorize multiple series.
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
+  /**
+   * If true, the charts will not listen to the mouse move event.
+   * It might breaks interactive features, but save some computation power.
+   * @default false
+   */
   disableAxisListener: PropTypes.bool,
   /**
    * If `true`, render the line highlight item.
    */
   disableLineItemHighlight: PropTypes.bool,
+  /**
+   * The height of the chart in px. If not defined, it takes the height of the parent element.
+   * @default undefined
+   */
   height: PropTypes.number,
   /**
    * Indicate which axis to display the left of the charts.
@@ -279,6 +298,12 @@ LineChart.propTypes = {
     slotProps: PropTypes.object,
     slots: PropTypes.object,
   }),
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,
@@ -424,7 +449,15 @@ LineChart.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   }),
+  /**
+   * The width of the chart in px. If not defined, it takes the width of the parent element.
+   * @default undefined
+   */
   width: PropTypes.number,
+  /**
+   * The configuration of the x axes.
+   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,
@@ -461,6 +494,10 @@ LineChart.propTypes = {
       valueFormatter: PropTypes.func,
     }),
   ),
+  /**
+   * The configuration of the y axes.
+   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -55,6 +55,13 @@ export interface LineChartProps
     Omit<ChartsAxisProps, 'slots' | 'slotProps'> {
   series: MakeOptional<LineSeriesType, 'type'>[];
   tooltip?: ChartsTooltipProps;
+  /**
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
+   * The two proerties accept the next values:
+   * - 'none': display nothing.
+   * - 'line': display a line at the current mouse position.
+   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   */
   axisHighlight?: ChartsAxisHighlightProps;
   /**
    * @deprecated Consider using `slotProps.legend` instead.

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -56,11 +56,11 @@ export interface LineChartProps
   series: MakeOptional<LineSeriesType, 'type'>[];
   tooltip?: ChartsTooltipProps;
   /**
-   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
-   * The two proerties accept the next values:
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along the x- and y-axes.
+   * The two properties accept the following values:
    * - 'none': display nothing.
    * - 'line': display a line at the current mouse position.
-   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   * - 'band': display a band at the current mouse position. Only available with band scale.
    */
   axisHighlight?: ChartsAxisHighlightProps;
   /**
@@ -180,11 +180,11 @@ LineChart.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * Object `{ x, y }` that defines how the charts highlight the mouse position along x and y axes.
-   * The two proerties accept the next values:
+   * Object `{ x, y }` that defines how the charts highlight the mouse position along the x- and y-axes.
+   * The two properties accept the following values:
    * - 'none': display nothing.
    * - 'line': display a line at the current mouse position.
-   * - 'band': display a band at the current mouse position. Only available  with band scale.
+   * - 'band': display a band at the current mouse position. Only available with band scale.
    */
   axisHighlight: PropTypes.shape({
     x: PropTypes.oneOf(['band', 'line', 'none']),
@@ -231,13 +231,13 @@ LineChart.propTypes = {
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
   /**
-   * If true, the charts will not listen to the mouse move event.
-   * It might breaks interactive features, but save some computation power.
+   * If `true`, the charts will not listen to the mouse move event.
+   * It might break interactive features, but will improve performance.
    * @default false
    */
   disableAxisListener: PropTypes.bool,
@@ -300,9 +300,9 @@ LineChart.propTypes = {
   }),
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
@@ -455,8 +455,8 @@ LineChart.propTypes = {
    */
   width: PropTypes.number,
   /**
-   * The configuration of the x axes.
-   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   * The configuration of the x-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_X_AXIS_KEY`.
    */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
@@ -495,8 +495,8 @@ LineChart.propTypes = {
     }),
   ),
   /**
-   * The configuration of the y axes.
-   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   * The configuration of the y-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_Y_AXIS_KEY`.
    */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -190,9 +190,21 @@ PieChart.propTypes = {
    * Color palette used to colorize multiple series.
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
+  /**
+   * If true, the charts will not listen to the mouse move event.
+   * It might breaks interactive features, but save some computation power.
+   * @default false
+   */
   disableAxisListener: PropTypes.bool,
+  /**
+   * The height of the chart in px. If not defined, it takes the height of the parent element.
+   * @default undefined
+   */
   height: PropTypes.number,
   /**
    * Indicate which axis to display the left of the charts.
@@ -242,6 +254,12 @@ PieChart.propTypes = {
     slotProps: PropTypes.object,
     slots: PropTypes.object,
   }),
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,
@@ -401,7 +419,15 @@ PieChart.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   }),
+  /**
+   * The width of the chart in px. If not defined, it takes the width of the parent element.
+   * @default undefined
+   */
   width: PropTypes.number,
+  /**
+   * The configuration of the x axes.
+   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,
@@ -438,6 +464,10 @@ PieChart.propTypes = {
       valueFormatter: PropTypes.func,
     }),
   ),
+  /**
+   * The configuration of the y axes.
+   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -191,13 +191,13 @@ PieChart.propTypes = {
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
   /**
-   * If true, the charts will not listen to the mouse move event.
-   * It might breaks interactive features, but save some computation power.
+   * If `true`, the charts will not listen to the mouse move event.
+   * It might break interactive features, but will improve performance.
    * @default false
    */
   disableAxisListener: PropTypes.bool,
@@ -256,9 +256,9 @@ PieChart.propTypes = {
   }),
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
@@ -425,8 +425,8 @@ PieChart.propTypes = {
    */
   width: PropTypes.number,
   /**
-   * The configuration of the x axes.
-   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   * The configuration of the x-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_X_AXIS_KEY`.
    */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
@@ -465,8 +465,8 @@ PieChart.propTypes = {
     }),
   ),
   /**
-   * The configuration of the y axes.
-   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   * The configuration of the y-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_Y_AXIS_KEY`.
    */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/x-charts/src/ResponsiveChartContainer/index.tsx
+++ b/packages/x-charts/src/ResponsiveChartContainer/index.tsx
@@ -3,7 +3,6 @@ import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import ownerWindow from '@mui/utils/ownerWindow';
 import { styled } from '@mui/material/styles';
 import { ChartContainer, ChartContainerProps } from '../ChartContainer';
-import { MakeOptional } from '../models/helpers';
 
 const useChartDimensions = (
   inWidth?: number,
@@ -90,7 +89,19 @@ const useChartDimensions = (
   return [rootRef, inWidth ?? width, inHeight ?? height];
 };
 
-export type ResponsiveChartContainerProps = MakeOptional<ChartContainerProps, 'width' | 'height'>;
+export interface ResponsiveChartContainerProps
+  extends Omit<ChartContainerProps, 'width' | 'height'> {
+  /**
+   * The width of the chart in px. If not defined, it takes the width of the parent element.
+   * @default undefined
+   */
+  width?: number;
+  /**
+   * The height of the chart in px. If not defined, it takes the height of the parent element.
+   * @default undefined
+   */
+  height?: number;
+}
 
 const ResizableContainer = styled('div', {
   name: 'MuiResponsiveChart',

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -169,9 +169,21 @@ ScatterChart.propTypes = {
    * Color palette used to colorize multiple series.
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
+  /**
+   * If true, the charts will not listen to the mouse move event.
+   * It might breaks interactive features, but save some computation power.
+   * @default false
+   */
   disableAxisListener: PropTypes.bool,
+  /**
+   * The height of the chart in px. If not defined, it takes the height of the parent element.
+   * @default undefined
+   */
   height: PropTypes.number,
   /**
    * Indicate which axis to display the left of the charts.
@@ -221,6 +233,12 @@ ScatterChart.propTypes = {
     slotProps: PropTypes.object,
     slots: PropTypes.object,
   }),
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,
@@ -348,7 +366,15 @@ ScatterChart.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   }),
+  /**
+   * The width of the chart in px. If not defined, it takes the width of the parent element.
+   * @default undefined
+   */
   width: PropTypes.number,
+  /**
+   * The configuration of the x axes.
+   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,
@@ -385,6 +411,10 @@ ScatterChart.propTypes = {
       valueFormatter: PropTypes.func,
     }),
   ),
+  /**
+   * The configuration of the y axes.
+   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -170,13 +170,13 @@ ScatterChart.propTypes = {
    */
   colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
   /**
-   * If true, the charts will not listen to the mouse move event.
-   * It might breaks interactive features, but save some computation power.
+   * If `true`, the charts will not listen to the mouse move event.
+   * It might break interactive features, but will improve performance.
    * @default false
    */
   disableAxisListener: PropTypes.bool,
@@ -235,9 +235,9 @@ ScatterChart.propTypes = {
   }),
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
@@ -372,8 +372,8 @@ ScatterChart.propTypes = {
    */
   width: PropTypes.number,
   /**
-   * The configuration of the x axes.
-   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   * The configuration of the x-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_X_AXIS_KEY`.
    */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
@@ -412,8 +412,8 @@ ScatterChart.propTypes = {
     }),
   ),
   /**
-   * The configuration of the y axes.
-   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   * The configuration of the y-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_Y_AXIS_KEY`.
    */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -234,13 +234,13 @@ SparkLineChart.propTypes = {
    */
   data: PropTypes.arrayOf(PropTypes.number).isRequired,
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
   /**
-   * If true, the charts will not listen to the mouse move event.
-   * It might breaks interactive features, but save some computation power.
+   * If `true`, the charts will not listen to the mouse move event.
+   * It might break interactive features, but will improve performance.
    * @default false
    */
   disableAxisListener: PropTypes.bool,
@@ -251,9 +251,9 @@ SparkLineChart.propTypes = {
   height: PropTypes.number,
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin: PropTypes.shape({
     bottom: PropTypes.number,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -233,10 +233,28 @@ SparkLineChart.propTypes = {
    * Data to plot.
    */
   data: PropTypes.arrayOf(PropTypes.number).isRequired,
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset: PropTypes.arrayOf(PropTypes.object),
   desc: PropTypes.string,
+  /**
+   * If true, the charts will not listen to the mouse move event.
+   * It might breaks interactive features, but save some computation power.
+   * @default false
+   */
   disableAxisListener: PropTypes.bool,
+  /**
+   * The height of the chart in px. If not defined, it takes the height of the parent element.
+   * @default undefined
+   */
   height: PropTypes.number,
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,
@@ -296,6 +314,10 @@ SparkLineChart.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   }),
+  /**
+   * The width of the chart in px. If not defined, it takes the width of the parent element.
+   * @default undefined
+   */
   width: PropTypes.number,
   /**
    * The xAxis configuration.

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -30,17 +30,17 @@ import { getTickNumber } from '../hooks/useTicks';
 
 export type CartesianContextProviderProps = {
   /**
-   * The configuration of the x axes.
-   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   * The configuration of the x-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_X_AXIS_KEY`.
    */
   xAxis?: MakeOptional<AxisConfig, 'id'>[];
   /**
-   * The configuration of the y axes.
-   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   * The configuration of the y-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_Y_AXIS_KEY`.
    */
   yAxis?: MakeOptional<AxisConfig, 'id'>[];
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset?: DatasetType;
   children: React.ReactNode;
@@ -68,23 +68,23 @@ type DefaultizedAxisConfig = {
 
 export const CartesianContext = React.createContext<{
   /**
-   * Mapping from x axis key to scaling configuration
+   * Mapping from x-axis key to scaling configuration.
    */
   xAxis: {
     DEFAULT_X_AXIS_KEY: AxisDefaultized;
   } & DefaultizedAxisConfig;
   /**
-   * Mapping from y axis key to scaling configuration
+   * Mapping from y-axis key to scaling configuration.
    */
   yAxis: {
     DEFAULT_X_AXIS_KEY: AxisDefaultized;
   } & DefaultizedAxisConfig;
   /**
-   * The x axes ids sorted by order they got provided.
+   * The x-axes IDs sorted by order they got provided.
    */
   xAxisIds: string[];
   /**
-   * The y axes ids sorted by order they got provided.
+   * The y-axes IDs sorted by order they got provided.
    */
   yAxisIds: string[];
   // @ts-ignore
@@ -321,12 +321,12 @@ CartesianContextProvider.propTypes = {
   // ----------------------------------------------------------------------
   children: PropTypes.node,
   /**
-   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
   dataset: PropTypes.arrayOf(PropTypes.object),
   /**
-   * The configuration of the x axes.
-   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   * The configuration of the x-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_X_AXIS_KEY`.
    */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
@@ -365,8 +365,8 @@ CartesianContextProvider.propTypes = {
     }),
   ),
   /**
-   * The configuration of the y axes.
-   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   * The configuration of the y-axes.
+   * If not provided, a default axis config is used with id set to `DEFAULT_Y_AXIS_KEY`.
    */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -68,15 +68,24 @@ type DefaultizedAxisConfig = {
 
 export const CartesianContext = React.createContext<{
   /**
-   * Mapping from axis key to scaling function
+   * Mapping from x axis key to scaling configuration
    */
   xAxis: {
     DEFAULT_X_AXIS_KEY: AxisDefaultized;
   } & DefaultizedAxisConfig;
+  /**
+   * Mapping from y axis key to scaling configuration
+   */
   yAxis: {
     DEFAULT_X_AXIS_KEY: AxisDefaultized;
   } & DefaultizedAxisConfig;
+  /**
+   * The x axes ids sorted by order they got provided.
+   */
   xAxisIds: string[];
+  /**
+   * The y axes ids sorted by order they got provided.
+   */
   yAxisIds: string[];
   // @ts-ignore
 }>({ xAxis: {}, yAxis: {}, xAxisIds: [], yAxisIds: [] });
@@ -311,7 +320,14 @@ CartesianContextProvider.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   children: PropTypes.node,
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset: PropTypes.arrayOf(PropTypes.object),
+  /**
+   * The configuration of the x axes.
+   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   */
   xAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,
@@ -348,6 +364,10 @@ CartesianContextProvider.propTypes = {
       valueFormatter: PropTypes.func,
     }),
   ),
+  /**
+   * The configuration of the y axes.
+   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   */
   yAxis: PropTypes.arrayOf(
     PropTypes.shape({
       axisId: PropTypes.string,

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -29,8 +29,19 @@ import { MakeOptional } from '../models/helpers';
 import { getTickNumber } from '../hooks/useTicks';
 
 export type CartesianContextProviderProps = {
+  /**
+   * The configuration of the x axes.
+   * If not provided, a default axis config is used with id `DEFAULT_X_AXIS_KEY`.
+   */
   xAxis?: MakeOptional<AxisConfig, 'id'>[];
+  /**
+   * The configuration of the y axes.
+   * If not provided, a default axis config is used with id `DEFAULT_Y_AXIS_KEY`.
+   */
   yAxis?: MakeOptional<AxisConfig, 'id'>[];
+  /**
+   * An array of object that can be used to populate series and axis data using there `dataKey` property.
+   */
   dataset?: DatasetType;
   children: React.ReactNode;
 };

--- a/packages/x-charts/src/context/DrawingProvider.tsx
+++ b/packages/x-charts/src/context/DrawingProvider.tsx
@@ -13,19 +13,19 @@ export interface DrawingProviderProps extends LayoutConfig {
  */
 export type DrawingArea = {
   /**
-   * The gape between the left border of the SVG and the drawing area.
+   * The gap between the left border of the SVG and the drawing area.
    */
   left: number;
   /**
-   * The gape between the top border of the SVG and the drawing area.
+   * The gap between the top border of the SVG and the drawing area.
    */
   top: number;
   /**
-   * The gape between the bottom border of the SVG and the drawing area.
+   * The gap between the bottom border of the SVG and the drawing area.
    */
   bottom: number;
   /**
-   * The gape between the right border of the SVG and the drawing area.
+   * The gap between the right border of the SVG and the drawing area.
    */
   right: number;
   /**
@@ -72,9 +72,9 @@ DrawingProvider.propTypes = {
   height: PropTypes.number.isRequired,
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin: PropTypes.shape({
     bottom: PropTypes.number,

--- a/packages/x-charts/src/context/DrawingProvider.tsx
+++ b/packages/x-charts/src/context/DrawingProvider.tsx
@@ -70,6 +70,12 @@ DrawingProvider.propTypes = {
   // ----------------------------------------------------------------------
   children: PropTypes.node,
   height: PropTypes.number.isRequired,
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,

--- a/packages/x-charts/src/context/DrawingProvider.tsx
+++ b/packages/x-charts/src/context/DrawingProvider.tsx
@@ -12,11 +12,29 @@ export interface DrawingProviderProps extends LayoutConfig {
  * Defines the area in which it is possible to draw the charts.
  */
 export type DrawingArea = {
+  /**
+   * The gape between the left border of the SVG and the drawing area.
+   */
   left: number;
+  /**
+   * The gape between the top border of the SVG and the drawing area.
+   */
   top: number;
+  /**
+   * The gape between the bottom border of the SVG and the drawing area.
+   */
   bottom: number;
+  /**
+   * The gape between the right border of the SVG and the drawing area.
+   */
   right: number;
+  /**
+   * The width of the drawing area.
+   */
   width: number;
+  /**
+   * The height of the drawing area.
+   */
   height: number;
 };
 

--- a/packages/x-charts/src/context/HighlightProvider.tsx
+++ b/packages/x-charts/src/context/HighlightProvider.tsx
@@ -11,7 +11,21 @@ export type HighlightOptions = 'none' | 'item' | 'series';
 export type FadeOptions = 'none' | 'series' | 'global';
 
 export type HighlightScope = {
+  /**
+   * The scope of elements highlighted.
+   * - 'none': no highlight.
+   * - 'item': only highlight the item.
+   * - 'series': highlight all element of the same seies.
+   * @default 'none'
+   */
   highlighted: HighlightOptions;
+  /**
+   * The scope of elements faded.
+   * - 'none': no fading.
+   * - 'series': only fade element of the same series.
+   * - 'global': fade lal element that are no highlighted.
+   * @default 'none'
+   */
   faded: FadeOptions;
 };
 type HighlighActions<T extends ChartSeriesType = ChartSeriesType> =
@@ -26,6 +40,9 @@ type HighlighActions<T extends ChartSeriesType = ChartSeriesType> =
     };
 
 type HighlighState = {
+  /**
+   * The item that triggers highlight state.
+   */
   item: null | ItemHighlighData<ChartSeriesType>;
   scope: HighlightScope;
   dispatch: React.Dispatch<HighlighActions>;

--- a/packages/x-charts/src/context/HighlightProvider.tsx
+++ b/packages/x-charts/src/context/HighlightProvider.tsx
@@ -12,18 +12,18 @@ export type FadeOptions = 'none' | 'series' | 'global';
 
 export type HighlightScope = {
   /**
-   * The scope of elements highlighted.
+   * The scope of highlighted elements.
    * - 'none': no highlight.
    * - 'item': only highlight the item.
-   * - 'series': highlight all element of the same seies.
+   * - 'series': highlight all elements of the same series.
    * @default 'none'
    */
   highlighted: HighlightOptions;
   /**
-   * The scope of elements faded.
+   * The scope of faded elements.
    * - 'none': no fading.
    * - 'series': only fade element of the same series.
-   * - 'global': fade lal element that are no highlighted.
+   * - 'global': fade all elements that are not highlighted.
    * @default 'none'
    */
   faded: FadeOptions;
@@ -41,7 +41,7 @@ type HighlighActions<T extends ChartSeriesType = ChartSeriesType> =
 
 type HighlighState = {
   /**
-   * The item that triggers highlight state.
+   * The item that triggers the highlight state.
    */
   item: null | ItemHighlighData<ChartSeriesType>;
   scope: HighlightScope;

--- a/packages/x-charts/src/context/InteractionProvider.tsx
+++ b/packages/x-charts/src/context/InteractionProvider.tsx
@@ -38,7 +38,7 @@ type InteractionState = {
    */
   item: null | ItemInteractionData<ChartSeriesType>;
   /**
-   * The x and y axes currently interacting.
+   * The x- and y-axes currently interacting.
    */
   axis: AxisInteractionData;
   dispatch: React.Dispatch<InteractionActions>;

--- a/packages/x-charts/src/context/InteractionProvider.tsx
+++ b/packages/x-charts/src/context/InteractionProvider.tsx
@@ -33,7 +33,13 @@ type InteractionActions<T extends ChartSeriesType = ChartSeriesType> =
     };
 
 type InteractionState = {
+  /**
+   * The item currently interacting.
+   */
   item: null | ItemInteractionData<ChartSeriesType>;
+  /**
+   * The x and y axes currently interacting.
+   */
   axis: AxisInteractionData;
   dispatch: React.Dispatch<InteractionActions>;
 };

--- a/packages/x-charts/src/context/SeriesContextProvider.tsx
+++ b/packages/x-charts/src/context/SeriesContextProvider.tsx
@@ -18,7 +18,8 @@ export type SeriesContextProviderProps = {
   dataset?: DatasetType;
   /**
    * The array of series to display.
-   * Each type of series has it's own specificity. Please refer the appropriated docs page to know it.
+   * Each type of series has its own specificity.
+   * Please refer to the appropriate docs page to learn more about it.
    */
   series: AllSeriesType[];
   /**

--- a/packages/x-charts/src/context/SeriesContextProvider.tsx
+++ b/packages/x-charts/src/context/SeriesContextProvider.tsx
@@ -16,6 +16,10 @@ import { ChartsColorPalette, blueberryTwilightPalette } from '../colorPalettes';
 
 export type SeriesContextProviderProps = {
   dataset?: DatasetType;
+  /**
+   * The array of series to display.
+   * Each type of series has it's own specificity. Please refer the appropriated docs page to know it.
+   */
   series: AllSeriesType[];
   /**
    * Color palette used to colorize multiple series.

--- a/packages/x-charts/src/internals/components/ChartsText.tsx
+++ b/packages/x-charts/src/internals/components/ChartsText.tsx
@@ -22,7 +22,7 @@ interface GetWordsByLinesParams {
    */
   style?: ChartsTextStyle;
   /**
-   * If true, the line width is computed.
+   * If `true`, the line width is computed.
    * @default false
    */
   needsComputation?: boolean;

--- a/packages/x-charts/src/internals/geometry.ts
+++ b/packages/x-charts/src/internals/geometry.ts
@@ -6,8 +6,8 @@ let warnedOnce = false;
  * Return the minimal translation along the x-axis to avoid overflow of a rectangle of a given width, height, and rotation.
  * This assumes that all rectangles have the same height and angle between -90 and 90.
  * Otherwise it would be problematic because you need the height/width of the next rectangle to do the correct computation.
- * @param width the side along the x axis.
- * @param height the side along the y axis.
+ * @param width the side along the x-axis.
+ * @param height the side along the y-axis.
  * @param angle the rotation in degrees.
  */
 export function getMinXTranslation(width: number, height: number, angle: number = 0) {

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -181,21 +181,21 @@ interface AxisScaleConfig {
 
 export type AxisConfig<S extends ScaleName = ScaleName, V = any> = {
   /**
-   * Id used to identify axis in different parts of the charts.
+   * Id used to identify the axis.
    */
   id: string;
   /**
    * The minimal value of the domain.
-   * If not provided, it get computed to display the entire chart data.
+   * If not provided, it gets computed to display the entire chart data.
    */
   min?: number | Date;
   /**
    * The maximal value of the domain.
-   * If not provided, it get computed to display the entire chart data.
+   * If not provided, it gets computed to display the entire chart data.
    */
   max?: number | Date;
   /**
-   * The data used by 'band' and 'point' scales.
+   * The data used by `'band'` and `'point'` scales.
    */
   data?: V[];
   /**
@@ -217,7 +217,7 @@ export type AxisDefaultized<S extends ScaleName = ScaleName, V = any> = Omit<
 > &
   AxisScaleConfig[S] & {
     /**
-     * An indication of the number of ticks expected.
+     * An indication of the expected number of ticks.
      */
     tickNumber: number;
   };

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -180,12 +180,26 @@ interface AxisScaleConfig {
 }
 
 export type AxisConfig<S extends ScaleName = ScaleName, V = any> = {
+  /**
+   * Id used to identify axis in different parts of the charts.
+   */
   id: string;
+  /**
+   * The minimal value of the domain.
+   * If not provided, it get computed to display the entire chart data.
+   */
   min?: number | Date;
+  /**
+   * The maximal value of the domain.
+   * If not provided, it get computed to display the entire chart data.
+   */
   max?: number | Date;
+  /**
+   * The data used by 'band' and 'point' scales.
+   */
   data?: V[];
   /**
-   * The key used to retrieve data from the dataset prop.
+   * The key used to retrieve `data` from the `dataset` prop.
    */
   dataKey?: string;
   valueFormatter?: (value: V) => string;
@@ -202,6 +216,9 @@ export type AxisDefaultized<S extends ScaleName = ScaleName, V = any> = Omit<
   'scaleType'
 > &
   AxisScaleConfig[S] & {
+    /**
+     * An indication of the number of ticks expected.
+     */
     tickNumber: number;
   };
 

--- a/packages/x-charts/src/models/layout.ts
+++ b/packages/x-charts/src/models/layout.ts
@@ -8,5 +8,11 @@ export interface CardinalDirections<T> {
 export type LayoutConfig = {
   width: number;
   height: number;
+  /**
+   * The margin between the SVG and the drawing area.
+   * It's used for leving space for extra information wuch as axes, or legend.
+   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
+   * @default object depends on the charts type.
+   */
   margin?: Partial<CardinalDirections<number>>;
 };

--- a/packages/x-charts/src/models/layout.ts
+++ b/packages/x-charts/src/models/layout.ts
@@ -10,9 +10,9 @@ export type LayoutConfig = {
   height: number;
   /**
    * The margin between the SVG and the drawing area.
-   * It's used for leving space for extra information wuch as axes, or legend.
-   * Accept and object with some of the next properties: `top`, `bottom`, `left`, and `right`.
-   * @default object depends on the charts type.
+   * It's used for leaving some space for extra information such as the x- and y-axis or legend.
+   * Accepts an object with the optional properties: `top`, `bottom`, `left`, and `right`.
+   * @default object Depends on the charts type.
    */
   margin?: Partial<CardinalDirections<number>>;
 };

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -16,13 +16,29 @@ export type CommonSeriesType<TValue> = {
 export type CommonDefaultizedProps = 'id' | 'valueFormatter' | 'data';
 
 export type CartesianSeriesType = {
+  /**
+   * The id of the x axis used to render the series.
+   */
   xAxisKey?: string;
+  /**
+   * The id of the y axis used to render the series.
+   */
   yAxisKey?: string;
 };
 
 export type StackableSeriesType = {
+  /**
+   * The key that identify the stacking group.
+   * Series with the same `stack` property will be stacked together.
+   */
   stack?: string;
+  /**
+   * Defines hos staked series handle negative values.
+   */
   stackOffset?: StackOffsetType;
+  /**
+   * The order in which series of the  same staking group are staked together.
+   */
   stackOrder?: StackOrderType;
 };
 

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -17,27 +17,27 @@ export type CommonDefaultizedProps = 'id' | 'valueFormatter' | 'data';
 
 export type CartesianSeriesType = {
   /**
-   * The id of the x axis used to render the series.
+   * The id of the x-axis used to render the series.
    */
   xAxisKey?: string;
   /**
-   * The id of the y axis used to render the series.
+   * The id of the y-axis used to render the series.
    */
   yAxisKey?: string;
 };
 
 export type StackableSeriesType = {
   /**
-   * The key that identify the stacking group.
+   * The key that identifies the stacking group.
    * Series with the same `stack` property will be stacked together.
    */
   stack?: string;
   /**
-   * Defines hos staked series handle negative values.
+   * Defines how stacked series handle negative values.
    */
   stackOffset?: StackOffsetType;
   /**
-   * The order in which series of the  same staking group are staked together.
+   * The order in which series' of the same group are stacked together.
    */
   stackOrder?: StackOrderType;
 };

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -112,7 +112,7 @@
   { "name": "PieSeriesType", "kind": "Interface" },
   { "name": "PieValueType", "kind": "TypeAlias" },
   { "name": "ResponsiveChartContainer", "kind": "Variable" },
-  { "name": "ResponsiveChartContainerProps", "kind": "TypeAlias" },
+  { "name": "ResponsiveChartContainerProps", "kind": "Interface" },
   { "name": "ScaleName", "kind": "TypeAlias" },
   { "name": "Scatter", "kind": "Function" },
   { "name": "ScatterChart", "kind": "Variable" },


### PR DESCRIPTION
The chart's API pages were somewhat empty. It's just because most of the props don't have JSDocs 🫣

I'm adding some of them. I've splited the PR by commit with JSdocs, and commits with scripts