### PR TITLE
[core] Cleanup script and alias setup

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,7 +18,9 @@ const defaultAlias = {
   '@mui/x-tree-view': resolveAliasPath('./packages/x-tree-view/src'),
   '@mui/markdown': '@mui/monorepo/packages/markdown',
   '@mui/material-nextjs': '@mui/monorepo/packages/mui-material-nextjs/src',
-  '@mui-internal/api-docs-builder': resolveAliasPath('./node_modules/@mui/monorepo/packages/api-docs-builder'),
+  '@mui-internal/api-docs-builder': resolveAliasPath(
+    './node_modules/@mui/monorepo/packages/api-docs-builder',
+  ),
   '@mui-internal/docs-utilities': '@mui/monorepo/packages/docs-utilities',
   '@mui-internal/test-utils': resolveAliasPath(
     './node_modules/@mui/monorepo/packages/test-utils/src',

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,7 +18,7 @@ const defaultAlias = {
   '@mui/x-tree-view': resolveAliasPath('./packages/x-tree-view/src'),
   '@mui/markdown': '@mui/monorepo/packages/markdown',
   '@mui/material-nextjs': '@mui/monorepo/packages/mui-material-nextjs/src',
-  '@mui-internal/api-docs-builder': '@mui/monorepo/packages/api-docs-builder',
+  '@mui-internal/api-docs-builder': resolveAliasPath('./node_modules/@mui/monorepo/packages/api-docs-builder'),
   '@mui-internal/docs-utilities': '@mui/monorepo/packages/docs-utilities',
   '@mui-internal/test-utils': resolveAliasPath(
     './node_modules/@mui/monorepo/packages/test-utils/src',

--- a/docs/scripts/generateProptypes.ts
+++ b/docs/scripts/generateProptypes.ts
@@ -6,7 +6,7 @@ import {
   getPropTypesFromFile,
   injectPropTypesInFile,
 } from '@mui/monorepo/packages/typescript-to-proptypes';
-import { fixBabelGeneratorIssues, fixLineEndings } from '@mui/monorepo/packages/docs-utilities';
+import { fixBabelGeneratorIssues, fixLineEndings } from '@mui-internal/docs-utilities';
 import { createXTypeScriptProjects, XTypeScriptProject } from './createXTypeScriptProjects';
 
 async function generateProptypes(project: XTypeScriptProject, sourceFile: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,8 @@
       "@mui/x-license-pro/*": ["./packages/x-license-pro/src/*"],
       "@mui-internal/test-utils": ["./node_modules/@mui/monorepo/packages/test-utils/src"],
       "@mui-internal/test-utils/*": ["./node_modules/@mui/monorepo/packages/test-utils/src/*"],
+      "@mui-internal/api-docs-builder": ["./node_modules/@mui/monorepo/packages/api-docs-builder"],
+      "@mui-internal/api-docs-builder/*": ["./node_modules/@mui/monorepo/packages/api-docs-builder/*"],
       "test/*": ["./test/*"],
       "docs/*": ["./node_modules/@mui/monorepo/docs"],
       "docsx/*": ["./docs/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,11 @@
       "@mui-internal/test-utils": ["./node_modules/@mui/monorepo/packages/test-utils/src"],
       "@mui-internal/test-utils/*": ["./node_modules/@mui/monorepo/packages/test-utils/src/*"],
       "@mui-internal/api-docs-builder": ["./node_modules/@mui/monorepo/packages/api-docs-builder"],
-      "@mui-internal/api-docs-builder/*": ["./node_modules/@mui/monorepo/packages/api-docs-builder/*"],
+      "@mui-internal/api-docs-builder/*": [
+        "./node_modules/@mui/monorepo/packages/api-docs-builder/*"
+      ],
+      "@mui-internal/docs-utilities": ["./node_modules/@mui/monorepo/packages/docs-utilities"],
+      "@mui-internal/docs-utilities/*": ["./node_modules/@mui/monorepo/packages/docs-utilities/*"],
       "test/*": ["./test/*"],
       "docs/*": ["./node_modules/@mui/monorepo/docs"],
       "docsx/*": ["./docs/*"]


### PR DESCRIPTION
Extracted a few core fixes from https://github.com/mui/mui-x/pull/9528

Avoid the `Could not resolve` errors when running `proptypes` or `docs:api` scripts.


### Before
![Screenshot 2024-01-19 at 14 55 31](https://github.com/mui/mui-x/assets/4941090/91a24451-3f3b-44db-bb90-5c99e72f8ceb)

### After
![Screenshot 2024-01-19 at 15 05 36](https://github.com/mui/mui-x/assets/4941090/b206e849-dd2c-4e74-bfd0-362dc0e8afe5)
