### PR TITLE
[DateCalendar] Allow to override the format of the header with a prop

### DIFF
--- a/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.js
+++ b/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { DateRangeCalendar } from '@mui/x-date-pickers-pro/DateRangeCalendar';
+
+export default function CustomCalendarHeaderFormat() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={['DateCalendar', 'DateRangeCalendar']}>
+        <DateCalendar
+          defaultValue={dayjs('2022-04-17')}
+          slotProps={{ calendarHeader: { format: 'MM/YYYY' } }}
+        />
+        <DateRangeCalendar
+          defaultValue={[dayjs('2022-04-17'), dayjs('2022-04-21')]}
+          calendars={2}
+          slotProps={{ calendarHeader: { format: 'MM/YYYY' } }}
+        />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.tsx
+++ b/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { DateRangeCalendar } from '@mui/x-date-pickers-pro/DateRangeCalendar';
+
+export default function CustomCalendarHeaderFormat() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={['DateCalendar', 'DateRangeCalendar']}>
+        <DateCalendar
+          defaultValue={dayjs('2022-04-17')}
+          slotProps={{ calendarHeader: { format: 'MM/YYYY' } }}
+        />
+        <DateRangeCalendar
+          defaultValue={[dayjs('2022-04-17'), dayjs('2022-04-21')]}
+          calendars={2}
+          slotProps={{ calendarHeader: { format: 'MM/YYYY' } }}
+        />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.tsx.preview
+++ b/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.tsx.preview
@@ -1,9 +1,9 @@
 <DateCalendar
-    defaultValue={dayjs('2022-04-17')}
-    slotProps={{ calendarHeader: { format: 'MM/YYYY' }}}
+  defaultValue={dayjs('2022-04-17')}
+  slotProps={{ calendarHeader: { format: 'MM/YYYY' } }}
 />
 <DateRangeCalendar
-    defaultValue={[dayjs('2022-04-17'), dayjs('2022-04-21')]}
-    calendars={2}
-    slotProps={{ calendarHeader: { format: 'MM/YYYY' }}}
+  defaultValue={[dayjs('2022-04-17'), dayjs('2022-04-21')]}
+  calendars={2}
+  slotProps={{ calendarHeader: { format: 'MM/YYYY' } }}
 />

--- a/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.tsx.preview
+++ b/docs/data/date-pickers/adapters-locale/CustomCalendarHeaderFormat.tsx.preview
@@ -1,0 +1,9 @@
+<DateCalendar
+    defaultValue={dayjs('2022-04-17')}
+    slotProps={{ calendarHeader: { format: 'MM/YYYY' }}}
+/>
+<DateRangeCalendar
+    defaultValue={[dayjs('2022-04-17'), dayjs('2022-04-21')]}
+    calendars={2}
+    slotProps={{ calendarHeader: { format: 'MM/YYYY' }}}
+/>

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -219,7 +219,7 @@ Some locales might keep using English placeholders, because that format is commo
 
 ### Custom toolbar format
 
-To customize the format used in the toolbar, use the `toolbarFormat` prop of the toolbar slot.
+To customize the format used in the toolbar, use the `toolbarFormat` prop of the `toolbar` slot.
 
 :::info
 This prop is available on all pickers.
@@ -244,3 +244,13 @@ This prop is available on all components that render a day calendar, including t
 The example below adds a dot at the end of each day in the calendar header:
 
 {{"demo": "CustomDayOfWeekFormat.js"}}
+
+### Custom calendar header format
+
+To customize the format used on the calendar header, use the `format` prop of the `calendarHeader` slot.
+
+:::info
+This prop is available on all pickers with date edition.
+:::
+
+{{"demo": "CustomCalendarHeaderFormat.js"}}

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -250,7 +250,7 @@ The example below adds a dot at the end of each day in the calendar header:
 To customize the format used on the calendar header, use the `format` prop of the `calendarHeader` slot.
 
 :::info
-This prop is available on all pickers with date edition.
+This prop is available on all components that render a day calendar, including the Date Calendar as well as all Date Pickers, Date Time Pickers, and Date Range Pickers.
 :::
 
 {{"demo": "CustomCalendarHeaderFormat.js"}}

