### PR TITLE
[docs] Cleanup and fix Pickers Playground styling

### DIFF
--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -82,21 +82,28 @@ function TriBooleanGroupControl({
     [onChange],
   );
   return (
-    <FormControl sx={{ gap: 1 }}>
-      <FormLabel id={id}>{label}</FormLabel>
-      <ToggleButtonGroup
-        aria-labelledby={id}
-        value={value ?? ''}
-        exclusive
-        onChange={handleChange}
-        size="small"
-        color="primary"
-        fullWidth
-      >
-        <ToggleButton value={''}>Undefined</ToggleButton>
-        <ToggleButton value>True</ToggleButton>
-        <ToggleButton value={false}>False</ToggleButton>
-      </ToggleButtonGroup>
+    <FormControl>
+      <FormControlLabel
+        sx={{ gap: 1, m: 0, alignItems: 'start' }}
+        label={label}
+        id={id}
+        labelPlacement="top"
+        control={
+          <ToggleButtonGroup
+            aria-labelledby={id}
+            value={value ?? ''}
+            exclusive
+            onChange={handleChange}
+            size="small"
+            color="primary"
+            fullWidth
+          >
+            <ToggleButton value={''}>Undefined</ToggleButton>
+            <ToggleButton value>True</ToggleButton>
+            <ToggleButton value={false}>False</ToggleButton>
+          </ToggleButtonGroup>
+        }
+      />
     </FormControl>
   );
 }
@@ -129,8 +136,8 @@ function BooleanGroupControl({
         id={id}
         checked={value}
         onChange={handleChange as any}
-        control={<Switch />}
         labelPlacement="start"
+        control={<Switch />}
       />
     </FormControl>
   );

--- a/docs/src/modules/components/PickersPlayground.tsx
+++ b/docs/src/modules/components/PickersPlayground.tsx
@@ -40,7 +40,6 @@ import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePi
 import { isDatePickerView, isTimeView } from '@mui/x-date-pickers/internals';
 
 const ComponentSection = styled('div')(({ theme }) => ({
-  padding: theme.spacing(4),
   display: 'flex',
   flexDirection: 'column',
   gap: theme.spacing(2),
@@ -56,8 +55,7 @@ const ComponentSection = styled('div')(({ theme }) => ({
 }));
 
 const PropControlsSection = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
+  flexGrow: 1,
   background: alpha(theme.palette.grey[50], 0.5),
   ...(theme.palette.mode === 'dark' && {
     backgroundColor: alpha(theme.palette.grey[900], 0.3),
@@ -84,13 +82,7 @@ function TriBooleanGroupControl({
     [onChange],
   );
   return (
-    <FormControl
-      sx={{
-        flexDirection: 'column',
-        gap: 1,
-        // alignItems: 'center',
-      }}
-    >
+    <FormControl sx={{ gap: 1 }}>
       <FormLabel id={id}>{label}</FormLabel>
       <ToggleButtonGroup
         aria-labelledby={id}
@@ -126,18 +118,20 @@ function BooleanGroupControl({
     [onChange],
   );
   return (
-    <FormControl
-      size="small"
-      sx={{
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        gap: 4,
-      }}
-    >
-      <FormLabel id={id}>{label}</FormLabel>
-      <Switch checked={value} onChange={handleChange} />
+    <FormControl>
+      <FormControlLabel
+        sx={{
+          justifyContent: 'space-between',
+          ml: 0,
+          width: '100%',
+        }}
+        label={label}
+        id={id}
+        checked={value}
+        onChange={handleChange as any}
+        control={<Switch />}
+        labelPlacement="start"
+      />
     </FormControl>
   );
 }
@@ -517,7 +511,7 @@ export default function PickersPlayground() {
           flexDirection: { xs: 'column', md: 'row' },
         }}
       >
-        <ComponentSection sx={{ width: { xs: '100%', sm: '60%' } }}>
+        <ComponentSection sx={{ width: { xs: '100%', md: '60%' }, padding: { xs: 2, md: 4 } }}>
           <FormControl fullWidth>
             <InputLabel id="selected-component-family-label">Selected components</InputLabel>
             <Select
@@ -592,8 +586,8 @@ export default function PickersPlayground() {
             </DemoContainer>
           )}
         </ComponentSection>
-        <Divider orientation="vertical" light sx={{ display: { xs: 'none', sm: 'flex' } }} />
-        <Divider light sx={{ display: { xs: 'auto', sm: 'none' } }} />
+        <Divider orientation="vertical" light sx={{ display: { xs: 'none', md: 'flex' } }} />
+        <Divider light sx={{ display: { xs: 'auto', md: 'none' } }} />
         <PropControlsSection>
           <Typography
             id="usage-props"
@@ -603,6 +597,7 @@ export default function PickersPlayground() {
               scrollMarginTop: 160,
               fontFamily: 'General Sans',
               p: 3,
+              pl: { xs: 2, md: 3 },
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
@@ -611,7 +606,7 @@ export default function PickersPlayground() {
             Playground
           </Typography>
           <Divider light />
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, pt: 2, pl: 3, pr: 2 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, p: 2, pl: { md: 3 } }}>
             <TriBooleanGroupControl
               label="Toolbar hidden"
               value={isToolbarHidden}


### PR DESCRIPTION
Follow-up on https://github.com/mui/mui-x/pull/11555

I let some things slip through. 🙈 

P.S. Don't mind the slight difference in background colors, that's `deployed` vs `local` diff.

## Label colors

| Before | After |
|--------|--------|
| ![Screenshot 2024-01-16 at 16 19 17](https://github.com/mui/mui-x/assets/4941090/fe82cc42-9fe6-4513-8dd4-69880e9de81f) | ![Screenshot 2024-01-16 at 16 19 27](https://github.com/mui/mui-x/assets/4941090/3bf43138-914b-4e83-8b83-8afb06493e08) | 


## Broken layout between `sm` and `md`

| Before | After |
|--------|--------|
| ![Screenshot 2024-01-16 at 16 20 18](https://github.com/mui/mui-x/assets/4941090/16910385-13ff-4ac1-a69f-b0882da600fc) | ![Screenshot 2024-01-16 at 16 20 42](https://github.com/mui/mui-x/assets/4941090/74afe217-de40-4472-961b-e6559e1cfd6f) |


## Misaligned containers (on mobile) and missing padding

| Before | After |
|--------|--------|
| ![Screenshot 2024-01-16 at 16 21 25](https://github.com/mui/mui-x/assets/4941090/115733c9-954e-4e37-9d63-adeb9d237ddf) | ![Screenshot 2024-01-16 at 16 21 31](https://github.com/mui/mui-x/assets/4941090/f55cd71a-be9e-4275-8af8-3c266d68a186) |