### PR TITLE
[docs] Add a note about `AdapterDateFnsV3` on the Getting Started page

### DIFF
--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -43,7 +43,7 @@ For `date-fns`, import the locale and pass it to `LocalizationProvider`:
 :::info
 Both `date-fns` major versions (v2.x and v3.x) are supported.
 
-A single adapter can not work for both `date-fns` v2.x and v3.x, because the way functions are exported has been changed in v3.x.
+A single adapter cannot work for both `date-fns` v2.x and v3.x, because the way functions are exported has been changed in v3.x.
 
 To use `date-fns` v3.x, you will have to import the adapter from `@mui/x-date-pickers/AdapterDateFnsV3` instead of `@mui/x-date-pickers/AdapterDateFns`.
 :::

--- a/docs/src/modules/components/PickersRenderingInstructions.js
+++ b/docs/src/modules/components/PickersRenderingInstructions.js
@@ -28,7 +28,7 @@ export default function PickersRenderingInstructions() {
     ...(libraryUsed === 'date-fns'
       ? [
           '// If you are using date-fns v3.x, please import `AdapterDateFnsV3`',
-          "import { AdapterDateFnsV3 } from '@mui/x-date-pickers/AdapterDateFnsV3'",
+          `import { AdapterDateFnsV3 } from '${componentPackage}/AdapterDateFnsV3'`,
         ]
       : []),
     '',

--- a/docs/src/modules/components/PickersRenderingInstructions.js
+++ b/docs/src/modules/components/PickersRenderingInstructions.js
@@ -21,7 +21,16 @@ export default function PickersRenderingInstructions() {
 
   const commandLines = [
     `import { LocalizationProvider } from '${componentPackage}';`,
+    ...(libraryUsed === 'date-fns'
+      ? ['// If you are using date-fns v2.x, please import `AdapterDateFns`']
+      : []),
     `import { ${adapterName} } from '${componentPackage}/${adapterName}'`,
+    ...(libraryUsed === 'date-fns'
+      ? [
+          '// If you are using date-fns v3.x, please import `AdapterDateFnsV3`',
+          "import { AdapterDateFnsV3 } from '@mui/x-date-pickers/AdapterDateFnsV3'",
+        ]
+      : []),
     '',
     'function App({ children }) {',
     '  return (',


### PR DESCRIPTION
Not the prettiest code :grimacing: 
But I think it will reduce the amount of people trying to use `AdapterDateFns` with the latest date-fns releases