--- a/docs/pages/x/api/date-pickers/date-range-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.json
@@ -99,6 +99,12 @@
   "slots": [
     {
       "class": null,
+      "name": "calendarHeader",
+      "description": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
+      "default": "PickersCalendarHeader"
+    },
+    {
+      "class": null,
       "name": "day",
       "description": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",
       "default": "DateRangePickersDay"

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -150,6 +150,12 @@
     },
     {
       "class": null,
+      "name": "calendarHeader",
+      "description": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
+      "default": "PickersCalendarHeader"
+    },
+    {
+      "class": null,
       "name": "clearButton",
       "description": "Button to clear the value.",
       "default": "IconButton"

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -146,6 +146,12 @@
     },
     {
       "class": null,
+      "name": "calendarHeader",
+      "description": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
+      "default": "PickersCalendarHeader"
+    },
+    {
+      "class": null,
       "name": "clearButton",
       "description": "Button to clear the value.",
       "default": "IconButton"

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -146,6 +146,12 @@
     },
     {
       "class": null,
+      "name": "calendarHeader",
+      "description": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
+      "default": "PickersCalendarHeader"
+    },
+    {
+      "class": null,
       "name": "clearButton",
       "description": "Button to clear the value.",
       "default": "IconButton"

--- a/docs/pages/x/api/date-pickers/pickers-calendar-header.json
+++ b/docs/pages/x/api/date-pickers/pickers-calendar-header.json
@@ -2,6 +2,10 @@
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "className": { "type": { "name": "string" } },
+    "format": {
+      "type": { "name": "string" },
+      "default": "`${adapter.formats.month} ${adapter.formats.year}`"
+    },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -127,6 +127,12 @@
     },
     {
       "class": null,
+      "name": "calendarHeader",
+      "description": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
+      "default": "PickersCalendarHeader"
+    },
+    {
+      "class": null,
       "name": "day",
       "description": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",
       "default": "DateRangePickersDay"

--- a/docs/translations/api-docs/date-pickers/date-range-calendar.json
+++ b/docs/translations/api-docs/date-pickers/date-range-calendar.json
@@ -187,6 +187,7 @@
     "dayDragging": { "description": "Styles applied to the day calendar container when dragging" }
   },
   "slotDescriptions": {
+    "calendarHeader": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
     "day": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",
     "leftArrowIcon": "Icon displayed in the left view switch button.",
     "nextIconButton": "Button allowing to switch to the right view.",

--- a/docs/translations/api-docs/date-pickers/date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker.json
@@ -264,6 +264,7 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "actionBar": "Custom component for the action bar, it is placed below the picker views.",
+    "calendarHeader": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
     "clearButton": "Button to clear the value.",
     "clearIcon": "Icon to display inside the clear button.",
     "day": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker.json
@@ -259,6 +259,7 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "actionBar": "Custom component for the action bar, it is placed below the picker views.",
+    "calendarHeader": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
     "clearButton": "Button to clear the value.",
     "clearIcon": "Icon to display inside the clear button.",
     "day": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker.json
@@ -259,6 +259,7 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "actionBar": "Custom component for the action bar, it is placed below the picker views.",
+    "calendarHeader": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
     "clearButton": "Button to clear the value.",
     "clearIcon": "Icon to display inside the clear button.",
     "day": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",

--- a/docs/translations/api-docs/date-pickers/pickers-calendar-header.json
+++ b/docs/translations/api-docs/date-pickers/pickers-calendar-header.json
@@ -11,6 +11,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "format": {
+      "description": "Format used to display the date.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "slotProps": {
       "description": "The props used for each component slot.",
       "deprecated": "",

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker.json
@@ -214,6 +214,7 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "actionBar": "Custom component for the action bar, it is placed below the picker views.",
+    "calendarHeader": "Custom component for calendar header. Check the <a href=\"https://mui.com/x/api/date-pickers/pickers-calendar-header/\">PickersCalendarHeader</a> component.",
     "day": "Custom component for day in range pickers. Check the <a href=\"https://mui.com/x/api/date-pickers/date-range-picker-day/\">DateRangePickersDay</a> component.",
     "layout": "Custom component for wrapping the layout. It wraps the toolbar, views, action bar, and shortcuts.",
     "leftArrowIcon": "Icon displayed in the left view switch button.",

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { resolveComponentProps } from '@mui/base/utils';
+import { resolveComponentProps, useSlotProps } from '@mui/base/utils';
 import { styled, useThemeProps } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/utils';
 import { Watermark } from '@mui/x-license-pro';
-import { PickersCalendarHeader } from '@mui/x-date-pickers/PickersCalendarHeader';
+import {
+  PickersCalendarHeader,
+  PickersCalendarHeaderProps,
+} from '@mui/x-date-pickers/PickersCalendarHeader';
 import {
   applyDefaultDate,
   BaseDateValidationProps,
@@ -329,6 +332,32 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
     timezone,
   });
 
+  // When disabled, limit the view to the selected date
+  const minDateWithDisabled = (disabled && value[0]) || minDate;
+  const maxDateWithDisabled = (disabled && value[1]) || maxDate;
+
+  const CalendarHeader = slots?.calendarHeader ?? PickersCalendarHeader;
+  const calendarHeaderProps: PickersCalendarHeaderProps<TDate> = useSlotProps({
+    elementType: CalendarHeader,
+    externalSlotProps: slotProps?.calendarHeader,
+    additionalProps: {
+      views: ['day'],
+      view: 'day',
+      currentMonth: calendarState.currentMonth,
+      onMonthChange: (newMonth, direction) => handleChangeMonth({ newMonth, direction }),
+      minDate: minDateWithDisabled,
+      maxDate: maxDateWithDisabled,
+      disabled,
+      disablePast,
+      disableFuture,
+      reduceAnimations,
+      slots,
+      slotProps,
+      timezone,
+    },
+    ownerState: props,
+  });
+
   const prevValue = React.useRef<DateRange<TDate> | null>(null);
   React.useEffect(() => {
     const date = rangePosition === 'start' ? value[0] : value[1];
@@ -396,10 +425,6 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
     readOnly,
     disabled,
   };
-
-  // When disabled, limit the view to the selected date
-  const minDateWithDisabled = (disabled && value[0]) || minDate;
-  const maxDateWithDisabled = (disabled && value[1]) || maxDate;
 
   const [rangePreviewDay, setRangePreviewDay] = React.useState<TDate | null>(null);
 
@@ -530,21 +555,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
       {calendarMonths.map((month, index) => (
         <DateRangeCalendarMonthContainer key={month} className={classes.monthContainer}>
           {calendars === 1 ? (
-            <PickersCalendarHeader
-              views={['day']}
-              view={'day'}
-              currentMonth={calendarState.currentMonth}
-              onMonthChange={(newMonth, direction) => handleChangeMonth({ newMonth, direction })}
-              minDate={minDateWithDisabled}
-              maxDate={maxDateWithDisabled}
-              disabled={disabled}
-              disablePast={disablePast}
-              disableFuture={disableFuture}
-              reduceAnimations={reduceAnimations}
-              slots={slots}
-              slotProps={slotProps}
-              timezone={timezone}
-            />
+            <CalendarHeader {...calendarHeaderProps} />
           ) : (
             <DateRangeCalendarArrowSwitcher
               onGoToPrevious={selectPreviousMonth}
@@ -558,7 +569,10 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
               slots={slots}
               slotProps={slotProps}
             >
-              {utils.format(visibleMonths[month], 'monthAndYear')}
+              {utils.formatByString(
+                visibleMonths[month],
+                calendarHeaderProps.format ?? `${utils.formats.month} ${utils.formats.year}`,
+              )}
             </DateRangeCalendarArrowSwitcher>
           )}
 

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
@@ -4,6 +4,8 @@ import { SlotComponentProps } from '@mui/base/utils';
 import { Theme } from '@mui/material/styles';
 import { TimezoneProps } from '@mui/x-date-pickers/models';
 import {
+  PickersCalendarHeader,
+  PickersCalendarHeaderProps,
   PickersCalendarHeaderSlotsComponent,
   PickersCalendarHeaderSlotsComponentsProps,
 } from '@mui/x-date-pickers/PickersCalendarHeader';
@@ -31,6 +33,12 @@ export interface DateRangeCalendarSlotsComponent<TDate>
     Omit<DayCalendarSlotsComponent<TDate>, 'day'>,
     PickersCalendarHeaderSlotsComponent {
   /**
+   * Custom component for calendar header.
+   * Check the [PickersCalendarHeader](https://mui.com/x/api/date-pickers/pickers-calendar-header/) component.
+   * @default PickersCalendarHeader
+   */
+  calendarHeader?: React.ElementType<PickersCalendarHeaderProps<TDate>>;
+  /**
    * Custom component for day in range pickers.
    * Check the [DateRangePickersDay](https://mui.com/x/api/date-pickers/date-range-picker-day/) component.
    * @default DateRangePickersDay
@@ -42,6 +50,11 @@ export interface DateRangeCalendarSlotsComponentsProps<TDate>
   extends PickersArrowSwitcherSlotsComponentsProps,
     Omit<DayCalendarSlotsComponentsProps<TDate>, 'day'>,
     PickersCalendarHeaderSlotsComponentsProps<TDate> {
+  calendarHeader?: SlotComponentProps<
+    typeof PickersCalendarHeader,
+    {},
+    DateRangeCalendarProps<TDate>
+  >;
   day?: SlotComponentProps<
     typeof DateRangePickerDay,
     {},

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -4,8 +4,7 @@ import { spy } from 'sinon';
 import { fireEvent, userEvent, screen } from '@mui-internal/test-utils';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { PickersDay } from '@mui/x-date-pickers/PickersDay';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { createPickerRenderer, AdapterClassToUse, adapterToUse } from 'test/utils/pickers';
+import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -103,28 +102,12 @@ describe('<DateCalendar />', () => {
     expect(disabledDays.length).to.equal(31);
   });
 
-  it('should render header label text according to monthAndYear format', () => {
-    render(
-      <LocalizationProvider
-        dateAdapter={AdapterClassToUse}
-        dateFormats={{ monthAndYear: 'yyyy/MM' }}
-      >
-        <DateCalendar defaultValue={adapterToUse.date(new Date(2019, 0, 1))} />,
-      </LocalizationProvider>,
-    );
-
-    expect(screen.getByText('2019/01')).toBeVisible();
-  });
-
   it('should render column header according to dayOfWeekFormatter', () => {
     render(
-      <LocalizationProvider dateAdapter={AdapterClassToUse}>
-        <DateCalendar
-          defaultValue={adapterToUse.date(new Date(2019, 0, 1))}
-          dayOfWeekFormatter={(day) => `${day}.`}
-        />
-        ,
-      </LocalizationProvider>,
+      <DateCalendar
+        defaultValue={adapterToUse.date(new Date(2019, 0, 1))}
+        dayOfWeekFormatter={(day) => `${day}.`}
+      />,
     );
 
     ['Su.', 'Mo.', 'Tu.', 'We.', 'Th.', 'Fr.', 'Sa.'].forEach((formattedDay) => {
@@ -134,16 +117,27 @@ describe('<DateCalendar />', () => {
 
   it('should render week number when `displayWeekNumber=true`', () => {
     render(
-      <LocalizationProvider dateAdapter={AdapterClassToUse}>
-        <DateCalendar
-          value={adapterToUse.date(new Date(2019, 0, 1))}
-          onChange={() => {}}
-          displayWeekNumber
-        />
-      </LocalizationProvider>,
+      <DateCalendar
+        value={adapterToUse.date(new Date(2019, 0, 1))}
+        onChange={() => {}}
+        displayWeekNumber
+      />,
     );
 
     expect(screen.getAllByRole('rowheader').length).to.equal(5);
+  });
+
+  describe('Slot: calendarHeader', () => {
+    it('should allow to override the format', () => {
+      render(
+        <DateCalendar
+          defaultValue={adapterToUse.date(new Date(2019, 0, 1))}
+          slotProps={{ calendarHeader: { format: 'yyyy/MM' } }}
+        />,
+      );
+
+      expect(screen.getByText('2019/01')).toBeVisible();
+    });
   });
 
   describe('view: day', () => {

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -274,6 +274,11 @@ PickersCalendarHeader.propTypes = {
   disabled: PropTypes.bool,
   disableFuture: PropTypes.bool,
   disablePast: PropTypes.bool,
+  /**
+   * Format used to display the date.
+   * @default `${adapter.formats.month} ${adapter.formats.year}`
+   */
+  format: PropTypes.string,
   labelId: PropTypes.string,
   maxDate: PropTypes.any.isRequired,
   minDate: PropTypes.any.isRequired,

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -146,6 +146,7 @@ const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TD
     labelId,
     className,
     timezone,
+    format = `${utils.formats.month} ${utils.formats.year}`,
     ...other
   } = props;
 
@@ -207,6 +208,8 @@ const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TD
     return null;
   }
 
+  const label = utils.formatByString(month, format);
+
   return (
     <PickersCalendarHeaderRoot
       {...other}
@@ -222,17 +225,14 @@ const PickersCalendarHeader = React.forwardRef(function PickersCalendarHeader<TD
         aria-live="polite"
         className={classes.labelContainer}
       >
-        <PickersFadeTransitionGroup
-          reduceAnimations={reduceAnimations}
-          transKey={utils.format(month, 'monthAndYear')}
-        >
+        <PickersFadeTransitionGroup reduceAnimations={reduceAnimations} transKey={label}>
           <PickersCalendarHeaderLabel
             id={labelId}
             data-mui-test="calendar-month-and-year-text"
             ownerState={ownerState}
             className={classes.label}
           >
-            {utils.format(month, 'monthAndYear')}
+            {label}
           </PickersCalendarHeaderLabel>
         </PickersFadeTransitionGroup>
         {views.length > 1 && !disabled && (

--- a/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.types.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.types.tsx
@@ -16,6 +16,11 @@ export interface ExportedPickersArrowSwitcherProps {
    */
   slotProps?: PickersArrowSwitcherSlotsComponentsProps;
   classes?: Partial<PickersArrowSwitcherClasses>;
+  /**
+   * Format used to display the date.
+   * @default `${adapter.formats.month} ${adapter.formats.year}`
+   */
+  format?: string;
 }
 
 export interface PickersArrowSwitcherProps


### PR DESCRIPTION
Part of #10776

- [x] Add `calendarHeader` slot support on `DateRangeCalendar`
- [x] Allow to override the format in the header using `slotProps.calendarHeader.format`
- [x] Remove some useless `LocalizationProvider` on tests (not related to this PR, I just saw them while working on it)

I can mark this as breaking and add it to the migration guide if you want.