### PR TITLE
[DataGrid] Allow passing readonly arrays to `pageSizeOptions` prop

### DIFF
--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -26,6 +26,10 @@ const GridPaginationRoot = styled(TablePagination)(({ theme }) => ({
   },
 })) as typeof TablePagination;
 
+// A mutable version of a readonly array.
+
+type MutableArray<A> = A extends readonly (infer T)[] ? T[] : never;
+
 export const GridPagination = React.forwardRef<unknown, Partial<TablePaginationProps>>(
   function GridPagination(props, ref) {
     const apiRef = useGridApiContext();
@@ -103,7 +107,10 @@ export const GridPagination = React.forwardRef<unknown, Partial<TablePaginationP
         component="div"
         count={rowCount}
         page={paginationModel.page <= lastPage ? paginationModel.page : lastPage}
-        rowsPerPageOptions={pageSizeOptions}
+        // TODO: Remove the cast once the type is fixed in MUI and that the min MUI version
+        // for x-data-grid is past the fix.
+        // Note that MUI will not mutate the array, so this is safe.
+        rowsPerPageOptions={pageSizeOptions as MutableArray<typeof pageSizeOptions>}
         rowsPerPage={paginationModel.pageSize}
         onPageChange={handlePageChange}
         onRowsPerPageChange={handlePageSizeChange}

--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -107,9 +107,9 @@ export const GridPagination = React.forwardRef<unknown, Partial<TablePaginationP
         component="div"
         count={rowCount}
         page={paginationModel.page <= lastPage ? paginationModel.page : lastPage}
-        // TODO: Remove the cast once the type is fixed in MUI and that the min MUI version
+        // TODO: Remove the cast once the type is fixed in Material UI and that the min Material UI version
         // for x-data-grid is past the fix.
-        // Note that MUI will not mutate the array, so this is safe.
+        // Note that Material UI will not mutate the array, so this is safe.
         rowsPerPageOptions={pageSizeOptions as MutableArray<typeof pageSizeOptions>}
         rowsPerPage={paginationModel.pageSize}
         onPageChange={handlePageChange}

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -299,7 +299,7 @@ export interface DataGridPropsWithDefaultValues {
    * Select the pageSize dynamically using the component UI.
    * @default [25, 50, 100]
    */
-  pageSizeOptions: Array<number | { value: number; label: string }>;
+  pageSizeOptions: ReadonlyArray<number | { value: number; label: string }>;
   /**
    * Sets the type of space between rows added by `getRowSpacing`.
    * @default "margin"


### PR DESCRIPTION
Contributes to #10685

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
