### PR TITLE
[charts] Do not propagate `innerRadius` and `outerRadius` to the DOM

### DIFF
--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -106,6 +106,8 @@ function PieArcLabel(props: PieArcLabelProps) {
     endAngle,
     paddingAngle,
     arcLabelRadius,
+    innerRadius,
+    outerRadius,
     cornerRadius,
     formattedArcLabel,
     isHighlighted,


### PR DESCRIPTION
Remove an error when plotting pie charts. Probably introduced when adding the support of `labelRadius`