### PR TITLE
[docs] Improve slots definitions for charts

### DIFF
--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -81,6 +81,32 @@ It will remove the header showing the x-axis value from the tooltip.
 />
 ```
 
+### Overriding content
+
+To modify the tooltip content, use `slots.itemContent` or `slots.axisContent`.
+The first one is rendered when tooltip trigger is set to `"item"`.
+The second one when  trigger is set to `"axis"`.
+
+```jsx
+// With single component
+<LineChart
+  slots={{
+    itemContent: CustomItemTooltip
+  }}
+/>
+
+// With composition
+<ChartContainer>
+  // ...
+  <Tooltip 
+    trigger='item'
+    slots={{
+      itemContent: CustomItemTooltip
+    }}
+  />
+</ChartContainer>
+```
+
 ## Composition
 
 If you're using composition, by default, the axis will be listening for mouse events to get its current x/y values.

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -85,7 +85,7 @@ It will remove the header showing the x-axis value from the tooltip.
 
 To modify the tooltip content, use `slots.itemContent` or `slots.axisContent`.
 The first one is rendered when tooltip trigger is set to `"item"`.
-The second one when  trigger is set to `"axis"`.
+The second one when trigger is set to `"axis"`.
 
 ```jsx
 // With single component
@@ -98,7 +98,7 @@ The second one when  trigger is set to `"axis"`.
 // With composition
 <ChartContainer>
   // ...
