### PR TITLE
[charts] Add `arcLabelRadius` property

### DIFF
--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -45,12 +45,18 @@ Pie series shape is described by multiple properties:
 
 - `innerRadius` The radius between the center and the beginning of the arc. The default is set to 0.
 - `outerRadius` The radius between the center and the end of the arc. The default is the largest value available in the drawing area.
+- `arcLabelRadius` The radius between the center and the arc label.
 - `paddingAngle` The angle (in degrees) between two arcs.
 - `cornerRadius` Similar to the CSS `border-radius`.
 - `startAngle`/`endAngle` The angle range of the pie chart. Values are given in degrees.
 - `cx`/`cy` The center of the pie charts. By default the middle of the drawing area.
 
 {{"demo": "PieShapeNoSnap.js", "hideToolbar": true, "bg": "playground"}}
+
+The following properties accept percentage string (for example `'50%'`).
+
+- `innerRadius`/`outerRadius`/`arcLabelRadius` with `'100%'` equivalent to maximal radius fitting in the drawing area.
+- `cx`, `cy` with `'100%'` equivalent to the drawing area width/height.
 
 ## Labels
 

--- a/docs/pages/x/api/charts/pie-arc-label-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-label-plot.json
@@ -8,17 +8,21 @@
       }
     },
     "arcLabelMinAngle": { "type": { "name": "number" } },
+    "arcLabelRadius": {
+      "type": { "name": "number" },
+      "default": "(innerRadius - outerRadius) / 2"
+    },
     "cornerRadius": { "type": { "name": "number" }, "default": "0" },
     "faded": {
       "type": {
         "name": "shape",
-        "description": "{ additionalRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
+        "description": "{ additionalRadius?: number, arcLabelRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
       }
     },
     "highlighted": {
       "type": {
         "name": "shape",
-        "description": "{ additionalRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
+        "description": "{ additionalRadius?: number, arcLabelRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
       }
     },
     "innerRadius": { "type": { "name": "number" }, "default": "0" },

