### PR TITLE
[charts] Allow percentage values for pie chart center and radius

### DIFF
--- a/docs/pages/x/api/charts/pie-arc-label-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-label-plot.json
@@ -1,10 +1,6 @@
 {
   "props": {
-    "outerRadius": {
-      "type": { "name": "number" },
-      "default": "R_max The maximal radius that fit into the drawing area.",
-      "required": true
-    },
+    "outerRadius": { "type": { "name": "number" }, "required": true },
     "arcLabel": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/charts/pie-arc-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-plot.json
@@ -1,10 +1,6 @@
 {
   "props": {
-    "outerRadius": {
-      "type": { "name": "number" },
-      "default": "R_max The maximal radius that fit into the drawing area.",
-      "required": true
-    },
+    "outerRadius": { "type": { "name": "number" }, "required": true },
     "cornerRadius": { "type": { "name": "number" }, "default": "0" },
     "faded": {
       "type": {

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -46,23 +46,27 @@ export interface PieArcLabelPlotSlotProps {
 }
 
 export interface PieArcLabelPlotProps
-  extends DefaultizedProps<
-    Pick<
-      DefaultizedPieSeriesType,
-      | 'data'
-      | 'faded'
-      | 'highlighted'
-      | 'innerRadius'
-      | 'outerRadius'
-      | 'cornerRadius'
-      | 'paddingAngle'
-      | 'arcLabel'
-      | 'arcLabelMinAngle'
-      | 'id'
-      | 'highlightScope'
-    >,
-    'outerRadius'
+  extends Pick<
+    DefaultizedPieSeriesType,
+    | 'data'
+    | 'faded'
+    | 'highlighted'
+    | 'cornerRadius'
+    | 'paddingAngle'
+    | 'arcLabel'
+    | 'arcLabelMinAngle'
+    | 'id'
+    | 'highlightScope'
   > {
+  /**
+   * The radius between circle center and the begining of the arc.
+   * @default 0
+   */
+  innerRadius?: number;
+  /**
+   * The radius between circle center and the end of the arc.
+   */
+  outerRadius: number;
   /**
    * Overridable component slots.
    * @default {}
@@ -227,7 +231,6 @@ PieArcLabelPlot.propTypes = {
   innerRadius: PropTypes.number,
   /**
    * The radius between circle center and the end of the arc.
-   * @default R_max The maximal radius that fit into the drawing area.
    */
   outerRadius: PropTypes.number.isRequired,
   /**

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -13,7 +13,6 @@ import {
   useTransformData,
 } from './dataTransform/useTransformData';
 import { PieArcLabel, PieArcLabelProps } from './PieArcLabel';
-import { DefaultizedProps } from '../models/helpers';
 
 const RATIO = 180 / Math.PI;
 

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useTransition } from '@react-spring/web';
 import {
+  ComputedPieRadius,
   DefaultizedPieSeriesType,
   DefaultizedPieValueType,
   PieSeriesType,
@@ -46,26 +47,18 @@ export interface PieArcLabelPlotSlotProps {
 
 export interface PieArcLabelPlotProps
   extends Pick<
-    DefaultizedPieSeriesType,
-    | 'data'
-    | 'faded'
-    | 'highlighted'
-    | 'cornerRadius'
-    | 'paddingAngle'
-    | 'arcLabel'
-    | 'arcLabelMinAngle'
-    | 'id'
-    | 'highlightScope'
-  > {
-  /**
-   * The radius between circle center and the begining of the arc.
-   * @default 0
-   */
-  innerRadius?: number;
-  /**
-   * The radius between circle center and the end of the arc.
-   */
-  outerRadius: number;
+      DefaultizedPieSeriesType,
+      | 'data'
+      | 'faded'
+      | 'highlighted'
+      | 'cornerRadius'
+      | 'paddingAngle'
+      | 'arcLabel'
+      | 'arcLabelMinAngle'
+      | 'id'
+      | 'highlightScope'
+    >,
+    ComputedPieRadius {
   /**
    * Overridable component slots.
    * @default {}

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useTransition } from '@react-spring/web';
 import { PieArc, PieArcProps } from './PieArc';
 import {
+  ComputedPieRadius,
   DefaultizedPieSeriesType,
   DefaultizedPieValueType,
   PieItemIdentifier,
@@ -24,18 +25,10 @@ export interface PieArcPlotSlotProps {
 
 export interface PieArcPlotProps
   extends Pick<
-    DefaultizedPieSeriesType,
-    'data' | 'faded' | 'highlighted' | 'cornerRadius' | 'paddingAngle' | 'id' | 'highlightScope'
-  > {
-  /**
-   * The radius between circle center and the begining of the arc.
-   * @default 0
-   */
-  innerRadius?: number;
-  /**
-   * The radius between circle center and the end of the arc.
-   */
-  outerRadius: number;
+      DefaultizedPieSeriesType,
+      'data' | 'faded' | 'highlighted' | 'cornerRadius' | 'paddingAngle' | 'id' | 'highlightScope'
+    >,
+    ComputedPieRadius {
   /**
    * Overridable component slots.
    * @default {}

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -13,7 +13,6 @@ import {
   ValueWithHighlight,
   useTransformData,
 } from './dataTransform/useTransformData';
-import { DefaultizedProps } from '../models/helpers';
 
 export interface PieArcPlotSlots {
   pieArc?: React.JSXElementConstructor<PieArcProps>;

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -24,21 +24,19 @@ export interface PieArcPlotSlotProps {
 }
 
 export interface PieArcPlotProps
-  extends DefaultizedProps<
-    Pick<
-      DefaultizedPieSeriesType,
-      | 'data'
-      | 'faded'
-      | 'highlighted'
-      | 'innerRadius'
-      | 'outerRadius'
-      | 'cornerRadius'
-      | 'paddingAngle'
-      | 'id'
-      | 'highlightScope'
-    >,
-    'outerRadius'
+  extends Pick<
+    DefaultizedPieSeriesType,
+    'data' | 'faded' | 'highlighted' | 'cornerRadius' | 'paddingAngle' | 'id' | 'highlightScope'
   > {
+  /**
+   * The radius between circle center and the begining of the arc.
+   * @default 0
+   */
+  innerRadius?: number;
+  /**
+   * The radius between circle center and the end of the arc.
+   */
+  outerRadius: number;
   /**
    * Overridable component slots.
    * @default {}
@@ -218,7 +216,6 @@ PieArcPlot.propTypes = {
   onClick: PropTypes.func,
   /**
    * The radius between circle center and the end of the arc.
-   * @default R_max The maximal radius that fit into the drawing area.
    */
   outerRadius: PropTypes.number.isRequired,
   /**

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -310,8 +310,8 @@ PieChart.propTypes = {
       arcLabelMinAngle: PropTypes.number,
       color: PropTypes.string,
       cornerRadius: PropTypes.number,
-      cx: PropTypes.number,
-      cy: PropTypes.number,
+      cx: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      cy: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       data: PropTypes.arrayOf(
         PropTypes.shape({
           color: PropTypes.string,
@@ -342,8 +342,8 @@ PieChart.propTypes = {
         highlighted: PropTypes.oneOf(['item', 'none', 'series']),
       }),
       id: PropTypes.string,
-      innerRadius: PropTypes.number,
-      outerRadius: PropTypes.number,
+      innerRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      outerRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       paddingAngle: PropTypes.number,
       sortingValues: PropTypes.oneOfType([
         PropTypes.oneOf(['asc', 'desc', 'none']),

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -4,6 +4,7 @@ import { SeriesContext } from '../context/SeriesContextProvider';
 import { DrawingContext } from '../context/DrawingProvider';
 import { PieArcPlot, PieArcPlotProps, PieArcPlotSlotProps, PieArcPlotSlots } from './PieArcPlot';
 import { PieArcLabelPlotSlots, PieArcLabelPlotSlotProps, PieArcLabelPlot } from './PieArcLabelPlot';
+import { getPercentageValue } from '../internals/utils';
 
 export interface PiePlotSlots extends PieArcPlotSlots, PieArcLabelPlotSlots {}
 
@@ -58,27 +59,30 @@ function PiePlot(props: PiePlotProps) {
     <g>
       {seriesOrder.map((seriesId) => {
         const {
-          innerRadius,
-          outerRadius,
+          innerRadius: innerRadiusParam,
+          outerRadius: outerRadiusParam,
           cornerRadius,
           paddingAngle,
           data,
-          cx,
-          cy,
+          cx: cxParam,
+          cy: cyParam,
           highlighted,
           faded,
           highlightScope,
         } = series[seriesId];
+
+        const outerRadius = getPercentageValue(
+          outerRadiusParam ?? availableRadius,
+          availableRadius,
+        );
+        const innerRadius = getPercentageValue(innerRadiusParam ?? 0, availableRadius);
+        const cx = getPercentageValue(cxParam ?? '50%', width);
+        const cy = getPercentageValue(cyParam ?? '50%', height);
         return (
-          <g
-            key={seriesId}
-            transform={`translate(${cx === undefined ? center.x : left + cx}, ${
-              cy === undefined ? center.y : top + cy
-            })`}
-          >
+          <g key={seriesId} transform={`translate(${left + cx}, ${top + cy})`}>
             <PieArcPlot
               innerRadius={innerRadius}
-              outerRadius={outerRadius ?? availableRadius}
+              outerRadius={outerRadius}
               cornerRadius={cornerRadius}
               paddingAngle={paddingAngle}
               id={seriesId}
@@ -96,24 +100,26 @@ function PiePlot(props: PiePlotProps) {
       })}
       {seriesOrder.map((seriesId) => {
         const {
-          innerRadius,
-          outerRadius,
+          innerRadius: innerRadiusParam,
+          outerRadius: outerRadiusParam,
           cornerRadius,
           paddingAngle,
           arcLabel,
           arcLabelMinAngle,
           data,
-          cx,
-          cy,
+          cx: cxParam,
+          cy: cyParam,
           highlightScope,
         } = series[seriesId];
+        const outerRadius = getPercentageValue(
+          outerRadiusParam ?? availableRadius,
+          availableRadius,
+        );
+        const innerRadius = getPercentageValue(innerRadiusParam ?? 0, availableRadius);
+        const cx = getPercentageValue(cxParam ?? '50%', width);
+        const cy = getPercentageValue(cyParam ?? '50%', height);
         return (
-          <g
-            key={seriesId}
-            transform={`translate(${cx === undefined ? center.x : left + cx}, ${
-              cy === undefined ? center.y : top + cy
-            })`}
-          >
+          <g key={seriesId} transform={`translate(${left + cx}, ${top + cy})`}>
             <PieArcLabelPlot
               innerRadius={innerRadius}
               outerRadius={outerRadius ?? availableRadius}

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -49,10 +49,6 @@ function PiePlot(props: PiePlotProps) {
   }
   const availableRadius = Math.min(width, height) / 2;
 
-  const center = {
-    x: left + width / 2,
-    y: top + height / 2,
-  };
   const { series, seriesOrder } = seriesData;
 
   return (

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { InteractionContext } from '../../context/InteractionProvider';
-import { DefaultizedPieSeriesType, DefaultizedPieValueType } from '../../models/seriesType/pie';
+import {
+  ComputedPieRadius,
+  DefaultizedPieSeriesType,
+  DefaultizedPieValueType,
+} from '../../models/seriesType/pie';
 import { getIsHighlighted, getIsFaded } from '../../hooks/useInteractionItemProps';
 
 export interface AnimatedObject {
@@ -21,17 +25,8 @@ export function useTransformData(
   series: Pick<
     DefaultizedPieSeriesType,
     'cornerRadius' | 'paddingAngle' | 'id' | 'highlightScope' | 'highlighted' | 'faded' | 'data'
-  > & {
-    /**
-     * The radius between circle center and the begining of the arc.
-     * @default 0
-     */
-    innerRadius?: number;
-    /**
-     * The radius between circle center and the end of the arc.
-     */
-    outerRadius: number;
-  },
+  > &
+    ComputedPieRadius,
 ) {
   const {
     id: seriesId,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -19,21 +19,20 @@ export interface ValueWithHighlight extends DefaultizedPieValueType, AnimatedObj
 }
 
 export function useTransformData(
-  series: DefaultizedProps<
-    Pick<
-      DefaultizedPieSeriesType,
-      | 'innerRadius'
-      | 'outerRadius'
-      | 'cornerRadius'
-      | 'paddingAngle'
-      | 'id'
-      | 'highlightScope'
-      | 'highlighted'
-      | 'faded'
-      | 'data'
-    >,
-    'outerRadius'
-  >,
+  series: Pick<
+    DefaultizedPieSeriesType,
+    'cornerRadius' | 'paddingAngle' | 'id' | 'highlightScope' | 'highlighted' | 'faded' | 'data'
+  > & {
+    /**
+     * The radius between circle center and the begining of the arc.
+     * @default 0
+     */
+    innerRadius?: number;
+    /**
+     * The radius between circle center and the end of the arc.
+     */
+    outerRadius: number;
+  },
 ) {
   const {
     id: seriesId,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { InteractionContext } from '../../context/InteractionProvider';
 import { DefaultizedPieSeriesType, DefaultizedPieValueType } from '../../models/seriesType/pie';
 import { getIsHighlighted, getIsFaded } from '../../hooks/useInteractionItemProps';
-import { DefaultizedProps } from '../../models/helpers';
 
 export interface AnimatedObject {
   innerRadius: number;

--- a/packages/x-charts/src/internals/utils.ts
+++ b/packages/x-charts/src/internals/utils.ts
@@ -22,8 +22,8 @@ export function getSVGPoint(svg: SVGSVGElement, event: MouseEvent) {
 }
 
 /**
- * Helper that conver values and percentages into values.
- * @param value The value provided by the developper. Can either be a number or a string with '%' or 'px'.
+ * Helper that converts values and percentages into values.
+ * @param value The value provided by the developer. Can either be a number or a string with '%' or 'px'.
  * @param refValue The numerical value associated to 100%.
  * @returns The numerical value associated to the provided value.
  */
@@ -48,6 +48,6 @@ export function getPercentageValue(value: number | string, refValue: number) {
     }
   }
   throw Error(
-    `MUI-Charts: Received the unknown value "${value}". It should be a number, or a string with a percentage value.`,
+    `MUI-Charts: Received an unknown value "${value}". It should be a number, or a string with a percentage value.`,
   );
 }

--- a/packages/x-charts/src/internals/utils.ts
+++ b/packages/x-charts/src/internals/utils.ts
@@ -20,3 +20,34 @@ export function getSVGPoint(svg: SVGSVGElement, event: MouseEvent) {
   pt.y = event.clientY;
   return pt.matrixTransform(svg.getScreenCTM()!.inverse());
 }
+
+/**
+ * Helper that conver values and percentages into values.
+ * @param value The value provided by the developper. Can either be a number or a string with '%' or 'px'.
+ * @param refValue The numerical value associated to 100%.
+ * @returns The numerical value associated to the provided value.
+ */
+export function getPercentageValue(value: number | string, refValue: number) {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (value === '100%') {
+    // Avoid potential rounding issues
+    return refValue;
+  }
+  if (value.endsWith('%')) {
+    const percentage = Number.parseFloat(value.slice(0, value.length - 1));
+    if (!Number.isNaN(percentage)) {
+      return (percentage * refValue) / 100;
+    }
+  }
+  if (value.endsWith('px')) {
+    const val = Number.parseFloat(value.slice(0, value.length - 2));
+    if (!Number.isNaN(val)) {
+      return val;
+    }
+  }
+  throw Error(
+    `MUI-Charts: Received the unknown value "${value}". It should be a number, or a string with a percentage value.`,
+  );
+}

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -26,6 +26,7 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
   innerRadius?: number | string;
   /**
    * The radius between circle center and the end of the arc.
+   * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the maximal radius that fit into the drawing area.
    * @default '100%'
    */
@@ -61,12 +62,14 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
   arcLabelMinAngle?: number;
   /**
    * The x coordinate of the pie center.
+   * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the width the drawing area.
    * @default '50%'
    */
   cx?: number | string;
   /**
    * The y coordinate of the pie center.
+   * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the height the drawing area.
    * @default '50%'
    */

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -117,3 +117,18 @@ export interface DefaultizedPieSeriesType
   extends DefaultizedProps<PieSeriesType, CommonDefaultizedProps> {
   data: DefaultizedPieValueType[];
 }
+
+/**
+ * Props received when the parent components has done the percentage conversion.
+ */
+export interface ComputedPieRadius {
+  /**
+   * The radius between circle center and the begining of the arc.
+   * @default 0
+   */
+  innerRadius?: number;
+  /**
+   * The radius between circle center and the end of the arc.
+   */
+  outerRadius: number;
+}

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -19,14 +19,17 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
   data: Tdata[];
   /**
    * The radius between circle center and the begining of the arc.
+   * Can be a number (in px) or a string with a percentage such as '50%'.
+   * The '100%' is the maximal radius that fit into the drawing area.
    * @default 0
    */
-  innerRadius?: number;
+  innerRadius?: number | string;
   /**
    * The radius between circle center and the end of the arc.
-   * @default R_max The maximal radius that fit into the drawing area.
+   * The '100%' is the maximal radius that fit into the drawing area.
+   * @default '100%'
    */
-  outerRadius?: number;
+  outerRadius?: number | string;
   /**
    * The radius applied to arc corners (similar to border radius).
    * @default 0
@@ -58,14 +61,16 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
   arcLabelMinAngle?: number;
   /**
    * The x coordinate of the pie center.
-   * @default width/2 the center of the drawing area.
+   * The '100%' is the width the drawing area.
+   * @default '50%'
    */
-  cx?: number;
+  cx?: number | string;
   /**
    * The y coordinate of the pie center.
-   * @default height/2 the center of the drawing area.
+   * The '100%' is the height the drawing area.
+   * @default '50%'
    */
-  cy?: number;
+  cy?: number | string;
   /**
    * Override the arc attibutes when it is highlighted.
    */

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -89,6 +89,7 @@
   { "name": "cheerfulFiestaPalette", "kind": "Variable" },
   { "name": "cheerfulFiestaPaletteDark", "kind": "Variable" },
   { "name": "cheerfulFiestaPaletteLight", "kind": "Variable" },
+  { "name": "ComputedPieRadius", "kind": "Interface" },
   { "name": "ContinuouseScaleName", "kind": "TypeAlias" },
   { "name": "CurveType", "kind": "TypeAlias" },
   { "name": "DEFAULT_MARGINS", "kind": "Variable" },


### PR DESCRIPTION
Fix #11309

The inner radius value for 100% is the maximal radius.

My initial idea was to take:
- outer radius at 100% = the maximal radius that fits in the drawing area
- inner radius at 100% = the outer radius

This would ensure that the inner radius is always smaller than the outer radius.

But if you want to put multiple pie charts inside each other, you will need to do some computation to get the outer radius of one pie to match the inner radius of the other one.

The percentage is supported only at the `PiePlot` level. To place sub-components you already need to manipulate the drawing area, so the diff between having to compute `width/2` vs providing `'50%'` is small enough to remove percent support