### PR TITLE
[data grid] Fix focus visible style on scrollbar

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
@@ -47,6 +47,8 @@ const ScrollbarVertical = styled(Scrollbar)({
     'calc(var(--DataGrid-hasScrollY) * (100% - var(--DataGrid-topContainerHeight) - var(--DataGrid-bottomContainerHeight) - var(--DataGrid-hasScrollX) * var(--DataGrid-scrollbarSize)))',
   overflowY: 'auto',
   overflowX: 'hidden',
+  // Disable focus-visible style, it's a scrollbar.
+  outline: 0,
   '& > div': {
     width: 'var(--size)',
   },
@@ -59,6 +61,8 @@ const ScrollbarHorizontal = styled(Scrollbar)({
   height: 'var(--size)',
   overflowY: 'hidden',
   overflowX: 'auto',
+  // Disable focus-visible style, it's a scrollbar.
+  outline: 0,
   '& > div': {
     height: 'var(--size)',
   },


### PR DESCRIPTION
A quick win, I noticed this by chance, providing an example in #12401. It's a small regression from #10059.

Before:

https://github.com/mui/mui-x/assets/3165635/1d0e3081-2be4-4d57-b828-c587e0a8dbb0

After:

https://github.com/mui/mui-x/assets/3165635/71e461e4-b774-4032-a064-f9873dcabd26

Similar to https://github.com/mui/material-ui/pull/9147 but also different. There are no focus rings for scroll containers, it's not what end-users expect.

BTW, great to see that the keyboard actually works, it doesn't on AG Grid 🙈, a positive differentiator 👍 