### PR TITLE
[pickers] Remove the `hasLeadingZeros` property from `FieldSection`

### DIFF
--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -80,10 +80,9 @@ To keep the same behavior, you can replace it by `hasLeadingZerosInFormat`
 
  React.useEffect(() => {
      const firstSection = fieldRef.current!.getSections()[0]
--     console.log(firstSection.hasLeadingZeros)
-+     console.log(firstSection.hasLeadingZerosInFormat)
+-    console.log(firstSection.hasLeadingZeros)
++    console.log(firstSection.hasLeadingZerosInFormat)
  }, [])
-
 
  return (
    <DateField unstableFieldRef={fieldRef} />

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -63,8 +63,6 @@ For example:
 
 The same applies to `slotProps` and `componentsProps`.
 :::
-<<<<<<< Updated upstream
-=======
 
 ### Replace `defaultCalendarMonth` with `referenceDate`
 
@@ -103,4 +101,3 @@ To keep the same behavior, you can replace it by `hasLeadingZerosInFormat`
    <DateField unstableFieldRef={fieldRef} />
  );
 ```
->>>>>>> Stashed changes

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -64,18 +64,6 @@ For example:
 The same applies to `slotProps` and `componentsProps`.
 :::
 
-### Replace `defaultCalendarMonth` with `referenceDate`
-
-The `defaultCalendarMonth` has been removed in favor of the more flexible `referenceDate` prop.
-It was available in `DateCalendar` and all the pickers using it for date editing.
-
-The new `referenceDate` prop is not limited to the default month, learn more on this prop on [the `DateCalendar` doc](/x/react-date-pickers/date-calendar/#choose-the-initial-year-month) or [the `referenceDate` doc](/x/react-date-pickers/base-concepts/#reference-date-when-no-value-is-defined).
-
-```diff
-- <DateCalendar defaultCalendarMonth={dayjs('2022-04-01')};
-+ <DateCalendar referenceDate{dayjs('2022-04-01')} />
-```
-
 ## Field components
 
 ### Replace the section `hasLeadingZeros` property
@@ -84,7 +72,7 @@ The new `referenceDate` prop is not limited to the default month, learn more on 
 This only impacts you if you are using the `unstableFieldRef` prop to imperatively access the section object.
 :::
 
-The `hasLeadingZeros` has been removed from the sections in favor of the more precise `hasLeadingZerosInFormat` and `hasLeadingZerosInInput` properties.
+The property `hasLeadingZeros` has been removed from the sections in favor of the more precise `hasLeadingZerosInFormat` and `hasLeadingZerosInInput` properties.
 To keep the same behavior, you can replace it by `hasLeadingZerosInFormat`
 
 ```diff

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -63,3 +63,44 @@ For example:
 
 The same applies to `slotProps` and `componentsProps`.
 :::
+<<<<<<< Updated upstream
+=======
+
+### Replace `defaultCalendarMonth` with `referenceDate`
+
+The `defaultCalendarMonth` has been removed in favor of the more flexible `referenceDate` prop.
+It was available in `DateCalendar` and all the pickers using it for date editing.
+
+The new `referenceDate` prop is not limited to the default month, learn more on this prop on [the `DateCalendar` doc](/x/react-date-pickers/date-calendar/#choose-the-initial-year-month) or [the `referenceDate` doc](/x/react-date-pickers/base-concepts/#reference-date-when-no-value-is-defined).
+
+```diff
+- <DateCalendar defaultCalendarMonth={dayjs('2022-04-01')};
++ <DateCalendar referenceDate{dayjs('2022-04-01')} />
+```
+
+## Field components
+
+### Replace the section `hasLeadingZeros` property
+
+:::success
+This only impacts you if you are using the `unstableFieldRef` prop to imperatively access the section object.
+:::
+
+The `hasLeadingZeros` has been removed from the sections in favor of the more precise `hasLeadingZerosInFormat` and `hasLeadingZerosInInput` properties.
+To keep the same behavior, you can replace it by `hasLeadingZerosInFormat`
+
+```diff
+ const fieldRef = React.useRef<FieldRef<FieldSection>>(null);
+
+ React.useEffect(() => {
+     const firstSection = fieldRef.current!.getSections()[0]
+-     console.log(firstSection.hasLeadingZeros)
++     console.log(firstSection.hasLeadingZerosInFormat)
+ }, [])
+
+
+ return (
+   <DateField unstableFieldRef={fieldRef} />
+ );
+```
+>>>>>>> Stashed changes

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -8,7 +8,6 @@ const COMMON_PROPERTIES = {
   type: 'year',
   modified: false,
   format: 'YYYY',
-  hasLeadingZeros: true,
   hasLeadingZerosInFormat: true,
   maxLength: 4,
 } as const;

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -558,7 +558,6 @@ export const splitFormatIntoSections = <TDate>(
       maxLength,
       value: sectionValue,
       placeholder: getSectionPlaceholder(utils, timezone, localeText, sectionConfig, token),
-      hasLeadingZeros: hasLeadingZerosInFormat,
       hasLeadingZerosInFormat,
       hasLeadingZerosInInput,
       startSeparator: sections.length === 0 ? startSeparator : '',

--- a/packages/x-date-pickers/src/models/fields.ts
+++ b/packages/x-date-pickers/src/models/fields.ts
@@ -47,12 +47,6 @@ export interface FieldSection {
   /**
    * If `true`, the value of this section is supposed to have leading zeroes when parsed by the date library.
    * For example, the value `1` should be rendered as "01" instead of "1".
-   * @deprecated Will be removed in v7, use `hasLeadingZerosInFormat` instead.
-   */
-  hasLeadingZeros: boolean;
-  /**
-   * If `true`, the value of this section is supposed to have leading zeroes when parsed by the date library.
-   * For example, the value `1` should be rendered as "01" instead of "1".
    */
   hasLeadingZerosInFormat: boolean;
   /**


### PR DESCRIPTION
Closes #10987 

### Changelog

#### Breaking changes

- The property `hasLeadingZeros` has been removed from the sections in favor of the more precise `hasLeadingZerosInFormat` and `hasLeadingZerosInInput` properties.
  To keep the same behavior, you can replace it by `hasLeadingZerosInFormat`:

  ```diff
   const fieldRef = React.useRef<FieldRef<FieldSection>>(null);

   React.useEffect(() => {
       const firstSection = fieldRef.current!.getSections()[0]
  -    console.log(firstSection.hasLeadingZeros)
  +    console.log(firstSection.hasLeadingZerosInFormat)
   }, [])

   return (
     <DateField unstableFieldRef={fieldRef} />
   );
  ```