### PR TITLE
[core] Add `docs:serve` script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "author": "MUI Team",
   "license": "MIT",
   "scripts": {
-    "build": "rimraf docs/export && cross-env NODE_ENV=production next build --profile && yarn build-sw",
+    "build": "rimraf ./export && cross-env NODE_ENV=production next build --profile && yarn build-sw",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev --port 3001",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev --port 3001",
     "deploy": "git push -f upstream next:docs-next",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
-    "start": "next start",
+    "serve": "serve ./export -l 3010",
     "create-playground": "cpy --cwd=scripts playground.template.tsx ../../pages/playground --rename=index.tsx",
     "typescript": "tsc -p tsconfig.json",
     "typescript:transpile": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" scripts/formattedTSDemos",
@@ -52,8 +52,8 @@
     "core-js": "^2.6.12",
     "cross-env": "^7.0.3",
     "date-fns": "^2.30.0",
-    "date-fns-v3": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
     "date-fns-jalali": "^2.21.3-1",
+    "date-fns-v3": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
     "dayjs": "^1.11.10",
     "doctrine": "^3.0.0",
     "exceljs": "^4.4.0",
@@ -98,6 +98,7 @@
     "@types/stylis": "^4.2.5",
     "@types/webpack-bundle-analyzer": "^4.6.3",
     "cpy-cli": "^5.0.0",
-    "gm": "^1.25.0"
+    "gm": "^1.25.0",
+    "serve": "^14.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "yarn && yarn docs:dev",
     "docs:dev": "yarn workspace docs dev",
-    "docs:start": "yarn workspace docs start",
+    "docs:serve": "yarn workspace docs serve",
     "docs:create-playground": "yarn workspace docs create-playground",
     "docs:api": "NODE_OPTIONS=--max-old-space-size=4096 yarn docs:api:build && yarn docs:api:buildX",
     "docs:api:build": "cross-env BABEL_ENV=development babel-node -i \"/node_modules/(?!@mui)/\" -x .ts,.tsx,.js ./scripts/buildApiDocs/index.ts",


### PR DESCRIPTION
We no longer use `next export` - it was replaced by the `output: 'export'` flag in `next.config` in https://github.com/mui/mui-x/pull/11182.
Because of this change, we can no longer use `next start` to serve the production build locally.
This PR adds a replacement `docs:serve` script that serves the `export` folder locally.