### PR TITLE
[core] Remove leftover `legacy` `browserlistrc` entry

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -36,27 +36,6 @@ opera 76
 safari 14
 samsung 13.0
 
-# Same as `stable` but with IE 11
-
-[legacy]
-ie 11
-and_chr 91
-and_ff 89
-and_qq 10.4
-and_uc 12.12
-android 91
-baidu 7.12
-chrome 90
-edge 91
-firefox 78
-ios_saf 12.2
-kaios 2.5
-op_mini all
-op_mob 73
-opera 76
-safari 14
-samsung 13.0
-
 # snapshot of `npx browserslist "maintained node versions"`
 
 # On update check all #stable-snapshot markers


### PR DESCRIPTION
Follow-up on https://github.com/mui/mui-x/pull/12151.