### PR TITLE
[code-infra] Move next config to ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -123,6 +123,12 @@ module.exports = {
       },
     },
     {
+      files: ['**/*.mjs'],
+      rules: {
+        'import/extensions': ['error', 'ignorePackages'],
+      },
+    },
+    {
       files: ['packages/*/src/**/*{.ts,.tsx,.js}'],
       excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx'],
       rules: {

--- a/docs/constants.js
+++ b/docs/constants.js
@@ -1,0 +1,6 @@
+// These are also loaded by scripts that only undestand CommonJS. (l10n)
+
+module.exports = {
+  SOURCE_CODE_REPO: 'https://github.com/mui/mui-x',
+  SOURCE_GITHUB_BRANCH: 'next', // #default-branch-switch
+};

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -9,7 +9,7 @@ import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import withDocsInfra from '@mui/monorepo/docs/nextConfigDocsInfra.js';
 import { findPages } from './src/modules/utils/find.mjs';
 import { LANGUAGES, LANGUAGES_SSR } from './config.js';
-import { SOURCE_CODE_REPO, SOURCE_GITHUB_BRANCH } from './constants.js';
+import constants from './constants.js';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 const require = createRequire(import.meta.url);
@@ -37,8 +37,8 @@ export default withDocsInfra({
   env: {
     // docs-infra
     LIB_VERSION: pkg.version,
-    SOURCE_CODE_REPO,
-    SOURCE_GITHUB_BRANCH,
+    SOURCE_CODE_REPO: constants.SOURCE_CODE_REPO,
+    SOURCE_GITHUB_BRANCH: constants.SOURCE_GITHUB_BRANCH,
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '6.docs-feedback.yml',
     // MUI X related
     DATA_GRID_VERSION: dataGridPkg.version,

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -9,6 +9,7 @@ import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import withDocsInfra from '@mui/monorepo/docs/nextConfigDocsInfra.js';
 import { findPages } from './src/modules/utils/find.mjs';
 import { LANGUAGES, LANGUAGES_SSR } from './config.js';
+import { SOURCE_CODE_REPO, SOURCE_GITHUB_BRANCH } from './constants.js';
 
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 const require = createRequire(import.meta.url);
@@ -36,8 +37,8 @@ export default withDocsInfra({
   env: {
     // docs-infra
     LIB_VERSION: pkg.version,
-    SOURCE_CODE_REPO: 'https://github.com/mui/mui-x',
-    SOURCE_GITHUB_BRANCH: 'next', // #default-branch-switch
+    SOURCE_CODE_REPO,
+    SOURCE_GITHUB_BRANCH,
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '6.docs-feedback.yml',
     // MUI X related
     DATA_GRID_VERSION: dataGridPkg.version,

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,21 +1,36 @@
 // @ts-check
-const path = require('path');
-// @ts-ignore
-const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-// const withTM = require('next-transpile-modules')(['@mui/monorepo']);
+import * as path from 'path';
+import * as url from 'url';
+import * as fs from 'fs';
+import { createRequire } from 'module';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+// const withTM from 'next-transpile-modules')(['@mui/monorepo'];
 // @ts-expect-error This expected error should be gone once we update the monorepo
-const withDocsInfra = require('@mui/monorepo/docs/nextConfigDocsInfra');
-const pkg = require('../package.json');
-const dataGridPkg = require('../packages/grid/x-data-grid/package.json');
-const datePickersPkg = require('../packages/x-date-pickers/package.json');
-const chartsPkg = require('../packages/x-charts/package.json');
-const treeViewPkg = require('../packages/x-tree-view/package.json');
-const { findPages } = require('./src/modules/utils/find');
-const { LANGUAGES, LANGUAGES_SSR } = require('./config');
+import withDocsInfra from '@mui/monorepo/docs/nextConfigDocsInfra.js';
+import { findPages } from './src/modules/utils/find.mjs';
+import { LANGUAGES, LANGUAGES_SSR } from './config.js';
 
-const workspaceRoot = path.join(__dirname, '../');
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+const require = createRequire(import.meta.url);
 
-module.exports = withDocsInfra({
+const workspaceRoot = path.join(currentDirectory, '../');
+
+/**
+ * @param {string} pkgPath
+ * @returns {{version: string}}
+ */
+function loadPkg(pkgPath) {
+  const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, pkgPath, 'package.json'), 'utf8');
+  return JSON.parse(pkgContent);
+}
+
+const pkg = loadPkg('.');
+const dataGridPkg = loadPkg('./packages/grid/x-data-grid');
+const datePickersPkg = loadPkg('./packages/x-date-pickers');
+const chartsPkg = loadPkg('./packages/x-charts');
+const treeViewPkg = loadPkg('./packages/x-tree-view');
+
+export default withDocsInfra({
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',
   env: {
@@ -56,8 +71,8 @@ module.exports = withDocsInfra({
         ...config.resolve,
         alias: {
           ...config.resolve.alias,
-          docs: path.resolve(__dirname, '../node_modules/@mui/monorepo/docs'),
-          docsx: path.resolve(__dirname, '../docs'),
+          docs: path.resolve(currentDirectory, '../node_modules/@mui/monorepo/docs'),
+          docsx: path.resolve(currentDirectory, '../docs'),
         },
       },
       module: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -94,6 +94,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@types/doctrine": "^0.0.9",
     "@types/stylis": "^4.2.5",
+    "@types/webpack-bundle-analyzer": "^4.6.3",
     "cpy-cli": "^5.0.0",
     "gm": "^1.25.0",
     "typescript-to-proptypes": "^2.2.1"

--- a/docs/src/modules/utils/find.mjs
+++ b/docs/src/modules/utils/find.mjs
@@ -1,5 +1,8 @@
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 
 const jsRegex = /\.js$/;
 const blackList = ['/.eslintrc', '/_document', '/_app'];
@@ -7,9 +10,9 @@ const blackList = ['/.eslintrc', '/_document', '/_app'];
 // Returns the Next.js pages available in a nested format.
 // The output is in the next.js format.
 // Each pathname is a route you can navigate to.
-function findPages(
+export function findPages(
   options = {},
-  directory = path.resolve(__dirname, '../../../pages'),
+  directory = path.resolve(currentDirectory, '../../../pages'),
   pages = [],
 ) {
   fs.readdirSync(directory).forEach((item) => {
@@ -71,7 +74,3 @@ function findPages(
 
   return pages;
 }
-
-module.exports = {
-  findPages,
-};

--- a/docs/src/modules/utils/findPages.js
+++ b/docs/src/modules/utils/findPages.js
@@ -1,6 +1,0 @@
-import path from 'path';
-import { findPages } from 'docsx/src/modules/utils/find';
-
-const pages = findPages({ front: true }, path.resolve(__dirname, '../pages/api-docs'));
-
-export default pages;

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "isolatedModules": true,
     /* files are emitted by babel */
     "noEmit": true,
@@ -14,7 +15,7 @@
     "pages/**/*.ts*",
     "data/**/*",
     "src/modules/components/**/*",
-    "next.config.js",
+    "next.config.mjs",
     "../node_modules/@mui/material/themeCssVarsAugmentation",
     "../node_modules/dayjs/plugin/utc.d.ts",
     "../node_modules/dayjs/plugin/timezone.d.ts",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "allowJs": true,
     "isolatedModules": true,
     /* files are emitted by babel */
     "noEmit": true,

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "isolatedModules": true,
     /* files are emitted by babel */
     "noEmit": true,

--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -12,7 +12,7 @@ import localeNames from './localeNames';
 import {
   SOURCE_CODE_REPO as DOCS_SOURCE_CODE_REPO,
   SOURCE_GITHUB_BRANCH as DOCS_SOURCE_GITHUB_BRANCH,
-} from '../docs/constants.js';
+} from '../docs/constants';
 
 const MyOctokit = Octokit.plugin(retry);
 

--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -9,7 +9,10 @@ import * as yargs from 'yargs';
 import { Octokit } from '@octokit/rest';
 import { retry } from '@octokit/plugin-retry';
 import localeNames from './localeNames';
-import nextConfig from '../docs/next.config';
+import {
+  SOURCE_CODE_REPO as DOCS_SOURCE_CODE_REPO,
+  SOURCE_GITHUB_BRANCH as DOCS_SOURCE_GITHUB_BRANCH,
+} from '../docs/constants.js';
 
 const MyOctokit = Octokit.plugin(retry);
 
@@ -344,7 +347,7 @@ const generateDocReport = async (
         localeName,
         missingKeysCount: infoPerPackage[packageKey].missingKeys.length,
         totalKeysCount: baseTranslationsNumber[packageKey],
-        githubLink: `${nextConfig.env.SOURCE_CODE_REPO}/blob/${nextConfig.env.SOURCE_GITHUB_BRANCH}/${info.path}`,
+        githubLink: `${DOCS_SOURCE_CODE_REPO}/blob/${DOCS_SOURCE_GITHUB_BRANCH}/${info.path}`,
       });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@mui/monorepo/tsconfig.json",
   "compilerOptions": {
+    "module": "esnext",
+    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     // Already tested with eslint
     "noUnusedLocals": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@mui/monorepo/tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     // Already tested with eslint
     "noUnusedLocals": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3203,12 +3203,17 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@>=18.0.0", "@types/node@^14.0.1", "@types/node@^18.19.10":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@>=18.0.0", "@types/node@^18.19.10":
   version "18.19.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.10.tgz#4de314ab66faf6bc8ba691021a091ddcdf13a158"
   integrity sha512-IZD8kAM02AW1HRDTPOlz3npFava678pr8Ie9Vp8uRhBROXAv8MXT2pCnGZZAKYdromsNQLHQcfWQ6EOatVLtqA==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^14.0.1":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -3372,6 +3377,15 @@
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.10.tgz#04ffa7f406ab628f7f7e97ca23e290cd8ab15efc"
   integrity sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==
+
+"@types/webpack-bundle-analyzer@^4.6.3":
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.3.tgz#53c26f21134ca2e5049fd2af4f2ffbf8dfe87b4f"
+  integrity sha512-XYU3m7oRb1tlE8YhwkKLi1xba2buNB9V4VkQtOVTfJuUm/413pE/UCMVcPDFFBwpzGkr9y1WbSEvdPjKVPt0gw==
+  dependencies:
+    "@types/node" "*"
+    tapable "^2.2.0"
+    webpack "^5"
 
 "@types/ws@^7.4.7":
   version "7.4.7"
@@ -12429,10 +12443,20 @@ react-hook-form@^7.49.3:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.49.3.tgz#576a4567f8a774830812f4855e89f5da5830435c"
   integrity sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==
 
-"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-is@^16.13.1, react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-reconciler@^0.29.0:
   version "0.29.0"
@@ -14852,7 +14876,7 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.90.0:
+webpack@^5, webpack@^5.90.0:
   version "5.90.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.90.0.tgz#313bfe16080d8b2fee6e29b6c986c0714ad4290e"
   integrity sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3203,17 +3203,12 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@>=18.0.0", "@types/node@^18.19.10":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@>=18.0.0", "@types/node@^14.0.1", "@types/node@^18.19.10":
   version "18.19.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.10.tgz#4de314ab66faf6bc8ba691021a091ddcdf13a158"
   integrity sha512-IZD8kAM02AW1HRDTPOlz3npFava678pr8Ie9Vp8uRhBROXAv8MXT2pCnGZZAKYdromsNQLHQcfWQ6EOatVLtqA==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@^14.0.1":
-  version "14.18.63"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -12443,20 +12438,10 @@ react-hook-form@^7.49.3:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.49.3.tgz#576a4567f8a774830812f4855e89f5da5830435c"
   integrity sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==
 
-"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-react-is@^16.13.1, react-is@^16.7.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-is@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-reconciler@^0.29.0:
   version "0.29.0"


### PR DESCRIPTION
See https://github.com/mui/material-ui/pull/40869

I extracted a few constants into a separate cjs file, they are used in one of the scritps. ATM the scripts have poor ESM support. We'll improve that separately by ditching babel-node. We'll also think deeper about docs config once we start extracting more things into the next.js plugin.