### PR TITLE
[code-infra] Integrate changes from Core's #40842

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,11 +21,9 @@ const defaultAlias = {
   '@mui-internal/api-docs-builder': resolveAliasPath(
     './node_modules/@mui/monorepo/packages/api-docs-builder',
   ),
-  '@mui-internal/docs-utilities': '@mui/monorepo/packages/docs-utilities',
   '@mui-internal/test-utils': resolveAliasPath(
     './node_modules/@mui/monorepo/packages/test-utils/src',
   ),
-  'typescript-to-proptypes': '@mui/monorepo/packages/typescript-to-proptypes/src',
   docs: resolveAliasPath('./node_modules/@mui/monorepo/docs'),
   test: resolveAliasPath('./test'),
   packages: resolveAliasPath('./packages'),

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -16,7 +16,6 @@ const alias = {
   '@mui/monorepo': '../node_modules/@mui/monorepo',
   '@mui/material-nextjs': '../node_modules/@mui/monorepo/packages/mui-material-nextjs/src',
   '@mui-internal/api-docs-builder': '../node_modules/@mui/monorepo/packages/api-docs-builder',
-  '@mui-internal/docs-utilities': '../node_modules/@mui/monorepo/packages/docs-utilities',
   docs: '../node_modules/@mui/monorepo/docs',
   docsx: './',
 };

--- a/docs/package.json
+++ b/docs/package.json
@@ -92,8 +92,8 @@
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@mui-internal/docs-utils": "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils",
-    "@mui-internal/typescript-to-proptypes": "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/typescript-to-proptypes",
+    "@mui-internal/docs-utils": "^1.0.0",
+    "@mui-internal/typescript-to-proptypes": "^1.0.2",
     "@types/doctrine": "^0.0.9",
     "@types/stylis": "^4.2.5",
     "cpy-cli": "^5.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -92,10 +92,11 @@
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
+    "@mui-internal/docs-utils": "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils",
+    "@mui-internal/typescript-to-proptypes": "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/typescript-to-proptypes",
     "@types/doctrine": "^0.0.9",
     "@types/stylis": "^4.2.5",
     "cpy-cli": "^5.0.0",
-    "gm": "^1.25.0",
-    "typescript-to-proptypes": "^2.2.1"
+    "gm": "^1.25.0"
   }
 }

--- a/docs/scripts/createXTypeScriptProjects.ts
+++ b/docs/scripts/createXTypeScriptProjects.ts
@@ -3,7 +3,7 @@ import {
   createTypeScriptProject,
   CreateTypeScriptProjectOptions,
   TypeScriptProject,
-} from '@mui/monorepo/packages/api-docs-builder/utils/createTypeScriptProject';
+} from '@mui-internal/docs-utils';
 import { getComponentFilesInFolder } from './utils';
 
 const workspaceRoot = path.resolve(__dirname, '../../');

