### PR TITLE
[codemod] Clean the components to slots codemod usage

### DIFF
--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -92,9 +92,9 @@ The list includes these transformers
 
 #### `rename-components-to-slots-pickers`
 
-Renames the `components` and `componentsProps` props to `slots` and `slotProps` respectively.
+Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
 
-This change only affects pickers components.
+This change only affects Date and Time Picker components.
 
 ```diff
  <DatePicker
@@ -106,7 +106,7 @@ This change only affects pickers components.
 ```
 
 ```bash
-npx @mui/x-codemod v6.0.0/pickers/rename-components-to-slots <path>
+npx @mui/x-codemod v7.0.0/pickers/rename-components-to-slots <path>
 ```
 
 #### `rename-default-calendar-month-to-reference-date`
@@ -118,6 +118,10 @@ Replace the `defaultCalendarMonth` prop with the `referenceDate` prop.
 + <DateCalendar referenceDate{dayjs('2022-04-01')} />
 ```
 
+```bash
+npx @mui/x-codemod v7.0.0/pickers/rename-default-calendar-month-to-reference-date <path>
+```
+
 #### `rename-day-picker-classes`
 
 Rename the `dayPickerClasses` variable to `dayCalendarClasses`.
@@ -125,6 +129,10 @@ Rename the `dayPickerClasses` variable to `dayCalendarClasses`.
 ```diff
 - import { dayPickerClasses } from '@mui/x-date-pickers/DateCalendar';
 + import { dayCalendarClasses } from '@mui/x-date-pickers/DateCalendar';
+```
+
+```bash
+npx @mui/x-codemod v7.0.0/pickers/rename-day-picker-classes <path>
 ```
 
 ### Data grid codemods
@@ -145,19 +153,19 @@ The list includes these transformers
 
 Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
 
-This change only affects data grid components.
+This change only affects Grid components.
 
 ```diff
  <DataGrid
 -  components={{ Toolbar: CustomToolbar }}
 +  slots={{ toolbar: CustomToolbar }}
--  componentsProps={{ actionBar: { actions: ['clear'] } }}
-+  slotProps={{ actionBar: { actions: ['clear'] } }}
+-  componentsProps={{ toolbar: { showQuickFilter: true }}}
++  slotProps={{ toolbar: { showQuickFilter: true }}}
  />;
 ```
 
 ```bash
-npx @mui/x-codemod v6.0.0/data-grid/rename-components-to-slots <path>
+npx @mui/x-codemod v7.0.0/data-grid/rename-components-to-slots <path>
 ```
 
 ## v6.0.0
@@ -490,7 +498,7 @@ npx @mui/x-codemod v6.0.0/pickers/rename-default-toolbar-title-localeText <path>
 
 Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
 
-This change only affects pickers components.
+This change only affects Date and Time Pickers components.
 
 ```diff
  <DatePicker
@@ -789,7 +797,7 @@ npx @mui/x-codemod v6.0.0/data-grid/replace-onCellFocusOut-prop <path>
 
 Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
 
-This change only affects data grid components.
+This change only affects Grid components.
 
 ```diff
  <DataGrid

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -797,7 +797,7 @@ npx @mui/x-codemod v6.0.0/data-grid/replace-onCellFocusOut-prop <path>
 
 Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
 
-This change only affects Grid components.
+This change only affects Data Grid components.
 
 ```diff
  <DataGrid

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -86,8 +86,28 @@ npx @mui/x-codemod v7.0.0/pickers/preset-safe <path|folder>
 
 The list includes these transformers
 
