### PR TITLE
[TreeView] Avoid unnecessary re-rendering when focus or blur

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
@@ -17,7 +17,9 @@ export const useTreeViewFocus: TreeViewPlugin<UseTreeViewFocusSignature> = ({
 }) => {
   const setFocusedNodeId = useEventCallback((nodeId: React.SetStateAction<string | null>) => {
     const cleanNodeId = typeof nodeId === 'function' ? nodeId(state.focusedNodeId) : nodeId;
-    setState((prevState) => ({ ...prevState, focusedNodeId: cleanNodeId }));
+    if(nodeId!=cleanNodeId){
+        setState((prevState) => ({ ...prevState, focusedNodeId: cleanNodeId }));
+    }
   });
 
   const isNodeFocused = React.useCallback(

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
@@ -17,7 +17,7 @@ export const useTreeViewFocus: TreeViewPlugin<UseTreeViewFocusSignature> = ({
 }) => {
   const setFocusedNodeId = useEventCallback((nodeId: React.SetStateAction<string | null>) => {
     const cleanNodeId = typeof nodeId === 'function' ? nodeId(state.focusedNodeId) : nodeId;
-    if(nodeId!=cleanNodeId){
+    if(nodeId!==cleanNodeId){
         setState((prevState) => ({ ...prevState, focusedNodeId: cleanNodeId }));
     }
   });

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
@@ -17,7 +17,7 @@ export const useTreeViewFocus: TreeViewPlugin<UseTreeViewFocusSignature> = ({
 }) => {
   const setFocusedNodeId = useEventCallback((nodeId: React.SetStateAction<string | null>) => {
     const cleanNodeId = typeof nodeId === 'function' ? nodeId(state.focusedNodeId) : nodeId;
-    if(nodeId!==cleanNodeId){
+    if (nodeId!==cleanNodeId) {
         setState((prevState) => ({ ...prevState, focusedNodeId: cleanNodeId }));
     }
   });


### PR DESCRIPTION
Fixes #11518

1. When there is a form element in the treeitem, the focus and blur will be triggered at intervals, which will call setState and trigger the re-rendering of the root component.
2. So only when nodeId and cleanNodeId are different, setState will be called.
