### PR TITLE
[charts] Improve dataset typing

### DIFF
--- a/packages/x-charts/src/BarChart/formatter.ts
+++ b/packages/x-charts/src/BarChart/formatter.ts
@@ -1,15 +1,24 @@
 import { stack as d3Stack } from 'd3-shape';
 import { getStackingGroups } from '../internals/stackSeries';
-import { ChartSeries, Formatter } from '../models/seriesType/config';
+import {
+  ChartSeries,
+  DatasetElementType,
+  DatasetType,
+  Formatter,
+} from '../models/seriesType/config';
 import defaultizeValueFormatter from '../internals/defaultizeValueFormatter';
 import { DefaultizedProps } from '../models/helpers';
+
+let warnOnce = false;
+
+type BarDataset = DatasetType<number | null>;
 
 const formatter: Formatter<'bar'> = (params, dataset) => {
   const { seriesOrder, series } = params;
   const stackingGroups = getStackingGroups(params);
 
   // Create a data set with format adapted to d3
-  const d3Dataset: { [id: string]: number }[] = dataset ?? [];
+  const d3Dataset: BarDataset = (dataset as BarDataset) ?? [];
   seriesOrder.forEach((id) => {
     const data = series[id].data;
     if (data !== undefined) {
@@ -36,7 +45,7 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
   stackingGroups.forEach((stackingGroup) => {
     const { ids, stackingOffset, stackingOrder } = stackingGroup;
     // Get stacked values, and derive the domain
-    const stackedSeries = d3Stack()
+    const stackedSeries = d3Stack<any, DatasetElementType<number | null>, string>()
       .keys(
         ids.map((id) => {
           // Use dataKey if needed and available
@@ -44,6 +53,7 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
           return series[id].data === undefined && dataKey !== undefined ? dataKey : id;
         }),
       )
+      .value((d, key) => d[key] ?? 0) // defaultize null value to 0
       .order(stackingOrder)
       .offset(stackingOffset)(d3Dataset);
 
@@ -52,7 +62,22 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
       completedSeries[id] = {
         layout: 'vertical',
         ...series[id],
-        data: dataKey ? dataset!.map((d) => d[dataKey]) : series[id].data!,
+        data: dataKey
+          ? dataset!.map((data) => {
+              const value = data[dataKey];
+              if (typeof value !== 'number') {
+                if (process.env.NODE_ENV !== 'production' && !warnOnce && value !== null) {
+                  warnOnce = true;
+                  console.error([
+                    `MUI-X charts: your dataset key "${dataKey}" is used for plotting bars, but contains non number elements.`,
+                    'Bar plots only support numbers and null values.',
+                  ]);
+                }
+                return 0;
+              }
+              return value;
+            })
+          : series[id].data!,
         stackedData: stackedSeries[index].map(([a, b]) => [a, b]),
       };
     });

--- a/packages/x-charts/src/BarChart/formatter.ts
+++ b/packages/x-charts/src/BarChart/formatter.ts
@@ -69,7 +69,7 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
                 if (process.env.NODE_ENV !== 'production' && !warnOnce && value !== null) {
                   warnOnce = true;
                   console.error([
-                    `MUI-X charts: your dataset key "${dataKey}" is used for plotting bars, but contains non number elements.`,
+                    `MUI-X charts: your dataset key "${dataKey}" is used for plotting bars, but contains nonnumerical elements.`,
                     'Bar plots only support numbers and null values.',
                   ]);
                 }

--- a/packages/x-charts/src/LineChart/formatter.ts
+++ b/packages/x-charts/src/LineChart/formatter.ts
@@ -1,8 +1,15 @@
 import { stack as d3Stack } from 'd3-shape';
 import { getStackingGroups } from '../internals/stackSeries';
-import { ChartSeries, Formatter } from '../models/seriesType/config';
+import {
+  ChartSeries,
+  DatasetElementType,
+  DatasetType,
+  Formatter,
+} from '../models/seriesType/config';
 import defaultizeValueFormatter from '../internals/defaultizeValueFormatter';
 import { DefaultizedProps } from '../models/helpers';
+
+let warnOnce = false;
 
 // For now it's a copy past of bar charts formatter, but maybe will diverge later
 const formatter: Formatter<'line'> = (params, dataset) => {
@@ -10,7 +17,7 @@ const formatter: Formatter<'line'> = (params, dataset) => {
   const stackingGroups = getStackingGroups(params);
 
   // Create a data set with format adapted to d3
-  const d3Dataset: { [id: string]: number | null }[] = dataset ?? [];
+  const d3Dataset: DatasetType<number | null> = (dataset as DatasetType<number | null>) ?? [];
   seriesOrder.forEach((id) => {
     const data = series[id].data;
     if (data !== undefined) {
@@ -36,7 +43,7 @@ const formatter: Formatter<'line'> = (params, dataset) => {
   stackingGroups.forEach((stackingGroup) => {
     // Get stacked values, and derive the domain
     const { ids, stackingOrder, stackingOffset } = stackingGroup;
-    const stackedSeries = d3Stack<any, { [id: string]: number | null }, string>()
+    const stackedSeries = d3Stack<any, DatasetElementType<number | null>, string>()
       .keys(
         ids.map((id) => {
           // Use dataKey if needed and available
@@ -52,7 +59,22 @@ const formatter: Formatter<'line'> = (params, dataset) => {
       const dataKey = series[id].dataKey;
       completedSeries[id] = {
         ...series[id],
-        data: dataKey ? dataset!.map((d) => d[dataKey]) : series[id].data!,
+        data: dataKey
+          ? dataset!.map((data) => {
+              const value = data[dataKey];
+              if (typeof value !== 'number') {
+                if (process.env.NODE_ENV !== 'production' && !warnOnce && value !== null) {
+                  warnOnce = true;
+                  console.error([
+                    `MUI-X charts: your dataset key "${dataKey}" is used for plotting line, but contains non number elements.`,
+                    'Line plots only support numbers and null values.',
+                  ]);
+                }
+                return 0;
+              }
+              return value;
+            })
+          : series[id].data!,
         stackedData: stackedSeries[index].map(([a, b]) => [a, b]),
       };
     });

--- a/packages/x-charts/src/LineChart/formatter.ts
+++ b/packages/x-charts/src/LineChart/formatter.ts
@@ -9,7 +9,7 @@ import {
 import defaultizeValueFormatter from '../internals/defaultizeValueFormatter';
 import { DefaultizedProps } from '../models/helpers';
 
-let warnOnce = false;
+let warnedOnce = false;
 
 // For now it's a copy past of bar charts formatter, but maybe will diverge later
 const formatter: Formatter<'line'> = (params, dataset) => {
@@ -63,10 +63,10 @@ const formatter: Formatter<'line'> = (params, dataset) => {
           ? dataset!.map((data) => {
               const value = data[dataKey];
               if (typeof value !== 'number') {
-                if (process.env.NODE_ENV !== 'production' && !warnOnce && value !== null) {
-                  warnOnce = true;
+                if (process.env.NODE_ENV !== 'production' && !warnedOnce && value !== null) {
+                  warnedOnce = true;
                   console.error([
-                    `MUI-X charts: your dataset key "${dataKey}" is used for plotting line, but contains non number elements.`,
+                    `MUI-X charts: your dataset key "${dataKey}" is used for plotting line, but contains nonnumerical elements.`,
                     'Line plots only support numbers and null values.',
                   ]);
                 }

--- a/packages/x-charts/src/context/SeriesContextProvider.tsx
+++ b/packages/x-charts/src/context/SeriesContextProvider.tsx
@@ -34,7 +34,7 @@ export type FormattedSeries = { [type in ChartSeriesType]?: FormatterResult<type
 export const SeriesContext = React.createContext<FormattedSeries>({});
 
 const seriesTypeFormatter: {
-  [type in ChartSeriesType]?: (series: any, dataset?: DatasetType<number>) => any;
+  [type in ChartSeriesType]?: (series: any, dataset?: DatasetType) => any;
 } = {
   bar: barSeriesFormatter,
   scatter: scatterSeriesFormatter,
@@ -50,7 +50,7 @@ const seriesTypeFormatter: {
  * @param colors The color palette used to defaultize series colors
  * @returns An object structuring all the series by type.
  */
-const formatSeries = (series: AllSeriesType[], colors: string[], dataset?: DatasetType<number>) => {
+const formatSeries = (series: AllSeriesType[], colors: string[], dataset?: DatasetType) => {
   // Group series by type
   const seriesGroups: { [type in ChartSeriesType]?: FormatterParams<type> } = {};
   series.forEach((seriesData, seriesIndex: number) => {

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -77,13 +77,14 @@ export type FormatterResult<T extends ChartSeriesType> = {
   ? { stackingGroups: StackingGroupsType }
   : {});
 
-export type DatasetType<T extends number | string | Date = number | string | Date> = {
+export type DatasetElementType<T> = {
   [key: string]: T;
-}[];
+};
+export type DatasetType<T = number | string | Date | null | undefined> = DatasetElementType<T>[];
 
 export type Formatter<T extends ChartSeriesType> = (
   params: FormatterParams<T>,
-  dataset?: DatasetType<number>,
+  dataset?: DatasetType,
 ) => FormatterResult<T>;
 
 export type LegendParams = {


### PR DESCRIPTION
When working on https://github.com/mui/material-ui/pull/40107 I noticed `null` was not accepted as a data set value. This PR fixes this issue by allowing `null` and `undefined`.

On a larger topic, I think devs tend to put various things in the dataset. The result of their data fetching without preprocessing to enable rich tooltip for example. I'm wondering if the default type should be `unknown` such that they can put whatever they want in the dataset, and do stricter type-checking into formatters