### PR TITLE
[DataGrid] Remove legacy editing API event: `rowEditCommit`

### DIFF
--- a/docs/data/data-grid/events/events.json
+++ b/docs/data/data-grid/events/events.json
@@ -302,14 +302,6 @@
   },
   {
     "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
-    "name": "rowEditCommit",
-    "description": "Fired when the props of the edit input are committed.",
-    "params": "GridRowId",
-    "event": "MuiEvent<MuiBaseEvent>",
-    "componentProp": "onRowEditCommit"
-  },
-  {
-    "projects": ["x-data-grid", "x-data-grid-pro", "x-data-grid-premium"],
     "name": "rowEditStart",
     "description": "Fired when the row turns to edit mode.",
     "params": "GridRowEditStartParams",

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -416,9 +416,9 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
   - When [Tree data](/x/react-data-grid/tree-data/) feature is used, the grid role is now `role="treegrid"` instead of `role="grid"`.
   - The Data Grid cells now have `role="gridcell"` instead of `role="cell"`.
 
-<!-- ### Editing
+### Editing
 
-- -->
+- The `rowEditCommit` event and the related prop `onRowEditCommit` was removed. The [`processRowUpdate`](/x/react-data-grid/editing/#the-processrowupdate-callback) prop can be used in its place.
 
 ### Other exports
 

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -455,13 +455,6 @@
         "describedArgs": ["params", "event", "details"]
       }
     },
-    "onRowEditCommit": {
-      "type": { "name": "func" },
-      "signature": {
-        "type": "function(id: GridRowId, event: MuiEvent<MuiBaseEvent>) => void",
-        "describedArgs": ["id", "event"]
-      }
-    },
     "onRowEditStart": {
       "type": { "name": "func" },
       "signature": {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -409,13 +409,6 @@
         "describedArgs": ["params", "event", "details"]
       }
     },
-    "onRowEditCommit": {
-      "type": { "name": "func" },
-      "signature": {
-        "type": "function(id: GridRowId, event: MuiEvent<MuiBaseEvent>) => void",
-        "describedArgs": ["id", "event"]
-      }
-    },
     "onRowEditStart": {
       "type": { "name": "func" },
       "signature": {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -322,13 +322,6 @@
         "describedArgs": ["params", "event", "details"]
       }
     },
-    "onRowEditCommit": {
-      "type": { "name": "func" },
-      "signature": {
-        "type": "function(id: GridRowId, event: MuiEvent<MuiBaseEvent>) => void",
-        "describedArgs": ["id", "event"]
-      }
-    },
     "onRowEditStart": {
       "type": { "name": "func" },
       "signature": {

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -490,13 +490,6 @@
         "details": "Additional details for this callback."
       }
     },
-    "onRowEditCommit": {
-      "description": "Callback fired when the row changes are committed.",
-      "typeDescriptions": {
-        "id": "The row id.",
-        "event": "The event that caused this prop to be called."
-      }
-    },
     "onRowEditStart": {
       "description": "Callback fired when the row turns to edit mode.",
       "typeDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -447,13 +447,6 @@
         "details": "Additional details for this callback."
       }
     },
-    "onRowEditCommit": {
-      "description": "Callback fired when the row changes are committed.",
-      "typeDescriptions": {
-        "id": "The row id.",
-        "event": "The event that caused this prop to be called."
-      }
-    },
     "onRowEditStart": {
       "description": "Callback fired when the row turns to edit mode.",
       "typeDescriptions": {

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -345,13 +345,6 @@
         "details": "Additional details for this callback."
       }
     },
