### PR TITLE
[charts] Added `@mui/utils` as a dependency

### DIFF
--- a/docs/data/charts/getting-started/getting-started.md
+++ b/docs/data/charts/getting-started/getting-started.md
@@ -32,6 +32,53 @@ The `next` tag is used to download the latest, **pre-release**, v7 version.
 Remove it to get the current stable version.
 :::
 
+The Charts package has a peer dependency on `@mui/material`.
+If you are not already using it in your project, you can install it with:
+
+<codeblock storageKey="package-manager">
+```bash npm
+npm install @mui/material @emotion/react @emotion/styled
+```
+```bash yarn
+yarn add @mui/material @emotion/react @emotion/styled
+```
+```bash pnpm
+pnpm add @mui/material @emotion/react @emotion/styled
+```
+</codeblock>
+
+<!-- #react-peer-version -->
+
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
+
+```json
+"peerDependencies": {
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
+},
+```
+
+### Style engine
+
+Material UI is using [Emotion](https://emotion.sh/docs/introduction) as a styling engine by default. If you want to use [`styled-components`](https://styled-components.com/) instead, run:
+
+<codeblock storageKey="package-manager">
+```bash npm
+npm install @mui/styled-engine-sc styled-components
+```
+
+```bash yarn
+yarn add @mui/styled-engine-sc styled-components
+```
+
+```bash pnpm
+pnpm add @mui/styled-engine-sc styled-components
+```
+
+</codeblock>
+
+Take a look at the [Styled engine guide](/material-ui/guides/styled-components/) for more information about how to configure `styled-components` as the style engine.
+
 ### Usage with Next.js
 
 If you're using MUI X Charts with Next.js, you might face the following error:

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -42,6 +42,7 @@
     "@babel/runtime": "^7.23.5",
     "@mui/base": "^5.0.0-beta.26",
     "@mui/system": "^5.14.20",
+    "@mui/utils": "^5.14.20",
     "@react-spring/rafz": "^9.7.3",
     "@react-spring/web": "^9.7.3",
     "clsx": "^2.0.0",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


---
This adds `@mui/utils` as a dependency for the charts package.
I included the section about the `peerDependencies` from the pickers page as well.

Fixes #11338 