### PR TITLE
[data grid] Added a guard for reorder cells

### DIFF
--- a/packages/grid/x-data-grid/src/components/GridRow.tsx
+++ b/packages/grid/x-data-grid/src/components/GridRow.tsx
@@ -277,8 +277,11 @@ const GridRow = React.forwardRef<HTMLDivElement, GridRowProps>(function GridRow(
       'width' | 'colSpan' | 'showRightBorder' | 'indexRelativeToAllColumns'
     >,
   ) => {
+    const isReorderCell = column.field === '__reorder__';
     const disableDragEvents =
-      (disableColumnReorder && column.disableReorder) ||
+      // when the cell is a reorder cell we are not allowing to reorder the col anyways
+      // fixes https://github.com/mui/mui-x/issues/11126
+      (!isReorderCell && disableColumnReorder && column.disableReorder) ||
       (!rowReordering &&
         !!sortModel.length &&
         treeDepth > 1 &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

Prevents `disableColumnReorder` prop from disabling dragevents on the reorder cell.

Fixes #11126 