### PR TITLE
v7.0.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.4`.
 
 - [charts] Remove animation on sparkline (#11311) @oliviertassinari
 - [charts] Use voronoi cells to trigger interaction with scatter items (#10981) @alexfauquette
+- [charts] Add `@mui/utils` as a dependency (#11351) @michelengelen
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
   Users needed to hover the item to highlight the scatter item or show the tooltip.
   Now they can interact with data by triggering the closest element. See the [docs page](https://next.mui.com/x/react-charts/scatter/#interaction) for more info.
 
-- 📚 Add [Pickers FAQ page](https://mui.com/x/react-date-pickers/faq/)
+- 📚 Add [Pickers FAQ page](https://next.mui.com/x/react-date-pickers/faq/)
 - 🎉 The Data Grid Header filters feature is now stable
 - 🌍 Improve Danish (da-DK) locale on Data Grid
 - 🐞 Bugfixes
@@ -24,7 +24,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 #### Breaking changes
 
 - The header filters feature is now stable. `unstable_` prefix is removed from prop `headerFilters` and related exports.
-  From https://github.com/mui/mui-x/pull/11270
+  See [migration docs](https://next.mui.com/x/migration/migration-data-grid-v6/#filtering) for more details.
 
 - The `GridColDef['type']` has been narrowed down to only accept the built-in column types.
   TypeScript users need to use the `GridColDef` interface when defining columns:
@@ -53,7 +53,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
 Same changes as in `@mui/x-data-grid@7.0.0-alpha.4`, plus:
 
-- [DataGridPro] Make Header filters feature stable (#11243) @MBilalShafi
+- [DataGridPro] Make header filters feature stable (#11243) @MBilalShafi
 
 #### `@mui/x-data-grid-premium@7.0.0-alpha.4` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
 
@@ -86,8 +86,6 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.4`.
 
 ### Core
 