-  <Tooltip 
+  <Tooltip
     trigger='item'
     slots={{
       itemContent: CustomItemTooltip

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -111,10 +111,30 @@
     "import { BarChart } from '@mui/x-charts';"
   ],
   "slots": [
-    { "name": "axisLine", "description": "", "class": null },
-    { "name": "axisTick", "description": "", "class": null },
-    { "name": "axisTickLabel", "description": "", "class": null },
-    { "name": "axisLabel", "description": "", "class": null },
+    {
+      "name": "axisLine",
+      "description": "Custom component for the axis main line.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTick",
+      "description": "Custom component for the axis tick.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTickLabel",
+      "description": "Custom component for tick label.",
+      "default": "ChartsText",
+      "class": null
+    },
+    {
+      "name": "axisLabel",
+      "description": "Custom component for axis label.",
+      "default": "ChartsText",
+      "class": null
+    },
     {
       "name": "bar",
       "description": "The component that renders the bar.",
@@ -127,9 +147,24 @@
       "default": "DefaultChartsLegend",
       "class": null
     },
-    { "name": "popper", "description": "", "class": null },
-    { "name": "axisContent", "description": "", "class": null },
-    { "name": "itemContent", "description": "", "class": null }
+    {
+      "name": "popper",
+      "description": "Custom component for the tooltip popper.",
+      "default": "ChartsTooltipRoot",
+      "class": null
+    },
+    {
+      "name": "axisContent",
+      "description": "Custom component for displaying tooltip content when triggered by axis event.",
+      "default": "DefaultChartsAxisTooltipContent",
+      "class": null
+    },
+    {
+      "name": "itemContent",
+      "description": "Custom component for displaying tooltip content when triggered by item event.",
+      "default": "DefaultChartsItemTooltipContent",
+      "class": null
+    }
   ],
   "classes": [],
   "muiName": "MuiBarChart",

--- a/docs/pages/x/api/charts/charts-legend.json
+++ b/docs/pages/x/api/charts/charts-legend.json
@@ -3,6 +3,12 @@
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "direction": { "type": { "name": "enum", "description": "'column'<br>&#124;&nbsp;'row'" } },
     "hidden": { "type": { "name": "bool" }, "default": "false" },
+    "position": {
+      "type": {
+        "name": "shape",
+        "description": "{ horizontal: 'left'<br>&#124;&nbsp;'middle'<br>&#124;&nbsp;'right', vertical: 'bottom'<br>&#124;&nbsp;'middle'<br>&#124;&nbsp;'top' }"
+      }
+    },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {
       "type": { "name": "object" },

--- a/docs/pages/x/api/charts/charts-tooltip.json
+++ b/docs/pages/x/api/charts/charts-tooltip.json
@@ -31,9 +31,24 @@
     "import { ChartsTooltip } from '@mui/x-charts';"
   ],
   "slots": [
-    { "name": "popper", "description": "", "class": null },
-    { "name": "axisContent", "description": "", "class": null },
-    { "name": "itemContent", "description": "", "class": null }
+    {
+      "name": "popper",
+      "description": "Custom component for the tooltip popper.",
+      "default": "ChartsTooltipRoot",
+      "class": null
+    },
+    {
+      "name": "axisContent",
+      "description": "Custom component for displaying tooltip content when triggered by axis event.",
+      "default": "DefaultChartsAxisTooltipContent",
+      "class": null
+    },
+    {
+      "name": "itemContent",
+      "description": "Custom component for displaying tooltip content when triggered by item event.",
+      "default": "DefaultChartsItemTooltipContent",
+      "class": null
+    }
   ],
   "classes": [
     {

--- a/docs/pages/x/api/charts/default-charts-legend.json
+++ b/docs/pages/x/api/charts/default-charts-legend.json
@@ -9,6 +9,13 @@
       "type": { "name": "enum", "description": "'column'<br>&#124;&nbsp;'row'" },
       "required": true
     },
+    "position": {
+      "type": {
+        "name": "shape",
+        "description": "{ horizontal: 'left'<br>&#124;&nbsp;'middle'<br>&#124;&nbsp;'right', vertical: 'bottom'<br>&#124;&nbsp;'middle'<br>&#124;&nbsp;'top' }"
+      },
+      "required": true
+    },
     "hidden": { "type": { "name": "bool" }, "default": "false" },
     "itemGap": { "type": { "name": "number" }, "default": "10" },
     "itemMarkHeight": { "type": { "name": "number" }, "default": "20" },

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -106,10 +106,30 @@
     "import { LineChart } from '@mui/x-charts';"
   ],
   "slots": [
-    { "name": "axisLine", "description": "", "class": null },
-    { "name": "axisTick", "description": "", "class": null },
-    { "name": "axisTickLabel", "description": "", "class": null },
-    { "name": "axisLabel", "description": "", "class": null },
+    {
+      "name": "axisLine",
+      "description": "Custom component for the axis main line.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTick",
+      "description": "Custom component for the axis tick.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTickLabel",
+      "description": "Custom component for tick label.",
+      "default": "ChartsText",
+      "class": null
+    },
+    {
+      "name": "axisLabel",
+      "description": "Custom component for axis label.",
+      "default": "ChartsText",
+      "class": null
+    },
     {
       "name": "area",
       "description": "The component that renders the area.",
@@ -130,9 +150,24 @@
       "default": "DefaultChartsLegend",
       "class": null
     },
-    { "name": "popper", "description": "", "class": null },
-    { "name": "axisContent", "description": "", "class": null },
-    { "name": "itemContent", "description": "", "class": null }
+    {
+      "name": "popper",
+      "description": "Custom component for the tooltip popper.",
+      "default": "ChartsTooltipRoot",
+      "class": null
+    },
+    {
+      "name": "axisContent",
+      "description": "Custom component for displaying tooltip content when triggered by axis event.",
+      "default": "DefaultChartsAxisTooltipContent",
+      "class": null
+    },
+    {
+      "name": "itemContent",
+      "description": "Custom component for displaying tooltip content when triggered by item event.",
+      "default": "DefaultChartsItemTooltipContent",
+      "class": null
+    }
   ],
   "classes": [],
   "muiName": "MuiLineChart",

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -102,10 +102,30 @@
     "import { PieChart } from '@mui/x-charts';"
   ],
   "slots": [
-    { "name": "axisLine", "description": "", "class": null },
-    { "name": "axisTick", "description": "", "class": null },
-    { "name": "axisTickLabel", "description": "", "class": null },
-    { "name": "axisLabel", "description": "", "class": null },
+    {
+      "name": "axisLine",
+      "description": "Custom component for the axis main line.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTick",
+      "description": "Custom component for the axis tick.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTickLabel",
+      "description": "Custom component for tick label.",
+      "default": "ChartsText",
+      "class": null
+    },
+    {
+      "name": "axisLabel",
+      "description": "Custom component for axis label.",
+      "default": "ChartsText",
+      "class": null
+    },
     { "name": "pieArc", "description": "", "class": null },
     { "name": "pieArcLabel", "description": "", "class": null },
     {
@@ -114,9 +134,24 @@
       "default": "DefaultChartsLegend",
       "class": null
     },
-    { "name": "popper", "description": "", "class": null },
-    { "name": "axisContent", "description": "", "class": null },
-    { "name": "itemContent", "description": "", "class": null }
+    {
+      "name": "popper",
+      "description": "Custom component for the tooltip popper.",
+      "default": "ChartsTooltipRoot",
+      "class": null
+    },
+    {
+      "name": "axisContent",
+      "description": "Custom component for displaying tooltip content when triggered by axis event.",
+      "default": "DefaultChartsAxisTooltipContent",
+      "class": null
+    },
+    {
+      "name": "itemContent",
+      "description": "Custom component for displaying tooltip content when triggered by item event.",
+      "default": "DefaultChartsItemTooltipContent",
+      "class": null
+    }
   ],
   "classes": [],
   "muiName": "MuiPieChart",

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -103,10 +103,30 @@
     "import { ScatterChart } from '@mui/x-charts';"
   ],
   "slots": [
-    { "name": "axisLine", "description": "", "class": null },
-    { "name": "axisTick", "description": "", "class": null },
-    { "name": "axisTickLabel", "description": "", "class": null },
-    { "name": "axisLabel", "description": "", "class": null },
+    {
+      "name": "axisLine",
+      "description": "Custom component for the axis main line.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTick",
+      "description": "Custom component for the axis tick.",
+      "default": "'line'",
+      "class": null
+    },
+    {
+      "name": "axisTickLabel",
+      "description": "Custom component for tick label.",
+      "default": "ChartsText",
+      "class": null
+    },
+    {
+      "name": "axisLabel",
+      "description": "Custom component for axis label.",
+      "default": "ChartsText",
+      "class": null
+    },
     { "name": "scatter", "description": "", "class": null },
     {
       "name": "legend",
@@ -114,9 +134,24 @@
       "default": "DefaultChartsLegend",
       "class": null
     },
-    { "name": "popper", "description": "", "class": null },
-    { "name": "axisContent", "description": "", "class": null },
-    { "name": "itemContent", "description": "", "class": null }
+    {
+      "name": "popper",
+      "description": "Custom component for the tooltip popper.",
+      "default": "ChartsTooltipRoot",
+      "class": null
+    },
+    {
+      "name": "axisContent",
+      "description": "Custom component for displaying tooltip content when triggered by axis event.",
+      "default": "DefaultChartsAxisTooltipContent",
+      "class": null
+    },
+    {
+      "name": "itemContent",
+      "description": "Custom component for displaying tooltip content when triggered by item event.",
+      "default": "DefaultChartsItemTooltipContent",
+      "class": null
+    }
   ],
   "classes": [],
   "muiName": "MuiScatterChart",

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -74,9 +74,24 @@
       "default": "BarElementPath",
       "class": null
     },
