### PR TITLE
[pickers] v7: Move the exports of the `calendarHeader` slot to `@mui/x-date-pickers/PickersCalendarHeader`

### DIFF
--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -64,7 +64,7 @@ For example:
 The same applies to `slotProps` and `componentsProps`.
 :::
 
-### Change the imports of the `¢alendarHeader` slot
+### Change the imports of the `calendarHeader` slot
 
 The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DateCalendar` to `@mui/x-date-pickers/PIckersCalendarHeader`:
 

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -64,6 +64,24 @@ For example:
 The same applies to `slotProps` and `componentsProps`.
 :::
 
+### Change the imports of the `¢alendarHeader` slot
+
+The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DatePicker` to `@mui/x-date-pickers/PIckersCalendarHeader`:
+
+```diff
+  export {
+    pickersCalendarHeaderClasses,
+    PickersCalendarHeaderClassKey,
+    PickersCalendarHeaderClasses,
+    PickersCalendarHeader,
+    PickersCalendarHeaderProps,
+    PickersCalendarHeaderSlotsComponent,
+    PickersCalendarHeaderSlotsComponentsProps,
+    ExportedPickersCalendarHeaderProps,
+- } from '@mui/x-date-pickers/DatePicker';
++ } from '@mui/x-date-pickers/PickersCalendarHeader';
+```
+
 ## Field components
 
 ### Replace the section `hasLeadingZeros` property

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -66,7 +66,7 @@ The same applies to `slotProps` and `componentsProps`.
 
 ### Change the imports of the `¢alendarHeader` slot
 
-The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DatePicker` to `@mui/x-date-pickers/PIckersCalendarHeader`:
+The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DateCalendar` to `@mui/x-date-pickers/PIckersCalendarHeader`:
 
 ```diff
   export {
@@ -78,7 +78,7 @@ The imports related to the `calendarHeader` slot have been moved from `@mui/x-da
     PickersCalendarHeaderSlotsComponent,
     PickersCalendarHeaderSlotsComponentsProps,
     ExportedPickersCalendarHeaderProps,
-- } from '@mui/x-date-pickers/DatePicker';
+- } from '@mui/x-date-pickers/DateCalendar';
 + } from '@mui/x-date-pickers/PickersCalendarHeader';
 ```
 

--- a/packages/x-date-pickers/src/DateCalendar/index.ts
+++ b/packages/x-date-pickers/src/DateCalendar/index.ts
@@ -21,6 +21,3 @@ export type {
   PickersSlideTransitionClasses,
 } from './pickersSlideTransitionClasses';
 export type { ExportedSlideTransitionProps } from './PickersSlideTransition';
-
-// TODO v7: Remove and export the `PickersCalendarHeader` folder from the root instead.
-export * from '../PickersCalendarHeader';

--- a/packages/x-date-pickers/src/index.ts
+++ b/packages/x-date-pickers/src/index.ts
@@ -43,6 +43,9 @@ export * from './PickersLayout';
 export * from './PickersActionBar';
 export * from './PickersShortcuts';
 
+// Other slots
+export * from './PickersCalendarHeader';
+
 export { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from './internals/utils/utils';
 
 export * from './models';

--- a/packages/x-date-pickers/src/themeAugmentation/overrides.d.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/overrides.d.ts
@@ -1,10 +1,10 @@
 import {
   DateCalendarClassKey,
   DayCalendarClassKey,
-  PickersCalendarHeaderClassKey,
   PickersFadeTransitionGroupClassKey,
   PickersSlideTransitionClassKey,
 } from '../DateCalendar';
+import { PickersCalendarHeaderClassKey } from '../PickersCalendarHeader';
 import { DayCalendarSkeletonClassKey } from '../DayCalendarSkeleton';
 import {
   ClockClassKey,

--- a/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
@@ -2,9 +2,9 @@ import { createTheme } from '@mui/material/styles';
 import {
   dateCalendarClasses,
   dayPickerClasses,
-  pickersCalendarHeaderClasses,
   pickersSlideTransitionClasses,
 } from '../DateCalendar';
+import { pickersCalendarHeaderClasses } from '../PickersCalendarHeader';
 import { dayCalendarSkeletonClasses } from '../DayCalendarSkeleton';
 import {
   clockClasses,


### PR DESCRIPTION
## Breaking change

### Change the imports of the `calendarHeader` slot

- The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DateCalendar` to `@mui/x-date-pickers/PIckersCalendarHeader`:

  ```diff
    export {
      pickersCalendarHeaderClasses,
      PickersCalendarHeaderClassKey,
      PickersCalendarHeaderClasses,
      PickersCalendarHeader,
      PickersCalendarHeaderProps,
      PickersCalendarHeaderSlotsComponent,
      PickersCalendarHeaderSlotsComponentsProps,
      ExportedPickersCalendarHeaderProps,
  - } from '@mui/x-date-pickers/DateCalendar';
  + } from '@mui/x-date-pickers/PickersCalendarHeader';
  ```

Closes #11019
