### PR TITLE
[core] Sort prop asc

### DIFF
--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -61,32 +61,32 @@ const PieArcRoot = styled(animated.path, {
 
 export type PieArcProps = Omit<React.ComponentPropsWithoutRef<'path'>, 'id'> &
   PieArcOwnerState & {
-    startAngle: SpringValue<number>;
-    endAngle: SpringValue<number>;
-    innerRadius: SpringValue<number>;
-    outerRadius: SpringValue<number>;
     cornerRadius: SpringValue<number>;
-    paddingAngle: SpringValue<number>;
+    endAngle: SpringValue<number>;
     highlightScope?: Partial<HighlightScope>;
+    innerRadius: SpringValue<number>;
     onClick?: (event: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
+    outerRadius: SpringValue<number>;
+    paddingAngle: SpringValue<number>;
+    startAngle: SpringValue<number>;
   };
 
 function PieArc(props: PieArcProps) {
   const {
-    id,
-    dataIndex,
     classes: innerClasses,
     color,
+    cornerRadius,
+    dataIndex,
+    endAngle,
     highlightScope,
-    onClick,
+    id,
+    innerRadius,
     isFaded,
     isHighlighted,
-    startAngle,
-    endAngle,
-    paddingAngle,
-    innerRadius,
+    onClick,
     outerRadius,
-    cornerRadius,
+    paddingAngle,
+    startAngle,
     ...other
   } = props;
 

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -83,21 +83,21 @@ export interface PieArcLabelPlotProps
 
 function PieArcLabelPlot(props: PieArcLabelPlotProps) {
   const {
-    slots,
-    slotProps,
-    innerRadius,
-    outerRadius,
-    arcLabelRadius,
-    cornerRadius = 0,
-    paddingAngle = 0,
-    id,
-    highlightScope,
-    highlighted,
-    faded = { additionalRadius: -5 },
-    data,
     arcLabel,
     arcLabelMinAngle = 0,
+    arcLabelRadius,
+    cornerRadius = 0,
+    data,
+    faded = { additionalRadius: -5 },
+    highlighted,
+    highlightScope,
+    id,
+    innerRadius,
+    outerRadius,
+    paddingAngle = 0,
     skipAnimation,
+    slotProps,
+    slots,
     ...other
   } = props;
 


### PR DESCRIPTION
Convention, helps with PRs conflicts.

Side note, it's kind of weird for `arcLabelMinAngle` to still render a `<text>` element but have it empty, maybe we could skip the text in the first place.