### PR TITLE
[pickers] Fix views height consistency

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -78,7 +78,7 @@ const DateRangeCalendarMonthContainer = styled('div', {
 }));
 
 const DateRangeCalendarArrowSwitcher = styled(PickersArrowSwitcher)({
-  padding: '16px 16px 8px 16px',
+  padding: '12px 16px 4px 16px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -45,13 +45,13 @@ const PickersCalendarHeaderRoot = styled('div', {
 }>({
   display: 'flex',
   alignItems: 'center',
-  marginTop: 16,
-  marginBottom: 8,
+  marginTop: 12,
+  marginBottom: 4,
   paddingLeft: 24,
   paddingRight: 12,
   // prevent jumping in safari
-  maxHeight: 30,
-  minHeight: 30,
+  maxHeight: 40,
+  minHeight: 40,
 });
 
 const PickersCalendarHeaderLabelContainer = styled('div', {

--- a/packages/x-date-pickers/src/internals/constants/dimensions.ts
+++ b/packages/x-date-pickers/src/internals/constants/dimensions.ts
@@ -2,6 +2,6 @@ export const DAY_SIZE = 36;
 export const DAY_MARGIN = 2;
 export const DIALOG_WIDTH = 320;
 export const MAX_CALENDAR_HEIGHT = 280;
-export const VIEW_HEIGHT = 334;
+export const VIEW_HEIGHT = 336;
 export const DIGITAL_CLOCK_VIEW_HEIGHT = 232;
 export const MULTI_SECTION_CLOCK_SECTION_WIDTH = 48;


### PR DESCRIPTION
Extract https://github.com/mui/mui-x/pull/9528/commits/19b9cbde59591a6001393e583582f3d3c514f7db and https://github.com/mui/mui-x/pull/9528/commits/95c320ae7078686fe015e3a2c9c9e8cc37e28379.

While working on integrating DateRangeCalendar and time clock in a two column layout for the Date Time Range picker I've noticed that there is an inconsistency in the calendar height, particularly the `PickersCalendarHeader`, which was 2px too short on regular DateCalendar.
The [MD2 spec](https://m2.material.io/components/date-pickers#specs:~:text=Mobile%20calendar%20picker-,Calendar%20header,-The%20mobile%20calendar) calls for a header height of 56px instead of the 54px, which we currently have.

Extracting the change into a separate PR to separate the Argos diff.