### PR TITLE
[DataGrid] Prevent paste operations in non-editable cells (#11984)

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
@@ -121,10 +121,16 @@ class CellValueUpdater {
     }
 
     const { apiRef, getRowId } = this.options;
-    const colDef = apiRef.current.getColumn(field);
-    if (!colDef || !colDef.editable) {
+    const cellParams = apiRef.current.getCellParams(rowId, field);
+    if (!cellParams.isEditable) {
       return;
     }
+
+    const colDef = apiRef.current.getColumn(field);
+    if (!colDef) {
+      return;
+    }
+
     const row = this.rowsToUpdate[rowId] || { ...apiRef.current.getRow(rowId) };
     if (!row) {
       return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Description 


Fixes #11984 

- When pasting, only the column's editable property was being referenced, but now the isCellEditable prop is also taken into consideration.

## Test results

The table below shows which cells can be overwritten with paste

|                              | `isCellEditable` prop returns `true` | `isCellEditable` prop returns `false` | 
| ---------------------------- | ------------------------------- | -------------------------------- | 
| `colDef.editable` is `true`  | :o:                             | :x:   (:o: before the fix)                       | 
| `colDef.editable` is `false` | :x:                             | :x:                              | 


:o: : Can paste, :x: : Can not paste
