### PR TITLE
[docs] Improve data grid `pageSizeOptions` prop documentation

### DIFF
--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -11,14 +11,20 @@ By default, each page contains 100 rows. The user can change the size of the pag
 
 ### Page size options
 
-You can configure the page size the user can choose from with the `pageSizeOptions` prop.
-
-It's possible to customize the options shown in the "Rows per page" select using the `pageSizeOptions` prop.
+You can customize the options shown in the "Rows per page" select using the `pageSizeOptions` prop.
 You should either provide an array of:
 
 - **numbers**, each number will be used for the option's label and value.
 
-- **objects**, the `value` and `label` keys will be used respectively for the value and label of the option (useful for language strings such as 'All').
+  ```jsx
+  <DataGrid pageSizeOptions={[5, 10, 25]}>
+  ```
+
+- **objects**, the `value` and `label` keys will be used respectively for the value and label of the option.
+
+  ```jsx
+  <DataGrid pageSizeOptions={[5, 10, 25, { value: 1000, label: '1,000' }]}>
+  ```
 
 {{"demo": "PageSizeCustomOptions.js", "bg": "inline"}}
 
@@ -32,7 +38,7 @@ You can't use both the `autoPageSize` and `autoHeight` props at the same time be
 
 {{"demo": "PageSizeAuto.js", "bg": "inline"}}
 
-## Pagination on Pro and Premium
+## Pagination on Pro and Premium [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')[<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 The default pagination behavior depends on your plan.
 

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -12,7 +12,7 @@ By default, each page contains 100 rows. The user can change the size of the pag
 ### Page size options
 
 You can customize the options shown in the "Rows per page" select using the `pageSizeOptions` prop.
-You should either provide an array of:
+You should provide an array of items, each item should be one of these types:
 
 - **numbers**, each number will be used for the option's label and value.
 

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -23,7 +23,7 @@ You should provide an array of items, each item should be one of these types:
 - **object**, the `value` and `label` keys will be used respectively for the value and label of the option.
 
   ```jsx
-  <DataGrid pageSizeOptions={[5, 10, 25, { value: 1000, label: '1,000' }]}>
+  <DataGrid pageSizeOptions={[10, 100, { value: 1000, label: '1,000' }]}>
   ```
 
 {{"demo": "PageSizeCustomOptions.js", "bg": "inline"}}

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -14,13 +14,13 @@ By default, each page contains 100 rows. The user can change the size of the pag
 You can customize the options shown in the "Rows per page" select using the `pageSizeOptions` prop.
 You should provide an array of items, each item should be one of these types:
 
-- **numbers**, each number will be used for the option's label and value.
+- **number**, each number will be used for the option's label and value.
 
   ```jsx
   <DataGrid pageSizeOptions={[5, 10, 25]}>
   ```
 
-- **objects**, the `value` and `label` keys will be used respectively for the value and label of the option.
+- **object**, the `value` and `label` keys will be used respectively for the value and label of the option.
 
   ```jsx
   <DataGrid pageSizeOptions={[5, 10, 25, { value: 1000, label: '1,000' }]}>


### PR DESCRIPTION
This is a continuation of #9438. I saw this from https://github.com/mui/material-ui/issues/40589

Preview https://deploy-preview-11682--material-ui-x.netlify.app/x/react-data-grid/pagination/#page-size-options 