### PR TITLE
[charts] Allow to skip animation on sparkline bar

### DIFF
--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -73,11 +73,11 @@ Charts containers already use the `useReducedMotion` from `@react-spring/web` to
 
 ```jsx
 // For a single component chart
-<BarChart  skipAnimation />
+<BarChart skipAnimation />
 
 // For a composed chart
 <ResponsiveChartContainer>
-  <BarPlot  skipAnimation />
+  <BarPlot skipAnimation />
 </ResponsiveChartContainer>
 ```
 

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -25,6 +25,12 @@
     },
     "showHighlight": { "type": { "name": "bool" }, "default": "false" },
     "showTooltip": { "type": { "name": "bool" }, "default": "false" },
+    "skipAnimation": {
+      "type": { "name": "bool" },
+      "default": "false",
+      "deprecated": true,
+      "deprecationInfo": "In v7 animation are skiped for sparkline."
+    },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {
       "type": { "name": "object" },

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -29,7 +29,7 @@
       "type": { "name": "bool" },
       "default": "false",
       "deprecated": true,
-      "deprecationInfo": "In v7 animation are skiped for sparkline."
+      "deprecationInfo": "In v7 animations are skipped for sparkline."
     },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -25,6 +25,7 @@
     "showTooltip": {
       "description": "Set to <code>true</code> to enable the tooltip in the sparkline."
     },
+    "skipAnimation": { "description": "If <code>true</code>, bar animations are skiped." },
     "slotProps": { "description": "The props used for each component slot." },
     "slots": { "description": "Overridable component slots." },
     "valueFormatter": {

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -102,6 +102,12 @@ export interface SparkLineChartProps
    */
   margin?: Partial<CardinalDirections<number>>;
   /**
+   * If `true`, bar animations are skiped.
+   * @deprecated In v7 animation are skiped for sparkline.
+   * @default false
+   */
+  skipAnimation?: boolean;
+  /**
    * Overridable component slots.
    * @default {}
    */
@@ -149,6 +155,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
     valueFormatter = (value: number | null) => (value === null ? '' : value.toString()),
     area,
     curve = 'linear',
+    skipAnimation = false,
   } = props;
 
   const defaultXHighlight: { x: 'band' | 'none' } =
@@ -191,7 +198,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
     >
       {plotType === 'bar' && (
         <BarPlot
-          skipAnimation
+          skipAnimation={skipAnimation}
           slots={slots}
           slotProps={slotProps}
           sx={{ shapeRendering: 'auto' }}
@@ -303,6 +310,12 @@ SparkLineChart.propTypes = {
    * @default false
    */
   showTooltip: PropTypes.bool,
+  /**
+   * If `true`, bar animations are skiped.
+   * @deprecated In v7 animation are skiped for sparkline.
+   * @default false
+   */
+  skipAnimation: PropTypes.bool,
   /**
    * The props used for each component slot.
    * @default {}

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -103,7 +103,7 @@ export interface SparkLineChartProps
   margin?: Partial<CardinalDirections<number>>;
   /**
    * If `true`, bar animations are skiped.
-   * @deprecated In v7 animation are skiped for sparkline.
+   * @deprecated In v7 animations are skipped for sparkline.
    * @default false
    */
   skipAnimation?: boolean;
@@ -312,7 +312,7 @@ SparkLineChart.propTypes = {
   showTooltip: PropTypes.bool,
   /**
    * If `true`, bar animations are skiped.
-   * @deprecated In v7 animation are skiped for sparkline.
+   * @deprecated In v7 animations are skipped for sparkline.
    * @default false
    */
   skipAnimation: PropTypes.bool,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -190,7 +190,12 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
       }
     >
       {plotType === 'bar' && (
-        <BarPlot slots={slots} slotProps={slotProps} sx={{ shapeRendering: 'auto' }} />
+        <BarPlot
+          skipAnimation
+          slots={slots}
+          slotProps={slotProps}
+          sx={{ shapeRendering: 'auto' }}
+        />
       )}
 
       {plotType === 'line' && (


### PR DESCRIPTION
Fix #12152

The bar animation has been added by error in sparkline with #9926 in the v6.0.0-alpha.16.

For v7 it has been removed by #11311

Since the behavior is here since the beginning of v6.0.0 I propose to add the `skipAnimation` props to sparkline to keep the same default as before, and keep v7 as it is