### PR TITLE
[TreeView] Rename `useTreeItem` to `useTreeItemState`

### DIFF
--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -253,3 +253,28 @@ you can use the new `onNodeSelectionToggle` prop which is called whenever a node
 ```
 
 :::
+
+### Use `useTreeItemState` instead of `useTreeItem`
+
+The `useTreeItem` hook has been renamed `useTreeItemState`.
+This will help create a new headless version of the `TreeItem` component based on a future `useTreeItem` hook.
+
+```diff
+-import { TreeItem, useTreeItem } from '@mui/x-tree-view/TreeItem';
++import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
+
+ const CustomContent = React.forwardRef((props, ref) => {
+-  const { disabled }  = useTreeItem(props.nodeId);
++  const { disabled }  = useTreeItemState(props.nodeId);
+
+   // Render some UI
+ });
+
+ function App() {
+   return (
+     <SimpleTreeView>
+       <TreeItem ContentComponent={CustomContent} />
+     </SimpleTreeView>
+   )
+ }
+```

--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -178,7 +178,7 @@ you need to use the new `collapseIcon` slot on this component:
   </SimpleTreeView>
 ```
 
-### Rename `onNodeToggle`, `expanded` and `defaultExpanded`
+### ✅ Rename `onNodeToggle`, `expanded` and `defaultExpanded`
 
 The expansion props have been renamed to better describe their behaviors:
 
@@ -216,7 +216,7 @@ you can use the new `onNodeExpansionToggle` prop which is called whenever a node
 
 :::
 
-### Rename `onNodeSelect`, `selected`, and `defaultSelected`
+### ✅ Rename `onNodeSelect`, `selected`, and `defaultSelected`
 
 The selection props have been renamed to better describe their behaviors:
 
@@ -254,7 +254,7 @@ you can use the new `onNodeSelectionToggle` prop which is called whenever a node
 
 :::
 
-### Use `useTreeItemState` instead of `useTreeItem`
+### ✅ Use `useTreeItemState` instead of `useTreeItem`
 
 The `useTreeItem` hook has been renamed `useTreeItemState`.
 This will help create a new headless version of the `TreeItem` component based on a future `useTreeItem` hook.

--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -264,8 +264,8 @@ This will help create a new headless version of the `TreeItem` component based o
 +import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
 
  const CustomContent = React.forwardRef((props, ref) => {
--  const { disabled }  = useTreeItem(props.nodeId);
-+  const { disabled }  = useTreeItemState(props.nodeId);
+-  const { disabled } = useTreeItem(props.nodeId);
++  const { disabled } = useTreeItemState(props.nodeId);
 
    // Render some UI
  });

