### PR TITLE
[DataGridPremium] Allow aggregation to be applied for non-aggregable columns

### DIFF
--- a/docs/data/data-grid/aggregation/aggregation.md
+++ b/docs/data/data-grid/aggregation/aggregation.md
@@ -46,6 +46,14 @@ This will disable all features related to aggregation, even if a model is provid
 
 To disable aggregation on a specific column, set the `aggregable` property on its column definition (`GridColDef`) to `false`.
 
+The aggregation will not be available on the Grid UI but could still be applied in a **read-only mode**, i.e no option will be available in the column menu to update it. To apply such an aggregation, provide aggregation model in one of the following ways.
+
+1. Pass `aggregation.model` to the `initialState` prop. This will initialize the aggregation with the provided model.
+2. Provide the `aggregationModel` prop. This will control the aggregation with the provided model.
+3. Call the API method `setAggregationModel`. This will set the aggregation with the provided model.
+
+In the demo below, the **Year** column is not aggregable, yet it's aggregated in a read-only mode by providing an initial aggregation model.
+
 {{"demo": "AggregationColDefAggregable.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Usage with row grouping

--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
@@ -45,7 +45,7 @@ export const canColumnHaveAggregationFunction = ({
   aggregationFunctionName: string;
   aggregationFunction: GridAggregationFunction | undefined;
 }): boolean => {
-  if (!colDef || !colDef.aggregable) {
+  if (!colDef) {
     return false;
   }
 

--- a/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
+++ b/packages/grid/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
@@ -107,7 +107,7 @@ export const useGridAggregationPreProcessors = (
 
   const addColumnMenuButtons = React.useCallback<GridPipeProcessor<'columnMenu'>>(
     (columnMenuItems, colDef) => {
-      if (props.disableAggregation) {
+      if (props.disableAggregation || !colDef.aggregable) {
         return columnMenuItems;
       }
 

--- a/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/grid/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -119,7 +119,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
         expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5', '5' /* Agg */]);
       });
 
-      it('should ignore aggregation rule with colDef.aggregable = false', () => {
+      it('should respect aggregation rule with colDef.aggregable = false', () => {
         render(
           <Test
             columns={[
@@ -140,7 +140,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
           />,
         );
         expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5', '5' /* Agg */]);
-        expect(getColumnValues(1)).to.deep.equal(['0', '1', '2', '3', '4', '5', '' /* Agg */]);
+        expect(getColumnValues(1)).to.deep.equal(['0', '1', '2', '3', '4', '5', '5' /* Agg */]);
       });
 
       it('should ignore aggregation rules with invalid aggregation functions', () => {
@@ -514,7 +514,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
   });
 
   describe('colDef: aggregable', () => {
-    it('should not aggregate if colDef.aggregable = false', () => {
+    it('should respect `initialState.aggregation.model` prop even if colDef.aggregable = false', () => {
       render(
         <Test
           initialState={{ aggregation: { model: { id: 'max' } } }}
@@ -527,7 +527,23 @@ describe('<DataGridPremium /> - Aggregation', () => {
           ]}
         />,
       );
-      expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5']);
+      expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5', '5']);
+    });
+
+    it('should respect `aggregationModel` prop even if colDef.aggregable = false', () => {
+      render(
+        <Test
+          aggregationModel={{ id: 'max' }}
+          columns={[
+            {
+              field: 'id',
+              type: 'number',
+              aggregable: false,
+            },
+          ]}
+        />,
+      );
+      expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5', '5']);
     });
 
     it('should not render column menu select if colDef.aggregable = false', () => {


### PR DESCRIPTION
Handles `colDef.aggregable` part of #10552

## Changelog

### Breaking changes

- Non-aggregable columns could now be aggregated programmatically to create read-only aggregation rules by controlling or initializing `aggregationModel`, or by updating the `aggregationModel` by API method `apiRef.current.setAggregationModel`.