### PR TITLE
[docs] Polish What's new in MUI X blog titles

### DIFF
--- a/docs/src/modules/components/WhatsNewLayout.js
+++ b/docs/src/modules/components/WhatsNewLayout.js
@@ -18,7 +18,7 @@ import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 
 const entries = [
   {
-    title: 'MUI X v7.0.0-beta.0',
+    title: 'MUI X v7.0.0-beta.0',
     description:
       'Featuring new components and multiple enhancements for both developers and end-users.',
     date: new Date(2024, 0, 29),
@@ -47,7 +47,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X v6.18.0',
+    title: 'MUI X v6.18.0',
     description: 'New stable components, polished features, better performance, and more.',
     date: new Date(2023, 10, 13),
     url: 'https://mui.com/blog/mui-x-end-v6-features/',
@@ -79,7 +79,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X v6.11.0',
+    title: 'MUI X v6.11.0',
     description: 'A roundup of all new features since v6.0.0.',
     date: new Date(2023, 7, 14),
     url: 'https://mui.com/blog/mui-x-mid-v6-features/',
@@ -111,7 +111,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X v6.0.0',
+    title: 'MUI X v6.0.0',
     description: 'A new major is available, with many new features and improvements.',
     date: new Date(2023, 2, 6),
     url: 'https://mui.com/blog/mui-x-v6/',
@@ -147,7 +147,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X Date Pickers v5.0.0',
+    title: 'MUI X Date Pickers v5.0.0',
     description:
       'After some months of polishing in pre-releases, the Date Pickers finally get a stable.',
     date: new Date(2022, 8, 22),
@@ -168,7 +168,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X Data Grid v5.15.0',
+    title: 'MUI X Data Grid v5.15.0',
     description:
       'This version brings an amazing set of new supported use cases with the Data Grid Premium.',
     date: new Date(2022, 7, 12),
@@ -196,7 +196,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X v5.0.0',
+    title: 'MUI X v5.0.0',
     description: 'A new Data Grid virtualization engine, and improvements in several APIs.',
     date: new Date(2021, 10, 22),
     url: 'https://mui.com/blog/mui-x-v5/',

--- a/docs/src/modules/components/WhatsNewLayout.js
+++ b/docs/src/modules/components/WhatsNewLayout.js
@@ -47,7 +47,7 @@ const entries = [
     ],
   },
   {
-    title: 'MUI X v6.18.x',
+    title: 'MUI X v6.18.0',
     description: 'New stable components, polished features, better performance, and more.',
     date: new Date(2023, 10, 13),
     url: 'https://mui.com/blog/mui-x-end-v6-features/',
@@ -147,7 +147,7 @@ const entries = [
     ],
   },
   {
-    title: 'Date Pickers v5.0.0',
+    title: 'MUI X Date Pickers v5.0.0',
     description:
       'After some months of polishing in pre-releases, the Date Pickers finally get a stable.',
     date: new Date(2022, 8, 22),
@@ -168,7 +168,7 @@ const entries = [
     ],
   },
   {
-    title: 'Data Grid v5.15',
+    title: 'MUI X Data Grid v5.15.0',
     description:
       'This version brings an amazing set of new supported use cases with the Data Grid Premium.',
     date: new Date(2022, 7, 12),


### PR DESCRIPTION
This change brings two main things:

- Use a full brand name to help position each component as a standalone.
- Use an exact version number to help anchor the change to a specific version to install.

Before: https://deploy-preview-12307--material-ui-x.netlify.app/x/whats-new/
After: https://deploy-preview-12309--material-ui-x.netlify.app/x/whats-new/

---

I saw these opportunities from #11396 while I was reviewing the AG Grid's design teamwork on https://ag-grid.com/whats-new/. As far as I could audit it, it wasn't done by them but one of the engineers on the team https://github.com/ag-grid/ag-grid/blame/v31.0.1/grid-packages/ag-grid-docs/documentation/src/pages/whats-new.module.scss. So nothing much to learn from this other than: there is a clear gap in design execution that wasn't/isn't prioritized.