### PR TITLE
[code-infra] Use `experimental.cpus` to control amount of export workers in Next.js

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -13,6 +13,10 @@ const { LANGUAGES, LANGUAGES_SSR } = require('./config');
 const workspaceRoot = path.join(__dirname, '../');
 
 module.exports = withDocsInfra({
+  experimental: {
+    workerThreads: true,
+    cpus: 3,
+  },
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',
   env: {


### PR DESCRIPTION
Port https://github.com/mui/material-ui/pull/41132
