### PR TITLE
[pickers] Correctly format `MultiSectionDigitalClock` number sections

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
@@ -315,6 +315,7 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
             },
             items: getTimeSectionOptions({
               value: utils.getMinutes(valueOrReferenceDate),
+              utils,
               isDisabled: (minutes) => disabled || isTimeDisabled(minutes, 'minutes'),
               resolveLabel: (minutes) => utils.format(utils.setMinutes(now, minutes), 'minutes'),
               timeStep: timeSteps.minutes,
@@ -331,6 +332,7 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
             },
             items: getTimeSectionOptions({
               value: utils.getSeconds(valueOrReferenceDate),
+              utils,
               isDisabled: (seconds) => disabled || isTimeDisabled(seconds, 'seconds'),
               resolveLabel: (seconds) => utils.format(utils.setSeconds(now, seconds), 'seconds'),
               timeStep: timeSteps.seconds,

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.utils.ts
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.utils.ts
@@ -58,8 +58,9 @@ export const getHourSectionOptions = <TDate>({
   return result;
 };
 
-interface IGetTimeSectionOptions {
+interface IGetTimeSectionOptions<TDate> {
   value: number | null;
+  utils: MuiPickersAdapter<TDate>;
   isDisabled: (value: number) => boolean;
   timeStep: number;
   resolveLabel: (value: number) => string;
@@ -67,14 +68,15 @@ interface IGetTimeSectionOptions {
   resolveAriaLabel: (value: string) => string;
 }
 
-export const getTimeSectionOptions = ({
+export const getTimeSectionOptions = <TDate>({
   value,
+  utils,
   isDisabled,
   timeStep,
   resolveLabel,
   resolveAriaLabel,
   hasValue = true,
-}: IGetTimeSectionOptions): MultiSectionDigitalClockOption<number>[] => {
+}: IGetTimeSectionOptions<TDate>): MultiSectionDigitalClockOption<number>[] => {
   const isSelected = (timeValue: number) => {
     if (value === null) {
       return false;
@@ -88,7 +90,7 @@ export const getTimeSectionOptions = ({
       const timeValue = timeStep * index;
       return {
         value: timeValue,
-        label: resolveLabel(timeValue),
+        label: utils.formatNumber(resolveLabel(timeValue)),
         isDisabled,
         isSelected,
         ariaLabel: resolveAriaLabel(timeValue.toString()),


### PR DESCRIPTION
Backport #11296 