### PR TITLE
[test] Skip flaky e2e test in webkit

### DIFF
--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -229,6 +229,10 @@ async function initializeEnvironment(
       });
 
       it('should reorder columns by dropping into the header', async () => {
+        // this test sometimes fails on webkit for some reason
+        if (browserType.name() === 'webkit' && process.env.CIRCLECI) {
+          return;
+        }
         await renderFixture('DataGrid/ColumnReorder');
 
         expect(await page.locator('[role="row"]').first().textContent()).to.equal('brandyear');


### PR DESCRIPTION
Cherry-pick https://github.com/mui/mui-x/pull/11110 from `next`