### PR TITLE
[core] Cherry pick follow up

### DIFF
--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -25,6 +25,7 @@ jobs:
           branch: master
           body: 'Cherry-pick of #{old_pull_request_id}'
           cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
+          author: ${{ github.event.user.name }} <${{ github.event.user.email }}>
           labels: |
             cherry-pick
 env:

--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -1,3 +1,5 @@
+name: Cherry pick next to master
+
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -25,7 +25,7 @@ jobs:
           branch: master
           body: 'Cherry-pick of #{old_pull_request_id}'
           cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
-          author: ${{ github.event.user.name }} <${{ github.event.user.email }}>
+          title: '{old_title} (@${{ github.event.pull_request.user.login }})'
           labels: |
             cherry-pick
 env:


### PR DESCRIPTION
Follow up on #11382

- Add a job name to fix:
![Screenshot 2023-12-20 at 10 53 56](https://github.com/mui/mui-x/assets/4941090/23decac4-2b66-4478-9f99-f9cf065db871)
- Re-use the PR author as the author of the cherry-pick PR. This should help reduce the headache of updating the author of the cherry-pick PR on the generated release changelog.