### PR TITLE
[docs] Document `false` default values for boolean props

### DIFF
--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -17,7 +17,7 @@
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "disableAxisListener": { "type": { "name": "bool" } },
+    "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {
@@ -40,7 +40,7 @@
       },
       "default": "null"
     },
-    "skipAnimation": { "type": { "name": "bool" } },
+    "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "topAxis": {

--- a/docs/pages/x/api/charts/bar-plot.json
+++ b/docs/pages/x/api/charts/bar-plot.json
@@ -1,6 +1,6 @@
 {
   "props": {
-    "skipAnimation": { "type": { "name": "bool" } },
+    "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/x/api/charts/charts-legend.json
+++ b/docs/pages/x/api/charts/charts-legend.json
@@ -2,7 +2,7 @@
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "direction": { "type": { "name": "enum", "description": "'column'<br>&#124;&nbsp;'row'" } },
-    "hidden": { "type": { "name": "bool" } },
+    "hidden": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/x/api/charts/charts-text.json
+++ b/docs/pages/x/api/charts/charts-text.json
@@ -2,7 +2,7 @@
   "props": {
     "text": { "type": { "name": "string" }, "required": true },
     "lineHeight": { "type": { "name": "number" } },
-    "needsComputation": { "type": { "name": "bool" } },
+    "needsComputation": { "type": { "name": "bool" }, "default": "false" },
     "style": { "type": { "name": "object" } }
   },
   "slots": [],

--- a/docs/pages/x/api/charts/charts-x-axis.json
+++ b/docs/pages/x/api/charts/charts-x-axis.json
@@ -2,8 +2,8 @@
   "props": {
     "axisId": { "type": { "name": "string" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "disableLine": { "type": { "name": "bool" } },
-    "disableTicks": { "type": { "name": "bool" } },
+    "disableLine": { "type": { "name": "bool" }, "default": "false" },
+    "disableTicks": { "type": { "name": "bool" }, "default": "false" },
     "fill": { "type": { "name": "string" }, "default": "'currentColor'" },
     "label": { "type": { "name": "string" } },
     "labelFontSize": {

--- a/docs/pages/x/api/charts/charts-y-axis.json
+++ b/docs/pages/x/api/charts/charts-y-axis.json
@@ -2,8 +2,8 @@
   "props": {
     "axisId": { "type": { "name": "string" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "disableLine": { "type": { "name": "bool" } },
-    "disableTicks": { "type": { "name": "bool" } },
+    "disableLine": { "type": { "name": "bool" }, "default": "false" },
+    "disableTicks": { "type": { "name": "bool" }, "default": "false" },
     "fill": { "type": { "name": "string" }, "default": "'currentColor'" },
     "label": { "type": { "name": "string" } },
     "labelFontSize": {

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -17,7 +17,7 @@
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "disableAxisListener": { "type": { "name": "bool" } },
+    "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "disableLineItemHighlight": { "type": { "name": "bool" } },
     "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {

--- a/docs/pages/x/api/charts/pie-arc-label-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-label-plot.json
@@ -27,7 +27,7 @@
     },
     "innerRadius": { "type": { "name": "number" }, "default": "0" },
     "paddingAngle": { "type": { "name": "number" }, "default": "0" },
-    "skipAnimation": { "type": { "name": "bool" } },
+    "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/x/api/charts/pie-arc-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-plot.json
@@ -27,7 +27,7 @@
       }
     },
     "paddingAngle": { "type": { "name": "number" }, "default": "0" },
-    "skipAnimation": { "type": { "name": "bool" } },
+    "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -11,7 +11,7 @@
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "disableAxisListener": { "type": { "name": "bool" } },
+    "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {
@@ -34,7 +34,7 @@
       },
       "default": "null"
     },
-    "skipAnimation": { "type": { "name": "bool" } },
+    "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "topAxis": {
       "type": {

--- a/docs/pages/x/api/charts/pie-plot.json
+++ b/docs/pages/x/api/charts/pie-plot.json
@@ -7,7 +7,7 @@
         "describedArgs": ["event", "pieItemIdentifier", "item"]
       }
     },
-    "skipAnimation": { "type": { "name": "bool" } },
+    "skipAnimation": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -11,8 +11,8 @@
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "disableAxisListener": { "type": { "name": "bool" } },
-    "disableVoronoi": { "type": { "name": "bool" } },
+    "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
+    "disableVoronoi": { "type": { "name": "bool" }, "default": "false" },
     "height": { "type": { "name": "number" }, "default": "undefined" },
     "leftAxis": {
       "type": {

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -4,12 +4,12 @@
       "type": { "name": "arrayOf", "description": "Array&lt;number&gt;" },
       "required": true
     },
-    "area": { "type": { "name": "bool" } },
+    "area": { "type": { "name": "bool" }, "default": "false" },
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" }
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "disableAxisListener": { "type": { "name": "bool" } },
+    "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "height": { "type": { "name": "number" }, "default": "undefined" },
     "margin": {
       "type": {
@@ -22,8 +22,8 @@
       "type": { "name": "enum", "description": "'bar'<br>&#124;&nbsp;'line'" },
       "default": "'line'"
     },
-    "showHighlight": { "type": { "name": "bool" } },
-    "showTooltip": { "type": { "name": "bool" } },
+    "showHighlight": { "type": { "name": "bool" }, "default": "false" },
+    "showTooltip": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "valueFormatter": {

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -20,9 +20,9 @@
     "apiRef": { "type": { "name": "shape", "description": "{ current: object }" } },
     "aria-label": { "type": { "name": "string" } },
     "aria-labelledby": { "type": { "name": "string" } },
-    "autoHeight": { "type": { "name": "bool" } },
-    "autoPageSize": { "type": { "name": "bool" } },
-    "autosizeOnMount": { "type": { "name": "bool" } },
+    "autoHeight": { "type": { "name": "bool" }, "default": "false" },
+    "autoPageSize": { "type": { "name": "bool" }, "default": "false" },
+    "autosizeOnMount": { "type": { "name": "bool" }, "default": "false" },
     "autosizeOptions": {
       "type": {
         "name": "shape",
@@ -30,9 +30,9 @@
       }
     },
     "cellModesModel": { "type": { "name": "object" } },
-    "cellSelection": { "type": { "name": "bool" } },
+    "cellSelection": { "type": { "name": "bool" }, "default": "false" },
     "cellSelectionModel": { "type": { "name": "object" } },
-    "checkboxSelection": { "type": { "name": "bool" } },
+    "checkboxSelection": { "type": { "name": "bool" }, "default": "false" },
     "checkboxSelectionVisibleOnly": {
       "type": { "name": "custom", "description": "bool" },
       "default": "false"
@@ -54,24 +54,24 @@
     "detailPanelExpandedRowIds": {
       "type": { "name": "arrayOf", "description": "Array&lt;number<br>&#124;&nbsp;string&gt;" }
     },
-    "disableAggregation": { "type": { "name": "bool" } },
-    "disableAutosize": { "type": { "name": "bool" } },
-    "disableChildrenFiltering": { "type": { "name": "bool" } },
-    "disableChildrenSorting": { "type": { "name": "bool" } },
-    "disableClipboardPaste": { "type": { "name": "bool" } },
-    "disableColumnFilter": { "type": { "name": "bool" } },
-    "disableColumnMenu": { "type": { "name": "bool" } },
-    "disableColumnPinning": { "type": { "name": "bool" } },
-    "disableColumnReorder": { "type": { "name": "bool" } },
-    "disableColumnResize": { "type": { "name": "bool" } },
-    "disableColumnSelector": { "type": { "name": "bool" } },
-    "disableDensitySelector": { "type": { "name": "bool" } },
-    "disableMultipleColumnsFiltering": { "type": { "name": "bool" } },
-    "disableMultipleColumnsSorting": { "type": { "name": "bool" } },
-    "disableMultipleRowSelection": { "type": { "name": "bool" } },
-    "disableRowGrouping": { "type": { "name": "bool" } },
-    "disableRowSelectionOnClick": { "type": { "name": "bool" } },
-    "disableVirtualization": { "type": { "name": "bool" } },
+    "disableAggregation": { "type": { "name": "bool" }, "default": "false" },
+    "disableAutosize": { "type": { "name": "bool" }, "default": "false" },
+    "disableChildrenFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "disableChildrenSorting": { "type": { "name": "bool" }, "default": "false" },
+    "disableClipboardPaste": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnFilter": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnMenu": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnPinning": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnReorder": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnResize": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableMultipleColumnsFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "disableMultipleColumnsSorting": { "type": { "name": "bool" }, "default": "false" },
+    "disableMultipleRowSelection": { "type": { "name": "bool" }, "default": "false" },
+    "disableRowGrouping": { "type": { "name": "bool" }, "default": "false" },
+    "disableRowSelectionOnClick": { "type": { "name": "bool" }, "default": "false" },
+    "disableVirtualization": { "type": { "name": "bool" }, "default": "false" },
     "editMode": {
       "type": { "name": "enum", "description": "'cell'<br>&#124;&nbsp;'row'" },
       "default": "\"cell\""
@@ -169,15 +169,15 @@
       }
     },
     "groupingColDef": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;object" } },
-    "headerFilters": { "type": { "name": "bool" } },
-    "hideFooter": { "type": { "name": "bool" } },
-    "hideFooterPagination": { "type": { "name": "bool" } },
+    "headerFilters": { "type": { "name": "bool" }, "default": "false" },
+    "hideFooter": { "type": { "name": "bool" }, "default": "false" },
+    "hideFooterPagination": { "type": { "name": "bool" }, "default": "false" },
     "hideFooterRowCount": {
       "type": { "name": "custom", "description": "bool" },
       "default": "false"
     },
-    "hideFooterSelectedRowCount": { "type": { "name": "bool" } },
-    "ignoreDiacritics": { "type": { "name": "bool" } },
+    "hideFooterSelectedRowCount": { "type": { "name": "bool" }, "default": "false" },
+    "ignoreDiacritics": { "type": { "name": "bool" }, "default": "false" },
     "ignoreValueFormatterDuringExport": {
       "type": {
         "name": "union",
@@ -210,8 +210,8 @@
         "returned": "boolean"
       }
     },
-    "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" } },
-    "keepNonExistentRowsSelected": { "type": { "name": "bool" } },
+    "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" }, "default": "false" },
+    "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
     "loading": { "type": { "name": "bool" } },
     "localeText": { "type": { "name": "object" } },
     "logger": {
@@ -526,7 +526,7 @@
       },
       "default": "[25, 50, 100]"
     },
-    "pagination": { "type": { "name": "bool" } },
+    "pagination": { "type": { "name": "bool" }, "default": "false" },
     "paginationMode": {
       "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" },
       "default": "\"client\""
@@ -564,7 +564,7 @@
     "rowHeight": { "type": { "name": "number" }, "default": "52" },
     "rowModesModel": { "type": { "name": "object" } },
     "rowPositionsDebounceMs": { "type": { "name": "number" }, "default": "166" },
-    "rowReordering": { "type": { "name": "bool" } },
+    "rowReordering": { "type": { "name": "bool" }, "default": "false" },
     "rowSelection": { "type": { "name": "bool" }, "default": "true" },
     "rowSelectionModel": {
       "type": {
@@ -582,8 +582,8 @@
     "rowThreshold": { "type": { "name": "number" }, "default": "3" },
     "scrollbarSize": { "type": { "name": "number" } },
     "scrollEndThreshold": { "type": { "name": "number" }, "default": "80" },
-    "showCellVerticalBorder": { "type": { "name": "bool" } },
-    "showColumnVerticalBorder": { "type": { "name": "bool" } },
+    "showCellVerticalBorder": { "type": { "name": "bool" }, "default": "false" },
+    "showColumnVerticalBorder": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" } },
     "slots": { "type": { "name": "object" } },
     "sortingMode": {
@@ -612,7 +612,7 @@
       "additionalInfo": { "sx": true }
     },
     "throttleRowsMs": { "type": { "name": "number" }, "default": "0" },
-    "treeData": { "type": { "name": "bool" } }
+    "treeData": { "type": { "name": "bool" }, "default": "false" }
   },
   "slots": [
     {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -11,9 +11,9 @@
     "apiRef": { "type": { "name": "shape", "description": "{ current: object }" } },
     "aria-label": { "type": { "name": "string" } },
     "aria-labelledby": { "type": { "name": "string" } },
-    "autoHeight": { "type": { "name": "bool" } },
-    "autoPageSize": { "type": { "name": "bool" } },
-    "autosizeOnMount": { "type": { "name": "bool" } },
+    "autoHeight": { "type": { "name": "bool" }, "default": "false" },
+    "autoPageSize": { "type": { "name": "bool" }, "default": "false" },
+    "autosizeOnMount": { "type": { "name": "bool" }, "default": "false" },
     "autosizeOptions": {
       "type": {
         "name": "shape",
@@ -21,7 +21,7 @@
       }
     },
     "cellModesModel": { "type": { "name": "object" } },
-    "checkboxSelection": { "type": { "name": "bool" } },
+    "checkboxSelection": { "type": { "name": "bool" }, "default": "false" },
     "checkboxSelectionVisibleOnly": {
       "type": { "name": "custom", "description": "bool" },
       "default": "false"
@@ -43,21 +43,21 @@
     "detailPanelExpandedRowIds": {
       "type": { "name": "arrayOf", "description": "Array&lt;number<br>&#124;&nbsp;string&gt;" }
     },
-    "disableAutosize": { "type": { "name": "bool" } },
-    "disableChildrenFiltering": { "type": { "name": "bool" } },
-    "disableChildrenSorting": { "type": { "name": "bool" } },
-    "disableColumnFilter": { "type": { "name": "bool" } },
-    "disableColumnMenu": { "type": { "name": "bool" } },
-    "disableColumnPinning": { "type": { "name": "bool" } },
-    "disableColumnReorder": { "type": { "name": "bool" } },
-    "disableColumnResize": { "type": { "name": "bool" } },
-    "disableColumnSelector": { "type": { "name": "bool" } },
-    "disableDensitySelector": { "type": { "name": "bool" } },
-    "disableMultipleColumnsFiltering": { "type": { "name": "bool" } },
-    "disableMultipleColumnsSorting": { "type": { "name": "bool" } },
-    "disableMultipleRowSelection": { "type": { "name": "bool" } },
-    "disableRowSelectionOnClick": { "type": { "name": "bool" } },
-    "disableVirtualization": { "type": { "name": "bool" } },
+    "disableAutosize": { "type": { "name": "bool" }, "default": "false" },
+    "disableChildrenFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "disableChildrenSorting": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnFilter": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnMenu": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnPinning": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnReorder": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnResize": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableMultipleColumnsFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "disableMultipleColumnsSorting": { "type": { "name": "bool" }, "default": "false" },
+    "disableMultipleRowSelection": { "type": { "name": "bool" }, "default": "false" },
+    "disableRowSelectionOnClick": { "type": { "name": "bool" }, "default": "false" },
+    "disableVirtualization": { "type": { "name": "bool" }, "default": "false" },
     "editMode": {
       "type": { "name": "enum", "description": "'cell'<br>&#124;&nbsp;'row'" },
       "default": "\"cell\""
@@ -146,15 +146,15 @@
       }
     },
     "groupingColDef": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;object" } },
-    "headerFilters": { "type": { "name": "bool" } },
-    "hideFooter": { "type": { "name": "bool" } },
-    "hideFooterPagination": { "type": { "name": "bool" } },
+    "headerFilters": { "type": { "name": "bool" }, "default": "false" },
+    "hideFooter": { "type": { "name": "bool" }, "default": "false" },
+    "hideFooterPagination": { "type": { "name": "bool" }, "default": "false" },
     "hideFooterRowCount": {
       "type": { "name": "custom", "description": "bool" },
       "default": "false"
     },
-    "hideFooterSelectedRowCount": { "type": { "name": "bool" } },
-    "ignoreDiacritics": { "type": { "name": "bool" } },
+    "hideFooterSelectedRowCount": { "type": { "name": "bool" }, "default": "false" },
+    "ignoreDiacritics": { "type": { "name": "bool" }, "default": "false" },
     "ignoreValueFormatterDuringExport": {
       "type": {
         "name": "union",
@@ -187,8 +187,8 @@
         "returned": "boolean"
       }
     },
-    "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" } },
-    "keepNonExistentRowsSelected": { "type": { "name": "bool" } },
+    "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" }, "default": "false" },
+    "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
     "loading": { "type": { "name": "bool" } },
     "localeText": { "type": { "name": "object" } },
     "logger": {
@@ -473,7 +473,7 @@
       },
       "default": "[25, 50, 100]"
     },
