### PR TITLE
[docs] Fix parsing of `x-date-pickers-pro` demo adapter imports

### DIFF
--- a/docs/src/modules/utils/postProcessImport.test.ts
+++ b/docs/src/modules/utils/postProcessImport.test.ts
@@ -35,4 +35,23 @@ describe('postProcessImport', () => {
       });
     });
   });
+
+  describe('@mui/x-date-pickers-pro imports', () => {
+    const ALL_ADAPTERS = [
+      ...ADAPTERS,
+      'AdapterDateFnsJalali',
+      'AdapterMomentHijri',
+      'AdapterMomentJalaali',
+    ];
+    ALL_ADAPTERS.forEach((adapter) => {
+      it('should provide correct adapter', () => {
+        const resolvedDep = postProcessImport(`@mui/x-date-pickers-pro/${adapter}`);
+
+        const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
+        expect(resolvedDep).to.deep.equal({
+          [expectedLibrary]: DATE_ADAPTER_VERSIONS[expectedLibrary],
+        });
+      });
+    });
+  });
 });

--- a/docs/src/modules/utils/postProcessImport.ts
+++ b/docs/src/modules/utils/postProcessImport.ts
@@ -18,7 +18,7 @@ export const ADAPTER_TO_LIBRARY: Record<string, string> = {
   AdapterMomentJalaali: 'moment-jalaali',
 };
 
-const PICKERS_ADAPTER_REGEX = /^@mui\/(lab|x-date-pickers)\/(?<adapterName>Adapter.*)/;
+const PICKERS_ADAPTER_REGEX = /^@mui\/(lab|x-date-pickers(?:-pro)?)\/(?<adapterName>Adapter.*)/;
 
 export const postProcessImport = (importName: string): Record<string, string> | null => {
   // e.g. date-fns


### PR DESCRIPTION
Noticed that after https://github.com/mui/mui-x/pull/11463 and specifically https://github.com/mui/mui-x/pull/11463/files#diff-41c21e2dc42b8c223fc2fa17580e58041afa590fe34d9fbe9a1ffbe5e17d318bL46 our demos using `@mui/x-date-pickers-pro/<adapterName>` import no longer work, because the regex doesn't account for the possibility of the adapter being imported from the pro package.