### PR TITLE
[TimePicker] Add missing toolbar classes descriptions

### DIFF
--- a/docs/pages/x/api/date-pickers/time-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/time-picker-toolbar.json
@@ -26,49 +26,49 @@
     {
       "key": "ampmLabel",
       "className": "MuiTimePickerToolbar-ampmLabel",
-      "description": "",
+      "description": "Styles applied to the meridiem label element.",
       "isGlobal": false
     },
     {
       "key": "ampmLandscape",
       "className": "MuiTimePickerToolbar-ampmLandscape",
-      "description": "",
+      "description": "Styles applied to the meridiem selection element in landscape mode.",
       "isGlobal": false
     },
     {
       "key": "ampmSelection",
       "className": "MuiTimePickerToolbar-ampmSelection",
-      "description": "",
+      "description": "Styles applied to the meridiem selection element.",
       "isGlobal": false
     },
     {
       "key": "hourMinuteLabel",
       "className": "MuiTimePickerToolbar-hourMinuteLabel",
-      "description": "",
+      "description": "Styles applied to the time sections element.",
       "isGlobal": false
     },
     {
       "key": "hourMinuteLabelLandscape",
       "className": "MuiTimePickerToolbar-hourMinuteLabelLandscape",
-      "description": "",
+      "description": "Styles applied to the time sections element in landscape mode.",
       "isGlobal": false
     },
     {
       "key": "hourMinuteLabelReverse",
       "className": "MuiTimePickerToolbar-hourMinuteLabelReverse",
-      "description": "",
+      "description": "Styles applied to the time sections element in \"rtl\" theme mode.",
       "isGlobal": false
     },
     {
       "key": "root",
       "className": "MuiTimePickerToolbar-root",
-      "description": "",
+      "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "separator",
       "className": "MuiTimePickerToolbar-separator",
-      "description": "",
+      "description": "Styles applied to the separator element.",
       "isGlobal": false
     }
   ],

--- a/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
@@ -13,13 +13,34 @@
     "view": { "description": "Currently visible picker view." }
   },
   "classDescriptions": {
-    "ampmLabel": { "description": "" },
-    "ampmLandscape": { "description": "" },
-    "ampmSelection": { "description": "" },
-    "hourMinuteLabel": { "description": "" },
-    "hourMinuteLabelLandscape": { "description": "" },
-    "hourMinuteLabelReverse": { "description": "" },
-    "root": { "description": "" },
-    "separator": { "description": "" }
+    "ampmLabel": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the meridiem label element"
+    },
+    "ampmLandscape": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the meridiem selection element in landscape mode"
+    },
+    "ampmSelection": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the meridiem selection element"
+    },
+    "hourMinuteLabel": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the time sections element"
+    },
+    "hourMinuteLabelLandscape": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the time sections element in landscape mode"
+    },
+    "hourMinuteLabelReverse": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the time sections element in &quot;rtl&quot; theme mode"
+    },
+    "root": { "description": "Styles applied to the root element." },
+    "separator": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the separator element"
+    }
   }
 }

--- a/packages/x-date-pickers/src/TimePicker/timePickerToolbarClasses.ts
+++ b/packages/x-date-pickers/src/TimePicker/timePickerToolbarClasses.ts
@@ -4,13 +4,21 @@ import {
 } from '@mui/utils';
 
 export interface TimePickerToolbarClasses {
+  /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the separator element. */
   separator: string;
+  /** Styles applied to the time sections element. */
   hourMinuteLabel: string;
+  /** Styles applied to the time sections element in landscape mode. */
   hourMinuteLabelLandscape: string;
+  /** Styles applied to the time sections element in "rtl" theme mode. */
   hourMinuteLabelReverse: string;
+  /** Styles applied to the meridiem selection element. */
   ampmSelection: string;
+  /** Styles applied to the meridiem selection element in landscape mode. */
   ampmLandscape: string;
+  /** Styles applied to the meridiem label element. */
   ampmLabel: string;
 }
 


### PR DESCRIPTION
Fixes:
> New comment :-1:
>> CSS classes don't have description
> sent from https://mui.com/x/api/date-pickers/time-picker-toolbar/

https://mui-org.slack.com/archives/C04U3R2V9UK/p1706548112786409