### PR TITLE
[docs] Fix incorrect component name in the "Custom slots and subcomponents" page

### DIFF
--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -79,7 +79,7 @@ function MyApp() {
 
 ```jsx
 // ✅ The `toolbar` slot is defined only once, it will never remount.
-const CustomActionBar = ({ name, setName }) => (
+const CustomToolbar = ({ name, setName }) => (
   <input value={name} onChange={(event) => setName(event.target.value)} />
 );
 


### PR DESCRIPTION
Based on #11003