### PR TITLE
[DataGrid] Fix `disableResetButton` and `disableShowHideToggle` flags to not exclude each other

### DIFF
--- a/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
+++ b/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
@@ -255,7 +255,7 @@ function GridColumnsManagement(props: GridColumnsManagementProps) {
           </GridColumnsManagementEmptyText>
         )}
       </GridColumnsManagementBody>
-      {currentColumns.length > 0 ? (
+      {(!disableShowHideToggle || !disableResetButton) && currentColumns.length > 0 ? (
         <GridColumnsManagementFooter ownerState={rootProps} className={classes.footer}>
           {!disableShowHideToggle ? (
             <FormControlLabel

--- a/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
+++ b/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
@@ -255,7 +255,7 @@ function GridColumnsManagement(props: GridColumnsManagementProps) {
           </GridColumnsManagementEmptyText>
         )}
       </GridColumnsManagementBody>
-      {!disableShowHideToggle && !disableResetButton && currentColumns.length > 0 ? (
+      {currentColumns.length > 0 ? (
         <GridColumnsManagementFooter ownerState={rootProps} className={classes.footer}>
           {!disableShowHideToggle ? (
             <FormControlLabel


### PR DESCRIPTION
It was not possible to render either reset or show/hide - redundant logical check allowed only both on or off. disableShowHideToggle and disableResetButton are still checked at next lines.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