-    "onRowEditCommit": {
-      "description": "Callback fired when the row changes are committed.",
-      "typeDescriptions": {
-        "id": "The row id.",
-        "event": "The event that caused this prop to be called."
-      }
-    },
     "onRowEditStart": {
       "description": "Callback fired when the row turns to edit mode.",
       "typeDescriptions": {

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -762,12 +762,6 @@ DataGridPremiumRaw.propTypes = {
    */
   onRowDoubleClick: PropTypes.func,
   /**
-   * Callback fired when the row changes are committed.
-   * @param {GridRowId} id The row id.
-   * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
-   */
-  onRowEditCommit: PropTypes.func,
-  /**
    * Callback fired when the row turns to edit mode.
    * @param {GridRowParams} params With all properties from [[GridRowParams]].
    * @param {MuiEvent<React.KeyboardEvent | React.MouseEvent>} event The event that caused this prop to be called.

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -678,12 +678,6 @@ DataGridProRaw.propTypes = {
    */
   onRowDoubleClick: PropTypes.func,
   /**
-   * Callback fired when the row changes are committed.
-   * @param {GridRowId} id The row id.
-   * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
-   */
-  onRowEditCommit: PropTypes.func,
-  /**
    * Callback fired when the row turns to edit mode.
    * @param {GridRowParams} params With all properties from [[GridRowParams]].
    * @param {MuiEvent<React.KeyboardEvent | React.MouseEvent>} event The event that caused this prop to be called.

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -534,12 +534,6 @@ DataGridRaw.propTypes = {
    */
   onRowDoubleClick: PropTypes.func,
   /**
-   * Callback fired when the row changes are committed.
-   * @param {GridRowId} id The row id.
-   * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
-   */
-  onRowEditCommit: PropTypes.func,
-  /**
    * Callback fired when the row turns to edit mode.
    * @param {GridRowParams} params With all properties from [[GridRowParams]].
    * @param {MuiEvent<React.KeyboardEvent | React.MouseEvent>} event The event that caused this prop to be called.

--- a/packages/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/x-data-grid/src/models/events/gridEventLookup.ts
@@ -19,7 +19,7 @@ import type { GridSortModel } from '../gridSortModel';
 import type { GridRowSelectionModel } from '../gridRowSelectionModel';
 import type { ElementSize } from '../elementSize';
 import type { MuiBaseEvent } from '../muiEvent';
-import type { GridGroupNode, GridRowId } from '../gridRows';
+import type { GridGroupNode } from '../gridRows';
 import type { GridColumnVisibilityModel } from '../../hooks/features/columns';
 import type { GridStrategyProcessorName } from '../../hooks/core/strategyProcessing';
 import { GridRowEditStartParams, GridRowEditStopParams } from '../params/gridRowParams';

--- a/packages/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/x-data-grid/src/models/events/gridEventLookup.ts
@@ -507,10 +507,6 @@ export interface GridEventLookup
     params: GridRowEditStopParams;
     event: MuiBaseEvent;
   };
-  /**
-   * Fired when the props of the edit input are committed.
-   */
-  rowEditCommit: { params: GridRowId; event: MuiBaseEvent };
 
   // Focus
   /**

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -470,12 +470,6 @@ export interface DataGridPropsWithoutDefaultValue<R extends GridValidRowModel = 
    */
   onCellEditStop?: GridEventListener<'cellEditStop'>;
   /**
-   * Callback fired when the row changes are committed.
-   * @param {GridRowId} id The row id.
-   * @param {MuiEvent<MuiBaseEvent>} event The event that caused this prop to be called.
-   */
-  onRowEditCommit?: GridEventListener<'rowEditCommit'>;
-  /**
    * Callback fired when the row turns to edit mode.
    * @param {GridRowParams} params With all properties from [[GridRowParams]].
    * @param {MuiEvent<React.KeyboardEvent | React.MouseEvent>} event The event that caused this prop to be called.


### PR DESCRIPTION
Closes #12071

## Changelog

### Breaking changes

- The `rowEditCommit` event and the related prop `onRowEditCommit` was removed. The [`processRowUpdate`](https://next.mui.com/x/react-data-grid/editing/#the-processrowupdate-callback) prop can be used in place.