### PR TITLE
[test] Create local wrapper over describeConformance

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
     "@mui/icons-material": "^5.15.9",
     "@mui/material": "^5.15.9",
-    "@mui/monorepo": "https://github.com/michaldudak/material-ui.git#generalize-test-utils",
+    "@mui/monorepo": "https://github.com/mui/material-ui.git#master",
     "@mui/utils": "^5.15.9",
     "@next/eslint-plugin-next": "14.0.4",
     "@octokit/plugin-retry": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
     "@mui/icons-material": "^5.15.9",
     "@mui/material": "^5.15.9",
-    "@mui/monorepo": "https://github.com/mui/material-ui.git#master",
+    "@mui/monorepo": "https://github.com/michaldudak/material-ui.git#generalize-test-utils",
     "@mui/utils": "^5.15.9",
     "@next/eslint-plugin-next": "14.0.4",
     "@octokit/plugin-retry": "^6.0.1",

--- a/packages/x-data-grid/src/components/panel/GridPanel.test.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/x-data-grid';
 import { GridRootPropsContext } from '@mui/x-data-grid/context/GridRootPropsContext';
 import Popper from '@mui/material/Popper';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<GridPanel />', () => {
   const { render } = createRenderer();

--- a/packages/x-data-grid/src/components/panel/GridPanel.test.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import {
   GridPanel,
   gridPanelClasses as classes,
@@ -8,6 +8,7 @@ import {
 } from '@mui/x-data-grid';
 import { GridRootPropsContext } from '@mui/x-data-grid/context/GridRootPropsContext';
 import Popper from '@mui/material/Popper';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<GridPanel />', () => {
   const { render } = createRenderer();

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -21,7 +21,7 @@ import {
   dateRangeCalendarClasses as classes,
 } from '@mui/x-date-pickers-pro/DateRangeCalendar';
 import { DateRangePickerDay } from '@mui/x-date-pickers-pro/DateRangePickerDay';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 import { DateRangePosition } from './DateRangeCalendar.types';
 
 const getPickerDay = (name: string, picker = 'January 2018') =>

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -5,7 +5,6 @@ import {
   screen,
   fireEvent,
   getByRole,
-  describeConformance,
   fireTouchChangedEvent,
   userEvent,
 } from '@mui-internal/test-utils';
@@ -22,6 +21,7 @@ import {
   dateRangeCalendarClasses as classes,
 } from '@mui/x-date-pickers-pro/DateRangeCalendar';
 import { DateRangePickerDay } from '@mui/x-date-pickers-pro/DateRangePickerDay';
+import describeConformance from 'test/utils/describeConformance';
 import { DateRangePosition } from './DateRangeCalendar.types';
 
 const getPickerDay = (name: string, picker = 'January 2018') =>

--- a/packages/x-date-pickers-pro/src/DateRangePicker/describes.DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/describes.DateRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DateRangePicker /> - Describes', () => {
   const { render } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/DateRangePicker/describes.DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/describes.DateRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DateRangePicker /> - Describes', () => {
   const { render } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import {
   DateRangePickerDay,
   dateRangePickerDayClasses as classes,
 } from '@mui/x-date-pickers-pro/DateRangePickerDay';
 import { wrapPickerMount, createPickerRenderer, adapterToUse } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DateRangePickerDay />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.test.tsx
@@ -4,7 +4,7 @@ import {
   dateRangePickerDayClasses as classes,
 } from '@mui/x-date-pickers-pro/DateRangePickerDay';
 import { wrapPickerMount, createPickerRenderer, adapterToUse } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DateRangePickerDay />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describes.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describes.DesktopDateRangePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance, screen, userEvent } from '@mui-internal/test-utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import {
   adapterToUse,
   createPickerRenderer,
@@ -13,6 +13,7 @@ import {
 } from 'test/utils/pickers';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DesktopDateRangePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describes.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describes.DesktopDateRangePicker.test.tsx
