### PR TITLE
[docs] Refactor `Localization` documentation sections

### DIFF
--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -101,4 +101,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -95,10 +95,10 @@ The following demo shows how to add a badge on some day based on server side dat
 
 {{"demo": "DateCalendarServerRequest.js"}}
 
-## Validation
-
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
-
 ## Localization
 
 You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -101,4 +101,4 @@ You can find the documentation in the [Validation page](/x/react-date-pickers/va
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/).
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.

--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -97,7 +97,7 @@ The following demo shows how to add a badge on some day based on server side dat
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-field/CustomDateFormat.js
+++ b/docs/data/date-pickers/date-field/CustomDateFormat.js
@@ -6,21 +6,17 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DateField } from '@mui/x-date-pickers/DateField';
 
 export default function CustomDateFormat() {
-  const [value, setValue] = React.useState(dayjs('2022-04-17'));
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['DateField', 'DateField']}>
         <DateField
           label="Dash separator"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17')}
           format="MM-DD-YYYY"
         />
         <DateField
           label="Full letter month"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17')}
           format="LL"
         />
       </DemoContainer>

--- a/docs/data/date-pickers/date-field/CustomDateFormat.tsx
+++ b/docs/data/date-pickers/date-field/CustomDateFormat.tsx
@@ -1,26 +1,22 @@
 import * as React from 'react';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DateField } from '@mui/x-date-pickers/DateField';
 
 export default function CustomDateFormat() {
-  const [value, setValue] = React.useState<Dayjs | null>(dayjs('2022-04-17'));
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['DateField', 'DateField']}>
         <DateField
           label="Dash separator"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17')}
           format="MM-DD-YYYY"
         />
         <DateField
           label="Full letter month"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17')}
           format="LL"
         />
       </DemoContainer>

--- a/docs/data/date-pickers/date-field/CustomDateFormat.tsx.preview
+++ b/docs/data/date-pickers/date-field/CustomDateFormat.tsx.preview
@@ -1,12 +1,10 @@
 <DateField
   label="Dash separator"
-  value={value}
-  onChange={(newValue) => setValue(newValue)}
+  defaultValue={dayjs('2022-04-17')}
   format="MM-DD-YYYY"
 />
 <DateField
   label="Full letter month"
-  value={value}
-  onChange={(newValue) => setValue(newValue)}
+  defaultValue={dayjs('2022-04-17')}
   format="LL"
 />

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -34,7 +34,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-Use the `LocalizationProvider` to change the date-library locale used in the time field.
+Use the `LocalizationProvider` to change the date-library locale used in the date field.
 See the [localization documentation page](/x/react-date-pickers/localization/) for more details.
 
 ## Validation

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -42,4 +42,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -28,17 +28,17 @@ The value of the component can be uncontrolled or controlled.
 Learn more about the _Controlled and uncontrolled_ pattern in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
-## Customize the date format
+## Localization
+
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
+
+### Customize the date format
 
 {{"demo": "CustomDateFormat.js"}}
 
 :::info
 You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
 :::
-
-## Localization
-
-See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -37,7 +37,7 @@ See the [Date format and localization](/x/react-date-pickers/adapters-locale/) a
 {{"demo": "CustomDateFormat.js"}}
 
 :::info
