### PR TITLE
[core] Remove reference to non-existant GitHub labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/3.pro-support.yml
+++ b/.github/ISSUE_TEMPLATE/3.pro-support.yml
@@ -1,7 +1,7 @@
 name: 'Pro plan: question ❔'
 description: I'm a Pro plan user, I can't find a solution to my problem with MUI X.
 title: '[question] '
-labels: ['status: waiting for maintainer', 'pro plan', 'support: commercial']
+labels: ['status: waiting for maintainer', 'support: commercial']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/4.premium-support.yml
+++ b/.github/ISSUE_TEMPLATE/4.premium-support.yml
@@ -1,7 +1,7 @@
 name: 'Premium plan: question ❔'
 description: I'm a Premium plan user, I can't find a solution to my problem with MUI X.
 title: '[question] '
-labels: ['status: waiting for maintainer', 'Premium plan', 'support: commercial']
+labels: ['status: waiting for maintainer', 'support: commercial']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This is related to #10488 and https://github.com/mui/mui-x/issues/10582#issuecomment-1824837043, I noticed this as I was explaining to Greg how the labeling system works around support.