### PR TITLE
[pickers] Fix toolbar components props handling

### DIFF
--- a/docs/pages/x/api/date-pickers/date-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-picker-toolbar.json
@@ -12,6 +12,13 @@
       },
       "required": true
     },
+    "views": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'year'&gt;"
+      },
+      "required": true
+    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-range-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker-toolbar.json
@@ -1,5 +1,15 @@
 {
   "props": {
+    "onViewChange": {
+      "type": { "name": "func" },
+      "required": true,
+      "signature": { "type": "function(view: TView) => void", "describedArgs": ["view"] }
+    },
+    "view": { "type": { "name": "enum", "description": "'day'" }, "required": true },
+    "views": {
+      "type": { "name": "arrayOf", "description": "Array&lt;'day'&gt;" },
+      "required": true
+    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-time-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker-toolbar.json
@@ -5,6 +5,13 @@
       "required": true,
       "signature": { "type": "function(view: TView) => void", "describedArgs": ["view"] }
     },
+    "views": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'meridiem'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'month'<br>&#124;&nbsp;'seconds'<br>&#124;&nbsp;'year'&gt;"
+      },
+      "required": true
+    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "sx": {

--- a/docs/pages/x/api/date-pickers/date-time-range-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/date-time-range-picker-toolbar.json
@@ -12,6 +12,13 @@
       },
       "required": true
     },
+    "views": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;'day'<br>&#124;&nbsp;'hours'<br>&#124;&nbsp;'meridiem'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'&gt;"
+      },
+      "required": true
+    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "sx": {

--- a/docs/pages/x/api/date-pickers/time-picker-toolbar.json
+++ b/docs/pages/x/api/date-pickers/time-picker-toolbar.json
@@ -12,6 +12,13 @@
       },
       "required": true
     },
