### PR TITLE
[core] Fix shortcuts when Caps Lock enabled

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
@@ -304,11 +304,13 @@ function defaultPasteResolver({
   });
 }
 
-const isPasteShortcut = (event: React.KeyboardEvent) => {
-  if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'v') {
-    if (event.shiftKey || event.altKey) {
-      return false;
-    }
+function isPasteShortcut(event: React.KeyboardEvent) {
+  if (
+    (event.ctrlKey || event.metaKey) &&
+    event.key.toLowerCase() === 'v' &&
+    !event.shiftKey &&
+    !event.altKey
+  ) {
     return true;
   }
   return false;

--- a/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
@@ -20,6 +20,7 @@ import {
   GridPipeProcessor,
   useGridRegisterPipeProcessor,
   getPublicApiRef,
+  isPasteShortcut,
 } from '@mui/x-data-grid/internals';
 import { GRID_DETAIL_PANEL_TOGGLE_FIELD, GRID_REORDER_COL_DEF } from '@mui/x-data-grid-pro';
 import { unstable_debounce as debounce } from '@mui/utils';
@@ -303,18 +304,6 @@ function defaultPasteResolver({
     }
   });
 }
-
-function isPasteShortcut(event: React.KeyboardEvent) {
-  if (
-    (event.ctrlKey || event.metaKey) &&
-    event.key.toLowerCase() === 'v' &&
-    !event.shiftKey &&
-    !event.altKey
-  ) {
-    return true;
-  }
-  return false;
-};
 
 export const useGridClipboardImport = (
   apiRef: React.MutableRefObject<GridPrivateApiPremium>,

--- a/packages/x-data-grid/src/hooks/features/clipboard/useGridClipboard.ts
+++ b/packages/x-data-grid/src/hooks/features/clipboard/useGridClipboard.ts
@@ -74,7 +74,14 @@ export const useGridClipboard = (
 
   const handleCopy = React.useCallback(
     (event: KeyboardEvent) => {
-      if (!((event.ctrlKey || event.metaKey) && event.key === 'c')) {
+      if (
+        !(
+          (event.ctrlKey || event.metaKey) &&
+          event.key.toLowerCase() === 'c' &&
+          !event.shiftKey &&
+          !event.altKey
+        )
+      ) {
         return;
       }
 

--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -29,7 +29,7 @@ import {
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { gridEditRowsStateSelector } from './gridEditingSelectors';
 import { GridRowId } from '../../../models/gridRows';
-import { isPrintableKey } from '../../../utils/keyboardUtils';
+import { isPrintableKey, isPasteShortcut } from '../../../utils/keyboardUtils';
 import { buildWarning } from '../../../utils/warning';
 import { gridRowsDataRowIdToIdLookupSelector } from '../rows/gridRowsSelector';
 import { deepClone } from '../../../utils/utils';
@@ -171,12 +171,7 @@ export const useGridCellEditing = (
         }
         if (isPrintableKey(event)) {
           reason = GridCellEditStartReasons.printableKeyDown;
-        } else if (
-          (event.ctrlKey || event.metaKey) &&
-          event.key.toLowerCase() === 'v' &&
-          !event.shiftKey &&
-          !event.altKey
-        ) {
+        } else if (isPasteShortcut(event)) {
           reason = GridCellEditStartReasons.pasteKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridCellEditStartReasons.enterKeyDown;

--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -171,7 +171,12 @@ export const useGridCellEditing = (
         }
         if (isPrintableKey(event)) {
           reason = GridCellEditStartReasons.printableKeyDown;
-        } else if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
+        } else if (
+          (event.ctrlKey || event.metaKey) &&
+          event.key.toLowerCase() === 'v' &&
+          !event.shiftKey &&
+          !event.altKey
+        ) {
           reason = GridCellEditStartReasons.pasteKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridCellEditStartReasons.enterKeyDown;

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -30,7 +30,7 @@ import {
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { gridEditRowsStateSelector } from './gridEditingSelectors';
 import { GridRowId } from '../../../models/gridRows';
-import { isPrintableKey } from '../../../utils/keyboardUtils';
+import { isPrintableKey, isPasteShortcut } from '../../../utils/keyboardUtils';
 import {
   gridColumnFieldsSelector,
   gridVisibleColumnFieldsSelector,
@@ -246,12 +246,7 @@ export const useGridRowEditing = (
 
         if (isPrintableKey(event)) {
           reason = GridRowEditStartReasons.printableKeyDown;
-        } else if (
-          (event.ctrlKey || event.metaKey) &&
-          event.key.toLowerCase() === 'v' &&
-          !event.shiftKey &&
-          !event.altKey
-        ) {
+        } else if (isPasteShortcut(event)) {
           reason = GridRowEditStartReasons.printableKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridRowEditStartReasons.enterKeyDown;

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -246,7 +246,12 @@ export const useGridRowEditing = (
 
         if (isPrintableKey(event)) {
           reason = GridRowEditStartReasons.printableKeyDown;
-        } else if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
+        } else if (
+          (event.ctrlKey || event.metaKey) &&
+          event.key.toLowerCase() === 'v' &&
+          !event.shiftKey &&
+          !event.altKey
+        ) {
           reason = GridRowEditStartReasons.printableKeyDown;
         } else if (event.key === 'Enter') {
           reason = GridRowEditStartReasons.enterKeyDown;

--- a/packages/x-data-grid/src/internals/index.ts
+++ b/packages/x-data-grid/src/internals/index.ts
@@ -146,7 +146,7 @@ export {
   getActiveElement,
   isEventTargetInPortal,
 } from '../utils/domUtils';
-export { isNavigationKey } from '../utils/keyboardUtils';
+export { isNavigationKey, isPasteShortcut } from '../utils/keyboardUtils';
 export * from '../utils/utils';
 export * from '../utils/fastMemo';
 export { buildWarning } from '../utils/warning';

--- a/packages/x-data-grid/src/utils/keyboardUtils.ts
+++ b/packages/x-data-grid/src/utils/keyboardUtils.ts
@@ -47,3 +47,17 @@ export const isKeyboardEvent = (event: any): event is React.KeyboardEvent<HTMLEl
   !!event.key;
 
 export const isHideMenuKey = (key: React.KeyboardEvent['key']) => isTabKey(key) || isEscapeKey(key);
+
+// In theory, on macOS, ctrl + v doesn't trigger a paste, so the function should return false.
+// However, maybe it's overkill to fix, so let's be lazy.
+export function isPasteShortcut(event: React.KeyboardEvent) {
+  if (
+    (event.ctrlKey || event.metaKey) &&
+    event.key.toLowerCase() === 'v' &&
+    !event.shiftKey &&
+    !event.altKey
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -302,7 +302,10 @@ export const useField = <
     // eslint-disable-next-line default-case
     switch (true) {
       // Select all
-      case event.key === 'a' && (event.ctrlKey || event.metaKey): {
+      case (event.ctrlKey || event.metaKey) &&
+        event.key.toLowerCase() === 'a' &&
+        !event.shiftKey &&
+        !event.altKey: {
         // prevent default to make sure that the next line "select all" while updating
         // the internal state at the same time.
         event.preventDefault();


### PR DESCRIPTION
IMHO, if we close #11790, I think it should be after we fully fixed the issue. #11965 is a step, but there is more. Here is a quick PR to go more in depth:

- `toLowerCase` is missing in a good chunk of other cases
- We don't need a double if
- We can apply the same alternative keys check in all the other places
- Left a note about a bug in macOS but I suspect it's overkill to fix (not worth the extra bundle size)