### PR TITLE
[docs] Improve Pickers `name` prop examples

### DIFF
--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.js
@@ -7,10 +7,10 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 export default function FormPropsDatePickers() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker', 'DatePicker']}>
+      <DemoContainer components={['DatePicker', 'DatePicker', 'DatePicker']}>
         <DatePicker label="disabled" disabled />
         <DatePicker label="readOnly" readOnly />
-        <DatePicker label="name" name="date_picker" />
+        <DatePicker label="name" name="startDate" />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx
@@ -7,10 +7,10 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 export default function FormPropsDatePickers() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker', 'DatePicker']}>
+      <DemoContainer components={['DatePicker', 'DatePicker', 'DatePicker']}>
         <DatePicker label="disabled" disabled />
         <DatePicker label="readOnly" readOnly />
-        <DatePicker label="name" name="date_picker" />
+        <DatePicker label="name" name="startDate" />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
+++ b/docs/data/date-pickers/date-picker/FormPropsDatePickers.tsx.preview
@@ -1,3 +1,3 @@
 <DatePicker label="disabled" disabled />
 <DatePicker label="readOnly" readOnly />
-<DatePicker label="name" name="date_picker" />
+<DatePicker label="name" name="startDate" />

--- a/docs/data/date-pickers/date-range-picker/SingleInputDateRangePicker.js
+++ b/docs/data/date-pickers/date-range-picker/SingleInputDateRangePicker.js
@@ -9,7 +9,10 @@ export default function SingleInputDateRangePicker() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['SingleInputDateRangeField']}>
-        <DateRangePicker slots={{ field: SingleInputDateRangeField }} />
+        <DateRangePicker
+          slots={{ field: SingleInputDateRangeField }}
+          name="allowedRange"
+        />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-range-picker/SingleInputDateRangePicker.tsx
+++ b/docs/data/date-pickers/date-range-picker/SingleInputDateRangePicker.tsx
@@ -9,7 +9,10 @@ export default function SingleInputDateRangePicker() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['SingleInputDateRangeField']}>
-        <DateRangePicker slots={{ field: SingleInputDateRangeField }} />
+        <DateRangePicker
+          slots={{ field: SingleInputDateRangeField }}
+          name="allowedRange"
+        />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-range-picker/SingleInputDateRangePicker.tsx.preview
+++ b/docs/data/date-pickers/date-range-picker/SingleInputDateRangePicker.tsx.preview
@@ -1,1 +1,4 @@
-<DateRangePicker slots={{ field: SingleInputDateRangeField }} />
+<DateRangePicker
+  slots={{ field: SingleInputDateRangeField }}
+  name="allowedRange"
+/>

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -83,7 +83,8 @@ This prop will be ignored on the mobile picker.
 
 ### Use a single input field
 
-You can pass the `SingleInputDateRangeField` component to the Date Range Picker to use it for keyboard editing:
+You can pass the `SingleInputDateRangeField` component to the Date Range Picker to use it for keyboard editing.
+In such case the Picker component can pass the `name` prop to the input.
 
 {{"demo": "SingleInputDateRangePicker.js"}}
 

--- a/docs/data/date-pickers/date-time-picker/FormPropsDateTimePickers.js
+++ b/docs/data/date-pickers/date-time-picker/FormPropsDateTimePickers.js
@@ -7,10 +7,12 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 export default function FormPropsDateTimePickers() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DateTimePicker', 'DateTimePicker']}>
+      <DemoContainer
+        components={['DateTimePicker', 'DateTimePicker', 'DateTimePicker']}
+      >
         <DateTimePicker label="disabled" disabled />
         <DateTimePicker label="readOnly" readOnly />
-        <DateTimePicker label="name" name="date_time_picker" />
+        <DateTimePicker label="name" name="startDateTime" />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-time-picker/FormPropsDateTimePickers.tsx
+++ b/docs/data/date-pickers/date-time-picker/FormPropsDateTimePickers.tsx
@@ -7,10 +7,12 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 export default function FormPropsDateTimePickers() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DateTimePicker', 'DateTimePicker']}>
+      <DemoContainer
+        components={['DateTimePicker', 'DateTimePicker', 'DateTimePicker']}
+      >
         <DateTimePicker label="disabled" disabled />
         <DateTimePicker label="readOnly" readOnly />
-        <DateTimePicker label="name" name="date_time_picker" />
+        <DateTimePicker label="name" name="startDateTime" />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/date-time-picker/FormPropsDateTimePickers.tsx.preview
+++ b/docs/data/date-pickers/date-time-picker/FormPropsDateTimePickers.tsx.preview
@@ -1,3 +1,3 @@
 <DateTimePicker label="disabled" disabled />
 <DateTimePicker label="readOnly" readOnly />
-<DateTimePicker label="name" name="date_time_picker" />
+<DateTimePicker label="name" name="startDateTime" />

--- a/docs/data/date-pickers/time-picker/FormPropsTimePickers.js
+++ b/docs/data/date-pickers/time-picker/FormPropsTimePickers.js
@@ -7,10 +7,10 @@ import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 export default function FormPropsTimePickers() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['TimePicker', 'TimePicker']}>
+      <DemoContainer components={['TimePicker', 'TimePicker', 'TimePicker']}>
         <TimePicker label="disabled" disabled />
         <TimePicker label="readOnly" readOnly />
-        <TimePicker label="name" name="time_picker" />
+        <TimePicker label="name" name="startTime" />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/time-picker/FormPropsTimePickers.tsx
+++ b/docs/data/date-pickers/time-picker/FormPropsTimePickers.tsx
@@ -7,10 +7,10 @@ import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 export default function FormPropsTimePickers() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['TimePicker', 'TimePicker']}>
+      <DemoContainer components={['TimePicker', 'TimePicker', 'TimePicker']}>
         <TimePicker label="disabled" disabled />
         <TimePicker label="readOnly" readOnly />
-        <TimePicker label="name" name="time_picker" />
+        <TimePicker label="name" name="startTime" />
       </DemoContainer>
     </LocalizationProvider>
   );

--- a/docs/data/date-pickers/time-picker/FormPropsTimePickers.tsx.preview
+++ b/docs/data/date-pickers/time-picker/FormPropsTimePickers.tsx.preview
@@ -1,3 +1,3 @@
 <TimePicker label="disabled" disabled />
 <TimePicker label="readOnly" readOnly />
-<TimePicker label="name" name="time_picker" />
+<TimePicker label="name" name="startTime" />


### PR DESCRIPTION
Follow-up on #11025 

- Use more form related `name` prop values;
- Add `name` prop usage example on `DateRangePicker` example with single input field;
- Add relevant `components` item to avoid layout issues;
![Screenshot 2023-12-15 at 14 15 49](https://github.com/mui/mui-x/assets/4941090/fe3c7041-0b31-4a79-af2a-ca13c2264542)
