### PR TITLE
[DataGrid] Vertical scrolling performance

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -783,8 +783,8 @@
       "isGlobal": false
     },
     {
-      "key": "cellOffset",
-      "className": "MuiDataGridPremium-cellOffset",
+      "key": "cellOffsetLeft",
+      "className": "MuiDataGridPremium-cellOffsetLeft",
       "description": "Styles applied to the left offset cell element.",
       "isGlobal": false
     },

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -783,6 +783,12 @@
       "isGlobal": false
     },
     {
+      "key": "cellOffset",
+      "className": "MuiDataGridPremium-cellOffset",
+      "description": "Styles applied to the left offset cell element.",
+      "isGlobal": false
+    },
+    {
       "key": "cellSkeleton",
       "className": "MuiDataGridPremium-cellSkeleton",
       "description": "Styles applied to the skeleton cell element.",

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -785,7 +785,7 @@
     {
       "key": "cellOffsetLeft",
       "className": "MuiDataGridPremium-cellOffsetLeft",
-      "description": "Styles applied to the left offset cell element.",
+      "description": "",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -722,8 +722,8 @@
       "isGlobal": false
     },
     {
-      "key": "cellOffset",
-      "className": "MuiDataGridPro-cellOffset",
+      "key": "cellOffsetLeft",
+      "className": "MuiDataGridPro-cellOffsetLeft",
       "description": "Styles applied to the left offset cell element.",
       "isGlobal": false
     },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -722,6 +722,12 @@
       "isGlobal": false
     },
     {
+      "key": "cellOffset",
+      "className": "MuiDataGridPro-cellOffset",
+      "description": "Styles applied to the left offset cell element.",
+      "isGlobal": false
+    },
+    {
       "key": "cellSkeleton",
       "className": "MuiDataGridPro-cellSkeleton",
       "description": "Styles applied to the skeleton cell element.",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -724,7 +724,7 @@
     {
       "key": "cellOffsetLeft",
       "className": "MuiDataGridPro-cellOffsetLeft",
-      "description": "Styles applied to the left offset cell element.",
+      "description": "",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -607,8 +607,8 @@
       "isGlobal": false
     },
     {
-      "key": "cellOffset",
-      "className": "MuiDataGrid-cellOffset",
+      "key": "cellOffsetLeft",
+      "className": "MuiDataGrid-cellOffsetLeft",
       "description": "Styles applied to the left offset cell element.",
       "isGlobal": false
     },

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -609,7 +609,7 @@
     {
       "key": "cellOffsetLeft",
       "className": "MuiDataGrid-cellOffsetLeft",
-      "description": "Styles applied to the left offset cell element.",
+      "description": "",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -607,6 +607,12 @@
       "isGlobal": false
     },
     {
+      "key": "cellOffset",
+      "className": "MuiDataGrid-cellOffset",
+      "description": "Styles applied to the left offset cell element.",
+      "isGlobal": false
+    },
+    {
       "key": "cellSkeleton",
       "className": "MuiDataGrid-cellSkeleton",
       "description": "Styles applied to the skeleton cell element.",

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -763,7 +763,7 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
-    "cellOffset": {
+    "cellOffsetLeft": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the left offset cell element"
     },

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -763,6 +763,10 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
+    "cellOffset": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the left offset cell element"
+    },
     "cellSkeleton": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the skeleton cell element"

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -763,10 +763,7 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
-    "cellOffsetLeft": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the left offset cell element"
-    },
+    "cellOffsetLeft": { "description": "" },
     "cellSkeleton": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the skeleton cell element"

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -705,6 +705,10 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
+    "cellOffset": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the left offset cell element"
+    },
     "cellSkeleton": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the skeleton cell element"

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -705,7 +705,7 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
-    "cellOffset": {
+    "cellOffsetLeft": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the left offset cell element"
     },

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -705,10 +705,7 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
-    "cellOffsetLeft": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the left offset cell element"
-    },
+    "cellOffsetLeft": { "description": "" },
     "cellSkeleton": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the skeleton cell element"

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -571,10 +571,7 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
-    "cellOffsetLeft": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the left offset cell element"
-    },
+    "cellOffsetLeft": { "description": "" },
     "cellSkeleton": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the skeleton cell element"

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -571,7 +571,7 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
-    "cellOffset": {
+    "cellOffsetLeft": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the left offset cell element"
     },

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -571,6 +571,10 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the empty cell element"
     },
+    "cellOffset": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the left offset cell element"
+    },
     "cellSkeleton": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the skeleton cell element"

