### PR TITLE
[docs] Add recipe for hiding separator on non-resizable columns

### DIFF
--- a/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.js
+++ b/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.js
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { DataGridPro, gridClasses } from '@mui/x-data-grid-pro';
+
+const rows = [
+  {
+    id: 1,
+    username: '@MUI',
+    age: 20,
+  },
+];
+
+const columns = [
+  {
+    field: 'id',
+  },
+  {
+    field: 'username',
+    width: 125,
+    minWidth: 150,
+    maxWidth: 200,
+    resizable: false,
+  },
+  { field: 'age', resizable: false },
+];
+
+export default function ColumnHeaderHideSeparator() {
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <DataGridPro
+        columns={columns}
+        rows={rows}
+        sx={{
+          [`& .${gridClasses.columnSeparator}`]: {
+            [`&:not(.${gridClasses['columnSeparator--resizable']})`]: {
+              display: 'none',
+            },
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.js
+++ b/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.js
@@ -15,12 +15,14 @@ const columns = [
   },
   {
     field: 'username',
-    width: 125,
-    minWidth: 150,
-    maxWidth: 200,
+    width: 200,
     resizable: false,
   },
-  { field: 'age', resizable: false },
+  {
+    field: 'age',
+    width: 100,
+    resizable: false,
+  },
 ];
 
 export default function ColumnHeaderHideSeparator() {

--- a/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.tsx
+++ b/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { DataGridPro, GridColDef, gridClasses } from '@mui/x-data-grid-pro';
+
+const rows = [
+  {
+    id: 1,
+    username: '@MUI',
+    age: 20,
+  },
+];
+
+const columns: GridColDef[] = [
+  {
+    field: 'id',
+  },
+  {
+    field: 'username',
+    width: 125,
+    minWidth: 150,
+    maxWidth: 200,
+    resizable: false,
+  },
+  { field: 'age', resizable: false },
+];
+
+export default function ColumnHeaderHideSeparator() {
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <DataGridPro
+        columns={columns}
+        rows={rows}
+        sx={{
+          [`& .${gridClasses.columnSeparator}`]: {
+            [`&:not(.${gridClasses['columnSeparator--resizable']})`]: {
+              display: 'none',
+            },
+          },
+        }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.tsx
+++ b/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.tsx
@@ -15,12 +15,14 @@ const columns: GridColDef[] = [
   },
   {
     field: 'username',
-    width: 125,
-    minWidth: 150,
-    maxWidth: 200,
+    width: 200,
     resizable: false,
   },
-  { field: 'age', resizable: false },
+  {
+    field: 'age',
+    width: 100,
+    resizable: false,
+  },
 ];
 
 export default function ColumnHeaderHideSeparator() {

--- a/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.tsx.preview
+++ b/docs/data/data-grid/style-recipes/ColumnHeaderHideSeparator.tsx.preview
@@ -1,0 +1,11 @@
+<DataGridPro
+  columns={columns}
+  rows={rows}
+  sx={{
+    [`& .${gridClasses.columnSeparator}`]: {
+      [`&:not(.${gridClasses['columnSeparator--resizable']})`]: {
+        display: 'none',
+      },
+    },
+  }}
+/>

--- a/docs/data/data-grid/style-recipes/style-recipes.md
+++ b/docs/data/data-grid/style-recipes/style-recipes.md
@@ -13,6 +13,17 @@ Removing the visible `focus` state hurts the accessibility of the grid.
 
 {{"demo": "CellFocusNoOutline.js", "bg": "inline", "defaultCodeOpen": false}}
 
+## Remove drag handle for columns that are not resizeable
+
+In the MUI Data Grid, each column has a resize handle that allows users to adjust the width of the column.
+However, there might be cases where you want to disable this feature for certain columns.
+
+To hide the drag handles on columns that are not resizable, you can use the resizable property in the GridColDef object.
+When the column is not resizable, the drag handle will not have the `columnSeparator--resizable` class.
+We can use that to hide the separator.
+
+{{"demo": "ColumnHeaderHideSeparator.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Styling Cells without impacting aggregation cells [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 Aggregation cells do not receive a special class, so styling cells without impacting them needs a small workaround in the `getClassName` function.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

Adds a recipe that shows how to hide the separator (and with that the drag handle) on non-resizable columns.

Fixes #12017 