--- a/docs/data/tree-view/simple-tree-view/customization/CustomContentTreeView.js
+++ b/docs/data/tree-view/simple-tree-view/customization/CustomContentTreeView.js
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
-import { TreeItem, useTreeItem } from '@mui/x-tree-view/TreeItem';
+import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
 
 const CustomContentRoot = styled('div')(({ theme }) => ({
   '&': { padding: theme.spacing(0.5, 1) },
@@ -30,7 +30,7 @@ const CustomContent = React.forwardRef(function CustomContent(props, ref) {
     handleExpansion,
     handleSelection,
     preventSelection,
-  } = useTreeItem(nodeId);
+  } = useTreeItemState(nodeId);
 
   const icon = iconProp || expansionIcon || displayIcon;
 

--- a/docs/data/tree-view/simple-tree-view/customization/CustomContentTreeView.tsx
+++ b/docs/data/tree-view/simple-tree-view/customization/CustomContentTreeView.tsx
@@ -7,7 +7,7 @@ import Avatar from '@mui/material/Avatar';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import {
   TreeItem,
-  useTreeItem,
+  useTreeItemState,
   TreeItemProps,
   TreeItemContentProps,
 } from '@mui/x-tree-view/TreeItem';
@@ -38,7 +38,7 @@ const CustomContent = React.forwardRef(function CustomContent(
     handleExpansion,
     handleSelection,
     preventSelection,
-  } = useTreeItem(nodeId);
+  } = useTreeItemState(nodeId);
 
   const icon = iconProp || expansionIcon || displayIcon;
 

--- a/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.js
+++ b/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.js
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
-import { TreeItem, useTreeItem } from '@mui/x-tree-view/TreeItem';
+import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
 
 const CustomContent = React.forwardRef(function CustomContent(props, ref) {
   const {
@@ -24,7 +24,7 @@ const CustomContent = React.forwardRef(function CustomContent(props, ref) {
     handleExpansion,
     handleSelection,
     preventSelection,
-  } = useTreeItem(nodeId);
+  } = useTreeItemState(nodeId);
 
   const icon = iconProp || expansionIcon || displayIcon;
 

--- a/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.tsx
+++ b/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.tsx
@@ -6,7 +6,7 @@ import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import {
   TreeItem,
   TreeItemProps,
-  useTreeItem,
+  useTreeItemState,
   TreeItemContentProps,
 } from '@mui/x-tree-view/TreeItem';
 
@@ -32,7 +32,7 @@ const CustomContent = React.forwardRef(function CustomContent(
     handleExpansion,
     handleSelection,
     preventSelection,
-  } = useTreeItem(nodeId);
+  } = useTreeItemState(nodeId);
 
   const icon = iconProp || expansionIcon || displayIcon;
 

--- a/docs/data/tree-view/simple-tree-view/customization/customization.md
+++ b/docs/data/tree-view/simple-tree-view/customization/customization.md
@@ -36,7 +36,7 @@ Use `treeItemClasses` to target internal elements of the Tree Item component and
 
 ### Adding custom content
 
-Use the `ContentComponent` prop and the `useTreeItem` hook to replace the Tree Item content with an entirely custom component.
+Use the `ContentComponent` prop and the `useTreeItemState` hook to replace the Tree Item content with an entirely custom component.
 The demo below shows how to add an avatar and custom typography elements.
 
 {{"demo": "CustomContentTreeView.js"}}

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -218,6 +218,7 @@ npx @mui/x-codemod@next v7.0.0/tree-view/preset-safe <path|folder>
 The list includes these transformers
 
 - [`rename-tree-view-simple-tree-view`](#rename-tree-view-simple-tree-view)
+- [`rename-use-tree-item`](#rename-use-tree-item)
 - [`rename-expansion-props`](#rename-expansion-props)
 - [`rename-selection-props`](#rename-selection-props)
 
@@ -239,6 +240,30 @@ Renames the `TreeView` component to `SimpleTreeView`
 -    </TreeView>
 +    </SimpleTreeView>
    );
+```
+
+#### `rename-use-tree-item`
+
+Renames the `useTreeItem` hook to `useTreeItemState`
+
+```diff
+-import { TreeItem, useTreeItem } from '@mui/x-tree-view/TreeItem';
++import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
+
+ const CustomContent = React.forwardRef((props, ref) => {
+-  const { disabled }  = useTreeItem(props.nodeId);
++  const { disabled }  = useTreeItemState(props.nodeId);
+
+   // Render some UI
+ });
+
+ function App() {
+   return (
+     <SimpleTreeView>
+       <TreeItem ContentComponent={CustomContent} />
+     </SimpleTreeView>
+   )
+ }
 ```
 
 #### `rename-expansion-props`

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -251,8 +251,8 @@ Renames the `useTreeItem` hook to `useTreeItemState`
 +import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
 
  const CustomContent = React.forwardRef((props, ref) => {
--  const { disabled }  = useTreeItem(props.nodeId);
-+  const { disabled }  = useTreeItemState(props.nodeId);
+-  const { disabled } = useTreeItem(props.nodeId);
++  const { disabled } = useTreeItemState(props.nodeId);
 
    // Render some UI
  });

--- a/packages/x-codemod/src/v7.0.0/tree-view/preset-safe/actual.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/tree-view/preset-safe/actual.spec.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as React from 'react';
 import { TreeView, treeViewClasses } from '@mui/x-tree-view/TreeView';
-import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import { TreeItem, useTreeItem } from '@mui/x-tree-view/TreeItem';
 
 const className = treeViewClasses.root;
 

--- a/packages/x-codemod/src/v7.0.0/tree-view/preset-safe/expected.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/tree-view/preset-safe/expected.spec.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as React from 'react';
 import { SimpleTreeView, simpleTreeViewClasses } from '@mui/x-tree-view/SimpleTreeView';
-import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import { TreeItem, useTreeItemState } from '@mui/x-tree-view/TreeItem';
 
 const className = simpleTreeViewClasses.root;
 

--- a/packages/x-codemod/src/v7.0.0/tree-view/preset-safe/index.ts
+++ b/packages/x-codemod/src/v7.0.0/tree-view/preset-safe/index.ts
@@ -1,5 +1,6 @@
 import transformRenameExpansionProps from '../rename-expansion-props';
 import transformRenameSelectionProps from '../rename-selection-props';
+import transformRenameUseTreeItem from '../rename-use-tree-item';
 import transformRenameTreeViewSimpleTreeView from '../rename-tree-view-simple-tree-view';
 
 import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
@@ -7,6 +8,7 @@ import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
   file.source = transformRenameExpansionProps(file, api, options);
   file.source = transformRenameSelectionProps(file, api, options);
+  file.source = transformRenameUseTreeItem(file, api, options);
   file.source = transformRenameTreeViewSimpleTreeView(file, api, options);
 
   return file.source;

--- a/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/actual-nested-imports.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/actual-nested-imports.spec.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import { useTreeItem } from '@mui/x-tree-view/TreeItem';
+
+function App() {
+  const state = useTreeItem('node1');
+}

--- a/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/actual-root-imports.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/actual-root-imports.spec.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import { useTreeItem } from '@mui/x-tree-view';
+
+function App() {
+  const state = useTreeItem('node1');
+}

--- a/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/expected-nested-imports.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/expected-nested-imports.spec.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import { useTreeItemState } from '@mui/x-tree-view/TreeItem';
+
+function App() {
+  const state = useTreeItemState('node1');
+}

--- a/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/expected-root-imports.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/expected-root-imports.spec.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+import { useTreeItemState } from '@mui/x-tree-view';
+
+function App() {
+  const state = useTreeItemState('node1');
+}

--- a/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/index.ts
+++ b/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/index.ts
@@ -1,0 +1,37 @@
+import { ASTPath, ImportDeclaration } from 'jscodeshift';
+import type { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
+
+const PACKAGE_REGEXP = /@mui\/x-tree-view(\/TreeItem|)/;
+
+const matchImport = (path: ASTPath<ImportDeclaration>) =>
+  (path.node.source.value?.toString() ?? '').match(PACKAGE_REGEXP);
+
+export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const printOptions = options.printOptions || {
+    quote: 'single',
+    trailingComma: true,
+  };
+
+  const matchingImports = root.find(j.ImportDeclaration).filter((path) => !!matchImport(path));
+
+  // Rename the import specifiers
+  // - import { useTreeItem } from '@mui/x-tree-view/TreeItem'
+  // + import { useTreeItemState } from '@mui/x-tree-view/TreeItem'
+  matchingImports
+    .find(j.ImportSpecifier)
+    .filter((path) => path.node.imported.name === 'useTreeItem')
+    .replaceWith(j.importSpecifier(j.identifier('useTreeItemState')));
+
+  // Rename the import usage
+  // - useTreeItem(nodeId);
+  // + useTreeItemState(nodeId)
+  root
+    .find(j.Identifier)
+    .filter((path) => path.node.name === 'useTreeItem')
+    .replaceWith(j.identifier('useTreeItemState'));
+
+  return root.toSource(printOptions);
+}

--- a/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/rename-use-tree-item.ts
+++ b/packages/x-codemod/src/v7.0.0/tree-view/rename-use-tree-item/rename-use-tree-item.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from '.';
+import readFile from '../../../util/readFile';
+
+function read(fileName) {
+  return readFile(path.join(__dirname, fileName));
+}
+
+const TEST_FILES = ['nested-imports', 'root-imports'];
+
+describe('v7.0.0/tree-view', () => {
+  describe('rename-use-tree-item', () => {
+    TEST_FILES.forEach((testFile) => {
+      const actualPath = `./actual-${testFile}.spec.tsx`;
+      const expectedPath = `./expected-${testFile}.spec.tsx`;
+
+      describe(`${testFile.replace(/-/g, ' ')}`, () => {
+        it('transforms imports as needed', () => {
+          const actual = transform(
+            { source: read(actualPath) },
+            { jscodeshift: jscodeshift.withParser('tsx') },
+            {},
+          );
+
+          const expected = read(expectedPath);
+          expect(actual).to.equal(expected, 'The transformed version should be correct');
+        });
+
+        it('should be idempotent', () => {
+          const actual = transform(
+            { source: read(expectedPath) },
+            { jscodeshift: jscodeshift.withParser('tsx') },
+            {},
+          );
+
+          const expected = read(expectedPath);
+          expect(actual).to.equal(expected, 'The transformed version should be correct');
+        });
+      });
+    });
+  });
+});

--- a/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { useTreeItem } from './useTreeItem';
+import { useTreeItemState } from './useTreeItemState';
 
 export interface TreeItemContentProps extends React.HTMLAttributes<HTMLElement> {
   className?: string;
@@ -76,7 +76,7 @@ const TreeItemContent = React.forwardRef(function TreeItemContent(
     handleExpansion,
     handleSelection,
     preventSelection,
-  } = useTreeItem(nodeId);
+  } = useTreeItemState(nodeId);
 
   const icon = iconProp || expansionIcon || displayIcon;
 

--- a/packages/x-tree-view/src/TreeItem/index.ts
+++ b/packages/x-tree-view/src/TreeItem/index.ts
@@ -1,6 +1,6 @@
 export { TreeItem } from './TreeItem';
 export type { TreeItemProps } from './TreeItem.types';
 export * from './treeItemClasses';
-export * from './useTreeItem';
+export * from './useTreeItemState';
 export { TreeItemContent } from './TreeItemContent';
 export type { TreeItemContentProps, TreeItemContentClassKey } from './TreeItemContent';

--- a/packages/x-tree-view/src/TreeItem/useTreeItemState.ts
+++ b/packages/x-tree-view/src/TreeItem/useTreeItemState.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTreeViewContext } from '../internals/TreeViewProvider/useTreeViewContext';
 import { DefaultTreeViewPlugins } from '../internals/plugins';
 
-export function useTreeItem(nodeId: string) {
+export function useTreeItemState(nodeId: string) {
   const {
     instance,
     selection: { multiSelect },

--- a/scripts/x-tree-view.exports.json
+++ b/scripts/x-tree-view.exports.json
@@ -36,5 +36,5 @@
   { "name": "TreeViewItemId", "kind": "TypeAlias" },
   { "name": "TreeViewProps", "kind": "Interface" },
   { "name": "unstable_resetCleanupTracking", "kind": "Variable" },
-  { "name": "useTreeItem", "kind": "Function" }
+  { "name": "useTreeItemState", "kind": "Function" }
 ]


### PR DESCRIPTION
We discussed it briefly during a meeting.
If we want a clean headless version of the `TreeItem`, we need to create a `useTreeItem` hook but the name is already taken by a utility hook.