--- a/packages/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rows.DataGridPro.test.tsx
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { expect } from 'chai';
 import {
   $,
+  $$,
   grid,
   getCell,
   getRow,
@@ -450,7 +451,7 @@ describe('<DataGridPro /> - Rows', () => {
       virtualScroller.scrollTop = 10e6; // scroll to the bottom
       act(() => virtualScroller.dispatchEvent(new Event('scroll')));
 
-      const lastCell = $('[role="row"]:last-child [role="gridcell"]:first-child')!;
+      const lastCell = $$('[role="row"]:last-child [role="gridcell"]')[0];
       expect(lastCell).to.have.text('995');
       expect(renderingZone.children.length).to.equal(
         Math.floor((height - 1) / rowHeight) + rowBuffer,
@@ -486,11 +487,13 @@ describe('<DataGridPro /> - Rows', () => {
         />,
       );
       const firstRow = getRow(0);
-      expect(firstRow.children).to.have.length(Math.floor(width / columnWidth) + columnBuffer);
+      expect($$(firstRow, '[role="gridcell"]')).to.have.length(
+        Math.floor(width / columnWidth) + columnBuffer,
+      );
       const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
       virtualScroller.scrollLeft = 301;
       act(() => virtualScroller.dispatchEvent(new Event('scroll')));
-      expect(firstRow.children).to.have.length(
+      expect($$(firstRow, '[role="gridcell"]')).to.have.length(
         columnBuffer + 1 + Math.floor(width / columnWidth) + columnBuffer,
       );
     });
@@ -517,15 +520,14 @@ describe('<DataGridPro /> - Rows', () => {
       render(
         <TestCaseVirtualization nbRows={1} columnBuffer={0} columnThreshold={columnThreshold} />,
       );
-      const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
-      const renderingZone = document.querySelector('.MuiDataGrid-virtualScrollerRenderZone')!;
-      let firstRow = renderingZone.querySelector('[role="row"]:first-child')!;
-      let firstColumn = firstRow.firstChild!;
+      const virtualScroller = grid('virtualScroller')!;
+      const renderingZone = grid('virtualScrollerRenderZone')!;
+      const firstRow = $(renderingZone, '[role="row"]:first-child')!;
+      let firstColumn = $$(firstRow, '[role="gridcell"]')[0];
       expect(firstColumn).to.have.attr('data-colindex', '0');
       virtualScroller.scrollLeft = columnThreshold * columnWidth;
       act(() => virtualScroller.dispatchEvent(new Event('scroll')));
-      firstRow = renderingZone.querySelector('[role="row"]:first-child')!;
-      firstColumn = firstRow.firstChild!;
+      firstColumn = $(renderingZone, '[role="row"] > [role="gridcell"]')!;
       expect(firstColumn).to.have.attr('data-colindex', '3');
     });
 
@@ -546,16 +548,14 @@ describe('<DataGridPro /> - Rows', () => {
         act(() => virtualScroller.dispatchEvent(new Event('scroll')));
 
         const dimensions = apiRef.current.state.dimensions;
-        const lastCell = document.querySelector(
-          '[role="row"]:last-child [role="gridcell"]:first-child',
-        )!;
+        const lastCell = $$('[role="row"]:last-child [role="gridcell"]')[0];
         expect(lastCell).to.have.text('31');
         expect(virtualScroller.scrollHeight).to.equal(
           dimensions.headerHeight + nbRows * rowHeight + dimensions.scrollbarSize,
         );
       });
 
-      it('should not virtualized the last page if smaller than viewport', () => {
+      it('should not virtualize the last page if smaller than viewport', () => {
         render(
           <TestCaseVirtualization
             pagination
@@ -564,19 +564,15 @@ describe('<DataGridPro /> - Rows', () => {
             height={500}
           />,
         );
-        const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
+        const virtualScroller = grid('virtualScroller')!;
         virtualScroller.scrollTop = 10e6; // scroll to the bottom
         virtualScroller.dispatchEvent(new Event('scroll'));
 
-        const lastCell = document.querySelector(
-          '[role="row"]:last-child [role="gridcell"]:first-child',
-        )!;
+        const lastCell = $$('[role="row"]:last-child [role="gridcell"]')[0];
         expect(lastCell).to.have.text('99');
         expect(virtualScroller.scrollTop).to.equal(0);
         expect(virtualScroller.scrollHeight).to.equal(virtualScroller.clientHeight);
-        expect(
-          document.querySelector('.MuiDataGrid-virtualScrollerRenderZone')!.children,
-        ).to.have.length(4);
+        expect(grid('virtualScrollerRenderZone')!.children).to.have.length(4);
       });
 
       it('should paginate small dataset in auto page-size #1492', () => {
@@ -585,18 +581,14 @@ describe('<DataGridPro /> - Rows', () => {
         );
         const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
 
-        const lastCell = document.querySelector(
-          '[role="row"]:last-child [role="gridcell"]:first-child',
-        )!;
+        const lastCell = $$('[role="row"]:last-child [role="gridcell"]')[0];
         expect(lastCell).to.have.text('6');
         const rows = document.querySelectorAll('.MuiDataGrid-row[role="row"]')!;
         expect(rows.length).to.equal(7);
 
         expect(virtualScroller.scrollTop).to.equal(0);
         expect(virtualScroller.scrollHeight).to.equal(virtualScroller.clientHeight);
-        expect(
-          document.querySelector('.MuiDataGrid-virtualScrollerRenderZone')!.children,
-        ).to.have.length(7);
+        expect(grid('virtualScrollerRenderZone')!.children).to.have.length(7);
       });
     });
 

--- a/packages/x-data-grid/src/components/GridRow.tsx
+++ b/packages/x-data-grid/src/components/GridRow.tsx
@@ -515,7 +515,7 @@ const GridRow = React.forwardRef<HTMLDivElement, GridRowProps>(function GridRow(
       {...other}
     >
       {leftCells}
-      <div className={gridClasses.cellOffset} role="presentation" />
+      <div className={gridClasses.cellOffsetLeft} role="presentation" />
       {cells}
       {emptyCellWidth > 0 && <EmptyCell width={emptyCellWidth} />}
       {rightCells.length > 0 && <div role="presentation" style={{ flex: '1' }} />}

--- a/packages/x-data-grid/src/components/GridRow.tsx
+++ b/packages/x-data-grid/src/components/GridRow.tsx
@@ -515,7 +515,7 @@ const GridRow = React.forwardRef<HTMLDivElement, GridRowProps>(function GridRow(
       {...other}
     >
       {leftCells}
-      <div className={gridClasses.offsetCell} role="presentation" />
+      <div className={gridClasses.cellOffset} role="presentation" />
       {cells}
       {emptyCellWidth > 0 && <EmptyCell width={emptyCellWidth} />}
       {rightCells.length > 0 && <div role="presentation" style={{ flex: '1' }} />}

--- a/packages/x-data-grid/src/components/GridRow.tsx
+++ b/packages/x-data-grid/src/components/GridRow.tsx
@@ -91,8 +91,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
       isLastVisible && 'row--lastVisible',
       rowHeight === 'auto' && 'row--dynamicHeight',
     ],
-    pinnedLeft: ['pinnedLeft'],
-    pinnedRight: ['pinnedRight'],
   };
 
   return composeClasses(slots, getDataGridUtilityClass, classes);
@@ -517,6 +515,7 @@ const GridRow = React.forwardRef<HTMLDivElement, GridRowProps>(function GridRow(
       {...other}
     >
       {leftCells}
+      <div className={gridClasses.offsetCell} role="presentation" />
       {cells}
       {emptyCellWidth > 0 && <EmptyCell width={emptyCellWidth} />}
       {rightCells.length > 0 && <div role="presentation" style={{ flex: '1' }} />}

--- a/packages/x-data-grid/src/components/GridScrollbarFillerCell.tsx
+++ b/packages/x-data-grid/src/components/GridScrollbarFillerCell.tsx
@@ -23,9 +23,6 @@ const Style = styled('div')({
     position: 'sticky',
     right: 0,
   },
-  [`&:not(.${classes.header}):not(.${classes.pinnedRight})`]: {
-    transform: 'translate3d(var(--DataGrid-offsetLeft), 0, 0)',
-  },
 });
 
 function GridScrollbarFillerCell({

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -572,7 +572,7 @@ export const GridRootStyles = styled('div', {
         },
       },
     },
-    [`& .${c.offsetCell}`]: {
+    [`& .${c.cellOffset}`]: {
       flex: '0 0 auto',
       display: 'inline-block',
       width: 'var(--DataGrid-offsetLeft)',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -572,8 +572,10 @@ export const GridRootStyles = styled('div', {
         },
       },
     },
-    [`& .${c.cell}:not(.${c['cell--pinnedLeft']}):not(.${c['cell--pinnedRight']})`]: {
-      transform: 'translate3d(var(--DataGrid-offsetLeft), 0, 0)',
+    [`& .${c.offsetCell}`]: {
+      flex: '0 0 auto',
+      display: 'inline-block',
+      width: 'var(--DataGrid-offsetLeft)',
     },
     [`& .${c.columnHeaderDraggableContainer}`]: {
       display: 'flex',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -572,7 +572,7 @@ export const GridRootStyles = styled('div', {
         },
       },
     },
-    [`& .${c.cellOffset}`]: {
+    [`& .${c.cellOffsetLeft}`]: {
       flex: '0 0 auto',
       display: 'inline-block',
       width: 'var(--DataGrid-offsetLeft)',

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -113,6 +113,7 @@ export interface GridClasses {
    */
   cellSkeleton: string;
   /**
+   * @ignore - do not document.
    * Styles applied to the left offset cell element.
    */
   cellOffsetLeft: string;

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -113,6 +113,10 @@ export interface GridClasses {
    */
   cellSkeleton: string;
   /**
+   * Styles applied to the left offset cell element.
+   */
+  cellOffset: string;
+  /**
    * Styles applied to the selection checkbox element.
    */
   checkboxInput: string;
@@ -634,6 +638,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'cellCheckbox',
   'cellEmpty',
   'cellSkeleton',
+  'cellOffset',
   'checkboxInput',
   'columnHeader--alignCenter',
   'columnHeader--alignLeft',

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -115,7 +115,7 @@ export interface GridClasses {
   /**
    * Styles applied to the left offset cell element.
    */
-  cellOffset: string;
+  cellOffsetLeft: string;
   /**
    * Styles applied to the selection checkbox element.
    */
@@ -638,7 +638,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'cellCheckbox',
   'cellEmpty',
   'cellSkeleton',
-  'cellOffset',
+  'cellOffsetLeft',
   'checkboxInput',
   'columnHeader--alignCenter',
   'columnHeader--alignLeft',

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -65,7 +65,6 @@ export const useGridVirtualScroller = () => {
   const gridRootRef = apiRef.current.rootElementRef;
   const mainRef = apiRef.current.mainElementRef;
   const scrollerRef = apiRef.current.virtualScrollerRef;
-  const renderZoneRef = React.useRef<HTMLDivElement>(null);
   const scrollbarVerticalRef = React.useRef<HTMLDivElement>(null);
   const scrollbarHorizontalRef = React.useRef<HTMLDivElement>(null);
   const contentHeight = dimensions.contentSize.height;
@@ -343,6 +342,16 @@ export const useGridVirtualScroller = () => {
 
     for (let i = 0; i < renderedRows.length; i += 1) {
       const { id, model } = renderedRows[i];
+
+      const rowIndexInPage = (currentPage?.range?.firstRowIndex || 0) + firstRowToRender + i;
+      let index = rowIndexOffset + rowIndexInPage;
+      if (isRowWithFocusedCellNotInRange && cellFocus?.id === id) {
+        index = indexOfRowWithFocusedCell;
+        isRowWithFocusedCellRendered = true;
+      } else if (isRowWithFocusedCellRendered) {
+        index -= 1;
+      }
+
       const isRowNotVisible = isRowWithFocusedCellNotInRange && cellFocus!.id === id;
 
       const baseRowHeight = !apiRef.current.rowHasAutoHeight(id)
@@ -358,7 +367,7 @@ export const useGridVirtualScroller = () => {
 
       let isFirstVisible = false;
       if (params.position === undefined) {
-        isFirstVisible = i === 0;
+        isFirstVisible = rowIndexInPage === 0;
       }
 
       let isLastVisible = false;
@@ -392,14 +401,6 @@ export const useGridVirtualScroller = () => {
       if (cellTabIndex !== null && cellTabIndex.id === id) {
         const cellParams = apiRef.current.getCellParams(id, cellTabIndex.field);
         tabbableCell = cellParams.cellMode === 'view' ? cellTabIndex.field : null;
-      }
-
-      let index = rowIndexOffset + (currentPage?.range?.firstRowIndex || 0) + firstRowToRender + i;
-      if (isRowWithFocusedCellNotInRange && cellFocus?.id === id) {
-        index = indexOfRowWithFocusedCell;
-        isRowWithFocusedCellRendered = true;
-      } else if (isRowWithFocusedCellRendered) {
-        index -= 1;
       }
 
       rows.push(
@@ -532,7 +533,7 @@ export const useGridVirtualScroller = () => {
       style: contentSize,
       role: 'presentation',
     }),
-    getRenderZoneProps: () => ({ ref: renderZoneRef, role: 'rowgroup' }),
+    getRenderZoneProps: () => ({ role: 'rowgroup' }),
     getScrollbarVerticalProps: () => ({ ref: scrollbarVerticalRef, role: 'presentation' }),
     getScrollbarHorizontalProps: () => ({ ref: scrollbarHorizontalRef, role: 'presentation' }),
   };


### PR DESCRIPTION
Follow-up of https://github.com/mui/mui-x/pull/10059#issuecomment-1904425888

Restore the vertical scrolling performance.

Changes:
 - Remove the `transform: translate(...)` style on cells and use an offset filler cell instead
 - ~Remove the virtual scroller render zone DOM node, keep only the virtual scroller content and rename it to "centerContainer" to match the "topContainer" and "bottomContainer"~