### PR TITLE
[TreeView] Correctly detect if an item is expandable

### DIFF
--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -184,6 +184,40 @@ describe('<TreeItem />', () => {
 
     expect(getByTestId('2')).not.to.have.attribute('aria-expanded');
   });
+  it('should treat multiple empty conditional arrays as empty', () => {
+    const { getByTestId } = render(
+      <SimpleTreeView defaultExpandedNodes={['1']}>
+        <TreeItem nodeId="1" label="1" data-testid="1">
+          <TreeItem nodeId="2" label="2" data-testid="2">
+            {[].map((_, index) => (
+              <React.Fragment key={index}>a child</React.Fragment>
+            ))}
+            {[].map((_, index) => (
+              <React.Fragment key={index}>a child</React.Fragment>
+            ))}
+          </TreeItem>
+        </TreeItem>
+      </SimpleTreeView>,
+    );
+
+    expect(getByTestId('2')).not.to.have.attribute('aria-expanded');
+  });
+  it('should treat one conditional empty and one conditional with results as expandable', () => {
+    const { getByTestId } = render(
+      <SimpleTreeView defaultExpandedNodes={['1', '2']}>
+        <TreeItem nodeId="1" label="1" data-testid="1">
+          <TreeItem nodeId="2" label="2" data-testid="2">
+            {[]}
+            {[1].map((_, index) => (
+              <React.Fragment key={index}>a child</React.Fragment>
+            ))}
+          </TreeItem>
+        </TreeItem>
+      </SimpleTreeView>,
+    );
+
+    expect(getByTestId('2')).to.have.attribute('aria-expanded', 'true');
+  });
 
   it('should not call onClick when children are clicked', () => {
     const handleClick = spy();

--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -218,6 +218,19 @@ describe('<TreeItem />', () => {
 
     expect(getByTestId('2')).to.have.attribute('aria-expanded', 'true');
   });
+  it('should handle edge case of nested array of array', () => {
+    const { getByTestId } = render(
+      <SimpleTreeView defaultExpandedNodes={['1', '2']}>
+        <TreeItem nodeId="1" label="1" data-testid="1">
+          <TreeItem nodeId="2" label="2" data-testid="2">
+            {[[]]}
+          </TreeItem>
+        </TreeItem>
+      </SimpleTreeView>,
+    );
+
+    expect(getByTestId('2')).not.to.have.attribute('aria-expanded');
+  });
 
   it('should not call onClick when children are clicked', () => {
     const handleClick = spy();

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -187,7 +187,16 @@ export const TreeItem = React.forwardRef(function TreeItem(
     icon: inSlots?.icon,
   };
 
-  const expandable = Boolean(Array.isArray(children) ? children.length : children);
+  const isExpandable = (reactChildren: React.ReactNode) => {
+    if (Array.isArray(reactChildren)) {
+      return (
+        reactChildren.length > 0 &&
+        reactChildren.some((child) => (Array.isArray(child) ? child.length > 0 : true))
+      );
+    }
+    return Boolean(reactChildren);
+  };
+  const expandable = isExpandable(children);
   const expanded = instance.isNodeExpanded(nodeId);
   const focused = instance.isNodeFocused(nodeId);
   const selected = instance.isNodeSelected(nodeId);

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -191,7 +191,7 @@ export const TreeItem = React.forwardRef(function TreeItem(
     if (Array.isArray(reactChildren)) {
       return (
         reactChildren.length > 0 &&
-        reactChildren.some((child) => (Array.isArray(child) ? child.length > 0 : true))
+        reactChildren.some(isExpandable)
       );
     }
     return Boolean(reactChildren);

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -189,10 +189,7 @@ export const TreeItem = React.forwardRef(function TreeItem(
 
   const isExpandable = (reactChildren: React.ReactNode) => {
     if (Array.isArray(reactChildren)) {
-      return (
-        reactChildren.length > 0 &&
-        reactChildren.some(isExpandable)
-      );
+      return reactChildren.length > 0 && reactChildren.some(isExpandable);
     }
     return Boolean(reactChildren);
   };

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewJSXNodes/useTreeViewJSXNodes.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewJSXNodes/useTreeViewJSXNodes.tsx
@@ -71,7 +71,17 @@ const useTreeViewJSXNodesItemPlugin: TreeViewItemPlugin = ({ props, ref }) => {
 
   const { instance } = useTreeViewContext<[UseTreeViewJSXNodesSignature]>();
 
-  const expandable = Boolean(Array.isArray(children) ? children.length : children);
+  const isExpandable = (reactChildren: React.ReactNode) => {
+    if (Array.isArray(reactChildren)) {
+      return (
+        reactChildren.length > 0 &&
+        reactChildren.some((child) => (Array.isArray(child) ? child.length > 0 : true))
+      );
+    }
+    return Boolean(reactChildren);
+  };
+
+  const expandable = isExpandable(children);
 
   const [treeItemElement, setTreeItemElement] = React.useState<HTMLLIElement | null>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewJSXNodes/useTreeViewJSXNodes.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewJSXNodes/useTreeViewJSXNodes.tsx
@@ -73,10 +73,7 @@ const useTreeViewJSXNodesItemPlugin: TreeViewItemPlugin = ({ props, ref }) => {
 
   const isExpandable = (reactChildren: React.ReactNode) => {
     if (Array.isArray(reactChildren)) {
-      return (
-        reactChildren.length > 0 &&
-        reactChildren.some((child) => (Array.isArray(child) ? child.length > 0 : true))
-      );
+      return reactChildren.length > 0 && reactChildren.some(isExpandable);
     }
     return Boolean(reactChildren);
   };


### PR DESCRIPTION
Expandable state was not being detected correctly when multiple conditional arrays would return null. The resulting children prop in react created: `children: [Array(0), Array(0)]` which would set expandable to true. Changed logic to check for multiple different scenarios where children could would have content but be empty in the dom. 

Closes #11948
