### PR TITLE
[docs] Point to the source of @mui/x-data-grid-generator

### DIFF
--- a/packages/grid/x-data-grid-generator/README.md
+++ b/packages/grid/x-data-grid-generator/README.md
@@ -1,3 +1,5 @@
 # `@mui/x-data-grid-generator`
 
-Use this package to generate some data and build demos for the grid!
+This package is used to generate data and build demos for the [MUI X Data Grid](https://mui.com/x/react-data-grid/).
+
+⚠️ Do not use this package in production.

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -8,11 +8,14 @@
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"
   },
-  "homepage": "https://mui.com/x/react-data-grid/",
+  "homepage": "https://github.com/mui/mui-x/tree/master/packages/grid/x-data-grid-generator",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
+  "keywords": [
+    "mui-x"
+  ],
   "scripts": {
     "typescript": "tsc -p tsconfig.json",
     "build": "yarn build:legacy && yarn build:modern && yarn build:node && yarn build:stable && yarn build:types && yarn build:copy-files ",

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -18,6 +18,7 @@
     "react-component",
     "material-ui",
     "mui",
+    "mui-x",
     "react-table",
     "table",
     "datatable",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -18,6 +18,7 @@
     "react-component",
     "material-ui",
     "mui",
+    "mui-x",
     "react-table",
     "table",
     "datatable",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -22,6 +22,7 @@
     "react-component",
     "material-ui",
     "mui",
+    "mui-x",
     "react-table",
     "table",
     "datatable",

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -17,6 +17,7 @@
     "react",
     "react-component",
     "mui",
+    "mui-x",
     "material-ui",
     "material design",
     "charts"

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -9,6 +9,7 @@
     "react",
     "react-component",
     "mui",
+    "mui-x",
     "codemod",
     "jscodeshift"
   ],

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -17,6 +17,7 @@
     "react",
     "react-component",
     "mui",
+    "mui-x",
     "material-ui",
     "material design",
     "datepicker",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -21,6 +21,7 @@
     "react",
     "react-component",
     "mui",
+    "mui-x",
     "material-ui",
     "material design",
     "datepicker",

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -21,6 +21,7 @@
     "react",
     "react-component",
     "mui",
+    "mui-x",
     "material-ui",
     "material design",
     "treeview"


### PR DESCRIPTION
Make it clearer from https://www.npmjs.com/package/@mui/x-data-grid-generator where the source of the package is located at.

I have noticed this from https://mui.zendesk.com/agent/tickets/14319, the link we have right now is not really relevant.