### PR TITLE
[DataGrid] Fix `onFilterModelChange` being fired with stale field value

### DIFF
--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -305,7 +305,7 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
           ...item,
           field,
           operator: newOperator.value,
-          value: eraseItemValue ? undefined : item.value,
+          value: eraseItemValue ? undefined : '',
         });
       },
       [apiRef, applyFilterChanges, item, currentColumn, currentOperator],

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -296,16 +296,17 @@ const GridFilterForm = React.forwardRef<HTMLDivElement, GridFilterFormProps>(
           column.filterOperators!.find((operator) => operator.value === item.operator) ||
           column.filterOperators![0];
 
-        // Erase filter value if the input component is modified
+        // Erase filter value if the input component or filtered column type is modified
         const eraseItemValue =
           !newOperator.InputComponent ||
-          newOperator.InputComponent !== currentOperator?.InputComponent;
+          newOperator.InputComponent !== currentOperator?.InputComponent ||
+          column.type !== currentColumn!.type;
 
         applyFilterChanges({
           ...item,
           field,
           operator: newOperator.value,
-          value: eraseItemValue ? undefined : '',
+          value: eraseItemValue ? undefined : item.value,
         });
       },
       [apiRef, applyFilterChanges, item, currentColumn, currentOperator],

--- a/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
+++ b/packages/grid/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
@@ -57,7 +57,7 @@ function GridFilterInputValue(props: GridTypeFilterInputValueProps) {
 
   React.useEffect(() => {
     const itemPlusTag = item as ItemPlusTag;
-    if (itemPlusTag.fromInput !== id) {
+    if (itemPlusTag.fromInput !== id || item.value === undefined) {
       setFilterValueState(String(item.value ?? ''));
     }
   }, [id, item]);

--- a/packages/grid/x-data-grid/src/tests/filterPanel.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filterPanel.DataGrid.test.tsx
@@ -182,11 +182,11 @@ describe('<DataGrid /> - Filter panel', () => {
 
     setColumnValue('slogan');
 
-    expect(getColumnValues(0)).to.deep.equal([]);
+    expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas', 'Puma']);
     expect(screen.getByRole<HTMLSelectElement>('combobox', { name: 'Operator' }).value).to.equal(
       'equals',
     );
-    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Value' }).value).to.equal('Puma');
+    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Value' }).value).to.equal('');
   });
 
   it('should reset value if operator is not available for the new column', () => {
@@ -340,7 +340,7 @@ describe('<DataGrid /> - Filter panel', () => {
 
     setColumnValue('origin');
 
-    expect(getColumnValues(0)).to.deep.equal(['REF_2', 'REF_3']);
+    expect(getColumnValues(0)).to.deep.equal(['REF_1', 'REF_2', 'REF_3']);
   });
 
   it('should reset filter value if not available in the new valueOptions with operator "isAnyOf"', () => {
@@ -411,7 +411,7 @@ describe('<DataGrid /> - Filter panel', () => {
 
     expect(getColumnValues(0)).to.deep.equal(['REF_1']);
     setColumnValue('origin');
-    expect(getColumnValues(0)).to.deep.equal(['REF_2', 'REF_3']);
+    expect(getColumnValues(0)).to.deep.equal(['REF_1', 'REF_2', 'REF_3']);
   });
 
   it('should reset filter value if moving from multiple to single value operator', () => {

--- a/packages/grid/x-data-grid/src/tests/filterPanel.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/filterPanel.DataGrid.test.tsx
@@ -182,11 +182,11 @@ describe('<DataGrid /> - Filter panel', () => {
 
     setColumnValue('slogan');
 
-    expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas', 'Puma']);
+    expect(getColumnValues(0)).to.deep.equal([]);
     expect(screen.getByRole<HTMLSelectElement>('combobox', { name: 'Operator' }).value).to.equal(
       'equals',
     );
-    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Value' }).value).to.equal('');
+    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Value' }).value).to.equal('Puma');
   });
 
   it('should reset value if operator is not available for the new column', () => {
@@ -340,7 +340,7 @@ describe('<DataGrid /> - Filter panel', () => {
 
     setColumnValue('origin');
 
-    expect(getColumnValues(0)).to.deep.equal(['REF_1', 'REF_2', 'REF_3']);
+    expect(getColumnValues(0)).to.deep.equal(['REF_2', 'REF_3']);
   });
 
   it('should reset filter value if not available in the new valueOptions with operator "isAnyOf"', () => {
@@ -411,7 +411,7 @@ describe('<DataGrid /> - Filter panel', () => {
 
     expect(getColumnValues(0)).to.deep.equal(['REF_1']);
     setColumnValue('origin');
-    expect(getColumnValues(0)).to.deep.equal(['REF_1', 'REF_2', 'REF_3']);
+    expect(getColumnValues(0)).to.deep.equal(['REF_2', 'REF_3']);
   });
 
   it('should reset filter value if moving from multiple to single value operator', () => {


### PR DESCRIPTION
## Description

Upon investigation, we discovered that this issue occurs when a user wants to filter a value in a String column and then tries to change the String Column to a Number column. When this happens, the program tries to parse the string value the user initially inputted in the Value Text field to a number value, because it's unable to do that, it clears out the value from the Text Field but the value still remains in the items object in the program.

The solution to this would be to reset the item value property when the user switches from one column to another.

[Loom Video](https://www.loom.com/share/d3f38557fcd54acabc4241c178d95606?sid=29b3f889-ed0f-40a9-9a82-728dddc05a85)

Fixes https://github.com/mui/mui-x/issues/10489
Closes https://github.com/mui/mui-x/pull/10711

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
