### PR TITLE
[l10n] Add missing Danish (da-DK) locale export

### DIFF
--- a/packages/x-date-pickers/src/locales/index.ts
+++ b/packages/x-date-pickers/src/locales/index.ts
@@ -1,6 +1,7 @@
 export * from './beBY';
 export * from './caES';
 export * from './csCZ';
+export * from './daDK';
 export * from './deDE';
 export * from './elGR';
 export * from './enUS';

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -24,6 +24,7 @@
   { "name": "ClockPointerProps", "kind": "Interface" },
   { "name": "ClockProps", "kind": "Interface" },
   { "name": "csCZ", "kind": "Variable" },
+  { "name": "daDK", "kind": "Variable" },
   { "name": "DateBuilderReturnType", "kind": "TypeAlias" },
   { "name": "DateCalendar", "kind": "Variable" },
   { "name": "dateCalendarClasses", "kind": "Variable" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -23,6 +23,7 @@
   { "name": "ClockPointerProps", "kind": "Interface" },
   { "name": "ClockProps", "kind": "Interface" },
   { "name": "csCZ", "kind": "Variable" },
+  { "name": "daDK", "kind": "Variable" },
   { "name": "DateBuilderReturnType", "kind": "TypeAlias" },
   { "name": "DateCalendar", "kind": "Variable" },
   { "name": "dateCalendarClasses", "kind": "Variable" },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds a missing export for the daDK locale in `packages/x-date-pickers/src/locales/index.ts`