### PR TITLE
[DateRangePicker] Remove `calendars` prop on `Mobile`

### DIFF
--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -1,10 +1,6 @@
 {
   "props": {
     "autoFocus": { "type": { "name": "bool" } },
-    "calendars": {
-      "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
-      "default": "2"
-    },
     "closeOnSelect": {
       "type": { "name": "bool" },
       "default": "`true` for desktop, `false` for mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop)."

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -3,7 +3,7 @@
     "autoFocus": { "type": { "name": "bool" } },
     "calendars": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },
-      "default": "2"
+      "default": "1 if `displayStaticWrapperAs === 'mobile'`, 2 otherwise."
     },
     "currentMonthCalendarPosition": {
       "type": { "name": "enum", "description": "1<br>&#124;&nbsp;2<br>&#124;&nbsp;3" },

--- a/docs/translations/api-docs/date-pickers/mobile-date-range-picker/mobile-date-range-picker.json
+++ b/docs/translations/api-docs/date-pickers/mobile-date-range-picker/mobile-date-range-picker.json
@@ -4,9 +4,6 @@
     "autoFocus": {
       "description": "If <code>true</code>, the main element is focused during the first mount. This main element is: - the element chosen by the visible view if any (i.e: the selected day on the <code>day</code> view). - the <code>input</code> element if there is a field rendered."
     },
-    "calendars": {
-      "description": "The number of calendars to render on <strong>desktop</strong>."
-    },
     "closeOnSelect": {
       "description": "If <code>true</code>, the popover or modal will close after submitting the full date."
     },

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
@@ -97,11 +97,6 @@ export interface ExportedDateRangeCalendarProps<TDate>
    */
   onMonthChange?: (month: TDate) => void;
   /**
-   * The number of calendars to render.
-   * @default 2
-   */
-  calendars?: 1 | 2 | 3;
-  /**
    * Position the current month is rendered in.
    * @default 1
    */
@@ -138,6 +133,11 @@ export interface DateRangeCalendarProps<TDate>
    * @param {PickerSelectionState | undefined} selectionState Indicates if the date range selection is complete.
    */
   onChange?: (value: DateRange<TDate>, selectionState?: PickerSelectionState) => void;
+  /**
+   * The number of calendars to render.
+   * @default 2
+   */
+  calendars?: 1 | 2 | 3;
   className?: string;
   classes?: Partial<DateRangeCalendarClasses>;
   /**

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -88,11 +88,6 @@ MobileDateRangePicker.propTypes = {
    * - the `input` element if there is a field rendered.
    */
   autoFocus: PropTypes.bool,
-  /**
-   * The number of calendars to render on **desktop**.
-   * @default 2
-   */
-  calendars: PropTypes.oneOf([1, 2, 3]),
   className: PropTypes.string,
   /**
    * If `true`, the popover or modal will close after submitting the full date.

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -44,6 +44,7 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
   const props = {
     ...defaultizedProps,
     viewRenderers,
+    // Force one calendar on mobile to avoid layout issues
     calendars: 1,
     views: ['day'] as const,
     openTo: 'day' as const,

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.types.ts
@@ -22,11 +22,6 @@ export interface MobileDateRangePickerProps<TDate>
   extends BaseDateRangePickerProps<TDate>,
     MobileRangeOnlyPickerProps<TDate> {
   /**
-   * The number of calendars to render on **desktop**.
-   * @default 2
-   */
-  calendars?: 1 | 2 | 3;
-  /**
    * Overridable component slots.
    * @default {}
    */

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -81,7 +81,7 @@ StaticDateRangePicker.propTypes = {
   autoFocus: PropTypes.bool,
   /**
    * The number of calendars to render.
-   * @default 2
+   * @default 1 if `displayStaticWrapperAs === 'mobile'`, 2 otherwise.
    */
   calendars: PropTypes.oneOf([1, 2, 3]),
   className: PropTypes.string,

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.types.ts
@@ -22,6 +22,11 @@ export interface StaticDateRangePickerProps<TDate>
   extends BaseDateRangePickerProps<TDate>,
     MakeOptional<StaticRangeOnlyPickerProps, 'displayStaticWrapperAs'> {
   /**
+   * The number of calendars to render.
+   * @default 1 if `displayStaticWrapperAs === 'mobile'`, 2 otherwise.
+   */
+  calendars?: 1 | 2 | 3;
+  /**
    * Overridable component slots.
    * @default {}
    */


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-x/pull/9528

Relevant commits with discussions from that PR: https://github.com/mui/mui-x/pull/9528/commits/6b772d9fe3d30018bccaa9f1d369874a23e1cee4, https://github.com/mui/mui-x/pull/9528/commits/4875a16e520fab0e3fcdd586a659b5b93500a1bb.

WDYT, should we ship it in v6 as well?
You could say that it is a BC, but at the same time - it never worked anyways and I'd say it's more of a (bug/TS)fix. 🤷 