+    "views": {
+      "type": {
+        "name": "arrayOf",
+        "description": "Array&lt;'hours'<br>&#124;&nbsp;'meridiem'<br>&#124;&nbsp;'minutes'<br>&#124;&nbsp;'seconds'&gt;"
+      },
+      "required": true
+    },
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "hidden": { "type": { "name": "bool" }, "default": "`true` for Desktop, `false` for Mobile." },
     "sx": {

--- a/docs/translations/api-docs/date-pickers/date-picker-toolbar/date-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-picker-toolbar/date-picker-toolbar.json
@@ -14,7 +14,8 @@
     "toolbarPlaceholder": {
       "description": "Toolbar value placeholder—it is displayed when the value is empty."
     },
-    "view": { "description": "Currently visible picker view." }
+    "view": { "description": "Currently visible picker view." },
+    "views": { "description": "Available views." }
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/date-pickers/date-range-picker-toolbar/date-range-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-range-picker-toolbar/date-range-picker-toolbar.json
@@ -3,13 +3,19 @@
   "propDescriptions": {
     "classes": { "description": "Override or extend the styles applied to the component." },
     "hidden": { "description": "If <code>true</code>, show the toolbar even in desktop mode." },
+    "onViewChange": {
+      "description": "Callback called when a toolbar is clicked",
+      "typeDescriptions": { "view": "The view to open" }
+    },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     },
     "toolbarFormat": { "description": "Toolbar date format." },
     "toolbarPlaceholder": {
       "description": "Toolbar value placeholder—it is displayed when the value is empty."
-    }
+    },
+    "view": { "description": "Currently visible picker view." },
+    "views": { "description": "Available views." }
   },
   "classDescriptions": {
     "container": {

--- a/docs/translations/api-docs/date-pickers/date-time-picker-toolbar/date-time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-time-picker-toolbar/date-time-picker-toolbar.json
@@ -17,7 +17,8 @@
     "toolbarTitle": {
       "description": "If provided, it will be used instead of <code>dateTimePickerToolbarTitle</code> from localization."
     },
-    "view": { "description": "Currently visible picker view." }
+    "view": { "description": "Currently visible picker view." },
+    "views": { "description": "Available views." }
   },
   "classDescriptions": {
     "ampmLabel": { "description": "Styles applied to {{nodeName}}.", "nodeName": "am/pm labels" },

--- a/docs/translations/api-docs/date-pickers/date-time-range-picker-toolbar/date-time-range-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/date-time-range-picker-toolbar/date-time-range-picker-toolbar.json
@@ -14,7 +14,8 @@
     "toolbarPlaceholder": {
       "description": "Toolbar value placeholder—it is displayed when the value is empty."
     },
-    "view": { "description": "Currently visible picker view." }
+    "view": { "description": "Currently visible picker view." },
+    "views": { "description": "Available views." }
   },
   "classDescriptions": {
     "endToolbar": {

--- a/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
+++ b/docs/translations/api-docs/date-pickers/time-picker-toolbar/time-picker-toolbar.json
@@ -14,7 +14,8 @@
     "toolbarPlaceholder": {
       "description": "Toolbar value placeholder—it is displayed when the value is empty."
     },
-    "view": { "description": "Currently visible picker view." }
+    "view": { "description": "Currently visible picker view." },
+    "views": { "description": "Available views." }
   },
   "classDescriptions": {
     "ampmLabel": {

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -31,18 +31,16 @@ const useUtilityClasses = (ownerState: DateRangePickerToolbarProps<any>) => {
 };
 
 export interface DateRangePickerToolbarProps<TDate extends PickerValidDate>
-  extends Omit<
-      BaseToolbarProps<DateRange<TDate>, 'day'>,
-      'views' | 'view' | 'onViewChange' | 'onChange' | 'isLandscape'
-    >,
-    Pick<UseRangePositionResponse, 'rangePosition' | 'onRangePositionChange'> {
+  extends ExportedDateRangePickerToolbarProps,
+    Omit<BaseToolbarProps<DateRange<TDate>, 'day'>, 'onChange' | 'isLandscape'>,
+    Pick<UseRangePositionResponse, 'rangePosition' | 'onRangePositionChange'> {}
+
+export interface ExportedDateRangePickerToolbarProps extends ExportedBaseToolbarProps {
   /**
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<DateRangePickerToolbarClasses>;
 }
-
-export interface ExportedDateRangePickerToolbarProps extends ExportedBaseToolbarProps {}
 
 const DateRangePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiDateRangePickerToolbar',
@@ -82,6 +80,9 @@ const DateRangePickerToolbar = React.forwardRef(function DateRangePickerToolbar<
     onRangePositionChange,
     toolbarFormat,
     className,
+    onViewChange,
+    view,
+    views,
     ...other
   } = props;
 

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -144,6 +144,12 @@ DateRangePickerToolbar.propTypes = {
    */
   hidden: PropTypes.bool,
   onRangePositionChange: PropTypes.func.isRequired,
+  /**
+   * Callback called when a toolbar is clicked
+   * @template TView
+   * @param {TView} view The view to open
+   */
+  onViewChange: PropTypes.func.isRequired,
   rangePosition: PropTypes.oneOf(['end', 'start']).isRequired,
   readOnly: PropTypes.bool,
   /**
@@ -165,6 +171,14 @@ DateRangePickerToolbar.propTypes = {
    */
   toolbarPlaceholder: PropTypes.node,
   value: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /**
+   * Currently visible picker view.
+   */
+  view: PropTypes.oneOf(['day']).isRequired,
+  /**
+   * Available views.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day'])).isRequired,
 } as any;
 
 export { DateRangePickerToolbar };

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
@@ -111,8 +111,30 @@ const DateTimeRangePickerToolbar = React.forwardRef(function DateTimeRangePicker
     onChange,
     classes: inClasses,
     view,
+    isLandscape,
+    views,
+    ampm,
+    disabled,
+    readOnly,
+    hidden,
+    toolbarFormat,
+    toolbarPlaceholder,
+    titleId,
+    sx,
     ...other
   } = props;
+
+  const commonToolbarProps = {
+    isLandscape,
+    views,
+    ampm,
+    disabled,
+    readOnly,
+    hidden,
+    toolbarFormat,
+    toolbarPlaceholder,
+    titleId,
+  };
 
   const localeText = useLocaleText<TDate>();
 
@@ -165,9 +187,10 @@ const DateTimeRangePickerToolbar = React.forwardRef(function DateTimeRangePicker
       className={clsx(className, classes.root)}
       ownerState={ownerState}
       ref={ref}
+      sx={sx}
+      {...other}
     >
       <DateTimeRangePickerToolbarStart<TDate>
-        {...other}
         value={start}
         onViewChange={handleStartRangeViewChange}
         toolbarTitle={localeText.start}
@@ -176,9 +199,9 @@ const DateTimeRangePickerToolbar = React.forwardRef(function DateTimeRangePicker
         view={rangePosition === 'start' ? view : undefined}
         className={classes.startToolbar}
         onChange={handleOnChange}
+        {...commonToolbarProps}
       />
       <DateTimeRangePickerToolbarEnd<TDate>
-        {...other}
         value={end}
         onViewChange={handleEndRangeViewChange}
         toolbarTitle={localeText.end}
@@ -187,6 +210,7 @@ const DateTimeRangePickerToolbar = React.forwardRef(function DateTimeRangePicker
         view={rangePosition === 'end' ? view : undefined}
         className={classes.endToolbar}
         onChange={handleOnChange}
+        {...commonToolbarProps}
       />
     </DateTimeRangePickerToolbarRoot>
   );

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
@@ -268,6 +268,9 @@ DateTimeRangePickerToolbar.propTypes = {
    * Currently visible picker view.
    */
   view: PropTypes.oneOf(['day', 'hours', 'meridiem', 'minutes', 'seconds']).isRequired,
+  /**
+   * Available views.
+   */
   views: PropTypes.arrayOf(
     PropTypes.oneOf(['day', 'hours', 'meridiem', 'minutes', 'seconds']).isRequired,
   ).isRequired,

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.types.ts
@@ -21,7 +21,7 @@ export interface DesktopDateRangePickerSlotProps<
 > extends BaseDateRangePickerSlotProps<TDate>,
     Omit<
       UseDesktopRangePickerSlotProps<TDate, 'day', TEnableAccessibleFieldDOMStructure>,
-      'tabs'
+      'tabs' | 'toolbar'
     > {}
 
 export interface DesktopDateRangePickerProps<

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.types.ts
@@ -19,7 +19,10 @@ export interface MobileDateRangePickerSlotProps<
   TDate extends PickerValidDate,
   TEnableAccessibleFieldDOMStructure extends boolean,
 > extends BaseDateRangePickerSlotProps<TDate>,
-    Omit<UseMobileRangePickerSlotProps<TDate, 'day', TEnableAccessibleFieldDOMStructure>, 'tabs'> {}
+    Omit<
+      UseMobileRangePickerSlotProps<TDate, 'day', TEnableAccessibleFieldDOMStructure>,
+      'tabs' | 'toolbar'
+    > {}
 
 export interface MobileDateRangePickerProps<
   TDate extends PickerValidDate,

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.types.ts
@@ -17,7 +17,7 @@ export interface StaticDateRangePickerSlots<TDate extends PickerValidDate>
 
 export interface StaticDateRangePickerSlotProps<TDate extends PickerValidDate>
   extends BaseDateRangePickerSlotProps<TDate>,
-    UseStaticRangePickerSlotProps<TDate, 'day'> {}
+    Omit<UseStaticRangePickerSlotProps<TDate, 'day'>, 'toolbar'> {}
 
 export interface StaticDateRangePickerProps<TDate extends PickerValidDate>
   extends BaseDateRangePickerProps<TDate>,

--- a/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/props.d.ts
@@ -3,7 +3,8 @@ import { DateRangePickerDayProps } from '../DateRangePickerDay';
 import { MultiInputDateRangeFieldProps } from '../MultiInputDateRangeField/MultiInputDateRangeField.types';
 import { SingleInputDateRangeFieldProps } from '../SingleInputDateRangeField/SingleInputDateRangeField.types';
 import { DateRangeCalendarProps } from '../DateRangeCalendar';
-import { DateRangePickerProps, DateRangePickerToolbarProps } from '../DateRangePicker';
+import { DateRangePickerProps } from '../DateRangePicker';
+import { ExportedDateRangePickerToolbarProps } from '../DateRangePicker/DateRangePickerToolbar';
 import { DesktopDateRangePickerProps } from '../DesktopDateRangePicker';
 import { MobileDateRangePickerProps } from '../MobileDateRangePicker';
 import { StaticDateRangePickerProps } from '../StaticDateRangePicker';
@@ -21,7 +22,7 @@ export interface PickersProComponentsPropsList {
   MuiDateRangeCalendar: DateRangeCalendarProps<PickerValidDate>;
   MuiDateRangePickerDay: DateRangePickerDayProps<PickerValidDate>;
   MuiDateTimeRangePickerTabs: ExportedDateTimeRangePickerTabsProps;
-  MuiDateRangePickerToolbar: DateRangePickerToolbarProps<PickerValidDate>;
+  MuiDateRangePickerToolbar: ExportedDateRangePickerToolbarProps;
   MuiDateTimeRangePickerToolbar: ExportedDateTimeRangePickerToolbarProps;
 
   // Multi input range fields

--- a/packages/x-date-pickers-pro/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers-pro/src/themeAugmentation/themeAugmentation.spec.ts
@@ -76,7 +76,7 @@ createTheme({
       defaultProps: {
         toolbarPlaceholder: 'empty',
         // @ts-expect-error invalid MuiDateRangePickerToolbar prop
-        someRandomProp: true,
+        view: 'day',
       },
       styleOverrides: {
         root: {
@@ -96,7 +96,7 @@ createTheme({
       defaultProps: {
         toolbarPlaceholder: 'empty',
         // @ts-expect-error invalid MuiDateTimeRangePickerToolbar prop
-        someRandomProp: true,
+        view: 'day',
       },
       styleOverrides: {
         root: {

--- a/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
@@ -77,6 +77,8 @@ export const DatePickerToolbar = React.forwardRef(function DatePickerToolbar<
     toolbarPlaceholder = '––',
     views,
     className,
+    onViewChange,
+    view,
     ...other
   } = props;
   const utils = useUtils<TDate>();

--- a/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
@@ -166,5 +166,8 @@ DatePickerToolbar.propTypes = {
    * Currently visible picker view.
    */
   view: PropTypes.oneOf(['day', 'month', 'year']).isRequired,
+  /**
+   * Available views.
+   */
   views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired).isRequired,
 } as any;

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -23,8 +23,6 @@ import { pickersToolbarClasses } from '../internals';
 import { PickerValidDate } from '../models';
 
 export interface ExportedDateTimePickerToolbarProps extends ExportedBaseToolbarProps {
-  ampm?: boolean;
-  ampmInClock?: boolean;
   /**
    * Override or extend the styles applied to the component.
    */
@@ -39,6 +37,8 @@ export interface DateTimePickerToolbarProps<TDate extends PickerValidDate>
    * If provided, it will be used instead of `dateTimePickerToolbarTitle` from localization.
    */
   toolbarTitle?: React.ReactNode;
+  ampm?: boolean;
+  ampmInClock?: boolean;
 }
 
 const useUtilityClasses = (ownerState: DateTimePickerToolbarProps<any> & { theme: Theme }) => {

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -436,6 +436,9 @@ DateTimePickerToolbar.propTypes = {
    * Currently visible picker view.
    */
   view: PropTypes.oneOf(['day', 'hours', 'meridiem', 'minutes', 'month', 'seconds', 'year']),
+  /**
+   * Available views.
+   */
   views: PropTypes.arrayOf(
     PropTypes.oneOf(['day', 'hours', 'meridiem', 'minutes', 'month', 'seconds', 'year']).isRequired,
   ).isRequired,

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -318,6 +318,9 @@ TimePickerToolbar.propTypes = {
    * Currently visible picker view.
    */
   view: PropTypes.oneOf(['hours', 'meridiem', 'minutes', 'seconds']).isRequired,
+  /**
+   * Available views.
+   */
   views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'meridiem', 'minutes', 'seconds']).isRequired)
     .isRequired,
 } as any;

--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -76,7 +76,17 @@ export const PickersToolbar = React.forwardRef(function PickersToolbar<
   ref: React.Ref<HTMLDivElement>,
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiPickersToolbar' });
-  const { children, className, toolbarTitle, hidden, titleId } = props;
+  const {
+    children,
+    className,
+    toolbarTitle,
+    hidden,
+    titleId,
+    isLandscape,
+    classes: inClasses,
+    landscapeDirection,
+    ...other
+  } = props;
 
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
@@ -91,6 +101,7 @@ export const PickersToolbar = React.forwardRef(function PickersToolbar<
       data-mui-test="picker-toolbar"
       className={clsx(classes.root, className)}
       ownerState={ownerState}
+      {...other}
     >
       <Typography
         data-mui-test="picker-toolbar-title"

--- a/packages/x-date-pickers/src/internals/models/props/toolbar.ts
+++ b/packages/x-date-pickers/src/internals/models/props/toolbar.ts
@@ -18,6 +18,9 @@ export interface BaseToolbarProps<TValue, TView extends DateOrTimeViewWithMeridi
    * @param {TView} view The view to open
    */
   onViewChange: (view: TView) => void;
+  /**
+   * Available views.
+   */
   views: readonly TView[];
   disabled?: boolean;
   readOnly?: boolean;

--- a/packages/x-date-pickers/src/themeAugmentation/props.d.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/props.d.ts
@@ -19,22 +19,21 @@ import { PickersToolbarButtonProps } from '../internals/components/PickersToolba
 import { ExportedPickersToolbarTextProps } from '../internals/components/PickersToolbarText';
 import { DateOrTimeView, PickerValidDate } from '../models';
 
-import { DatePickerProps, DatePickerToolbarProps } from '../DatePicker';
+import { DatePickerProps } from '../DatePicker';
+import { ExportedDatePickerToolbarProps } from '../DatePicker/DatePickerToolbar';
 import { DesktopDatePickerProps } from '../DesktopDatePicker';
 import { MobileDatePickerProps } from '../MobileDatePicker';
 import { StaticDatePickerProps } from '../StaticDatePicker';
 
-import {
-  DateTimePickerProps,
-  DateTimePickerTabsProps,
-  DateTimePickerToolbarProps,
-} from '../DateTimePicker';
+import { DateTimePickerProps, DateTimePickerTabsProps } from '../DateTimePicker';
+import { ExportedDateTimePickerToolbarProps } from '../DateTimePicker/DateTimePickerToolbar';
 import { DesktopDateTimePickerProps } from '../DesktopDateTimePicker';
 import { MobileDateTimePickerProps } from '../MobileDateTimePicker';
 import { StaticDateTimePickerProps } from '../StaticDateTimePicker';
 import { DateTimeFieldProps } from '../DateTimeField';
 
-import { TimePickerProps, TimePickerToolbarProps } from '../TimePicker';
+import { TimePickerProps } from '../TimePicker';
+import { ExportedTimePickerToolbarProps } from '../TimePicker/TimePickerToolbar';
 import { DesktopTimePickerProps } from '../DesktopTimePicker';
 import { MobileTimePickerProps } from '../MobileTimePicker';
 import { StaticTimePickerProps } from '../StaticTimePicker';
@@ -60,10 +59,10 @@ export interface PickersComponentsPropsList {
   MuiClockPointer: ClockPointerProps;
   MuiDateCalendar: DateCalendarProps<PickerValidDate>;
   MuiDateField: DateFieldProps<PickerValidDate, any>;
-  MuiDatePickerToolbar: DatePickerToolbarProps<PickerValidDate>;
+  MuiDatePickerToolbar: ExportedDatePickerToolbarProps;
   MuiDateTimeField: DateTimeFieldProps<PickerValidDate, any>;
   MuiDateTimePickerTabs: DateTimePickerTabsProps;
-  MuiDateTimePickerToolbar: DateTimePickerToolbarProps<PickerValidDate>;
+  MuiDateTimePickerToolbar: ExportedDateTimePickerToolbarProps;
   MuiDayCalendar: DayCalendarProps<PickerValidDate>;
   MuiDayCalendarSkeleton: DayCalendarSkeletonProps;
   MuiDigitalClock: ExportedDigitalClockProps<PickerValidDate>;
@@ -85,7 +84,7 @@ export interface PickersComponentsPropsList {
   MuiPickersYear: ExportedPickersYearProps;
   MuiTimeClock: TimeClockProps<PickerValidDate>;
   MuiTimeField: TimeFieldProps<PickerValidDate, any>;
-  MuiTimePickerToolbar: TimePickerToolbarProps<PickerValidDate>;
+  MuiTimePickerToolbar: ExportedTimePickerToolbarProps;
   MuiYearCalendar: YearCalendarProps<PickerValidDate>;
 
   // Date Pickers

--- a/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
@@ -195,9 +195,9 @@ createTheme({
     },
     MuiDatePickerToolbar: {
       defaultProps: {
-        disabled: true,
+        hidden: false,
         // @ts-expect-error invalid MuiDatePickerToolbar prop
-        someRandomProp: true,
+        view: 'day',
       },
       styleOverrides: {
         root: {
@@ -230,9 +230,9 @@ createTheme({
     },
     MuiDateTimePickerToolbar: {
       defaultProps: {
-        disabled: true,
+        hidden: false,
         // @ts-expect-error invalid MuiDateTimePickerToolbar prop
-        someRandomProp: true,
+        view: 'day',
       },
       styleOverrides: {
         root: {
@@ -523,9 +523,9 @@ createTheme({
     },
     MuiTimePickerToolbar: {
       defaultProps: {
-        disabled: true,
+        hidden: false,
         // @ts-expect-error invalid MuiTimePickerToolbar prop
-        someRandomProp: true,
+        view: 'hours',
       },
       styleOverrides: {
         root: {


### PR DESCRIPTION
Noticed this problem when I started working on https://github.com/mui/mui-x/issues/12048 and discovered that I can't pass `data-testid` to the toolbar slot and hope that it ends up on the root element.

Checking the toolbar props more thoroughly I noticed that they are too loose, the current solution allows providing internal props, that ought to be passed only internally and can't be overridden via `defaultProps` in the theme.

This is technically a breaking change, but one that I'd say isn't very impactful to the user and technically is more of a bug fix.

WDYT about backporting it to v6? 🤔 