### PR TITLE
[pickers] Fix `DateCalendar` crashing when given an invalid value

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/useCalendarState.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/useCalendarState.tsx
@@ -162,7 +162,7 @@ export const useCalendarState = <TDate extends unknown>(params: UseCalendarState
 
   const [calendarState, dispatch] = React.useReducer(reducerFn, {
     isMonthSwitchingAnimating: false,
-    focusedDay: value || now,
+    focusedDay: utils.isValid(value) ? value! : now,
     currentMonth: utils.startOfMonth(referenceDate),
     slideDirection: 'left',
   });


### PR DESCRIPTION
Fixes #11062

Does not occur in v7 because `focusedDay` is initialized to equal `referenceDate` which does a similar test.

Once `focusedDay` contains an invalid date, it is passed to `findClosestEnabledDate` in `DayCalendar` and the method does not like it.