### PR TITLE
[DataGrid] Replace eval with new Function

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -259,7 +259,11 @@ const buildAggregatedFilterItemsApplier = (
 
   // We generate a new function with `eval()` to avoid expensive patterns for JS engines
   // such as a dynamic object assignment, e.g. `{ [dynamicKey]: value }`.
-  const filterItemTemplate = `"use strict";
+  const filterItemCore = new Function(
+    'appliers',
+    'row',
+    'shouldApplyFilter',
+    `"use strict";
 ${appliers
   .map(
     (applier, i) =>
@@ -280,20 +284,11 @@ ${appliers
   .join('\n')}
 };
 
-return result$$;`;
-
-  const filterItemCore = new Function(
-    'appliers',
-    'row',
-    'shouldApplyFilter',
-    filterItemTemplate.replaceAll('$$', String(filterItemsApplierId)),
+return result$$;`.replaceAll('$$', String(filterItemsApplierId)),
   );
-  const filterItem: GridFilterItemApplierNotAggregated = (row, shouldApplyItem) => {
-    return filterItemCore(appliers, row, shouldApplyItem);
-  };
   filterItemsApplierId += 1;
 
-  return filterItem;
+  return (row, shouldApplyItem) => filterItemCore(appliers, row, shouldApplyItem);
 };
 
 export const shouldQuickFilterExcludeHiddenColumns = (filterModel: GridFilterModel) => {

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -30,7 +30,7 @@ function getHasEval() {
   }
 
   try {
-    hasEval = new Function('return true') as any;
+    hasEval = new Function('return true')() as boolean;
   } catch (_: unknown) {
     hasEval = false;
   }

--- a/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
+++ b/packages/grid/x-data-grid/src/hooks/features/filter/gridFilterUtils.ts
@@ -257,7 +257,7 @@ const buildAggregatedFilterItemsApplier = (
     };
   }
 
-  // We generate a new function with `eval()` to avoid expensive patterns for JS engines
+  // We generate a new function with `new Function()` to avoid expensive patterns for JS engines
   // such as a dynamic object assignment, e.g. `{ [dynamicKey]: value }`.
   const filterItemCore = new Function(
     'appliers',
@@ -288,7 +288,10 @@ return result$$;`.replaceAll('$$', String(filterItemsApplierId)),
   );
   filterItemsApplierId += 1;
 
-  return (row, shouldApplyItem) => filterItemCore(appliers, row, shouldApplyItem);
+  // Assign to the arrow function a name to help debugging
+  const filterItem: GridFilterItemApplierNotAggregated = (row, shouldApplyItem) =>
+    filterItemCore(appliers, row, shouldApplyItem);
+  return filterItem;
 };
 
 export const shouldQuickFilterExcludeHiddenColumns = (filterModel: GridFilterModel) => {


### PR DESCRIPTION
I was curious if we could improve this logic:

- `getRowId` was removed in #10897, no need to provide it as an argument anymore.
- Avoid the need for `atob('ZXZhbA==')`, it feels like obfuscation and fix #11046
- ~eval and new Function are by default sloopy https://2ality.com/2014/01/eval.html, made it strict.~