### PR TITLE
[TreeView] Remove unused props from prop-types and typing

### DIFF
--- a/docs/pages/x/api/tree-view/simple-tree-view.json
+++ b/docs/pages/x/api/tree-view/simple-tree-view.json
@@ -10,24 +10,6 @@
     "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
     "disableSelection": { "type": { "name": "bool" }, "default": "false" },
     "expandedNodes": { "type": { "name": "arrayOf", "description": "Array&lt;string&gt;" } },
-    "getItemId": {
-      "type": { "name": "func" },
-      "default": "`(item) => item.id`",
-      "signature": {
-        "type": "function(item: R) => string",
-        "describedArgs": ["item"],
-        "returned": "string"
-      }
-    },
-    "getItemLabel": {
-      "type": { "name": "func" },
-      "default": "`(item) => item.label`",
-      "signature": {
-        "type": "function(item: R) => string",
-        "describedArgs": ["item"],
-        "returned": "string"
-      }
-    },
     "id": { "type": { "name": "string" } },
     "multiSelect": { "type": { "name": "bool" }, "default": "false" },
     "onExpandedNodesChange": {

--- a/docs/pages/x/api/tree-view/tree-view.json
+++ b/docs/pages/x/api/tree-view/tree-view.json
@@ -10,24 +10,6 @@
     "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
     "disableSelection": { "type": { "name": "bool" }, "default": "false" },
     "expandedNodes": { "type": { "name": "arrayOf", "description": "Array&lt;string&gt;" } },
-    "getItemId": {
-      "type": { "name": "func" },
-      "default": "`(item) => item.id`",
-      "signature": {
-        "type": "function(item: R) => string",
-        "describedArgs": ["item"],
-        "returned": "string"
-      }
-    },
-    "getItemLabel": {
-      "type": { "name": "func" },
-      "default": "`(item) => item.label`",
-      "signature": {
-        "type": "function(item: R) => string",
-        "describedArgs": ["item"],
-        "returned": "string"
-      }
-    },
     "id": { "type": { "name": "string" } },
     "multiSelect": { "type": { "name": "bool" }, "default": "false" },
     "onExpandedNodesChange": {

--- a/docs/translations/api-docs/tree-view/simple-tree-view/simple-tree-view.json
+++ b/docs/translations/api-docs/tree-view/simple-tree-view/simple-tree-view.json
@@ -16,14 +16,6 @@
     "expandedNodes": {
       "description": "Expanded node ids. Used when the item&#39;s expansion is controlled."
     },
-    "getItemId": {
-      "description": "Used to determine the string label for a given item.",
-      "typeDescriptions": { "item": "The item to check.", "string": "The id of the item." }
-    },
-    "getItemLabel": {
-      "description": "Used to determine the string label for a given item.",
-      "typeDescriptions": { "item": "The item to check.", "string": "The label of the item." }
-    },
     "id": {
       "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
     },

--- a/docs/translations/api-docs/tree-view/tree-view/tree-view.json
+++ b/docs/translations/api-docs/tree-view/tree-view/tree-view.json
@@ -16,14 +16,6 @@
     "expandedNodes": {
       "description": "Expanded node ids. Used when the item&#39;s expansion is controlled."
     },
-    "getItemId": {
-      "description": "Used to determine the string label for a given item.",
-      "typeDescriptions": { "item": "The item to check.", "string": "The id of the item." }
-    },
-    "getItemLabel": {
-      "description": "Used to determine the string label for a given item.",
-      "typeDescriptions": { "item": "The item to check.", "string": "The label of the item." }
-    },
     "id": {
       "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide this prop. It falls back to a randomly generated id."
     },

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.plugins.ts
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.plugins.ts
@@ -20,4 +20,7 @@ export type SimpleTreeViewPluginSlotProps = DefaultTreeViewPluginSlotProps;
 
 // We can't infer this type from the plugin, otherwise we would lose the generics.
 export interface SimpleTreeViewPluginParameters<Multiple extends boolean | undefined>
-  extends Omit<DefaultTreeViewPluginParameters<any, Multiple>, 'items' | 'isItemDisabled'> {}
+  extends Omit<
+    DefaultTreeViewPluginParameters<any, Multiple>,
+    'items' | 'isItemDisabled' | 'getItemLabel' | 'getItemId'
+  > {}

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -146,24 +146,6 @@ SimpleTreeView.propTypes = {
    */
   expandedNodes: PropTypes.arrayOf(PropTypes.string),
   /**
-   * Used to determine the string label for a given item.
-   *
-   * @template R
-   * @param {R} item The item to check.
-   * @returns {string} The id of the item.
-   * @default `(item) => item.id`
-   */
-  getItemId: PropTypes.func,
-  /**
-   * Used to determine the string label for a given item.
-   *
-   * @template R
-   * @param {R} item The item to check.
-   * @returns {string} The label of the item.
-   * @default `(item) => item.label`
-   */
-  getItemLabel: PropTypes.func,
-  /**
    * This prop is used to help implement the accessibility logic.
    * If you don't provide this prop. It falls back to a randomly generated id.
    */

--- a/packages/x-tree-view/src/TreeView/TreeView.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.tsx
@@ -123,24 +123,6 @@ TreeView.propTypes = {
    */
   expandedNodes: PropTypes.arrayOf(PropTypes.string),
   /**
-   * Used to determine the string label for a given item.
-   *
-   * @template R
-   * @param {R} item The item to check.
-   * @returns {string} The id of the item.
-   * @default `(item) => item.id`
-   */
-  getItemId: PropTypes.func,
-  /**
-   * Used to determine the string label for a given item.
-   *
-   * @template R
-   * @param {R} item The item to check.
-   * @returns {string} The label of the item.
-   * @default `(item) => item.label`
-   */
-  getItemLabel: PropTypes.func,
-  /**
    * This prop is used to help implement the accessibility logic.
    * If you don't provide this prop. It falls back to a randomly generated id.
    */


### PR DESCRIPTION
Those props are specific to the `RichTreeView`