### PR TITLE
[DataGridPremium] Allow programmatically grouping non-groupable columns

### DIFF
--- a/docs/data/data-grid/row-grouping/RowGroupingReadOnly.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingReadOnly.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { DataGridPremium } from '@mui/x-data-grid-premium';
+import { useMovieData } from '@mui/x-data-grid-generator';
+
+export default function RowGroupingReadOnly() {
+  const data = useMovieData();
+
+  const columns = React.useMemo(
+    () =>
+      data.columns.map((c) => ({
+        ...c,
+        groupable: c.field !== 'company',
+      })),
+    [data.columns],
+  );
+
+  const [rowGroupingModel, setRowGroupingModel] = React.useState([
+    'company',
+    'director',
+  ]);
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGridPremium
+        {...data}
+        columns={columns}
+        rowGroupingModel={rowGroupingModel}
+        onRowGroupingModelChange={(model) => setRowGroupingModel(model)}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/row-grouping/RowGroupingReadOnly.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingReadOnly.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { DataGridPremium, GridRowGroupingModel } from '@mui/x-data-grid-premium';
+import { useMovieData } from '@mui/x-data-grid-generator';
+
+export default function RowGroupingReadOnly() {
+  const data = useMovieData();
+
+  const columns = React.useMemo(
+    () =>
+      data.columns.map((c) => ({
+        ...c,
+        groupable: c.field !== 'company',
+      })),
+    [data.columns],
+  );
+
+  const [rowGroupingModel, setRowGroupingModel] =
+    React.useState<GridRowGroupingModel>(['company', 'director']);
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGridPremium
+        {...data}
+        columns={columns}
+        rowGroupingModel={rowGroupingModel}
+        onRowGroupingModelChange={(model) => setRowGroupingModel(model)}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/row-grouping/RowGroupingReadOnly.tsx.preview
+++ b/docs/data/data-grid/row-grouping/RowGroupingReadOnly.tsx.preview
@@ -1,0 +1,6 @@
+<DataGridPremium
+  {...data}
+  columns={columns}
+  rowGroupingModel={rowGroupingModel}
+  onRowGroupingModelChange={(model) => setRowGroupingModel(model)}
+/>

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -39,6 +39,14 @@ You can use the `onRowGroupingModelChange` prop to listen to changes to the grou
 
 {{"demo": "RowGroupingControlled.js", "bg": "inline", "defaultCodeOpen": false}}
 
+### Read-only row groups
+
+The columns with `colDef.groupable` set to `false` could be initialized, passed in the `rowGroupingModel` prop, or set using API method `setRowGroupingModel` to generate read-only row groups. These groups could be programatically added or updated but the users could not alter them from the UI.
+
+In the following example, the column `company` is not groupable and is used in the `rowGroupingModel` prop to generate read-only row group.
+
+{{"demo": "RowGroupingReadOnly.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Grouping columns
 
 ### Single grouping column

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -39,14 +39,6 @@ You can use the `onRowGroupingModelChange` prop to listen to changes to the grou
 
 {{"demo": "RowGroupingControlled.js", "bg": "inline", "defaultCodeOpen": false}}
 
-### Read-only row groups
-
-The columns with `colDef.groupable` set to `false` could be initialized, passed in the `rowGroupingModel` prop, or set using API method `setRowGroupingModel` to generate read-only row groups. These groups could be programatically added or updated but the users could not alter them from the UI.
-
-In the following example, the column `company` is not groupable and is used in the `rowGroupingModel` prop to generate read-only row group.
-
-{{"demo": "RowGroupingReadOnly.js", "bg": "inline", "defaultCodeOpen": false}}
-
 ## Grouping columns
 
 ### Single grouping column
@@ -198,6 +190,14 @@ In case you need to disable grouping on specific column(s), set the `groupable` 
 In the example below, the `director` column can not be grouped. And in all example, the `title` and `gross` columns can not be grouped.
 
 {{"demo": "RowGroupingColDefCanBeGrouped.js", "bg": "inline", "defaultCodeOpen": false}}
+
+### Grouping non-groupable columns programmatically
+
+The columns with `colDef.groupable` set to `false` could be grouped programmatically by initialiing, passing in the `rowGroupingModel` prop, or updating `rowGroupingModel` by the API method `setRowGroupingModel` to generate read-only row groups. The users could not alter such groups from the UI.
+
+In the following example, the column `company` is not groupable from the UI but the `rowGroupingModel` prop is passed to generate a row group.
+
+{{"demo": "RowGroupingReadOnly.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Using `groupingValueGetter` for complex grouping value
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -193,9 +193,13 @@ In the example below, the `director` column can not be grouped. And in all examp
 
 ### Grouping non-groupable columns programmatically
 
-The columns with `colDef.groupable` set to `false` could be grouped programmatically by initialiing, passing in the `rowGroupingModel` prop, or updating `rowGroupingModel` by the API method `setRowGroupingModel` to generate read-only row groups. The users could not alter such groups from the UI.
+To apply row grouping programmatically on non-groupable columns (columns with `groupable: false` in the [column definition](/x/api/data-grid/grid-col-def/)), you can provide row grouping model in one of the following ways:
 
-In the following example, the column `company` is not groupable from the UI but the `rowGroupingModel` prop is passed to generate a row group.
+1. Pass `rowGrouping.model` to the `initialState` prop. This will [initialize the grouping](/x/react-data-grid/row-grouping/#initialize-the-row-grouping) with the provided model.
+2. Provide the `rowGroupingModel` prop. This will [control the grouping](/x/react-data-grid/row-grouping/#controlled-row-grouping) with the provided model.
+3. Call the API method `setRowGroupingModel`. This will set the aggregation with the provided model.
+
+In the following example, the column `company` is not groupable from the UI but the `rowGroupingModel` prop is passed to generate a read-only row group.
 
 {{"demo": "RowGroupingReadOnly.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/packages/grid/x-data-grid-premium/src/components/GridColumnMenuRowGroupItem.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridColumnMenuRowGroupItem.tsx
@@ -30,9 +30,10 @@ function GridColumnMenuRowGroupItem(props: GridColumnMenuItemProps) {
       onClick(event);
     };
 
-    const name = columnsLookup[field].headerName ?? field;
+    const groupedColumn = columnsLookup[field];
+    const name = groupedColumn.headerName ?? field;
     return (
-      <MenuItem onClick={ungroupColumn} key={field}>
+      <MenuItem onClick={ungroupColumn} key={field} disabled={!groupedColumn.groupable}>
         <ListItemIcon>
           <rootProps.slots.columnMenuUngroupIcon fontSize="small" />
         </ListItemIcon>

--- a/packages/grid/x-data-grid-premium/src/components/GridPremiumColumnMenu.tsx
+++ b/packages/grid/x-data-grid-premium/src/components/GridPremiumColumnMenu.tsx
@@ -14,13 +14,11 @@ import { GridColumnMenuRowUngroupItem } from './GridColumnMenuRowUngroupItem';
 
 export function GridColumnMenuGroupingItem(props: GridColumnMenuItemProps) {
   const { colDef } = props;
+
   if (isGroupingColumn(colDef.field)) {
     return <GridColumnMenuRowGroupItem {...props} />;
   }
-  if (colDef.groupable) {
-    return <GridColumnMenuRowUngroupItem {...props} />;
-  }
-  return null;
+  return <GridColumnMenuRowUngroupItem {...props} />;
 }
 
 export const GRID_COLUMN_MENU_SLOTS_PREMIUM = {

--- a/packages/grid/x-data-grid-premium/src/hooks/features/rowGrouping/gridRowGroupingSelector.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/rowGrouping/gridRowGroupingSelector.ts
@@ -12,6 +12,5 @@ export const gridRowGroupingModelSelector = createSelector(
 export const gridRowGroupingSanitizedModelSelector = createSelectorMemoized(
   gridRowGroupingModelSelector,
   gridColumnLookupSelector,
-  (model, columnsLookup) =>
-    model.filter((field) => !!columnsLookup[field] && columnsLookup[field].groupable),
+  (model, columnsLookup) => model.filter((field) => !!columnsLookup[field]),
 );

--- a/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/rowGrouping.DataGridPremium.test.tsx
@@ -164,7 +164,7 @@ describe('<DataGridPremium /> - Row grouping', () => {
       expect(getColumnValues(0)).to.deep.equal(['Cat A (3)', '', '', '', 'Cat B (2)', '', '']);
     });
 
-    it('should ignore grouping criteria with colDef.groupable = false', () => {
+    it('should respect the grouping criteria with colDef.groupable = false', () => {
       render(
         <Test
           columns={[
@@ -184,7 +184,19 @@ describe('<DataGridPremium /> - Row grouping', () => {
           defaultGroupingExpansionDepth={-1}
         />,
       );
-      expect(getColumnValues(0)).to.deep.equal(['Cat A (3)', '', '', '', 'Cat B (2)', '', '']);
+      expect(getColumnValues(0)).to.deep.equal([
+        'Cat A (3)',
+        'Cat 1 (1)',
+        '',
+        'Cat 2 (2)',
+        '',
+        '',
+        'Cat B (2)',
+        'Cat 2 (1)',
+        '',
+        'Cat 1 (1)',
+        '',
+      ]);
     });
 
     it('should allow to use several time the same grouping criteria', () => {
@@ -1750,6 +1762,43 @@ describe('<DataGridPremium /> - Row grouping', () => {
       });
       fireEvent.click(menuItemCategory2);
       expect(apiRef.current.state.rowGrouping.model).to.deep.equal([]);
+    });
+
+    it('should add a "Stop grouping {field}" menu item for each grouping criteria with colDef.groupable = false but it should be disabled', () => {
+      render(
+        <Test
+          columns={[
+            {
+              field: 'id',
+            },
+            {
+              field: 'category1',
+              groupable: false,
+            },
+            {
+              field: 'category2',
+              groupable: false,
+            },
+          ]}
+          initialState={{
+            rowGrouping: {
+              model: ['category1', 'category2'],
+            },
+          }}
+        />,
+      );
+
+      act(() => apiRef.current.showColumnMenu('__row_group_by_columns_group__'));
+      clock.runToLast();
+      expect(screen.queryByRole('menu')).not.to.equal(null);
+      const menuItemCategory1 = screen.getByRole('menuitem', {
+        name: 'Stop grouping by category1',
+      });
+      expect(menuItemCategory1).to.have.class('Mui-disabled');
+      const menuItemCategory2 = screen.getByRole('menuitem', {
+        name: 'Stop grouping by category2',
+      });
+      expect(menuItemCategory2).to.have.class('Mui-disabled');
     });
 
     it('should use the colDef.headerName property for grouping menu item label', () => {


### PR DESCRIPTION
Handles `colDef.groupable` part of #10552

https://deploy-preview-11539--material-ui-x.netlify.app/x/react-data-grid/row-grouping/#read-only-row-groups

**ToDos:**
- [x] Update tests
- [x] Update docs
- [x] Update migration guide

## Changelog

### Breaking changes

- Non-groupable columns could now be grouped programmatically to create read-only row groups by controlling or initializing `rowGroupingModel`, or by updating the `rowGroupingModel` by API method `apiRef.current.setRowGroupingModel`.