### PR TITLE
[core] Remove IE 11 compat logic

### DIFF
--- a/docs/data/data-grid/column-definition/RenderExpandCellGrid.js
+++ b/docs/data/data-grid/column-definition/RenderExpandCellGrid.js
@@ -38,8 +38,7 @@ const GridCellExpand = React.memo(function GridCellExpand(props) {
     }
 
     function handleKeyDown(nativeEvent) {
-      // IE11, Edge (prior to using Bink?) use 'Esc'
-      if (nativeEvent.key === 'Escape' || nativeEvent.key === 'Esc') {
+      if (nativeEvent.key === 'Escape') {
         setShowFullCell(false);
       }
     }

--- a/docs/data/data-grid/column-definition/RenderExpandCellGrid.tsx
+++ b/docs/data/data-grid/column-definition/RenderExpandCellGrid.tsx
@@ -45,8 +45,7 @@ const GridCellExpand = React.memo(function GridCellExpand(
     }
 
     function handleKeyDown(nativeEvent: KeyboardEvent) {
-      // IE11, Edge (prior to using Bink?) use 'Esc'
-      if (nativeEvent.key === 'Escape' || nativeEvent.key === 'Esc') {
+      if (nativeEvent.key === 'Escape') {
         setShowFullCell(false);
       }
     }

--- a/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersPopper.tsx
@@ -338,8 +338,7 @@ export function PickersPopper(inProps: PickerPopperProps) {
 
   React.useEffect(() => {
     function handleKeyDown(nativeEvent: KeyboardEvent) {
-      // IE11, Edge (prior to using Blink?) use 'Esc'
-      if (open && (nativeEvent.key === 'Escape' || nativeEvent.key === 'Esc')) {
+      if (open && nativeEvent.key === 'Escape') {
         onDismiss();
       }
     }


### PR DESCRIPTION
Per https://github.com/mui/material-ui/issues/40958#issuecomment-1951351873, It's safe to say that IE 11 will be entirely gone from Material UI v6, so it makes sense for MUI X v7 too. This is simpler to reason with and a bit smaller in bundle size.

I saw this in https://github.com/mui/mui-x/pull/11965