### PR TITLE
[pickers] Modify `adapter.isValid` method to accept `TDate | null` instead of `any`

### DIFF
--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -63,3 +63,61 @@ For example:
 
 The same applies to `slotProps` and `componentsProps`.
 :::
+
+### Adapters
+
+:::success
+The following breaking changes only impact you if you are using the adapters outside the pickers like displayed in the following example:
+
+```tsx
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+
+const adapter = new AdapterDays();
+adapter.isValid(dayjs('2022-04-17T15:30'));
+```
+
+If you are just passing an adapter to `LocalizationProvider`, then you can safely skip this section.
+:::
+
+#### Restrict the input format of the `isValid` method
+
+The `isValid` method used to accept any type of value and tried to parse them before checking their validity.
+The method has been simplified and now only accepts an already-parsed date or `null` (ie: the same formats used by the `value` prop in our components)
+
+```diff
+const adapterDayjs = new AdapterDayjs();
+const adapterLuxon = new AdapterLuxon();
+const adapterDateFns = new AdapterDateFns();
+const adapterMoment = new AdatperMoment();
+
+// Supported formats
+const isValid = adapterDayjs.isValid(null); // Same for the other adapters
+const isValid = adapterLuxon.isValid(DateTime.now());
+const isValid = adapterMoment.isValid(moment());
+const isValid = adapterDateFns.isValid(new Date());
+
+// Non-supported formats (JS Date)
+- const isValid = adapterDayjs.isValid(new Date('2022-04-17'));
++ const isValid = adapterDayjs.isValid(dayjs('2022-04-17'));
+
+- const isValid = adapterLuxon.isValid(new Date('2022-04-17'));
++ const isValid = adapterLuxon.isValid(DateTime.fromISO('2022-04-17'));
+
+- const isValid = adapterMoment.isValid(new Date('2022-04-17'));
++ const isValid = adapterMoment.isValid(moment('2022-04-17'));
+
+// Non-supported formats (string)
+- const isValid = adapterDayjs.isValid('2022-04-17');
++ const isValid = adapterDayjs.isValid(dayjs('2022-04-17'));
+
+- const isValid = adapterLuxon.isValid('2022-04-17');
++ const isValid = adapterLuxon.isValid(DateTime.fromISO('2022-04-17'));
+
+- const isValid = adapterMoment.isValid('2022-04-17');
++ const isValid = adapterMoment.isValid(moment('2022-04-17'));
+
+- const isValid = adapterDateFns.isValid('2022-04-17');
++ const isValid = adapterDateFns.isValid(new Date('2022-04-17'));
+
+
+```

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -107,7 +107,8 @@ If you are just passing an adapter to `LocalizationProvider`, then you can safel
 ### Restrict the input format of the `isValid` method
 
 The `isValid` method used to accept any type of value and tried to parse them before checking their validity.
-The method has been simplified and now only accepts an already-parsed date or `null` (ie: the same formats used by the `value` prop in our components)
+The method has been simplified and now only accepts an already-parsed date or `null`.
+Which is the same type as the one accepted by the components `value` prop.
 
 ```diff
  const adapterDayjs = new AdapterDayjs();

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -85,18 +85,18 @@ The `isValid` method used to accept any type of value and tried to parse them be
 The method has been simplified and now only accepts an already-parsed date or `null` (ie: the same formats used by the `value` prop in our components)
 
 ```diff
-const adapterDayjs = new AdapterDayjs();
-const adapterLuxon = new AdapterLuxon();
-const adapterDateFns = new AdapterDateFns();
-const adapterMoment = new AdatperMoment();
+ const adapterDayjs = new AdapterDayjs();
+ const adapterLuxon = new AdapterLuxon();
+ const adapterDateFns = new AdapterDateFns();
+ const adapterMoment = new AdatperMoment();
 
-// Supported formats
-const isValid = adapterDayjs.isValid(null); // Same for the other adapters
-const isValid = adapterLuxon.isValid(DateTime.now());
-const isValid = adapterMoment.isValid(moment());
-const isValid = adapterDateFns.isValid(new Date());
+ // Supported formats
+ const isValid = adapterDayjs.isValid(null); // Same for the other adapters
+ const isValid = adapterLuxon.isValid(DateTime.now());
+ const isValid = adapterMoment.isValid(moment());
+ const isValid = adapterDateFns.isValid(new Date());
 
-// Non-supported formats (JS Date)
+ // Non-supported formats (JS Date)
 - const isValid = adapterDayjs.isValid(new Date('2022-04-17'));
 + const isValid = adapterDayjs.isValid(dayjs('2022-04-17'));
 
@@ -106,7 +106,7 @@ const isValid = adapterDateFns.isValid(new Date());
 - const isValid = adapterMoment.isValid(new Date('2022-04-17'));
 + const isValid = adapterMoment.isValid(moment('2022-04-17'));
 
-// Non-supported formats (string)
+ // Non-supported formats (string)
 - const isValid = adapterDayjs.isValid('2022-04-17');
 + const isValid = adapterDayjs.isValid(dayjs('2022-04-17'));
 

--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
@@ -300,8 +300,12 @@ export class AdapterDateFns implements MuiPickersAdapter<Date, DateFnsLocale> {
     return value === null;
   };
 
