### PR TITLE
[docs] Remove the description from the `className` prop

### DIFF
--- a/docs/pages/x/api/date-pickers/date-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-picker-toolbar.json
@@ -12,7 +12,6 @@
       },
       "required": true
     },
-    "className": { "type": { "name": "string" } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"––\"" }

--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/date-range-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-toolbar.json
@@ -1,6 +1,5 @@
 {
   "props": {
-    "className": { "type": { "name": "string" } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"––\"" }

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -5,7 +5,6 @@
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"
     },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/date-time-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker-toolbar.json
@@ -13,7 +13,6 @@
       "required": true
     },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"––\"" }

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/desktop-date-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-picker.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -5,7 +5,6 @@
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"
     },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/desktop-time-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/mobile-date-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-picker.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -5,7 +5,6 @@
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"
     },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/mobile-time-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/month-calendar.json
+++ b/docs/pages/x/api/date-pickers/month-calendar.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableFuture": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/pickers-calendar-header.json
+++ b/docs/pages/x/api/date-pickers/pickers-calendar-header.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "format": {
       "type": { "name": "string" },
       "default": "`${adapter.formats.month} ${adapter.formats.year}`"

--- a/docs/pages/x/api/date-pickers/static-date-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-picker.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "dayOfWeekFormatter": {
       "type": { "name": "func" },
       "default": "(_day: string, date: TDate) => adapter.format(date, 'weekdayShort').charAt(0).toUpperCase()",

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -5,7 +5,6 @@
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "2"
     },
-    "className": { "type": { "name": "string" } },
     "currentMonthCalendarPosition": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
       "default": "1"

--- a/docs/pages/x/api/date-pickers/static-date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "dayOfWeekFormatter": {
       "type": { "name": "func" },
       "default": "(_day: string, date: TDate) => adapter.format(date, 'weekdayShort').charAt(0).toUpperCase()",

--- a/docs/pages/x/api/date-pickers/static-time-picker.json
+++ b/docs/pages/x/api/date-pickers/static-time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "disableFuture": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/time-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/time-picker-toolbar.json
@@ -12,7 +12,6 @@
       },
       "required": true
     },