-    "pagination": { "type": { "name": "bool" } },
+    "pagination": { "type": { "name": "bool" }, "default": "false" },
     "paginationMode": {
       "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" },
       "default": "\"client\""
@@ -506,7 +506,7 @@
     "rowHeight": { "type": { "name": "number" }, "default": "52" },
     "rowModesModel": { "type": { "name": "object" } },
     "rowPositionsDebounceMs": { "type": { "name": "number" }, "default": "166" },
-    "rowReordering": { "type": { "name": "bool" } },
+    "rowReordering": { "type": { "name": "bool" }, "default": "false" },
     "rowSelection": { "type": { "name": "bool" }, "default": "true" },
     "rowSelectionModel": {
       "type": {
@@ -524,8 +524,8 @@
     "rowThreshold": { "type": { "name": "number" }, "default": "3" },
     "scrollbarSize": { "type": { "name": "number" } },
     "scrollEndThreshold": { "type": { "name": "number" }, "default": "80" },
-    "showCellVerticalBorder": { "type": { "name": "bool" } },
-    "showColumnVerticalBorder": { "type": { "name": "bool" } },
+    "showCellVerticalBorder": { "type": { "name": "bool" }, "default": "false" },
+    "showColumnVerticalBorder": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" } },
     "slots": { "type": { "name": "object" } },
     "sortingMode": {
@@ -550,7 +550,7 @@
       "additionalInfo": { "sx": true }
     },
     "throttleRowsMs": { "type": { "name": "number" }, "default": "0" },
-    "treeData": { "type": { "name": "bool" } }
+    "treeData": { "type": { "name": "bool" }, "default": "false" }
   },
   "slots": [
     {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -8,10 +8,10 @@
     "apiRef": { "type": { "name": "shape", "description": "{ current: object }" } },
     "aria-label": { "type": { "name": "string" } },
     "aria-labelledby": { "type": { "name": "string" } },
-    "autoHeight": { "type": { "name": "bool" } },
-    "autoPageSize": { "type": { "name": "bool" } },
+    "autoHeight": { "type": { "name": "bool" }, "default": "false" },
+    "autoPageSize": { "type": { "name": "bool" }, "default": "false" },
     "cellModesModel": { "type": { "name": "object" } },
-    "checkboxSelection": { "type": { "name": "bool" } },
+    "checkboxSelection": { "type": { "name": "bool" }, "default": "false" },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "clipboardCopyCellDelimiter": { "type": { "name": "string" }, "default": "'\\t'" },
     "columnBuffer": { "type": { "name": "number" }, "default": "3" },
@@ -25,12 +25,12 @@
       },
       "default": "\"standard\""
     },
-    "disableColumnFilter": { "type": { "name": "bool" } },
-    "disableColumnMenu": { "type": { "name": "bool" } },
-    "disableColumnSelector": { "type": { "name": "bool" } },
-    "disableDensitySelector": { "type": { "name": "bool" } },
-    "disableRowSelectionOnClick": { "type": { "name": "bool" } },
-    "disableVirtualization": { "type": { "name": "bool" } },
+    "disableColumnFilter": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnMenu": { "type": { "name": "bool" }, "default": "false" },
+    "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableRowSelectionOnClick": { "type": { "name": "bool" }, "default": "false" },
+    "disableVirtualization": { "type": { "name": "bool" }, "default": "false" },
     "editMode": {
       "type": { "name": "enum", "description": "'cell'<br>&#124;&nbsp;'row'" },
       "default": "\"cell\""
@@ -101,10 +101,10 @@
         "returned": "GridRowSpacing"
       }
     },
