### PR TITLE
[charts] Fix error with empty dataset

### DIFF
--- a/packages/x-charts/src/LineChart/extremums.ts
+++ b/packages/x-charts/src/LineChart/extremums.ts
@@ -8,6 +8,25 @@ export const getExtremumX: ExtremumGetter<'line'> = (params) => {
   return [minX, maxX];
 };
 
+type GetValuesTypes = (d: [number, number]) => [number, number];
+
+function getSeriesExtremums(
+  getValues: GetValuesTypes,
+  stackedData: [number, number][],
+): ExtremumGetterResult {
+  if (stackedData.length === 0) {
+    return [null, null];
+  }
+  return stackedData.reduce((seriesAcc, stackedValue) => {
+    const [base, value] = getValues(stackedValue);
+
+    if (seriesAcc[0] === null) {
+      return [Math.min(base, value), Math.max(base, value)] as [number, number];
+    }
+    return [Math.min(base, value, seriesAcc[0]), Math.max(base, value, seriesAcc[1])];
+  }, getValues(stackedData[0]));
+}
+
 export const getExtremumY: ExtremumGetter<'line'> = (params) => {
   const { series, axis, isDefaultAxis } = params;
 
@@ -19,25 +38,12 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
     )
     .reduce(
       (acc: ExtremumGetterResult, seriesId) => {
-        const isArea = series[seriesId].area !== undefined;
+        const { area, stackedData } = series[seriesId];
+        const isArea = area !== undefined;
 
-        const getValues: (d: [number, number]) => [number, number] = isArea
-          ? (d) => d
-          : (d) => [d[1], d[1]]; // Since this series is not used to display an area, we do not consider the base (the d[0]).
+        const getValues: GetValuesTypes = isArea ? (d) => d : (d) => [d[1], d[1]]; // Since this series is not used to display an area, we do not consider the base (the d[0]).
 
-        const seriesExtremums: ExtremumGetterResult = series[seriesId].stackedData.reduce(
-          (seriesAcc, stackedValue) => {
-            const [base, value] = getValues(stackedValue);
-
-            if (seriesAcc[0] === null) {
-              return [Math.min(base, value), Math.max(base, value)] as [number, number];
-            }
-            return [Math.min(base, value, seriesAcc[0]), Math.max(base, value, seriesAcc[1])];
-          },
-          series[seriesId].stackedData.length > 0
-            ? getValues(series[seriesId].stackedData[0])
-            : [null, null],
-        );
+        const seriesExtremums = getSeriesExtremums(getValues, stackedData);
 
         if (acc[0] === null) {
           return seriesExtremums;
@@ -45,6 +51,7 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
         if (seriesExtremums[0] === null) {
           return acc;
         }
+
         const [seriesMin, seriesMax] = seriesExtremums;
         return [Math.min(seriesMin, acc[0]), Math.max(seriesMax, acc[1])];
       },

--- a/packages/x-charts/src/LineChart/extremums.ts
+++ b/packages/x-charts/src/LineChart/extremums.ts
@@ -21,21 +21,31 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
       (acc: ExtremumGetterResult, seriesId) => {
         const isArea = series[seriesId].area !== undefined;
 
-        const getValues = isArea
-          ? (d: [number, number]) => d
-          : (d: [number, number]) => [d[1], d[1]]; // Id area should go from bottom to top, without area should only consider the top
+        const getValues: (d: [number, number]) => [number, number] = isArea
+          ? (d) => d
+          : (d) => [d[1], d[1]]; // Since this series is not used to display an area, we do not consider the base (the d[0]).
 
-        const [seriesMin, seriesMax] = series[seriesId].stackedData.reduce(
+        const seriesExtremums: ExtremumGetterResult = series[seriesId].stackedData.reduce(
           (seriesAcc, stackedValue) => {
             const [base, value] = getValues(stackedValue);
+
+            if (seriesAcc[0] === null) {
+              return [Math.min(base, value), Math.max(base, value)] as [number, number];
+            }
             return [Math.min(base, value, seriesAcc[0]), Math.max(base, value, seriesAcc[1])];
           },
-          getValues(series[seriesId].stackedData[0]),
+          series[seriesId].stackedData.length > 0
+            ? getValues(series[seriesId].stackedData[0])
+            : [null, null],
         );
 
-        if (acc[0] === null || acc[1] === null) {
-          return [seriesMin, seriesMax];
+        if (acc[0] === null) {
+          return seriesExtremums;
         }
+        if (seriesExtremums[0] === null) {
+          return acc;
+        }
+        const [seriesMin, seriesMax] = seriesExtremums;
         return [Math.min(seriesMin, acc[0]), Math.max(seriesMax, acc[1])];
       },
       [null, null],


### PR DESCRIPTION
Fix #11032

The issue was due to the initialisation of the reducer. It was looking for the first array item which does not exist when the data set is empty.