### PR TITLE
[fields] Support farsi digits

### DIFF
--- a/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
@@ -92,7 +92,14 @@ export const rangeFieldValueManager: FieldValueManager<DateRange<any>, any, Rang
 
     return [prevReferenceValue[1], value[1]];
   },
-  getSectionsFromValue: (utils, [start, end], fallbackSections, isRTL, getSectionsFromDate) => {
+  getSectionsFromValue: (
+    utils,
+    [start, end],
+    fallbackSections,
+    localizedDigits,
+    isRTL,
+    getSectionsFromDate,
+  ) => {
     const separatedFallbackSections =
       fallbackSections == null
         ? { startDate: null, endDate: null }
@@ -131,13 +138,15 @@ export const rangeFieldValueManager: FieldValueManager<DateRange<any>, any, Rang
         ...getSections(start, separatedFallbackSections.startDate, 'start'),
         ...getSections(end, separatedFallbackSections.endDate, 'end'),
       ],
+      localizedDigits,
       isRTL,
     );
   },
-  getValueStrFromSections: (sections, isRTL) => {
+  getValueStrFromSections: (sections, localizedDigits, isRTL) => {
     const dateRangeSections = splitDateRangeSections(sections);
     return createDateStrForInputFromSections(
       [...dateRangeSections.startDate, ...dateRangeSections.endDate],
+      localizedDigits,
       isRTL,
     );
   },

--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
@@ -131,6 +131,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'aa',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'PP',
   keyboardDate: 'P',

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.ts
@@ -131,6 +131,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'aa',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'PPP',
   keyboardDate: 'P',

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -80,6 +80,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'A',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'll',
   keyboardDate: 'L',

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
@@ -67,6 +67,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'a',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'DD',
   keyboardDate: 'D',

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.ts
@@ -66,6 +66,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'A',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'll',
   keyboardDate: 'L',

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.ts
@@ -57,6 +57,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'A',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'iYYYY, iMMMM Do',
   keyboardDateTime: 'iYYYY/iMM/iDD LT',

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.ts
@@ -56,6 +56,7 @@ const defaultFormats: AdapterFormats = {
   meridiem: 'A',
   minutes: 'mm',
   seconds: 'ss',
+  secondsNoLeadingZeros: 's',
 
   fullDate: 'jYYYY, jMMMM Do',
   keyboardDate: 'jYYYY/jMM/jDD',

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.test.tsx
@@ -12,6 +12,8 @@ const COMMON_PROPERTIES = {
   maxLength: 4,
 } as const;
 
+const DEFAULT_LOCALIZED_DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
 describe('useField utility functions', () => {
   describe('getSectionVisibleValue', () => {
     it('should not add invisible space when target = "non-input"', () => {
@@ -19,6 +21,7 @@ describe('useField utility functions', () => {
         getSectionVisibleValue(
           { ...COMMON_PROPERTIES, value: '1', placeholder: '', hasLeadingZerosInInput: true },
           'non-input',
+          DEFAULT_LOCALIZED_DIGITS,
         ),
       ).to.equal('1');
     });
@@ -28,6 +31,7 @@ describe('useField utility functions', () => {
         getSectionVisibleValue(
           { ...COMMON_PROPERTIES, value: '1', placeholder: '', hasLeadingZerosInInput: false },
           'input-ltr',
+          DEFAULT_LOCALIZED_DIGITS,
         ),
       ).to.equal('1\u200e');
     });
@@ -37,6 +41,7 @@ describe('useField utility functions', () => {
         getSectionVisibleValue(
           { ...COMMON_PROPERTIES, value: '1', placeholder: '', hasLeadingZerosInInput: false },
           'input-rtl',
+          DEFAULT_LOCALIZED_DIGITS,
         ),
       ).to.equal('\u20681\u200e\u2069');
     });
@@ -46,6 +51,7 @@ describe('useField utility functions', () => {
         getSectionVisibleValue(
           { ...COMMON_PROPERTIES, value: '1', placeholder: '', hasLeadingZerosInInput: true },
           'input-rtl',
+          DEFAULT_LOCALIZED_DIGITS,
         ),
       ).to.equal('\u20681\u2069');
     });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -39,6 +39,7 @@ export const useField = <
     updateValueFromValueStr,
     setTempAndroidValueStr,
     sectionsValueBoundaries,
+    localizedDigits,
     placeholder,
     timezone,
   } = useFieldState(params);
@@ -69,6 +70,7 @@ export const useField = <
     sections: state.sections,
     updateSectionValue,
     sectionsValueBoundaries,
+    localizedDigits,
     setTempAndroidValueStr,
     timezone,
   });
@@ -238,7 +240,7 @@ export const useField = <
       keyPressed = cleanValueStr;
     } else {
       const prevValueStr = cleanString(
-        fieldValueManager.getValueStrFromSections(state.sections, isRTL),
+        fieldValueManager.getValueStrFromSections(state.sections, localizedDigits, isRTL),
       );
 
       let startOfDiffIndex = -1;
@@ -386,6 +388,7 @@ export const useField = <
           activeSection,
           event.key as AvailableAdjustKeyCode,
           sectionsValueBoundaries,
+          localizedDigits,
           activeDateManager.date,
           { minutesStep },
         );
