### PR TITLE
[pickers] Change the input format of `adapter.getYearRange` to be consistent with `adapter.isWithinRange`

### DIFF
--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -63,3 +63,14 @@ For example:
 
 The same applies to `slotProps` and `componentsProps`.
 :::
+
+### Adapters
+
+#### Change the input format of the `getYearRange` method
+
+The `getYearRange` method used to accept two params and now accepts a tuple to be consistent with the `isWithinRange` method:
+
+```diff
+- adapter.getYearRange(start, end);
++ adapter.getYearRange([start, end])
+```

--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
@@ -574,7 +574,7 @@ export class AdapterDateFns implements MuiPickersAdapter<Date, DateFnsLocale> {
     return getWeek(value, { locale: this.locale });
   };
 
-  public getYearRange = (start: Date, end: Date) => {
+  public getYearRange = ([start, end]: [Date, Date]) => {
     const startDate = startOfYear(start);
     const endDate = endOfYear(end);
     const years: Date[] = [];

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
@@ -588,7 +588,7 @@ export class AdapterDateFnsJalali implements MuiPickersAdapter<Date, DateFnsLoca
     return getWeek(date, { locale: this.locale });
   };
 
-  public getYearRange = (start: Date, end: Date) => {
+  public getYearRange = ([start, end]: [Date, Date]) => {
     const startDate = startOfYear(start);
     const endDate = endOfYear(end);
     const years: Date[] = [];

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -714,7 +714,7 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
     return value.week();
   };
 
-  public getYearRange = (start: Dayjs, end: Dayjs) => {
+  public getYearRange = ([start, end]: [Dayjs, Dayjs]) => {
     const startDate = start.startOf('year');
     const endDate = end.endOf('year');
     const years: Dayjs[] = [];

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
@@ -556,7 +556,7 @@ export class AdapterLuxon implements MuiPickersAdapter<DateTime, string> {
     return value.weekNumber;
   };
 
-  public getYearRange = (start: DateTime, end: DateTime) => {
+  public getYearRange = ([start, end]: [DateTime, DateTime]) => {
     const startDate = start.startOf('year');
     const endDate = end.endOf('year');
 

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -608,7 +608,7 @@ export class AdapterMoment implements MuiPickersAdapter<Moment, string> {
     return value.week();
   };
 
-  public getYearRange = (start: Moment, end: Moment) => {
+  public getYearRange = ([start, end]: [Moment, Moment]) => {
     const startDate = this.moment(start).startOf('year');
     const endDate = this.moment(end).endOf('year');
     const years: Moment[] = [];

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
@@ -278,7 +278,7 @@ export class AdapterMomentHijri extends AdapterMoment implements MuiPickersAdapt
     return value.iWeek();
   };
 
-  public getYearRange = (start: Moment, end: Moment) => {
+  public getYearRange = ([start, end]: [Moment, Moment]) => {
     // moment-hijri only supports dates between 1356-01-01 H and 1499-12-29 H
     // We need to throw if outside min/max bounds, otherwise the while loop below will be infinite.
     if (start.isBefore('1937-03-14')) {

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
@@ -312,7 +312,7 @@ export class AdapterMomentJalaali
     return value.jWeek();
   };
 
-  public getYearRange = (start: Moment, end: Moment) => {
+  public getYearRange = ([start, end]: [Moment, Moment]) => {
     const startDate = this.moment(start).startOf('jYear');
     const endDate = this.moment(end).endOf('jYear');
     const years: Moment[] = [];

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -291,7 +291,7 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate>(
       aria-labelledby={gridLabelId}
       {...other}
     >
-      {utils.getYearRange(minDate, maxDate).map((year) => {
+      {utils.getYearRange([minDate, maxDate]).map((year) => {
         const yearNumber = utils.getYear(year);
         const isSelected = yearNumber === selectedYear;
         const isDisabled = disabled || isYearDisabled(year);

--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -453,7 +453,7 @@ export interface MuiPickersAdapter<TDate, TLocale = any> {
    */
   isBeforeDay(value: TDate, comparing: TDate): boolean;
   /**
-   * Check if the value is withing the provided range.
+   * Check if the value is within the provided range.
    * @template TDate
    * @param {TDate} value The value to test.
    * @param {[TDate, TDate]} range The range in which the value should be.
@@ -739,15 +739,13 @@ export interface MuiPickersAdapter<TDate, TLocale = any> {
    * @returns {number} The number of the week of the given date.
    */
   getWeekNumber(value: TDate): number;
-  // TODO v7: Replace with a single range param `[TDate, TDate]`, to be coherent with `isWithingRange`.
   /**
-   * Create a list with all the years between the start end the end date.
+   * Create a list with all the years between the start and the end date.
    * @template TDate
-   * @param {TDate} start The start of the range.
-   * @param {TDate} end The end of the range.
+   * @param {[TDate, TDate]} range The range of year to create.
    * @returns {TDate[]} List of all the years between the start end the end date.
    */
-  getYearRange(start: TDate, end: TDate): TDate[];
+  getYearRange(range: [TDate, TDate]): TDate[];
   /**
    * Allow to customize how the "am"` and "pm" strings are rendered.
    * @deprecated Use `utils.format(utils.setHours(utils.date()!, meridiem === 'am' ? 2 : 14), 'meridiem')` instead.

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -1012,15 +1012,15 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
   });
 
   it('Method: getYearRange', () => {
-    const yearRange = adapter.getYearRange(testDateIso, adapter.setYear(testDateIso, 2124));
+    const yearRange = adapter.getYearRange([testDateIso, adapter.setYear(testDateIso, 2124)]);
 
     expect(yearRange).to.have.length(107);
     expect(adapter.getYear(yearRange[yearRange.length - 1])).to.equal(2124);
 
-    const emptyYearRange = adapter.getYearRange(
+    const emptyYearRange = adapter.getYearRange([
       testDateIso,
       adapter.setYear(testDateIso, adapter.getYear(testDateIso) - 1),
-    );
+    ]);
 
     expect(emptyYearRange).to.have.length(0);
   });

--- a/test/utils/pickers/describeHijriAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeHijriAdapter/testCalculations.ts
@@ -192,7 +192,7 @@ export const testCalculations: DescribeHijriAdapterTestSuite = ({ adapter }) => 
     it('Minimum limit', () => {
       const anotherYear = adapter.setYear(testDateIso, 1355);
 
-      expect(() => adapter.getYearRange(anotherYear, testDateIso)).to.throw(
+      expect(() => adapter.getYearRange([anotherYear, testDateIso])).to.throw(
         'min date must be on or after 1356-01-01 H (1937-03-14)',
       );
     });
@@ -200,7 +200,7 @@ export const testCalculations: DescribeHijriAdapterTestSuite = ({ adapter }) => 
     it('Maximum limit', () => {
       const anotherYear = adapter.setYear(testDateIso, 1500);
 
-      expect(() => adapter.getYearRange(testDateIso, anotherYear)).to.throw(
+      expect(() => adapter.getYearRange([testDateIso, anotherYear])).to.throw(
         'max date must be on or before 1499-12-29 H (2076-11-26)',
       );
     });
@@ -208,7 +208,7 @@ export const testCalculations: DescribeHijriAdapterTestSuite = ({ adapter }) => 
 
   it('Method: getYearRange', () => {
     const anotherDate = adapter.setYear(testDateIso, 1445);
-    const yearRange = adapter.getYearRange(testDateIso, anotherDate);
+    const yearRange = adapter.getYearRange([testDateIso, anotherDate]);
     expect(yearRange).to.have.length(6);
   });
 };

--- a/test/utils/pickers/describeJalaliAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeJalaliAdapter/testCalculations.ts
@@ -366,7 +366,7 @@ export const testCalculations: DescribeJalaliAdapterTestSuite = ({ adapter }) =>
 
   it('Method: getYearRange', () => {
     const anotherDate = adapter.setYear(testDateIso, 1400);
-    const yearRange = adapter.getYearRange(testDateIso, anotherDate);
+    const yearRange = adapter.getYearRange([testDateIso, anotherDate]);
     expect(yearRange).to.have.length(4);
   });
 };


### PR DESCRIPTION
Closes #10977


### Changelog

#### Breaking changes

- The `adapter.getYearRange` method used to accept two params and now accepts a tuple to be consistent with the `adapter.isWithinRange` method:

  ```diff
  - adapter.getYearRange(start, end);
  + adapter.getYearRange([start, end])
  ```