### PR TITLE
[core] Update @mui/monorepo

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,8 +1878,8 @@
     react-transition-group "^4.4.5"
 
 "@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.14.18"
-  resolved "https://github.com/mui/material-ui.git#da4dbf993f403850cdd51a569af78451afd80c32"
+  version "5.14.19"
+  resolved "https://github.com/mui/material-ui.git#a07b4925255aa3fc7ae1255130e182e4573c58d7"
 
 "@mui/private-theming@^5.14.18":
   version "5.14.18"


### PR DESCRIPTION
I want to pull in a change to simplify the Algolia crawler configuration. This should allow:

```diff
              defaultValue: $(".algolia-lvl0")
                .map((index, element) => $(element).text())
                .get()
                .join(" > "),
            },
            lvl1: [".algolia-lvl1", ".markdown-body h1"],
            lvl2: [".algolia-lvl2", ".markdown-body h2"],
-           lvl3: [".algolia-lvl3", ".markdown-body h3, .MuiApi-item-title"],
+           lvl3: [".algolia-lvl3", ".markdown-body h3"],
            lvl4: [".algolia-lvl4", ".markdown-body h4"],
            content:
-             ".algolia-content, .markdown-body p, .markdown-body li, .markdown-body td:first-of-type, .prop-list-description",
+             ".algolia-content, .markdown-body p, .markdown-body li, .markdown-body td:first-of-type",
          },
```

https://crawler.algolia.com/admin/crawlers/739c29c8-99ea-4945-bd27-17a1df391902/overview. The `algolia-x` classes should be enough for the purpose of indexation.

---

A side note, handling https://github.com/mui/material-ui/pull/39808 is going to be painful. I brought the commit just before it.