### PR TITLE
[l10n] Improve Danish (da-DK) locale

### DIFF
--- a/packages/grid/x-data-grid/src/locales/daDK.ts
+++ b/packages/grid/x-data-grid/src/locales/daDK.ts
@@ -15,8 +15,8 @@ const daDKGrid: Partial<GridLocaleText> = {
   toolbarDensityComfortable: 'Luftig',
 
   // Columns selector toolbar button text
-  toolbarColumns: 'Kolonne',
-  toolbarColumnsLabel: 'Vælg kolonne',
+  toolbarColumns: 'Kolonner',
+  toolbarColumnsLabel: 'Vælg kolonner',
 
   // Filters toolbar button text
   toolbarFilters: 'Filtre',
@@ -48,12 +48,12 @@ const daDKGrid: Partial<GridLocaleText> = {
   filterPanelRemoveAll: 'Fjern alle',
   filterPanelDeleteIconLabel: 'Slet',
   filterPanelLogicOperator: 'Logisk operator',
-  filterPanelOperator: 'Operatorer',
+  filterPanelOperator: 'Operator',
   filterPanelOperatorAnd: 'Og',
   filterPanelOperatorOr: 'Eller',
-  filterPanelColumns: 'Kolonne',
+  filterPanelColumns: 'Kolonner',
   filterPanelInputLabel: 'Værdi',
-  filterPanelInputPlaceholder: 'Filter værdi',
+  filterPanelInputPlaceholder: 'Filterværdi',
 
   // Filter operators text
   filterOperatorContains: 'indeholder',
@@ -104,10 +104,10 @@ const daDKGrid: Partial<GridLocaleText> = {
 
   // Column menu text
   columnMenuLabel: 'Menu',
-  columnMenuShowColumns: 'Vis Kolonner',
+  columnMenuShowColumns: 'Vis kolonner',
   columnMenuManageColumns: 'Administrer kolonner',
-  columnMenuFilter: 'Filtre',
-  columnMenuHideColumn: 'Skjul',
+  columnMenuFilter: 'Filtrer',
+  columnMenuHideColumn: 'Skjul kolonne',
   columnMenuUnsort: 'Fjern sortering',
   columnMenuSortAsc: 'Sorter stigende',
   columnMenuSortDesc: 'Sorter faldende',
@@ -149,14 +149,14 @@ const daDKGrid: Partial<GridLocaleText> = {
   unpin: 'Frigiv',
 
   // Tree Data
-  treeDataGroupingHeaderName: 'Gruppering',
+  treeDataGroupingHeaderName: 'Gruppe',
   treeDataExpand: 'Vis underelementer',
   treeDataCollapse: 'Skjul underelementer',
 
   // Grouping columns
-  groupingColumnHeaderName: 'Gruppér',
+  groupingColumnHeaderName: 'Gruppe',
   groupColumn: (name) => `Gruppér efter ${name}`,
-  unGroupColumn: (name) => `Fjern gruppéring efter ${name}`,
+  unGroupColumn: (name) => `Fjern gruppering efter ${name}`,
 
   // Master/detail
   detailPanelToggle: 'Udvid/kollaps detaljepanel',
@@ -167,7 +167,7 @@ const daDKGrid: Partial<GridLocaleText> = {
   rowReorderingHeaderName: 'Omarrangering af rækker',
 
   // Aggregation
-  aggregationMenuItemHeader: 'Aggregation',
+  aggregationMenuItemHeader: 'Aggregering',
   aggregationFunctionLabelSum: 'sum',
   aggregationFunctionLabelAvg: 'gns',
   aggregationFunctionLabelMin: 'min',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Updated Danish translations. 

Some keys such as `columnMenuFilter`, `treeDataGroupingHeaderName` and  `groupingColumnHeaderName` are a tad unclear in whether they are verbs or nouns, as their English text value are homonyms in both cases.

In addition it's unclear why the English translation for `grouping` is `group` and not `grouping`, as the Danish term for `grouping` would be `gruppering` but Danish term for `group` is `gruppe` if it is a noun and `gruppér` if it is a verb. 

Same goes for `filter`, where the noun would be `filter` and the verb would be `filtrer` in Danish. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