-    { "name": "popper", "description": "", "class": null },
-    { "name": "axisContent", "description": "", "class": null },
-    { "name": "itemContent", "description": "", "class": null }
+    {
+      "name": "popper",
+      "description": "Custom component for the tooltip popper.",
+      "default": "ChartsTooltipRoot",
+      "class": null
+    },
+    {
+      "name": "axisContent",
+      "description": "Custom component for displaying tooltip content when triggered by axis event.",
+      "default": "DefaultChartsAxisTooltipContent",
+      "class": null
+    },
+    {
+      "name": "itemContent",
+      "description": "Custom component for displaying tooltip content when triggered by item event.",
+      "default": "DefaultChartsItemTooltipContent",
+      "class": null
+    }
   ],
   "classes": [],
   "muiName": "MuiSparkLineChart",

--- a/docs/translations/api-docs/charts/bar-chart/bar-chart.json
+++ b/docs/translations/api-docs/charts/bar-chart/bar-chart.json
@@ -66,14 +66,14 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "axisContent": "",
-    "axisLabel": "",
-    "axisLine": "",
-    "axisTick": "",
-    "axisTickLabel": "",
+    "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
+    "axisLabel": "Custom component for axis label.",
+    "axisLine": "Custom component for the axis main line.",
+    "axisTick": "Custom component for the axis tick.",
+    "axisTickLabel": "Custom component for tick label.",
     "bar": "The component that renders the bar.",
