### PR TITLE
[DataGrid] Export GridColumnUnsortedIconProps Interface for custom slots

### DIFF
--- a/packages/grid/x-data-grid/src/material/icons/GridColumnUnsortedIcon.tsx
+++ b/packages/grid/x-data-grid/src/material/icons/GridColumnUnsortedIcon.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { GridSortDirection } from '../../models/gridSortModel';
 
-interface GridColumnUnsortedIconProps extends SvgIconProps {
+export interface GridColumnUnsortedIconProps extends SvgIconProps {
   sortingOrder: GridSortDirection[];
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/mui-x/issues/11341

Export GridColumnUnsortedIconProps Interface for custom slots
