### PR TITLE
[charts] Fix RTL legend

### DIFF
--- a/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
@@ -106,6 +106,7 @@ function DefaultChartsLegend(props: LegendRendererProps) {
     labelStyle: inLabelStyle,
   } = props;
   const theme = useTheme();
+  const isRTL = theme.direction === 'rtl';
 
   const labelStyle = React.useMemo(
     () =>
@@ -276,16 +277,26 @@ function DefaultChartsLegend(props: LegendRendererProps) {
   return (
     <NoSsr>
       <ChartsLegendRoot className={classes.root}>
-        {seriesWithPosition.map(({ id, label, color, positionX, positionY }) => (
-          <g key={id} className={classes.series} transform={`translate(${positionX} ${positionY})`}>
+        {seriesWithPosition.map(({ id, label, color, positionX, positionY, innerWidth }) => (
+          <g
+            key={id}
+            className={classes.series}
+            transform={`translate(${isRTL ? availableWidth - positionX : positionX} ${positionY})`}
+          >
             <rect
               className={classes.mark}
+              x={isRTL ? -innerWidth : 0}
               y={-itemMarkHeight / 2}
               width={itemMarkWidth}
               height={itemMarkHeight}
               fill={color}
             />
-            <ChartsText style={labelStyle} text={label} x={itemMarkWidth + markGap} y={0} />
+            <ChartsText
+              style={labelStyle}
+              text={label}
+              x={isRTL ? 0 : itemMarkWidth + markGap}
+              y={0}
+            />
           </g>
         ))}
       </ChartsLegendRoot>

--- a/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
@@ -147,7 +147,7 @@ function DefaultChartsLegend(props: LegendRendererProps) {
   const availableWidth = totalWidth - padding.left - padding.right;
   const availableHeight = totalHeight - padding.top - padding.bottom;
 
-  const [seriesWithPosition, legendWidth] = React.useMemo(() => {
+  const [seriesWithPosition, legendWidth, legendHeight] = React.useMemo(() => {
     // Start at 0, 0. Will be modified later by padding and position.
     let x = 0;
     let y = 0;
@@ -215,63 +215,49 @@ function DefaultChartsLegend(props: LegendRendererProps) {
       return rep;
     });
 
-    // Move the legend according to padding and position
-    let gapX = 0;
-    let gapY = 0;
-    switch (position.horizontal) {
-      case 'left':
-        gapX = padding.left;
-        break;
-      case 'right':
-        gapX = totalWidth - padding.right - totalWidthUsed;
-        break;
-      default:
-        gapX = (totalWidth - totalWidthUsed) / 2;
-        break;
-    }
-    switch (position.vertical) {
-      case 'top':
-        gapY = padding.top;
-        break;
-      case 'bottom':
-        gapY = totalHeight - padding.bottom - totalHeightUsed;
-        break;
-      default:
-        gapY = (totalHeight - totalHeightUsed) / 2;
-        break;
-    }
     return [
       seriesWithRawPosition.map((item) => ({
         ...item,
-        // Add the gap due to the position
-        positionX: item.positionX + gapX,
-        // Add the gap due to the position
         positionY:
           item.positionY +
-          gapY +
           (direction === 'row'
             ? rowMaxHeight[item.rowIndex] / 2 // Get the center of the entire row
             : item.outerHeight / 2), // Get the center of the item
       })),
       totalWidthUsed,
+      totalHeightUsed,
     ];
   }, [
     seriesToDisplay,
-    position.horizontal,
-    position.vertical,
     getItemSpace,
     labelStyle,
     direction,
     availableWidth,
     availableHeight,
     itemGap,
-    padding.left,
-    padding.right,
-    padding.top,
-    padding.bottom,
-    totalWidth,
-    totalHeight,
   ]);
+
+  const gapX = React.useMemo(() => {
+    switch (position.horizontal) {
+      case 'left':
+        return padding.left;
+      case 'right':
+        return totalWidth - padding.right - legendWidth;
+      default:
+        return (totalWidth - legendWidth) / 2;
+    }
+  }, [position.horizontal, padding.left, padding.right, totalWidth, legendWidth]);
+
+  const gapY = React.useMemo(() => {
+    switch (position.vertical) {
+      case 'top':
+        return padding.top;
+      case 'bottom':
+        return totalHeight - padding.bottom - legendHeight;
+      default:
+        return (totalHeight - legendHeight) / 2;
+    }
+  }, [position.vertical, padding.top, padding.bottom, totalHeight, legendHeight]);
 
   if (hidden) {
     return null;
@@ -284,7 +270,7 @@ function DefaultChartsLegend(props: LegendRendererProps) {
           <g
             key={id}
             className={classes.series}
-            transform={`translate(${isRTL ? legendWidth - positionX : positionX} ${positionY})`}
+            transform={`translate(${gapX + (isRTL ? legendWidth - positionX : positionX)} ${gapY + positionY})`}
           >
             <rect
               className={classes.mark}

--- a/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
@@ -147,7 +147,7 @@ function DefaultChartsLegend(props: LegendRendererProps) {
   const availableWidth = totalWidth - padding.left - padding.right;
   const availableHeight = totalHeight - padding.top - padding.bottom;
 
-  const seriesWithPosition = React.useMemo(() => {
+  const [seriesWithPosition, legendWidth] = React.useMemo(() => {
     // Start at 0, 0. Will be modified later by padding and position.
     let x = 0;
     let y = 0;
@@ -240,18 +240,21 @@ function DefaultChartsLegend(props: LegendRendererProps) {
         gapY = (totalHeight - totalHeightUsed) / 2;
         break;
     }
-    return seriesWithRawPosition.map((item) => ({
-      ...item,
-      // Add the gap due to the position
-      positionX: item.positionX + gapX,
-      // Add the gap due to the position
-      positionY:
-        item.positionY +
-        gapY +
-        (direction === 'row'
-          ? rowMaxHeight[item.rowIndex] / 2 // Get the center of the entire row
-          : item.outerHeight / 2), // Get the center of the item
-    }));
+    return [
+      seriesWithRawPosition.map((item) => ({
+        ...item,
+        // Add the gap due to the position
+        positionX: item.positionX + gapX,
+        // Add the gap due to the position
+        positionY:
+          item.positionY +
+          gapY +
+          (direction === 'row'
+            ? rowMaxHeight[item.rowIndex] / 2 // Get the center of the entire row
+            : item.outerHeight / 2), // Get the center of the item
+      })),
+      totalWidthUsed,
+    ];
   }, [
     seriesToDisplay,
     position.horizontal,
@@ -277,15 +280,15 @@ function DefaultChartsLegend(props: LegendRendererProps) {
   return (
     <NoSsr>
       <ChartsLegendRoot className={classes.root}>
-        {seriesWithPosition.map(({ id, label, color, positionX, positionY, innerWidth }) => (
+        {seriesWithPosition.map(({ id, label, color, positionX, positionY }) => (
           <g
             key={id}
             className={classes.series}
-            transform={`translate(${isRTL ? availableWidth - positionX : positionX} ${positionY})`}
+            transform={`translate(${isRTL ? legendWidth - positionX : positionX} ${positionY})`}
           >
             <rect
               className={classes.mark}
-              x={isRTL ? -innerWidth : 0}
+              x={isRTL ? -itemMarkWidth : 0}
               y={-itemMarkHeight / 2}
               width={itemMarkWidth}
               height={itemMarkHeight}
@@ -294,7 +297,7 @@ function DefaultChartsLegend(props: LegendRendererProps) {
             <ChartsText
               style={labelStyle}
               text={label}
-              x={isRTL ? 0 : itemMarkWidth + markGap}
+              x={(isRTL ? -1 : 1) * (itemMarkWidth + markGap)}
               y={0}
             />
           </g>

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -29,6 +29,7 @@ import {
   ChartsXAxisProps,
   ChartsYAxisProps,
 } from '../models/axis';
+import { useIsRTL } from '../internals/useIsRTL';
 
 export interface PieChartSlots
   extends ChartsAxisSlots,
@@ -97,6 +98,7 @@ export interface PieChartProps
 }
 
 const defaultMargin = { top: 5, bottom: 5, left: 5, right: 100 };
+const defaultRTLMargin = { top: 5, bottom: 5, left: 100, right: 5 };
 
 /**
  * Demos:
@@ -121,7 +123,7 @@ function PieChart(props: PieChartProps) {
     tooltip = { trigger: 'item' },
     axisHighlight = { x: 'none', y: 'none' },
     skipAnimation,
-    legend = { direction: 'column', position: { vertical: 'middle', horizontal: 'right' } },
+    legend: legendProps,
     topAxis = null,
     leftAxis = null,
     rightAxis = null,
@@ -131,8 +133,15 @@ function PieChart(props: PieChartProps) {
     slotProps,
     onItemClick,
   } = props;
+  const isRTL = useIsRTL();
 
-  const margin = { ...defaultMargin, ...marginProps };
+  const margin = { ...(isRTL ? defaultRTLMargin : defaultMargin), ...marginProps };
+  const legend: ChartsLegendProps = {
+    direction: 'column',
+    position: { vertical: 'middle', horizontal: isRTL ? 'left' : 'right' },
+    ...legendProps,
+  };
+
   return (
     <ResponsiveChartContainer
       series={series.map((s) => ({ type: 'pie', ...s }))}

--- a/packages/x-charts/src/internals/useIsRTL.ts
+++ b/packages/x-charts/src/internals/useIsRTL.ts
@@ -1,0 +1,6 @@
+import { useTheme } from '@mui/material/styles';
+
+export const useIsRTL = () => {
+  const theme = useTheme();
+  return theme.direction === 'rtl';
+};


### PR DESCRIPTION
Fix #12118
![image](https://github.com/mui/mui-x/assets/45398769/de6e0caa-bb66-488b-8b7c-e34efcdaf633)


Maybe I should invert the order of square/text : put the square on the right of the text @samueltrevor do you have some insight on this aspect?