### PR TITLE
[DataGrid] Improve `fastObjectShallowCompare`

### DIFF
--- a/packages/x-data-grid/src/utils/fastObjectShallowCompare.ts
+++ b/packages/x-data-grid/src/utils/fastObjectShallowCompare.ts
@@ -19,9 +19,6 @@ export function fastObjectShallowCompare<T extends Record<string, any> | null>(a
     if (!is(a[key], b[key])) {
       return false;
     }
-    if (!(key in b)) {
-      return false;
-    }
   }
 
   /* eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
The guard removed here is not necessary due to the final `aLength === bLength` check. This optimization is done under the assumption that the objects are likely to be equal, so short-circuiting there is unlikely to happen.