### PR TITLE
[core] Simplify isSsr logic

### DIFF
--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -1,8 +1,9 @@
 // DOM utils taken from
 // https://github.com/recharts/recharts/blob/master/src/util/DOMUtils.ts
 
-const isSsr = (): boolean =>
-  !(typeof window !== 'undefined' && window.document && window.setTimeout);
+function isSsr(): boolean {
+  return typeof window === 'undefined';
+}
 
 interface StringCache {
   widthCache: Record<string, any>;


### PR DESCRIPTION
This is the logic we use in Material UI. It doesn't seem to fall short in practice.

Sure React uses something more advanced https://github.com/facebook/react/blob/1d5667a1273386f84e416059af7b6aba069e068e/packages/shared/ExecutionEnvironment.js but it seems dead code. Preact which focuses on bundle size, seems to use a simpler version: https://github.com/preactjs/preact/blob/f7ccb9010077ecb46fc271224bbc5e015e00efe6/compat/src/render.js#L18.

Same idea as https://github.com/mui/material-ui/pull/40471