### PR TITLE
[pickers] Add `DateTimeRangePicker` theme augmentation

### DIFF
--- a/docs/translations/api-docs/date-pickers/date-time-picker-tabs/date-time-picker-tabs.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker-tabs/date-time-picker-tabs.json
@@ -5,7 +5,7 @@
     "dateIcon": { "description": "Date tab icon." },
     "hidden": { "description": "Toggles visibility of the tabs allowing view switching." },
     "onViewChange": {
-      "description": "Callback called when a tab is clicked",
+      "description": "Callback called when a tab is clicked.",
       "typeDescriptions": { "view": "The view to open" }
     },
     "timeIcon": { "description": "Time tab icon." },

--- a/docs/translations/api-docs/date-pickers/date-time-range-picker-tabs/date-time-range-picker-tabs.json
+++ b/docs/translations/api-docs/date-pickers/date-time-range-picker-tabs/date-time-range-picker-tabs.json
@@ -5,7 +5,7 @@
     "dateIcon": { "description": "Date tab icon." },
     "hidden": { "description": "Toggles visibility of the tabs allowing view switching." },
     "onViewChange": {
-      "description": "Callback called when a tab is clicked",
+      "description": "Callback called when a tab is clicked.",
       "typeDescriptions": { "view": "The view to open" }
     },
     "timeIcon": { "description": "Time tab icon." },

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
@@ -55,17 +55,16 @@ export interface ExportedDateTimeRangePickerTabsProps extends ExportedBaseTabsPr
    * @default TimeIcon
    */
   timeIcon?: React.ReactElement;
