### PR TITLE
[charts] Adjusted `defaultizeValueFormatter` util to accept an optional `series.valueFormatter` value

### DIFF
--- a/packages/x-charts/src/internals/defaultizeValueFormatter.ts
+++ b/packages/x-charts/src/internals/defaultizeValueFormatter.ts
@@ -1,4 +1,9 @@
-function defaultizeValueFormatter<ISeries extends {}, IFormatter extends (v: any) => string>(
+import { isFunction } from './utils';
+
+function defaultizeValueFormatter<
+  ISeries extends { valueFormatter?: IFormatter },
+  IFormatter extends (v: any) => string,
+>(
   series: {
     [id: string]: ISeries;
   },
@@ -15,8 +20,8 @@ function defaultizeValueFormatter<ISeries extends {}, IFormatter extends (v: any
   } = {};
   Object.keys(series).forEach((seriesId) => {
     defaultizedSeries[seriesId] = {
-      valueFormatter: defaultValueFormatter,
       ...series[seriesId],
+      valueFormatter: isFunction(series[seriesId]) ? series[seriesId] : defaultValueFormatter,
     };
   });
   return defaultizedSeries;

--- a/packages/x-charts/src/internals/utils.ts
+++ b/packages/x-charts/src/internals/utils.ts
@@ -6,5 +6,9 @@ export function getSymbol(shape: SymbolsTypes): number {
   return symbolNames.indexOf(shape) || 0;
 }
 
+export function isFunction(value: any): value is Function {
+  return typeof value === 'function';
+}
+
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

slightly changes the way the series gets spread.
Because when you had a `valueFormatter` on the series that was simply undefined the default one did not get added, since it technically was defined (even if its value was `undefined`).

It also adds the simple `isFunction` util to the charts package