### PR TITLE
[DataGrid] make GridActionsCellItemProps.label type able to change to ReactElement

### DIFF
--- a/docs/data/data-grid/column-definition/ColumnTypesGrid.js
+++ b/docs/data/data-grid/column-definition/ColumnTypesGrid.js
@@ -122,13 +122,13 @@ export default function ColumnTypesGrid() {
           />,
           <GridActionsCellItem
             icon={<SecurityIcon />}
-            label="Toggle Admin"
+            label={<React.Fragment>Toggle Admin</React.Fragment>}
             onClick={toggleAdmin(params.id)}
             showInMenu
           />,
           <GridActionsCellItem
             icon={<FileCopyIcon />}
-            label="Duplicate User"
+            label={<React.Fragment>Duplicate User</React.Fragment>}
             onClick={duplicateUser(params.id)}
             showInMenu
           />,

--- a/docs/data/data-grid/column-definition/ColumnTypesGrid.tsx
+++ b/docs/data/data-grid/column-definition/ColumnTypesGrid.tsx
@@ -129,13 +129,13 @@ export default function ColumnTypesGrid() {
           />,
           <GridActionsCellItem
             icon={<SecurityIcon />}
-            label="Toggle Admin"
+            label={<React.Fragment>Toggle Admin</React.Fragment>}
             onClick={toggleAdmin(params.id)}
             showInMenu
           />,
           <GridActionsCellItem
             icon={<FileCopyIcon />}
-            label="Duplicate User"
+            label={<React.Fragment>Duplicate User</React.Fragment>}
             onClick={duplicateUser(params.id)}
             showInMenu
           />,

--- a/docs/data/data-grid/joy-ui/GridJoyUISlots.js
+++ b/docs/data/data-grid/joy-ui/GridJoyUISlots.js
@@ -62,8 +62,15 @@ const columns = [
         onClick={() => {}}
         label="Delete"
       />,
-      <GridActionsCellItem onClick={() => {}} label="Print" showInMenu />,
-      <GridActionsCellItem label="Duplicate User" showInMenu />,
+      <GridActionsCellItem
+        onClick={() => {}}
+        label={<React.Fragment>Print</React.Fragment>}
+        showInMenu
+      />,
+      <GridActionsCellItem
+        label={<React.Fragment>Duplicate User</React.Fragment>}
+        showInMenu
+      />,
     ],
     minWidth: 80,
     flex: 1,

--- a/docs/data/data-grid/joy-ui/GridJoyUISlots.tsx
+++ b/docs/data/data-grid/joy-ui/GridJoyUISlots.tsx
@@ -63,8 +63,15 @@ const columns: GridColDef[] = [
         onClick={() => {}}
         label="Delete"
       />,
-      <GridActionsCellItem onClick={() => {}} label="Print" showInMenu />,
-      <GridActionsCellItem label="Duplicate User" showInMenu />,
+      <GridActionsCellItem
+        onClick={() => {}}
+        label={<React.Fragment>Print</React.Fragment>}
+        showInMenu
+      />,
+      <GridActionsCellItem
+        label={<React.Fragment>Duplicate User</React.Fragment>}
+        showInMenu
+      />,
     ],
     minWidth: 80,
     flex: 1,

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -57,7 +57,7 @@ GridActionsCellItem.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   icon: PropTypes.element,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   showInMenu: PropTypes.bool,
 } as any;
 

--- a/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/grid/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -6,13 +6,12 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 
 export type GridActionsCellItemProps = {
-  label: string;
   icon?: React.ReactElement;
   /** from https://mui.com/material-ui/api/button-base/#ButtonBase-prop-component */
   component?: React.ElementType;
 } & (
-  | ({ showInMenu?: false; icon: React.ReactElement } & IconButtonProps)
-  | ({ showInMenu: true } & MenuItemProps)
+  | ({ showInMenu?: false; label: string; icon: React.ReactElement } & IconButtonProps)
+  | ({ showInMenu: true; label: React.ReactElement } & MenuItemProps)
 );
 
 const GridActionsCellItem = React.forwardRef<HTMLButtonElement, GridActionsCellItemProps>(

--- a/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -257,7 +257,7 @@ describe('<DataGrid /> - Rows', () => {
         <TestCase
           getActions={() => [
             <GridActionsCellItem icon={<span />} label="delete" />,
-            <GridActionsCellItem label="print" showInMenu />,
+            <GridActionsCellItem label={<React.Fragment>print</React.Fragment>} showInMenu />,
           ]}
         />,
       );
@@ -266,7 +266,13 @@ describe('<DataGrid /> - Rows', () => {
     });
 
     it('should show in a menu the actions marked as showInMenu', async () => {
-      render(<TestCase getActions={() => [<GridActionsCellItem label="print" showInMenu />]} />);
+      render(
+        <TestCase
+          getActions={() => [
+            <GridActionsCellItem label={<React.Fragment>print</React.Fragment>} showInMenu />,
+          ]}
+        />,
+      );
       expect(screen.queryByText('print')).to.equal(null);
       fireEvent.click(screen.getByRole('menuitem', { name: 'more' }));
       await waitFor(() => {
@@ -287,7 +293,13 @@ describe('<DataGrid /> - Rows', () => {
     it('should not select the row when clicking in a menu action', async () => {
       render(
         <TestCase
-          getActions={() => [<GridActionsCellItem icon={<span />} label="print" showInMenu />]}
+          getActions={() => [
+            <GridActionsCellItem
+              icon={<span />}
+              label={<React.Fragment>print</React.Fragment>}
+              showInMenu
+            />,
+          ]}
         />,
       );
       expect(getRow(0)).not.to.have.class('Mui-selected');
@@ -303,7 +315,13 @@ describe('<DataGrid /> - Rows', () => {
     });
 
     it('should not select the row when opening the menu', async () => {
-      render(<TestCase getActions={() => [<GridActionsCellItem label="print" showInMenu />]} />);
+      render(
+        <TestCase
+          getActions={() => [
+            <GridActionsCellItem label={<React.Fragment>print</React.Fragment>} showInMenu />,
+          ]}
+        />,
+      );
       expect(getRow(0)).not.to.have.class('Mui-selected');
       fireEvent.click(screen.getByRole('menuitem', { name: 'more' }));
       await waitFor(() => {
@@ -315,7 +333,9 @@ describe('<DataGrid /> - Rows', () => {
       render(
         <TestCase
           rows={[{ id: 1 }, { id: 2 }]}
-          getActions={() => [<GridActionsCellItem label="print" showInMenu />]}
+          getActions={() => [
+            <GridActionsCellItem label={<React.Fragment>print</React.Fragment>} showInMenu />,
+          ]}
         />,
       );
       expect(screen.queryAllByRole('menu')).to.have.length(2);
@@ -355,8 +375,16 @@ describe('<DataGrid /> - Rows', () => {
       render(
         <TestCase
           getActions={() => [
-            <GridActionsCellItem icon={<span />} label="print" showInMenu />,
-            <GridActionsCellItem icon={<span />} label="delete" showInMenu />,
+            <GridActionsCellItem
+              icon={<span />}
+              label={<React.Fragment>print</React.Fragment>}
+              showInMenu
+            />,
+            <GridActionsCellItem
+              icon={<span />}
+              label={<React.Fragment>delete</React.Fragment>}
+              showInMenu
+            />,
           ]}
         />,
       );
@@ -416,7 +444,11 @@ describe('<DataGrid /> - Rows', () => {
         <TestCase
           getActions={() => [
             <GridActionsCellItem icon={<span />} label="print" />,
-            <GridActionsCellItem icon={<span />} label="delete" showInMenu />,
+            <GridActionsCellItem
+              icon={<span />}
+              label={<React.Fragment>delete</React.Fragment>}
+              showInMenu
+            />,
           ]}
         />,
       );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #4329

Do I add https://github.com/flaviendelangle as co-author? I haven't done any other change than what is suggested.