-    "hideFooter": { "type": { "name": "bool" } },
-    "hideFooterPagination": { "type": { "name": "bool" } },
-    "hideFooterSelectedRowCount": { "type": { "name": "bool" } },
-    "ignoreDiacritics": { "type": { "name": "bool" } },
+    "hideFooter": { "type": { "name": "bool" }, "default": "false" },
+    "hideFooterPagination": { "type": { "name": "bool" }, "default": "false" },
+    "hideFooterSelectedRowCount": { "type": { "name": "bool" }, "default": "false" },
+    "ignoreDiacritics": { "type": { "name": "bool" }, "default": "false" },
     "ignoreValueFormatterDuringExport": {
       "type": {
         "name": "union",
@@ -129,7 +129,7 @@
         "returned": "boolean"
       }
     },
-    "keepNonExistentRowsSelected": { "type": { "name": "bool" } },
+    "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
     "loading": { "type": { "name": "bool" } },
     "localeText": { "type": { "name": "object" } },
     "logger": {
@@ -398,8 +398,8 @@
     },
     "rowThreshold": { "type": { "name": "number" }, "default": "3" },
     "scrollbarSize": { "type": { "name": "number" } },
-    "showCellVerticalBorder": { "type": { "name": "bool" } },
-    "showColumnVerticalBorder": { "type": { "name": "bool" } },
+    "showCellVerticalBorder": { "type": { "name": "bool" }, "default": "false" },
+    "showColumnVerticalBorder": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" } },
     "slots": { "type": { "name": "object" } },
     "sortingMode": {

--- a/docs/pages/x/api/data-grid/grid-filter-panel.json
+++ b/docs/pages/x/api/data-grid/grid-filter-panel.json
@@ -1,8 +1,8 @@
 {
   "props": {
     "columnsSort": { "type": { "name": "enum", "description": "'asc'<br>&#124;&nbsp;'desc'" } },
-    "disableAddFilterButton": { "type": { "name": "bool" } },
-    "disableRemoveAllButton": { "type": { "name": "bool" } },
+    "disableAddFilterButton": { "type": { "name": "bool" }, "default": "false" },
+    "disableRemoveAllButton": { "type": { "name": "bool" }, "default": "false" },
     "filterFormProps": {
       "type": {
         "name": "shape",

--- a/docs/pages/x/api/date-pickers/date-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-calendar.json
@@ -11,10 +11,10 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "focusedView": {
@@ -23,7 +23,7 @@
         "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
     "monthsPerRow": {
@@ -62,7 +62,7 @@
         "description": "'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'"
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "reduceAnimations": {
       "type": { "name": "bool" },
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
@@ -104,7 +104,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-field.json
+++ b/docs/pages/x/api/date-pickers/date-field.json
@@ -1,7 +1,7 @@
 {
   "props": {
-    "autoFocus": { "type": { "name": "bool" } },
-    "clearable": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "clearable": { "type": { "name": "bool" }, "default": "false" },
     "color": {
       "type": {
         "name": "enum",
@@ -10,9 +10,9 @@
       "default": "'primary'"
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focused": { "type": { "name": "bool" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -20,9 +20,9 @@
       "default": "\"dense\""
     },
     "FormHelperTextProps": { "type": { "name": "object" } },
-    "fullWidth": { "type": { "name": "bool" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
     "helperText": { "type": { "name": "node" } },
-    "hiddenLabel": { "type": { "name": "bool" } },
+    "hiddenLabel": { "type": { "name": "bool" }, "default": "false" },
     "id": { "type": { "name": "string" } },
     "InputLabelProps": { "type": { "name": "object" } },
     "inputProps": { "type": { "name": "object" } },
@@ -61,12 +61,12 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
-    "required": { "type": { "name": "bool" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
     "selectedSections": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -20,11 +20,11 @@
       "type": { "name": "string" },
       "default": "'@media (pointer: fine)'"
     },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -34,7 +34,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -82,7 +82,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(year: TDate) => void", "describedArgs": ["year"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -139,7 +139,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-range-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.json
@@ -23,15 +23,15 @@
       "default": "'start'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disableAutoMonthSwitching": { "type": { "name": "bool" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableDragEditing": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableDragEditing": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
     "onChange": {
@@ -53,7 +53,7 @@
       }
     },
     "rangePosition": { "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" } },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "reduceAnimations": {
       "type": { "name": "bool" },
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
@@ -79,7 +79,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-range-picker-day.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-day.json
@@ -16,19 +16,19 @@
         "description": "func<br>&#124;&nbsp;{ current?: { focusVisible: func } }"
       }
     },
-    "centerRipple": { "type": { "name": "bool" } },
+    "centerRipple": { "type": { "name": "bool" }, "default": "false" },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableMargin": { "type": { "name": "bool" } },
-    "disableRipple": { "type": { "name": "bool" } },
-    "disableTouchRipple": { "type": { "name": "bool" } },
-    "focusRipple": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableMargin": { "type": { "name": "bool" }, "default": "false" },
+    "disableRipple": { "type": { "name": "bool" }, "default": "false" },
+    "disableTouchRipple": { "type": { "name": "bool" }, "default": "false" },
+    "focusRipple": { "type": { "name": "bool" }, "default": "false" },
     "focusVisibleClassName": { "type": { "name": "string" } },
     "isVisuallySelected": { "type": { "name": "bool" } },
     "onFocusVisible": { "type": { "name": "func" } },
-    "selected": { "type": { "name": "bool" } },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "selected": { "type": { "name": "bool" }, "default": "false" },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "sx": {
       "type": {
         "name": "union",
@@ -36,7 +36,7 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "today": { "type": { "name": "bool" } },
+    "today": { "type": { "name": "bool" }, "default": "false" },
     "TouchRippleProps": { "type": { "name": "object" } },
     "touchRippleRef": {
       "type": {

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -32,13 +32,13 @@
       "type": { "name": "string" },
       "default": "'@media (pointer: fine)'"
     },
-    "disableAutoMonthSwitching": { "type": { "name": "bool" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableDragEditing": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableDragEditing": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -48,7 +48,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -91,7 +91,7 @@
         "describedArgs": ["newValue"]
       }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "rangePosition": { "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" } },
     "reduceAnimations": {
       "type": { "name": "bool" },
@@ -124,7 +124,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-time-field.json
+++ b/docs/pages/x/api/date-pickers/date-time-field.json
@@ -1,8 +1,8 @@
 {
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
-    "autoFocus": { "type": { "name": "bool" } },
-    "clearable": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "clearable": { "type": { "name": "bool" }, "default": "false" },
     "color": {
       "type": {
         "name": "enum",
@@ -11,10 +11,10 @@
       "default": "'primary'"
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focused": { "type": { "name": "bool" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -22,9 +22,9 @@
       "default": "\"dense\""
     },
     "FormHelperTextProps": { "type": { "name": "object" } },
-    "fullWidth": { "type": { "name": "bool" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
     "helperText": { "type": { "name": "node" } },
-    "hiddenLabel": { "type": { "name": "bool" } },
+    "hiddenLabel": { "type": { "name": "bool" }, "default": "false" },
     "id": { "type": { "name": "string" } },
     "InputLabelProps": { "type": { "name": "object" } },
     "inputProps": { "type": { "name": "object" } },
@@ -68,12 +68,12 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
-    "required": { "type": { "name": "bool" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
     "selectedSections": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -22,12 +22,12 @@
       "type": { "name": "string" },
       "default": "'@media (pointer: fine)'"
     },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -37,7 +37,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "maxDateTime": { "type": { "name": "any" } },
@@ -90,7 +90,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(year: TDate) => void", "describedArgs": ["year"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -155,8 +155,8 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
-    "skipDisabled": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
+    "skipDisabled": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.json
@@ -16,11 +16,11 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -30,7 +30,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -78,7 +78,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(year: TDate) => void", "describedArgs": ["year"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -135,7 +135,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -28,13 +28,13 @@
       "default": "'start'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disableAutoMonthSwitching": { "type": { "name": "bool" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableDragEditing": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableDragEditing": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -44,7 +44,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -87,7 +87,7 @@
         "describedArgs": ["newValue"]
       }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "rangePosition": { "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" } },
     "reduceAnimations": {
       "type": { "name": "bool" },
@@ -120,7 +120,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -18,12 +18,12 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -33,7 +33,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "maxDateTime": { "type": { "name": "any" } },
@@ -86,7 +86,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(year: TDate) => void", "describedArgs": ["year"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -151,8 +151,8 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
-    "skipDisabled": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
+    "skipDisabled": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/desktop-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-picker.json
@@ -9,11 +9,11 @@
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
       "type": { "name": "enum", "description": "'dense'<br>&#124;&nbsp;'spacious'" },
@@ -57,7 +57,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(view: TView) => void", "describedArgs": ["view"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -89,7 +89,7 @@
         "returned": "boolean"
       }
     },
-    "skipDisabled": { "type": { "name": "bool" } },
+    "skipDisabled": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/digital-clock.json
+++ b/docs/pages/x/api/date-pickers/digital-clock.json
@@ -4,10 +4,10 @@
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focusedView": { "type": { "name": "enum", "description": "'hours'" } },
     "maxTime": { "type": { "name": "any" } },
     "minTime": { "type": { "name": "any" } },
@@ -31,7 +31,7 @@
       "signature": { "type": "function(view: TView) => void", "describedArgs": ["view"] }
     },
     "openTo": { "type": { "name": "enum", "description": "'hours'" } },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid time using the validation props, except callbacks such as `shouldDisableTime`."
@@ -44,7 +44,7 @@
         "returned": "boolean"
       }
     },
-    "skipDisabled": { "type": { "name": "bool" } },
+    "skipDisabled": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.json
@@ -16,11 +16,11 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -30,7 +30,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -78,7 +78,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(year: TDate) => void", "describedArgs": ["year"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -135,7 +135,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -28,13 +28,13 @@
       "default": "'start'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disableAutoMonthSwitching": { "type": { "name": "bool" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableDragEditing": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableDragEditing": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -44,7 +44,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -87,7 +87,7 @@
         "describedArgs": ["newValue"]
       }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "rangePosition": { "type": { "name": "enum", "description": "'end'<br>&#124;&nbsp;'start'" } },
     "reduceAnimations": {
       "type": { "name": "bool" },
@@ -120,7 +120,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
@@ -18,12 +18,12 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
     "format": { "type": { "name": "string" } },
@@ -33,7 +33,7 @@
     },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "maxDateTime": { "type": { "name": "any" } },
@@ -86,7 +86,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(year: TDate) => void", "describedArgs": ["year"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -151,7 +151,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/mobile-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-picker.json
@@ -9,11 +9,11 @@
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
       "type": { "name": "enum", "description": "'dense'<br>&#124;&nbsp;'spacious'" },
@@ -57,7 +57,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(view: TView) => void", "describedArgs": ["view"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",

--- a/docs/pages/x/api/date-pickers/month-calendar.json
+++ b/docs/pages/x/api/date-pickers/month-calendar.json
@@ -4,9 +4,9 @@
     "className": { "type": { "name": "string" } },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
     "monthsPerRow": {

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
@@ -9,9 +9,9 @@
       },
       "default": "'column'"
     },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "divider": { "type": { "name": "node" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -41,7 +41,7 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
@@ -81,7 +81,7 @@
       "type": { "name": "string" },
       "default": "The timezone of the `value` or `defaultValue` prop is defined, 'default' otherwise."
     },
-    "useFlexGap": { "type": { "name": "bool" } },
+    "useFlexGap": { "type": { "name": "bool" }, "default": "false" },
     "value": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } }
   },
   "slots": [

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
@@ -10,10 +10,10 @@
       },
       "default": "'column'"
     },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "divider": { "type": { "name": "node" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -48,7 +48,7 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
@@ -96,7 +96,7 @@
       "type": { "name": "string" },
       "default": "The timezone of the `value` or `defaultValue` prop is defined, 'default' otherwise."
     },
-    "useFlexGap": { "type": { "name": "bool" } },
+    "useFlexGap": { "type": { "name": "bool" }, "default": "false" },
     "value": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } }
   },
   "slots": [

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
@@ -10,10 +10,10 @@
       },
       "default": "'column'"
     },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "divider": { "type": { "name": "node" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -44,7 +44,7 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
@@ -84,7 +84,7 @@
       "type": { "name": "string" },
       "default": "The timezone of the `value` or `defaultValue` prop is defined, 'default' otherwise."
     },
-    "useFlexGap": { "type": { "name": "bool" } },
+    "useFlexGap": { "type": { "name": "bool" }, "default": "false" },
     "value": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } }
   },
   "slots": [

--- a/docs/pages/x/api/date-pickers/multi-section-digital-clock.json
+++ b/docs/pages/x/api/date-pickers/multi-section-digital-clock.json
@@ -4,10 +4,10 @@
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focusedView": {
       "type": {
         "name": "enum",
@@ -41,7 +41,7 @@
         "description": "'hours'<br>&#124;&nbsp;'meridiem'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'"
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid time using the validation props, except callbacks such as `shouldDisableTime`."
@@ -54,7 +54,7 @@
         "returned": "boolean"
       }
     },
-    "skipDisabled": { "type": { "name": "bool" } },
+    "skipDisabled": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/pickers-action-bar.json
+++ b/docs/pages/x/api/date-pickers/pickers-action-bar.json
@@ -7,7 +7,7 @@
       },
       "default": "`['cancel', 'accept']` for mobile and `[]` for desktop"
     },
-    "disableSpacing": { "type": { "name": "bool" } },
+    "disableSpacing": { "type": { "name": "bool" }, "default": "false" },
     "sx": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/pickers-day.json
+++ b/docs/pages/x/api/date-pickers/pickers-day.json
@@ -10,18 +10,18 @@
         "description": "func<br>&#124;&nbsp;{ current?: { focusVisible: func } }"
       }
     },
-    "centerRipple": { "type": { "name": "bool" } },
+    "centerRipple": { "type": { "name": "bool" }, "default": "false" },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableMargin": { "type": { "name": "bool" } },
-    "disableRipple": { "type": { "name": "bool" } },
-    "disableTouchRipple": { "type": { "name": "bool" } },
-    "focusRipple": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableMargin": { "type": { "name": "bool" }, "default": "false" },
+    "disableRipple": { "type": { "name": "bool" }, "default": "false" },
+    "disableTouchRipple": { "type": { "name": "bool" }, "default": "false" },
+    "focusRipple": { "type": { "name": "bool" }, "default": "false" },
     "focusVisibleClassName": { "type": { "name": "string" } },
     "onFocusVisible": { "type": { "name": "func" } },
-    "selected": { "type": { "name": "bool" } },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "selected": { "type": { "name": "bool" }, "default": "false" },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "sx": {
       "type": {
         "name": "union",
@@ -29,7 +29,7 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "today": { "type": { "name": "bool" } },
+    "today": { "type": { "name": "bool" }, "default": "false" },
     "TouchRippleProps": { "type": { "name": "object" } },
     "touchRippleRef": {
       "type": {

--- a/docs/pages/x/api/date-pickers/pickers-shortcuts.json
+++ b/docs/pages/x/api/date-pickers/pickers-shortcuts.json
@@ -4,8 +4,8 @@
       "type": { "name": "enum", "description": "'accept'<br>&#124;&nbsp;'set'" },
       "default": "\"accept\""
     },
-    "dense": { "type": { "name": "bool" } },
-    "disablePadding": { "type": { "name": "bool" } },
+    "dense": { "type": { "name": "bool" }, "default": "false" },
+    "disablePadding": { "type": { "name": "bool" }, "default": "false" },
     "items": {
       "type": {
         "name": "arrayOf",

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -1,7 +1,7 @@
 {
   "props": {
-    "autoFocus": { "type": { "name": "bool" } },
-    "clearable": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "clearable": { "type": { "name": "bool" }, "default": "false" },
     "color": {
       "type": {
         "name": "enum",
@@ -10,9 +10,9 @@
       "default": "'primary'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focused": { "type": { "name": "bool" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -20,9 +20,9 @@
       "default": "\"dense\""
     },
     "FormHelperTextProps": { "type": { "name": "object" } },
-    "fullWidth": { "type": { "name": "bool" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
     "helperText": { "type": { "name": "node" } },
-    "hiddenLabel": { "type": { "name": "bool" } },
+    "hiddenLabel": { "type": { "name": "bool" }, "default": "false" },
     "id": { "type": { "name": "string" } },
     "InputLabelProps": { "type": { "name": "object" } },
     "inputProps": { "type": { "name": "object" } },
@@ -61,12 +61,12 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
-    "required": { "type": { "name": "bool" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
     "selectedSections": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -1,8 +1,8 @@
 {
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
-    "autoFocus": { "type": { "name": "bool" } },
-    "clearable": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "clearable": { "type": { "name": "bool" }, "default": "false" },
     "color": {
       "type": {
         "name": "enum",
@@ -11,10 +11,10 @@
       "default": "'primary'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focused": { "type": { "name": "bool" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -22,9 +22,9 @@
       "default": "\"dense\""
     },
     "FormHelperTextProps": { "type": { "name": "object" } },
-    "fullWidth": { "type": { "name": "bool" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
     "helperText": { "type": { "name": "node" } },
-    "hiddenLabel": { "type": { "name": "bool" } },
+    "hiddenLabel": { "type": { "name": "bool" }, "default": "false" },
     "id": { "type": { "name": "string" } },
     "InputLabelProps": { "type": { "name": "object" } },
     "inputProps": { "type": { "name": "object" } },
@@ -68,12 +68,12 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
-    "required": { "type": { "name": "bool" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
     "selectedSections": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -1,8 +1,8 @@
 {
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
-    "autoFocus": { "type": { "name": "bool" } },
-    "clearable": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "clearable": { "type": { "name": "bool" }, "default": "false" },
     "color": {
       "type": {
         "name": "enum",
@@ -11,10 +11,10 @@
       "default": "'primary'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focused": { "type": { "name": "bool" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -22,9 +22,9 @@
       "default": "\"dense\""
     },
     "FormHelperTextProps": { "type": { "name": "object" } },
-    "fullWidth": { "type": { "name": "bool" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
     "helperText": { "type": { "name": "node" } },
-    "hiddenLabel": { "type": { "name": "bool" } },
+    "hiddenLabel": { "type": { "name": "bool" }, "default": "false" },
     "id": { "type": { "name": "string" } },
     "InputLabelProps": { "type": { "name": "object" } },
     "inputProps": { "type": { "name": "object" } },
@@ -64,12 +64,12 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
-    "required": { "type": { "name": "bool" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
     "selectedSections": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/static-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-picker.json
@@ -12,17 +12,17 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
       "default": "\"mobile\""
     },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -115,7 +115,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -24,19 +24,19 @@
       "default": "'start'"
     },
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;any&gt;" } },
-    "disableAutoMonthSwitching": { "type": { "name": "bool" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableDragEditing": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableDragEditing": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
       "default": "\"mobile\""
     },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
@@ -100,7 +100,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.json
@@ -14,18 +14,18 @@
       }
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
       "default": "\"mobile\""
     },
     "displayWeekNumber": { "type": { "name": "bool" } },
     "fixedWeekNumber": { "type": { "name": "number" }, "default": "undefined" },
-    "loading": { "type": { "name": "bool" } },
+    "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "maxDate": { "type": { "name": "any" } },
     "maxDateTime": { "type": { "name": "any" } },
@@ -131,7 +131,7 @@
         "returned": "boolean"
       }
     },
-    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" } },
+    "showDaysOutsideCurrentMonth": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/static-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-time-picker.json
@@ -5,10 +5,10 @@
     "autoFocus": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "displayStaticWrapperAs": {
       "type": { "name": "enum", "description": "'desktop'<br>&#124;&nbsp;'mobile'" },
       "default": "\"mobile\""

--- a/docs/pages/x/api/date-pickers/time-clock.json
+++ b/docs/pages/x/api/date-pickers/time-clock.json
@@ -1,14 +1,14 @@
 {
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
-    "ampmInClock": { "type": { "name": "bool" } },
+    "ampmInClock": { "type": { "name": "bool" }, "default": "false" },
     "autoFocus": { "type": { "name": "bool" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focusedView": {
       "type": {
         "name": "enum",
@@ -42,7 +42,7 @@
         "description": "'hours'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'"
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid time using the validation props, except callbacks such as `shouldDisableTime`."

--- a/docs/pages/x/api/date-pickers/time-field.json
+++ b/docs/pages/x/api/date-pickers/time-field.json
@@ -1,8 +1,8 @@
 {
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
-    "autoFocus": { "type": { "name": "bool" } },
-    "clearable": { "type": { "name": "bool" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "clearable": { "type": { "name": "bool" }, "default": "false" },
     "color": {
       "type": {
         "name": "enum",
@@ -11,10 +11,10 @@
       "default": "'primary'"
     },
     "defaultValue": { "type": { "name": "any" } },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "focused": { "type": { "name": "bool" } },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
@@ -22,9 +22,9 @@
       "default": "\"dense\""
     },
     "FormHelperTextProps": { "type": { "name": "object" } },
-    "fullWidth": { "type": { "name": "bool" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
     "helperText": { "type": { "name": "node" } },
-    "hiddenLabel": { "type": { "name": "bool" } },
+    "hiddenLabel": { "type": { "name": "bool" }, "default": "false" },
     "id": { "type": { "name": "string" } },
     "InputLabelProps": { "type": { "name": "object" } },
     "inputProps": { "type": { "name": "object" } },
@@ -64,12 +64,12 @@
         "describedArgs": ["newValue"]
       }
     },
-    "readOnly": { "type": { "name": "bool" } },
+    "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
       "type": { "name": "any" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
-    "required": { "type": { "name": "bool" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
     "selectedSections": {
       "type": {
         "name": "union",

--- a/docs/pages/x/api/date-pickers/time-picker.json
+++ b/docs/pages/x/api/date-pickers/time-picker.json
@@ -13,11 +13,11 @@
       "type": { "name": "string" },
       "default": "'@media (pointer: fine)'"
     },
-    "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" } },
-    "disableOpenPicker": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableIgnoringDatePartForTimeValidation": { "type": { "name": "bool" }, "default": "false" },
+    "disableOpenPicker": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "format": { "type": { "name": "string" } },
     "formatDensity": {
       "type": { "name": "enum", "description": "'dense'<br>&#124;&nbsp;'spacious'" },
@@ -61,7 +61,7 @@
       "type": { "name": "func" },
       "signature": { "type": "function(view: TView) => void", "describedArgs": ["view"] }
     },
-    "open": { "type": { "name": "bool" } },
+    "open": { "type": { "name": "bool" }, "default": "false" },
     "openTo": {
       "type": {
         "name": "enum",
@@ -93,7 +93,7 @@
         "returned": "boolean"
       }
     },
-    "skipDisabled": { "type": { "name": "bool" } },
+    "skipDisabled": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": { "type": { "name": "object" }, "default": "{}" },
     "sx": {

--- a/docs/pages/x/api/date-pickers/year-calendar.json
+++ b/docs/pages/x/api/date-pickers/year-calendar.json
@@ -4,9 +4,9 @@
     "className": { "type": { "name": "string" } },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
-    "disableFuture": { "type": { "name": "bool" } },
-    "disableHighlightToday": { "type": { "name": "bool" } },
-    "disablePast": { "type": { "name": "bool" } },
+    "disableFuture": { "type": { "name": "bool" }, "default": "false" },
+    "disableHighlightToday": { "type": { "name": "bool" }, "default": "false" },
+    "disablePast": { "type": { "name": "bool" }, "default": "false" },
     "maxDate": { "type": { "name": "any" } },
     "minDate": { "type": { "name": "any" } },
     "onChange": {

--- a/docs/pages/x/api/tree-view/tree-item.json
+++ b/docs/pages/x/api/tree-view/tree-item.json
@@ -10,7 +10,7 @@
       "default": "TreeItemContent"
     },
     "ContentProps": { "type": { "name": "object" } },
-    "disabled": { "type": { "name": "bool" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
     "endIcon": { "type": { "name": "node" } },
     "expandIcon": { "type": { "name": "node" } },
     "icon": { "type": { "name": "node" } },

--- a/docs/pages/x/api/tree-view/tree-view.json
+++ b/docs/pages/x/api/tree-view/tree-view.json
@@ -15,11 +15,11 @@
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;string" },
       "default": "[]"
     },
-    "disabledItemsFocusable": { "type": { "name": "bool" } },
-    "disableSelection": { "type": { "name": "bool" } },
+    "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
+    "disableSelection": { "type": { "name": "bool" }, "default": "false" },
     "expanded": { "type": { "name": "arrayOf", "description": "Array&lt;string&gt;" } },
     "id": { "type": { "name": "string" } },
-    "multiSelect": { "type": { "name": "bool" } },
+    "multiSelect": { "type": { "name": "bool" }, "default": "false" },
     "onNodeFocus": {
       "type": { "name": "func" },
       "signature": {

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -401,17 +401,11 @@ const buildComponentDocumentation = async (options: {
         typeDescriptions,
       };
 
-      const jsdocDefaultValue = getJsdocDefaultValue(
+      const defaultValue = getJsdocDefaultValue(
         parseDoctrine(propDescriptor.description || '', {
           sloppy: true,
         }),
       );
-
-      // Only keep `default` for bool props if it isn't 'false'.
-      let defaultValue: string | undefined;
-      if (propDescriptor.type.name !== 'bool' || jsdocDefaultValue !== 'false') {
-        defaultValue = jsdocDefaultValue;
-      }
 
       if (prop.type.raw) {
         // Recast doesn't parse TypeScript


### PR DESCRIPTION
The fix: [`d233a21` (#11477)](https://github.com/mui/mui-x/pull/11477/commits/d233a21218f38cb202912c19b55bb4b1ad3e255c)
The remaining changes are generated by `yarn docs:api`.

I was confused by the missing default values in the docs.
I think it's much better when the default value is explicitly mentioned.

## Examples
- DataGrid https://mui.com/x/api/data-grid/data-grid/

| Before | After |
| ------- | ----- |
| <img width="578" src="https://github.com/mui/mui-x/assets/13808724/fca10c0a-e91b-41ab-8cd1-fb756819748e"> | <img width="586" src="https://github.com/mui/mui-x/assets/13808724/3d0a6a01-97a1-44bf-9dc6-bfed0414f92c"> |

- `DateCalendar`: https://mui.com/x/api/date-pickers/date-calendar/

| Before | After |
| ------- | ----- |
| <img width="574" src="https://github.com/mui/mui-x/assets/13808724/745f1905-6d72-424c-ae4a-f1827f88c53c"> | <img width="586" src="https://github.com/mui/mui-x/assets/13808724/b8d8facc-e2f2-439a-8259-019e396a7b78"> |
