### PR TITLE
[pickers] Fix field types to avoid error on latest `@types/react` version

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -172,7 +172,7 @@ export type UseFieldResponse<TForwardedProps extends UseFieldForwardedProps> = O
   keyof UseFieldForwardedProps
 > &
   Required<UseFieldForwardedProps> &
-  Pick<React.HTMLAttributes<HTMLInputElement>, 'autoCorrect' | 'inputMode' | 'placeholder'> & {
+  Pick<React.InputHTMLAttributes<HTMLInputElement>, 'autoCorrect' | 'inputMode' | 'placeholder'> & {
     ref: React.Ref<HTMLInputElement>;
     value: string;
     onChange: React.ChangeEventHandler<HTMLInputElement>;


### PR DESCRIPTION
The fix is a cherry-pick of this commit: https://github.com/mui/mui-x/pull/11280/commits/1f0b1049be4b0102730358c3b4e794a2525045a7
We can't merge the https://github.com/mui/mui-x/pull/11280 yet.
In the meantime, shipping only this fix should help users avoid problems like this: https://github.com/mui/mui-x/pull/11280#issuecomment-1851045582.