### PR TITLE
fix: Validate if the tree variable is defined #11417

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -440,7 +440,7 @@ export const useGridRows = (
       tree[GRID_ROOT_GROUP_ID] = { ...rootGroup, children: rootGroupChildren };
 
       // Removes potential remaining skeleton rows from the dataRowIds.
-      const dataRowIds = rootGroupChildren.filter((childId) => tree[childId]?.type === 'leaf');
+      const dataRowIds = rootGroupChildren.filter((childId) => tree?.[childId]?.type === 'leaf');
 
       apiRef.current.caches.rows.dataRowIdToModelLookup = dataRowIdToModelLookup;
       apiRef.current.caches.rows.dataRowIdToIdLookup = dataRowIdToIdLookup;


### PR DESCRIPTION
fixes: #11417

- when applying sort server side with a lazy loading DataGrid, and error an error was thrown because tree was undefined.
- Validate if tree is defined before getting the childId property value


- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
