### PR TITLE
[core] Use the @mui/internal-scripts package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -93,7 +93,7 @@
     "@babel/plugin-transform-react-constant-elements": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
     "@mui-internal/docs-utils": "^1.0.0",
-    "@mui-internal/typescript-to-proptypes": "^1.0.2",
+    "@mui/internal-scripts": "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui/internal-scripts",
     "@types/doctrine": "^0.0.9",
     "@types/stylis": "^4.2.5",
     "@types/webpack-bundle-analyzer": "^4.6.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -92,8 +92,8 @@
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@mui-internal/docs-utils": "^1.0.0",
-    "@mui/internal-scripts": "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui/internal-scripts",
+    "@mui-internal/docs-utils": "^1.0.2",
+    "@mui/internal-scripts": "^1.0.1",
     "@types/doctrine": "^0.0.9",
     "@types/stylis": "^4.2.5",
     "@types/webpack-bundle-analyzer": "^4.6.3",

--- a/docs/scripts/generateProptypes.ts
+++ b/docs/scripts/generateProptypes.ts
@@ -2,7 +2,10 @@ import * as yargs from 'yargs';
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as prettier from 'prettier';
-import { getPropTypesFromFile, injectPropTypesInFile } from '@mui-internal/typescript-to-proptypes';
+import {
+  getPropTypesFromFile,
+  injectPropTypesInFile,
+} from '@mui/internal-scripts/typescript-to-proptypes';
 import { fixBabelGeneratorIssues, fixLineEndings } from '@mui-internal/docs-utils';
 import { createXTypeScriptProjects, XTypeScriptProject } from './createXTypeScriptProjects';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,17 +1796,10 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
-"@mui-internal/docs-utils@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@mui-internal/docs-utils/-/docs-utils-1.0.0.tgz#b1cd8fafe00dca045896daa2977e26eb551b891a"
-  integrity sha512-TqbdoXrXAk9JhcsGjekriQVU6A0w7oo01CfTfm4mefcKT2Z+RhHeFzG4fJrugN718qLdolJKGMoD7f+u/yBSBw==
-  dependencies:
-    rimraf "^5.0.5"
-    typescript "^5.1.6"
-
-"@mui-internal/docs-utils@https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui-internal/docs-utils":
-  version "1.0.1"
-  resolved "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui-internal/docs-utils#7e71fe5378e9649a88fd94fb79339bcabd2e33d0"
+"@mui-internal/docs-utils@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@mui-internal/docs-utils/-/docs-utils-1.0.2.tgz#6b98ed43f0dda40d164875c9d0ba14034468e393"
+  integrity sha512-Rqj9SVLK8MktX3lc0A/LJbF7/N8tLXxa7i6IpYnEYREx5MG98oHn7CSXQ978T7FLIYb3AObtJb6Ujy8JemcIcQ==
   dependencies:
     rimraf "^5.0.5"
     typescript "^5.3.3"
@@ -1836,16 +1829,17 @@
   dependencies:
     "@babel/runtime" "^7.23.9"
 
-"@mui/internal-scripts@https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui/internal-scripts":
-  version "1.0.0"
-  resolved "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui/internal-scripts#5e6c455f470253e736764a481f9c639d2e103e22"
+"@mui/internal-scripts@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@mui/internal-scripts/-/internal-scripts-1.0.1.tgz#9c4d4bdc9d9434688ca2d57d044729b366d98215"
+  integrity sha512-vUSVgbEDsfEZt4/pvBKoqPZ0iCi/jujhQxoK6zLnzDITzzWf+gyhKqWcN/jNQjlKD0vLc2Xiqpqk3yj9C2RT+A==
   dependencies:
     "@babel/core" "^7.23.9"
     "@babel/plugin-syntax-class-properties" "^7.12.13"
     "@babel/plugin-syntax-jsx" "^7.23.3"
     "@babel/plugin-syntax-typescript" "^7.23.3"
     "@babel/types" "^7.23.9"
-    "@mui-internal/docs-utils" "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui-internal/docs-utils"
+    "@mui-internal/docs-utils" "^1.0.2"
     doctrine "^3.0.0"
     lodash "^4.17.21"
     typescript "^5.3.3"
