### PR TITLE
[DataDrid] Fix `upsertFilterItems` removing filters that are not part of the update

### DIFF
--- a/packages/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/filtering.DataGridPro.test.tsx
@@ -76,6 +76,64 @@ describe('<DataGridPro /> - Filter', () => {
     ],
   };
 
+  describe('api method: `upsertFilterItems`', () => {
+    it('should be able to add multiple filters', () => {
+      render(<TestCase getRowId={(row) => row.brand} />);
+
+      act(() =>
+        apiRef.current.upsertFilterItems([
+          {
+            field: 'brand',
+            value: 'i',
+            operator: 'contains',
+            id: 1,
+          },
+          {
+            field: 'brand',
+            value: 'as',
+            operator: 'contains',
+            id: 2,
+          },
+        ]),
+      );
+      expect(getColumnValues(0)).to.deep.equal(['Adidas']);
+    });
+
+    // See https://github.com/mui/mui-x/issues/11793
+    it('should not remove filters which are not passed to `upsertFilterItems`', () => {
+      render(<TestCase getRowId={(row) => row.brand} />);
+
+      act(() =>
+        apiRef.current.upsertFilterItems([
+          {
+            field: 'brand',
+            value: 'i',
+            operator: 'contains',
+            id: 1,
+          },
+          {
+            field: 'brand',
+            value: 'as',
+            operator: 'contains',
+            id: 2,
+          },
+        ]),
+      );
+      expect(getColumnValues(0)).to.deep.equal(['Adidas']);
+      act(() =>
+        apiRef.current.upsertFilterItems([
+          {
+            field: 'brand',
+            value: '',
+            operator: 'contains',
+            id: 2,
+          },
+        ]),
+      );
+      expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas']);
+    });
+  });
+
   it('slotProps `filterColumns` and `getColumnForNewFilter` should allow custom filtering', () => {
     const filterColumns = ({ field, columns, currentFilters }: FilterColumnsArgs) => {
       // remove already filtered fields from list of columns

--- a/packages/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
+++ b/packages/x-data-grid/src/hooks/features/filter/useGridFilter.tsx
@@ -174,14 +174,14 @@ export const useGridFilter = (
       const filterModel = gridFilterModelSelector(apiRef);
       const existingItems = [...filterModel.items];
       items.forEach((item) => {
-        const itemIndex = items.findIndex((filterItem) => filterItem.id === item.id);
+        const itemIndex = existingItems.findIndex((filterItem) => filterItem.id === item.id);
         if (itemIndex === -1) {
           existingItems.push(item);
         } else {
           existingItems[itemIndex] = item;
         }
       });
-      apiRef.current.setFilterModel({ ...filterModel, items }, 'upsertFilterItems');
+      apiRef.current.setFilterModel({ ...filterModel, items: existingItems }, 'upsertFilterItems');
     },
     [apiRef],
   );


### PR DESCRIPTION
## Description

Closes [11793](https://github.com/mui/mui-x/issues/11793)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