-    "itemContent": "",
+    "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
     "legend": "Custom rendering of the legend.",
-    "popper": ""
+    "popper": "Custom component for the tooltip popper."
   }
 }

--- a/docs/translations/api-docs/charts/charts-legend/charts-legend.json
+++ b/docs/translations/api-docs/charts/charts-legend/charts-legend.json
@@ -6,6 +6,7 @@
       "description": "The direction of the legend layout. The default depends on the chart."
     },
     "hidden": { "description": "Set to true to hide the legend." },
+    "position": { "description": "The position of the legend." },
     "slotProps": { "description": "The props used for each component slot." },
     "slots": { "description": "Overridable component slots." }
   },

--- a/docs/translations/api-docs/charts/charts-tooltip/charts-tooltip.json
+++ b/docs/translations/api-docs/charts/charts-tooltip/charts-tooltip.json
@@ -33,5 +33,9 @@
       "nodeName": "the valueCell element"
     }
   },
-  "slotDescriptions": { "axisContent": "", "itemContent": "", "popper": "" }
+  "slotDescriptions": {
+    "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
+    "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
+    "popper": "Custom component for the tooltip popper."
+  }
 }

--- a/docs/translations/api-docs/charts/default-charts-legend/default-charts-legend.json
+++ b/docs/translations/api-docs/charts/default-charts-legend/default-charts-legend.json
@@ -13,7 +13,8 @@
     "markGap": { "description": "Space between the mark and the label (in px)." },
     "padding": {
       "description": "Legend padding (in px). Can either be a single number, or an object with top, left, bottom, right properties."
-    }
+    },
+    "position": { "description": "The position of the legend." }
   },
   "classDescriptions": {
     "mark": { "description": "" },

--- a/docs/translations/api-docs/charts/line-chart/line-chart.json
+++ b/docs/translations/api-docs/charts/line-chart/line-chart.json
@@ -65,16 +65,16 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "area": "The component that renders the area.",
-    "axisContent": "",
-    "axisLabel": "",
-    "axisLine": "",
-    "axisTick": "",
-    "axisTickLabel": "",
-    "itemContent": "",
+    "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
+    "axisLabel": "Custom component for axis label.",
+    "axisLine": "Custom component for the axis main line.",
+    "axisTick": "Custom component for the axis tick.",
+    "axisTickLabel": "Custom component for tick label.",
+    "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
     "legend": "Custom rendering of the legend.",
     "line": "The component that renders the line.",
     "lineHighlight": "",
     "mark": "",
-    "popper": ""
+    "popper": "Custom component for the tooltip popper."
   }
 }

--- a/docs/translations/api-docs/charts/pie-chart/pie-chart.json
+++ b/docs/translations/api-docs/charts/pie-chart/pie-chart.json
@@ -52,15 +52,15 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "axisContent": "",
-    "axisLabel": "",
-    "axisLine": "",
-    "axisTick": "",
-    "axisTickLabel": "",
-    "itemContent": "",
+    "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
+    "axisLabel": "Custom component for axis label.",
+    "axisLine": "Custom component for the axis main line.",
+    "axisTick": "Custom component for the axis tick.",
+    "axisTickLabel": "Custom component for tick label.",
+    "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
     "legend": "Custom rendering of the legend.",
     "pieArc": "",
     "pieArcLabel": "",
-    "popper": ""
+    "popper": "Custom component for the tooltip popper."
   }
 }

