### PR TITLE
[github] Update `no-response` workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: MBilalShafi/no-response-add-label@v0.0.6
+      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,8 +1,10 @@
 name: No Response
 
-# Both `issue_comment` and `scheduled` event types are required for this Action
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
 # to work properly.
 on:
+  issues:
+    types: [closed]
   issue_comment:
     types: [created]
   schedule:
@@ -18,7 +20,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: MBilalShafi/no-response-add-label@6291e5d1a4eaffe530b2ec434991f258641a8599
+      - uses: MBilalShafi/no-response-add-label@v0.0.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response


### PR DESCRIPTION
Context: https://github.com/mui/mui-x/issues/10810#issuecomment-1844849589

Added an enhancement to auto-remove the label `status: waiting for maintainer` on the issue close or auto-remove the label `status: waiting for author` on the issue comment and close, if the issue was closed by the author.

Here's a test of the updated action carried out on a test repo: https://github.com/MBilalShafi/test-github-action/issues/6
The action is configured on that repo, feel free to play around with it.