### PR TITLE
[data grid] Use readonly array result for getTreeDataPath

### DIFF
--- a/packages/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -153,7 +153,7 @@ interface DataGridProRegularProps<R extends GridValidRowModel> {
    * @param {R} row The row from which we want the path.
    * @returns {string[]} The path to the row.
    */
-  getTreeDataPath?: (row: R) => string[];
+  getTreeDataPath?: (row: R) => readonly string[];
 }
 
 export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel = any>

--- a/packages/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -214,7 +214,7 @@ describe('<DataGridPro /> - Tree data', () => {
       ]);
       setProps({
         getTreeDataPath: (row) => [...row.name.split('.').reverse()],
-      } as DataGridProProps);
+      } as Pick<DataGridProProps, 'getTreeDataPath'>);
       expect(getColumnValues(1)).to.deep.equal([
         'A',
         'A.A',


### PR DESCRIPTION
We do not try to modify the array after receiving it, so let's accept an immutable array. This is still compatible with existing usage of getTreeDataPath.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
