### PR TITLE
[core] Fixed wrong package names in migration docs

### DIFF
--- a/docs/data/migration/migration-charts-v6/migration-charts-v6.md
+++ b/docs/data/migration/migration-charts-v6/migration-charts-v6.md
@@ -12,7 +12,7 @@ TBD
 
 ## Start using the new release
 
-In `package.json`, change the version of the date pickers package to `next`.
+In `package.json`, change the version of the charts package to `next`.
 
 ```diff
 -"@mui/x-charts": "6.x.x",

--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -14,7 +14,7 @@ TBD
 
 ## Start using the alpha release
 
-In `package.json`, change the version of the date pickers package to `next`.
+In `package.json`, change the version of the tree view package to `next`.
 
 ```diff
 -"@mui/x-tree-view": "6.x.x",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

I did put in some wrong package names in the migration docs for charts and tree view.
This replaces them with the correct names