-}
-
-export interface DateTimeRangePickerTabsProps
-  extends ExportedDateTimeRangePickerTabsProps,
-    BaseTabsProps<DateOrTimeViewWithMeridiem>,
-    Pick<UseRangePositionResponse, 'rangePosition' | 'onRangePositionChange'> {
   /**
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<DateTimeRangePickerTabsClasses>;
 }
+
+export interface DateTimeRangePickerTabsProps
+  extends ExportedDateTimeRangePickerTabsProps,
+    BaseTabsProps<DateOrTimeViewWithMeridiem>,
+    Pick<UseRangePositionResponse, 'rangePosition' | 'onRangePositionChange'> {}
 
 const useUtilityClasses = (ownerState: DateTimeRangePickerTabsProps) => {
   const { classes } = ownerState;

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
@@ -223,7 +223,7 @@ DateTimeRangePickerTabs.propTypes = {
   hidden: PropTypes.bool,
   onRangePositionChange: PropTypes.func.isRequired,
   /**
-   * Callback called when a tab is clicked
+   * Callback called when a tab is clicked.
    * @template TView
    * @param {TView} view The view to open
    */

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
@@ -38,13 +38,15 @@ type DateTimeRangeViews = Exclude<DateOrTimeViewWithMeridiem, 'year' | 'month'>;
 
 export interface DateTimeRangePickerToolbarProps<TDate>
   extends BaseToolbarProps<DateRange<TDate>, DateTimeRangeViews>,
-    Pick<UseRangePositionResponse, 'rangePosition' | 'onRangePositionChange'> {
-  classes?: Partial<DateTimeRangePickerToolbarClasses>;
+    Pick<UseRangePositionResponse, 'rangePosition' | 'onRangePositionChange'>,
+    ExportedDateTimeRangePickerToolbarProps {
   ampm?: boolean;
   toolbarVariant?: WrapperVariant;
 }
 
-export interface ExportedDateTimeRangePickerToolbarProps extends ExportedBaseToolbarProps {}
+export interface ExportedDateTimeRangePickerToolbarProps extends ExportedBaseToolbarProps {
+  classes?: Partial<DateTimeRangePickerToolbarClasses>;
+}
 
 const DateTimeRangePickerToolbarRoot = styled('div', {
   name: 'MuiDateTimeRangePickerToolbar',

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.types.ts
@@ -17,7 +17,7 @@ export interface DesktopDateTimeRangePickerSlots<TDate>
 
 export interface DesktopDateTimeRangePickerSlotProps<TDate>
   extends BaseDateTimeRangePickerSlotProps<TDate>,
-    Omit<UseDesktopRangePickerSlotProps<TDate, DateTimeRangePickerView>, 'tabs'> {}
+    Omit<UseDesktopRangePickerSlotProps<TDate, DateTimeRangePickerView>, 'tabs' | 'toolbar'> {}
 
 export interface DesktopDateTimeRangePickerProps<TDate>
   extends BaseDateTimeRangePickerProps<TDate>,

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.types.ts
@@ -17,7 +17,7 @@ export interface MobileDateTimeRangePickerSlots<TDate>
 
 export interface MobileDateTimeRangePickerSlotProps<TDate>
   extends BaseDateTimeRangePickerSlotProps<TDate>,
-    Omit<UseMobileRangePickerSlotProps<TDate, DateTimeRangePickerView>, 'tabs'> {}
+    Omit<UseMobileRangePickerSlotProps<TDate, DateTimeRangePickerView>, 'tabs' | 'toolbar'> {}
 
 export interface MobileDateTimeRangePickerProps<TDate>
   extends BaseDateTimeRangePickerProps<TDate>,

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -13,6 +13,7 @@ import {
   BaseFieldProps,
   DateOrTimeViewWithMeridiem,
   UsePickerValueFieldResponse,
+  ExportedBaseTabsProps,
 } from '@mui/x-date-pickers/internals';
 import {
   DesktopRangePickerAdditionalViewProps,
@@ -188,7 +189,7 @@ export const useDesktopRangePicker = <
       ...slotProps?.tabs,
       rangePosition,
       onRangePositionChange,
-    },
+    } as ExportedBaseTabsProps,
     toolbar: {
       ...slotProps?.toolbar,
       rangePosition,

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -11,6 +11,7 @@ import {
   useLocaleText,
   DateOrTimeViewWithMeridiem,
   UsePickerValueFieldResponse,
+  ExportedBaseTabsProps,
 } from '@mui/x-date-pickers/internals';
 import useId from '@mui/utils/useId';
 import {
@@ -157,7 +158,7 @@ export const useMobileRangePicker = <
       ...innerSlotProps?.tabs,
       rangePosition,
       onRangePositionChange,
-    },
+    } as ExportedBaseTabsProps,
     toolbar: {
       ...innerSlotProps?.toolbar,
       titleId: labelId,

--- a/packages/x-date-pickers-pro/src/themeAugmentation/components.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/components.d.ts
@@ -9,23 +9,31 @@ export interface PickersProComponents<Theme = unknown> {
     defaultProps?: ComponentsProps['MuiDateRangePickerDay'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePickerDay'];
   };
+  MuiDateTimeRangePickerTabs?: {
+    defaultProps?: ComponentsProps['MuiDateTimeRangePickerTabs'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiDateTimeRangePickerTabs'];
+  };
   MuiDateRangePickerToolbar?: {
     defaultProps?: ComponentsProps['MuiDateRangePickerToolbar'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiDateRangePickerToolbar'];
+  };
+  MuiDateTimeRangePickerToolbar?: {
+    defaultProps?: ComponentsProps['MuiDateTimeRangePickerToolbar'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiDateTimeRangePickerToolbar'];
   };
 
   // Multi input range fields
   MuiMultiInputDateRangeField?: {
     defaultProps?: ComponentsProps['MuiMultiInputDateRangeField'];
-    styleOverrides?: ComponentsOverrides['MuiMultiInputDateRangeField'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiMultiInputDateRangeField'];
   };
   MuiMultiInputDateTimeRangeField?: {
     defaultProps?: ComponentsProps['MuiMultiInputDateTimeRangeField'];
-    styleOverrides?: ComponentsOverrides['MuiMultiInputDateTimeRangeField'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiMultiInputDateTimeRangeField'];
   };
   MuiMultiInputTimeRangeField?: {
     defaultProps?: ComponentsProps['MuiMultiInputTimeRangeField'];
-    styleOverrides?: ComponentsOverrides['MuiMultiInputTimeRangeField'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiMultiInputTimeRangeField'];
   };
 
   // Single input range fields
@@ -51,6 +59,17 @@ export interface PickersProComponents<Theme = unknown> {
   };
   MuiStaticDateRangePicker?: {
     defaultProps?: ComponentsProps['MuiStaticDateRangePicker'];
+  };
+
+  // Date Time Range Pickers
+  MuiDateTimeRangePicker?: {
+    defaultProps?: ComponentsProps['MuiDateTimeRangePicker'];
+  };
+  MuiDesktopDateTimeRangePicker?: {
+    defaultProps?: ComponentsProps['MuiDesktopDateTimeRangePicker'];
+  };
+  MuiMobileDateTimeRangePicker?: {
+    defaultProps?: ComponentsProps['MuiMobileDateTimeRangePicker'];
   };
 }
 

--- a/packages/x-date-pickers-pro/src/themeAugmentation/overrides.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/overrides.d.ts
@@ -2,12 +2,19 @@ import { DateRangePickerDayClassKey } from '../DateRangePickerDay';
 import { DateRangeCalendarClassKey } from '../DateRangeCalendar';
 import { DateRangePickerToolbarClassKey } from '../DateRangePicker';
 import { MultiInputRangeFieldClassKey } from '../models';
+import {
+  DateTimeRangePickerTabsClassKey,
+  DateTimeRangePickerToolbarClassKey,
+} from '../DateTimeRangePicker';
 
 // prettier-ignore
 export interface PickersProComponentNameToClassKey {
   MuiDateRangeCalendar: DateRangeCalendarClassKey;
   MuiDateRangePickerDay: DateRangePickerDayClassKey;
   MuiDateRangePickerToolbar: DateRangePickerToolbarClassKey;
+
+  MuiDateTimeRangePickerTabs: DateTimeRangePickerTabsClassKey;
+  MuiDateTimeRangePickerToolbar: DateTimeRangePickerToolbarClassKey;
 
   // Multi input range fields
   MuiMultiInputDateRangeField: MultiInputRangeFieldClassKey;

--- a/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
@@ -11,17 +11,18 @@ import { MultiInputDateTimeRangeFieldProps } from '../MultiInputDateTimeRangeFie
 import { MultiInputTimeRangeFieldProps } from '../MultiInputTimeRangeField';
 import { SingleInputDateTimeRangeFieldProps } from '../SingleInputDateTimeRangeField';
 import { SingleInputTimeRangeFieldProps } from '../SingleInputTimeRangeField';
-import { DateTimeRangePickerProps, DateTimeRangePickerToolbarProps } from '../DateTimeRangePicker';
+import { DateTimeRangePickerProps } from '../DateTimeRangePicker';
 import { DesktopDateTimeRangePickerProps } from '../DesktopDateTimeRangePicker';
 import { MobileDateTimeRangePickerProps } from '../MobileDateTimeRangePicker';
 import { ExportedDateTimeRangePickerTabsProps } from '../DateTimeRangePicker/DateTimeRangePickerTabs';
+import { ExportedDateTimeRangePickerToolbarProps } from '../DateTimeRangePicker/DateTimeRangePickerToolbar';
 
 export interface PickersProComponentsPropsList {
   MuiDateRangeCalendar: DateRangeCalendarProps<unknown>;
   MuiDateRangePickerDay: DateRangePickerDayProps<unknown>;
   MuiDateTimeRangePickerTabs: ExportedDateTimeRangePickerTabsProps;
   MuiDateRangePickerToolbar: DateRangePickerToolbarProps<unknown>;
-  MuiDateTimeRangePickerToolbar: DateTimeRangePickerToolbarProps<unknown>;
+  MuiDateTimeRangePickerToolbar: ExportedDateTimeRangePickerToolbarProps;
 
   // Multi input range fields
   MuiMultiInputDateRangeField: MultiInputDateRangeFieldProps<unknown>;

--- a/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
@@ -11,11 +11,17 @@ import { MultiInputDateTimeRangeFieldProps } from '../MultiInputDateTimeRangeFie
 import { MultiInputTimeRangeFieldProps } from '../MultiInputTimeRangeField';
 import { SingleInputDateTimeRangeFieldProps } from '../SingleInputDateTimeRangeField';
 import { SingleInputTimeRangeFieldProps } from '../SingleInputTimeRangeField';
+import { DateTimeRangePickerProps, DateTimeRangePickerToolbarProps } from '../DateTimeRangePicker';
+import { DesktopDateTimeRangePickerProps } from '../DesktopDateTimeRangePicker';
+import { MobileDateTimeRangePickerProps } from '../MobileDateTimeRangePicker';
+import { DateTimeRangePickerTabsProps } from '../DateTimeRangePicker/DateTimeRangePickerTabs';
 
 export interface PickersProComponentsPropsList {
   MuiDateRangeCalendar: DateRangeCalendarProps<unknown>;
   MuiDateRangePickerDay: DateRangePickerDayProps<unknown>;
+  MuiDateTimeRangePickerTabs: DateTimeRangePickerTabsProps;
   MuiDateRangePickerToolbar: DateRangePickerToolbarProps<unknown>;
+  MuiDateTimeRangePickerToolbar: DateTimeRangePickerToolbarProps<unknown>;
 
   // Multi input range fields
   MuiMultiInputDateRangeField: MultiInputDateRangeFieldProps<unknown>;
@@ -32,6 +38,11 @@ export interface PickersProComponentsPropsList {
   MuiDesktopDateRangePicker: DesktopDateRangePickerProps<unknown>;
   MuiMobileDateRangePicker: MobileDateRangePickerProps<unknown>;
   MuiStaticDateRangePicker: StaticDateRangePickerProps<unknown>;
+
+  // Date Time Range Pickers
+  MuiDateTimeRangePicker: DateTimeRangePickerProps<unknown>;
+  MuiDesktopDateTimeRangePicker: DesktopDateTimeRangePickerProps<unknown>;
+  MuiMobileDateTimeRangePicker: MobileDateTimeRangePickerProps<unknown>;
 }
 
 declare module '@mui/material/styles' {

--- a/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
@@ -14,12 +14,12 @@ import { SingleInputTimeRangeFieldProps } from '../SingleInputTimeRangeField';
 import { DateTimeRangePickerProps, DateTimeRangePickerToolbarProps } from '../DateTimeRangePicker';
 import { DesktopDateTimeRangePickerProps } from '../DesktopDateTimeRangePicker';
 import { MobileDateTimeRangePickerProps } from '../MobileDateTimeRangePicker';
-import { DateTimeRangePickerTabsProps } from '../DateTimeRangePicker/DateTimeRangePickerTabs';
+import { ExportedDateTimeRangePickerTabsProps } from '../DateTimeRangePicker/DateTimeRangePickerTabs';
 
 export interface PickersProComponentsPropsList {
   MuiDateRangeCalendar: DateRangeCalendarProps<unknown>;
   MuiDateRangePickerDay: DateRangePickerDayProps<unknown>;
-  MuiDateTimeRangePickerTabs: DateTimeRangePickerTabsProps;
+  MuiDateTimeRangePickerTabs: ExportedDateTimeRangePickerTabsProps;
   MuiDateRangePickerToolbar: DateRangePickerToolbarProps<unknown>;
   MuiDateTimeRangePickerToolbar: DateTimeRangePickerToolbarProps<unknown>;
 

--- a/packages/x-date-pickers-pro/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/themeAugmentation.spec.ts
@@ -94,7 +94,7 @@ createTheme({
 
     MuiDateTimeRangePickerToolbar: {
       defaultProps: {
-        toolbarVariant: 'desktop',
+        toolbarPlaceholder: 'empty',
         // @ts-expect-error invalid MuiDateTimeRangePickerToolbar prop
         someRandomProp: true,
       },

--- a/packages/x-date-pickers-pro/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/themeAugmentation.spec.ts
@@ -5,6 +5,10 @@ import { dateRangePickerDayClasses } from '../DateRangePickerDay';
 import { multiInputDateRangeFieldClasses } from '../MultiInputDateRangeField';
 import { multiInputDateTimeRangeFieldClasses } from '../MultiInputDateTimeRangeField';
 import { multiInputTimeRangeFieldClasses } from '../MultiInputTimeRangeField';
+import {
+  dateTimeRangePickerTabsClasses,
+  dateTimeRangePickerToolbarClasses,
+} from '../DateTimeRangePicker';
 
 createTheme({
   components: {
@@ -27,6 +31,7 @@ createTheme({
         },
       },
     },
+
     MuiDateRangePickerDay: {
       defaultProps: {
         color: 'red',
@@ -46,6 +51,27 @@ createTheme({
         },
       },
     },
+
+    MuiDateTimeRangePickerTabs: {
+      defaultProps: {
+        className: 'empty',
+        // @ts-expect-error invalid MuiDateTimeRangePickerTabs prop
+        someRandomProp: true,
+      },
+      styleOverrides: {
+        root: {
+          backgroundColor: 'red',
+          [`.${dateTimeRangePickerTabsClasses.filler}`]: {
+            backgroundColor: 'green',
+          },
+        },
+        // @ts-expect-error invalid MuiDateTimeRangePickerTabs class key
+        content: {
+          backgroundColor: 'blue',
+        },
+      },
+    },
+
     MuiDateRangePickerToolbar: {
       defaultProps: {
         toolbarPlaceholder: 'empty',
@@ -60,6 +86,26 @@ createTheme({
           },
         },
         // @ts-expect-error invalid MuiDateRangePickerToolbar class key
+        content: {
+          backgroundColor: 'blue',
+        },
+      },
+    },
+
+    MuiDateTimeRangePickerToolbar: {
+      defaultProps: {
+        toolbarVariant: 'desktop',
+        // @ts-expect-error invalid MuiDateTimeRangePickerToolbar prop
+        someRandomProp: true,
+      },
+      styleOverrides: {
+        root: {
+          backgroundColor: 'red',
+          [`.${dateTimeRangePickerToolbarClasses.startToolbar}`]: {
+            backgroundColor: 'green',
+          },
+        },
+        // @ts-expect-error invalid MuiDateTimeRangePickerToolbar class key
         content: {
           backgroundColor: 'blue',
         },
@@ -86,6 +132,7 @@ createTheme({
         },
       },
     },
+
     MuiMultiInputDateTimeRangeField: {
       defaultProps: {
         disabled: true,
@@ -105,6 +152,7 @@ createTheme({
         },
       },
     },
+
     MuiMultiInputTimeRangeField: {
       defaultProps: {
         disabled: true,
@@ -133,6 +181,7 @@ createTheme({
         someRandomProp: true,
       },
     },
+
     MuiSingleInputDateTimeRangeField: {
       defaultProps: {
         disabled: true,
@@ -140,6 +189,7 @@ createTheme({
         someRandomProp: true,
       },
     },
+
     MuiSingleInputTimeRangeField: {
       defaultProps: {
         disabled: true,
@@ -156,6 +206,7 @@ createTheme({
         someRandomProp: true,
       },
     },
+
     MuiDesktopDateRangePicker: {
       defaultProps: {
         open: true,
@@ -163,6 +214,7 @@ createTheme({
         someRandomProp: true,
       },
     },
+
     MuiMobileDateRangePicker: {
       defaultProps: {
         open: true,
@@ -170,10 +222,36 @@ createTheme({
         someRandomProp: true,
       },
     },
+
     MuiStaticDateRangePicker: {
       defaultProps: {
         disabled: true,
         // @ts-expect-error invalid MuiStaticDateRangePicker prop
+        someRandomProp: true,
+      },
+    },
+
+    // Date Time Range Pickers
+    MuiDateTimeRangePicker: {
+      defaultProps: {
+        open: true,
+        // @ts-expect-error invalid MuiDateTimeRangePicker prop
+        someRandomProp: true,
+      },
+    },
+
+    MuiDesktopDateTimeRangePicker: {
+      defaultProps: {
+        open: true,
+        // @ts-expect-error invalid MuiDesktopDateTimeRangePicker prop
+        someRandomProp: true,
+      },
+    },
+
+    MuiMobileDateTimeRangePicker: {
+      defaultProps: {
+        open: true,
+        // @ts-expect-error invalid MuiMobileDateTimeRangePicker prop
         someRandomProp: true,
       },
     },

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -159,7 +159,7 @@ DateTimePickerTabs.propTypes = {
    */
   hidden: PropTypes.bool,
   /**
-   * Callback called when a tab is clicked
+   * Callback called when a tab is clicked.
    * @template TView
    * @param {TView} view The view to open
    */

--- a/packages/x-date-pickers/src/internals/models/props/tabs.ts
+++ b/packages/x-date-pickers/src/internals/models/props/tabs.ts
@@ -6,12 +6,13 @@ export interface BaseTabsProps<TView extends DateOrTimeViewWithMeridiem> {
    */
   view: TView;
   /**
-   * Callback called when a tab is clicked
+   * Callback called when a tab is clicked.
    * @template TView
    * @param {TView} view The view to open
    */
   onViewChange: (view: TView) => void;
-  className?: string;
 }
 
-export interface ExportedBaseTabsProps {}
+export interface ExportedBaseTabsProps {
+  className?: string;
+}


### PR DESCRIPTION
Continuation of https://github.com/mui/mui-x/pull/9528

- Add new theme augmentation entries.
- Fix some inconsistently exported props.