@@ -14445,7 +14439,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@>=3 < 6", typescript@^5.1.6, typescript@^5.3.3:
+"typescript@>=3 < 6", typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,7 +193,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
-"@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.23.7", "@babel/core@^7.23.9", "@babel/core@^7.7.5":
+"@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.23.9", "@babel/core@^7.7.5":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
   integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
@@ -1796,7 +1796,7 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
-"@mui-internal/docs-utils@1.0.0", "@mui-internal/docs-utils@^1.0.0":
+"@mui-internal/docs-utils@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@mui-internal/docs-utils/-/docs-utils-1.0.0.tgz#b1cd8fafe00dca045896daa2977e26eb551b891a"
   integrity sha512-TqbdoXrXAk9JhcsGjekriQVU6A0w7oo01CfTfm4mefcKT2Z+RhHeFzG4fJrugN718qLdolJKGMoD7f+u/yBSBw==
@@ -1804,21 +1804,12 @@
     rimraf "^5.0.5"
     typescript "^5.1.6"
 
-"@mui-internal/typescript-to-proptypes@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@mui-internal/typescript-to-proptypes/-/typescript-to-proptypes-1.0.2.tgz#93ccfe6f611ffc700e99570a34737842c6cc0c70"
-  integrity sha512-KpnPqY8MCQBHwmFMCZZxXwG3uREgMAbXKLBzcxlBhYxssZcYdsE/aImWE0B50QfVHBPjkNmt4dcI2UO2VEzS9w==
+"@mui-internal/docs-utils@https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui-internal/docs-utils":
+  version "1.0.1"
+  resolved "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui-internal/docs-utils#7e71fe5378e9649a88fd94fb79339bcabd2e33d0"
   dependencies:
-    "@babel/core" "^7.23.7"
-    "@babel/plugin-syntax-class-properties" "^7.12.13"
-    "@babel/plugin-syntax-jsx" "^7.23.3"
-    "@babel/plugin-syntax-typescript" "^7.23.3"
-    "@babel/types" "^7.23.6"
-    "@mui-internal/docs-utils" "1.0.0"
-    doctrine "^3.0.0"
-    lodash "^4.17.21"
+    rimraf "^5.0.5"
     typescript "^5.3.3"
-    uuid "^9.0.1"
 
 "@mui/base@5.0.0-beta.36", "@mui/base@^5.0.0-beta.36":
   version "5.0.0-beta.36"
@@ -1844,6 +1835,21 @@
   integrity sha512-6tLQoM6RylQuDnHR6qQay0G0pJgKmrhn5MIm0IfrwtmSO8eV5iUFR+nNUTXsWa24gt7ZbIKnJ962UlYaeXa4bg==
   dependencies:
     "@babel/runtime" "^7.23.9"
+
+"@mui/internal-scripts@https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui/internal-scripts":
+  version "1.0.0"
+  resolved "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui/internal-scripts#5e6c455f470253e736764a481f9c639d2e103e22"
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.23.3"
+    "@babel/plugin-syntax-typescript" "^7.23.3"
+    "@babel/types" "^7.23.9"
+    "@mui-internal/docs-utils" "https://pkg.csb.dev/mui/material-ui/commit/299402d7/@mui-internal/docs-utils"
+    doctrine "^3.0.0"
+    lodash "^4.17.21"
+    typescript "^5.3.3"
+    uuid "^9.0.1"
 
 "@mui/joy@^5.0.0-beta.27":
   version "5.0.0-beta.27"


### PR DESCRIPTION
This PR integrates changes from Core's https://github.com/mui/material-ui/pull/41079.

[It was decided](https://www.notion.so/mui-org/Publishing-internal-packages-87b7e5ec5a6b44ec8a2787e94ec34d8b?pvs=4#80eac69a4ad44503a962966873be5aca) that (almost) all the shared code-infra modules will be a part of a single @mui/internal-scripts package. This PR introduces this package in place of @mui-internal/typescript-to-proptypes. 