### PR TITLE
[MUIX-11171] - onRowEditStop not called when blurring the row from a non-editable cell

### DIFF
--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -149,7 +149,10 @@ export const useGridRowEditing = (
       nextFocusedCell.current = null;
       focusTimeout.current = setTimeout(() => {
         focusTimeout.current = null;
-        if (nextFocusedCell.current?.id !== params.id) {
+        if (
+          nextFocusedCell.current?.id !== params.id ||
+          nextFocusedCell.current?.isEditable === false
+        ) {
           // The row might have been deleted during the click
           if (!apiRef.current.getRow(params.id)) {
             return;


### PR DESCRIPTION
## Description
Update implementation to ensure that `onRowEditStop` is triggered when user clicks on an uneditable cell after editing a cell on same row.

https://www.loom.com/share/911cef0d17f5442794ee8e71d80b650e

Fixes #11171 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