-  public isValid = (value: any) => {
-    return isValid(this.date(value));
+  public isValid = (value: Date | null) => {
+    if (value == null) {
+      return false;
+    }
+
+    return isValid(value);
   };
 
   public format = (value: Date, formatKey: keyof AdapterFormats) => {

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
@@ -312,8 +312,12 @@ export class AdapterDateFnsJalali implements MuiPickersAdapter<Date, DateFnsLoca
     return value === null;
   };
 
-  public isValid = (value: any) => {
-    return isValid(this.date(value));
+  public isValid = (value: Date | null) => {
+    if (value == null) {
+      return false;
+    }
+
+    return isValid(value);
   };
 
   public format = (value: Date, formatKey: keyof AdapterFormats) => {

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -435,8 +435,12 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
     return value === null;
   };
 
-  public isValid = (value: any) => {
-    return this.dayjs(value).isValid();
+  public isValid = (value: Dayjs | null) => {
+    if (value == null) {
+      return false;
+    }
+
+    return value.isValid();
   };
 
   public format = (value: Dayjs, formatKey: keyof AdapterFormats) => {

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
@@ -265,16 +265,12 @@ export class AdapterLuxon implements MuiPickersAdapter<DateTime, string> {
     return value === null;
   };
 
-  public isValid = (value: any): boolean => {
-    if (DateTime.isDateTime(value)) {
-      return value.isValid;
-    }
-
+  public isValid = (value: DateTime | null): boolean => {
     if (value === null) {
       return false;
     }
 
-    return this.isValid(this.date(value));
+    return value.isValid;
   };
 
   public format = (value: DateTime, formatKey: keyof AdapterFormats) => {

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -345,8 +345,12 @@ export class AdapterMoment implements MuiPickersAdapter<Moment, string> {
     return value === null;
   };
 
-  public isValid = (value: any) => {
-    return this.moment(value).isValid();
+  public isValid = (value: Moment | null) => {
+    if (value == null) {
+      return false;
+    }
+
+    return value.isValid();
   };
 
   public format = (value: Moment, formatKey: keyof AdapterFormats) => {

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
@@ -179,15 +179,6 @@ export class AdapterMomentJalaali
       .toLocaleLowerCase();
   };
 
-  public isValid = (value: any) => {
-    // We can't to `this.moment(value)` because moment-jalaali looses the invalidity information when creating a new moment object from an existing one
-    if (!this.moment.isMoment(value)) {
-      return false;
-    }
-
-    return value.isValid();
-  };
-
   public formatNumber = (numberToFormat: string) => {
     return numberToFormat
       .replace(/\d/g, (match) => NUMBER_SYMBOL_MAP[match as keyof typeof NUMBER_SYMBOL_MAP])

--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -320,13 +320,12 @@ export interface MuiPickersAdapter<TDate, TLocale = any> {
    * @returns {boolean} `true` if the date is null.
    */
   isNull(value: TDate | null): boolean;
-  // TODO v7: Type `value` to be `TDate | null` and make sure the `isValid(null)` returns `false`.
   /**
    * Check if the date is valid.
-   * @param {any} value The value to test.
-   * @returns {boolean} `true` if the value is valid.
+   * @param {TDate | null} value The value to test.
+   * @returns {boolean} `true` if the value is a valid date according to the date library.
    */
-  isValid(value: any): boolean;
+  isValid(value: TDate | null): boolean;
   /**
    * Format a date using an adapter format string (see the `AdapterFormats` interface)
    * @template TDate

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -255,9 +255,7 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
     expect(adapter.isValid(testDateIso)).to.equal(true);
     expect(adapter.isValid(testDateLocale)).to.equal(true);
     expect(adapter.isValid(invalidDate)).to.equal(false);
-    expect(adapter.isValid(undefined)).to.equal(true);
     expect(adapter.isValid(null)).to.equal(false);
-    expect(adapter.isValid('2018-42-30T11:60:00.000Z')).to.equal(false);
   });
 
   describe('Method: getDiff', () => {


### PR DESCRIPTION
Fixes #10970


### Changelog

#### Breaking changes

-  The `adapter.isValid` method used to accept any type of value and tried to parse them before checking their validity.
    The method has been simplified and now only accepts an already-parsed date or `null`.
    Which is the same type as the one accepted by the components `value` prop.
    
    ```diff
     const adapterDayjs = new AdapterDayjs();
     const adapterLuxon = new AdapterLuxon();
     const adapterDateFns = new AdapterDateFns();
     const adapterMoment = new AdatperMoment();
    
     // Supported formats
     const isValid = adapterDayjs.isValid(null); // Same for the other adapters
     const isValid = adapterLuxon.isValid(DateTime.now());
     const isValid = adapterMoment.isValid(moment());
     const isValid = adapterDateFns.isValid(new Date());
    
     // Non-supported formats (JS Date)
    - const isValid = adapterDayjs.isValid(new Date('2022-04-17'));
    + const isValid = adapterDayjs.isValid(dayjs('2022-04-17'));
    
    - const isValid = adapterLuxon.isValid(new Date('2022-04-17'));
    + const isValid = adapterLuxon.isValid(DateTime.fromISO('2022-04-17'));
    
    - const isValid = adapterMoment.isValid(new Date('2022-04-17'));
    + const isValid = adapterMoment.isValid(moment('2022-04-17'));
    
     // Non-supported formats (string)
    - const isValid = adapterDayjs.isValid('2022-04-17');
    + const isValid = adapterDayjs.isValid(dayjs('2022-04-17'));
    
    - const isValid = adapterLuxon.isValid('2022-04-17');
    + const isValid = adapterLuxon.isValid(DateTime.fromISO('2022-04-17'));
    
    - const isValid = adapterMoment.isValid('2022-04-17');
    + const isValid = adapterMoment.isValid(moment('2022-04-17'));
    
    - const isValid = adapterDateFns.isValid('2022-04-17');
    + const isValid = adapterDateFns.isValid(new Date('2022-04-17'));
    ```