-    "className": { "type": { "name": "string" } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "toolbarFormat": { "type": { "name": "string" } },
     "toolbarPlaceholder": { "type": { "name": "node" }, "default": "\"––\"" }

--- a/docs/pages/x/api/date-pickers/time-picker.json
+++ b/docs/pages/x/api/date-pickers/time-picker.json
@@ -3,7 +3,6 @@
     "ampm": { "type": { "name": "bool" }, "default": "`utils.is12HourCycleInCurrentLocale()`" },
     "ampmInClock": { "type": { "name": "bool" }, "default": "true on desktop, false on mobile" },
     "autoFocus": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/year-calendar.json
+++ b/docs/pages/x/api/date-pickers/year-calendar.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "defaultValue": { "type": { "name": "any" } },
     "disabled": { "type": { "name": "bool" } },
     "disableFuture": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/tree-view/rich-tree-view.json
+++ b/docs/pages/x/api/tree-view/rich-tree-view.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "defaultCollapseIcon": { "type": { "name": "node" } },
     "defaultEndIcon": { "type": { "name": "node" } },
     "defaultExpandedNodes": {

--- a/docs/pages/x/api/tree-view/simple-tree-view.json
+++ b/docs/pages/x/api/tree-view/simple-tree-view.json
@@ -2,7 +2,6 @@
   "props": {
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "defaultCollapseIcon": { "type": { "name": "node" } },
     "defaultEndIcon": { "type": { "name": "node" } },
     "defaultExpandedNodes": {

--- a/docs/pages/x/api/tree-view/tree-item.json
+++ b/docs/pages/x/api/tree-view/tree-item.json
@@ -3,7 +3,6 @@
     "nodeId": { "type": { "name": "string" }, "required": true },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "collapseIcon": { "type": { "name": "node" } },
     "ContentComponent": {
       "type": { "name": "custom", "description": "element type" },

--- a/docs/pages/x/api/tree-view/tree-view.json
+++ b/docs/pages/x/api/tree-view/tree-view.json
@@ -2,7 +2,6 @@
   "props": {
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
-    "className": { "type": { "name": "string" } },
     "defaultCollapseIcon": { "type": { "name": "node" } },
     "defaultEndIcon": { "type": { "name": "node" } },
     "defaultExpandedNodes": {

--- a/docs/translations/api-docs/date-pickers/date-picker-toolbar/date-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-picker-toolbar/date-picker-toolbar.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "className": { "description": "className applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "onViewChange": {
       "description": "Callback called when a toolbar is clicked",

--- a/docs/translations/api-docs/date-pickers/date-picker/date-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-picker/date-picker.json
@@ -4,7 +4,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/date-range-picker-toolbar/date-range-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-toolbar/date-range-picker-toolbar.json
@@ -1,7 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "className": { "description": "className applied to the root component." },
+    "className": { "description": "Class name applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "toolbarFormat": { "description": "Toolbar date format." },
     "toolbarPlaceholder": {

--- a/docs/translations/api-docs/date-pickers/date-range-picker-toolbar/date-range-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-toolbar/date-range-picker-toolbar.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "className": { "description": "Class name applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "toolbarFormat": { "description": "Toolbar date format." },
     "toolbarPlaceholder": {

--- a/docs/translations/api-docs/date-pickers/date-range-picker/date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker/date-range-picker.json
@@ -7,7 +7,6 @@
     "calendars": {
       "description": "The number of calendars to render on <strong>desktop</strong>."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/date-time-picker-toolbar/date-time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker-toolbar/date-time-picker-toolbar.json
@@ -2,7 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root component." },
+    "className": { "description": "Class name applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "onViewChange": {
       "description": "Callback called when a toolbar is clicked",

--- a/docs/translations/api-docs/date-pickers/date-time-picker-toolbar/date-time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker-toolbar/date-time-picker-toolbar.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "Class name applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "onViewChange": {
       "description": "Callback called when a toolbar is clicked",

--- a/docs/translations/api-docs/date-pickers/date-time-picker/date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker/date-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/desktop-date-picker/desktop-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-picker/desktop-date-picker.json
@@ -4,7 +4,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/desktop-date-range-picker/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-range-picker/desktop-date-range-picker.json
@@ -7,7 +7,6 @@
     "calendars": {
       "description": "The number of calendars to render on <strong>desktop</strong>."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/desktop-date-time-picker/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-date-time-picker/desktop-date-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/desktop-time-picker/desktop-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/desktop-time-picker/desktop-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/mobile-date-picker/mobile-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-picker/mobile-date-picker.json
@@ -4,7 +4,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker/mobile-date-range-picker.json
@@ -7,7 +7,6 @@
     "calendars": {
       "description": "The number of calendars to render on <strong>desktop</strong>."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/mobile-date-time-picker/mobile-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-time-picker/mobile-date-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/mobile-time-picker/mobile-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-time-picker/mobile-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/month-calendar/month-calendar.json
+++ b/docs/translations/api-docs/date-pickers/month-calendar/month-calendar.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "defaultValue": {
       "description": "The default selected value. Used when the component is not controlled."
     },

--- a/docs/translations/api-docs/date-pickers/pickers-calendar-header/pickers-calendar-header.json
+++ b/docs/translations/api-docs/date-pickers/pickers-calendar-header/pickers-calendar-header.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "format": { "description": "Format used to display the date." },
     "slotProps": { "description": "The props used for each component slot." },
     "slots": { "description": "Overridable component slots." },

--- a/docs/translations/api-docs/date-pickers/static-date-picker/static-date-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-picker/static-date-picker.json
@@ -4,7 +4,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "dayOfWeekFormatter": {
       "description": "Formats the day of week displayed in the calendar header.",
       "typeDescriptions": {

--- a/docs/translations/api-docs/date-pickers/static-date-range-picker/static-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-range-picker/static-date-range-picker.json
@@ -5,7 +5,6 @@
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
     "calendars": { "description": "The number of calendars to render." },
-    "className": { "description": "Class name applied to the root element." },
     "currentMonthCalendarPosition": { "description": "Position the current month is rendered in." },
     "dayOfWeekFormatter": {
       "description": "Formats the day of week displayed in the calendar header.",

--- a/docs/translations/api-docs/date-pickers/static-date-time-picker/static-date-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-date-time-picker/static-date-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "dayOfWeekFormatter": {
       "description": "Formats the day of week displayed in the calendar header.",
       "typeDescriptions": {

--- a/docs/translations/api-docs/date-pickers/static-time-picker/static-time-picker.json
+++ b/docs/translations/api-docs/date-pickers/static-time-picker/static-time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "defaultValue": {
       "description": "The default value. Used when the component is not controlled."
     },

--- a/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
@@ -1,7 +1,7 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "className": { "description": "className applied to the root component." },
+    "className": { "description": "Class name applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "onViewChange": {
       "description": "Callback called when a toolbar is clicked",

--- a/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "className": { "description": "Class name applied to the root component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
     "onViewChange": {
       "description": "Callback called when a toolbar is clicked",

--- a/docs/translations/api-docs/date-pickers/time-picker/time-picker.json
+++ b/docs/translations/api-docs/date-pickers/time-picker/time-picker.json
@@ -8,7 +8,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "className": { "description": "Class name applied to the root element." },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/docs/translations/api-docs/date-pickers/year-calendar/year-calendar.json
+++ b/docs/translations/api-docs/date-pickers/year-calendar/year-calendar.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "defaultValue": {
       "description": "The default selected value. Used when the component is not controlled."
     },

--- a/docs/translations/api-docs/tree-view/rich-tree-view/rich-tree-view.json
+++ b/docs/translations/api-docs/tree-view/rich-tree-view/rich-tree-view.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "defaultCollapseIcon": { "description": "The default icon used to collapse the node." },
     "defaultEndIcon": {
       "description": "The default icon displayed next to a end node. This is applied to all tree nodes and can be overridden by the TreeItem <code>icon</code> prop."

--- a/docs/translations/api-docs/tree-view/simple-tree-view/simple-tree-view.json
+++ b/docs/translations/api-docs/tree-view/simple-tree-view/simple-tree-view.json
@@ -3,7 +3,6 @@
   "propDescriptions": {
     "children": { "description": "The content of the component." },
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "defaultCollapseIcon": { "description": "The default icon used to collapse the node." },
     "defaultEndIcon": {
       "description": "The default icon displayed next to a end node. This is applied to all tree nodes and can be overridden by the TreeItem <code>icon</code> prop."

--- a/docs/translations/api-docs/tree-view/tree-item/tree-item.json
+++ b/docs/translations/api-docs/tree-view/tree-item/tree-item.json
@@ -3,7 +3,6 @@
   "propDescriptions": {
     "children": { "description": "The content of the component." },
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "collapseIcon": { "description": "The icon used to collapse the node." },
     "ContentComponent": {
       "description": "The component used for the content node.",

--- a/docs/translations/api-docs/tree-view/tree-view/tree-view.json
+++ b/docs/translations/api-docs/tree-view/tree-view/tree-view.json
@@ -3,7 +3,6 @@
   "propDescriptions": {
     "children": { "description": "The content of the component." },
     "classes": { "description": "Override or extend the styles applied to the component." },
-    "className": { "description": "className applied to the root element." },
     "defaultCollapseIcon": { "description": "The default icon used to collapse the node." },
     "defaultEndIcon": {
       "description": "The default icon displayed next to a end node. This is applied to all tree nodes and can be overridden by the TreeItem <code>icon</code> prop."

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -57,7 +57,7 @@ DateRangePicker.propTypes = {
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -56,9 +56,6 @@ DateRangePicker.propTypes = {
    * @default 2
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -128,9 +128,6 @@ DateRangePickerToolbar.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   classes: PropTypes.object,
-  /**
-   * Class name applied to the root component.
-   */
   className: PropTypes.string,
   disabled: PropTypes.bool,
   /**

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -129,7 +129,7 @@ DateRangePickerToolbar.propTypes = {
   // ----------------------------------------------------------------------
   classes: PropTypes.object,
   /**
-   * className applied to the root component.
+   * Class name applied to the root component.
    */
   className: PropTypes.string,
   disabled: PropTypes.bool,

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -93,7 +93,7 @@ DesktopDateRangePicker.propTypes = {
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -92,9 +92,6 @@ DesktopDateRangePicker.propTypes = {
    * @default 2
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -92,9 +92,6 @@ MobileDateRangePicker.propTypes = {
    * @default 2
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -93,7 +93,7 @@ MobileDateRangePicker.propTypes = {
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -84,9 +84,6 @@ StaticDateRangePicker.propTypes = {
    * @default 2
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * Position the current month is rendered in.

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -85,7 +85,7 @@ StaticDateRangePicker.propTypes = {
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -53,7 +53,7 @@ DatePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -52,9 +52,6 @@ DatePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
@@ -117,9 +117,6 @@ DatePickerToolbar.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   classes: PropTypes.object,
-  /**
-   * className applied to the root component.
-   */
   className: PropTypes.string,
   disabled: PropTypes.bool,
   /**

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -62,9 +62,6 @@ DateTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -63,7 +63,7 @@ DateTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -375,7 +375,7 @@ DateTimePickerToolbar.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root component.
+   * Class name applied to the root component.
    */
   className: PropTypes.string,
   disabled: PropTypes.bool,

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -374,9 +374,6 @@ DateTimePickerToolbar.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * Class name applied to the root component.
-   */
   className: PropTypes.string,
   disabled: PropTypes.bool,
   /**

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -99,9 +99,6 @@ DesktopDatePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -100,7 +100,7 @@ DesktopDatePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -158,9 +158,6 @@ DesktopDateTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -159,7 +159,7 @@ DesktopDateTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -147,9 +147,6 @@ DesktopTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -148,7 +148,7 @@ DesktopTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -96,9 +96,6 @@ MobileDatePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -97,7 +97,7 @@ MobileDatePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -118,9 +118,6 @@ MobileDateTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -119,7 +119,7 @@ MobileDateTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -110,9 +110,6 @@ MobileTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -111,7 +111,7 @@ MobileTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -309,9 +309,6 @@ MonthCalendar.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * The default selected value.

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -310,7 +310,7 @@ MonthCalendar.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.types.ts
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.types.ts
@@ -17,9 +17,6 @@ export interface MonthCalendarProps<TDate>
     BaseDateValidationProps<TDate>,
     TimezoneProps {
   autoFocus?: boolean;
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -266,9 +266,6 @@ PickersCalendarHeader.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   currentMonth: PropTypes.any.isRequired,
   disabled: PropTypes.bool,

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -267,7 +267,7 @@ PickersCalendarHeader.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   currentMonth: PropTypes.any.isRequired,

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.types.ts
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.types.ts
@@ -69,9 +69,6 @@ export interface PickersCalendarHeaderProps<TDate>
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<PickersCalendarHeaderClasses>;
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -80,7 +80,7 @@ StaticDatePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/StaticDatePicker.tsx
@@ -79,9 +79,6 @@ StaticDatePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * Formats the day of week displayed in the calendar header.

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -101,9 +101,6 @@ StaticDateTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * Formats the day of week displayed in the calendar header.

--- a/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -102,7 +102,7 @@ StaticDateTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
@@ -92,9 +92,6 @@ StaticTimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * The default value.

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.tsx
@@ -93,7 +93,7 @@ StaticTimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
@@ -63,7 +63,7 @@ TimePicker.propTypes = {
    */
   autoFocus: PropTypes.bool,
   /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
@@ -62,9 +62,6 @@ TimePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -271,9 +271,6 @@ TimePickerToolbar.propTypes = {
   ampm: PropTypes.bool,
   ampmInClock: PropTypes.bool,
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   disabled: PropTypes.bool,
   /**

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -272,7 +272,7 @@ TimePickerToolbar.propTypes = {
   ampmInClock: PropTypes.bool,
   classes: PropTypes.object,
   /**
-   * className applied to the root component.
+   * Class name applied to the root component.
    */
   className: PropTypes.string,
   disabled: PropTypes.bool,

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -272,7 +272,7 @@ TimePickerToolbar.propTypes = {
   ampmInClock: PropTypes.bool,
   classes: PropTypes.object,
   /**
-   * Class name applied to the root component.
+   * @ignore
    */
   className: PropTypes.string,
   disabled: PropTypes.bool,

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -327,7 +327,7 @@ YearCalendar.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -326,9 +326,6 @@ YearCalendar.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * The default selected value.

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.types.ts
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.types.ts
@@ -18,9 +18,6 @@ export interface YearCalendarProps<TDate>
     BaseDateValidationProps<TDate>,
     TimezoneProps {
   autoFocus?: boolean;
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-date-pickers/src/internals/models/props/basePickerProps.tsx
+++ b/packages/x-date-pickers/src/internals/models/props/basePickerProps.tsx
@@ -18,9 +18,6 @@ export interface BasePickerProps<
   TExternalProps extends UsePickerViewsProps<TValue, TDate, TView, any, any>,
   TAdditionalProps extends {},
 > extends UsePickerBaseProps<TValue, TDate, TView, TError, TExternalProps, TAdditionalProps> {
-  /**
-   * Class name applied to the root element.
-   */
   className?: string;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/x-date-pickers/src/internals/models/props/toolbar.ts
+++ b/packages/x-date-pickers/src/internals/models/props/toolbar.ts
@@ -34,9 +34,6 @@ export interface ExportedBaseToolbarProps {
    * @default "––"
    */
   toolbarPlaceholder?: React.ReactNode;
-  /**
-   * className applied to the root component.
-   */
   className?: string;
   /**
    * If `true`, show the toolbar even in desktop mode.

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
@@ -148,9 +148,6 @@ RichTreeView.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * The default icon used to collapse the node.

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
@@ -149,7 +149,7 @@ RichTreeView.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.types.ts
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.types.ts
@@ -34,9 +34,6 @@ export interface RichTreeViewSlotsComponentsProps<
 }
 
 export interface RichTreeViewPropsBase extends React.HTMLAttributes<HTMLUListElement> {
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -111,9 +111,6 @@ SimpleTreeView.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * The default icon used to collapse the node.

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -112,7 +112,7 @@ SimpleTreeView.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.types.ts
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.types.ts
@@ -28,9 +28,6 @@ export interface SimpleTreeViewProps<Multiple extends boolean | undefined>
    * The props used for each component slot.
    */
   slotProps?: SimpleTreeViewSlotProps;
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -307,9 +307,6 @@ TreeItem.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * className applied to the root element.
-   */
   className: PropTypes.string,
   /**
    * The icon used to collapse the node.

--- a/packages/x-tree-view/src/TreeItem/TreeItem.types.ts
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.types.ts
@@ -11,9 +11,6 @@ export interface TreeItemProps extends Omit<React.HTMLAttributes<HTMLLIElement>,
    * The content of the component.
    */
   children?: React.ReactNode;
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
@@ -4,9 +4,6 @@ import clsx from 'clsx';
 import { useTreeItem } from './useTreeItem';
 
 export interface TreeItemContentProps extends React.HTMLAttributes<HTMLElement> {
-  /**
-   * className applied to the root element.
-   */
   className?: string;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
@@ -126,9 +126,6 @@ TreeItemContent.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object.isRequired,
-  /**
-   * className applied to the root element.
-   */
   className: PropTypes.string,
   /**
    * The icon to display next to the tree node's label. Either a parent or end icon.

--- a/packages/x-tree-view/src/TreeView/TreeView.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.tsx
@@ -94,9 +94,6 @@ TreeView.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
-  /**
-   * @ignore
-   */
   className: PropTypes.string,
   /**
    * The default icon used to collapse the node.

--- a/packages/x-tree-view/src/TreeView/TreeView.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.tsx
@@ -95,7 +95,7 @@ TreeView.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * className applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**


### PR DESCRIPTION
A convention we use for the className prop through the codebase.

The reason is because className should be available everywhere and spread to the root everywhere, so documenting it is redundant. In the API pages, it helps increase the SNR, you are not going to check the page to know if the className prop is available, it should always be.