### PR TITLE
[code-infra] Migrate all prettier APIs to the async version

### DIFF
--- a/docs/scripts/api/buildApi.ts
+++ b/docs/scripts/api/buildApi.ts
@@ -12,13 +12,13 @@ import { DocumentedInterfaces } from './utils';
 
 const DEFAULT_PRETTIER_CONFIG_PATH = path.join(process.cwd(), 'prettier.config.js');
 
-export function writePrettifiedFile(
+export async function writePrettifiedFile(
   filename: string,
   data: string,
   prettierConfigPath: string = DEFAULT_PRETTIER_CONFIG_PATH,
   options: object = {},
 ) {
-  const prettierConfig = prettier.resolveConfig.sync(filename, {
+  const prettierConfig = await prettier.resolveConfig(filename, {
     config: prettierConfigPath,
   });
   if (prettierConfig === null) {
@@ -27,10 +27,14 @@ export function writePrettifiedFile(
     );
   }
 
-  fs.writeFileSync(filename, prettier.format(data, { ...prettierConfig, filepath: filename }), {
-    encoding: 'utf8',
-    ...options,
-  });
+  fs.writeFileSync(
+    filename,
+    await prettier.format(data, { ...prettierConfig, filepath: filename }),
+    {
+      encoding: 'utf8',
+      ...options,
+    },
+  );
 }
 
 const bracketsRegexp = /\[\[([^\]]+)\]\]/g;
@@ -40,58 +44,60 @@ const bracketsRegexp = /\[\[([^\]]+)\]\]/g;
  * @param {string} directory
  * @param {DocumentedInterfaces} documentedInterfaces
  */
-export default function linkifyTranslation(
+export default async function linkifyTranslation(
   directory: string,
   documentedInterfaces: DocumentedInterfaces,
 ) {
   const items = fs.readdirSync(directory);
 
-  items.forEach((item) => {
-    const itemPath = path.resolve(directory, item);
+  await Promise.all(
+    items.map(async (item) => {
+      const itemPath = path.resolve(directory, item);
 
-    if (fs.statSync(itemPath).isDirectory()) {
-      linkifyTranslation(itemPath, documentedInterfaces);
-      return;
-    }
-
-    const text = fs.readFileSync(itemPath).toString();
-
-    if (!bracketsRegexp.test(text)) {
-      return;
-    }
-
-    const linkified = text.replaceAll(bracketsRegexp, (match: string, content: string) => {
-      if (!documentedInterfaces.get(content)) {
-        return content;
+      if (fs.statSync(itemPath).isDirectory()) {
+        await linkifyTranslation(itemPath, documentedInterfaces);
+        return;
       }
-      const url = `/x/api/data-grid/${kebabCase(content)}/`;
-      return `<a href='${url}'>${content}</a>`;
-    });
 
-    writePrettifiedFile(itemPath, linkified);
-  });
+      const text = fs.readFileSync(itemPath).toString();
+
+      if (!bracketsRegexp.test(text)) {
+        return;
+      }
+
+      const linkified = text.replaceAll(bracketsRegexp, (match: string, content: string) => {
+        if (!documentedInterfaces.get(content)) {
+          return content;
+        }
+        const url = `/x/api/data-grid/${kebabCase(content)}/`;
+        return `<a href='${url}'>${content}</a>`;
+      });
+
+      await writePrettifiedFile(itemPath, linkified);
+    }),
+  );
 }
 
-function run() {
+async function run() {
   const projects = createXTypeScriptProjects();
 
   // Create documentation folder if it does not exist
   const apiPagesFolder = path.resolve('./docs/pages/x/api');
   const dataGridTranslationFolder = path.resolve('./docs/translations/api-docs/data-grid/');
 
-  const documentedInterfaces = buildInterfacesDocumentation({
+  const documentedInterfaces = await buildInterfacesDocumentation({
     projects,
     apiPagesFolder,
   });
 
-  linkifyTranslation(dataGridTranslationFolder, documentedInterfaces);
+  await linkifyTranslation(dataGridTranslationFolder, documentedInterfaces);
 
-  buildGridEventsDocumentation({
+  await buildGridEventsDocumentation({
     projects,
     documentedInterfaces,
   });
 
-  buildGridSelectorsDocumentation({
+  await buildGridSelectorsDocumentation({
     project: projects.get('x-data-grid-premium')!,
     apiPagesFolder,
   });

--- a/docs/scripts/api/buildGridEventsDocumentation.ts
+++ b/docs/scripts/api/buildGridEventsDocumentation.ts
@@ -18,7 +18,9 @@ interface BuildEventsDocumentationOptions {
 
 const GRID_PROJECTS: XProjectNames[] = ['x-data-grid', 'x-data-grid-pro', 'x-data-grid-premium'];
 
-export default function buildGridEventsDocumentation(options: BuildEventsDocumentationOptions) {
+export default async function buildGridEventsDocumentation(
+  options: BuildEventsDocumentationOptions,
+) {
   const { projects, documentedInterfaces } = options;
 
   const events: {
@@ -32,50 +34,59 @@ export default function buildGridEventsDocumentation(options: BuildEventsDocumen
     };
   } = {};
 
-  GRID_PROJECTS.forEach((projectName) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const projectName of GRID_PROJECTS) {
     const project = projects.get(projectName)!;
     const gridEventLookupSymbol = project.exports.GridEventLookup;
     const gridEventLookupType = project.checker.getTypeAtLocation(
       (gridEventLookupSymbol.declarations![0] as ts.InterfaceDeclaration).name,
     ) as ts.EnumType;
 
-    gridEventLookupType.getProperties().forEach((event) => {
-      const tags = getSymbolJSDocTags(event);
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all(
+      gridEventLookupType.getProperties().map(async (event) => {
+        const tags = getSymbolJSDocTags(event);
 
-      if (tags.ignore) {
-        return;
-      }
-
-      if (events[event.name]) {
-        events[event.name].projects.push(project.name);
-      } else {
-        const declaration = event.declarations?.find(ts.isPropertySignature);
-        if (!declaration) {
+        if (tags.ignore) {
           return;
         }
 
-        const description = linkify(
-          getSymbolDescription(event, project),
-          documentedInterfaces,
-          'html',
-        );
+        if (events[event.name]) {
+          events[event.name].projects.push(project.name);
+        } else {
+          const declaration = event.declarations?.find(ts.isPropertySignature);
+          if (!declaration) {
+            return;
+          }
 
-        const eventParams: { [key: string]: any } = {};
-        const symbol = project.checker.getTypeAtLocation(declaration.name).symbol;
-        symbol.members?.forEach((member, memberName) => {
-          eventParams[memberName.toString()] = stringifySymbol(member, project);
-        });
+          const description = linkify(
+            getSymbolDescription(event, project),
+            documentedInterfaces,
+            'html',
+          );
 
-        events[event.name] = {
-          projects: [project.name],
-          name: event.name,
-          description: renderMarkdown(description),
-          params: linkify(eventParams.params, documentedInterfaces, 'html'),
-          event: `MuiEvent<${eventParams.event ?? '{}'}>`,
-        };
-      }
-    });
-  });
+          const eventParams: { [key: string]: string } = {};
+          const symbol = project.checker.getTypeAtLocation(declaration.name).symbol;
+
+          if (symbol.members) {
+            await Promise.all(
+              Array.from(symbol.members.entries(), async ([memberName, member]) => {
+                eventParams[memberName.toString()] = await stringifySymbol(member, project);
+              }),
+            );
+          }
+
+          events[event.name] = {
+            projects: [project.name],
+            name: event.name,
+            description: renderMarkdown(description),
+            params: linkify(eventParams.params, documentedInterfaces, 'html'),
+            event: `MuiEvent<${eventParams.event ?? '{}'}>`,
+          };
+        }
+      }),
+    );
+  }
 
   const defaultProject = projects.get('x-data-grid-premium')!;
 
@@ -114,7 +125,7 @@ export default function buildGridEventsDocumentation(options: BuildEventsDocumen
 
   const sortedEvents = Object.values(events).sort((a, b) => a.name.localeCompare(b.name));
 
-  writePrettifiedFile(
+  await writePrettifiedFile(
     path.resolve(defaultProject.workspaceRoot, 'docs/data/data-grid/events/events.json'),
     JSON.stringify(sortedEvents),
     defaultProject,

--- a/docs/scripts/api/buildInterfacesDocumentation.ts
+++ b/docs/scripts/api/buildInterfacesDocumentation.ts
@@ -86,12 +86,15 @@ const OTHER_GRID_INTERFACES_WITH_DEDICATED_PAGES = [
   'GridAggregationFunction',
 ];
 
-const parseProperty = (propertySymbol: ts.Symbol, project: XTypeScriptProject): ParsedProperty => ({
+const parseProperty = async (
+  propertySymbol: ts.Symbol,
+  project: XTypeScriptProject,
+): Promise<ParsedProperty> => ({
   name: propertySymbol.name,
   description: getSymbolDescription(propertySymbol, project),
   tags: getSymbolJSDocTags(propertySymbol),
   isOptional: !!propertySymbol.declarations?.find(ts.isPropertySignature)?.questionToken,
-  typeStr: stringifySymbol(propertySymbol, project),
+  typeStr: await stringifySymbol(propertySymbol, project),
   projects: [project.name],
 });
 
@@ -102,11 +105,11 @@ interface ProjectInterface {
   declaration: ts.InterfaceDeclaration;
 }
 
-const parseInterfaceSymbol = (
+const parseInterfaceSymbol = async (
   interfaceName: string,
   documentedInterfaces: DocumentedInterfaces,
   projects: XTypeScriptProjects,
-): ParsedObject | null => {
+): Promise<ParsedObject | null> => {
   const projectInterfaces = documentedInterfaces
     .get(interfaceName)!
     .map((projectName) => {
@@ -148,17 +151,20 @@ const parseInterfaceSymbol = (
   };
 
   const properties: Record<string, ParsedProperty> = {};
-  projectInterfaces.forEach(({ type, project }) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const { type, project } of projectInterfaces) {
     const propertiesOnProject = type.getProperties();
 
-    propertiesOnProject.forEach((propertySymbol) => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const propertySymbol of propertiesOnProject) {
       if (properties[propertySymbol.name]) {
         properties[propertySymbol.name].projects.push(project.name);
       } else {
-        properties[propertySymbol.name] = parseProperty(propertySymbol, project);
+        // eslint-disable-next-line no-await-in-loop
+        properties[propertySymbol.name] = await parseProperty(propertySymbol, project);
       }
-    });
-  });
+    }
+  }
 
   parsedInterface.properties = Object.values(properties)
     .filter((property) => !property.tags.ignore)
@@ -224,7 +230,7 @@ function generateMarkdownFromProperties(
   return text;
 }
 
-function generateImportStatement(objects: ParsedObject[], projects: XTypeScriptProjects) {
+async function generateImportStatement(objects: ParsedObject[], projects: XTypeScriptProjects) {
   let imports = '```js\n';
 
   const projectImports = Array.from(projects.values())
@@ -245,7 +251,7 @@ function generateImportStatement(objects: ParsedObject[], projects: XTypeScriptP
     // Display the imports from the pro packages above imports from the community packages
     .sort((a, b) => b.length - a.length);
 
-  imports += prettier.format(projectImports.join('\n// or\n'), {
+  imports += await prettier.format(projectImports.join('\n// or\n'), {
     singleQuote: true,
     semi: false,
     trailingComma: 'none',
@@ -256,14 +262,14 @@ function generateImportStatement(objects: ParsedObject[], projects: XTypeScriptP
   return imports;
 }
 
-function generateMarkdown(
+async function generateMarkdown(
   object: ParsedObject,
   projects: XTypeScriptProjects,
   documentedInterfaces: DocumentedInterfaces,
 ) {
   const demos = object.tags.demos;
   const description = linkify(object.description, documentedInterfaces, 'html');
-  const imports = generateImportStatement([object], projects);
+  const imports = await generateImportStatement([object], projects);
 
   let text = `# ${object.name} Interface\n`;
   text += `<p class="description">${description}</p>\n\n`;
@@ -291,7 +297,9 @@ interface BuildInterfacesDocumentationOptions {
   apiPagesFolder: string;
 }
 
-export default function buildInterfacesDocumentation(options: BuildInterfacesDocumentationOptions) {
+export default async function buildInterfacesDocumentation(
+  options: BuildInterfacesDocumentationOptions,
+) {
   const { projects, apiPagesFolder } = options;
 
   const allProjectsName = Array.from(projects.keys());
@@ -312,9 +320,17 @@ export default function buildInterfacesDocumentation(options: BuildInterfacesDoc
     documentedInterfaces.set(interfaceName, packagesWithThisInterface);
   });
 
-  documentedInterfaces.forEach((packagesWithThisInterface, interfaceName) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [interfaceName, packagesWithThisInterface] of Array.from(
+    documentedInterfaces.entries(),
+  )) {
     const project = projects.get(packagesWithThisInterface[0])!;
-    const parsedInterface = parseInterfaceSymbol(interfaceName, documentedInterfaces, projects);
+    // eslint-disable-next-line no-await-in-loop
+    const parsedInterface = await parseInterfaceSymbol(
+      interfaceName,
+      documentedInterfaces,
+      projects,
+    );
     if (!parsedInterface) {
       return;
     }
@@ -331,7 +347,8 @@ export default function buildInterfacesDocumentation(options: BuildInterfacesDoc
           type: property.typeStr,
         })),
       };
-      writePrettifiedFile(
+      // eslint-disable-next-line no-await-in-loop
+      await writePrettifiedFile(
         path.resolve(apiPagesFolder, project.documentationFolderName, `${slug}.json`),
         JSON.stringify(json),
         project,
@@ -339,14 +356,17 @@ export default function buildInterfacesDocumentation(options: BuildInterfacesDoc
       // eslint-disable-next-line no-console
       console.log('Built JSON file for', parsedInterface.name);
     } else {
-      const markdown = generateMarkdown(parsedInterface, projects, documentedInterfaces);
-      writePrettifiedFile(
+      // eslint-disable-next-line no-await-in-loop
+      const markdown = await generateMarkdown(parsedInterface, projects, documentedInterfaces);
+      // eslint-disable-next-line no-await-in-loop
+      await writePrettifiedFile(
         path.resolve(apiPagesFolder, project.documentationFolderName, `${slug}.md`),
         markdown,
         project,
       );
 
-      writePrettifiedFile(
+      // eslint-disable-next-line no-await-in-loop
+      await writePrettifiedFile(
         path.resolve(apiPagesFolder, project.documentationFolderName, `${slug}.js`),
         `import * as React from 'react';
     import MarkdownDocs from '@mui/monorepo/docs/src/modules/components/MarkdownDocs';
@@ -362,7 +382,7 @@ export default function buildInterfacesDocumentation(options: BuildInterfacesDoc
       // eslint-disable-next-line no-console
       console.log('Built API docs for', parsedInterface.name);
     }
-  });
+  }
 
   return documentedInterfaces;
 }

--- a/docs/scripts/api/buildInterfacesDocumentation.ts
+++ b/docs/scripts/api/buildInterfacesDocumentation.ts
@@ -332,7 +332,7 @@ export default async function buildInterfacesDocumentation(
       projects,
     );
     if (!parsedInterface) {
-      return;
+      continue;
     }
 
     const slug = kebabCase(parsedInterface.name);

--- a/docs/scripts/api/utils.ts
+++ b/docs/scripts/api/utils.ts
@@ -33,7 +33,7 @@ export function escapeCell(value: string) {
     .replace(/\r?\n/g, '<br />');
 }
 
-export const formatType = (rawType: string) => {
+export const formatType = async (rawType: string) => {
   if (!rawType) {
     return '';
   }
@@ -41,7 +41,7 @@ export const formatType = (rawType: string) => {
   const prefix = 'type FakeType = ';
   const signatureWithTypeName = `${prefix}${rawType}`;
 
-  const prettifiedSignatureWithTypeName = prettier.format(signatureWithTypeName, {
+  const prettifiedSignatureWithTypeName = await prettier.format(signatureWithTypeName, {
     printWidth: 999,
     singleQuote: true,
     semi: false,
@@ -52,7 +52,7 @@ export const formatType = (rawType: string) => {
   return prettifiedSignatureWithTypeName.slice(prefix.length).replace(/\n$/, '');
 };
 
-export const stringifySymbol = (symbol: ts.Symbol, project: XTypeScriptProject) => {
+export const stringifySymbol = async (symbol: ts.Symbol, project: XTypeScriptProject) => {
   let rawType: string;
 
   const declaration = symbol.declarations?.[0];
@@ -88,8 +88,12 @@ export function linkify(
   });
 }
 
-export function writePrettifiedFile(filename: string, data: string, project: XTypeScriptProject) {
-  const prettierConfig = prettier.resolveConfig.sync(filename, {
+export async function writePrettifiedFile(
+  filename: string,
+  data: string,
+  project: XTypeScriptProject,
+) {
+  const prettierConfig = await prettier.resolveConfig(filename, {
     config: project.prettierConfigPath,
   });
   if (prettierConfig === null) {
@@ -98,9 +102,13 @@ export function writePrettifiedFile(filename: string, data: string, project: XTy
     );
   }
 
-  fse.writeFileSync(filename, prettier.format(data, { ...prettierConfig, filepath: filename }), {
-    encoding: 'utf8',
-  });
+  fse.writeFileSync(
+    filename,
+    await prettier.format(data, { ...prettierConfig, filepath: filename }),
+    {
+      encoding: 'utf8',
+    },
+  );
 }
 
 /**

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -104,18 +104,18 @@ async function transpileFile(tsxPath, program, ignoreCache = false) {
     }
     const { code } = await babel.transformAsync(source, transformOptions);
 
-    const prettierConfig = prettier.resolveConfig.sync(jsPath, {
+    const prettierConfig = await prettier.resolveConfig(jsPath, {
       config: path.join(workspaceRoot, 'prettier.config.js'),
     });
-    const prettierFormat = (jsSource) =>
+    const prettierFormat = async (jsSource) =>
       prettier.format(jsSource, { ...prettierConfig, filepath: jsPath });
 
-    const prettified = prettierFormat(code);
+    const prettified = await prettierFormat(code);
     const formatted = fixBabelGeneratorIssues(prettified);
     const correctedLineEndings = fixLineEndings(source, formatted);
 
     // removed blank lines change potential formatting
-    await fse.writeFile(jsPath, prettierFormat(correctedLineEndings));
+    await fse.writeFile(jsPath, await prettierFormat(correctedLineEndings));
     return TranspileResult.Success;
   } catch (err) {
     console.error('Something went wrong transpiling %s\n%s\n', tsxPath, err);

--- a/docs/scripts/generateProptypes.ts
+++ b/docs/scripts/generateProptypes.ts
@@ -9,10 +9,6 @@ import {
 import { fixBabelGeneratorIssues, fixLineEndings } from '@mui/monorepo/packages/docs-utilities';
 import { createXTypeScriptProjects, XTypeScriptProject } from './createXTypeScriptProjects';
 
-const prettierConfig = prettier.resolveConfig.sync(process.cwd(), {
-  config: path.join(__dirname, '../../prettier.config.js'),
-});
-
 async function generateProptypes(project: XTypeScriptProject, sourceFile: string) {
   const components = getPropTypesFromFile({
     filePath: sourceFile,
@@ -120,7 +116,11 @@ async function generateProptypes(project: XTypeScriptProject, sourceFile: string
     throw new Error('Unable to produce inject propTypes into code.');
   }
 
-  const prettified = prettier.format(result, { ...prettierConfig, filepath: sourceFile });
+  const prettierConfig = await prettier.resolveConfig(process.cwd(), {
+    config: path.join(__dirname, '../../prettier.config.js'),
+  });
+
+  const prettified = await prettier.format(result, { ...prettierConfig, filepath: sourceFile });
   const formatted = fixBabelGeneratorIssues(prettified);
   const correctedLineEndings = fixLineEndings(sourceContent, formatted);
 


### PR DESCRIPTION
Upcoming prettier deprecates those APIs. Rewriting these calls in advance to avoid cluttering the PR with new formatting changes