### PR TITLE
[DateRangePicker] Fix `autoFocus` behavior 

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -598,7 +598,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<TDate>(
             renderLoading={renderLoading}
             slots={slotsForDayCalendar}
             slotProps={slotPropsForDayCalendar}
-            autoFocus={month === focusedMonth}
+            autoFocus={visibleMonths[month] === focusedMonth}
             fixedWeekNumber={fixedWeekNumber}
             displayWeekNumber={displayWeekNumber}
             timezone={timezone}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes autoFocus for `DateRangePicker`.
- Fixed mistake in logic for `DayCalendarForRange`'s`autoFocus` prop.