--- a/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
@@ -63,14 +63,14 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "axisContent": "",
-    "axisLabel": "",
-    "axisLine": "",
-    "axisTick": "",
-    "axisTickLabel": "",
-    "itemContent": "",
+    "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
+    "axisLabel": "Custom component for axis label.",
+    "axisLine": "Custom component for the axis main line.",
+    "axisTick": "Custom component for the axis tick.",
+    "axisTickLabel": "Custom component for tick label.",
+    "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
     "legend": "Custom rendering of the legend.",
-    "popper": "",
+    "popper": "Custom component for the tooltip popper.",
     "scatter": ""
   }
 }

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -41,12 +41,12 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "area": "The component that renders the area.",
-    "axisContent": "",
+    "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
     "bar": "The component that renders the bar.",
-    "itemContent": "",
+    "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
     "line": "The component that renders the line.",
     "lineHighlight": "",
     "mark": "",
-    "popper": ""
+    "popper": "Custom component for the tooltip popper."
   }
 }

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -125,6 +125,9 @@ ChartsLegend.propTypes = {
    * @default false
    */
   hidden: PropTypes.bool,
+  /**
+   * The position of the legend.
+   */
   position: PropTypes.shape({
     horizontal: PropTypes.oneOf(['left', 'middle', 'right']).isRequired,
     vertical: PropTypes.oneOf(['bottom', 'middle', 'top']).isRequired,

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -23,6 +23,9 @@ export interface ChartsLegendSlotProps {
 }
 
 export type ChartsLegendProps = {
+  /**
+   * The position of the legend.
+   */
   position?: AnchorPosition;
   /**
    * Override or extend the styles applied to the component.

--- a/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
@@ -359,6 +359,9 @@ DefaultChartsLegend.propTypes = {
       top: PropTypes.number,
     }),
   ]),
+  /**
+   * The position of the legend.
+   */
   position: PropTypes.shape({
     horizontal: PropTypes.oneOf(['left', 'middle', 'right']).isRequired,
     vertical: PropTypes.oneOf(['bottom', 'middle', 'top']).isRequired,

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -22,8 +22,20 @@ import { ChartsAxisContentProps, ChartsAxisTooltipContent } from './ChartsAxisTo
 import { ChartsTooltipClasses, getChartsTooltipUtilityClass } from './chartsTooltipClasses';
 
 export interface ChartsTooltipSlots {
+  /**
+   * Custom component for the tooltip popper.
+   * @default ChartsTooltipRoot
+   */
   popper?: React.ElementType<PopperProps>;
+  /**
+   * Custom component for displaying tooltip content when triggered by axis event.
+   * @default DefaultChartsAxisTooltipContent
+   */
   axisContent?: React.ElementType<ChartsAxisContentProps>;
+  /**
+   * Custom component for displaying tooltip content when triggered by item event.
+   * @default DefaultChartsItemTooltipContent
+   */
   itemContent?: React.ElementType<ChartsItemContentProps>;
 }
 

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -31,9 +31,25 @@ export type D3ContinuouseScale<Range = number, Output = number> =
   | ScaleLinear<Range, Output>;
 
 export interface ChartsAxisSlots {
+  /**
+   * Custom component for the axis main line.
+   * @default 'line'
+   */
   axisLine?: React.JSXElementConstructor<React.SVGAttributes<SVGPathElement>>;
+  /**
+   * Custom component for the axis tick.
+   * @default 'line'
+   */
   axisTick?: React.JSXElementConstructor<React.SVGAttributes<SVGPathElement>>;
+  /**
+   * Custom component for tick label.
+   * @default ChartsText
+   */
   axisTickLabel?: React.JSXElementConstructor<ChartsTextProps>;
+  /**
+   * Custom component for axis label.
+   * @default ChartsText
+   */
   axisLabel?: React.JSXElementConstructor<ChartsTextProps>;
 }
 


### PR DESCRIPTION
Fix #12268
Fix #10352

- First commit ass some slots definition for the tooltip and axis
- Second commit is the result of `yarn proptypes & yarn docs:api`
- Third commit is adding a section in tooltip to show how to use those slots