### PR TITLE
[DataGrid] Initialize `apiRef` early

### DIFF
--- a/packages/grid/x-data-grid/src/hooks/core/useGridApiInitialization.ts
+++ b/packages/grid/x-data-grid/src/hooks/core/useGridApiInitialization.ts
@@ -141,6 +141,10 @@ export function useGridApiInitialization<
 
   useGridApiMethod(privateApiRef, { subscribeEvent, publishEvent } as any, 'public');
 
+  if (inputApiRef && !inputApiRef.current?.state) {
+    inputApiRef.current = publicApiRef.current;
+  }
+
   React.useImperativeHandle(inputApiRef, () => publicApiRef.current, [publicApiRef]);
 
   React.useEffect(() => {

--- a/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/rows.DataGrid.test.tsx
@@ -31,6 +31,7 @@ import {
   getRow,
   getActiveCell,
   getCell,
+  microtasks,
 } from 'test/utils/helperFn';
 import Dialog from '@mui/material/Dialog';
 
@@ -311,6 +312,7 @@ describe('<DataGrid /> - Rows', () => {
       await waitFor(() => {
         expect(getRow(0)).not.to.have.class('Mui-selected');
       });
+      await microtasks();
     });
 
     it('should not select the row when opening the menu', async () => {


### PR DESCRIPTION
I need this for https://github.com/mui/mui-x/pull/11164, where I use `apiRef` in the `sortComparator` for the grouping column + `sortingModel` in the `initialState`.
The demo throws an error, because when initial sorting happens the `apiRef` is not initialized yet (this is also the reason why [Netlify deployment fails](https://app.netlify.com/sites/material-ui-x/deploys/65afb15407d3a90008444ea9))

A simpler example to illustrate the issue:
Before: https://codesandbox.io/p/sandbox/gallant-wu-gh2svt
After: https://codesandbox.io/p/sandbox/heuristic-spence-nmkx2w