--- a/docs/scripts/generateProptypes.ts
+++ b/docs/scripts/generateProptypes.ts
@@ -2,11 +2,8 @@ import * as yargs from 'yargs';
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as prettier from 'prettier';
-import {
-  getPropTypesFromFile,
-  injectPropTypesInFile,
-} from '@mui/monorepo/packages/typescript-to-proptypes';
-import { fixBabelGeneratorIssues, fixLineEndings } from '@mui-internal/docs-utilities';
+import { getPropTypesFromFile, injectPropTypesInFile } from '@mui-internal/typescript-to-proptypes';
+import { fixBabelGeneratorIssues, fixLineEndings } from '@mui-internal/docs-utils';
 import { createXTypeScriptProjects, XTypeScriptProject } from './createXTypeScriptProjects';
 
 async function generateProptypes(project: XTypeScriptProject, sourceFile: string) {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
     "@mui/icons-material": "^5.15.7",
     "@mui/material": "^5.15.7",
-    "@mui/monorepo": "https://github.com/mui/material-ui.git#master",
+    "@mui/monorepo": "https://github.com/michaldudak/material-ui.git#npm-publishing/typescript-to-proptypes",
     "@mui/utils": "^5.15.7",
     "@next/eslint-plugin-next": "14.0.4",
     "@octokit/plugin-retry": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
     "@mui/icons-material": "^5.15.7",
     "@mui/material": "^5.15.7",
-    "@mui/monorepo": "https://github.com/michaldudak/material-ui.git#npm-publishing/typescript-to-proptypes",
+    "@mui/monorepo": "https://github.com/mui/material-ui.git#master",
     "@mui/utils": "^5.15.7",
     "@next/eslint-plugin-next": "14.0.4",
     "@octokit/plugin-retry": "^6.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,8 +32,6 @@
       "@mui-internal/api-docs-builder/*": [
         "./node_modules/@mui/monorepo/packages/api-docs-builder/*"
       ],
-      "@mui-internal/docs-utilities": ["./node_modules/@mui/monorepo/packages/docs-utilities"],
-      "@mui-internal/docs-utilities/*": ["./node_modules/@mui/monorepo/packages/docs-utilities/*"],
       "test/*": ["./test/*"],
       "docs/*": ["./node_modules/@mui/monorepo/docs"],
       "docsx/*": ["./docs/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,23 +1796,25 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
-"@mui-internal/docs-utils@https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils":
+"@mui-internal/docs-utils@1.0.0", "@mui-internal/docs-utils@^1.0.0":
   version "1.0.0"
-  resolved "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils#6e910a5684160395518813f694d3992fecd7de6c"
+  resolved "https://registry.yarnpkg.com/@mui-internal/docs-utils/-/docs-utils-1.0.0.tgz#b1cd8fafe00dca045896daa2977e26eb551b891a"
+  integrity sha512-TqbdoXrXAk9JhcsGjekriQVU6A0w7oo01CfTfm4mefcKT2Z+RhHeFzG4fJrugN718qLdolJKGMoD7f+u/yBSBw==
   dependencies:
     rimraf "^5.0.5"
     typescript "^5.1.6"
 
-"@mui-internal/typescript-to-proptypes@https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/typescript-to-proptypes":
-  version "1.0.0"
-  resolved "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/typescript-to-proptypes#529869b83fe7225e6473427e82db66363b9c5649"
+"@mui-internal/typescript-to-proptypes@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@mui-internal/typescript-to-proptypes/-/typescript-to-proptypes-1.0.2.tgz#93ccfe6f611ffc700e99570a34737842c6cc0c70"
+  integrity sha512-KpnPqY8MCQBHwmFMCZZxXwG3uREgMAbXKLBzcxlBhYxssZcYdsE/aImWE0B50QfVHBPjkNmt4dcI2UO2VEzS9w==
   dependencies:
     "@babel/core" "^7.23.7"
     "@babel/plugin-syntax-class-properties" "^7.12.13"
     "@babel/plugin-syntax-jsx" "^7.23.3"
     "@babel/plugin-syntax-typescript" "^7.23.3"
     "@babel/types" "^7.23.6"
-    "@mui-internal/docs-utils" "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils"
+    "@mui-internal/docs-utils" "1.0.0"
     doctrine "^3.0.0"
     lodash "^4.17.21"
     typescript "^5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,9 +1890,9 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/monorepo@https://github.com/michaldudak/material-ui.git#npm-publishing/typescript-to-proptypes":
+"@mui/monorepo@https://github.com/mui/material-ui.git#master":
   version "5.15.7"
-  resolved "https://github.com/michaldudak/material-ui.git#f9dffaa39d8a9a1a3be66e09a848106bc4d4335e"
+  resolved "https://github.com/mui/material-ui.git#475e186f1e31d194e1d80621effa8a866411ec30"
   dependencies:
     "@googleapis/sheets" "^5.0.5"
     "@slack/bolt" "^3.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,7 +193,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
-"@babel/core@^7.11.1", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.23.9", "@babel/core@^7.7.5":
+"@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.23.7", "@babel/core@^7.23.9", "@babel/core@^7.7.5":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
   integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
@@ -529,7 +529,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.10.4", "@babel/plugin-syntax-class-properties@^7.12.13":
+"@babel/plugin-syntax-class-properties@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
   integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
@@ -592,7 +592,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.10.4", "@babel/plugin-syntax-jsx@^7.23.3":
+"@babel/plugin-syntax-jsx@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz#8f2e4f8a9b5f9aa16067e142c1ac9cd9f810f473"
   integrity sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==
@@ -1318,7 +1318,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.11.0", "@babel/types@^7.2.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.4.4", "@babel/types@^7.6.1":
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.19", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.4", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.4.4", "@babel/types@^7.6.1":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
   integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
@@ -1796,6 +1796,28 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
+"@mui-internal/docs-utils@https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils":
+  version "1.0.0"
+  resolved "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils#6e910a5684160395518813f694d3992fecd7de6c"
+  dependencies:
+    rimraf "^5.0.5"
+    typescript "^5.1.6"
+
+"@mui-internal/typescript-to-proptypes@https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/typescript-to-proptypes":
+  version "1.0.0"
+  resolved "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/typescript-to-proptypes#529869b83fe7225e6473427e82db66363b9c5649"
+  dependencies:
+    "@babel/core" "^7.23.7"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.23.3"
+    "@babel/plugin-syntax-typescript" "^7.23.3"
+    "@babel/types" "^7.23.6"
+    "@mui-internal/docs-utils" "https://pkg.csb.dev/mui/material-ui/commit/a7883c38/@mui-internal/docs-utils"
+    doctrine "^3.0.0"
+    lodash "^4.17.21"
+    typescript "^5.3.3"
+    uuid "^9.0.1"
+
 "@mui/base@5.0.0-beta.34", "@mui/base@^5.0.0-beta.34":
   version "5.0.0-beta.34"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.34.tgz#44b0f203250a6e3b2d810f37c9720d114182abd0"
@@ -1866,9 +1888,9 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/monorepo@https://github.com/mui/material-ui.git#master":
+"@mui/monorepo@https://github.com/michaldudak/material-ui.git#npm-publishing/typescript-to-proptypes":
   version "5.15.7"
-  resolved "https://github.com/mui/material-ui.git#19ff6ada02dafa827531653801a3b657d58047ba"
+  resolved "https://github.com/michaldudak/material-ui.git#f9dffaa39d8a9a1a3be66e09a848106bc4d4335e"
   dependencies:
     "@googleapis/sheets" "^5.0.5"
     "@slack/bolt" "^3.17.1"
@@ -7952,9 +7974,9 @@ gm@^1.25.0:
     debug "^3.1.0"
 
 google-auth-library@^9.0.0, google-auth-library@^9.5.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.6.0.tgz#47a20aad0a358e9798c2adc489a89f1938e9c3ff"
-  integrity sha512-bM/buCwCeYZjmnzGstwREu3BsnbmnuI064ZGur0NmHyXUxubWMJTCO9kxsyy4T6jdzacHJY3XQWHxX4D4Mc+EA==
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.5.0.tgz#fd97b78bc1512025b9c9ad3998c60e2d75b6137e"
+  integrity sha512-OUbP509lWVlZxuMY+Cgomw49VzZFP9myIcVeYEpeBlbXJbPC4R+K4BmO9hd3ciYM5QIwm5W1PODcKjqxtkye9Q==
   dependencies:
     base64-js "^1.3.0"
     ecdsa-sig-formatter "^1.0.11"
@@ -10035,7 +10057,7 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -14246,7 +14268,7 @@ tslib@2.5.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-tslib@^1.13.0, tslib@^1.8.1:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -14406,27 +14428,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript-to-proptypes@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/typescript-to-proptypes/-/typescript-to-proptypes-2.2.1.tgz#45fd201f6526bc45da3c5c0faa3b00cc23707613"
-  integrity sha512-FxVo0Rcf/c6dmHxA1DlAmpxct+1SuuDyX3Rl8MkfQt//yvZCMhWOuWZvJ3aP0/5eZTYIb+DpPt7htTL6A1xK9A==
-  dependencies:
-    "@babel/core" "^7.11.1"
-    "@babel/plugin-syntax-class-properties" "^7.10.4"
-    "@babel/plugin-syntax-jsx" "^7.10.4"
-    "@babel/types" "^7.11.0"
-    doctrine "^3.0.0"
-    lodash "^4.17.14"
-    tslib "^1.13.0"
-    typescript "3.8.3"
-    uuid "^8.1.0"
-
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-"typescript@>=3 < 6", typescript@^5.3.3:
+"typescript@>=3 < 6", typescript@^5.1.6, typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
@@ -14685,12 +14687,12 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.1.0, uuid@^8.3.0, uuid@^8.3.2:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==


### PR DESCRIPTION
Includes changes necessary to include code from https://github.com/mui/material-ui/pull/40842

It changes usage of `@mui-internal/docs-utils` and `@mui-internal/typescript-to-proptypes` from monorepo to npm packages.

~~Note - as of Jan 29, these packages are not actually published to npm - this PR uses the Codesandbox CI artifacts. I'll push them to npm when I'm certain they work.~~ The packages are published to npm.