### PR TITLE
[DataGrid] remove incorrect generic typing of `otherFieldsProps`

### DIFF
--- a/packages/grid/x-data-grid/src/models/params/gridCellParams.ts
+++ b/packages/grid/x-data-grid/src/models/params/gridCellParams.ts
@@ -187,5 +187,5 @@ export interface GridPreProcessEditCellProps<V = any, R extends GridValidRowMode
    * Object containing the props of the other fields.
    * Only available for row editing and when using the new editing API.
    */
-  otherFieldsProps?: Record<string, GridEditCellProps<V>>;
+  otherFieldsProps?: Record<string, GridEditCellProps>;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Minor fix of #5510 

The generic type of the current value was also passed to `otherFieldsProps` which incorrectly applied the type of the current field on every other field.

PS: I don't know if it would be possible to infer the correct type from `R extends GridValidRowModel`. That's beyond my typing knowledge. 😉 