### PR TITLE
[charts] Remove animation on sparkline

### DIFF
--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -71,11 +71,11 @@ Charts containers already use the `useReducedMotion` from `@react-spring/web` to
 
 ```jsx
 // For a single component chart
-<BarChart  skipAnimation />
+<BarChart skipAnimation />
 
 // For a composed chart
 <ResponsiveChartContainer>
-  <BarPlot  skipAnimation />
+  <BarPlot skipAnimation />
 </ResponsiveChartContainer>
 ```
 

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -173,7 +173,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
       }
     >
       {plotType === 'bar' && (
-        <BarPlot slots={slots} slotProps={slotProps} sx={{ shapeRendering: 'auto' }} />
+        <BarPlot skipAnimation slots={slots} slotProps={slotProps} sx={{ shapeRendering: 'auto' }} />
       )}
 
       {plotType === 'line' && (

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -173,7 +173,12 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
       }
     >
       {plotType === 'bar' && (
-        <BarPlot skipAnimation slots={slots} slotProps={slotProps} sx={{ shapeRendering: 'auto' }} />
+        <BarPlot
+          skipAnimation
+          slots={slots}
+          slotProps={slotProps}
+          sx={{ shapeRendering: 'auto' }}
+        />
       )}
 
       {plotType === 'line' && (


### PR DESCRIPTION
I was reading the latest blog post about MUI X and landed on this strange demo experience: https://next.mui.com/x/react-data-grid/custom-columns/#sparkline.

https://github.com/mui/mui-x/assets/3165635/d540aaff-03c3-4632-923b-710fa251865c

None of the Sparklines in https://www.notion.so/mui-org/Sparkline-component-fc42c8576f7a4a46858fbcd713146072 have animations. I think animation is nice if you have a few charts, and you don't need to quickly scan the values, but if that's not the case, e.g. sparkling, it degrades the UX.

This is a polish on top of #9926.

After: https://deploy-preview-11311--material-ui-x.netlify.app/x/react-data-grid/custom-columns/#sparkline

---

**Off-topic**. We have no label per component type, is this missing? e.g. LineChart, BarChart, Sparkline, etc.