### PR TITLE
[docs] Fix version links

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -265,7 +265,7 @@ function AppWrapper(props) {
             text: `v${process.env.CHARTS_VERSION}`,
             current: true,
           },
-          { text: 'v6', href: `https://mui.com${languagePrefix}/x/react-charts/getting-started` },
+          { text: 'v6', href: `https://mui.com${languagePrefix}/x/react-charts/` },
         ],
       };
     } else if (productId === 'x-tree-view') {

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -248,7 +248,7 @@ function AppWrapper(props) {
           },
           {
             text: 'v6',
-            href: `https://mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
+            href: `https://mui.com${languagePrefix}/x/react-date-pickers/`,
           },
           {
             text: 'v5',

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -232,8 +232,8 @@ function AppWrapper(props) {
             text: `v${process.env.DATA_GRID_VERSION}`,
             current: true,
           },
-          { text: 'v6', href: `https://mui.com${languagePrefix}/components/data-grid/` },
-          { text: 'v5', href: `https://v5.mui.com${languagePrefix}/components/data-grid/` },
+          { text: 'v6', href: `https://mui.com${languagePrefix}/x/react-data-grid/` },
+          { text: 'v5', href: `https://v5.mui.com${languagePrefix}/x/react-data-grid/` },
           { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
         ],
       };


### PR DESCRIPTION
- Fix a bug of redirecting to a non-existent charts v6 page
- Use direct Data Grid documentation links instead of aliases
- Use same (Overview) page for Pickers v6 link (align with Data Grid)