### PR TITLE
[core] make karma-parallel run under a new command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha --exclude '**/node_modules/**' && nyc report -r lcovonly",
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha --exclude '**/node_modules/**' && nyc report --reporter=html",
     "test:karma": "cross-env NODE_ENV=test TZ=UTC karma start test/karma.conf.js",
+    "test:karma:parallel": "cross-env NODE_ENV=test TZ=UTC PARALLEL=true karma start test/karma.conf.js",
     "test:unit": "cross-env NODE_ENV=test TZ=UTC mocha -n expose_gc",
     "test:e2e": "cross-env NODE_ENV=production yarn test:e2e:build && concurrently --success first --kill-others \"yarn test:e2e:run\" \"yarn test:e2e:server\"",
     "test:e2e:build": "webpack --config test/e2e/webpack.config.js",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function setKarmaConfig(config) {
         timeout: (process.env.CIRCLECI === 'true' ? 5 : 2) * 1000,
       },
     },
-    frameworks: (process.env.CIRCLECI === 'true' ? [] : ['parallel']).concat(['mocha', 'webpack']),
+    frameworks: (process.env.PARALLEL === 'true' ? ['parallel'] : []).concat(['mocha', 'webpack']),
     files: [
       {
         pattern: 'test/karma.tests.js',
@@ -29,7 +29,7 @@ module.exports = function setKarmaConfig(config) {
         included: true,
       },
     ],
-    plugins: (process.env.CIRCLECI === 'true' ? [] : ['karma-parallel']).concat([
+    plugins: (process.env.PARALLEL === 'true' ? ['karma-parallel'] : []).concat([
       'karma-mocha',
       'karma-chrome-launcher',
       'karma-sourcemap-loader',


### PR DESCRIPTION
The DX of `karma-parallel` is bad when debugging a single test, this PR restores the behavior of `test:karma` and makes the parallel version available under a new command.
