### PR TITLE
[DataGrid] Fix wrong offset for right-pinned columns when toggling dark/light modes

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -66,7 +66,7 @@ export interface GetHeadersParams {
 
 const SpaceFiller = styled('div')({
   /* GridRootStyles conflict */
-  '&&': {
+  '&&&': {
     padding: 0,
     width: 'calc(var(--DataGrid-width) - var(--DataGrid-columnsTotalWidth))',
   },


### PR DESCRIPTION
Preview: https://deploy-preview-12233--material-ui-x.netlify.app/x/react-data-grid/column-pinning/#initializing-the-pinned-columns

Fixes:

https://github.com/mui/mui-x/assets/13808724/ae9e18f9-0f36-4508-967e-2e4ae98c052f