### PR TITLE
[charts] Remove a TS ignore

### DIFF
--- a/docs/data/charts/bars/BarsDataset.tsx
+++ b/docs/data/charts/bars/BarsDataset.tsx
@@ -103,7 +103,7 @@ const dataset = [
   },
 ];
 
-const valueFormatter = (value: number) => `${value}mm`;
+const valueFormatter = (value: number | null) => `${value}mm`;
 
 export default function BarsDataset() {
   return (

--- a/docs/data/charts/bars/HorizontalBars.tsx
+++ b/docs/data/charts/bars/HorizontalBars.tsx
@@ -97,7 +97,7 @@ const dataset = [
   },
 ];
 
-const valueFormatter = (value: number) => `${value}mm`;
+const valueFormatter = (value: number | null) => `${value}mm`;
 
 export default function HorizontalBars() {
   return (

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -33,7 +33,7 @@
     },
     "valueFormatter": {
       "type": { "name": "func" },
-      "default": "(v: number) => v.toString()",
+      "default": "(v: number | null) => (v === null ? '' : v.toString())",
       "signature": {
         "type": "function(value: number) => string",
         "describedArgs": ["value"],

--- a/packages/x-charts/src/BarChart/formatter.ts
+++ b/packages/x-charts/src/BarChart/formatter.ts
@@ -86,7 +86,9 @@ const formatter: Formatter<'bar'> = (params, dataset) => {
   return {
     seriesOrder,
     stackingGroups,
-    series: defaultizeValueFormatter(completedSeries, (v) => v?.toLocaleString()),
+    series: defaultizeValueFormatter(completedSeries, (v) =>
+      v === null ? '' : v.toLocaleString(),
+    ),
   };
 };
 

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
@@ -10,6 +10,7 @@ import {
   ChartsTooltipRow,
 } from './ChartsTooltipTable';
 import type { ChartsItemContentProps } from './ChartsItemTooltipContent';
+import { CommonSeriesType } from '../models/seriesType/common';
 
 function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeriesType>(
   props: ChartsItemContentProps<T>,
@@ -30,9 +31,10 @@ function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeries
           displayedLabel: series.label,
         };
 
-  // TODO: Manage to let TS understand series.data and series.valueFormatter are coherent
-  // @ts-ignore
-  const formattedValue = series.valueFormatter(series.data[itemData.dataIndex]);
+  const value = series.data[itemData.dataIndex];
+  const formattedValue = (
+    series.valueFormatter as CommonSeriesType<typeof value>['valueFormatter']
+  )?.(value);
   return (
     <ChartsTooltipPaper sx={sx} className={classes.root}>
       <ChartsTooltipTable className={classes.table}>

--- a/packages/x-charts/src/LineChart/formatter.ts
+++ b/packages/x-charts/src/LineChart/formatter.ts
@@ -83,7 +83,9 @@ const formatter: Formatter<'line'> = (params, dataset) => {
   return {
     seriesOrder,
     stackingGroups,
-    series: defaultizeValueFormatter(completedSeries, (v) => v?.toLocaleString()),
+    series: defaultizeValueFormatter(completedSeries, (v) =>
+      v === null ? '' : v.toLocaleString(),
+    ),
   };
 };
 

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -61,7 +61,7 @@ export interface SparkLineChartProps
    * Formatter used by the tooltip.
    * @param {number} value The value to format.
    * @returns {string} the formatted value.
-   * @default (v: number) => v.toString()
+   * @default (v: number | null) => (v === null ? '' : v.toString())
    */
   valueFormatter?: (value: number | null) => string;
   /**
@@ -328,7 +328,7 @@ SparkLineChart.propTypes = {
    * Formatter used by the tooltip.
    * @param {number} value The value to format.
    * @returns {string} the formatted value.
-   * @default (v: number) => v.toString()
+   * @default (v: number | null) => (v === null ? '' : v.toString())
    */
   valueFormatter: PropTypes.func,
   viewBox: PropTypes.shape({

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -63,7 +63,7 @@ export interface SparkLineChartProps
    * @returns {string} the formatted value.
    * @default (v: number) => v.toString()
    */
-  valueFormatter?: (value: number) => string;
+  valueFormatter?: (value: number | null) => string;
   /**
    * Set to `true` to enable the tooltip in the sparkline.
    * @default false
@@ -143,7 +143,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
     slotProps,
     data,
     plotType = 'line',
-    valueFormatter = (v: number) => v.toString(),
+    valueFormatter = (v: number | null) => (v === null ? '' : v.toString()),
     area,
     curve = 'linear',
   } = props;

--- a/packages/x-charts/src/hooks/useAxisEvents.ts
+++ b/packages/x-charts/src/hooks/useAxisEvents.ts
@@ -58,8 +58,8 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
           if (v <= valueAsNumber) {
             if (
               index === axisData.length - 1 ||
-              // @ts-ignore
-              Math.abs(value - v) < Math.abs(value - getAsANumber(axisData[index + 1]))
+              Math.abs(getAsANumber(value) - v) <
+                Math.abs(getAsANumber(value) - getAsANumber(axisData[index + 1]))
             ) {
               return true;
             }

--- a/packages/x-charts/src/models/seriesType/bar.ts
+++ b/packages/x-charts/src/models/seriesType/bar.ts
@@ -7,14 +7,14 @@ import {
 } from './common';
 
 export interface BarSeriesType
-  extends CommonSeriesType<number>,
+  extends CommonSeriesType<number | null>,
     CartesianSeriesType,
     StackableSeriesType {
   type: 'bar';
   /**
    * Data associated to each bar.
    */
-  data?: number[];
+  data?: (number | null)[];
   /**
    * The key used to retrive data from the dataset.
    */

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -9,7 +9,7 @@ export type CommonSeriesType<TValue> = {
    * @param {TValue} value The series' value to render.
    * @returns {string} The string to dispaly.
    */
-  valueFormatter?: (value: TValue) => string;
+  valueFormatter?: <V extends TValue>(value: V) => string;
   highlightScope?: Partial<HighlightScope>;
 };
 

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -40,7 +40,7 @@ export interface ShowMarkParams<AxisValue = number | Date> {
 }
 
 export interface LineSeriesType
-  extends CommonSeriesType<number>,
+  extends CommonSeriesType<number | null>,
     CartesianSeriesType,
     StackableSeriesType {
   type: 'line';


### PR DESCRIPTION
Using `valueFormatter: (value: TValue) => string` leads to `valueFormatter: (value: BarValueType & LineValueType & PieValueType) => string` when doing the union

Neest to use generic when defining function type

```ts
valueFormatter: <V extends TValue>(value: V) => string
```

Let me realised the bar charts did not have the typing for `null` which is weird


