### PR TITLE
[core] Fix security regressions in cherry-pick-next-to-master.yml

### DIFF
--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -6,6 +6,8 @@ on:
       - next
     types: ['closed']
 
+permissions: {}
+
 jobs:
   cherry_pick_to_master:
     runs-on: ubuntu-latest
@@ -16,11 +18,13 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598 # v2.0.0
         with:
           fetch-depth: 0
       - name: Cherry pick and create the new PR
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: carloscastrojumo/github-cherry-pick-action@a145da1b8142e752d3cbc11aaaa46a535690f0c5 # v1.0.9
         with:
           branch: master
           body: 'Cherry-pick of #{old_pull_request_id}'
@@ -28,5 +32,3 @@ jobs:
           title: '{old_title} (@${{ github.event.pull_request.user.login }})'
           labels: |
             cherry-pick
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #11468 

### Changes Done:

- Added a root level no permissions declaration which should solve `Token-Permissions` in https://github.com/mui/mui-x/security/code-scanning
- Pinned the dependencies to their corresponding SHAs
- Moved the `env` to the scope where it's needed, no need to define it globally.