### PR TITLE
[docs] Improve `DemoContainer` styling coverage

### DIFF
--- a/docs/data/date-pickers/base-concepts/ReferenceDateDefaultBehavior.js
+++ b/docs/data/date-pickers/base-concepts/ReferenceDateDefaultBehavior.js
@@ -8,7 +8,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 export default function ReferenceDateDefaultBehavior() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DateTimePicker', 'DateTimePicker']}>
+      <DemoContainer components={['DatePicker', 'DatePicker']}>
         <DemoItem label="No validation: uses today">
           <DatePicker />
         </DemoItem>

--- a/docs/data/date-pickers/base-concepts/ReferenceDateDefaultBehavior.tsx
+++ b/docs/data/date-pickers/base-concepts/ReferenceDateDefaultBehavior.tsx
@@ -8,7 +8,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 export default function ReferenceDateDefaultBehavior() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DateTimePicker', 'DateTimePicker']}>
+      <DemoContainer components={['DatePicker', 'DatePicker']}>
         <DemoItem label="No validation: uses today">
           <DatePicker />
         </DemoItem>

--- a/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
+++ b/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
@@ -80,7 +80,6 @@ export function DemoItem(props: DemoItemProps) {
     sx = {
       ...sx,
       [`& .${textFieldClasses.root}`]: {
-        ...sx?.[`& .${textFieldClasses.root}`],
         flexGrow: 1,
       },
     };

--- a/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
+++ b/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
@@ -165,7 +165,11 @@ export function DemoContainer(props: DemoGridProps) {
     } else {
       extraSx = {
         [`& > .${textFieldClasses.root}`]: {
-          minWidth: { xs: 300, md: 400 },
+          minWidth: {
+            xs: 300,
+            // If demo also contains MultiInputDateTimeRangeField, increase width to avoid cutting off the value.
+            md: childrenTypes.has('multi-input-range-field') ? 460 : 400,
+          },
         },
       };
     }

--- a/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
+++ b/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Stack, { StackProps } from '@mui/material/Stack';
+import Stack, { StackProps, stackClasses } from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { SxProps, Theme } from '@mui/material/styles';
 import { textFieldClasses } from '@mui/material/TextField';
@@ -63,27 +63,29 @@ interface DemoItemProps {
   label?: React.ReactNode;
   component?: string;
   children: React.ReactNode;
+  sx?: SxProps<Theme>;
 }
 /**
  * WARNING: This is an internal component used in documentation to achieve a desired layout.
  * Please do not use it in your application.
  */
 export function DemoItem(props: DemoItemProps) {
-  const { label, children, component } = props;
+  const { label, children, component, sx: sxProp } = props;
 
   let spacing: StackProps['spacing'];
-  let sx: StackProps['sx'];
+  let sx = sxProp;
 
   if (component && getChildTypeFromChildName(component) === 'multi-input-range-field') {
     spacing = 1.5;
     sx = {
+      ...sx,
       [`& .${textFieldClasses.root}`]: {
+        ...sx?.[`& .${textFieldClasses.root}`],
         flexGrow: 1,
       },
     };
   } else {
     spacing = 1;
-    sx = undefined;
   }
 
   return (
@@ -94,6 +96,15 @@ export function DemoItem(props: DemoItemProps) {
   );
 }
 
+DemoItem.displayName = 'DemoItem';
+
+const isDemoItem = (child: React.ReactNode): child is React.ReactElement<DemoItemProps> => {
+  if (React.isValidElement(child) && typeof child.type !== 'string') {
+    // @ts-ignore
+    return child.type.displayName === 'DemoItem';
+  }
+  return false;
+};
 /**
  * WARNING: This is an internal component used in documentation to achieve a desired layout.
  * Please do not use it in your application.
@@ -119,7 +130,9 @@ export function DemoContainer(props: DemoGridProps) {
 
   let direction: StackProps['direction'];
   let spacing: StackProps['spacing'];
-  let sx: StackProps['sx'] = {
+  let extraSx: SxProps<Theme> = {};
+  let demoItemSx: SxProps<Theme> = {};
+  const sx: SxProps<Theme> = {
     overflow: 'auto',
     // Add padding as overflow can hide the outline text field label.
     pt: 1,
@@ -145,29 +158,41 @@ export function DemoContainer(props: DemoGridProps) {
     // noop
   } else if (childrenTypes.has('single-input-range-field')) {
     if (!childrenSupportedSections.has('date-time')) {
-      sx = {
-        ...sx,
+      extraSx = {
         [`& > .${textFieldClasses.root}`]: {
           minWidth: 300,
         },
       };
     } else {
-      sx = {
-        ...sx,
+      extraSx = {
         [`& > .${textFieldClasses.root}`]: {
           minWidth: { xs: 300, md: 400 },
         },
       };
     }
   } else if (childrenSupportedSections.has('date-time')) {
-    sx = { ...sx, [`& > .${textFieldClasses.root}`]: { minWidth: 270 } };
+    extraSx = { [`& > .${textFieldClasses.root}`]: { minWidth: 270 } };
+    if (childrenTypes.has('multi-input-range-field')) {
+      // increase width for the multi input date time range fields
+      demoItemSx = { [`& > .${stackClasses.root} > .${textFieldClasses.root}`]: { minWidth: 210 } };
+    }
   } else {
-    sx = { ...sx, [`& > .${textFieldClasses.root}`]: { minWidth: 200 } };
+    extraSx = { [`& > .${textFieldClasses.root}`]: { minWidth: 200 } };
   }
-
+  const finalSx = {
+    ...sx,
+    ...extraSx,
+  };
   return (
-    <Stack direction={direction} spacing={spacing} sx={sx}>
-      {children}
+    <Stack direction={direction} spacing={spacing} sx={finalSx}>
+      {React.Children.map(children, (child) => {
+        if (React.isValidElement(child) && isDemoItem(child)) {
+          // Inject sx styles to the `DemoItem` if it is a direct child of `DemoContainer`.
+          // @ts-ignore
+          return React.cloneElement(child, { sx: { ...extraSx, ...demoItemSx } });
+        }
+        return child;
+      })}
     </Stack>
   );
 }


### PR DESCRIPTION
This PR was inspired by https://github.com/mui/mui-x/pull/9528/commits/f67c50b231a526a7fc47ec0f3272ec10ca901255, but the solution was incorrect and needed much improvement. 🙈 

The problems that were solved:
- The `sx` styles were lost whenever the component in question was wrapped in an intermediate `DemoItem`;
It was fixed by injecting the relevant styles to such an intermediate component, based on its name.
- MultiInputDateTimeRangeField had no explicit styling and thus its value was cut off.
![Screenshot 2023-12-05 at 18 10 33](https://github.com/mui/mui-x/assets/4941090/ede272e7-a020-4e48-a889-a75ed8beed28)
