### PR TITLE
[docs] Uplift the Date Pickers playground

### DIFF
--- a/docs/data/date-pickers/playground/playground.md
+++ b/docs/data/date-pickers/playground/playground.md
@@ -1,6 +1,6 @@
 ---
 product: date-pickers
-title: Customization playground
+title: Date and Time Pickers - Customization playground
 packageName: '@mui/x-date-pickers'
 githubLabel: 'component: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
@@ -9,6 +9,6 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Customization playground
 
-<p class="description">Play around with props that affect the layout of the Date and Time Pickers components.</p>
+<p class="description">Use this playground to experiment with the props that affect the layout of the Date and Time Picker components.</p>
 
 {{"demo": "PickersPlaygroundWrapper.js", "hideToolbar": true, "bg": "playground"}}

--- a/docs/data/date-pickers/playground/playground.md
+++ b/docs/data/date-pickers/playground/playground.md
@@ -9,6 +9,6 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Date and Time Pickers playground
 
-<p class="description">You can test all the props that affect the layout of the various components.</p>
+<p class="description">Play around with props that affect the design and featues of the Date and Time Pickers components.</p>
 
-{{"demo": "PickersPlaygroundWrapper.js", "hideToolbar": true, "bg": "inline"}}
+{{"demo": "PickersPlaygroundWrapper.js", "hideToolbar": true, "bg": "playground"}}

--- a/docs/data/date-pickers/playground/playground.md
+++ b/docs/data/date-pickers/playground/playground.md
@@ -1,13 +1,13 @@
 ---
 product: date-pickers
-title: Date and Time Picker React components
+title: Customization playground
 packageName: '@mui/x-date-pickers'
 githubLabel: 'component: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
 ---
 
-# Date and Time Pickers playground
+# Customization playground
 
 <p class="description">Play around with props that affect the layout of the Date and Time Pickers components.</p>
 

--- a/docs/data/date-pickers/playground/playground.md
+++ b/docs/data/date-pickers/playground/playground.md
@@ -9,6 +9,6 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 # Date and Time Pickers playground
 
-<p class="description">Play around with props that affect the design and featues of the Date and Time Pickers components.</p>
+<p class="description">Play around with props that affect the layout of the Date and Time Pickers components.</p>
 
 {{"demo": "PickersPlaygroundWrapper.js", "hideToolbar": true, "bg": "playground"}}

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -234,7 +234,6 @@ const pages: MuiPage[] = [
       { pathname: '/x/react-date-pickers', title: 'Overview' },
       { pathname: '/x/react-date-pickers/getting-started' },
       { pathname: '/x/react-date-pickers/base-concepts' },
-      { pathname: '/x/react-date-pickers/playground' },
       { pathname: '/x/react-date-pickers/faq', title: 'FAQ' },
       {
         pathname: '/x/react-date-pickers-components',
@@ -372,6 +371,7 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-date-pickers/custom-layout' },
           { pathname: '/x/react-date-pickers/custom-field' },
           { pathname: '/x/react-date-pickers/custom-opening-button' },
+          { pathname: '/x/react-date-pickers/playground', title: 'Customziation playground' },
         ],
       },
     ],

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -234,6 +234,7 @@ const pages: MuiPage[] = [
       { pathname: '/x/react-date-pickers', title: 'Overview' },
       { pathname: '/x/react-date-pickers/getting-started' },
       { pathname: '/x/react-date-pickers/base-concepts' },
+      { pathname: '/x/react-date-pickers/playground' },
       { pathname: '/x/react-date-pickers/faq', title: 'FAQ' },
       {
         pathname: '/x/react-date-pickers-components',
@@ -325,6 +326,11 @@ const pages: MuiPage[] = [
             ],
           },
           { pathname: '/x/react-date-pickers/fields', title: 'Field components' },
+          {
+            pathname: '/x/api/date-pickers-group',
+            title: 'API Reference',
+            children: [{ pathname: '/x/api/date-pickers', title: 'Index' }, ...pickersComponentApi],
+          },
         ],
       },
       {
@@ -367,12 +373,6 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-date-pickers/custom-field' },
           { pathname: '/x/react-date-pickers/custom-opening-button' },
         ],
