### PR TITLE
[docs] Add the 'point' scaleType to the axis documentation

### DIFF
--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -41,6 +41,7 @@ Those demonstrations use the defaultized values.
 The axis type is specified by its property `scaleType` which expect one of the following values:
 
 - `'band'`: Split the axis in equal band. Mostly used for bar charts.
+- `'point'`: Split the axis in equally spaced points. Mostly used for line charts on categories.
 - `'linear'`, `'log'`, `'sqrt'`: Map numerical values to the space available for the chart. `'linear'` is the default behavior.
 - `'time'`, `'utc'`: Map JavaScript `Date()` object to the space available for the chart.
 
@@ -51,7 +52,7 @@ Which expects an array of value coherent with the `scaleType`:
 
 - For `'linear'`, `'log'`, or `'sqrt'` it should contain numerical values
 - For `'time'` or `'utc'` it should contain `Date()` objects
-- For `'band'` it can contain `string`, or numerical values
+- For `'band'` or `'point'` it can contain `string`, or numerical values
 
 Some series types also require specific axis attributes:
 


### PR DESCRIPTION
Realised when answering #12161

That  `scaleType='point'`  is not documented.

It's a bit complex because normally it does not make sens to plot a line chart on categories. With categories you're supposed to use bar chart because their is not an obvious order relation between categories.

But i's usefull if for example you want to display yearly result without bothering with `Date` objects.