### PR TITLE
[docs] Clarify Pickers usage with Luxon

### DIFF
--- a/docs/data/date-pickers/timezone/LuxonTimezone.tsx
+++ b/docs/data/date-pickers/timezone/LuxonTimezone.tsx
@@ -7,7 +7,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 
 export default function LuxonTimezone() {
-  const [value, setValue] = React.useState<DateTime | null>(
+  const [value, setValue] = React.useState<DateTime<true> | DateTime<false> | null>(
     DateTime.fromISO('2022-04-17T15:30', { zone: 'America/New_York' }),
   );
 

--- a/docs/data/date-pickers/timezone/LuxonUTC.tsx
+++ b/docs/data/date-pickers/timezone/LuxonUTC.tsx
@@ -7,7 +7,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 
 export default function LuxonUTC() {
-  const [value, setValue] = React.useState<DateTime | null>(
+  const [value, setValue] = React.useState<DateTime<true> | DateTime<false> | null>(
     DateTime.fromISO('2022-04-17T15:30', { zone: 'UTC' }),
   );
 


### PR DESCRIPTION
Address https://github.com/mui/mui-x/issues/4751#issuecomment-1873898846

Be more explicit in the Luxon examples about the fact that the value can be in three states:
- Valid `DateTime`
- Invalid `DateTime`
- null