### PR TITLE
[TreeView] Fix invalid nodes state when updating `props.items`

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewNodes/useTreeViewNodes.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewNodes/useTreeViewNodes.ts
@@ -169,7 +169,7 @@ export const useTreeViewNodes: TreeViewPlugin<UseTreeViewNodesSignature> = ({
         }
       });
 
-      return { ...prevState, ...newState };
+      return { ...prevState, nodes: newState };
     });
   }, [
     instance,


### PR DESCRIPTION
Regression introduced in #12251, never released