-You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
+See [Date format and localization—Custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) for more details.
 :::
 
 ## Validation

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -38,7 +38,7 @@ You can find more information about [custom formats](/x/react-date-pickers/adapt
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -32,10 +32,13 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 {{"demo": "CustomDateFormat.js"}}
 
+:::info
+You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
+:::
+
 ## Localization
 
-Use the `LocalizationProvider` to change the date-library locale used in the date field.
-See the [localization documentation page](/x/react-date-pickers/localization/) for more details.
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -112,13 +112,13 @@ You can enable the clearable behavior:
 
 {{"demo": "ClearableProp.js"}}
 
-## Validation
-
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
-
 ## Localization
 
 You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
 
 ## Customization
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -118,7 +118,7 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.
 
 ## Customization
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -118,7 +118,7 @@ You can find the documentation in the [Validation page](/x/react-date-pickers/va
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/).
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
 
 ## Customization
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -114,7 +114,7 @@ You can enable the clearable behavior:
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -54,10 +54,10 @@ You can take advantage of the [DateRangePickerDay](/x/api/date-pickers/date-rang
 
 {{"demo": "CustomDateRangePickerDay.js"}}
 
-## Validation
-
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
-
 ## Localization
 
 You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -60,4 +60,4 @@ You can find the documentation in the [Validation page](/x/react-date-pickers/va
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/).
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -60,4 +60,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -56,7 +56,7 @@ You can take advantage of the [DateRangePickerDay](/x/api/date-pickers/date-rang
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -41,4 +41,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -37,7 +37,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -34,3 +34,11 @@ The value of the component can be uncontrolled or controlled.
 
 Learn more about the _Controlled and uncontrolled_ pattern in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
+
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -104,7 +104,7 @@ You can find the documentation in the [Custom field page](/x/react-date-pickers/
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -108,7 +108,7 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.
 
 ## Month Range Picker 🚧
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -102,6 +102,10 @@ To simplify range selection, you can add [shortcuts](/x/react-date-pickers/short
 
 You can find the documentation in the [Custom field page](/x/react-date-pickers/custom-field/).
 
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
 ## Validation
 
 You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/date-time-field/CustomDateTimeFormat.js
+++ b/docs/data/date-pickers/date-time-field/CustomDateTimeFormat.js
@@ -6,8 +6,6 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 
 export default function CustomDateTimeFormat() {
-  const [value, setValue] = React.useState(dayjs('2022-04-17T15:30'));
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer
@@ -15,20 +13,17 @@ export default function CustomDateTimeFormat() {
       >
         <DateTimeField
           label="Format with meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="L hh:mm a"
         />
         <DateTimeField
           label="Format without meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="L HH:mm"
         />
         <DateTimeField
           label="Localized format with full letter month"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="LLL"
         />
       </DemoContainer>

--- a/docs/data/date-pickers/date-time-field/CustomDateTimeFormat.tsx
+++ b/docs/data/date-pickers/date-time-field/CustomDateTimeFormat.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 
 export default function CustomDateTimeFormat() {
-  const [value, setValue] = React.useState<Dayjs | null>(dayjs('2022-04-17T15:30'));
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer
@@ -15,20 +13,17 @@ export default function CustomDateTimeFormat() {
       >
         <DateTimeField
           label="Format with meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="L hh:mm a"
         />
         <DateTimeField
           label="Format without meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="L HH:mm"
         />
         <DateTimeField
           label="Localized format with full letter month"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="LLL"
         />
       </DemoContainer>

--- a/docs/data/date-pickers/date-time-field/CustomDateTimeFormat.tsx.preview
+++ b/docs/data/date-pickers/date-time-field/CustomDateTimeFormat.tsx.preview
@@ -1,0 +1,15 @@
+<DateTimeField
+  label="Format with meridiem"
+  defaultValue={dayjs('2022-04-17T15:30')}
+  format="L hh:mm a"
+/>
+<DateTimeField
+  label="Format without meridiem"
+  defaultValue={dayjs('2022-04-17T15:30')}
+  format="L HH:mm"
+/>
+<DateTimeField
+  label="Localized format with full letter month"
+  defaultValue={dayjs('2022-04-17T15:30')}
+  format="LLL"
+/>

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -37,7 +37,7 @@ See the [Date format and localization](/x/react-date-pickers/adapters-locale/) a
 {{"demo": "CustomDateTimeFormat.js"}}
 
 :::info
-You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
+See [Date format and localization—Custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) for more details.
 :::
 
 ## Validation

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -42,4 +42,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -38,7 +38,7 @@ You can find more information about [custom formats](/x/react-date-pickers/adapt
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -32,10 +32,13 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 {{"demo": "CustomDateTimeFormat.js"}}
 
+:::info
+You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
+:::
+
 ## Localization
 
-Use the `LocalizationProvider` to change the date-library locale used in the date time field.
-See the [localization documentation page](/x/react-date-pickers/localization/) for more details.
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -28,17 +28,17 @@ The value of the component can be uncontrolled or controlled.
 Learn more about the _Controlled and uncontrolled_ pattern in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
-## Customize the date time format
+## Localization
+
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
+
+### Customize the date time format
 
 {{"demo": "CustomDateTimeFormat.js"}}
 
 :::info
 You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
 :::
-
-## Localization
-
-See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -112,7 +112,7 @@ You might be interested in using the [Time Clock](/x/react-date-pickers/time-clo
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -116,4 +116,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -110,10 +110,10 @@ You might be interested in using the [Time Clock](/x/react-date-pickers/time-clo
 
 {{"demo": "DateTimePickerViewRenderers.js"}}
 
-## Validation
-
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
-
 ## Localization
 
 You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -116,4 +116,4 @@ You can find the documentation in the [Validation page](/x/react-date-pickers/va
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/).
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -41,4 +41,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -37,7 +37,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -34,3 +34,11 @@ The value of the component can be uncontrolled or controlled.
 
 Learn more about the _Controlled and uncontrolled_ pattern in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
+
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -102,7 +102,7 @@ You can pass a different view renderer to the Date Time Range Picker to customiz
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -106,4 +106,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -100,6 +100,10 @@ You can pass a different view renderer to the Date Time Range Picker to customiz
 
 {{"demo": "DateTimeRangePickerViewRenderer.js"}}
 
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
 ## Validation
 
 You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/digital-clock/digital-clock.md
+++ b/docs/data/date-pickers/digital-clock/digital-clock.md
@@ -92,4 +92,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/digital-clock/digital-clock.md
+++ b/docs/data/date-pickers/digital-clock/digital-clock.md
@@ -86,6 +86,10 @@ The following example combines these properties to customize which options are r
 
 {{"demo": "DigitalClockSkipDisabled.js"}}
 
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
 ## Validation
 
 You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/digital-clock/digital-clock.md
+++ b/docs/data/date-pickers/digital-clock/digital-clock.md
@@ -88,7 +88,7 @@ The following example combines these properties to customize which options are r
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/time-clock/time-clock.md
+++ b/docs/data/date-pickers/time-clock/time-clock.md
@@ -60,4 +60,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/time-clock/time-clock.md
+++ b/docs/data/date-pickers/time-clock/time-clock.md
@@ -56,7 +56,7 @@ You can find more information about 12h/24h format in the [Date localization pag
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/time-clock/time-clock.md
+++ b/docs/data/date-pickers/time-clock/time-clock.md
@@ -54,6 +54,10 @@ You can find more information about 12h/24h format in the [Date localization pag
 
 {{"demo": "TimeClockAmPm.js"}}
 
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
 ## Validation
 
 You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/time-field/CustomTimeFormat.js
+++ b/docs/data/date-pickers/time-field/CustomTimeFormat.js
@@ -6,27 +6,22 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
 
 export default function CustomTimeFormat() {
-  const [value, setValue] = React.useState(dayjs('2022-04-17T15:30'));
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['TimeField', 'TimeField', 'TimeField']}>
         <TimeField
           label="Format with meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="hh:mm a"
         />
         <TimeField
           label="Format without meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="HH:mm"
         />
         <TimeField
           label="Format with seconds"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="HH:mm:ss"
         />
       </DemoContainer>

--- a/docs/data/date-pickers/time-field/CustomTimeFormat.tsx
+++ b/docs/data/date-pickers/time-field/CustomTimeFormat.tsx
@@ -1,32 +1,27 @@
 import * as React from 'react';
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
 
 export default function CustomTimeFormat() {
-  const [value, setValue] = React.useState<Dayjs | null>(dayjs('2022-04-17T15:30'));
-
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DemoContainer components={['TimeField', 'TimeField', 'TimeField']}>
         <TimeField
           label="Format with meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="hh:mm a"
         />
         <TimeField
           label="Format without meridiem"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="HH:mm"
         />
         <TimeField
           label="Format with seconds"
-          value={value}
-          onChange={(newValue) => setValue(newValue)}
+          defaultValue={dayjs('2022-04-17T15:30')}
           format="HH:mm:ss"
         />
       </DemoContainer>

--- a/docs/data/date-pickers/time-field/CustomTimeFormat.tsx.preview
+++ b/docs/data/date-pickers/time-field/CustomTimeFormat.tsx.preview
@@ -1,0 +1,15 @@
+<TimeField
+  label="Format with meridiem"
+  defaultValue={dayjs('2022-04-17T15:30')}
+  format="hh:mm a"
+/>
+<TimeField
+  label="Format without meridiem"
+  defaultValue={dayjs('2022-04-17T15:30')}
+  format="HH:mm"
+/>
+<TimeField
+  label="Format with seconds"
+  defaultValue={dayjs('2022-04-17T15:30')}
+  format="HH:mm:ss"
+/>

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -34,7 +34,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-Use the `LocalizationProvider` to change the date-library locale used in the date field.
+Use the `LocalizationProvider` to change the date-library locale used in the time field.
 See the [localization documentation page](/x/react-date-pickers/localization/) for more details.
 
 ## Validation

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -38,4 +38,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -37,7 +37,7 @@ See the [Date format and localization](/x/react-date-pickers/adapters-locale/) a
 {{"demo": "CustomTimeFormat.js"}}
 
 :::info
-You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
+See [Date format and localization—Custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) for more details.
 :::
 
 ## Validation

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -34,8 +34,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-Use the `LocalizationProvider` to change the date-library locale used in the time field.
-See the [localization documentation page](/x/react-date-pickers/localization/) for more details.
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
 
 ## Validation
 

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -28,13 +28,17 @@ The value of the component can be uncontrolled or controlled.
 Learn more about the _Controlled and uncontrolled_ pattern in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
-## Customize the time format
-
-{{"demo": "CustomTimeFormat.js"}}
-
 ## Localization
 
 See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
+
+### Customize the time format
+
+{{"demo": "CustomTimeFormat.js"}}
+
+:::info
+You can find more information about [custom formats](/x/react-date-pickers/adapters-locale/#custom-formats) in the documentation page.
+:::
 
 ## Validation
 

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -34,7 +34,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -110,7 +110,7 @@ You might be interested in using the [Time Clock](/x/react-date-pickers/time-clo
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -114,4 +114,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -108,6 +108,10 @@ You might be interested in using the [Time Clock](/x/react-date-pickers/time-clo
 
 {{"demo": "TimePickerViewRenderers.js"}}
 
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
 ## Validation
 
 You can find the documentation in the [Validation page](/x/react-date-pickers/validation/).

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -41,4 +41,4 @@ You can find the documentation about localization in the [Date format and locali
 
 ## Validation
 
-See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.
+See the [Validation](/x/react-date-pickers/validation/) documentation page for more details.

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -37,7 +37,7 @@ Learn more about the _Controlled and uncontrolled_ pattern in the [React documen
 
 ## Localization
 
-You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+See the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) documentation pages for more details.
 
 ## Validation
 

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -34,3 +34,11 @@ The value of the component can be uncontrolled or controlled.
 
 Learn more about the _Controlled and uncontrolled_ pattern in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
+
+## Localization
+
+You can find the documentation about localization in the [Date format and localization](/x/react-date-pickers/adapters-locale/) and [Translated components](/x/react-date-pickers/localization/) pages.
+
+## Validation
+
+See the documentation page [validation documentation page](/x/react-date-pickers/validation/) for more details.


### PR DESCRIPTION
Resolve topics discussed in https://mui-org.slack.com/archives/C04U3R2V9UK/p1707325208275059

- Consistently have `Localization` & `Validation` section in all Picker component pages
- Add callouts in `Customize the <x> format` sections to the `Custom format` documentation section
  - Simplify demos by using `defaultValue` instead of `controlled value`
- Make `Validation` section copyright consistent
- Simplify `Localization` section copyright