### PR TITLE
[data-grid] Make Autocomplete variant in Filters to standard

### DIFF
--- a/packages/x-data-grid/src/colDef/gridStringOperators.ts
+++ b/packages/x-data-grid/src/colDef/gridStringOperators.ts
@@ -120,5 +120,6 @@ export const getGridStringOperators = (
           : false;
     },
     InputComponent: GridFilterInputMultipleValue,
+    InputComponentProps: { variant: 'standard' },
   },
 ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/mui-x/issues/11786

preview: https://deploy-preview-12413--material-ui-x.netlify.app/x/react-data-grid/filtering/

select `is any of` filter from above demo to see updated variant

![image](https://github.com/mui/mui-x/assets/60743144/edae4638-65ca-4ce7-8898-300ec90fb116)


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
