### PR TITLE
[docs] Add end v6 blogpost to whats new page

### DIFF
--- a/docs/data/whats-new/WhatsNewLayout.js
+++ b/docs/data/whats-new/WhatsNewLayout.js
@@ -13,6 +13,39 @@ import { alpha } from '@mui/material/styles';
 
 const blogs = [
   {
+    title: 'MUI X v6.18.0',
+    description:
+      'New stable components, polished features, better performance and more.',
+    announcementDate: 'Monday, Nov 13, 2023',
+    url: 'https://mui.com/blog/mui-x-end-v6-features/',
+    highlightList: [
+      {
+        title: 'Charts - stable version',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#charts',
+      },
+      {
+        title: 'Tree view - stable version',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#tree-view',
+      },
+      {
+        title: 'Date and time clearable fields',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#clearable-field',
+      },
+      {
+        title: 'Customization Playgrounds for date and time pickers',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#customization-playgrounds',
+      },
+      {
+        title: 'DataGrid Column Autosizing',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#column-autosizing',
+      },
+      {
+        title: 'Sparklines on DataGrid ',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#sparkline-as-a-column-type',
+      },
+    ],
+  },
+  {
     title: 'MUI X v6.11.0',
     description: 'A roundup of all new features since v6.0.0.',
     announcementDate: 'Monday, Aug 14, 2023',

--- a/docs/data/whats-new/WhatsNewLayout.tsx
+++ b/docs/data/whats-new/WhatsNewLayout.tsx
@@ -21,6 +21,39 @@ type Blog = {
 
 const blogs: Blog[] = [
   {
+    title: 'MUI X v6.18.0',
+    description:
+      'New stable components, polished features, better performance and more.',
+    announcementDate: 'Monday, Nov 13, 2023',
+    url: 'https://mui.com/blog/mui-x-end-v6-features/',
+    highlightList: [
+      {
+        title: 'Charts - stable version',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#charts',
+      },
+      {
+        title: 'Tree view - stable version',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#tree-view',
+      },
+      {
+        title: 'Date and time clearable fields',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#clearable-field',
+      },
+      {
+        title: 'Customization Playgrounds for date and time pickers',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#customization-playgrounds',
+      },
+      {
+        title: 'DataGrid Column Autosizing',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#column-autosizing',
+      },
+      {
+        title: 'Sparklines on DataGrid ',
+        url: 'https://mui.com/blog/mui-x-end-v6-features/#sparkline-as-a-column-type',
+      },
+    ],
+  },
+  {
     title: 'MUI X v6.11.0',
     description: 'A roundup of all new features since v6.0.0.',
     announcementDate: 'Monday, Aug 14, 2023',


### PR DESCRIPTION
### Summary

Add links to most recent blog post about latest v6 features.

To merge after: https://github.com/mui/material-ui/pull/39700