### PR TITLE
[data grid] Fixed issue where pressing Delete key resets various cell values to empty string.

### DIFF
--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -328,8 +328,27 @@ export const useGridCellEditing = (
       const { id, field, deleteValue, initialValue } = params;
 
       let newValue = apiRef.current.getCellValue(id, field);
-      if (deleteValue || initialValue) {
-        newValue = deleteValue ? '' : initialValue;
+      if (deleteValue) {
+        const fieldType = apiRef.current.getColumn(field).type;
+        switch (fieldType) {
+          case 'boolean':
+            newValue = false;
+            break;
+          case 'date':
+          case 'dateTime':
+          case 'number':
+            newValue = undefined;
+            break;
+          case 'singleSelect':
+            newValue = null;
+            break;
+          case 'string':
+          default:
+            newValue = '';
+            break;
+        }
+      } else if (initialValue) {
+        newValue = initialValue;
       }
 
       const newProps = {

--- a/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -845,7 +845,10 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   describe('After pressing the backspace/delete key, the reset value type should match the column type', () => {
-    const setupTest = (rows: any, columns: GridColDef[]) => {
+    function setupTest(
+      rows: Record<string, string | number | Date | boolean>[],
+      columns: GridColDef[],
+    ) {
       const valueSetterMock = spy<GridValueSetter<(typeof columns)[number]>>(
         (value, row, column) => {
           return {
@@ -861,13 +864,13 @@ describe('<DataGrid /> - Keyboard', () => {
       render(<DataGrid rows={rows} columns={columns} autoHeight />);
 
       return { valueSetterMock };
-    };
+    }
 
     function testResetValue(
       keyType: 'Delete' | 'Backspace',
       field: string,
       type: GridColType,
-      value: any,
+      value: string | number | Date | boolean,
     ) {
       const columns: GridColDef[] = [
         { field: 'id', editable: true },

--- a/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -10,7 +10,14 @@ import {
   getColumnValues,
   getRow,
 } from 'test/utils/helperFn';
-import { DataGrid, DataGridProps, GridActionsCellItem, GridColDef, GridColType, GridValueSetter } from '@mui/x-data-grid';
+import {
+  DataGrid,
+  DataGridProps,
+  GridActionsCellItem,
+  GridColDef,
+  GridColType,
+  GridValueSetter,
+} from '@mui/x-data-grid';
 import { useBasicDemoData, getBasicGridData } from '@mui/x-data-grid-generator';
 import RestoreIcon from '@mui/icons-material/Restore';
 

--- a/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -10,7 +10,7 @@ import {
   getColumnValues,
   getRow,
 } from 'test/utils/helperFn';
-import { DataGrid, DataGridProps, GridActionsCellItem, GridColDef } from '@mui/x-data-grid';
+import { DataGrid, DataGridProps, GridActionsCellItem, GridColDef, GridColType, GridValueSetter } from '@mui/x-data-grid';
 import { useBasicDemoData, getBasicGridData } from '@mui/x-data-grid-generator';
 import RestoreIcon from '@mui/icons-material/Restore';
 
@@ -835,5 +835,129 @@ describe('<DataGrid /> - Keyboard', () => {
     const cell = getColumnHeaderCell(0);
     act(() => cell.focus());
     fireEvent.keyDown(cell, { key: 'ArrowDown' });
+  });
+
+  describe('After pressing the backspace/delete key, the reset value type should match the column type', () => {
+    const setupTest = (rows: any, columns: GridColDef[]) => {
+      const valueSetterMock = spy<GridValueSetter<(typeof columns)[number]>>(
+        (value, row, column) => {
+          return {
+            ...row,
+            [column.field]: value,
+          };
+        },
+      );
+      columns.forEach((column) => {
+        column.valueSetter = valueSetterMock;
+      });
+
+      render(<DataGrid rows={rows} columns={columns} autoHeight />);
+
+      return { valueSetterMock };
+    };
+
+    function testResetValue(
+      keyType: 'Delete' | 'Backspace',
+      field: string,
+      type: GridColType,
+      value: any,
+    ) {
+      const columns: GridColDef[] = [
+        { field: 'id', editable: true },
+        { field, editable: true, type },
+      ];
+      const rows = [{ id: 1, [field]: value }];
+      const { valueSetterMock } = setupTest(rows, columns);
+      const cell = getCell(0, 1);
+
+      cell.focus();
+      fireEvent.keyDown(cell, { key: keyType });
+
+      return {
+        cell: cell.textContent,
+        deletedValue: valueSetterMock.lastCall.args[0],
+      };
+    }
+
+    it(`should reset value on Backspace key press for number type`, () => {
+      const { cell, deletedValue } = testResetValue('Backspace', 'age', 'number', 24);
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(undefined);
+    });
+
+    it(`should reset value on Backspace key press for date type`, () => {
+      const { cell, deletedValue } = testResetValue('Backspace', 'birthdate', 'date', new Date());
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(undefined);
+    });
+
+    it(`should reset value on Backspace key press for dateTime type`, () => {
+      const { cell, deletedValue } = testResetValue(
+        'Backspace',
+        'appointment',
+        'dateTime',
+        new Date(),
+      );
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(undefined);
+    });
+
+    it(`should reset value on Backspace key press for boolean type`, () => {
+      const { cell, deletedValue } = testResetValue('Backspace', 'isVerified', 'boolean', true);
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(false);
+    });
+
+    it(`should reset value on Backspace key press for singleSelect type`, () => {
+      const { cell, deletedValue } = testResetValue(
+        'Backspace',
+        'status',
+        'singleSelect',
+        'active',
+      );
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(null);
+    });
+
+    it(`should reset value on Delete key press for string type`, () => {
+      const { cell, deletedValue } = testResetValue('Delete', 'name', 'string', 'John Doe');
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal('');
+    });
+
+    it(`should reset value on Delete key press for number type`, () => {
+      const { cell, deletedValue } = testResetValue('Delete', 'age', 'number', 24);
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(undefined);
+    });
+
+    it(`should reset value on Delete key press for date type`, () => {
+      const { cell, deletedValue } = testResetValue('Delete', 'birthdate', 'date', new Date());
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(undefined);
+    });
+
+    it(`should reset value on Delete key press for dateTime type`, () => {
+      const { cell, deletedValue } = testResetValue(
+        'Delete',
+        'appointment',
+        'dateTime',
+        new Date(),
+      );
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(undefined);
+    });
+
+    it(`should reset value on Delete key press for boolean type`, () => {
+      const { cell, deletedValue } = testResetValue('Delete', 'isVerified', 'boolean', true);
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(false);
+    });
+
+    it(`should reset value on Delete key press for singleSelect type`, () => {
+      const { cell, deletedValue } = testResetValue('Delete', 'status', 'singleSelect', 'active');
+      expect(cell).to.equal('');
+      expect(deletedValue).to.equal(null);
+    });
   });
 });


### PR DESCRIPTION
Fix #12125  [michelengelen](https://github.com/michelengelen)

This PR refines the value reset logic to align with column data types on Backspace/Delete key press.

UnitTesting
Implemented tests to check cell value reset upon Backspace and Delete key presses.

The video shows the correct default boolean value when the delete/backspace key is pressed.

![mui-x](https://github.com/mui/mui-x/assets/26635607/b2824d21-9ae4-4f03-b3be-de3ac9609e10)



