### PR TITLE
[DataGrid] Fix cell range classnames

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -228,7 +228,7 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>((props, ref) =>
       .join(' '),
   );
 
-  const classNames = [pipesClassName];
+  const classNames = [pipesClassName] as (string | undefined)[];
 
   if (column.cellClassName) {
     classNames.push(

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -219,10 +219,13 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>((props, ref) =>
 
   // There is a hidden grid state access in `applyPipeProcessor('cellClassName', ...)`
   const pipesClassName = useGridSelector(apiRef, () =>
-    apiRef.current.unstable_applyPipeProcessors('cellClassName', [], {
-      id: rowId,
-      field,
-    }).filter(Boolean).join(' ')
+    apiRef.current
+      .unstable_applyPipeProcessors('cellClassName', [], {
+        id: rowId,
+        field,
+      })
+      .filter(Boolean)
+      .join(' '),
   );
 
   const classNames = [pipesClassName];

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -217,10 +217,15 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>((props, ref) =>
 
   const { classes: rootClasses, getCellClassName } = rootProps;
 
-  const classNames = apiRef.current.unstable_applyPipeProcessors('cellClassName', [], {
-    id: rowId,
-    field,
-  }) as (string | undefined)[];
+  // There is a hidden grid state access in `applyPipeProcessor('cellClassName', ...)`
+  const pipesClassName = useGridSelector(apiRef, () =>
+    apiRef.current.unstable_applyPipeProcessors('cellClassName', [], {
+      id: rowId,
+      field,
+    }).filter(Boolean).join(' ')
+  );
+
+  const classNames = [pipesClassName];
 
   if (column.cellClassName) {
     classNames.push(


### PR DESCRIPTION
Closes #11891 

Cell range classnames weren't being updated because the cells aren't re-rendering as much as before. 