### PR TITLE
[charts] Adjusted `defaultizeValueFormatter` util to accept an optional `series.valueFormatter` value 

### DIFF
--- a/packages/x-charts/src/internals/defaultizeValueFormatter.ts
+++ b/packages/x-charts/src/internals/defaultizeValueFormatter.ts
@@ -1,4 +1,7 @@
-function defaultizeValueFormatter<ISeries extends {}, IFormatter extends (v: any) => string>(
+function defaultizeValueFormatter<
+  ISeries extends { valueFormatter?: IFormatter },
+  IFormatter extends (v: any) => string,
+>(
   series: {
     [id: string]: ISeries;
   },
@@ -15,8 +18,8 @@ function defaultizeValueFormatter<ISeries extends {}, IFormatter extends (v: any
   } = {};
   Object.keys(series).forEach((seriesId) => {
     defaultizedSeries[seriesId] = {
-      valueFormatter: defaultValueFormatter,
       ...series[seriesId],
+      valueFormatter: series[seriesId].valueFormatter ?? defaultValueFormatter,
     };
   });
   return defaultizedSeries;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
