### PR TITLE
[docs] Clarify Pickers usage with Luxon

### DIFF
--- a/docs/data/date-pickers/timezone/LuxonTimezone.tsx
+++ b/docs/data/date-pickers/timezone/LuxonTimezone.tsx
@@ -7,7 +7,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 
 export default function LuxonTimezone() {
-  const [value, setValue] = React.useState<DateTime | null>(
+  const [value, setValue] = React.useState<DateTime<true> | DateTime<false> | null>(
     DateTime.fromISO('2022-04-17T15:30', { zone: 'America/New_York' }),
   );
 

--- a/docs/data/date-pickers/timezone/LuxonUTC.tsx
+++ b/docs/data/date-pickers/timezone/LuxonUTC.tsx
@@ -7,7 +7,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 
 export default function LuxonUTC() {
-  const [value, setValue] = React.useState<DateTime | null>(
+  const [value, setValue] = React.useState<DateTime<true> | DateTime<false> | null>(
     DateTime.fromISO('2022-04-17T15:30', { zone: 'UTC' }),
   );
 

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -40,10 +40,6 @@
     "disableColumnSelector": { "type": { "name": "bool" }, "default": "false" },
     "disableDensitySelector": { "type": { "name": "bool" }, "default": "false" },
     "disableEval": { "type": { "name": "bool" }, "default": "false" },
-    "disableMultipleRowSelection": {
-      "type": { "name": "bool" },
-      "default": "false (`!props.checkboxSelection` for MIT Data Grid)"
-    },
     "disableRowSelectionOnClick": { "type": { "name": "bool" }, "default": "false" },
     "disableVirtualization": { "type": { "name": "bool" }, "default": "false" },
     "editMode": {

--- a/docs/translations/api-docs/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid.json
@@ -111,11 +111,6 @@
       "deprecated": "",
       "typeDescriptions": {}
     },
-    "disableMultipleRowSelection": {
-      "description": "If <code>true</code>, multiple selection using the Ctrl/CMD or Shift key is disabled. The MIT DataGrid will ignore this prop, unless <code>checkboxSelection</code> is enabled.",
-      "deprecated": "",
-      "typeDescriptions": {}
-    },
     "disableRowSelectionOnClick": {
       "description": "If <code>true</code>, the selection on click on a row or cell is disabled.",
       "deprecated": "",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -95,7 +95,7 @@
     }
   },
   "devDependencies": {
-    "@types/luxon": "^3.3.3",
+    "@types/luxon": "^3.3.7",
     "date-fns": "^2.30.0",
     "dayjs": "^1.11.10",
     "luxon": "^3.4.3",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -97,7 +97,7 @@
     }
   },
   "devDependencies": {
-    "@types/luxon": "^3.3.3",
+    "@types/luxon": "^3.3.7",
     "@types/moment-jalaali": "^0.7.8",
     "date-fns": "^2.30.0",
     "date-fns-jalali": "^2.13.0-0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,10 +2935,10 @@
   dependencies:
     lru-cache "*"
 
-"@types/luxon@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.3.tgz#b2e20a9536f91ab3e6e7895c91883e1a7ad49a6e"
-  integrity sha512-/BJF3NT0pRMuxrenr42emRUF67sXwcZCd+S1ksG/Fcf9O7C3kKCY4uJSbKBE4KDUIYr3WMsvfmWD8hRjXExBJQ==
+"@types/luxon@^3.3.7":
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.7.tgz#043d413b6492a012de47503907bdf3ec4f827933"
+  integrity sha512-gKc9P2d4g5uYwmy4s/MO/yOVPmvHyvzka1YH6i5dM03UrFofHSmgc0D0ymbDRStFWHusk6cwwF6nhLm/ckBbbQ==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"


### PR DESCRIPTION
Cherry-pick #11545

Had to bump `@types/luxon` to avoid the problem of `DateTime` not supporting a generic.