### PR TITLE
[charts][docs] Avoid use of shorthand

### DIFF
--- a/docs/data/charts/lines/LineDataset.js
+++ b/docs/data/charts/lines/LineDataset.js
@@ -541,7 +541,7 @@ export default function LineDataset() {
       xAxis={[
         {
           dataKey: 'year',
-          valueFormatter: (v) => v.toString(),
+          valueFormatter: (value) => value.toString(),
           min: 1985,
           max: 2022,
         },

--- a/docs/data/charts/lines/LineDataset.tsx
+++ b/docs/data/charts/lines/LineDataset.tsx
@@ -542,7 +542,7 @@ export default function LineDataset() {
       xAxis={[
         {
           dataKey: 'year',
-          valueFormatter: (v) => v.toString(),
+          valueFormatter: (value) => value.toString(),
           min: 1985,
           max: 2022,
         },

--- a/docs/data/charts/tooltip/Formatting.js
+++ b/docs/data/charts/tooltip/Formatting.js
@@ -87,8 +87,8 @@ export default function Formatting() {
     <LineChart
       {...lineChartsParams}
       xAxis={[{ data: years, scaleType: 'time', valueFormatter: yearFormatter }]}
-      series={lineChartsParams.series.map((s) => ({
-        ...s,
+      series={lineChartsParams.series.map((serie) => ({
+        ...serie,
         valueFormatter: currencyFormatter,
       }))}
     />

--- a/docs/data/charts/tooltip/Formatting.tsx
+++ b/docs/data/charts/tooltip/Formatting.tsx
@@ -87,8 +87,8 @@ export default function Formatting() {
     <LineChart
       {...lineChartsParams}
       xAxis={[{ data: years, scaleType: 'time', valueFormatter: yearFormatter }]}
-      series={lineChartsParams.series.map((s) => ({
-        ...s,
+      series={lineChartsParams.series.map((serie) => ({
+        ...serie,
         valueFormatter: currencyFormatter,
       }))}
     />

--- a/docs/data/charts/tooltip/Formatting.tsx.preview
+++ b/docs/data/charts/tooltip/Formatting.tsx.preview
@@ -1,8 +1,8 @@
 <LineChart
   {...lineChartsParams}
   xAxis={[{ data: years, scaleType: 'time', valueFormatter: yearFormatter }]}
-  series={lineChartsParams.series.map((s) => ({
-    ...s,
+  series={lineChartsParams.series.map((serie) => ({
+    ...serie,
     valueFormatter: currencyFormatter,
   }))}
 />

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -33,7 +33,7 @@
     },
     "valueFormatter": {
       "type": { "name": "func" },
-      "default": "(v: number | null) => (v === null ? '' : v.toString())",
+      "default": "(value: number | null) => (value === null ? '' : value.toString())",
       "signature": {
         "type": "function(value: number) => string",
         "describedArgs": ["value"],

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -61,7 +61,7 @@ export interface SparkLineChartProps
    * Formatter used by the tooltip.
    * @param {number} value The value to format.
    * @returns {string} the formatted value.
-   * @default (v: number | null) => (v === null ? '' : v.toString())
+   * @default (value: number | null) => (value === null ? '' : value.toString())
    */
   valueFormatter?: (value: number | null) => string;
   /**
@@ -143,7 +143,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
     slotProps,
     data,
     plotType = 'line',
-    valueFormatter = (v: number | null) => (v === null ? '' : v.toString()),
+    valueFormatter = (value: number | null) => (value === null ? '' : value.toString()),
     area,
     curve = 'linear',
   } = props;
@@ -328,7 +328,7 @@ SparkLineChart.propTypes = {
    * Formatter used by the tooltip.
    * @param {number} value The value to format.
    * @returns {string} the formatted value.
-   * @default (v: number | null) => (v === null ? '' : v.toString())
+   * @default (value: number | null) => (value === null ? '' : value.toString())
    */
   valueFormatter: PropTypes.func,
   viewBox: PropTypes.shape({


### PR DESCRIPTION
I think we should avoid shorthands for the docs. It made me work harder to figure out how to do https://github.com/mui/mui-public/pull/147:

Before: https://next.mui.com/x/api/charts/spark-line-chart/#spark-line-chart-prop-valueFormatter

<img src="https://github.com/mui/mui-x/assets/3165635/237deaab-4bc9-4d05-9a2e-1fff9237f7e9" width="574">

After: https://deploy-preview-12000--material-ui-x.netlify.app/x/api/charts/spark-line-chart/#spark-line-chart-prop-valueFormatter