### PR TITLE
[DataGrid] Don't evaluate hasEval when disableEval is set

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -66,6 +66,7 @@
     "disableColumnResize": { "type": { "name": "bool" }, "default": "false" },
     "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
     "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableEval": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleColumnsFiltering": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleColumnsSorting": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleRowSelection": {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -53,6 +53,7 @@
     "disableColumnResize": { "type": { "name": "bool" }, "default": "false" },
     "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
     "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableEval": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleColumnsFiltering": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleColumnsSorting": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleRowSelection": {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -29,6 +29,7 @@
     "disableColumnMenu": { "type": { "name": "bool" }, "default": "false" },
     "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
     "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
+    "disableEval": { "type": { "name": "bool" }, "default": "false" },
     "disableMultipleRowSelection": {
       "type": { "name": "bool" },
       "default": "false (`!props.checkboxSelection` for MIT Data Grid)"

--- a/docs/translations/api-docs/data-grid/data-grid-premium-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium-pt.json
@@ -33,6 +33,7 @@
     "disableColumnResize": "If <code>true</code>, resizing columns is disabled.",
     "disableColumnSelector": "If <code>true</code>, hiding/showing columns is disabled.",
     "disableDensitySelector": "If <code>true</code>, the density selector is disabled.",
+    "disableEval": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
     "disableMultipleRowSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium-zh.json
@@ -33,6 +33,7 @@
     "disableColumnResize": "If <code>true</code>, resizing columns is disabled.",
     "disableColumnSelector": "If <code>true</code>, hiding/showing columns is disabled.",
     "disableDensitySelector": "If <code>true</code>, the density selector is disabled.",
+    "disableEval": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
     "disableMultipleRowSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium.json
@@ -186,6 +186,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "disableEval": {
+      "description": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "disableMultipleColumnsFiltering": {
       "description": "If <code>true</code>, filtering with multiple columns is disabled.",
       "deprecated": "",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-pt.json
@@ -29,6 +29,7 @@
     "disableColumnResize": "If <code>true</code>, resizing columns is disabled.",
     "disableColumnSelector": "If <code>true</code>, hiding/showing columns is disabled.",
     "disableDensitySelector": "If <code>true</code>, the density selector is disabled.",
+    "disableEval": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
     "disableMultipleRowSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro-zh.json
@@ -29,6 +29,7 @@
     "disableColumnResize": "If <code>true</code>, resizing columns is disabled.",
     "disableColumnSelector": "If <code>true</code>, hiding/showing columns is disabled.",
     "disableDensitySelector": "If <code>true</code>, the density selector is disabled.",
+    "disableEval": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
     "disableMultipleColumnsFiltering": "If <code>true</code>, filtering with multiple columns is disabled.",
     "disableMultipleColumnsSorting": "If <code>true</code>, sorting with multiple columns is disabled.",
     "disableMultipleRowSelection": "If <code>true</code>, multiple selection using the Ctrl or CMD key is disabled.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro.json
@@ -151,6 +151,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "disableEval": {
+      "description": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "disableMultipleColumnsFiltering": {
       "description": "If <code>true</code>, filtering with multiple columns is disabled.",
       "deprecated": "",

--- a/docs/translations/api-docs/data-grid/data-grid-pt.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pt.json
@@ -21,6 +21,7 @@
     "disableColumnMenu": "If <code>true</code>, the column menu is disabled.",
     "disableColumnSelector": "If <code>true</code>, hiding/showing columns is disabled.",
     "disableDensitySelector": "If <code>true</code>, the density selector is disabled.",
+    "disableEval": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
     "disableRowSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",
     "editMode": "Controls whether to use the cell or row editing.",

--- a/docs/translations/api-docs/data-grid/data-grid-zh.json
+++ b/docs/translations/api-docs/data-grid/data-grid-zh.json
@@ -21,6 +21,7 @@
     "disableColumnMenu": "If <code>true</code>, the column menu is disabled.",
     "disableColumnSelector": "If <code>true</code>, hiding/showing columns is disabled.",
     "disableDensitySelector": "If <code>true</code>, the density selector is disabled.",
+    "disableEval": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
     "disableRowSelectionOnClick": "If <code>true</code>, the selection on click on a row or cell is disabled.",
     "disableVirtualization": "If <code>true</code>, the virtualization is disabled.",
     "editMode": "Controls whether to use the cell or row editing.",

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -96,6 +96,11 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
+    "disableEval": {
+      "description": "If <code>true</code>, <code>eval()</code> is not used for performance optimization.",
+      "deprecated": "",
+      "typeDescriptions": {}
+    },
     "disableMultipleRowSelection": {
       "description": "If <code>true</code>, multiple selection using the Ctrl/CMD or Shift key is disabled. The MIT DataGrid will ignore this prop, unless <code>checkboxSelection</code> is enabled.",
       "deprecated": "",

--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -274,7 +274,6 @@ DataGridPremiumRaw.propTypes = {
   /**
    * If `true`, `eval()` is not used for performance optimization.
    * @default false
-   * @ignore - do not document
    */
   disableEval: PropTypes.bool,
   /**

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -238,7 +238,6 @@ DataGridProRaw.propTypes = {
   /**
    * If `true`, `eval()` is not used for performance optimization.
    * @default false
-   * @ignore - do not document
    */
   disableEval: PropTypes.bool,
   /**

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -162,7 +162,6 @@ DataGridRaw.propTypes = {
   /**
    * If `true`, `eval()` is not used for performance optimization.
    * @default false
-   * @ignore - do not document
    */
   disableEval: PropTypes.bool,
   /**

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -26,12 +26,13 @@ import {
 const globalScope = (typeof window === 'undefined' ? globalThis : window) as any;
 const evalCode = globalScope[atob('ZXZhbA==')] as <T>(source: string) => T;
 
-let hasEval: boolean;
-try {
-  hasEval = evalCode<boolean>('true');
-} catch (_: unknown) {
-  hasEval = false;
-}
+const getHasEval = () => {
+  try {
+    return evalCode<boolean>('true');
+  } catch (_: unknown) {
+    return false;
+  }
+};
 
 type GridFilterItemApplier = {
   fn: (row: GridValidRowModel) => boolean;
@@ -236,7 +237,7 @@ const buildAggregatedFilterItemsApplier = (
     return null;
   }
 
-  if (!hasEval || disableEval) {
+  if (disableEval || !getHasEval()) {
     // This is the original logic, which is used if `eval()` is not supported (aka prevented by CSP).
     return (row, shouldApplyFilter) => {
       const resultPerItemId: GridFilterItemResult = {};

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -26,12 +26,20 @@ import {
 const globalScope = (typeof window === 'undefined' ? globalThis : window) as any;
 const evalCode = globalScope[atob('ZXZhbA==')] as <T>(source: string) => T;
 
+let hasEval: boolean | undefined;
+
 const getHasEval = () => {
-  try {
-    return evalCode<boolean>('true');
-  } catch (_: unknown) {
-    return false;
+  if (hasEval !== undefined) {
+    return hasEval;
   }
+
+  try {
+    hasEval = evalCode<boolean>('true');
+  } catch (_: unknown) {
+    hasEval = false;
+  }
+
+  return hasEval;
 };
 
 type GridFilterItemApplier = {

--- a/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/grid/x-data-grid/src/models/props/DataGridProps.ts
@@ -190,7 +190,6 @@ export interface DataGridPropsWithDefaultValues {
   /**
    * If `true`, `eval()` is not used for performance optimization.
    * @default false
-   * @ignore - do not document
    */
   disableEval: boolean;
   /**


### PR DESCRIPTION
Merry christmas!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #11465 

I had the same issue as #11465 and changed the evaluation of hasEval so that it no longer writes a warning/error in the console in case eval is blocked by the csp. 

I also made disableEval appeir in the DataGrid API as per @flaviendelangle but I'm of course open to reverting this in case it's not wanted.

This change also makes it so that the eval check won't be executed if `filterMode='server'` regardless of the disableEval prop.