### PR TITLE
[DataGrid] getCellParams when component renders, and not between rerenders

### DIFF
--- a/docs/pages/x/api/data-grid/grid-api.json
+++ b/docs/pages/x/api/data-grid/grid-api.json
@@ -61,6 +61,12 @@
       },
       "required": true
     },
+    "getCellParamsRaw": {
+      "type": {
+        "description": "&lt;R extends GridValidRowModel = any, V = unknown, F = V, N extends GridTreeNode = GridTreeNode&gt;(id: GridRowId, field: string) =&gt; GridCellParams&lt;R, V, F, N&gt;"
+      },
+      "required": true
+    },
     "getCellSelectionModel": {
       "type": { "description": "() =&gt; GridCellSelectionModel" },
       "required": true,

--- a/docs/translations/api-docs/data-grid/grid-api.json
+++ b/docs/translations/api-docs/data-grid/grid-api.json
@@ -32,6 +32,9 @@
     "getCellParams": {
       "description": "Gets the <a href=\"/x/api/data-grid/grid-cell-params/\">GridCellParams</a> object that is passed as argument in events."
     },
+    "getCellParamsRaw": {
+      "description": "Gets the <a href=\"/x/api/data-grid/grid-cell-params/\">GridCellParams</a> object, without invoking <code>valueGetter</code> and <code>valueFormatter</code>, nor asserting<br />if cell is editable.<br />Here, the <code>value</code> and <code>formattedValue</code> properties are always the raw value."
+    },
     "getCellSelectionModel": {
       "description": "Returns an object containing the selection state of the cells.<br />The keys of the object correpond to the row IDs.<br />The value of each key is another object whose keys are the fields and values are the selection state."
     },

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -180,17 +180,31 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>((props, ref) =>
 
   const field = column.field;
 
-  const cellParamsWithAPI = useGridSelector(
+  // [1] We use the selector just as a sentinel on the state, to signal if this GridCell
+  // has changed computed state
+  useGridSelector(
     apiRef,
     () => {
       // This is required because `.getCellParams` tries to get the `state.rows.tree` entry
       // associated with `rowId`/`fieldId`, but this selector runs after the state has been
       // updated, while `rowId`/`fieldId` reference an entry in the old state.
       try {
-        const cellParams = apiRef.current.getCellParams<any, any, any, GridTreeNodeWithRender>(
+        let cellParams = apiRef.current.getCellParamsRaw<any, any, any, GridTreeNodeWithRender>(
           rowId,
           field,
         );
+
+        const { colDef } = cellParams;
+        if (
+          !colDef ||
+          (!colDef.valueGetter && !colDef.valueFormatter) ||
+          colDef.type === 'custom'
+        ) {
+          cellParams = apiRef.current.getCellParams<any, any, any, GridTreeNodeWithRender>(
+            rowId,
+            field,
+          );
+        }
 
         const result = cellParams as CellParamsWithAPI;
         result.api = apiRef.current;
@@ -204,6 +218,20 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>((props, ref) =>
     },
     objectShallowCompare,
   );
+
+  // [2] Then we get the latest params (with valueGetter/valueFormatter/isEditable computation)
+  let cellParamsWithAPI = EMPTY_CELL_PARAMS;
+  try {
+    cellParamsWithAPI = apiRef.current.getCellParams<any, any, any, GridTreeNodeWithRender>(
+      rowId,
+      field,
+    ) as CellParamsWithAPI;
+    cellParamsWithAPI.api = apiRef.current;
+  } catch (e) {
+    if (!(e instanceof MissingRowIdError)) {
+      throw e;
+    }
+  }
 
   const isSelected = useGridSelector(apiRef, () =>
     apiRef.current.unstable_applyPipeProcessors('isCellSelected', false, {

--- a/packages/x-data-grid/src/models/api/gridParamsApi.ts
+++ b/packages/x-data-grid/src/models/api/gridParamsApi.ts
@@ -41,6 +41,23 @@ export interface GridParamsApi {
    */
   getCellElement: (id: GridRowId, field: string) => HTMLDivElement | null;
   /**
+   * Gets the [[GridCellParams]] object, without invoking `valueGetter` and `valueFormatter`, nor asserting
+   * if cell is editable.
+   * Here, the `value` and `formattedValue` properties are always the raw value.
+   * @param {GridRowId} id The id of the row.
+   * @param {string} field The column field.
+   * @returns {GridCellParams} The cell params.
+   */
+  getCellParamsRaw: <
+    R extends GridValidRowModel = any,
+    V = unknown,
+    F = V,
+    N extends GridTreeNode = GridTreeNode,
+  >(
+    id: GridRowId,
+    field: string,
+  ) => GridCellParams<R, V, F, N>;
+  /**
    * Gets the [[GridCellParams]] object that is passed as argument in events.
    * @param {GridRowId} id The id of the row.
    * @param {string} field The column field.


### PR DESCRIPTION
Fixes #12190 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
