### PR TITLE
[docs] Clean the codemod README

### DIFF
--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -43,7 +43,7 @@ Apart from the removed methods and exports that require manual intervention, aro
 :::
 
 :::info
-If you want to run the codemods one by one, check out the codemods included in the [preset-safe codemod for data grid](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-data-grid) for more details.
+If you want to run the codemods one by one, check out the codemods included in the [preset-safe codemod for data grid](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-data-grid-v600) for more details.
 :::
 
 Breaking changes that are handled by `preset-safe` codemod are denoted by a ✅ emoji in the table of contents on the right side of the screen or next to the specific point that is handled by it.

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -44,7 +44,7 @@ Apart from the removed methods and exports that require manual intervention, aro
 :::
 
 :::info
-If you want to run the codemods one by one, check out the codemods included in the [preset-safe codemod for data grid](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-data-grid) for more details.
+If you want to run the codemods one by one, check out the codemods included in the [preset-safe codemod for data grid](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-data-grid-v700) for more details.
 :::
 
 Breaking changes that are handled by `preset-safe` codemod are denoted by a ✅ emoji in the table of contents on the right side of the screen or next to the specific point that is handled by it.

--- a/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
+++ b/docs/data/migration/migration-pickers-v5/migration-pickers-v5.md
@@ -39,7 +39,7 @@ npx @mui/x-codemod v6.0.0/preset-safe <path>
 ```
 
 :::info
-If you want to run the transformers one by one, check out the transformers included in the [preset-safe codemod for pickers](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-pickers) for more details.
+If you want to run the transformers one by one, check out the transformers included in the [preset-safe codemod for pickers](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-pickers-v600) for more details.
 :::
 
 Breaking changes that are handled by this codemod are denoted by a ✅ emoji in the table of contents on the right side of the screen.

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -44,7 +44,7 @@ If you want to run the transformers one by one, check out the transformers inclu
 
 Breaking changes that are handled by this codemod are denoted by a ✅ emoji in the table of contents on the right side of the screen.
 
-If you have already applied the `v6.0.0/pickers/preset-safe` (or `v6.0.0/preset-safe`) codemod, then you should not need to take any further action on these items.
+If you have already applied the `v7.0.0/pickers/preset-safe` (or `v7.0.0/preset-safe`) codemod, then you should not need to take any further action on these items.
 
 All other changes must be handled manually.
 

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -21,10 +21,48 @@ In `package.json`, change the version of the date pickers package to `next`.
 +"@mui/x-date-pickers": "next",
 ```
 
-## Breaking changes
-
 Since `v7` is a major release, it contains changes that affect the public API.
 These changes were done for consistency, improved stability and to make room for new features.