-- [core] Ignore the `WhatsNewLayout` demo screenshot (#11312) @cherniavskii
-- [core] Update @mui/monorepo (#11276) @oliviertassinari
 - [docs] General revision of the Charts docs (#11249) @danilo-leal
 
 ## 7.0.0-alpha.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,95 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 7.0.0-alpha.4
+
+_Dec 8, 2023_
+
+We'd like to offer a big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
+
+- 🚀 The scatter charts now use voronoi to trigger items
+
+  Users needed to hover the item to highlight the scatter item or show the tooltip.
+  Now they can interact with data by triggering the closest element. See the [docs page](https://next.mui.com/x/react-charts/scatter/#interaction) for more info.
+
+- 📚 Add [Pickers FAQ page](https://mui.com/x/react-date-pickers/faq/)
+- 🎉 The Data Grid Header filters feature is now stable
+- 🌍 Improve Danish (da-DK) locale on Data Grid
+- 🐞 Bugfixes
+
+### Data Grid
+
+#### Breaking changes
+
+- The header filters feature is now stable. `unstable_` prefix is removed from prop `headerFilters` and related exports.
+  From https://github.com/mui/mui-x/pull/11270
+
+- The `GridColDef['type']` has been narrowed down to only accept the built-in column types.
+  TypeScript users need to use the `GridColDef` interface when defining columns:
+
+  ```tsx
+  // 🛑 `type` is inferred as `string` and is too wide
+  const columns = [{ type: 'number', field: 'id' }];
+  <DataGrid columns={columns} />;
+
+  // ✅ `type` is `'number'`
+  const columns: GridColDef[] = [{ type: 'number', field: 'id' }];
+  <DataGrid columns={columns} />;
+
+  // ✅ Alternalively, `as const` can be used to narrow down the type
+  const columns = [{ type: 'number' as const, field: 'id' }];
+  <DataGrid columns={columns} />;
+  ```
+
+#### `@mui/x-data-grid@7.0.0-alpha.4`
+
+- [DataGrid] Added a guard for reorder cells (#11159) @michelengelen
+- [DataGrid] Narrow down `GridColDef['type']` (#11270) @cherniavskii
+- [l10n] Improve Danish (da-DK) locale (#11304) @goibon
+
+#### `@mui/x-data-grid-pro@7.0.0-alpha.4` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@7.0.0-alpha.4`, plus:
+
+- [DataGridPro] Make Header filters feature stable (#11243) @MBilalShafi
+
+#### `@mui/x-data-grid-premium@7.0.0-alpha.4` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@7.0.0-alpha.4`.
+
+### Date Pickers
+
+#### `@mui/x-date-pickers@7.0.0-alpha.4`
+
+- [fields] Rework `PickersTextField` (#11258) @flaviendelangle
+- [pickers] Fix `MultiSectionDigitalClock` issues (#11305) @LukasTy
+- [pickers] Fix views height consistency (#11337) @LukasTy
+
+#### `@mui/x-date-pickers-pro@7.0.0-alpha.4` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-date-pickers@7.0.0-alpha.4`.
+
+### Charts / `@mui/x-charts@7.0.0-alpha.4`
+
+- [charts] Remove animation on sparkline (#11311) @oliviertassinari
+- [charts] Use voronoi cells to trigger interaction with scatter items (#10981) @alexfauquette
+
+### Tree View / `@mui/x-tree-view@7.0.0-alpha.4`
+
+### Docs
+
+- [docs] Add FAQ page (#11271) @noraleonte
+- [docs] Add a doc section on how to override the start of the week with each adapter (#11223) @flaviendelangle
+- [docs] Added params to `onPaginationModelChange` docs (#10191) @JFBenzs
+- [docs] Fix typo (#11324) @cadam11
+- [docs] Improve `DemoContainer` styling coverage (#11315) @LukasTy
+
+### Core
+
+- [core] Ignore the `WhatsNewLayout` demo screenshot (#11312) @cherniavskii
+- [core] Update @mui/monorepo (#11276) @oliviertassinari
+- [docs] General revision of the Charts docs (#11249) @danilo-leal
+
 ## 7.0.0-alpha.3
 
 _Dec 4, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -951,6 +951,46 @@ Here is an example of the renaming for the `<ChartsTooltip />` component.
 - [core] Update release instructions as per v7 configuration (#10962) @MBilalShafi
 - [license] Correctly throw errors (#10924) @oliviertassinari
 
+## 6.18.4
+
+_Dec 8, 2023_
+
+We'd like to offer a big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
+
+- 📚 Add [Pickers FAQ page](https://mui.com/x/react-date-pickers/faq/)
+- 🌍 Improve Danish (da-DK) locale on Data Grid
+- 🐞 Bugfixes
+
+### Data Grid
+
+#### `@mui/x-data-grid@6.18.4`
+
+- [DataGrid] Fix cell slot style override (#11215) @oliviertassinari
+- [l10n] Improve Danish (da-DK) locale (#11346) @goibon
+
+#### `@mui/x-data-grid-pro@6.18.4` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@6.18.4`.
+
+#### `@mui/x-data-grid-premium@6.18.4` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@6.18.4`.
+
+### Date Pickers
+
+#### `@mui/x-date-pickers@6.18.4`
+
+- [pickers] Fix `MultiSectionDigitalClock` issues (#11308) @LukasTy
+
+#### `@mui/x-date-pickers-pro@6.18.4` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-date-pickers@6.18.4`.
+
+### Docs
+
+- [docs] Fix typo (#11323) @cadam11
+- [docs] Add FAQ page (#11347) @noraleonte
+
 ## 6.18.3
 
 _Dec 4, 2023_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,6 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.4`.
 - [charts] Remove animation on sparkline (#11311) @oliviertassinari
 - [charts] Use voronoi cells to trigger interaction with scatter items (#10981) @alexfauquette
 
-### Tree View / `@mui/x-tree-view@7.0.0-alpha.4`
-
 ### Docs
 
 - [docs] Add FAQ page (#11271) @noraleonte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,9 +83,6 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.4`.
 - [docs] Added params to `onPaginationModelChange` docs (#10191) @JFBenzs
 - [docs] Fix typo (#11324) @cadam11
 - [docs] Improve `DemoContainer` styling coverage (#11315) @LukasTy
-
-### Core
-
 - [docs] General revision of the Charts docs (#11249) @danilo-leal
 
 ## 7.0.0-alpha.3

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "private": true,
   "scripts": {
     "start": "yarn && yarn docs:dev",

--- a/packages/grid/x-data-grid-generator/package.json
+++ b/packages/grid/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@mui/base": "^5.0.0-beta.26",
-    "@mui/x-data-grid-premium": "7.0.0-alpha.3",
+    "@mui/x-data-grid-premium": "7.0.0-alpha.4",
     "chance": "^1.1.11",
     "clsx": "^2.0.0",
     "lru-cache": "^7.18.3"

--- a/packages/grid/x-data-grid-premium/package.json
+++ b/packages/grid/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "The Premium plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -46,8 +46,8 @@
     "@babel/runtime": "^7.23.5",
     "@mui/system": "^5.14.20",
     "@mui/utils": "^5.14.20",
-    "@mui/x-data-grid": "7.0.0-alpha.3",
-    "@mui/x-data-grid-pro": "7.0.0-alpha.3",
+    "@mui/x-data-grid": "7.0.0-alpha.4",
+    "@mui/x-data-grid-pro": "7.0.0-alpha.4",
     "@mui/x-license-pro": "7.0.0-alpha.1",
     "@types/format-util": "^1.0.4",
     "clsx": "^2.0.0",

--- a/packages/grid/x-data-grid-pro/package.json
+++ b/packages/grid/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "The Pro plan edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -46,7 +46,7 @@
     "@babel/runtime": "^7.23.5",
     "@mui/system": "^5.14.20",
     "@mui/utils": "^5.14.20",
-    "@mui/x-data-grid": "7.0.0-alpha.3",
+    "@mui/x-data-grid": "7.0.0-alpha.4",
     "@mui/x-license-pro": "7.0.0-alpha.1",
     "@types/format-util": "^1.0.4",
     "clsx": "^2.0.0",

--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "The community edition of the data grid component (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-charts",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "The community edition of the charts components (MUI X).",
   "author": "MUI Team",
   "main": "./src/index.js",
@@ -46,9 +46,9 @@
     "@react-spring/web": "^9.7.3",
     "clsx": "^2.0.0",
     "d3-color": "^3.1.0",
+    "d3-delaunay": "^6.0.4",
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
-    "d3-delaunay": "^6.0.4",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {
@@ -68,9 +68,9 @@
   },
   "devDependencies": {
     "@types/d3-color": "^3.1.3",
+    "@types/d3-delaunay": "^6.0.4",
     "@types/d3-scale": "^4.0.8",
-    "@types/d3-shape": "^3.1.6",
-    "@types/d3-delaunay": "^6.0.4"
+    "@types/d3-shape": "^3.1.6"
   },
   "exports": {
     ".": {

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers-pro",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "The commercial edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",
@@ -46,7 +46,7 @@
     "@mui/base": "^5.0.0-beta.26",
     "@mui/system": "^5.14.20",
     "@mui/utils": "^5.14.20",
-    "@mui/x-date-pickers": "7.0.0-alpha.3",
+    "@mui/x-date-pickers": "7.0.0-alpha.4",
     "@mui/x-license-pro": "7.0.0-alpha.1",
     "clsx": "^2.0.0",
     "prop-types": "^15.8.1",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-date-pickers",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "The community edition of the date picker components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-tree-view",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.4",
   "description": "The community edition of the tree view components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-tree-view",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.1",
   "description": "The community edition of the tree view components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",


### PR DESCRIPTION
- [x] Compare the last tag with the branch upon which you want to release (`next` for the alpha / beta releases and `master` for the current stable version).
      To do so, use `yarn release:changelog` The options are the following:

  ```bash
  yarn release:changelog
     --githubToken   YOUR_GITHUB_TOKEN (needs "public_repo" permission)
     --lastRelease   The release to compare against (default: the last one)
     --release       The branch to release (default: master)
  ```

  You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.

  In case of a problem, another method to generate the changelog is available at the end of this page.

- [x] Clean the generated changelog, to match the format of [https://github.com/mui/mui-x/releases](https://github.com/mui/mui-x/releases).
- [x] Update the root `package.json`'s version
- [x] Update the versions of the other `package.json` files and of the dependencies with `yarn release:version` (`yarn release:version prerelease` for alpha / beta releases).
- [x] Open PR with changes and wait for review and green CI.
- [ ] Merge PR once CI is green, and it has been approved.

### Release the packages

- [ ] Checkout the last version of the working branch
- [ ] Make sure you have the latest dependencies installed: `yarn`.
- [ ] Build the packages: `yarn release:build`.
- [ ] Release the versions on npm: `yarn release:publish` (you need your 2FA device).
- [ ] Push the newly created tag: `yarn release:tag`.

### Publish the documentation

The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` releases, `docs-v5` for `v5.X` releases, ...)

- [ ] Push the working branch on the documentation release branch to deploy the documentation with the latest changes.

<!-- #default-branch-switch -->

```bash
git push upstream next:docs-next -f
```

You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-next)
Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-next` deployment.

### Publish GitHub release

- [ ] After documentation is deployed, publish a new release on [GitHub releases page](https://github.com/mui/mui-x/releases)