### PR TITLE
[core] Automate cherry-pick of PRs from `next` -> `master`

### DIFF
--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+    branches:
+      - next
+    types: ['closed']
+
+jobs:
+  cherry_pick_to_master:
+    runs-on: ubuntu-latest
+    name: Cherry pick into master
+    permissions:
+      pull-requests: write
+      contents: write
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick and create the new PR
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        with:
+          branch: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+          inherit_labels: false
+          labels: |
+            cherry-pick
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           branch: master
           token: ${{ secrets.GITHUB_TOKEN }}
-          inherit_labels: false
+          body: 'Cherry-pick of #{old_pull_request_id}'
           labels: |
             cherry-pick
 env:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This might be useful for the PRs that need to be cherry-picked to master during the alpha and beta phases of development.

Tested the workflow on a test repo, and it seems to work as expected!