+- [`rename-components-to-slots-pickers`](#rename-components-to-slots-pickers)
 - [`rename-default-calendar-month-to-reference-date`](#rename-default-calendar-month-to-reference-date)
 - [`rename-day-picker-classes`](/rename-day-picker-classes)
+
+#### `rename-components-to-slots-pickers`
+
+Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
+
+This change only affects pickers components.
+
+```diff
+ <DatePicker
+-  components={{ Toolbar: CustomToolbar }}
++  slots={{ toolbar: CustomToolbar }}
+-  componentsProps={{ actionBar: { actions: ['clear'] } }}
++  slotProps={{ actionBar: { actions: ['clear'] } }}
+ />;
+```
+
+```bash
+npx @mui/x-codemod v6.0.0/pickers/rename-components-to-slots <path>
+```
 
 #### `rename-default-calendar-month-to-reference-date`
 
@@ -119,7 +139,26 @@ npx @mui/x-codemod v7.0.0/data-grid/preset-safe <path|folder>
 
 The list includes these transformers
 
-NO CODEMOD ADDED YET
+- [`rename-components-to-slots-data-grid`](#rename-components-to-slots-data-grid)
+
+#### `rename-components-to-slots-data-grid`
+
+Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
+
+This change only affects data grid components.
+
+```diff
+ <DataGrid
+-  components={{ Toolbar: CustomToolbar }}
++  slots={{ toolbar: CustomToolbar }}
+-  componentsProps={{ actionBar: { actions: ['clear'] } }}
++  slotProps={{ actionBar: { actions: ['clear'] } }}
+ />;
+```
+
+```bash
+npx @mui/x-codemod v6.0.0/data-grid/rename-components-to-slots <path>
+```
 
 ## v6.0.0
 

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -153,7 +153,7 @@ The list includes these transformers
 
 Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
 
-This change only affects Grid components.
+This change only affects Data Grid components.
 
 ```diff
  <DataGrid

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -92,7 +92,7 @@ The list includes these transformers
 
 #### `rename-components-to-slots-pickers`
 
-Renames the `components` and `componentsProps` props to `slots` and `slotProps`, respectively.
+Renames the `components` and `componentsProps` props to `slots` and `slotProps` respectively.
 
 This change only affects pickers components.
 

--- a/packages/x-codemod/src/v7.0.0/data-grid/rename-components-to-slots/index.ts
+++ b/packages/x-codemod/src/v7.0.0/data-grid/rename-components-to-slots/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../../v6.0.0/data-grid/rename-components-to-slots';

--- a/packages/x-codemod/src/v7.0.0/pickers/preset-safe/actual.spec.js
+++ b/packages/x-codemod/src/v7.0.0/pickers/preset-safe/actual.spec.js
@@ -1,6 +1,8 @@
-import { DatePicker } from '@mui/x-date-pickers';
+import { DatePicker, dayPickerClasses } from '@mui/x-date-pickers';
 import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import TextField from '@mui/material/TextField';
+
+const className = dayPickerClasses.root;
 
 <div>
   <DateRangePicker

--- a/packages/x-codemod/src/v7.0.0/pickers/preset-safe/expected.spec.js
+++ b/packages/x-codemod/src/v7.0.0/pickers/preset-safe/expected.spec.js
@@ -1,6 +1,8 @@
-import { DatePicker } from '@mui/x-date-pickers';
+import { DatePicker, dayCalendarClasses } from '@mui/x-date-pickers';
 import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import TextField from '@mui/material/TextField';
+
+const className = dayCalendarClasses.root;
 
 <div>
   <DateRangePicker

--- a/packages/x-codemod/src/v7.0.0/pickers/preset-safe/index.ts
+++ b/packages/x-codemod/src/v7.0.0/pickers/preset-safe/index.ts
@@ -1,11 +1,13 @@
-import transformRenameComponentsToSlots from '../../../v6.0.0/pickers/rename-components-to-slots';
+import transformRenameComponentsToSlots from '../rename-components-to-slots';
 import transformRenameDefaultCalendarMonthToReferenceDate from '../rename-default-calendar-month-to-reference-date';
+import transformRenameDayPickerClasses from '../rename-day-picker-classes';
 
 import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
 
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
   file.source = transformRenameComponentsToSlots(file, api, options);
   file.source = transformRenameDefaultCalendarMonthToReferenceDate(file, api, options);
+  file.source = transformRenameDayPickerClasses(file, api, options);
 
   return file.source;
 }

--- a/packages/x-codemod/src/v7.0.0/pickers/rename-components-to-slots/index.ts
+++ b/packages/x-codemod/src/v7.0.0/pickers/rename-components-to-slots/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../../v6.0.0/pickers/rename-components-to-slots';


### PR DESCRIPTION
- [x] Add the `rename-components-to-slots-pickers` codemod to the v7.0.0 folder so that people can individually run it (otherwise it's in the v7 preset but to run it alone you have to go to the v6 folder)

- [x] Add `rename-day-picker-classes` to the preset