### PR TITLE
[code-infra] Use `experimental.cpus` to control amount of export workers in Next.js

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -32,6 +32,10 @@ const chartsPkg = loadPkg('./packages/x-charts');
 const treeViewPkg = loadPkg('./packages/x-tree-view');
 
 export default withDocsInfra({
+  experimental: {
+    workerThreads: true,
+    cpus: 3,
+  },
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',
   env: {


### PR DESCRIPTION
Port of https://github.com/mui/material-ui/pull/41132