### PR TITLE
[pickers] fix: to centering buttons text align for year-month picker when using some reset css

### DIFF
--- a/packages/x-date-pickers/src/MonthCalendar/PickersMonth.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/PickersMonth.tsx
@@ -74,6 +74,7 @@ const PickersMonthButton = styled('button', {
   height: 36,
   width: 72,
   borderRadius: 18,
+  textAlign: 'center',
   cursor: 'pointer',
   '&:focus': {
     backgroundColor: theme.vars

--- a/packages/x-date-pickers/src/YearCalendar/PickersYear.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/PickersYear.tsx
@@ -68,6 +68,7 @@ const PickersYearButton = styled('button', {
   height: 36,
   width: 72,
   borderRadius: 18,
+  textAlign: 'center',
   cursor: 'pointer',
   '&:focus': {
     backgroundColor: theme.vars


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Why 

When I was using x-date-pickers with the reset CSS library destyle.css, I realized that the alignment of the text inside the buttons used in the year and month picker components was unintentionally affected.

Reproduced repository: https://github.com/Akagire/mui-x-date-pickers-yearmonth-cal-shifting

### What I did

To ensure the appearance is independent of the browser's default styles, I've applied text align to center those buttons.