@@ -13,7 +13,7 @@ import {
 } from 'test/utils/pickers';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DesktopDateRangePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describes.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describes.MobileDateRangePicker.test.tsx
@@ -12,7 +12,7 @@ import {
   describeValue,
   describePicker,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MobileDateRangePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describes.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describes.MobileDateRangePicker.test.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  describeConformance,
-  screen,
-  userEvent,
-  fireDiscreteEvent,
-} from '@mui-internal/test-utils';
+import { screen, userEvent, fireDiscreteEvent } from '@mui-internal/test-utils';
 import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker';
 import {
   adapterToUse,
@@ -17,6 +12,7 @@ import {
   describeValue,
   describePicker,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MobileDateRangePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.conformance.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MultiInputDateRangeField />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/MultiInputDateRangeField.conformance.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MultiInputDateRangeField />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.conformance.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MultiInputDateTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputDateTimeRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MultiInputDateTimeRangeField />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/MultiInputDateTimeRangeField.conformance.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import { MultiInputDateTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputDateTimeRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MultiInputDateTimeRangeField />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.conformance.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MultiInputTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputTimeRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MultiInputTimeRangeField />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.conformance.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/MultiInputTimeRangeField.conformance.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import { MultiInputTimeRangeField } from '@mui/x-date-pickers-pro/MultiInputTimeRangeField';
 import { createPickerRenderer, wrapPickerMount } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MultiInputTimeRangeField />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<SingleInputDateRangeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describes.SingleInputDateRangeField.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
-import { describeConformance } from '@mui-internal/test-utils';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<SingleInputDateRangeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describes.SingleInputDateTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describes.SingleInputDateTimeRangeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SingleInputDateTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputDateTimeRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<SingleInputDateTimeRangeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describes.SingleInputDateTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describes.SingleInputDateTimeRangeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import { SingleInputDateTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputDateTimeRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<SingleInputDateTimeRangeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describes.SingleInputTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describes.SingleInputTimeRangeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import { SingleInputTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputTimeRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<SingleInputTimeRangeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describes.SingleInputTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describes.SingleInputTimeRangeField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SingleInputTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputTimeRangeField';
 import { createPickerRenderer, wrapPickerMount, describeRangeValidation } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<SingleInputTimeRangeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -9,7 +9,7 @@ import {
   adapterToUse,
   describeRangeValidation,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<StaticDateRangePicker />', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { isWeekend } from 'date-fns';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
-import { describeConformance, screen } from '@mui-internal/test-utils';
+import { screen } from '@mui-internal/test-utils';
 import {
   wrapPickerMount,
   createPickerRenderer,
   adapterToUse,
   describeRangeValidation,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<StaticDateRangePicker />', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers/src/DateCalendar/tests/describes.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/describes.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, screen, userEvent } from '@mui-internal/test-utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import { DateCalendar, dateCalendarClasses as classes } from '@mui/x-date-pickers/DateCalendar';
 import { pickersDayClasses } from '@mui/x-date-pickers/PickersDay';
 import {
@@ -10,6 +10,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DateCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DateCalendar/tests/describes.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/describes.DateCalendar.test.tsx
@@ -10,7 +10,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DateCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { describeConformance, userEvent } from '@mui-internal/test-utils';
+import { userEvent } from '@mui-internal/test-utils';
 import TextField from '@mui/material/TextField';
 import { DateField } from '@mui/x-date-pickers/DateField';
 import {
@@ -12,6 +12,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DateField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/describes.DateField.test.tsx
@@ -12,7 +12,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DateField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DateTimeField/tests/describes.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/describes.DateTimeField.test.tsx
@@ -12,7 +12,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DateTimeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DateTimeField/tests/describes.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/describes.DateTimeField.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
-import { describeConformance, userEvent } from '@mui-internal/test-utils';
+import { userEvent } from '@mui-internal/test-utils';
 import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import {
   adapterToUse,
@@ -12,6 +12,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DateTimeField /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.test.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { describeConformance } from '@mui-internal/test-utils';
 import {
   DayCalendarSkeleton,
   dayCalendarSkeletonClasses as classes,
 } from '@mui/x-date-pickers/DayCalendarSkeleton';
 import { createPickerRenderer } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DayCalendarSkeleton />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.test.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.test.tsx
@@ -4,7 +4,7 @@ import {
   dayCalendarSkeletonClasses as classes,
 } from '@mui/x-date-pickers/DayCalendarSkeleton';
 import { createPickerRenderer } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DayCalendarSkeleton />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { screen, userEvent, describeConformance } from '@mui-internal/test-utils';
+import { screen, userEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,
@@ -13,6 +13,7 @@ import {
   formatFullTimeValue,
 } from 'test/utils/pickers';
 import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DesktopTimePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describes.DesktopTimePicker.test.tsx
@@ -13,7 +13,7 @@ import {
   formatFullTimeValue,
 } from 'test/utils/pickers';
 import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DesktopTimePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
@@ -11,7 +11,7 @@ import {
   formatFullTimeValue,
 } from 'test/utils/pickers';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<DigitalClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/describes.DigitalClock.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, describeConformance } from '@mui-internal/test-utils';
+import { screen } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,
@@ -11,6 +11,7 @@ import {
   formatFullTimeValue,
 } from 'test/utils/pickers';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<DigitalClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  describeConformance,
-  screen,
-  userEvent,
-  fireTouchChangedEvent,
-} from '@mui-internal/test-utils';
+import { screen, userEvent, fireTouchChangedEvent } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,
@@ -20,6 +15,7 @@ import {
   formatFullTimeValue,
 } from 'test/utils/pickers';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MobileTimePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describes.MobileTimePicker.test.tsx
@@ -15,7 +15,7 @@ import {
   formatFullTimeValue,
 } from 'test/utils/pickers';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MobileTimePicker /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
@@ -9,7 +9,7 @@ import {
   describeValue,
 } from 'test/utils/pickers';
 import { MonthCalendar, monthCalendarClasses as classes } from '@mui/x-date-pickers/MonthCalendar';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MonthCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describes.MonthCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, userEvent, screen } from '@mui-internal/test-utils';
+import { userEvent, screen } from '@mui-internal/test-utils';
 import {
   wrapPickerMount,
   createPickerRenderer,
@@ -9,6 +9,7 @@ import {
   describeValue,
 } from 'test/utils/pickers';
 import { MonthCalendar, monthCalendarClasses as classes } from '@mui/x-date-pickers/MonthCalendar';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MonthCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, describeConformance } from '@mui-internal/test-utils';
+import { screen } from '@mui-internal/test-utils';
 import {
   createPickerRenderer,
   wrapPickerMount,
@@ -11,6 +11,7 @@ import {
 } from 'test/utils/pickers';
 import { MultiSectionDigitalClock } from '@mui/x-date-pickers/MultiSectionDigitalClock';
 import { formatMeridiem } from '@mui/x-date-pickers/internals';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<MultiSectionDigitalClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describes.MultiSectionDigitalClock.test.tsx
@@ -11,7 +11,7 @@ import {
 } from 'test/utils/pickers';
 import { MultiSectionDigitalClock } from '@mui/x-date-pickers/MultiSectionDigitalClock';
 import { formatMeridiem } from '@mui/x-date-pickers/internals';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<MultiSectionDigitalClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer({ clock: 'fake' });

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, fireEvent, screen } from '@mui-internal/test-utils';
+import { fireEvent, screen } from '@mui-internal/test-utils';
 import ButtonBase from '@mui/material/ButtonBase';
 import { PickersDay, pickersDayClasses as classes } from '@mui/x-date-pickers/PickersDay';
 import { adapterToUse, wrapPickerMount, createPickerRenderer } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<PickersDay />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
+++ b/packages/x-date-pickers/src/PickersDay/PickersDay.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, screen } from '@mui-internal/test-utils';
 import ButtonBase from '@mui/material/ButtonBase';
 import { PickersDay, pickersDayClasses as classes } from '@mui/x-date-pickers/PickersDay';
 import { adapterToUse, wrapPickerMount, createPickerRenderer } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<PickersDay />', () => {
   const { render } = createPickerRenderer();

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  fireTouchChangedEvent,
-  screen,
-  getAllByRole,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { fireTouchChangedEvent, screen, getAllByRole, fireEvent } from '@mui-internal/test-utils';
 import {
   adapterToUse,
   wrapPickerMount,
@@ -15,6 +9,7 @@ import {
   describeValidation,
 } from 'test/utils/pickers';
 import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<StaticTimePicker />', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -9,7 +9,7 @@ import {
   describeValidation,
 } from 'test/utils/pickers';
 import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<StaticTimePicker />', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers/src/TimeClock/tests/describes.TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/describes.TimeClock.test.tsx
@@ -13,7 +13,7 @@ import {
   timeClockHandler,
   describeValue,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<TimeClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer();

--- a/packages/x-date-pickers/src/TimeClock/tests/describes.TimeClock.test.tsx
+++ b/packages/x-date-pickers/src/TimeClock/tests/describes.TimeClock.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, screen } from '@mui-internal/test-utils';
+import { screen } from '@mui-internal/test-utils';
 import {
   clockPointerClasses,
   TimeClock,
@@ -13,6 +13,7 @@ import {
   timeClockHandler,
   describeValue,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<TimeClock /> - Describes', () => {
   const { render, clock } = createPickerRenderer();

--- a/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { userEvent, screen, describeConformance } from '@mui-internal/test-utils';
+import { userEvent, screen } from '@mui-internal/test-utils';
 import { YearCalendar, yearCalendarClasses as classes } from '@mui/x-date-pickers/YearCalendar';
 import {
   wrapPickerMount,
@@ -9,6 +9,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<YearCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describes.YearCalendar.test.tsx
@@ -9,7 +9,7 @@ import {
   describeValidation,
   describeValue,
 } from 'test/utils/pickers';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<YearCalendar /> - Describes', () => {
   const { render, clock } = createPickerRenderer({

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createRenderer } from '@mui-internal/test-utils';
 import { RichTreeView, richTreeViewClasses as classes } from '@mui/x-tree-view/RichTreeView';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<RichTreeView />', () => {
   const { render } = createRenderer();

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { RichTreeView, richTreeViewClasses as classes } from '@mui/x-tree-view/RichTreeView';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<RichTreeView />', () => {
   const { render } = createRenderer();

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
@@ -1,17 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  act,
-  createRenderer,
-  ErrorBoundary,
-  fireEvent,
-  screen,
-  describeConformance,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, ErrorBoundary, fireEvent, screen } from '@mui-internal/test-utils';
 import Portal from '@mui/material/Portal';
 import { SimpleTreeView, simpleTreeViewClasses as classes } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<SimpleTreeView />', () => {
   const { render } = createRenderer();

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
@@ -5,7 +5,7 @@ import { act, createRenderer, ErrorBoundary, fireEvent, screen } from '@mui-inte
 import Portal from '@mui/material/Portal';
 import { SimpleTreeView, simpleTreeViewClasses as classes } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem } from '@mui/x-tree-view/TreeItem';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<SimpleTreeView />', () => {
   const { render } = createRenderer();

--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -8,7 +8,7 @@ import { TreeItem, treeItemClasses as classes } from '@mui/x-tree-view/TreeItem'
 import { TreeViewContextValue } from '@mui/x-tree-view/internals/TreeViewProvider';
 import { TreeViewContext } from '@mui/x-tree-view/internals/TreeViewProvider/TreeViewContext';
 import { DefaultTreeViewPlugins } from '@mui/x-tree-view/internals';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 const TEST_TREE_VIEW_CONTEXT_VALUE: TreeViewContextValue<DefaultTreeViewPlugins> = {
   instance: {

--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -2,19 +2,13 @@ import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  act,
-  createEvent,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createEvent, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 import { TreeItem, treeItemClasses as classes } from '@mui/x-tree-view/TreeItem';
 import { TreeViewContextValue } from '@mui/x-tree-view/internals/TreeViewProvider';
 import { TreeViewContext } from '@mui/x-tree-view/internals/TreeViewProvider/TreeViewContext';
 import { DefaultTreeViewPlugins } from '@mui/x-tree-view/internals';
+import describeConformance from 'test/utils/describeConformance';
 
 const TEST_TREE_VIEW_CONTEXT_VALUE: TreeViewContextValue<DefaultTreeViewPlugins> = {
   instance: {

--- a/packages/x-tree-view/src/TreeView/TreeView.test.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createRenderer } from '@mui-internal/test-utils';
 import { TreeView, treeViewClasses as classes } from '@mui/x-tree-view/TreeView';
-import describeConformance from 'test/utils/describeConformance';
+import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<TreeView />', () => {
   const { render } = createRenderer();

--- a/packages/x-tree-view/src/TreeView/TreeView.test.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { TreeView, treeViewClasses as classes } from '@mui/x-tree-view/TreeView';
+import describeConformance from 'test/utils/describeConformance';
 
 describe('<TreeView />', () => {
   const { render } = createRenderer();

--- a/test/utils/describeConformance.ts
+++ b/test/utils/describeConformance.ts
@@ -1,0 +1,20 @@
+import {
+  describeConformance as baseDescribeConformance,
+  ConformanceOptions,
+} from '@mui-internal/test-utils';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export default function describeConformance(
+  minimalElement: React.ReactElement,
+  getOptions: () => ConformanceOptions,
+) {
+  function getOptionsWithDefaults() {
+    return {
+      ThemeProvider,
+      createTheme,
+      ...getOptions(),
+    };
+  }
+
+  return baseDescribeConformance(minimalElement, getOptionsWithDefaults);
+}

--- a/test/utils/describeConformance.ts
+++ b/test/utils/describeConformance.ts
@@ -4,7 +4,7 @@ import {
 } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
-export default function describeConformance(
+export function describeConformance(
   minimalElement: React.ReactElement,
   getOptions: () => ConformanceOptions,
 ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,9 +1890,9 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/monorepo@https://github.com/mui/material-ui.git#master":
+"@mui/monorepo@https://github.com/michaldudak/material-ui.git#generalize-test-utils":
   version "5.15.10"
-  resolved "https://github.com/mui/material-ui.git#c5b4ebac51979272121a3b4369e43cf41509dad8"
+  resolved "https://github.com/michaldudak/material-ui.git#aded9c872b948d53c76ad15a7fb69ae6a60e5345"
   dependencies:
     "@googleapis/sheets" "^5.0.5"
     "@slack/bolt" "^3.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,9 +1890,9 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/monorepo@https://github.com/michaldudak/material-ui.git#generalize-test-utils":
+"@mui/monorepo@https://github.com/mui/material-ui.git#master":
   version "5.15.10"
-  resolved "https://github.com/michaldudak/material-ui.git#aded9c872b948d53c76ad15a7fb69ae6a60e5345"
+  resolved "https://github.com/mui/material-ui.git#a367c25dcaaddf5e72cceb5a9d8ef571607486c2"
   dependencies:
     "@googleapis/sheets" "^5.0.5"
     "@slack/bolt" "^3.17.1"


### PR DESCRIPTION
Core's https://github.com/mui/material-ui/pull/41175 removes test-utils dependency on @mui/material. With this change, the default ThemeProvider and createTheme are not provided and must be passed in by the caller. This change wraps the describeConformance so it's not needed to provide these fields in each describeConformance call.

This PR integrates the latest master from the Core monorepo.