### PR TITLE
[DataGrid] follow warning message guideline for `autoPageSize` and `autoHeight`

### DIFF
--- a/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/grid/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -116,7 +116,12 @@ DataGridPremiumRaw.propTypes = {
   autoPageSize: chainPropTypes(PropTypes.bool, (props: any) => {
     if (props.autoHeight && props.autoPageSize) {
       return new Error(
-        'MUI: The `autoPageSize` prop will conflict with `autoHeight` prop when both of them are enabled.',
+        [
+          'MUI: `<DataGrid autoPageSize={true} autoHeight={true} />` are not valid props.',
+          'You can not use both the `autoPageSize` and `autoHeight` props at the same time because `autoHeight` scales the height of the Data Grid according to the `pageSize`.',
+          '',
+          'Please remove one of these two props.',
+        ].join('\n'),
       );
     }
     return null;

--- a/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -99,7 +99,12 @@ DataGridProRaw.propTypes = {
   autoPageSize: chainPropTypes(PropTypes.bool, (props: any) => {
     if (props.autoHeight && props.autoPageSize) {
       return new Error(
-        'MUI: The `autoPageSize` prop will conflict with `autoHeight` prop when both of them are enabled.',
+        [
+          'MUI: `<DataGrid autoPageSize={true} autoHeight={true} />` are not valid props.',
+          'You can not use both the `autoPageSize` and `autoHeight` props at the same time because `autoHeight` scales the height of the Data Grid according to the `pageSize`.',
+          '',
+          'Please remove one of these two props.',
+        ].join('\n'),
       );
     }
     return null;

--- a/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/grid/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -80,7 +80,12 @@ DataGridRaw.propTypes = {
   autoPageSize: chainPropTypes(PropTypes.bool, (props: any) => {
     if (props.autoHeight && props.autoPageSize) {
       return new Error(
-        'MUI: The `autoPageSize` prop will conflict with `autoHeight` prop when both of them are enabled.',
+        [
+          'MUI: `<DataGrid autoPageSize={true} autoHeight={true} />` are not valid props.',
+          'You can not use both the `autoPageSize` and `autoHeight` props at the same time because `autoHeight` scales the height of the Data Grid according to the `pageSize`.',
+          '',
+          'Please remove one of these two props.',
+        ].join('\n'),
       );
     }
     return null;

--- a/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -1116,7 +1116,12 @@ describe('<DataGrid /> - Rows', () => {
       expect(() => {
         render(<TestCase autoPageSize autoHeight />);
       }).toErrorDev(
-        'MUI: The `autoPageSize` prop will conflict with `autoHeight` prop when both of them are enabled.',
+        [
+          'MUI: `<DataGrid autoPageSize={true} autoHeight={true} />` are not valid props.',
+          'You can not use both the `autoPageSize` and `autoHeight` props at the same time because `autoHeight` scales the height of the Data Grid according to the `pageSize`.',
+          '',
+          'Please remove one of these two props.',
+        ].join('\n'),
       );
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

the warning doesn't follow the [guideline](https://www.notion.so/mui-org/Technical-writing-guidance-7e55b517ac2e489a9ddb6d0f6dd765de?pvs=4#85219822c3194b6f8a49ee08ea82b90a), so I updated it. More context in https://github.com/mui/mui-x/pull/11554#discussion_r1441871710.