### PR TITLE
[docs] Improve Support page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ Premium package:
 
 - [`@mui/x-data-grid-premium`](https://www.npmjs.com/package/@mui/x-data-grid-premium)
 
-## Questions and feedback
+## Support
 
+<<<<<<< HEAD
 ### GitHub
 
 We use GitHub issues as a bug and feature request tracker.
@@ -108,6 +109,9 @@ You can create an [issue](https://github.com/mui/mui-x/issues) on this repositor
 Please always provide a reproduction case.
 As a starting point, we recommend you [browse the documentation](https://mui.com/x/introduction/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case.
 Or you can use a [basic template](https://mui.com/r/x-issue-template) to build your reproduction case.
+=======
+From community guidance to critical business support, we're here to help. Read the [support guide](https://mui.com/x/introduction/support/).
+>>>>>>> a7c8d297f ([docs] Improve Support page)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -88,26 +88,7 @@ Premium package:
 
 ## Support
 
-### GitHub
-
-We use GitHub issues as a bug and feature request tracker.
-If you think you've found a bug, or you have a new feature idea, please start by [making sure it hasn't already been reported or fixed](https://github.com/mui/mui-x/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
-You can search through existing issues and pull requests to see if someone has reported one similar to yours.
-
-[Open an issue](https://github.com/mui/mui-x/issues/new/choose) in the MUI X repo.
-
-### Stack Overflow
-
-Visit Stack Overflow to ask questions and read crowdsourced answers from expert developers in the MUI X community, as well as MUI X maintainers.
-
-[Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui-x) on Stack Overflow using the "mui-x" tag.
-
-### Bugs and feature requests
-
-You can create an [issue](https://github.com/mui/mui-x/issues) on this repository.
-Please always provide a reproduction case.
-As a starting point, we recommend you [browse the documentation](https://mui.com/x/introduction/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case.
-Or you can use a [basic template](https://mui.com/r/x-issue-template) to build your reproduction case.
+From community guidance to critical business support, we're here to help. Read the [support guide](https://mui.com/x/introduction/support/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Premium package:
 
 ## Support
 
-<<<<<<< HEAD
 ### GitHub
 
 We use GitHub issues as a bug and feature request tracker.
@@ -109,9 +108,6 @@ You can create an [issue](https://github.com/mui/mui-x/issues) on this repositor
 Please always provide a reproduction case.
 As a starting point, we recommend you [browse the documentation](https://mui.com/x/introduction/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case.
 Or you can use a [basic template](https://mui.com/r/x-issue-template) to build your reproduction case.
-=======
-From community guidance to critical business support, we're here to help. Read the [support guide](https://mui.com/x/introduction/support/).
->>>>>>> a7c8d297f ([docs] Improve Support page)
 
 ## Contributing
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -12,6 +12,16 @@ If you think you've found a bug, or you have a new feature idea:
    You can search through existing issues and pull requests to see if someone has reported one similar to yours.
 2. Then, if no duplicates exist, [open an issue](https://github.com/mui/mui-x/issues/new/choose) in the MUI X repository.
 
+### Bug reproductions
+
+We require bug reports to be accompanied by a minimal reproduction so we can solve the problem.
+You have a few options possible to provide it:
+
+- (Simplest) You can browse the documentation, find an example close to your use case, and then open it in a live editor:
+  [![Forking an example](https://mui.com/static/docs/forking-an-example.png)](/x/react-date-pickers/getting-started/#render-your-first-component)
+
+- You can use the [official template](https://mui.com/r/issue-template/) to build a reproduction case.
+
 ## Stack Overflow
 
 We use Stack Overflow for how-to questions. Answers are crowdsourced from expert developers in the MUI X community as well as MUI X maintainers.

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -1,6 +1,10 @@
 # Support
 
+<<<<<<< HEAD
 <p class="description">Learn how to get support for MUI X components; including feature requests, bug fixes, answers to how-to questions, and technical support from the team.</p>
+=======
+<p class="description">Learn how to get support for MUI X components, including feature requests, bug fixes, and technical support from the team.</p>
+>>>>>>> febfecd3f (Polish content)
 
 ## GitHub
 
@@ -62,7 +66,7 @@ This includes issues introduced by external sources, like browser upgrades or ch
 
 ## Community
 
-We have a [Discord Server](https://mui.com/r/discord/) to allow the MUI X community to gather.
+We have a [Discord Server](https://mui.com/r/discord/) to bring the MUI X community together.
 Our tools are used by thousands of developers and teams all around the world, many of whom actively engage with the community.
 
 You can join Discord to engage in lively discussions, share your projects, and interact with developers just like you from all around the world. We'd love for you to be a part of our community!

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -1,10 +1,6 @@
 # Support
 
-<<<<<<< HEAD
-<p class="description">Learn how to get support for MUI X components; including feature requests, bug fixes, answers to how-to questions, and technical support from the team.</p>
-=======
-<p class="description">Learn how to get support for MUI X components, including feature requests, bug fixes, and technical support from the team.</p>
->>>>>>> febfecd3f (Polish content)
+<p class="description">Learn how to get support for MUI X components, including feature requests, bug fixes, and technical support from the team.</p>
 
 ## GitHub
 
@@ -69,4 +65,8 @@ This includes issues introduced by external sources, like browser upgrades or ch
 We have a [Discord Server](https://mui.com/r/discord/) to bring the MUI X community together.
 Our tools are used by thousands of developers and teams all around the world, many of whom actively engage with the community.
 
-You can join Discord to engage in lively discussions, share your projects, and interact with developers just like you from all around the world. We'd love for you to be a part of our community!
+You can join Discord to engage in lively discussions, share your projects, and interact with developers just like you from all around the world. We'd love for you to join us!
+
+:::warning
+How-to questions are not accepted on Discord, they should be asked on [Stack Overflow](#stack-overflow).
+:::

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -12,16 +12,6 @@ If you think you've found a bug, or you have a new feature idea:
    You can search through existing issues and pull requests to see if someone has reported one similar to yours.
 2. Then, if no duplicates exist, [open an issue](https://github.com/mui/mui-x/issues/new/choose) in the MUI X repository.
 
-### Bug reproductions
-
-We require bug reports to be accompanied by a minimal reproduction so we can solve the problem.
-You have a few options possible to provide it:
-
-- (Simplest) You can browse the documentation, find an example close to your use case, and then open it in a live editor:
-  [![Forking an example](https://mui.com/static/docs/forking-an-example.png)](/x/react-date-pickers/getting-started/#render-your-first-component)
-
-- You can use the [official template](https://mui.com/r/issue-template/) to build a reproduction case.
-
 ## Stack Overflow
 
 We use Stack Overflow for how-to questions. Answers are crowdsourced from expert developers in the MUI X community as well as MUI X maintainers.

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -1,20 +1,29 @@
 # Support
 
-<p class="description">How to get support for MUI X components, including feature requests, bug fixes, answers to how-to questions, and technical support from the team.</p>
+<p class="description">Learn how to get support for MUI X components; including feature requests, bug fixes, answers to how-to questions, and technical support from the team.</p>
 
 ## GitHub
 
 We use GitHub issues as a bug and feature request tracker.
-If you think you've found a bug, or you have a new feature idea, please start by [making sure it hasn't already been reported or fixed](https://github.com/mui/mui-x/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
-You can search through existing issues and pull requests to see if someone has reported one similar to yours.
 
-[Open an issue](https://github.com/mui/mui-x/issues/new/choose) in the MUI X repo.
+If you think you've found a bug, or you have a new feature idea:
+
+1. Please start by [making sure it hasn't already been reported or fixed](https://github.com/mui/mui-x/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
+   You can search through existing issues and pull requests to see if someone has reported one similar to yours.
+2. Then, if no duplicates exist, [open an issue](https://github.com/mui/mui-x/issues/new/choose) in the MUI X repository.
 
 ## Stack Overflow
 
-Visit Stack Overflow to ask questions and read crowdsourced answers from expert developers in the MUI community, as well as MUI maintainers.
+We use Stack Overflow for how-to questions. Answers are crowdsourced from expert developers in the MUI X community as well as MUI X maintainers.
 
-[Post a question about MUI X](https://stackoverflow.com/questions/tagged/mui-x) on Stack Overflow using the "mui-x" tag.
+You can search through existing questions and answers to see if someone has asked a similar question using one of [these tags](https://stackoverflow.com/questions/tagged/mui-x+or+mui-x-charts+or+mui-x-data-grid+or+mui-x-date-picker):
+
+- mui-x
+- mui-x-data-grid
+- mui-x-date-picker
+- mui-x-charts
+
+If you can't find your answer, [ask a new question](https://stackoverflow.com/questions/ask?tags=reactjs%20mui-x) using the relevant tags.
 
 ## Technical support
 
@@ -22,7 +31,7 @@ Visit Stack Overflow to ask questions and read crowdsourced answers from expert 
 The technical support covers only MUI X components.
 :::
 
-When purchasing a MUI X Pro or Premium license you get access to technical support until the end of your subscription.
+When purchasing a MUI X Pro or Premium license you get access to technical support until the end of your active license.
 Support is available on multiple channels, but the recommended channels are:
 
 - GitHub: You can [open a new issue](https://github.com/mui/mui-x/issues/new/choose) and leave your Order ID (or Support key), so we can prioritize accordingly.
@@ -34,9 +43,10 @@ Including your Order ID (or Support key) in the issue helps us prioritize the is
 2. MUI X Premium: The same as MUI X Pro, but with higher priority.
 3. MUI X Priority Support add-on (coming soon): Provides a 24h SLA for the first answer.
 
-### Long-term support (LTS)
+## Long-term support (LTS)
 
-Bug fixes, performance enhancements, and other improvements are delivered in new releases. However, MUI remains committed to providing security updates and addressing regressions for the immediate predecessor of the current major version.
+Bug fixes, performance enhancements, and other improvements are delivered in new releases.
+However, we remain committed to providing security updates and addressing regressions for the immediate predecessor of the current major version.
 
 This includes issues introduced by external sources, like browser upgrades or changes to upstream dependencies.
 
@@ -44,8 +54,15 @@ This includes issues introduced by external sources, like browser upgrades or ch
 
 - MUI X v7: ✅ Pre-release (Continuous support - Stable release: March 2024)
 - MUI X v6: ✅ Stable major (Continuous support)
-- MUI X v5: ⚠️ Long term support (Guaranteed Support for security issues and regressions).
+- MUI X v5: ⚠️ Long-term support (Guaranteed Support for security issues and regressions).
 - MUI X v4: 🅧 No longer supported.
 - MUI X v3: 🅧 Never existed.
 - MUI X v2: 🅧 Never existed.
 - MUI X v1: 🅧 Never existed.
+
+## Community
+
+We have a [Discord Server](https://mui.com/r/discord/) to allow the MUI X community to gather.
+Our tools are used by thousands of developers and teams all around the world, many of whom actively engage with the community.
+
+You can join Discord to engage in lively discussions, share your projects, and interact with developers just like you from all around the world. We'd love for you to be a part of our community!


### PR DESCRIPTION
My idea is to create a standard for the Support page, starting with MUI X.

To then go to the core and update Material UI support, create Base UI, MUI System support pages, etc. I'm not a fan of https://mui.com/material-ui/getting-started/support/.

Preview: https://deploy-preview-11556--material-ui-x.netlify.app/x/introduction/support/