### PR TITLE
Update AdapterDateFns.ts

### DIFF
--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.ts
@@ -42,8 +42,7 @@ import startOfWeek from 'date-fns/startOfWeek';
 import startOfYear from 'date-fns/startOfYear';
 import isWithinInterval from 'date-fns/isWithinInterval';
 import defaultLocale from 'date-fns/locale/en-US';
-// @ts-ignore
-import longFormatters from 'date-fns/_lib/format/longFormatters';
+import { longFormatters } from 'date-fns/_lib/format/longFormatters';
 import { AdapterFormats, AdapterOptions, MuiPickersAdapter } from '../models';
 import { AdapterDateFnsBase } from '../AdapterDateFnsBase';
 


### PR DESCRIPTION
Proper import now that date-fns longFormatters no longer exports default.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
