### PR TITLE
[docs] Fix <title> generation (#11182)

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -105,6 +105,7 @@ module.exports = withDocsInfra({
       },
     };
   },
+  distDir: 'export',
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
   exportPathMap: () => {
@@ -149,18 +150,25 @@ module.exports = withDocsInfra({
 
     return map;
   },
-  rewrites: async () => {
-    return [
-      { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
-      { source: '/api/:rest*', destination: '/api-docs/:rest*' },
-    ];
-  },
-  // redirects only take effect in the development, not production (because of `next export`).
-  redirects: async () => [
-    {
-      source: '/',
-      destination: '/x/introduction/',
-      permanent: false,
-    },
-  ],
+  // Used to signal we run yarn build
+  ...(process.env.NODE_ENV === 'production'
+    ? {
+        output: 'export',
+      }
+    : {
+        rewrites: async () => {
+          return [
+            { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
+            { source: '/api/:rest*', destination: '/api-docs/:rest*' },
+          ];
+        },
+        // redirects only take effect in the development, not production (because of `next export`).
+        redirects: async () => [
+          {
+            source: '/',
+            destination: '/x/introduction/',
+            permanent: false,
+          },
+        ],
+      }),
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,12 +5,11 @@
   "author": "MUI Team",
   "license": "MIT",
   "scripts": {
-    "build": "cross-env NODE_ENV=production next build --profile",
+    "build": "rimraf docs/export && cross-env NODE_ENV=production next build --profile && yarn build-sw",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev --port 3001",
     "deploy": "git push upstream master:docs-v6",
-    "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",
     "create-playground": "cpy --cwd=scripts playground.template.tsx ../../pages/playground --rename=index.tsx",

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
   publish = "docs/export/"
 
   # Default build command.
-  command = "yarn docs:build && yarn docs:export"
+  command = "yarn docs:build"
 
 [build.environment]
   NODE_VERSION = "18"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "docs:api:buildX": "cross-env BABEL_ENV=development babel-node -i \"/node_modules/(?!@mui)/\" -x .ts,.tsx,.js ./docs/scripts/api/buildApi.ts",
     "docs:link-check": "cross-env BABEL_ENV=development babel-node -i \"/node_modules/(?!@mui)/\" --extensions \".tsx,.ts,.js\" ./docs/scripts/reportBrokenLinks.js",
     "docs:build": "yarn workspace docs build",
-    "docs:export": "yarn workspace docs export",
     "docs:typescript:formatted": "yarn workspace docs typescript:transpile",
     "docs:populate:demos": "yarn workspace docs populate:demos",
     "docs:importDocsStatic": "node scripts/importDocsStatic.mjs",


### PR DESCRIPTION
Cherry pick https://github.com/mui/mui-x/pull/11182

@oliviertassinari I've seen it because of ahrefs, but then realised it's only running on `mui.com/x` and not `next.mui.com/x`

So I added a crawler on the second one to be sure we are not blind on SEO during version migration