### PR TITLE
[pickers] Apply the `layout.tabs` class to `Tabs` slot

### DIFF
--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import Tab from '@mui/material/Tab';
 import Tabs, { tabsClasses } from '@mui/material/Tabs';
 import { styled, useThemeProps } from '@mui/material/styles';
-import { unstable_composeClasses as composeClasses } from '@mui/utils';
+import composeClasses from '@mui/utils/composeClasses';
 import { TimeIcon, DateRangeIcon } from '../icons';
 import { DateOrTimeViewWithMeridiem } from '../internals/models';
 import { useLocaleText } from '../internals/hooks/useUtils';
@@ -101,6 +102,7 @@ const DateTimePickerTabs = function DateTimePickerTabs(inProps: DateTimePickerTa
     timeIcon = <TimeIcon />,
     view,
     hidden = typeof window === 'undefined' || window.innerHeight < 667,
+    className,
   } = props;
 
   const localeText = useLocaleText();
@@ -120,7 +122,7 @@ const DateTimePickerTabs = function DateTimePickerTabs(inProps: DateTimePickerTa
       variant="fullWidth"
       value={viewToTab(view)}
       onChange={handleChange}
-      className={classes.root}
+      className={clsx(className, classes.root)}
     >
       <Tab
         value="date"

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -147,6 +147,7 @@ DateTimePickerTabs.propTypes = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
+  className: PropTypes.string,
   /**
    * Date tab icon.
    * @default DateRange

--- a/packages/x-date-pickers/src/PickersLayout/pickersLayoutClasses.ts
+++ b/packages/x-date-pickers/src/PickersLayout/pickersLayoutClasses.ts
@@ -1,7 +1,5 @@
-import {
-  unstable_generateUtilityClass as generateUtilityClass,
-  unstable_generateUtilityClasses as generateUtilityClasses,
-} from '@mui/utils';
+import generateUtilityClass from '@mui/utils/generateUtilityClass';
+import generateUtilityClasses from '@mui/utils/generateUtilityClasses';
 
 export interface PickersLayoutClasses {
   /** Styles applied to the root element. */
@@ -28,5 +26,5 @@ export function getPickersLayoutUtilityClass(slot: string) {
 
 export const pickersLayoutClasses = generateUtilityClasses<PickersLayoutClassKey>(
   'MuiPickersLayout',
-  ['root', 'landscape', 'contentWrapper', 'toolbar', 'actionBar', 'shortcuts'],
+  ['root', 'landscape', 'contentWrapper', 'toolbar', 'actionBar', 'tabs', 'shortcuts'],
 );

--- a/packages/x-date-pickers/src/PickersLayout/usePickerLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/usePickerLayout.tsx
@@ -116,7 +116,9 @@ const usePickerLayout = <TValue, TDate, TView extends DateOrTimeViewWithMeridiem
 
   const Tabs = slots?.tabs;
   const tabs =
-    view && Tabs ? <Tabs view={view} onViewChange={onViewChange} {...slotProps?.tabs} /> : null;
+    view && Tabs ? (
+      <Tabs view={view} onViewChange={onViewChange} className={classes.tabs} {...slotProps?.tabs} />
+    ) : null;
 
   // Shortcuts
 

--- a/packages/x-date-pickers/src/internals/models/props/tabs.ts
+++ b/packages/x-date-pickers/src/internals/models/props/tabs.ts
@@ -11,6 +11,7 @@ export interface BaseTabsProps<TView extends DateOrTimeViewWithMeridiem> {
    * @param {TView} view The view to open
    */
   onViewChange: (view: TView) => void;
+  className?: string;
 }
 
 export interface ExportedBaseTabsProps {}


### PR DESCRIPTION
Extract bug-fix from https://github.com/mui/mui-x/pull/9528/commits/bb7d90bbc073ddc77baea8a9cd3a74a9444bab9f

### Before
![Screenshot 2024-01-22 at 16 35 31](https://github.com/mui/mui-x/assets/4941090/16db5710-894b-4988-b641-4509f4b5ddff)

### After
![Screenshot 2024-01-22 at 16 38 26](https://github.com/mui/mui-x/assets/4941090/ea19d232-c2b0-4db2-83f2-796b1c86309d)
