### PR TITLE
[pickers] Fix `MultiSectionDigitalClock` issues

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -205,6 +205,7 @@ export const MultiSectionDigitalClockSection = React.forwardRef(
               aria-label={option.ariaLabel}
               aria-selected={isSelected}
               tabIndex={tabIndex}
+              className={classes.item}
               {...slotProps?.digitalClockSectionItem}
             >
               {option.label}

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -61,7 +61,12 @@ const MultiSectionDigitalClockSectionRoot = styled(MenuList, {
     '@media (prefers-reduced-motion: no-preference)': {
       scrollBehavior: ownerState.alreadyRendered ? 'smooth' : 'auto',
     },
-    '&:hover': {
+    '@media (pointer: fine)': {
+      '&:hover': {
+        overflowY: 'auto',
+      },
+    },
+    '@media (pointer: none), (pointer: coarse)': {
       overflowY: 'auto',
     },
     '&:not(:first-of-type)': {

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/multiSectionDigitalClockSectionClasses.ts
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/multiSectionDigitalClockSectionClasses.ts
@@ -11,8 +11,8 @@ export interface MultiSectionDigitalClockSectionClasses {
 export type MultiSectionDigitalClockSectionClassKey = keyof MultiSectionDigitalClockSectionClasses;
 
 export function getMultiSectionDigitalClockSectionUtilityClass(slot: string) {
-  return generateUtilityClass('MuiMultiSectionDigitalClock', slot);
+  return generateUtilityClass('MuiMultiSectionDigitalClockSection', slot);
 }
 
 export const multiSectionDigitalClockSectionClasses: MultiSectionDigitalClockSectionClasses =
-  generateUtilityClasses('MuiMultiSectionDigitalClock', ['root', 'item']);
+  generateUtilityClasses('MuiMultiSectionDigitalClockSection', ['root', 'item']);


### PR DESCRIPTION
Cherry-pick fixes introduced in #9528 

- Fix scrolling on mobile https://github.com/mui/mui-x/pull/9528/commits/0fd69b33e9dae7119060641ec0ad3f5a5297c3fd
- Apply class name to an item https://github.com/mui/mui-x/pull/9528/commits/787ed6ce96ae8b3bd5f4945e421abe205c128a58
- Fix component name: https://github.com/mui/mui-x/pull/9528/commits/a38e5b99b00f7964d6ecc59b268bbe6cae3b0933
You could say that it is a breaking change, but I'd say that this is just a bugfix, because we had duplicate items with the same name and no way to correctly target them.
### Before

![Screenshot 2023-12-04 at 15 29 58](https://github.com/mui/mui-x/assets/4941090/033f89e3-3d65-453c-aa54-1854860b8540)

### After 

![Screenshot 2023-12-04 at 15 29 27](https://github.com/mui/mui-x/assets/4941090/57cb2eac-e09e-443a-9c07-f68a3a953f9f)
