### PR TITLE
[docs] Add a card grid to the installation page

### DIFF
--- a/docs/data/introduction/installation/installation.md
+++ b/docs/data/introduction/installation/installation.md
@@ -11,20 +11,6 @@ MUI X components have a peer dependency on `@mui/material`: the installation [in
 
 ## Components
 
-Note that you only need to install the packages corresponding to the components you're using—e.g. data grid users don't need to install date and time pickers.
+Note that you only need to install the packages corresponding to the components you're using—e.g., Data Grid users don't need to install the Date and Time Pickers.
 
-### Data Grid
-
-The installation [instructions](/x/react-data-grid/getting-started/#installation).
-
-### Date and Time Pickers
-
-The installation [instructions](/x/react-date-pickers/getting-started/#installation).
-
-### Charts
-
-The installation [instructions](/x/react-charts/#getting-started).
-
-### Tree View
-
-The installation [instructions](/x/react-tree-view/getting-started/#installation).
+{{"component": "modules/components/InstallationGrid.js"}}

--- a/docs/src/modules/components/InstallationGrid.js
+++ b/docs/src/modules/components/InstallationGrid.js
@@ -9,20 +9,21 @@ import BarChartRoundedIcon from '@mui/icons-material/BarChartRounded';
 const content = [
   {
     title: 'Data Grid',
-    description: 'Feature-rich and fast table extension.',
+    description: 'Fast, feature-rich data table.',
     link: '/x/react-data-grid/getting-started/#installation',
     icon: <PivotTableChartRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Date and Time Pickers',
-    description: 'Let users pick a date and time, or both together.',
+    description: 'A suite of components for selecting dates, times, and ranges.',
     link: '/x/react-date-pickers/getting-started/#installation',
     icon: <CalendarMonthRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Charts',
     link: '/x/react-charts/#getting-started',
-    description: 'Features bar, lines, pie, scatter, and more types of graphs.',
+    description:
+      'A collection of data visualization graphs, including bar, line, pie, scatter, and more.',
     icon: <BarChartRoundedIcon fontSize="small" color="primary" />,
   },
   {

--- a/docs/src/modules/components/InstallationGrid.js
+++ b/docs/src/modules/components/InstallationGrid.js
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import Grid from '@mui/material/Unstable_Grid2';
+import InfoCard from 'docs/src/components/action/InfoCard';
+import TableChartRounded from '@mui/icons-material/TableChartRounded';
+import DateRangeRounded from '@mui/icons-material/DateRangeRounded';
+import AccountTreeRounded from '@mui/icons-material/AccountTreeRounded';
+import ShowChartRounded from '@mui/icons-material/ShowChartRounded';
+
+const content = [
+  {
+    title: 'Data Grid',
+    link: '/x/react-data-grid/getting-started/#installation',
+    icon: <TableChartRounded fontSize="small" color="primary" />,
+  },
+  {
+    title: 'Date and Time Pickers',
+    link: '/x/react-date-pickers/getting-started/#installation',
+    icon: <DateRangeRounded fontSize="small" color="primary" />,
+  },
+  {
+    title: 'Charts',
+    link: '/x/react-charts/#getting-started',
+    icon: <ShowChartRounded fontSize="small" color="primary" />,
+  },
+  {
+    title: 'Tree View',
+    link: '/x/react-tree-view/getting-started/#installation',
+    icon: <AccountTreeRounded fontSize="small" color="primary" />,
+  },
+];
+
+export default function InstallationGrid() {
+  return (
+    <Grid container spacing={2}>
+      {content.map(({ icon, title, link }) => (
+        <Grid key={title} xs={12} sm={6}>
+          <InfoCard classNameTitle="algolia-lvl3" link={link} title={title} icon={icon} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/docs/src/modules/components/InstallationGrid.js
+++ b/docs/src/modules/components/InstallationGrid.js
@@ -9,21 +9,25 @@ import BarChartRoundedIcon from '@mui/icons-material/BarChartRounded';
 const content = [
   {
     title: 'Data Grid',
+    description: 'Feature-rich and fast table extension.',
     link: '/x/react-data-grid/getting-started/#installation',
     icon: <PivotTableChartRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Date and Time Pickers',
+    description: 'Let users pick a date and time, or both together.',
     link: '/x/react-date-pickers/getting-started/#installation',
     icon: <CalendarMonthRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Charts',
     link: '/x/react-charts/#getting-started',
+    description: 'Features bar, lines, pie, scatter, and more types of graphs.',
     icon: <BarChartRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Tree View',
+    description: 'Display hierarchical data, such as a file system navigator.',
     link: '/x/react-tree-view/getting-started/#installation',
     icon: <AccountTreeRounded fontSize="small" color="primary" />,
   },
@@ -32,9 +36,15 @@ const content = [
 export default function InstallationGrid() {
   return (
     <Grid container spacing={2}>
-      {content.map(({ icon, title, link }) => (
+      {content.map(({ icon, title, description, link }) => (
         <Grid key={title} xs={12} sm={6}>
-          <InfoCard classNameTitle="algolia-lvl3" link={link} title={title} icon={icon} />
+          <InfoCard
+            classNameTitle="algolia-lvl3"
+            link={link}
+            title={title}
+            description={description}
+            icon={icon}
+          />
         </Grid>
       ))}
     </Grid>

--- a/docs/src/modules/components/InstallationGrid.js
+++ b/docs/src/modules/components/InstallationGrid.js
@@ -1,26 +1,26 @@
 import * as React from 'react';
 import Grid from '@mui/material/Unstable_Grid2';
 import InfoCard from 'docs/src/components/action/InfoCard';
-import TableChartRounded from '@mui/icons-material/TableChartRounded';
-import DateRangeRounded from '@mui/icons-material/DateRangeRounded';
 import AccountTreeRounded from '@mui/icons-material/AccountTreeRounded';
-import ShowChartRounded from '@mui/icons-material/ShowChartRounded';
+import PivotTableChartRoundedIcon from '@mui/icons-material/PivotTableChartRounded';
+import CalendarMonthRoundedIcon from '@mui/icons-material/CalendarMonthRounded';
+import BarChartRoundedIcon from '@mui/icons-material/BarChartRounded';
 
 const content = [
   {
     title: 'Data Grid',
     link: '/x/react-data-grid/getting-started/#installation',
-    icon: <TableChartRounded fontSize="small" color="primary" />,
+    icon: <PivotTableChartRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Date and Time Pickers',
     link: '/x/react-date-pickers/getting-started/#installation',
-    icon: <DateRangeRounded fontSize="small" color="primary" />,
+    icon: <CalendarMonthRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Charts',
     link: '/x/react-charts/#getting-started',
-    icon: <ShowChartRounded fontSize="small" color="primary" />,
+    icon: <BarChartRoundedIcon fontSize="small" color="primary" />,
   },
   {
     title: 'Tree View',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

While working on https://github.com/mui/material-ui/pull/39832, I noticed a few relatively quick improvement opportunities for the MUI X docs! This one adds a card grid to the installation page to make it a bit more interesting to look at as well as less repetitive (there were four repeating "The installation instructions" text elements).

👉  https://deploy-preview-11177--material-ui-x.netlify.app/x/introduction/installation/