### PR TITLE
[core] Remove PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,6 @@ commands:
       - run:
           name: Install js dependencies
           command: yarn install
-          environment:
-            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: <<# parameters.browsers >>0<</ parameters.browsers >><<^ parameters.browsers >>1<</ parameters.browsers >>
       - when:
           condition: << parameters.browsers >>
           steps:

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -24,9 +24,6 @@ jobs:
           node-version: 18
           cache: 'yarn' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: yarn install
-        env:
-          # Don't need playwright in this job
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - name: yarn l10n --report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,8 +10,6 @@
 [build.environment]
   NODE_VERSION = "18"
   NODE_OPTIONS = "--max_old_space_size=4096"
-  # Not using `playwright` when building docs.
-  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 
 [[plugins]]
   package = "./node_modules/@mui/monorepo/packages/netlify-plugin-cache-docs"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "lerna run --no-bail --parallel typescript",
     "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
     "build:codesandbox": "yarn release:build",
-    "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
+    "install:codesandbox": "yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "release:version": "lerna version --exact --no-changelog --no-push --no-git-tag-version --no-private",
     "release:build": "lerna run --parallel --no-private --scope \"@mui/*\" build",


### PR DESCRIPTION
Since Playwright v1.38.0, it does not download browsers automatically: https://github.com/microsoft/playwright/releases/tag/v1.38.0, so PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD is noise.

I found this by chance, I wanted to run the Karma tests for https://github.com/mui/material-ui/pull/39981 and went down a deep rabbit hole as I was trying to make sense of a few strange things in the codebase.