@@ -486,8 +489,9 @@ export const useField = <
 
   const valueStr = React.useMemo(
     () =>
-      state.tempValueStrAndroid ?? fieldValueManager.getValueStrFromSections(state.sections, isRTL),
-    [state.sections, fieldValueManager, state.tempValueStrAndroid, isRTL],
+      state.tempValueStrAndroid ??
+      fieldValueManager.getValueStrFromSections(state.sections, localizedDigits, isRTL),
+    [state.sections, fieldValueManager, state.tempValueStrAndroid, localizedDigits, isRTL],
   );
 
   const inputMode = React.useMemo(() => {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -253,6 +253,7 @@ export interface FieldValueManager<TValue, TDate, TSection extends FieldSection>
    * @param {MuiPickersAdapter<TDate>} utils The utils to manipulate the date.
    * @param {TValue} value The current value to generate sections from.
    * @param {TSection[] | null} fallbackSections The sections to use as a fallback if a date is null or invalid.
+   * @param {string} localizedDigits The conversion table from localized to 0-9 digits.
    * @param {boolean} isRTL `true` if the direction is "right to left".
    * @param {(date: TDate) => FieldSectionWithoutPosition[]} getSectionsFromDate Returns the sections of the given date.
    * @returns {TSection[]}  The new section list.
@@ -261,6 +262,7 @@ export interface FieldValueManager<TValue, TDate, TSection extends FieldSection>
     utils: MuiPickersAdapter<TDate>,
     value: TValue,
     fallbackSections: TSection[] | null,
+    localizedDigits: string[],
     isRTL: boolean,
     getSectionsFromDate: (date: TDate) => FieldSectionWithoutPosition[],
   ) => TSection[];
@@ -268,10 +270,15 @@ export interface FieldValueManager<TValue, TDate, TSection extends FieldSection>
    * Creates the string value to render in the input based on the current section list.
    * @template TSection
    * @param {TSection[]} sections The current section list.
+   * @param {string} localizedDigits The conversion table from localized to 0-9 digits.
    * @param {boolean} isRTL `true` if the current orientation is "right to left"
    * @returns {string} The string value to render in the input.
    */
-  getValueStrFromSections: (sections: TSection[], isRTL: boolean) => string;
+  getValueStrFromSections: (
+    sections: TSection[],
+    localizedDigits: string[],
+    isRTL: boolean,
+  ) => string;
   /**
    * Returns the manager of the active date.
    * @template TValue, TDate, TSection

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -112,11 +112,50 @@ export const getLetterEditingOptions = <TDate>(
   }
 };
 
-export const cleanLeadingZeros = <TDate>(
-  utils: MuiPickersAdapter<TDate>,
-  valueStr: string,
-  size: number,
-) => {
+export const getLocalizedDigits = <TDate>(utils: MuiPickersAdapter<TDate>) => {
+  const today = utils.date(undefined);
+  const formattedZero = utils.format(utils.setSeconds(today, 0), 'secondsNoLeadingZeros');
+
+  if (formattedZero === '0') {
+    return ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+  }
+
+  return Array.from({ length: 10 }).map((_, index) =>
+    utils.format(utils.setSeconds(today, index), 'secondsNoLeadingZeros'),
+  );
+};
+
+const removeLocalizedDigits = (valueStr: string, localizedDigits: string[]) => {
+  if (localizedDigits[0] === '0') {
+    return valueStr;
+  }
+
+  const digits: string[] = [];
+  let currentFormattedDigit = '';
+  for (let i = 0; i < valueStr.length; i += 1) {
+    currentFormattedDigit += valueStr[i];
+    const matchingDigitIndex = localizedDigits.indexOf(currentFormattedDigit);
+    if (matchingDigitIndex > -1) {
+      digits.push(matchingDigitIndex.toString());
+      currentFormattedDigit = '';
+    }
+  }
+
+  return digits.join('');
+};
+
+const applyLocalizedDigits = (valueStr: string, localizedDigits: string[]) => {
+  if (localizedDigits[0] === '0') {
+    return valueStr;
+  }
+
+  return valueStr
+    .split('')
+    .map((char) => localizedDigits[Number(char)])
+    .join('');
+};
+
+export const cleanLeadingZeros = (valueStr: string, size: number) => {
   let cleanValueStr = valueStr;
 
   // Remove the leading zeros
@@ -132,9 +171,9 @@ export const cleanLeadingZeros = <TDate>(
 
 export const cleanDigitSectionValue = <TDate>(
   utils: MuiPickersAdapter<TDate>,
-  timezone: PickersTimezone,
   value: number,
   sectionBoundaries: FieldSectionValueBoundaries<TDate, any>,
+  localizedDigits: string[],
   section: Pick<
     FieldSection,
     | 'format'
@@ -165,13 +204,12 @@ export const cleanDigitSectionValue = <TDate>(
   }
 
   // queryValue without leading `0` (`01` => `1`)
-  const valueStr = value.toString();
-
+  let valueStr = value.toString();
   if (section.hasLeadingZerosInInput) {
-    return cleanLeadingZeros(utils, valueStr, section.maxLength!);
+    valueStr = cleanLeadingZeros(valueStr, section.maxLength!);
   }
 
-  return valueStr;
+  return applyLocalizedDigits(valueStr, localizedDigits);
 };
 
 export const adjustSectionValue = <TDate, TSection extends FieldSection>(
@@ -180,6 +218,7 @@ export const adjustSectionValue = <TDate, TSection extends FieldSection>(
   section: TSection,
   keyCode: AvailableAdjustKeyCode,
   sectionsValueBoundaries: FieldSectionsValueBoundaries<TDate>,
+  localizedDigits: string[],
   activeDate: TDate | null,
   stepsAttributes?: { minutesStep?: number },
 ): string => {
@@ -197,12 +236,12 @@ export const adjustSectionValue = <TDate, TSection extends FieldSection>(
     });
 
     const getCleanValue = (value: number) =>
-      cleanDigitSectionValue(utils, timezone, value, sectionBoundaries, section);
+      cleanDigitSectionValue(utils, value, sectionBoundaries, localizedDigits, section);
 
     const step =
       section.type === 'minutes' && stepsAttributes?.minutesStep ? stepsAttributes.minutesStep : 1;
 
-    const currentSectionValue = parseInt(section.value, 10);
+    const currentSectionValue = parseInt(removeLocalizedDigits(section.value, localizedDigits), 10);
     let newSectionValueNumber = currentSectionValue + delta * step;
 
     if (shouldSetAbsolute) {
@@ -275,6 +314,7 @@ export const adjustSectionValue = <TDate, TSection extends FieldSection>(
 export const getSectionVisibleValue = (
   section: FieldSectionWithoutPosition,
   target: 'input-rtl' | 'input-ltr' | 'non-input',
+  localizedDigits: string[],
 ) => {
   let value = section.value || section.placeholder;
 
@@ -286,7 +326,7 @@ export const getSectionVisibleValue = (
     section.hasLeadingZerosInInput &&
     !section.hasLeadingZerosInFormat
   ) {
-    value = Number(value).toString();
+    value = Number(removeLocalizedDigits(value, localizedDigits)).toString();
   }
 
   // In the input, we add an empty character at the end of each section without leading zeros.
@@ -316,6 +356,7 @@ export const cleanString = (dirtyString: string) =>
 
 export const addPositionPropertiesToSections = <TSection extends FieldSection>(
   sections: FieldSectionWithoutPosition<TSection>[],
+  localizedDigits: string[],
   isRTL: boolean,
 ): TSection[] => {
   let position = 0;
@@ -324,7 +365,11 @@ export const addPositionPropertiesToSections = <TSection extends FieldSection>(
 
   for (let i = 0; i < sections.length; i += 1) {
     const section = sections[i];
-    const renderedValue = getSectionVisibleValue(section, isRTL ? 'input-rtl' : 'input-ltr');
+    const renderedValue = getSectionVisibleValue(
+      section,
+      isRTL ? 'input-rtl' : 'input-ltr',
+      localizedDigits,
+    );
     const sectionStr = `${section.startSeparator}${renderedValue}${section.endSeparator}`;
 
     const sectionLength = cleanString(sectionStr).length;
@@ -502,6 +547,7 @@ export const splitFormatIntoSections = <TDate>(
   utils: MuiPickersAdapter<TDate>,
   timezone: PickersTimezone,
   localeText: PickersLocaleText<TDate>,
+  localizedDigits: string[],
   format: string,
   date: TDate | null,
   formatDensity: 'dense' | 'spacious',
@@ -549,7 +595,10 @@ export const splitFormatIntoSections = <TDate>(
         maxLength = sectionConfig.maxLength;
 
         if (isValidDate) {
-          sectionValue = cleanLeadingZeros(utils, sectionValue, maxLength);
+          sectionValue = applyLocalizedDigits(
+            cleanLeadingZeros(removeLocalizedDigits(sectionValue, localizedDigits), maxLength),
+            localizedDigits,
+          );
         }
       }
     }
@@ -678,6 +727,7 @@ export const splitFormatIntoSections = <TDate>(
 export const getDateFromDateSections = <TDate>(
   utils: MuiPickersAdapter<TDate>,
   sections: FieldSection[],
+  localizedDigits: string[],
 ) => {
   // If we have both a day and a weekDay section,
   // Then we skip the weekDay in the parsing because libraries like dayjs can't parse complicated formats containing a weekDay.
@@ -692,7 +742,7 @@ export const getDateFromDateSections = <TDate>(
     const shouldSkip = shouldSkipWeekDays && section.type === 'weekDay';
     if (!shouldSkip) {
       sectionFormats.push(section.format);
-      sectionValues.push(getSectionVisibleValue(section, 'non-input'));
+      sectionValues.push(getSectionVisibleValue(section, 'non-input', localizedDigits));
     }
   }
 
@@ -702,9 +752,17 @@ export const getDateFromDateSections = <TDate>(
   return utils.parse(dateWithoutSeparatorStr, formatWithoutSeparator)!;
 };
 
-export const createDateStrForInputFromSections = (sections: FieldSection[], isRTL: boolean) => {
+export const createDateStrForInputFromSections = (
+  sections: FieldSection[],
+  localizedDigits: string[],
+  isRTL: boolean,
+) => {
   const formattedSections = sections.map((section) => {
-    const dateValue = getSectionVisibleValue(section, isRTL ? 'input-rtl' : 'input-ltr');
+    const dateValue = getSectionVisibleValue(
+      section,
+      isRTL ? 'input-rtl' : 'input-ltr',
+      localizedDigits,
+    );
 
     return `${section.startSeparator}${dateValue}${section.endSeparator}`;
   });
@@ -725,6 +783,7 @@ export const createDateStrForInputFromSections = (sections: FieldSection[], isRT
 
 export const getSectionsBoundaries = <TDate>(
   utils: MuiPickersAdapter<TDate>,
+  localizedDigits: string[],
   timezone: PickersTimezone,
 ): FieldSectionsValueBoundaries<TDate> => {
   const today = utils.date(undefined, timezone);
@@ -779,12 +838,20 @@ export const getSectionsBoundaries = <TDate>(
     hours: ({ format }) => {
       const lastHourInDay = utils.getHours(endOfDay);
       const hasMeridiem =
-        utils.formatByString(utils.endOfDay(today), format) !== lastHourInDay.toString();
+        removeLocalizedDigits(
+          utils.formatByString(utils.endOfDay(today), format),
+          localizedDigits,
+        ) !== lastHourInDay.toString();
 
       if (hasMeridiem) {
         return {
           minimum: 1,
-          maximum: Number(utils.formatByString(utils.startOfDay(today), format)),
+          maximum: Number(
+            removeLocalizedDigits(
+              utils.formatByString(utils.startOfDay(today), format),
+              localizedDigits,
+            ),
+          ),
         };
       }
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldCharacterEditing.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldCharacterEditing.ts
@@ -28,6 +28,7 @@ interface UseFieldEditingParams<TDate, TSection extends FieldSection> {
   sections: TSection[];
   updateSectionValue: (params: UpdateSectionValueParams<TSection>) => void;
   sectionsValueBoundaries: FieldSectionsValueBoundaries<TDate>;
+  localizedDigits: string[];
   setTempAndroidValueStr: (newValue: string | null) => void;
   timezone: PickersTimezone;
 }
@@ -78,6 +79,7 @@ export const useFieldCharacterEditing = <TDate, TSection extends FieldSection>({
   sections,
   updateSectionValue,
   sectionsValueBoundaries,
+  localizedDigits,
   setTempAndroidValueStr,
   timezone,
 }: UseFieldEditingParams<TDate, TSection>) => {
@@ -299,9 +301,9 @@ export const useFieldCharacterEditing = <TDate, TSection extends FieldSection>({
 
       const newSectionValue = cleanDigitSectionValue(
         utils,
-        timezone,
         queryValueNumber,
         sectionBoundaries,
+        localizedDigits,
         section,
       );
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -17,6 +17,7 @@ import {
   getSectionsBoundaries,
   validateSections,
   getDateFromDateSections,
+  getLocalizedDigits,
 } from './useField.utils';
 import { InferError } from '../useValidation';
 import { FieldSection, FieldSelectedSections } from '../../../models';
@@ -88,29 +89,39 @@ export const useFieldState = <
     valueManager,
   });
 
+  const localizedDigits = React.useMemo(() => getLocalizedDigits(utils), [utils]);
+
   const sectionsValueBoundaries = React.useMemo(
-    () => getSectionsBoundaries<TDate>(utils, timezone),
-    [utils, timezone],
+    () => getSectionsBoundaries<TDate>(utils, localizedDigits, timezone),
+    [utils, localizedDigits, timezone],
   );
 
   const getSectionsFromValue = React.useCallback(
     (value: TValue, fallbackSections: TSection[] | null = null) =>
-      fieldValueManager.getSectionsFromValue(utils, value, fallbackSections, isRTL, (date) =>
-        splitFormatIntoSections(
-          utils,
-          timezone,
-          localeText,
-          format,
-          date,
-          formatDensity,
-          shouldRespectLeadingZeros,
-          isRTL,
-        ),
+      fieldValueManager.getSectionsFromValue(
+        utils,
+        value,
+        fallbackSections,
+        localizedDigits,
+        isRTL,
+        (date) =>
+          splitFormatIntoSections(
+            utils,
+            timezone,
+            localeText,
+            localizedDigits,
+            format,
+            date,
+            formatDensity,
+            shouldRespectLeadingZeros,
+            isRTL,
+          ),
       ),
     [
       fieldValueManager,
       format,
       localeText,
+      localizedDigits,
       isRTL,
       shouldRespectLeadingZeros,
       utils,
@@ -123,9 +134,10 @@ export const useFieldState = <
     () =>
       fieldValueManager.getValueStrFromSections(
         getSectionsFromValue(valueManager.emptyValue),
+        localizedDigits,
         isRTL,
       ),
-    [fieldValueManager, getSectionsFromValue, valueManager.emptyValue, isRTL],
+    [fieldValueManager, getSectionsFromValue, valueManager.emptyValue, localizedDigits, isRTL],
   );
 
   const [state, setState] = React.useState<UseFieldState<TValue, TSection>>(() => {
@@ -250,7 +262,7 @@ export const useFieldState = <
       modified: true,
     };
 
-    return addPositionPropertiesToSections<TSection>(newSections, isRTL);
+    return addPositionPropertiesToSections<TSection>(newSections, localizedDigits, isRTL);
   };
 
   const clearValue = () => {
@@ -305,6 +317,7 @@ export const useFieldState = <
         utils,
         timezone,
         localeText,
+        localizedDigits,
         format,
         date,
         formatDensity,
@@ -356,7 +369,7 @@ export const useFieldState = <
     const activeDateManager = fieldValueManager.getActiveDateManager(utils, state, activeSection);
     const newSections = setSectionValue(selectedSectionIndexes!.startIndex, newSectionValue);
     const newActiveDateSections = activeDateManager.getSections(newSections);
-    const newActiveDate = getDateFromDateSections(utils, newActiveDateSections);
+    const newActiveDate = getDateFromDateSections(utils, newActiveDateSections, localizedDigits);
 
     let values: Pick<UseFieldState<TValue, TSection>, 'value' | 'referenceValue'>;
     let shouldPublish: boolean;
@@ -446,6 +459,7 @@ export const useFieldState = <
     updateValueFromValueStr,
     setTempAndroidValueStr,
     sectionsValueBoundaries,
+    localizedDigits,
     placeholder,
     timezone,
   };

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -47,14 +47,21 @@ export const singleItemValueManager: SingleItemPickerValueManager = {
 export const singleItemFieldValueManager: FieldValueManager<any, any, FieldSection> = {
   updateReferenceValue: (utils, value, prevReferenceValue) =>
     value == null || !utils.isValid(value) ? prevReferenceValue : value,
-  getSectionsFromValue: (utils, date, prevSections, isRTL, getSectionsFromDate) => {
+  getSectionsFromValue: (
+    utils,
+    date,
+    prevSections,
+    localizedDigits,
+    isRTL,
+    getSectionsFromDate,
+  ) => {
     const shouldReUsePrevDateSections = !utils.isValid(date) && !!prevSections;
 
     if (shouldReUsePrevDateSections) {
       return prevSections;
     }
 
-    return addPositionPropertiesToSections(getSectionsFromDate(date), isRTL);
+    return addPositionPropertiesToSections(getSectionsFromDate(date), localizedDigits, isRTL);
   },
   getValueStrFromSections: createDateStrForInputFromSections,
   getActiveDateManager: (utils, state) => ({

--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -58,6 +58,11 @@ export interface AdapterFormats {
    * @example "00"
    */
   seconds: string;
+  /**
+   * The seconds without leading zeros.
+   * @example "0"
+   */
+  secondsNoLeadingZeros: string;
 
   // Date formats
   /** The localized full date.

--- a/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
+++ b/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
@@ -176,7 +176,7 @@ adapterToTest.forEach((adapterName) => {
       sectionConfig: ReturnType<typeof getDateSectionConfigFromFormatToken>,
     ) => {
       if (sectionConfig.contentType === 'digit' && sectionConfig.maxLength != null) {
-        return cleanLeadingZeros(adapter, valueStr, sectionConfig.maxLength);
+        return cleanLeadingZeros(valueStr, sectionConfig.maxLength);
       }
 
       return valueStr;


### PR DESCRIPTION
- [x] Initial rendering with leading zeros should use farsi digits
- [x] Editing with arrows should work
- [ ] Digit editing should work

For digit editing, it is unclear to me whether the keyboard fires with a farsi digit or with a 0-9 digit.
Maybe supporting both would be safer.