### PR TITLE
[docs] Fix Pickers CustomComponents Incorrect naming of a component in example

### DIFF
--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -79,7 +79,7 @@ function MyApp() {
 
 ```jsx
 // ✅ The `toolbar` slot is defined only once, it will never remount.
-const CustomActionBar = ({ name, setName }) => (
+const CustomToolbar = ({ name, setName }) => (
   <input value={name} onChange={(event) => setName(event.target.value)} />
 );
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #11002.