### PR TITLE
[core] Remove outdated ENABLE_AD env variable

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -16,7 +16,6 @@ module.exports = withDocsInfra({
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',
   env: {
-    ENABLE_AD: process.env.ENABLE_AD,
     LIB_VERSION: pkg.version,
     DATA_GRID_VERSION: dataGridPkg.version,
     DATE_PICKERS_VERSION: datePickersPkg.version,


### PR DESCRIPTION
I'm not sure what went wrong on this one, but it's likely when we refactored the logic to move the value to `ENABLE_AD_IN_DEV_MODE` abstracted under the docs infra that we lost track of this value.

<img src="https://github.com/mui/mui-x/assets/3165635/bf26156c-c89b-44c6-a779-26c037d67928" width="693">

Related to #10795