### PR TITLE
[docs] Fix charts API links

### DIFF
--- a/docs/data/charts/areas-demo/areas-demo.md
+++ b/docs/data/charts/areas-demo/areas-demo.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Areas demonstration
+productId: x-charts
 components: LineChart, LineElement, LineHighlightElement, LineHighlightPlot, LinePlot, MarkElement, MarkPlot, AreaElement, AreaPlot
 ---
 

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Axis
+productId: x-charts
 components: ChartsAxis, ChartsReferenceLine, ChartsText
 ---
 

--- a/docs/data/charts/bar-demo/bar-demo.md
+++ b/docs/data/charts/bar-demo/bar-demo.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Bar demonstration
+productId: x-charts
 components: BarChart, BarElement, BarPlot
 ---
 

--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -1,5 +1,6 @@
 ---
 title: React Bar chart
+productId: x-charts
 components: BarChart, BarElement, BarPlot
 ---
 

--- a/docs/data/charts/components/components.md
+++ b/docs/data/charts/components/components.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Custom components
+productId: x-charts
 components: ChartsClipPath, ChartsSurface, CartesianContextProvider, DrawingProvider, HighlightProvider, InteractionProvider, SeriesContextProvider
 ---
 

--- a/docs/data/charts/composition/composition.md
+++ b/docs/data/charts/composition/composition.md
@@ -1,5 +1,6 @@
 ---
 title: React Chart composition
+productId: x-charts
 githubLabel: 'component: charts'
 components: ChartContainer, ResponsiveChartContainer
 packageName: '@mui/x-charts'

--- a/docs/data/charts/funnel/funnel.md
+++ b/docs/data/charts/funnel/funnel.md
@@ -1,5 +1,6 @@
 ---
 title: React Funnel chart
+productId: x-charts
 ---
 
 # Charts - Funnel [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧

--- a/docs/data/charts/gantt/gantt.md
+++ b/docs/data/charts/gantt/gantt.md
@@ -1,5 +1,6 @@
 ---
 title: React Gantt chart
+productId: x-charts
 ---
 
 # Charts - Gantt [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧

--- a/docs/data/charts/gauge/gauge.md
+++ b/docs/data/charts/gauge/gauge.md
@@ -1,5 +1,6 @@
 ---
 title: React Gauge chart
+productId: x-charts
 ---
 
 # Charts - Gauge 🚧

--- a/docs/data/charts/getting-started/getting-started.md
+++ b/docs/data/charts/getting-started/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: React Chart library - Getting started
+productId: x-charts
 githubLabel: 'component: charts'
 packageName: '@mui/x-charts'
 ---

--- a/docs/data/charts/heat-map/heat-map.md
+++ b/docs/data/charts/heat-map/heat-map.md
@@ -1,5 +1,6 @@
 ---
 title: React Heat map chart
+productId: x-charts
 ---
 
 # Charts - Heat map 🚧

--- a/docs/data/charts/legend/legend.md
+++ b/docs/data/charts/legend/legend.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Legend
+productId: x-charts
 components: ChartsLegend, ChartsText
 ---
 

--- a/docs/data/charts/line-demo/line-demo.md
+++ b/docs/data/charts/line-demo/line-demo.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Line demonstration
+productId: x-charts
 components: LineChart, LineElement, LineHighlightElement, LineHighlightPlot, LinePlot, MarkElement, MarkPlot
 ---
 

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -1,5 +1,6 @@
 ---
 title: React Line chart
+productId: x-charts
 components: LineChart, LineElement, LineHighlightElement, LineHighlightPlot, LinePlot, MarkElement, MarkPlot, AreaElement, AreaPlot
 ---
 

--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -1,5 +1,6 @@
 ---
 title: React Chart library
+productId: x-charts
 githubLabel: 'component: charts'
 packageName: '@mui/x-charts'
 ---

--- a/docs/data/charts/pie-demo/pie-demo.md
+++ b/docs/data/charts/pie-demo/pie-demo.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Pie demonstration
+productId: x-charts
 components: PieArc, PieArcLabel, PieArcLabelPlot, PieArcPlot, PieChart, PiePlot
 ---
 

--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -1,5 +1,6 @@
 ---
 title: React Pie chart
+productId: x-charts
 components: PieArc, PieArcLabel, PieArcLabelPlot, PieArcPlot, PieChart, PiePlot
 ---
 

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -1,5 +1,6 @@
 ---
 title: React Radar chart
+productId: x-charts
 ---
 
 # Charts - Radar 🚧

--- a/docs/data/charts/sankey/sankey.md
+++ b/docs/data/charts/sankey/sankey.md
@@ -1,5 +1,6 @@
 ---
 title: React Sankey chart
+productId: x-charts
 ---
 
 # Charts - Sankey [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧

--- a/docs/data/charts/scatter-demo/scatter-demo.md
+++ b/docs/data/charts/scatter-demo/scatter-demo.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Scatter demonstration
+productId: x-charts
 components: Scatter, ScatterChart, ScatterPlot, ChartsVoronoiHandler
 ---
 

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -1,5 +1,6 @@
 ---
 title: React Scatter chart
+productId: x-charts
 components: Scatter, ScatterChart, ScatterPlot, ChartsVoronoiHandler
 ---
 

--- a/docs/data/charts/sparkline/sparkline.md
+++ b/docs/data/charts/sparkline/sparkline.md
@@ -1,5 +1,6 @@
 ---
 title: React Sparkline chart
+productId: x-charts
 components: SparkLineChart
 ---
 

--- a/docs/data/charts/stacking/stacking.md
+++ b/docs/data/charts/stacking/stacking.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Stacking
+productId: x-charts
 ---
 
 # Charts - Stacking

--- a/docs/data/charts/styling/styling.md
+++ b/docs/data/charts/styling/styling.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Styling
+productId: x-charts
 ---
 
 # Charts - Styling

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -1,5 +1,6 @@
 ---
 title: Charts - Tooltip
+productId: x-charts
 components: ChartsAxisTooltipContent, ChartsItemTooltipContent, ChartsTooltip, DefaultChartsAxisTooltipContent, DefaultChartsItemTooltipContent, ChartsAxisHighlight
 ---
 

--- a/docs/data/charts/tree-map/tree-map.md
+++ b/docs/data/charts/tree-map/tree-map.md
@@ -1,5 +1,6 @@
 ---
 title: React Tree map chart
+productId: x-charts
 ---
 
 # Charts - Treemap 🚧


### PR DESCRIPTION
> None of the links for the API work for the Chart components :/
>
> It is generally really difficult to understand how to get all the same feature set when using compositions because all the examples use the non-composition syntax. With the broken API links it is especially difficult.
>
> Thank you for this package, I'm looking forward to using it more. I <3 MUI

I removed the cherry pick because I integrated it in https://github.com/mui/mui-x/pull/11852