--- a/docs/pages/x/api/charts/pie-arc-plot.json
+++ b/docs/pages/x/api/charts/pie-arc-plot.json
@@ -1,17 +1,21 @@
 {
   "props": {
     "outerRadius": { "type": { "name": "number" }, "required": true },
+    "arcLabelRadius": {
+      "type": { "name": "number" },
+      "default": "(innerRadius - outerRadius) / 2"
+    },
     "cornerRadius": { "type": { "name": "number" }, "default": "0" },
     "faded": {
       "type": {
         "name": "shape",
-        "description": "{ additionalRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
+        "description": "{ additionalRadius?: number, arcLabelRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
       }
     },
     "highlighted": {
       "type": {
         "name": "shape",
-        "description": "{ additionalRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
+        "description": "{ additionalRadius?: number, arcLabelRadius?: number, color?: string, cornerRadius?: number, innerRadius?: number, outerRadius?: number, paddingAngle?: number }"
       }
     },
     "innerRadius": { "type": { "name": "number" }, "default": "0" },

--- a/docs/translations/api-docs/charts/pie-arc-label-plot.json
+++ b/docs/translations/api-docs/charts/pie-arc-label-plot.json
@@ -11,6 +11,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "arcLabelRadius": {
+      "description": "The radius between circle center and the arc label in px.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "cornerRadius": {
       "description": "The radius applied to arc corners (similar to border radius).",
       "deprecated": "",

--- a/docs/translations/api-docs/charts/pie-arc-plot.json
+++ b/docs/translations/api-docs/charts/pie-arc-plot.json
@@ -1,6 +1,11 @@
 {
   "componentDescription": "",
   "propDescriptions": {
+    "arcLabelRadius": {
+      "description": "The radius between circle center and the arc label in px.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "cornerRadius": {
       "description": "The radius applied to arc corners (similar to border radius).",
       "deprecated": "",

--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -61,6 +61,7 @@ export type PieArcLabelProps = PieArcLabelOwnerState &
     endAngle: SpringValue<number>;
     innerRadius: SpringValue<number>;
     outerRadius: SpringValue<number>;
+    arcLabelRadius: SpringValue<number>;
     cornerRadius: SpringValue<number>;
     paddingAngle: SpringValue<number>;
   } & {
@@ -77,8 +78,7 @@ const getLabelPosition =
     startAngle: number,
     endAngle: number,
     padAngle: number,
-    innerRadius: number,
-    outerRadius: number,
+    arcLabelRadius: number,
     cornerRadius: number,
   ) => {
     if (!formattedArcLabel) {
@@ -88,8 +88,8 @@ const getLabelPosition =
       padAngle,
       startAngle,
       endAngle,
-      innerRadius,
-      outerRadius,
+      innerRadius: arcLabelRadius,
+      outerRadius: arcLabelRadius,
     })!;
     if (variable === 'x') {
       return x;
@@ -105,8 +105,7 @@ function PieArcLabel(props: PieArcLabelProps) {
     startAngle,
     endAngle,
     paddingAngle,
-    innerRadius,
-    outerRadius,
+    arcLabelRadius,
     cornerRadius,
     formattedArcLabel,
     isHighlighted,
@@ -130,11 +129,11 @@ function PieArcLabel(props: PieArcLabelProps) {
       {...other}
       style={{
         x: to(
-          [startAngle, endAngle, paddingAngle, innerRadius, outerRadius, cornerRadius],
+          [startAngle, endAngle, paddingAngle, arcLabelRadius, cornerRadius],
           getLabelPosition(formattedArcLabel, 'x'),
         ),
         y: to(
-          [startAngle, endAngle, paddingAngle, innerRadius, outerRadius, cornerRadius],
+          [startAngle, endAngle, paddingAngle, arcLabelRadius, cornerRadius],
           getLabelPosition(formattedArcLabel, 'y'),
         ),
         ...style,

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -80,8 +80,9 @@ function PieArcLabelPlot(props: PieArcLabelPlotProps) {
   const {
     slots,
     slotProps,
-    innerRadius = 0,
+    innerRadius,
     outerRadius,
+    arcLabelRadius,
     cornerRadius = 0,
     paddingAngle = 0,
     id,
@@ -98,6 +99,7 @@ function PieArcLabelPlot(props: PieArcLabelPlotProps) {
   const transformedData = useTransformData({
     innerRadius,
     outerRadius,
+    arcLabelRadius,
     cornerRadius,
     paddingAngle,
     id,
@@ -127,6 +129,7 @@ function PieArcLabelPlot(props: PieArcLabelPlotProps) {
             paddingAngle: pA,
             innerRadius: iR,
             outerRadius: oR,
+            arcLabelRadius: aLR,
             cornerRadius: cR,
             ...style
           },
@@ -139,6 +142,7 @@ function PieArcLabelPlot(props: PieArcLabelPlotProps) {
               paddingAngle={pA}
               innerRadius={iR}
               outerRadius={oR}
+              arcLabelRadius={aLR}
               cornerRadius={cR}
               style={style}
               id={id}
@@ -172,6 +176,11 @@ PieArcLabelPlot.propTypes = {
    */
   arcLabelMinAngle: PropTypes.number,
   /**
+   * The radius between circle center and the arc label in px.
+   * @default (innerRadius - outerRadius) / 2
+   */
+  arcLabelRadius: PropTypes.number,
+  /**
    * The radius applied to arc corners (similar to border radius).
    * @default 0
    */
@@ -194,6 +203,7 @@ PieArcLabelPlot.propTypes = {
    */
   faded: PropTypes.shape({
     additionalRadius: PropTypes.number,
+    arcLabelRadius: PropTypes.number,
     color: PropTypes.string,
     cornerRadius: PropTypes.number,
     innerRadius: PropTypes.number,
@@ -205,6 +215,7 @@ PieArcLabelPlot.propTypes = {
    */
   highlighted: PropTypes.shape({
     additionalRadius: PropTypes.number,
+    arcLabelRadius: PropTypes.number,
     color: PropTypes.string,
     cornerRadius: PropTypes.number,
     innerRadius: PropTypes.number,

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -106,6 +106,7 @@ function PieArcPlot(props: PieArcPlotProps) {
             endAngle,
             paddingAngle: pA,
             innerRadius: iR,
+            arcLabelRadius,
             outerRadius: oR,
             cornerRadius: cR,
             ...style
@@ -150,6 +151,11 @@ PieArcPlot.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
+   * The radius between circle center and the arc label in px.
+   * @default (innerRadius - outerRadius) / 2
+   */
+  arcLabelRadius: PropTypes.number,
+  /**
    * The radius applied to arc corners (similar to border radius).
    * @default 0
    */
@@ -172,6 +178,7 @@ PieArcPlot.propTypes = {
    */
   faded: PropTypes.shape({
     additionalRadius: PropTypes.number,
+    arcLabelRadius: PropTypes.number,
     color: PropTypes.string,
     cornerRadius: PropTypes.number,
     innerRadius: PropTypes.number,
@@ -183,6 +190,7 @@ PieArcPlot.propTypes = {
    */
   highlighted: PropTypes.shape({
     additionalRadius: PropTypes.number,
+    arcLabelRadius: PropTypes.number,
     color: PropTypes.string,
     cornerRadius: PropTypes.number,
     innerRadius: PropTypes.number,

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -308,6 +308,7 @@ PieChart.propTypes = {
         PropTypes.func,
       ]),
       arcLabelMinAngle: PropTypes.number,
+      arcLabelRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       color: PropTypes.string,
       cornerRadius: PropTypes.number,
       cx: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -323,6 +324,7 @@ PieChart.propTypes = {
       endAngle: PropTypes.number,
       faded: PropTypes.shape({
         additionalRadius: PropTypes.number,
+        arcLabelRadius: PropTypes.number,
         color: PropTypes.string,
         cornerRadius: PropTypes.number,
         innerRadius: PropTypes.number,
@@ -331,6 +333,7 @@ PieChart.propTypes = {
       }),
       highlighted: PropTypes.shape({
         additionalRadius: PropTypes.number,
+        arcLabelRadius: PropTypes.number,
         color: PropTypes.string,
         cornerRadius: PropTypes.number,
         innerRadius: PropTypes.number,

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -98,6 +98,7 @@ function PiePlot(props: PiePlotProps) {
         const {
           innerRadius: innerRadiusParam,
           outerRadius: outerRadiusParam,
+          arcLabelRadius: arcLabelRadiusParam,
           cornerRadius,
           paddingAngle,
           arcLabel,
@@ -112,6 +113,12 @@ function PiePlot(props: PiePlotProps) {
           availableRadius,
         );
         const innerRadius = getPercentageValue(innerRadiusParam ?? 0, availableRadius);
+
+        const arcLabelRadius =
+          arcLabelRadiusParam === undefined
+            ? (outerRadius + innerRadius) / 2
+            : getPercentageValue(arcLabelRadiusParam, availableRadius);
+
         const cx = getPercentageValue(cxParam ?? '50%', width);
         const cy = getPercentageValue(cyParam ?? '50%', height);
         return (
@@ -119,6 +126,7 @@ function PiePlot(props: PiePlotProps) {
             <PieArcLabelPlot
               innerRadius={innerRadius}
               outerRadius={outerRadius ?? availableRadius}
+              arcLabelRadius={arcLabelRadius}
               cornerRadius={cornerRadius}
               paddingAngle={paddingAngle}
               id={seriesId}

--- a/packages/x-charts/src/PieChart/dataTransform/transition.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/transition.ts
@@ -63,36 +63,56 @@ export const defaultTransitionConfig: UseTransitionProps<ValueWithHighlight> = {
 
 export const defaultLabelTransitionConfig: UseTransitionProps<ValueWithHighlight> = {
   keys: (item) => item.id,
-  from: ({ innerRadius, outerRadius, cornerRadius, startAngle, endAngle, paddingAngle }) => ({
+  from: ({
+    innerRadius,
+    outerRadius,
+    arcLabelRadius,
+    cornerRadius,
+    startAngle,
+    endAngle,
+    paddingAngle,
+  }) => ({
     innerRadius,
     outerRadius: (innerRadius + outerRadius) / 2,
     cornerRadius,
+    arcLabelRadius,
     startAngle: (startAngle + endAngle) / 2,
     endAngle: (startAngle + endAngle) / 2,
     paddingAngle,
     opacity: 0,
   }),
-  leave: ({ innerRadius, startAngle, endAngle }) => ({
+  leave: ({ innerRadius, startAngle, endAngle, arcLabelRadius }) => ({
     innerRadius,
     outerRadius: innerRadius,
+    arcLabelRadius,
     startAngle: (startAngle + endAngle) / 2,
     endAngle: (startAngle + endAngle) / 2,
     opacity: 0,
   }),
-  enter: ({ innerRadius, outerRadius, startAngle, endAngle }) => ({
+  enter: ({ innerRadius, outerRadius, startAngle, endAngle, arcLabelRadius }) => ({
     innerRadius,
     outerRadius,
     startAngle,
     endAngle,
+    arcLabelRadius,
     opacity: 1,
   }),
-  update: ({ innerRadius, outerRadius, cornerRadius, startAngle, endAngle, paddingAngle }) => ({
+  update: ({
     innerRadius,
     outerRadius,
     cornerRadius,
     startAngle,
     endAngle,
     paddingAngle,
+    arcLabelRadius,
+  }) => ({
+    innerRadius,
+    outerRadius,
+    cornerRadius,
+    startAngle,
+    endAngle,
+    paddingAngle,
+    arcLabelRadius,
     opacity: 1,
   }),
   config: {

--- a/packages/x-charts/src/PieChart/dataTransform/transition.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/transition.ts
@@ -81,10 +81,10 @@ export const defaultLabelTransitionConfig: UseTransitionProps<ValueWithHighlight
     paddingAngle,
     opacity: 0,
   }),
-  leave: ({ innerRadius, startAngle, endAngle, arcLabelRadius }) => ({
+  leave: ({ innerRadius, startAngle, endAngle }) => ({
     innerRadius,
     outerRadius: innerRadius,
-    arcLabelRadius,
+    arcLabelRadius: innerRadius,
     startAngle: (startAngle + endAngle) / 2,
     endAngle: (startAngle + endAngle) / 2,
     opacity: 0,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -10,6 +10,7 @@ import { getIsHighlighted, getIsFaded } from '../../hooks/useInteractionItemProp
 export interface AnimatedObject {
   innerRadius: number;
   outerRadius: number;
+  arcLabelRadius: number;
   cornerRadius: number;
   startAngle: number;
   endAngle: number;
@@ -36,6 +37,7 @@ export function useTransformData(
     highlighted,
     paddingAngle: basePaddingAngle = 0,
     innerRadius: baseInnerRadius = 0,
+    arcLabelRadius: baseArcLabelRadius,
     outerRadius: baseOuterRadius,
     cornerRadius: baseCornerRadius = 0,
   } = series;
@@ -79,6 +81,9 @@ export function useTransformData(
         );
         const cornerRadius = attibuesOverride.cornerRadius ?? baseCornerRadius;
 
+        const arcLabelRadius =
+          attibuesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
+        console.log({ arcLabelRadius });
         return {
           ...item,
           ...attibuesOverride,
@@ -88,6 +93,7 @@ export function useTransformData(
           innerRadius,
           outerRadius,
           cornerRadius,
+          arcLabelRadius,
         };
       }),
     [
@@ -95,6 +101,7 @@ export function useTransformData(
       baseInnerRadius,
       baseOuterRadius,
       basePaddingAngle,
+      baseArcLabelRadius,
       data,
       faded,
       getHighlightStatus,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -65,28 +65,28 @@ export function useTransformData(
       data.map((item, itemIndex) => {
         const { isHighlighted, isFaded } = getHighlightStatus(itemIndex);
 
-        const attribuesOverride = {
+        const attributesOverride = {
           additionalRadius: 0,
           ...((isFaded && faded) || (isHighlighted && highlighted) || {}),
         };
         const paddingAngle = Math.max(
           0,
-          (Math.PI * (attribuesOverride.paddingAngle ?? basePaddingAngle)) / 180,
+          (Math.PI * (attributesOverride.paddingAngle ?? basePaddingAngle)) / 180,
         );
-        const innerRadius = Math.max(0, attribuesOverride.innerRadius ?? baseInnerRadius);
+        const innerRadius = Math.max(0, attributesOverride.innerRadius ?? baseInnerRadius);
 
         const outerRadius = Math.max(
           0,
-          attribuesOverride.outerRadius ?? baseOuterRadius + attribuesOverride.additionalRadius,
+          attributesOverride.outerRadius ?? baseOuterRadius + attributesOverride.additionalRadius,
         );
-        const cornerRadius = attribuesOverride.cornerRadius ?? baseCornerRadius;
+        const cornerRadius = attributesOverride.cornerRadius ?? baseCornerRadius;
 
         const arcLabelRadius =
-          attribuesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
+          attributesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
 
         return {
           ...item,
-          ...attribuesOverride,
+          ...attributesOverride,
           isFaded,
           isHighlighted,
           paddingAngle,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -65,28 +65,28 @@ export function useTransformData(
       data.map((item, itemIndex) => {
         const { isHighlighted, isFaded } = getHighlightStatus(itemIndex);
 
-        const attibuesOverride = {
+        const attribuesOverride = {
           additionalRadius: 0,
           ...((isFaded && faded) || (isHighlighted && highlighted) || {}),
         };
         const paddingAngle = Math.max(
           0,
-          (Math.PI * (attibuesOverride.paddingAngle ?? basePaddingAngle)) / 180,
+          (Math.PI * (attribuesOverride.paddingAngle ?? basePaddingAngle)) / 180,
         );
-        const innerRadius = Math.max(0, attibuesOverride.innerRadius ?? baseInnerRadius);
+        const innerRadius = Math.max(0, attribuesOverride.innerRadius ?? baseInnerRadius);
 
         const outerRadius = Math.max(
           0,
-          attibuesOverride.outerRadius ?? baseOuterRadius + attibuesOverride.additionalRadius,
+          attribuesOverride.outerRadius ?? baseOuterRadius + attribuesOverride.additionalRadius,
         );
-        const cornerRadius = attibuesOverride.cornerRadius ?? baseCornerRadius;
+        const cornerRadius = attribuesOverride.cornerRadius ?? baseCornerRadius;
 
         const arcLabelRadius =
-          attibuesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
+          attribuesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
 
         return {
           ...item,
-          ...attibuesOverride,
+          ...attribuesOverride,
           isFaded,
           isHighlighted,
           paddingAngle,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -82,7 +82,9 @@ export function useTransformData(
         const cornerRadius = attributesOverride.cornerRadius ?? baseCornerRadius;
 
         const arcLabelRadius =
-          attributesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
+          attributesOverride.arcLabelRadius ??
+          baseArcLabelRadius ??
+          (innerRadius + outerRadius) / 2;
 
         return {
           ...item,

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -83,7 +83,7 @@ export function useTransformData(
 
         const arcLabelRadius =
           attibuesOverride.arcLabelRadius ?? baseArcLabelRadius ?? (innerRadius + outerRadius) / 2;
-        console.log({ arcLabelRadius });
+
         return {
           ...item,
           ...attibuesOverride,

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -32,6 +32,13 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
    */
   outerRadius?: number | string;
   /**
+   * The radius between circle center and the arc label.
+   * Can be a number (in px) or a string with a percentage such as '50%'.
+   * The '100%' is the maximal radius that fit into the drawing area.
+   * @default (innerRadius - outerRadius) / 2
+   */
+  arcLabelRadius?: number | string;
+  /**
    * The radius applied to arc corners (similar to border radius).
    * @default 0
    */
@@ -87,6 +94,7 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
     outerRadius?: number;
     cornerRadius?: number;
     paddingAngle?: number;
+    arcLabelRadius?: number;
     color?: string;
   };
   /**
@@ -102,6 +110,7 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
     outerRadius?: number;
     cornerRadius?: number;
     paddingAngle?: number;
+    arcLabelRadius?: number;
     color?: string;
   };
 }
@@ -134,4 +143,9 @@ export interface ComputedPieRadius {
    * The radius between circle center and the end of the arc.
    */
   outerRadius: number;
+  /**
+   * The radius between circle center and the arc label in px.
+   * @default (innerRadius - outerRadius) / 2
+   */
+  arcLabelRadius?: number;
 }


### PR DESCRIPTION
Fix #11127

I kept the strategy of 100% is the maximal radius for same reason as before: having a single baseline for all radius dimensions