### PR TITLE
[docs] Fix use of quote, should use callout

### DIFF
--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -27,8 +27,10 @@ Alternatively, if you would like to delete a row, you would need to pass an extr
 apiRef.current.updateRows([{ id: 1, _action: 'delete' }]);
 ```
 
-> The free version of the `DataGrid` is limited to a single row update per `apiRef.current.updateRows` call.
-> Multiple row updates at a time are supported in [Pro](/x/introduction/licensing/#pro-plan) and [Premium](/x/introduction/licensing/#premium-plan) plans.
+:::info
+The free version of the `DataGrid` is limited to a single row update per `apiRef.current.updateRows` call.
+Multiple row updates at a time are supported in [Pro](/x/introduction/licensing/#pro-plan) and [Premium](/x/introduction/licensing/#premium-plan) plans.
+:::
 
 ## Infinite loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 


### PR DESCRIPTION
I found this by chance weird.

<img src="https://github.com/mui/mui-x/assets/3165635/be23be2c-bd91-4e1d-b383-240cc061dc51" width="791">

https://deploy-preview-11758--material-ui-x.netlify.app/x/react-data-grid/row-updates/#the-updaterows-method

I checked, and it's the only issue on MUI X's codebase. But there are more on the core:

- https://mui.com/system/styled/#how-can-i-use-the-sx-syntax-with-the-styled-utility
- https://mui.com/blog/callback-support-in-style-overrides/#experimental-sx-function
- https://mui.com/blog/docs-restructure-2022/#what-has-changed
- https://mui.com/blog/material-ui-is-now-mui/#a-new-website-amp-documentation

