### PR TITLE
[DataGrid] perf: remove querySelector call

### DIFF
--- a/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -52,7 +52,6 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
 
     const rippleRef = React.useRef<TouchRippleActions>(null);
     const handleRef = useForkRef(checkboxElement, ref);
-    const element = apiRef.current.getCellElement(id, field);
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const params: GridRowSelectionCheckboxParams = { value: event.target.checked, id };
@@ -60,10 +59,13 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
     };
 
     React.useLayoutEffect(() => {
-      if (tabIndex === 0 && element) {
-        element!.tabIndex = -1;
+      if (tabIndex === 0) {
+        const element = apiRef.current.getCellElement(id, field);
+        if (element) {
+          element.tabIndex = -1;
+        }
       }
-    }, [element, tabIndex]);
+    }, [tabIndex]);
 
     React.useEffect(() => {
       if (hasFocus) {

--- a/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -65,7 +65,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
           element.tabIndex = -1;
         }
       }
-    }, [apiRef, tabIndex]);
+    }, [apiRef, tabIndex, id, field]);
 
     React.useEffect(() => {
       if (hasFocus) {

--- a/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -65,7 +65,7 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridRender
           element.tabIndex = -1;
         }
       }
-    }, [tabIndex]);
+    }, [apiRef, tabIndex]);
 
     React.useEffect(() => {
       if (hasFocus) {


### PR DESCRIPTION
The cell checkbox renderer is calling `.querySelector` via an API function on each render.