### PR TITLE
[pickers] Avoid relying on locale in Luxon `isWithinRange` method

### DIFF
--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
@@ -169,16 +169,4 @@ describe('<AdapterLuxon />', () => {
       });
     });
   });
-
-  describe('isWithinRange functionality', () => {
-    const adapter = new AdapterLuxon({ locale: 'en-US' });
-    it('should be equal with values in different locale', () => {
-      expect(
-        adapter.isWithinRange(adapter.date('2022-04-17'), [
-          DateTime.fromISO('2022-04-17', { locale: 'en-GB' }),
-          DateTime.fromISO('2022-04-19', { locale: 'en-GB' }),
-        ]),
-      ).to.equal(true);
-    });
-  });
 });

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
@@ -169,4 +169,16 @@ describe('<AdapterLuxon />', () => {
       });
     });
   });
+
+  describe('isWithinRange functionality', () => {
+    const adapter = new AdapterLuxon({ locale: 'en-US' });
+    it('should be equal with values in different locale', () => {
+      expect(
+        adapter.isWithinRange(adapter.date('2022-04-17'), [
+          DateTime.fromISO('2022-04-17', { locale: 'en-GB' }),
+          DateTime.fromISO('2022-04-19', { locale: 'en-GB' }),
+        ]),
+      ).to.equal(true);
+    });
+  });
 });

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.ts
@@ -324,8 +324,8 @@ export class AdapterLuxon implements MuiPickersAdapter<DateTime, string> {
 
   public isWithinRange = (value: DateTime, [start, end]: [DateTime, DateTime]) => {
     return (
-      value.equals(start) ||
-      value.equals(end) ||
+      this.isEqual(value, start) ||
+      this.isEqual(value, end) ||
       (this.isAfter(value, start) && this.isBefore(value, end))
     );
   };

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -577,7 +577,7 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
       ).to.equal(false);
     });
 
-    it('should use inclusivity of range', () => {
+    it('should use inclusiveness of range', () => {
       expect(
         adapter.isWithinRange(adapter.date('2019-09-01T00:00:00.000Z')!, [
           adapter.date('2019-09-01T00:00:00.000Z')!,
@@ -603,6 +603,15 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
         adapter.isWithinRange(adapter.date('2019-12-01')!, [
           adapter.date('2019-09-01')!,
           adapter.date('2019-12-01')!,
+        ]),
+      ).to.equal(true);
+    });
+
+    it('should be equal with values in different locales', () => {
+      expect(
+        adapter.isWithinRange(adapter.date('2022-04-17'), [
+          adapterFr.date('2022-04-17'),
+          adapterFr.date('2022-04-19'),
         ]),
       ).to.equal(true);
     });


### PR DESCRIPTION
Fixes #11622

We used Luxon API for comparing equality, but it also includes some metadata in comparison (like locale the date was created it).
With this change, we are only going to compare the difference in time.
