### PR TITLE
[fields] Fix section pasting

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -180,7 +180,14 @@ export const useField = <
         (activeSection.contentType === 'digit' && digitsOnly) ||
         (activeSection.contentType === 'digit-with-letter' && digitsAndLetterOnly);
       if (isValidPastedValue) {
-        // Early return to let the paste update section, value
+        resetCharacterQuery();
+        updateSectionValue({
+          activeSection,
+          newSectionValue: pastedValue,
+          shouldGoToNextSection: true,
+        });
+        // prevent default to avoid the input change handler being called
+        event.preventDefault();
         return;
       }
       if (lettersOnly || digitsOnly) {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -562,7 +562,7 @@ async function initializeEnvironment(
           const input = page.getByRole('textbox');
 
           const isMac = platform() === 'darwin';
-          const modifier = isMac ? 'Meta' : 'Control';
+          const modifier = isMac || browserType.name() === 'webkit' ? 'Meta' : 'Control';
 
           await input.focus();
           // ensure that the focus is moved to the end section by typing naturally - with a timeout

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -96,7 +96,7 @@ async function initializeEnvironment(
   contextOptions?: BrowserContextOptions,
 ) {
   browser = await browserType.launch({
-    headless: true,
+    headless: false,
   });
   // eslint-disable-next-line no-console
   console.log(`Running on: ${browserType.name()}, version: ${browser.version()}.`);
@@ -554,15 +554,11 @@ async function initializeEnvironment(
         });
 
         it('should allow pasting a section', async () => {
-          // the pasting does not seem to work in chromium headless
-          if (browserType.name() === 'chromium') {
-            return;
-          }
           await renderFixture('DatePicker/BasicDesktopDatePicker');
           const input = page.getByRole('textbox');
 
           const isMac = platform() === 'darwin';
-          const modifier = isMac || browserType.name() === 'webkit' ? 'Meta' : 'Control';
+          const modifier = isMac ? 'Meta' : 'Control';
 
           await input.focus();
           // ensure that the focus is moved to the end section by typing naturally - with a timeout

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -554,6 +554,10 @@ async function initializeEnvironment(
         });
 
         it('should allow pasting a section', async () => {
+          // the pasting does not seem to work in chromium headless
+          if (browserType.name() === 'chromium') {
+            return;
+          }
           await renderFixture('DatePicker/BasicDesktopDatePicker');
           const input = page.getByRole('textbox');
 
@@ -564,15 +568,23 @@ async function initializeEnvironment(
           // ensure that the focus is moved to the end section by typing naturally - with a timeout
           await input.pressSequentially('04/11/2022');
           // move to day section
-          await page.keyboard.press('ArrowLeft');
+          await input.press('ArrowLeft');
           // copy day section value
-          await page.keyboard.press(`${modifier}+KeyC`);
+          await input.press(`${modifier}+KeyC`);
           // move to month section
-          await page.keyboard.press('ArrowLeft');
+          await input.press('ArrowLeft');
+          // initiate search query on month section
+          await input.press('1');
           // paste day section value to month section
-          await page.keyboard.press(`${modifier}+KeyV`);
+          await input.press(`${modifier}+KeyV`);
 
           expect(await input.inputValue()).to.equal('11/11/2022');
+
+          // move back to month section
+          await input.press('ArrowLeft');
+          // check that the search query has been cleared after pasting
+          await input.press('2');
+          expect(await input.inputValue()).to.equal('02/11/2022');
         });
       });
       describe('<MobileDatePicker />', () => {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -103,10 +103,6 @@ async function initializeEnvironment(
   context = await browser.newContext({
     // ensure consistent date formatting regardless of environment
     locale: 'en-US',
-    permissions: [
-      ...(browserType.name() !== 'firefox' ? ['clipboard-read'] : []),
-      ...(browserType.name() === 'chromium' ? ['clipboard-write'] : []),
-    ],
     ...contextOptions,
   });
   // Circle CI has low-performance CPUs.
@@ -558,8 +554,8 @@ async function initializeEnvironment(
         });
 
         it('should allow pasting a section', async () => {
-          // the pasting does not seem to work in chromium headless
-          if (browserType.name() === 'chromium') {
+          // Only firefox is capable of reliably running this test in CI and headless browsers
+          if (browserType.name() !== 'firefox' && process.env.CIRCLECI) {
             return;
           }
           await renderFixture('DatePicker/BasicDesktopDatePicker');

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,3 +1,4 @@
+import { platform } from 'node:os';
 import { expect } from 'chai';
 import {
   chromium,
@@ -547,9 +548,31 @@ async function initializeEnvironment(
           const input = page.getByRole('textbox');
 
           await input.focus();
-          await input.type('04/11/2022');
+          await input.fill('04/11/2022');
 
           expect(await input.inputValue()).to.equal('04/11/2022');
+        });
+
+        it('should allow pasting a section', async () => {
+          await renderFixture('DatePicker/BasicDesktopDatePicker');
+          const input = page.getByRole('textbox');
+
+          const isMac = platform() === 'darwin';
+          const modifier = isMac ? 'Meta' : 'Control';
+
+          await input.focus();
+          // ensure that the focus is moved to the end section by typing naturally - with a timeout
+          await input.pressSequentially('04/11/2022');
+          // move to day section
+          await page.keyboard.press('ArrowLeft');
+          // copy day section value
+          await page.keyboard.press(`${modifier}+KeyC`);
+          // move to month section
+          await page.keyboard.press('ArrowLeft');
+          // paste day section value to month section
+          await page.keyboard.press(`${modifier}+KeyV`);
+
+          expect(await input.inputValue()).to.equal('11/11/2022');
         });
       });
       describe('<MobileDatePicker />', () => {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -96,13 +96,17 @@ async function initializeEnvironment(
   contextOptions?: BrowserContextOptions,
 ) {
   browser = await browserType.launch({
-    headless: false,
+    headless: true,
   });
   // eslint-disable-next-line no-console
   console.log(`Running on: ${browserType.name()}, version: ${browser.version()}.`);
   context = await browser.newContext({
     // ensure consistent date formatting regardless of environment
     locale: 'en-US',
+    permissions: [
+      ...(browserType.name() !== 'firefox' ? ['clipboard-read'] : []),
+      ...(browserType.name() === 'chromium' ? ['clipboard-write'] : []),
+    ],
     ...contextOptions,
   });
   // Circle CI has low-performance CPUs.
@@ -554,6 +558,10 @@ async function initializeEnvironment(
         });
 
         it('should allow pasting a section', async () => {
+          // the pasting does not seem to work in chromium headless
+          if (browserType.name() === 'chromium') {
+            return;
+          }
           await renderFixture('DatePicker/BasicDesktopDatePicker');
           const input = page.getByRole('textbox');
 


### PR DESCRIPTION
Fixes #10880 

Currently, when we detect a section paste, we just `return` from the paste handler, thus handing the execution to a regular input change handler, which fails on non-chromium browsers, because on them the `event.data` contains the pasted value.

Changed the logic to update a section value with the pasted value and call `preventDefault` to avoid triggering the input change handler.

### Note
I tried hard to make the e2e test work, but sadly, headless and CI don't play along with Clipboard API nicely. Left only the `firefox` test functional. 🙈 

- Add e2e test asserting correct section copy and paste behavior
  - include an assertion of reset query resetting 
- Add unit test asserting correct section paste behavior