-      },
-      { pathname: '/x/react-date-pickers/playground' },
-      {
-        pathname: '/x/api/date-pickers-group',
-        title: 'API Reference',
-        children: [{ pathname: '/x/api/date-pickers', title: 'Index' }, ...pickersComponentApi],
       },
     ],
   },

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -50,10 +50,12 @@ const ComponentSection = styled('div')(({ theme }) => ({
   gap: theme.spacing(2),
   overflowX: 'auto',
   '& .MuiPickersLayout-root': {
-    borderRadius: 2,
+    borderRadius: 6,
     border: '1px dashed',
     borderColor:
-      theme.palette.mode === 'light' ? theme.palette.divider : alpha(theme.palette.grey[500], 0.1),
+      theme.palette.mode === 'light'
+        ? theme.palette.grey[300]
+        : alpha(theme.palette.grey[500], 0.1),
     ...(theme.palette.mode === 'dark' && {
       backgroundColor: alpha(theme.palette.grey[900], 0.2),
     }),
@@ -505,10 +507,6 @@ export default function PickersPlayground() {
           maxWidth: '100%',
           display: 'flex',
           flexDirection: { xs: 'column', md: 'row' },
-          '& .markdown-body pre': {
-            margin: 0,
-            borderRadius: 'md',
-          },
         }}
       >
         <ComponentSection sx={{ width: { xs: '100%', sm: '60%' } }}>

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -220,8 +220,9 @@ function ViewCheckbox({
   return (
     <Wrapper>
       <FormControlLabel
-        control={<Checkbox name={name} {...other} disabled={isDisabled} />}
+        control={<Checkbox name={name} {...other} disabled={isDisabled} size="small" />}
         label={name}
+        sx={{ textTransform: 'capitalize' }}
       />
     </Wrapper>
   );

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -5,9 +5,9 @@ import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import InputLabel from '@mui/material/InputLabel';
-import RadioGroup from '@mui/material/RadioGroup';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
 import FormControlLabel, { formControlLabelClasses } from '@mui/material/FormControlLabel';
-import Radio from '@mui/material/Radio';
 import Switch from '@mui/material/Switch';
 import FormGroup from '@mui/material/FormGroup';
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
@@ -81,19 +81,34 @@ function RadioGroupControl({
 }) {
   const id = React.useId();
   const handleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(event.target.value === '' ? undefined : event.target.value === 'true');
+    (event: React.MouseEvent<HTMLElement>, newValue: any) => {
+      if (newValue === null) {
+        return;
+      }
+      onChange(newValue === '' ? undefined : newValue);
     },
     [onChange],
   );
   return (
-    <FormControl>
+    <FormControl
+      sx={{
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
       <FormLabel id={id}>{label}</FormLabel>
-      <RadioGroup aria-labelledby={id} value={value ?? ''} onChange={handleChange} row>
-        <FormControlLabel value={''} control={<Radio />} label="undefined" />
-        <FormControlLabel value control={<Radio />} label="true" />
-        <FormControlLabel value={false} control={<Radio />} label="false" />
-      </RadioGroup>
+      <ToggleButtonGroup
+        aria-labelledby={id}
+        value={value ?? ''}
+        exclusive
+        onChange={handleChange}
+        size="small"
+      >
+        <ToggleButton value={''}>Undefined</ToggleButton>
+        <ToggleButton value>True</ToggleButton>
+        <ToggleButton value={false}>False</ToggleButton>
+      </ToggleButtonGroup>
     </FormControl>
   );
 }

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -9,7 +9,6 @@ import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel, { formControlLabelClasses } from '@mui/material/FormControlLabel';
 import Radio from '@mui/material/Radio';
 import Switch from '@mui/material/Switch';
-import FormHelperText from '@mui/material/FormHelperText';
 import FormGroup from '@mui/material/FormGroup';
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
 import Select from '@mui/material/Select';
@@ -75,12 +74,10 @@ function RadioGroupControl({
   label,
   value,
   onChange,
-  helperText,
 }: {
   label: string;
   value: boolean | undefined;
   onChange: (value: boolean | undefined) => void;
-  helperText?: string;
 }) {
   const id = React.useId();
   const handleChange = React.useCallback(
@@ -97,7 +94,6 @@ function RadioGroupControl({
         <FormControlLabel value control={<Radio />} label="true" />
         <FormControlLabel value={false} control={<Radio />} label="false" />
       </RadioGroup>
-      <FormHelperText>{helperText}</FormHelperText>
     </FormControl>
   );
 }

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -49,12 +49,9 @@ const ComponentSection = styled('div')(({ theme }) => ({
   gap: theme.spacing(2),
   overflowX: 'auto',
   '& .MuiPickersLayout-root': {
-    borderRadius: 6,
+    borderRadius: 8,
     border: '1px dashed',
-    borderColor:
-      theme.palette.mode === 'light'
-        ? theme.palette.grey[300]
-        : alpha(theme.palette.grey[500], 0.1),
+    borderColor: theme.palette.mode === 'light' ? theme.palette.grey[300] : theme.palette.divider,
     ...(theme.palette.mode === 'dark' && {
       backgroundColor: alpha(theme.palette.grey[900], 0.2),
     }),
@@ -92,9 +89,9 @@ function TriBooleanGroupControl({
   return (
     <FormControl
       sx={{
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
+        flexDirection: 'column',
+        gap: 1,
+        // alignItems: 'center',
       }}
     >
       <FormLabel id={id}>{label}</FormLabel>
@@ -104,6 +101,8 @@ function TriBooleanGroupControl({
         exclusive
         onChange={handleChange}
         size="small"
+        color="primary"
+        fullWidth
       >
         <ToggleButton value={''}>Undefined</ToggleButton>
         <ToggleButton value>True</ToggleButton>
@@ -615,16 +614,24 @@ export default function PickersPlayground() {
             Playground
           </Typography>
           <Divider light />
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pt: 2, pl: 3, pr: 2 }}>
-            <BooleanGroupControl
-              label="Static desktop mode"
-              value={isStaticDesktopMode}
-              onChange={setIsStaticDesktopMode}
-            />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, pt: 2, pl: 3, pr: 2 }}>
             <TriBooleanGroupControl
               label="Toolbar hidden"
               value={isToolbarHidden}
               onChange={setIsToolbarHidden}
+            />
+            {selectedPickers !== 'date-range' && (
+              <ViewSwitcher
+                showDateViews={selectedPickers === 'date' || selectedPickers === 'date-time'}
+                showTimeViews={selectedPickers === 'time' || selectedPickers === 'date-time'}
+                views={views}
+                handleViewsChange={handleViewsChange}
+              />
+            )}
+            <BooleanGroupControl
+              label="Static desktop mode"
+              value={isStaticDesktopMode}
+              onChange={setIsStaticDesktopMode}
             />
             {selectedPickers === 'date-time' && (
               <TriBooleanGroupControl
@@ -689,14 +696,6 @@ export default function PickersPlayground() {
               value={isLandscape}
               onChange={setIsLandscape}
             />
-            {selectedPickers !== 'date-range' && (
-              <ViewSwitcher
-                showDateViews={selectedPickers === 'date' || selectedPickers === 'date-time'}
-                showTimeViews={selectedPickers === 'time' || selectedPickers === 'date-time'}
-                views={views}
-                handleViewsChange={handleViewsChange}
-              />
-            )}
           </Box>
         </PropControlsSection>
       </Box>

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import dayjs, { Dayjs } from 'dayjs';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
@@ -8,6 +9,7 @@ import InputLabel from '@mui/material/InputLabel';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel, { formControlLabelClasses } from '@mui/material/FormControlLabel';
 import Radio from '@mui/material/Radio';
+import Switch from '@mui/material/Switch';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormGroup from '@mui/material/FormGroup';
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox';
@@ -15,6 +17,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Divider from '@mui/material/Divider';
 import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -76,12 +79,10 @@ function BooleanRadioGroupControl({
   label,
   value,
   onChange,
-  helperText,
 }: {
   label: string;
   value: boolean;
   onChange: (value: boolean) => void;
-  helperText?: string;
 }) {
   const id = React.useId();
   const handleChange = React.useCallback(
@@ -91,13 +92,22 @@ function BooleanRadioGroupControl({
     [onChange],
   );
   return (
-    <FormControl>
+    <FormControl
+      size="small"
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 4,
+      }}
+    >
       <FormLabel id={id}>{label}</FormLabel>
-      <RadioGroup aria-labelledby={id} value={value} onChange={handleChange} row>
+      <Switch checked={value} onChange={handleChange} />
+      {/* <RadioGroup aria-labelledby={id} value={value} onChange={handleChange} row>
         <FormControlLabel value control={<Radio />} label="true" />
         <FormControlLabel value={false} control={<Radio />} label="false" />
-      </RadioGroup>
-      <FormHelperText>{helperText}</FormHelperText>
+      </RadioGroup> */}
     </FormControl>
   );
 }
@@ -470,124 +480,36 @@ export default function PickersPlayground() {
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box
         sx={{
+          flexGrow: 1,
+          maxWidth: '100%',
           display: 'flex',
-          flexWrap: 'wrap',
-          width: '100%',
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: '8px',
+          flexDirection: { xs: 'column', md: 'row' },
+          '& .markdown-body pre': {
+            margin: 0,
+            borderRadius: 'md',
+          },
         }}
       >
         <Box
-          sx={{
+          sx={(theme) => ({
+            width: { xs: '100%', sm: '60%' },
+            p: 4,
             display: 'flex',
             flexDirection: 'column',
-            gap: 1.5,
-            bgcolor: 'action.hover',
-            padding: 2,
-            mx: {
-              xs: 2,
-              sm: 0,
-            },
-            flexGrow: 1,
-            width: {
-              xs: '100%',
-              sm: 312,
-            },
-          }}
-        >
-          <BooleanRadioGroupControl
-            label="Static desktop mode"
-            value={isStaticDesktopMode}
-            onChange={setIsStaticDesktopMode}
-          />
-          <RadioGroupControl
-            label="Toolbar hidden"
-            value={isToolbarHidden}
-            onChange={setIsToolbarHidden}
-          />
-          {selectedPickers === 'date-time' && (
-            <RadioGroupControl
-              label="Tabs hidden"
-              value={isTabsHidden}
-              onChange={setIsTabsHidden}
-            />
-          )}
-          <BooleanRadioGroupControl
-            label="Show days outside current month"
-            value={showDaysOutsideCurrentMonth}
-            onChange={setShowDaysOutsideCurrentMonth}
-          />
-          <BooleanRadioGroupControl
-            label="Fixed 6 weeks"
-            value={fixed6Weeks}
-            onChange={setFixed6Weeks}
-          />
-          <BooleanRadioGroupControl
-            label="Display week number"
-            value={displayWeekNumber}
-            onChange={setDisplayWeekNumber}
-          />
-          {selectedPickers !== 'date-range' && (
-            <BooleanRadioGroupControl
-              label="Disable day margin"
-              value={disableDayMargin}
-              onChange={setDisableDayMargin}
-            />
-          )}
-          {(selectedPickers === 'time' || selectedPickers === 'date-time') && (
-            <React.Fragment>
-              <RadioGroupControl label="AM/PM" value={ampm} onChange={setAmpm} />
-              <RadioGroupControl
-                label="ampmInClock"
-                value={ampmInClock}
-                onChange={setAmpmInClock}
-              />
-            </React.Fragment>
-          )}
-          {selectedPickers === 'date-range' && (
-            <React.Fragment>
-              <BooleanRadioGroupControl
-                label="Single calendar"
-                value={singleCalendar}
-                onChange={setSingleCalendar}
-              />
-              <BooleanRadioGroupControl
-                label="Display shortcuts"
-                value={displayShortcuts}
-                onChange={setDisplayShortcuts}
-              />
-            </React.Fragment>
-          )}
-          <BooleanRadioGroupControl
-            label="Custom actions"
-            value={customActions}
-            onChange={setCustomActions}
-          />
-          <BooleanRadioGroupControl
-            label="Landscape orientation"
-            value={isLandscape}
-            onChange={setIsLandscape}
-          />
-          {selectedPickers !== 'date-range' && (
-            <ViewSwitcher
-              showDateViews={selectedPickers === 'date' || selectedPickers === 'date-time'}
-              showTimeViews={selectedPickers === 'time' || selectedPickers === 'date-time'}
-              views={views}
-              handleViewsChange={handleViewsChange}
-            />
-          )}
-        </Box>
-        <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', sm: 'block' } }} />
-        <Box
-          sx={{
-            display: 'flex',
             gap: 2,
-            flexDirection: 'column',
-            margin: '0 auto',
-            padding: 2,
             overflowX: 'auto',
-          }}
+            '& .MuiPickersLayout-root': {
+              borderRadius: 2,
+              border: '1px dashed',
+              borderColor: 'divider',
+            },
+            [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
+              '& .MuiPickersLayout-root': {
+                backgroundColor: alpha(theme.palette.grey[900], 0.2),
+                borderColor: alpha(theme.palette.grey[500], 0.1),
+              },
+            },
+          })}
         >
           <FormControl fullWidth>
             <InputLabel id="selected-component-family-label">Selected components</InputLabel>
@@ -605,65 +527,175 @@ export default function PickersPlayground() {
               ))}
             </Select>
           </FormControl>
-          <Stack spacing={2} direction="row" flexWrap="wrap">
-            {selectedPickers === 'date' && (
-              <DemoContainer
-                components={['DesktopDatePicker', 'MobileDatePicker', 'StaticDatePicker']}
-              >
-                {DATE_PICKERS.map(({ name, component: Component, props }) => (
-                  <Component label={name} key={name} {...props} />
-                ))}
-              </DemoContainer>
-            )}
-            {selectedPickers === 'time' && (
-              <DemoContainer
-                components={['DesktopTimePicker', 'MobileTimePicker', 'StaticTimePicker']}
-              >
-                {TIME_PICKERS.map(({ name, component: Component, props }) => (
-                  <Component label={name} key={name} {...props} />
-                ))}
-              </DemoContainer>
-            )}
+          {selectedPickers === 'date' && (
+            <DemoContainer
+              components={['DesktopDatePicker', 'MobileDatePicker', 'StaticDatePicker']}
+              sx={{ flexGrow: 1 }}
+            >
+              {DATE_PICKERS.map(({ name, component: Component, props }) => (
+                <Component label={name} key={name} {...props} />
+              ))}
+            </DemoContainer>
+          )}
+          {selectedPickers === 'time' && (
+            <DemoContainer
+              components={['DesktopTimePicker', 'MobileTimePicker', 'StaticTimePicker']}
+              sx={{ flexGrow: 1 }}
+            >
+              {TIME_PICKERS.map(({ name, component: Component, props }) => (
+                <Component label={name} key={name} {...props} />
+              ))}
+            </DemoContainer>
+          )}
+          {selectedPickers === 'date-time' && (
+            <DemoContainer
+              components={['DesktopDateTimePicker', 'MobileDateTimePicker', 'StaticDateTimePicker']}
+              sx={{ flexGrow: 1 }}
+            >
+              {DATE_TIME_PICKERS.map(({ name, component: Component, props }) => (
+                <Component label={name} key={name} views={availableViews} {...props} />
+              ))}
+            </DemoContainer>
+          )}
+          {selectedPickers === 'date-range' && (
+            <DemoContainer
+              components={[
+                'DesktopDateRangePicker',
+                'MobileDateRangePicker',
+                'StaticDateRangePicker',
+              ]}
+              sx={{ flexGrow: 1 }}
+            >
+              {DATE_RANGE_PICKERS.map(({ name, component: Component, props }) => (
+                <Component
+                  key={name}
+                  label={name}
+                  calendars={singleCalendar ? 1 : undefined}
+                  {...props}
+                  slotProps={{
+                    ...props.slotProps,
+                    ...(displayShortcuts && {
+                      shortcuts: {
+                        items: shortcutsItems,
+                      },
+                    }),
+                  }}
+                />
+              ))}
+            </DemoContainer>
+          )}
+        </Box>
+        <Divider orientation="vertical" light sx={{ display: { xs: 'none', sm: 'flex' } }} />
+        <Divider light sx={{ display: { xs: 'auto', sm: 'none' } }} />
+        <Box
+          sx={(theme) => ({
+            display: 'flex',
+            flexDirection: 'column',
+            background: alpha(theme.palette.grey[50], 0.5),
+            [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
+              backgroundColor: alpha(theme.palette.grey[900], 0.3),
+            },
+          })}
+        >
+          <Typography
+            id="usage-props"
+            component="h3"
+            fontWeight="600"
+            sx={{
+              scrollMarginTop: 160,
+              fontFamily: 'General Sans',
+              p: 3,
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            Playground
+          </Typography>
+          <Divider light />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pt: 2, pl: 3, pr: 2 }}>
+            <BooleanRadioGroupControl
+              label="Static desktop mode"
+              value={isStaticDesktopMode}
+              onChange={setIsStaticDesktopMode}
+            />
+            <RadioGroupControl
+              label="Toolbar hidden"
+              value={isToolbarHidden}
+              onChange={setIsToolbarHidden}
+            />
             {selectedPickers === 'date-time' && (
-              <DemoContainer
-                components={[
-                  'DesktopDateTimePicker',
-                  'MobileDateTimePicker',
-                  'StaticDateTimePicker',
-                ]}
-              >
-                {DATE_TIME_PICKERS.map(({ name, component: Component, props }) => (
-                  <Component label={name} key={name} views={availableViews} {...props} />
-                ))}
-              </DemoContainer>
+              <RadioGroupControl
+                label="Tabs hidden"
+                value={isTabsHidden}
+                onChange={setIsTabsHidden}
+              />
+            )}
+            <BooleanRadioGroupControl
+              label="Show days outside current month"
+              value={showDaysOutsideCurrentMonth}
+              onChange={setShowDaysOutsideCurrentMonth}
+            />
+            <BooleanRadioGroupControl
+              label="Fixed 6 weeks"
+              value={fixed6Weeks}
+              onChange={setFixed6Weeks}
+            />
+            <BooleanRadioGroupControl
+              label="Display week number"
+              value={displayWeekNumber}
+              onChange={setDisplayWeekNumber}
+            />
+            {selectedPickers !== 'date-range' && (
+              <BooleanRadioGroupControl
+                label="Disable day margin"
+                value={disableDayMargin}
+                onChange={setDisableDayMargin}
+              />
+            )}
+            {(selectedPickers === 'time' || selectedPickers === 'date-time') && (
+              <React.Fragment>
+                <RadioGroupControl label="AM/PM" value={ampm} onChange={setAmpm} />
+                <RadioGroupControl
+                  label="ampmInClock"
+                  value={ampmInClock}
+                  onChange={setAmpmInClock}
+                />
+              </React.Fragment>
             )}
             {selectedPickers === 'date-range' && (
-              <DemoContainer
-                components={[
-                  'DesktopDateRangePicker',
-                  'MobileDateRangePicker',
-                  'StaticDateRangePicker',
-                ]}
-              >
-                {DATE_RANGE_PICKERS.map(({ name, component: Component, props }) => (
-                  <Component
-                    key={name}
-                    label={name}
-                    calendars={singleCalendar ? 1 : undefined}
-                    {...props}
-                    slotProps={{
-                      ...props.slotProps,
-                      ...(displayShortcuts && {
-                        shortcuts: {
-                          items: shortcutsItems,
-                        },
-                      }),
-                    }}
-                  />
-                ))}
-              </DemoContainer>
+              <React.Fragment>
+                <BooleanRadioGroupControl
+                  label="Single calendar"
+                  value={singleCalendar}
+                  onChange={setSingleCalendar}
+                />
+                <BooleanRadioGroupControl
+                  label="Display shortcuts"
+                  value={displayShortcuts}
+                  onChange={setDisplayShortcuts}
+                />
+              </React.Fragment>
             )}
-          </Stack>
+            <BooleanRadioGroupControl
+              label="Custom actions"
+              value={customActions}
+              onChange={setCustomActions}
+            />
+            <BooleanRadioGroupControl
+              label="Landscape orientation"
+              value={isLandscape}
+              onChange={setIsLandscape}
+            />
+            {selectedPickers !== 'date-range' && (
+              <ViewSwitcher
+                showDateViews={selectedPickers === 'date' || selectedPickers === 'date-time'}
+                showTimeViews={selectedPickers === 'time' || selectedPickers === 'date-time'}
+                views={views}
+                handleViewsChange={handleViewsChange}
+              />
+            )}
+          </Box>
         </Box>
       </Box>
     </LocalizationProvider>

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { alpha } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import dayjs, { Dayjs } from 'dayjs';
 import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
@@ -43,6 +43,32 @@ import { isDatePickerView } from '@mui/x-date-pickers/internals/utils/date-utils
 // eslint-disable-next-line no-restricted-imports
 import { isTimeView } from '@mui/x-date-pickers/internals/utils/time-utils';
 
+const ComponentSection = styled('div')(({ theme }) => ({
+  padding: theme.spacing(4),
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2),
+  overflowX: 'auto',
+  '& .MuiPickersLayout-root': {
+    borderRadius: 2,
+    border: '1px dashed',
+    borderColor:
+      theme.palette.mode === 'light' ? theme.palette.divider : alpha(theme.palette.grey[500], 0.1),
+    ...(theme.palette.mode === 'dark' && {
+      backgroundColor: alpha(theme.palette.grey[900], 0.2),
+    }),
+  },
+}));
+
+const PropControlsSection = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  background: alpha(theme.palette.grey[50], 0.5),
+  ...(theme.palette.mode === 'dark' && {
+    backgroundColor: alpha(theme.palette.grey[900], 0.3),
+  }),
+}));
+
 function RadioGroupControl({
   label,
   value,
@@ -74,7 +100,7 @@ function RadioGroupControl({
   );
 }
 
-function BooleanRadioGroupControl({
+function BooleanGroupControl({
   label,
   value,
   onChange,
@@ -86,7 +112,7 @@ function BooleanRadioGroupControl({
   const id = React.useId();
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(event.target.value === 'true');
+      onChange(event.target.checked);
     },
     [onChange],
   );
@@ -103,10 +129,6 @@ function BooleanRadioGroupControl({
     >
       <FormLabel id={id}>{label}</FormLabel>
       <Switch checked={value} onChange={handleChange} />
-      {/* <RadioGroup aria-labelledby={id} value={value} onChange={handleChange} row>
-        <FormControlLabel value control={<Radio />} label="true" />
-        <FormControlLabel value={false} control={<Radio />} label="false" />
-      </RadioGroup> */}
     </FormControl>
   );
 }
@@ -489,27 +511,7 @@ export default function PickersPlayground() {
           },
         }}
       >
-        <Box
-          sx={(theme) => ({
-            width: { xs: '100%', sm: '60%' },
-            p: 4,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-            overflowX: 'auto',
-            '& .MuiPickersLayout-root': {
-              borderRadius: 2,
-              border: '1px dashed',
-              borderColor: 'divider',
-            },
-            [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
-              '& .MuiPickersLayout-root': {
-                backgroundColor: alpha(theme.palette.grey[900], 0.2),
-                borderColor: alpha(theme.palette.grey[500], 0.1),
-              },
-            },
-          })}
-        >
+        <ComponentSection sx={{ width: { xs: '100%', sm: '60%' } }}>
           <FormControl fullWidth>
             <InputLabel id="selected-component-family-label">Selected components</InputLabel>
             <Select
@@ -583,19 +585,10 @@ export default function PickersPlayground() {
               ))}
             </DemoContainer>
           )}
-        </Box>
+        </ComponentSection>
         <Divider orientation="vertical" light sx={{ display: { xs: 'none', sm: 'flex' } }} />
         <Divider light sx={{ display: { xs: 'auto', sm: 'none' } }} />
-        <Box
-          sx={(theme) => ({
-            display: 'flex',
-            flexDirection: 'column',
-            background: alpha(theme.palette.grey[50], 0.5),
-            [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
-              backgroundColor: alpha(theme.palette.grey[900], 0.3),
-            },
-          })}
-        >
+        <PropControlsSection>
           <Typography
             id="usage-props"
             component="h3"
@@ -613,7 +606,7 @@ export default function PickersPlayground() {
           </Typography>
           <Divider light />
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, pt: 2, pl: 3, pr: 2 }}>
-            <BooleanRadioGroupControl
+            <BooleanGroupControl
               label="Static desktop mode"
               value={isStaticDesktopMode}
               onChange={setIsStaticDesktopMode}
@@ -630,23 +623,23 @@ export default function PickersPlayground() {
                 onChange={setIsTabsHidden}
               />
             )}
-            <BooleanRadioGroupControl
+            <BooleanGroupControl
               label="Show days outside current month"
               value={showDaysOutsideCurrentMonth}
               onChange={setShowDaysOutsideCurrentMonth}
             />
-            <BooleanRadioGroupControl
+            <BooleanGroupControl
               label="Fixed 6 weeks"
               value={fixed6Weeks}
               onChange={setFixed6Weeks}
             />
-            <BooleanRadioGroupControl
+            <BooleanGroupControl
               label="Display week number"
               value={displayWeekNumber}
               onChange={setDisplayWeekNumber}
             />
             {selectedPickers !== 'date-range' && (
-              <BooleanRadioGroupControl
+              <BooleanGroupControl
                 label="Disable day margin"
                 value={disableDayMargin}
                 onChange={setDisableDayMargin}
@@ -664,24 +657,24 @@ export default function PickersPlayground() {
             )}
             {selectedPickers === 'date-range' && (
               <React.Fragment>
-                <BooleanRadioGroupControl
+                <BooleanGroupControl
                   label="Single calendar"
                   value={singleCalendar}
                   onChange={setSingleCalendar}
                 />
-                <BooleanRadioGroupControl
+                <BooleanGroupControl
                   label="Display shortcuts"
                   value={displayShortcuts}
                   onChange={setDisplayShortcuts}
                 />
               </React.Fragment>
             )}
-            <BooleanRadioGroupControl
+            <BooleanGroupControl
               label="Custom actions"
               value={customActions}
               onChange={setCustomActions}
             />
-            <BooleanRadioGroupControl
+            <BooleanGroupControl
               label="Landscape orientation"
               value={isLandscape}
               onChange={setIsLandscape}
@@ -695,7 +688,7 @@ export default function PickersPlayground() {
               />
             )}
           </Box>
-        </Box>
+        </PropControlsSection>
       </Box>
     </LocalizationProvider>
   );

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { alpha } from '@mui/material/styles';
 import dayjs, { Dayjs } from 'dayjs';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import InputLabel from '@mui/material/InputLabel';

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -70,7 +70,7 @@ const PropControlsSection = styled('div')(({ theme }) => ({
   }),
 }));
 
-function RadioGroupControl({
+function TriBooleanGroupControl({
   label,
   value,
   onChange,
@@ -621,13 +621,13 @@ export default function PickersPlayground() {
               value={isStaticDesktopMode}
               onChange={setIsStaticDesktopMode}
             />
-            <RadioGroupControl
+            <TriBooleanGroupControl
               label="Toolbar hidden"
               value={isToolbarHidden}
               onChange={setIsToolbarHidden}
             />
             {selectedPickers === 'date-time' && (
-              <RadioGroupControl
+              <TriBooleanGroupControl
                 label="Tabs hidden"
                 value={isTabsHidden}
                 onChange={setIsTabsHidden}
@@ -657,8 +657,8 @@ export default function PickersPlayground() {
             )}
             {(selectedPickers === 'time' || selectedPickers === 'date-time') && (
               <React.Fragment>
-                <RadioGroupControl label="AM/PM" value={ampm} onChange={setAmpm} />
-                <RadioGroupControl
+                <TriBooleanGroupControl label="AM/PM" value={ampm} onChange={setAmpm} />
+                <TriBooleanGroupControl
                   label="ampmInClock"
                   value={ampmInClock}
                   onChange={setAmpmInClock}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds in some low-hanging design improvements to the Date and Time Pickers playground component. I've mostly standardized the styles here to other playground-like components we have throughout the Material UI docs. Additionally, I changed the place the "Playground" page was sitting relative to all other pickers pages — having it on the very first section makes more sense as it is a general tool (and also put the API reference close to the components pages).

One thing I'd appreciate help with is turning all the "true/false" radio button groups into switches. We can cut the unnecessary "false" and "true" labels there as well as simplify the interaction (switch is exactly for binary values! 😬). I left a start of this work on line 106 of the playground component!

https://deploy-preview-11555--material-ui-x.netlify.app/x/react-date-pickers/playground/