### PR TITLE
[data grid] Add baseTooltip to GridColumnHeaderSortIcon.tsx

### DIFF
--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
@@ -65,7 +65,6 @@ function GridColumnHeaderSortIconRaw(props: GridColumnHeaderSortIconProps) {
     <rootProps.slots.baseIconButton
       tabIndex={-1}
       aria-label={apiRef.current.getLocaleText('columnHeaderSortIconLabel')}
-      title={apiRef.current.getLocaleText('columnHeaderSortIconLabel')}
       size="small"
       {...rootProps.slotProps?.baseIconButton}
     >

--- a/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
+++ b/packages/grid/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
@@ -74,15 +74,21 @@ function GridColumnHeaderSortIconRaw(props: GridColumnHeaderSortIconProps) {
   );
 
   return (
-    <GridIconButtonContainer>
-      {index != null && (
-        <Badge badgeContent={index} color="default">
-          {iconButton}
-        </Badge>
-      )}
+    <rootProps.slots.baseTooltip
+      title={apiRef.current.getLocaleText('columnHeaderSortIconLabel')}
+      enterDelay={1000}
+      {...rootProps.slotProps?.baseTooltip}
+    >
+      <GridIconButtonContainer>
+        {index != null && (
+          <Badge badgeContent={index} color="default">
+            {iconButton}
+          </Badge>
+        )}
 
-      {index == null && iconButton}
-    </GridIconButtonContainer>
+        {index == null && iconButton}
+      </GridIconButtonContainer>
+    </rootProps.slots.baseTooltip>
   );
 }
 


### PR DESCRIPTION
GridColumnHeaderSortIcon had a default browser tooltip. I added the baseTooltip so it has the same appearance.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
