### PR TITLE
[charts] Make error message more explicit

### DIFF
--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -98,7 +98,7 @@ const useCompletedData = (): CompletedBarData[] => {
       if (verticalLayout) {
         if (!isBandScaleConfig(xAxisConfig)) {
           throw new Error(
-            `MUI-Charts: ${
+            `MUI-X-Charts: ${
               xAxisKey === DEFAULT_X_AXIS_KEY
                 ? 'The first `xAxis`'
                 : `The x-axis with id "${xAxisKey}"`
@@ -107,7 +107,7 @@ const useCompletedData = (): CompletedBarData[] => {
         }
         if (xAxis[xAxisKey].data === undefined) {
           throw new Error(
-            `MUI-Charts: ${
+            `MUI-X-Charts: ${
               xAxisKey === DEFAULT_X_AXIS_KEY
                 ? 'The first `xAxis`'
                 : `The x-axis with id "${xAxisKey}"`
@@ -118,7 +118,7 @@ const useCompletedData = (): CompletedBarData[] => {
       } else {
         if (!isBandScaleConfig(yAxisConfig)) {
           throw new Error(
-            `MUI-Charts: ${
+            `MUI-X-Charts: ${
               yAxisKey === DEFAULT_Y_AXIS_KEY
                 ? 'The first `yAxis`'
                 : `The y-axis with id "${yAxisKey}"`
@@ -128,7 +128,7 @@ const useCompletedData = (): CompletedBarData[] => {
 
         if (yAxis[yAxisKey].data === undefined) {
           throw new Error(
-            `MUI-Charts: ${
+            `MUI-X-Charts: ${
               yAxisKey === DEFAULT_Y_AXIS_KEY
                 ? 'The first `yAxis`'
                 : `The y-axis with id "${yAxisKey}"`

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -8,6 +8,7 @@ import { isBandScaleConfig } from '../models/axis';
 import { FormatterResult } from '../models/seriesType/config';
 import { HighlightScope } from '../context/HighlightProvider';
 import { BarSeriesType } from '../models';
+import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '../constants';
 
 /**
  * Solution of the equations
@@ -97,22 +98,42 @@ const useCompletedData = (): CompletedBarData[] => {
       if (verticalLayout) {
         if (!isBandScaleConfig(xAxisConfig)) {
           throw new Error(
-            `Axis with id "${xAxisKey}" shoud be of type "band" to display the bar series of id "${seriesId}"`,
+            `MUI-Charts: ${
+              xAxisKey === DEFAULT_X_AXIS_KEY
+                ? 'The first `xAxis`'
+                : `The x-axis with id "${xAxisKey}"`
+            } shoud be of type "band" to display the bar series of id "${seriesId}"`,
           );
         }
         if (xAxis[xAxisKey].data === undefined) {
-          throw new Error(`Axis with id "${xAxisKey}" shoud have data property`);
+          throw new Error(
+            `MUI-Charts: ${
+              xAxisKey === DEFAULT_X_AXIS_KEY
+                ? 'The first `xAxis`'
+                : `The x-axis with id "${xAxisKey}"`
+            } shoud have data property`,
+          );
         }
         baseScaleConfig = xAxisConfig;
       } else {
         if (!isBandScaleConfig(yAxisConfig)) {
           throw new Error(
-            `Axis with id "${yAxisKey}" shoud be of type "band" to display the bar series of id "${seriesId}"`,
+            `MUI-Charts: ${
+              yAxisKey === DEFAULT_Y_AXIS_KEY
+                ? 'The first `yAxis`'
+                : `The y-axis with id "${yAxisKey}"`
+            } shoud be of type "band" to display the bar series of id "${seriesId}"`,
           );
         }
 
         if (yAxis[yAxisKey].data === undefined) {
-          throw new Error(`Axis with id "${xAxisKey}" shoud have data property`);
+          throw new Error(
+            `MUI-Charts: ${
+              yAxisKey === DEFAULT_Y_AXIS_KEY
+                ? 'The first `yAxis`'
+                : `The y-axis with id "${yAxisKey}"`
+            } shoud have data property`,
+          );
         }
         baseScaleConfig = yAxisConfig;
       }

--- a/packages/x-charts/src/BarChart/formatter.ts
+++ b/packages/x-charts/src/BarChart/formatter.ts
@@ -32,7 +32,7 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
     } else if (dataset === undefined) {
       throw new Error(
         [
-          `MUI-Charts: bar series with id='${id}' has no data.`,
+          `MUI-X-Charts: bar series with id='${id}' has no data.`,
           'Either provide a data property to the series or use the dataset prop.',
         ].join('\n'),
       );

--- a/packages/x-charts/src/BarChart/formatter.ts
+++ b/packages/x-charts/src/BarChart/formatter.ts
@@ -32,7 +32,7 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
     } else if (dataset === undefined) {
       throw new Error(
         [
-          `MUI: bar series with id='${id}' has no data.`,
+          `MUI-Charts: bar series with id='${id}' has no data.`,
           'Either provide a data property to the series or use the dataset prop.',
         ].join('\n'),
       );

--- a/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
+++ b/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
@@ -95,16 +95,36 @@ function ChartsAxis(props: ChartsAxisProps) {
   const rightId = getAxisId(rightAxis);
 
   if (topId !== null && !xAxis[topId]) {
-    throw Error(`MUI: id used for top axis "${topId}" is not defined`);
+    throw Error(
+      [
+        `MUI-Charts: id used for top axis "${topId}" is not defined.`,
+        `Available ids are: ${xAxisIds.join(', ')}.`,
+      ].join('\n'),
+    );
   }
   if (leftId !== null && !yAxis[leftId]) {
-    throw Error(`MUI: id used for left axis "${leftId}" is not defined`);
+    throw Error(
+      [
+        `MUI-Charts: id used for left axis "${leftId}" is not defined.`,
+        `Available ids are: ${yAxisIds.join(', ')}.`,
+      ].join('\n'),
+    );
   }
   if (rightId !== null && !yAxis[rightId]) {
-    throw Error(`MUI: id used for right axis "${rightId}" is not defined`);
+    throw Error(
+      [
+        `MUI-Charts: id used for right axis "${rightId}" is not defined.`,
+        `Available ids are: ${yAxisIds.join(', ')}.`,
+      ].join('\n'),
+    );
   }
   if (bottomId !== null && !xAxis[bottomId]) {
-    throw Error(`MUI: id used for bottom axis "${bottomId}" is not defined`);
+    throw Error(
+      [
+        `MUI-Charts: id used for bottom axis "${bottomId}" is not defined.`,
+        `Available ids are: ${xAxisIds.join(', ')}.`,
+      ].join('\n'),
+    );
   }
   const topAxisProps = mergeProps(topAxis, slots, slotProps);
   const bottomAxisProps = mergeProps(bottomAxis, slots, slotProps);

--- a/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
+++ b/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
@@ -97,7 +97,7 @@ function ChartsAxis(props: ChartsAxisProps) {
   if (topId !== null && !xAxis[topId]) {
     throw Error(
       [
-        `MUI-Charts: id used for top axis "${topId}" is not defined.`,
+        `MUI-X-Charts: id used for top axis "${topId}" is not defined.`,
         `Available ids are: ${xAxisIds.join(', ')}.`,
       ].join('\n'),
     );
@@ -105,7 +105,7 @@ function ChartsAxis(props: ChartsAxisProps) {
   if (leftId !== null && !yAxis[leftId]) {
     throw Error(
       [
-        `MUI-Charts: id used for left axis "${leftId}" is not defined.`,
+        `MUI-X-Charts: id used for left axis "${leftId}" is not defined.`,
         `Available ids are: ${yAxisIds.join(', ')}.`,
       ].join('\n'),
     );
@@ -113,7 +113,7 @@ function ChartsAxis(props: ChartsAxisProps) {
   if (rightId !== null && !yAxis[rightId]) {
     throw Error(
       [
-        `MUI-Charts: id used for right axis "${rightId}" is not defined.`,
+        `MUI-X-Charts: id used for right axis "${rightId}" is not defined.`,
         `Available ids are: ${yAxisIds.join(', ')}.`,
       ].join('\n'),
     );
@@ -121,7 +121,7 @@ function ChartsAxis(props: ChartsAxisProps) {
   if (bottomId !== null && !xAxis[bottomId]) {
     throw Error(
       [
-        `MUI-Charts: id used for bottom axis "${bottomId}" is not defined.`,
+        `MUI-X-Charts: id used for bottom axis "${bottomId}" is not defined.`,
         `Available ids are: ${xAxisIds.join(', ')}.`,
       ].join('\n'),
     );

--- a/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
+++ b/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
@@ -11,11 +11,15 @@ type ChartsReferenceLineProps<TValue extends string | number | Date = string | n
 
 function ChartsReferenceLine(props: ChartsReferenceLineProps) {
   if (props.x !== undefined && props.y !== undefined) {
-    throw new Error('MUI-X-Charts: The ChartsReferenceLine can not have both `x` and `y` props set.');
+    throw new Error(
+      'MUI-X-Charts: The ChartsReferenceLine can not have both `x` and `y` props set.',
+    );
   }
 
   if (props.x === undefined && props.y === undefined) {
-    throw new Error('MUI-X-Charts: The ChartsReferenceLine should have a value in `x` or `y` prop.');
+    throw new Error(
+      'MUI-X-Charts: The ChartsReferenceLine should have a value in `x` or `y` prop.',
+    );
   }
 
   if (props.x !== undefined) {

--- a/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
+++ b/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
@@ -11,11 +11,11 @@ type ChartsReferenceLineProps<TValue extends string | number | Date = string | n
 
 function ChartsReferenceLine(props: ChartsReferenceLineProps) {
   if (props.x !== undefined && props.y !== undefined) {
-    throw new Error('MUI-X: The ChartsReferenceLine can not have both `x` and `y` props set.');
+    throw new Error('MUI-Charts: The ChartsReferenceLine can not have both `x` and `y` props set.');
   }
 
   if (props.x === undefined && props.y === undefined) {
-    throw new Error('MUI-X: The ChartsReferenceLine should have a value in `x` or `y` prop.');
+    throw new Error('MUI-Charts: The ChartsReferenceLine should have a value in `x` or `y` prop.');
   }
 
   if (props.x !== undefined) {

--- a/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
+++ b/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
@@ -11,11 +11,11 @@ type ChartsReferenceLineProps<TValue extends string | number | Date = string | n
 
 function ChartsReferenceLine(props: ChartsReferenceLineProps) {
   if (props.x !== undefined && props.y !== undefined) {
-    throw new Error('MUI-Charts: The ChartsReferenceLine can not have both `x` and `y` props set.');
+    throw new Error('MUI-X-Charts: The ChartsReferenceLine can not have both `x` and `y` props set.');
   }
 
   if (props.x === undefined && props.y === undefined) {
-    throw new Error('MUI-Charts: The ChartsReferenceLine should have a value in `x` or `y` prop.');
+    throw new Error('MUI-X-Charts: The ChartsReferenceLine should have a value in `x` or `y` prop.');
   }
 
   if (props.x !== undefined) {

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -68,7 +68,7 @@ function AreaPlot(props: AreaPlotProps) {
             }
             if (xData.length < stackedData.length) {
               throw new Error(
-                `MUI: data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
+                `MUI-Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
               );
             }
           }

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -6,6 +6,7 @@ import { CartesianContext } from '../context/CartesianContextProvider';
 import { AreaElement, AreaElementProps } from './AreaElement';
 import { getValueToPositionMapper } from '../hooks/useScale';
 import getCurveFactory from '../internals/getCurve';
+import { DEFAULT_X_AXIS_KEY } from '../constants';
 
 export interface AreaPlotSlots {
   area?: React.JSXElementConstructor<AreaElementProps>;
@@ -63,7 +64,11 @@ function AreaPlot(props: AreaPlotProps) {
           if (process.env.NODE_ENV !== 'production') {
             if (xData === undefined) {
               throw new Error(
-                `Axis of id "${xAxisKey}" should have data property to be able to display a line plot.`,
+                `MUI-Charts: ${
+                  xAxisKey === DEFAULT_X_AXIS_KEY
+                    ? 'The first `xAxis`'
+                    : `The x-axis with id "${xAxisKey}"`
+                } should have data property to be able to display a line plot.`,
               );
             }
             if (xData.length < stackedData.length) {

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -64,7 +64,7 @@ function AreaPlot(props: AreaPlotProps) {
           if (process.env.NODE_ENV !== 'production') {
             if (xData === undefined) {
               throw new Error(
-                `MUI-Charts: ${
+                `MUI-X-Charts: ${
                   xAxisKey === DEFAULT_X_AXIS_KEY
                     ? 'The first `xAxis`'
                     : `The x-axis with id "${xAxisKey}"`
@@ -73,7 +73,7 @@ function AreaPlot(props: AreaPlotProps) {
             }
             if (xData.length < stackedData.length) {
               throw new Error(
-                `MUI-Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
+                `MUI-X-Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
               );
             }
           }

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -5,6 +5,7 @@ import { CartesianContext } from '../context/CartesianContextProvider';
 import { LineHighlightElement, LineHighlightElementProps } from './LineHighlightElement';
 import { getValueToPositionMapper } from '../hooks/useScale';
 import { InteractionContext } from '../context/InteractionProvider';
+import { DEFAULT_X_AXIS_KEY } from '../constants';
 
 export interface LineHighlightPlotSlots {
   lineHighlight?: React.JSXElementConstructor<LineHighlightElementProps>;
@@ -80,7 +81,11 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
 
           if (xData === undefined) {
             throw new Error(
-              `Axis of id "${xAxisKey}" should have data property to be able to display a line plot.`,
+              `MUI-Charts: ${
+                xAxisKey === DEFAULT_X_AXIS_KEY
+                  ? 'The first `xAxis`'
+                  : `The x-axis with id "${xAxisKey}"`
+              } should have data property to be able to display a line plot.`,
             );
           }
           const x = xScale(xData[highlightedIndex]);

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -81,7 +81,7 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
 
           if (xData === undefined) {
             throw new Error(
-              `MUI-Charts: ${
+              `MUI-X-Charts: ${
                 xAxisKey === DEFAULT_X_AXIS_KEY
                   ? 'The first `xAxis`'
                   : `The x-axis with id "${xAxisKey}"`

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -66,7 +66,7 @@ function LinePlot(props: LinePlotProps) {
             }
             if (xData.length < stackedData.length) {
               throw new Error(
-                `MUI: data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
+                `MUI-Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
               );
             }
           }

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -6,6 +6,7 @@ import { CartesianContext } from '../context/CartesianContextProvider';
 import { LineElement, LineElementProps } from './LineElement';
 import { getValueToPositionMapper } from '../hooks/useScale';
 import getCurveFactory from '../internals/getCurve';
+import { DEFAULT_X_AXIS_KEY } from '../constants';
 
 export interface LinePlotSlots {
   line?: React.JSXElementConstructor<LineElementProps>;
@@ -61,7 +62,11 @@ function LinePlot(props: LinePlotProps) {
           if (process.env.NODE_ENV !== 'production') {
             if (xData === undefined) {
               throw new Error(
-                `Axis of id "${xAxisKey}" should have data property to be able to display a line plot`,
+                `MUI-Charts: ${
+                  xAxisKey === DEFAULT_X_AXIS_KEY
+                    ? 'The first `xAxis`'
+                    : `The x-axis with id "${xAxisKey}"`
+                } should have data property to be able to display a line plot`,
               );
             }
             if (xData.length < stackedData.length) {

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -62,7 +62,7 @@ function LinePlot(props: LinePlotProps) {
           if (process.env.NODE_ENV !== 'production') {
             if (xData === undefined) {
               throw new Error(
-                `MUI-Charts: ${
+                `MUI-X-Charts: ${
                   xAxisKey === DEFAULT_X_AXIS_KEY
                     ? 'The first `xAxis`'
                     : `The x-axis with id "${xAxisKey}"`
@@ -71,7 +71,7 @@ function LinePlot(props: LinePlotProps) {
             }
             if (xData.length < stackedData.length) {
               throw new Error(
-                `MUI-Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
+                `MUI-X-Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items)`,
               );
             }
           }

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -88,7 +88,7 @@ function MarkPlot(props: MarkPlotProps) {
 
           if (xData === undefined) {
             throw new Error(
-              `MUI-Charts: ${
+              `MUI-X-Charts: ${
                 xAxisKey === DEFAULT_X_AXIS_KEY
                   ? 'The first `xAxis`'
                   : `The x-axis with id "${xAxisKey}"`

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -4,6 +4,7 @@ import { SeriesContext } from '../context/SeriesContextProvider';
 import { CartesianContext } from '../context/CartesianContextProvider';
 import { MarkElement, MarkElementProps } from './MarkElement';
 import { getValueToPositionMapper } from '../hooks/useScale';
+import { DEFAULT_X_AXIS_KEY } from '../constants';
 
 export interface MarkPlotSlots {
   mark?: React.JSXElementConstructor<MarkElementProps>;
@@ -87,7 +88,11 @@ function MarkPlot(props: MarkPlotProps) {
 
           if (xData === undefined) {
             throw new Error(
-              `Axis of id "${xAxisKey}" should have data property to be able to display a line plot`,
+              `MUI-Charts: ${
+                xAxisKey === DEFAULT_X_AXIS_KEY
+                  ? 'The first `xAxis`'
+                  : `The x-axis with id "${xAxisKey}"`
+              } should have data property to be able to display a line plot`,
             );
           }
 

--- a/packages/x-charts/src/LineChart/formatter.ts
+++ b/packages/x-charts/src/LineChart/formatter.ts
@@ -31,7 +31,7 @@ const formatter: Formatter<'line'> = (params, dataset) => {
     } else if (dataset === undefined && process.env.NODE_ENV !== 'production') {
       throw new Error(
         [
-          `MUI-Charts: line series with id='${id}' has no data.`,
+          `MUI-X-Charts: line series with id='${id}' has no data.`,
           'Either provide a data property to the series or use the dataset prop.',
         ].join('\n'),
       );

--- a/packages/x-charts/src/LineChart/formatter.ts
+++ b/packages/x-charts/src/LineChart/formatter.ts
@@ -31,7 +31,7 @@ const formatter: Formatter<'line'> = (params, dataset) => {
     } else if (dataset === undefined && process.env.NODE_ENV !== 'production') {
       throw new Error(
         [
-          `MUI: line series with id='${id}' has no data.`,
+          `MUI-Charts: line series with id='${id}' has no data.`,
           'Either provide a data property to the series or use the dataset prop.',
         ].join('\n'),
       );

--- a/packages/x-charts/src/ResponsiveChartContainer/index.tsx
+++ b/packages/x-charts/src/ResponsiveChartContainer/index.tsx
@@ -74,13 +74,13 @@ const useChartDimensions = (
   if (process.env.NODE_ENV !== 'production') {
     if (displayError.current && inWidth === undefined && width === 0) {
       console.error(
-        `MUI: Charts does not have \`width\` prop, and its container has no \`width\` defined.`,
+        `MUI-Charts: ChartContainer does not have \`width\` prop, and its container has no \`width\` defined.`,
       );
       displayError.current = false;
     }
     if (displayError.current && inHeight === undefined && height === 0) {
       console.error(
-        `MUI: Charts does not have \`height\` prop, and its container has no \`height\` defined.`,
+        `MUI-Charts: ChartContainer does not have \`height\` prop, and its container has no \`height\` defined.`,
       );
       displayError.current = false;
     }

--- a/packages/x-charts/src/ResponsiveChartContainer/index.tsx
+++ b/packages/x-charts/src/ResponsiveChartContainer/index.tsx
@@ -74,13 +74,13 @@ const useChartDimensions = (
   if (process.env.NODE_ENV !== 'production') {
     if (displayError.current && inWidth === undefined && width === 0) {
       console.error(
-        `MUI-Charts: ChartContainer does not have \`width\` prop, and its container has no \`width\` defined.`,
+        `MUI-X-Charts: ChartContainer does not have \`width\` prop, and its container has no \`width\` defined.`,
       );
       displayError.current = false;
     }
     if (displayError.current && inHeight === undefined && height === 0) {
       console.error(
-        `MUI-Charts: ChartContainer does not have \`height\` prop, and its container has no \`height\` defined.`,
+        `MUI-X-Charts: ChartContainer does not have \`height\` prop, and its container has no \`height\` defined.`,
       );
       displayError.current = false;
     }

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -112,7 +112,7 @@ function CartesianContextProvider({
           return axisConfig;
         }
         if (dataset === undefined) {
-          throw Error('MUI-Charts: x-axis uses `dataKey` but no `dataset` is provided.');
+          throw Error('MUI-X-Charts: x-axis uses `dataKey` but no `dataset` is provided.');
         }
         return {
           ...axisConfig,
@@ -130,7 +130,7 @@ function CartesianContextProvider({
           return axisConfig;
         }
         if (dataset === undefined) {
-          throw Error('MUI-Charts: y-axis uses `dataKey` but no `dataset` is provided.');
+          throw Error('MUI-X-Charts: y-axis uses `dataKey` but no `dataset` is provided.');
         }
         return {
           ...axisConfig,

--- a/packages/x-charts/src/context/CartesianContextProvider.tsx
+++ b/packages/x-charts/src/context/CartesianContextProvider.tsx
@@ -112,7 +112,7 @@ function CartesianContextProvider({
           return axisConfig;
         }
         if (dataset === undefined) {
-          throw Error('MUI: x-axis uses `dataKey` but no `dataset` is provided.');
+          throw Error('MUI-Charts: x-axis uses `dataKey` but no `dataset` is provided.');
         }
         return {
           ...axisConfig,
@@ -130,7 +130,7 @@ function CartesianContextProvider({
           return axisConfig;
         }
         if (dataset === undefined) {
-          throw Error('MUI: y-axis uses `dataKey` but no `dataset` is provided.');
+          throw Error('MUI-Charts: y-axis uses `dataKey` but no `dataset` is provided.');
         }
         return {
           ...axisConfig,

--- a/packages/x-charts/src/context/SeriesContextProvider.tsx
+++ b/packages/x-charts/src/context/SeriesContextProvider.tsx
@@ -60,7 +60,7 @@ const formatSeries = (series: AllSeriesType[], colors: string[], dataset?: Datas
       seriesGroups[type] = { series: {}, seriesOrder: [] };
     }
     if (seriesGroups[type]?.series[id] !== undefined) {
-      throw new Error(`MUI-Charts: series' id "${id}" is not unique`);
+      throw new Error(`MUI-X-Charts: series' id "${id}" is not unique`);
     }
 
     seriesGroups[type]!.series[id] = {

--- a/packages/x-charts/src/context/SeriesContextProvider.tsx
+++ b/packages/x-charts/src/context/SeriesContextProvider.tsx
@@ -60,7 +60,7 @@ const formatSeries = (series: AllSeriesType[], colors: string[], dataset?: Datas
       seriesGroups[type] = { series: {}, seriesOrder: [] };
     }
     if (seriesGroups[type]?.series[id] !== undefined) {
-      throw new Error(`MUI: series' id "${id}" is not unique`);
+      throw new Error(`MUI-Charts: series' id "${id}" is not unique`);
     }
 
     seriesGroups[type]!.series[id] = {


### PR DESCRIPTION
This improvement the charts error message in 3 ways (one per commit):

- Use the prefix `MUI-Charts: ` to distinguish error messages that are charts from those coming from other MUI dependencies.
- Provide the array of available axes ids when the provided id is not found, to quickly know if it's a typo or a more serious error.
- Adapt the error message when the axis id is not specified by the user. It's frequent with composition to get an error `Axis of id "DEFAULT_X_AXIS_KEY" should be ...` which makes no sense for a new user.