### PR TITLE
[pickers] Use primary bolded text for all active toolbar sections

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickersToolbarText.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbarText.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import { styled, useThemeProps } from '@mui/material/styles';
-import { unstable_composeClasses as composeClasses } from '@mui/utils';
+import composeClasses from '@mui/utils/composeClasses';
 import {
   getPickersToolbarTextUtilityClass,
   pickersToolbarTextClasses,
@@ -43,7 +43,8 @@ const PickersToolbarTextRoot = styled(Typography, {
   transition: theme.transitions.create('color'),
   color: (theme.vars || theme).palette.text.secondary,
   [`&.${pickersToolbarTextClasses.selected}`]: {
-    color: (theme.vars || theme).palette.text.primary,
+    color: (theme.vars || theme).palette.primary.main,
+    fontWeight: theme.typography.fontWeightBold,
   },
 }));
 


### PR DESCRIPTION
Implement https://www.notion.so/mui-org/Pending-DateTimeRange-problems-3857f71f7f7d40508589320d2d453f32?pvs=4#36fc27f254b141128b8adfd35c3bd2f2

### Argos diff
https://app.argos-ci.com/mui/mui-x/builds/17026

### Before
https://codesandbox.io/p/sandbox/runtime-https-pdmpzq?file=%2Fsrc%2FDemo.tsx%3A39%2C31

### After
https://codesandbox.io/p/sandbox/naughty-babycat-nmxjc9?file=%2Fsrc%2FDemo.tsx%3A28%2C49

Seeing the difference makes me question this direction. 🤔 
The fact that for `DatePicker` we are using only text also raises further questions. 🤔 

IMHO the `DatePicker` and `TimePicker` are the biggest outliers and changes in their look are most disturbing. 🤷 