### PR TITLE
[charts] Fix `null` in line chart using dataset

### DIFF
--- a/packages/x-charts/src/LineChart/formatter.ts
+++ b/packages/x-charts/src/LineChart/formatter.ts
@@ -70,7 +70,7 @@ const formatter: Formatter<'line'> = (params, dataset) => {
                     'Line plots only support numbers and null values.',
                   ]);
                 }
-                return 0;
+                return null;
               }
               return value;
             })


### PR DESCRIPTION
When using null or undefined in the data set, it was replaced by `0` whereas `null` now has the meaning of 'no data'

Discovered when doing https://github.com/mui/material-ui/pull/40107