### PR TITLE
[code-infra] Update the Babel macro path

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -36,12 +36,6 @@ module.exports = function getBabelConfig(api) {
     ],
     plugins: [
       ...baseConfig.plugins,
-      [
-        'babel-plugin-transform-rename-import',
-        {
-          replacements: [{ original: '@mui-internal/babel-macros/MuiError.macro', replacement: 'react' }],
-        },
-      ],
       // for IE 11 support
       '@babel/plugin-transform-object-assign',
       'babel-plugin-preval',

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -39,7 +39,7 @@ module.exports = function getBabelConfig(api) {
       [
         'babel-plugin-transform-rename-import',
         {
-          replacements: [{ original: '@mui/utils/macros/MuiError.macro', replacement: 'react' }],
+          replacements: [{ original: '@mui-internal/babel-macros/MuiError.macro', replacement: 'react' }],
         },
       ],
       // for IE 11 support

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "babel-plugin-replace-imports": "^1.0.2",
     "babel-plugin-search-and-replace": "^1.1.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "babel-plugin-transform-rename-import": "^2.3.0",
     "chai": "^4.4.1",
     "chai-dom": "^1.12.0",
     "compression-webpack-plugin": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4437,11 +4437,6 @@ babel-plugin-transform-react-remove-prop-types@^0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
-babel-plugin-transform-rename-import@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-rename-import/-/babel-plugin-transform-rename-import-2.3.0.tgz#5d9d645f937b0ca5c26a24b2510a06277b6ffd9b"
-  integrity sha512-dPgJoT57XC0PqSnLgl2FwNvxFrWlspatX2dkk7yjKQj5HHGw071vAcOf+hqW8ClqcBDMvEbm6mevn5yHAD8mlQ==
-
 bail@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"


### PR DESCRIPTION
~~Updated the path of the MuiError Babel macro.~~

Removed the rename-imports Babel macro as per https://github.com/mui/material-ui/pull/40262#issuecomment-1866107076

This should be merged after the monorepo sources containing https://github.com/mui/material-ui/pull/40262 are pulled in.
