### PR TITLE
[TreeView] In the `RichTreeView`, do not use the item id as the HTML id attribute

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewNodes/useTreeViewNodes.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewNodes/useTreeViewNodes.ts
@@ -70,7 +70,7 @@ const updateNodesState = ({
       label,
       index,
       parentId,
-      idAttribute: id,
+      idAttribute: undefined,
       expandable: !!item.children?.length,
       disabled: isItemDisabled ? isItemDisabled(item) : false,
     };


### PR DESCRIPTION
## Problem

When using the following code:

```tsx
const ITEMS = [{ id: '1', label: 'Item 1' }]

<RichTreeView id="my-tree" items={ITEMS} />
```

Will produce the following HTML:

```html
<ul id="my-tree">
  <li class="MuiTreeItem-root" id="1" />
</ul>
```

With this behavior, it is very very easy to unintentionally set an id attribute to your item that is not unique in the whole document.$

## Solution

No setting the id attribute in state allows us to use the fallback which is `${treeId}-${nodeId}`:

```html
<ul id="my-tree">
  <li class="MuiTreeItem-root" id="my-tree-1" />
</ul>
```

We could add a new prop `getItemIdAttribute` to help people customize the id attribute.
Otherwise, they risk to do ugly things such as:

```tsx
<RichTreeView
  items={ITEMS}
  slotProps={{
    item: ({ someProp }) => ({ id: someProp }),
  }}
/>
```

And if they do that, we won't be able to use the ID at the TreeView level to set the `aria-activedescendant`.