### PR TITLE
[pickers] Modify `adapter.isEqual` method to accept `TDate | null` instead of any

### DIFF
--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -63,3 +63,48 @@ For example:
 
 The same applies to `slotProps` and `componentsProps`.
 :::
+
+### Adapters
+
+#### Restrict the input format of the `isEqual` method
+
+The `isEqual` method used to accept any type of value for its two input and tried to parse them before checking if they were equal.
+The method has been simplified and now only accepts an already-parsed date or `null` (ie: the same formats used by the `value` prop in the pickers)
+
+```diff
+ const adapterDayjs = new AdapterDayjs();
+ const adapterLuxon = new AdapterLuxon();
+ const adapterDateFns = new AdapterDateFns();
+ const adapterMoment = new AdatperMoment();
+
+ // Supported formats
+ const isValid = adapterDayjs.isEqual(null, null); // Same for the other adapters
+ const isValid = adapterLuxon.isEqual(DateTime.now(), DateTime.fromISO('2022-04-17'));
+ const isValid = adapterMoment.isEqual(moment(), moment('2022-04-17'));
+ const isValid = adapterDateFns.isEqual(new Date(), new Date('2022-04-17'));
+
+ // Non-supported formats (JS Date)
+- const isValid = adapterDayjs.isEqual(new Date(), new Date('2022-04-17'));
++ const isValid = adapterDayjs.isEqual(dayjs(), dayjs('2022-04-17'));
+
+- const isValid = adapterLuxon.isEqual(new Date(), new Date('2022-04-17'));
++ const isValid = adapterLuxon.isEqual(DateTime.now(), DateTime.fromISO('2022-04-17'));
+
+- const isValid = adapterMoment.isEqual(new Date(), new Date('2022-04-17'));
++ const isValid = adapterMoment.isEqual(moment(), moment('2022-04-17'));
+
+ // Non-supported formats (string)
+- const isValid = adapterDayjs.isEqual('2022-04-16', '2022-04-17');
++ const isValid = adapterDayjs.isEqual(dayjs('2022-04-17'), dayjs('2022-04-17'));
+
+- const isValid = adapterLuxon.isEqual('2022-04-16', '2022-04-17');
++ const isValid = adapterLuxon.isEqual(DateTime.fromISO('2022-04-17'), DateTime.fromISO('2022-04-17'));
+
+- const isValid = adapterMoment.isEqual('2022-04-16', '2022-04-17');
++ const isValid = adapterMoment.isEqual(moment('2022-04-17'), moment('2022-04-17'));
+
+- const isValid = adapterDateFns.isEqual('2022-04-16', '2022-04-17');
++ const isValid = adapterDateFns.isEqual(new Date('2022-04-17'), new Date('2022-04-17'));
+
+
+```

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -209,7 +209,11 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
     ...other
   } = props;
 
-  const { value, handleValueChange, timezone } = useControlledValueWithTimezone({
+  const { value, handleValueChange, timezone } = useControlledValueWithTimezone<
+    TDate,
+    DateRange<TDate>,
+    NonNullable<typeof onChange>
+  >({
     name: 'DateRangeCalendar',
     timezone: timezoneProp,
     value: valueProp,

--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
@@ -340,9 +340,13 @@ export class AdapterDateFns implements MuiPickersAdapter<Date, DateFnsLocale> {
     }
   };
 
-  public isEqual = (value: any, comparing: any) => {
+  public isEqual = (value: Date | null, comparing: Date | null) => {
     if (value === null && comparing === null) {
       return true;
+    }
+
+    if (value === null || comparing === null) {
+      return false;
     }
 
     return isEqual(value, comparing);

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
@@ -354,9 +354,13 @@ export class AdapterDateFnsJalali implements MuiPickersAdapter<Date, DateFnsLoca
     }
   };
 
-  public isEqual = (value: any, comparing: any) => {
+  public isEqual = (value: Date | null, comparing: Date | null) => {
     if (value === null && comparing === null) {
       return true;
+    }
+
+    if (value === null || comparing === null) {
+      return false;
     }
 
     return isEqual(value, comparing);

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -455,12 +455,16 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
     return value.diff(comparing, unit as AdapterUnits);
   };
 
-  public isEqual = (value: any, comparing: any) => {
+  public isEqual = (value: Dayjs | null, comparing: Dayjs | null) => {
     if (value === null && comparing === null) {
       return true;
     }
 
-    return this.dayjs(value).toDate().getTime() === this.dayjs(comparing).toDate().getTime();
+    if (value === null || comparing === null) {
+      return false;
+    }
+
+    return value.toDate().getTime() === comparing.toDate().getTime();
   };
 
   public isSameYear = (value: Dayjs, comparing: Dayjs) => {

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
@@ -301,17 +301,16 @@ export class AdapterLuxon implements MuiPickersAdapter<DateTime, string> {
     return value.diff(comparing).as('millisecond');
   };
 
-  public isEqual = (value: any, comparing: any) => {
+  public isEqual = (value: DateTime | null, comparing: DateTime | null) => {
     if (value === null && comparing === null) {
       return true;
     }
 
-    // Make sure that null will not be passed to this.date
     if (value === null || comparing === null) {
       return false;
     }
 
-    return +this.date(value)! === +this.date(comparing)!;
+    return +value === +comparing;
   };
 
   public isSameYear = (value: DateTime, comparing: DateTime) => {

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -367,12 +367,16 @@ export class AdapterMoment implements MuiPickersAdapter<Moment, string> {
     return value.diff(comparing, unit);
   };
 
-  public isEqual = (value: any, comparing: any) => {
+  public isEqual = (value: Moment | null, comparing: Moment | null) => {
     if (value === null && comparing === null) {
       return true;
     }
 
-    return this.moment(value).isSame(comparing);
+    if (value === null || comparing === null) {
+      return false;
+    }
+
+    return value.isSame(comparing);
   };
 
   public isSameYear = (value: Moment, comparing: Moment) => {

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
@@ -179,14 +179,6 @@ export class AdapterMomentHijri extends AdapterMoment implements MuiPickersAdapt
       .replace(/,/g, '،');
   };
 
-  public isEqual = (value: any, comparing: any) => {
-    if (value === null && comparing === null) {
-      return true;
-    }
-
-    return this.moment(value).isSame(comparing);
-  };
-
   public startOfYear = (value: Moment) => {
     return value.clone().startOf('iYear');
   };

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
@@ -194,14 +194,6 @@ export class AdapterMomentJalaali
       .replace(/,/g, '،');
   };
 
-  public isEqual = (value: any, comparing: any) => {
-    if (value === null && comparing === null) {
-      return true;
-    }
-
-    return this.moment(value).isSame(comparing);
-  };
-
   public isSameYear = (value: Moment, comparing: Moment) => {
     // `isSame` seems to mutate the date on `moment-jalaali`
     // @ts-ignore

--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -360,7 +360,6 @@ export interface MuiPickersAdapter<TDate, TLocale = any> {
    * @returns {number} The diff between the two dates.
    */
   getDiff(value: TDate, comparing: TDate | string, unit?: AdapterUnits): number;
-  // TODO v7: Type `value` and `comparing` to be `TDate | null`.
   /**
    * Check if the two dates are equal (e.g: they represent the same timestamp).
    * @param {any} value The reference date.


### PR DESCRIPTION
Fixes #10974