### PR TITLE
[docs] Remove Charts installation next tag call-out

### DIFF
--- a/docs/data/charts/getting-started/getting-started.md
+++ b/docs/data/charts/getting-started/getting-started.md
@@ -28,11 +28,6 @@ pnpm add @mui/x-charts
 
 </codeblock>
 
-:::info
-The `next` tag is used to download the latest, **pre-release**, v7 version.
-Remove it to get the current stable version.
-:::
-
 ### Usage with Next.js
 
 If you're using MUI X Charts with Next.js, you might face the following error:


### PR DESCRIPTION
Address docs-feedback:

> New comment
"The next tag is used to download the latest" - there is no "next" tag in string "npm install @mui/x-charts"
sent from https://mui.com/x/react-charts/getting-started/ (from section [Installation)](https://mui.com/x/react-charts/getting-started/#installation)