+Described below are the steps needed to migrate from v6 to v7.
+
+## Run codemods
+
+The `preset-safe` codemod will automatically adjust the bulk of your code to account for breaking changes in v7. You can run `v7.0.0/pickers/preset-safe` targeting only Date and Time Pickers or `v7.0.0/preset-safe` to target Data Grid as well.
+
+You can either run it on a specific file, folder, or your entire codebase when choosing the `<path>` argument.
+
+```bash
+// Date and Time Pickers specific
+npx @mui/x-codemod v7.0.0/pickers/preset-safe <path>
+// Target Data Grid as well
+npx @mui/x-codemod v7.0.0/preset-safe <path>
+```
+
+:::info
+If you want to run the transformers one by one, check out the transformers included in the [preset-safe codemod for pickers](https://github.com/mui/mui-x/blob/master/packages/x-codemod/README.md#preset-safe-for-pickers-v700) for more details.
+:::
+
+Breaking changes that are handled by this codemod are denoted by a ✅ emoji in the table of contents on the right side of the screen.
+
+If you have already applied the `v6.0.0/pickers/preset-safe` (or `v6.0.0/preset-safe`) codemod, then you should not need to take any further action on these items.
+
+All other changes must be handled manually.
+
+:::warning
+Not all use cases are covered by codemods. In some scenarios, like props spreading, cross-file dependencies, etc., the changes are not properly identified and therefore must be handled manually.
+
+For example, if a codemod tries to rename a prop, but this prop is hidden with the spread operator, it won't be transformed as expected.
+
+```tsx
+<DatePicker {...pickerProps} />
+```
+
+After running the codemods, make sure to test your application and that you don't have any console errors.
+
+Feel free to [open an issue](https://github.com/mui/mui-x/issues/new/choose) for support if you need help to proceed with your migration.
+:::
+
+## Component slots
 
 ### Rename `components` to `slots`
 
@@ -66,7 +104,7 @@ The same applies to `slotProps` and `componentsProps`.
 
 ### Change the imports of the `calendarHeader` slot
 
-The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DateCalendar` to `@mui/x-date-pickers/PIckersCalendarHeader`:
+The imports related to the `calendarHeader` slot have been moved from `@mui/x-date-pickers/DateCalendar` to `@mui/x-date-pickers/PickersCalendarHeader`:
 
 ```diff
   export {

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -56,13 +56,60 @@ through jscodeshift's `printOptions` command line argument
 npx @mui/x-codemod <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
 ```
 
-## Included scripts
+## v7.0.0
 
-### v6.0.0
+### 🚀 `preset-safe` for v7.0.0
 
-#### 🚀 `preset-safe`
+A combination of all important transformers for migrating v6 to v7.
+⚠️ This codemod should be run only once.
+It runs codemods for both Data Grid and Date and Time Pickers packages.
+To run codemods for a specific package, refer to the respective section.
 
-A combination of all important transformers for migrating v5 to v6. ⚠️ This codemod should be run only once. It runs codemods for both Data Grid and Date and Time Pickers packages. To run codemods for a specific package, refer to the respective section.
+```bash
+npx @mui/x-codemod v7.0.0/preset-safe <path|folder>
+```
+
+The corresponding sub-sections are listed below
+
+- [`preset-safe-for-pickers`](#preset-safe-for-pickers-v700)
+- [`preset-safe-for-data-grid`](#preset-safe-for-data-grid-v700)
+
+### Pickers codemods
+
+#### `preset-safe` for pickers v6.0.0
+
+The `preset-safe` codemods for pickers.
+
+```bash
+npx @mui/x-codemod v6.0.0/pickers/preset-safe <path|folder>
+```
+
+The list includes these transformers
+
+NO CODEMOD ADDED YET
+
+### Data grid codemods
+
+#### `preset-safe` for data grid v7.0.0
+
+The `preset-safe` codemods for data grid.
+
+```bash
+npx @mui/x-codemod v6.0.0/data-grid/preset-safe <path|folder>
+```
+
+The list includes these transformers
+
+NO CODEMOD ADDED YET
+
+## v6.0.0
+
+### 🚀 `preset-safe` for v6.0.0
+
+A combination of all important transformers for migrating v5 to v6.
+⚠️ This codemod should be run only once.
+It runs codemods for both Data Grid and Date and Time Pickers packages.
+To run codemods for a specific package, refer to the respective section.
 
 ```bash
 npx @mui/x-codemod v6.0.0/preset-safe <path|folder>
@@ -70,12 +117,12 @@ npx @mui/x-codemod v6.0.0/preset-safe <path|folder>
 
 The corresponding sub-sections are listed below
 
-- [`preset-safe-for-pickers`](#preset-safe-for-pickers)
-- [`preset-safe-for-data-grid`](#preset-safe-for-data-grid)
+- [`preset-safe-for-pickers`](#preset-safe-for-pickers-v600)
+- [`preset-safe-for-data-grid`](#preset-safe-for-data-grid-v600)
 
 ### Pickers codemods
 
-#### `preset-safe` for pickers
+#### `preset-safe` for pickers v6.0.0
 
 The `preset-safe` codemods for pickers.
 
@@ -402,7 +449,7 @@ npx @mui/x-codemod v6.0.0/pickers/rename-components-to-slots <path>
 
 ### Data grid codemods
 
-#### `preset-safe` for data grid
+#### `preset-safe` for data grid v6.0.0
 
 The `preset-safe` codemods for data grid.
 


### PR DESCRIPTION
Update the README of the `@mui/x-codemod` package to be ready to have both v6 and v7 codemods