### PR TITLE
[docs] Add `legacy` bundle drop mention in migration pages

### DIFF
--- a/docs/data/migration/migration-charts-v6/migration-charts-v6.md
+++ b/docs/data/migration/migration-charts-v6/migration-charts-v6.md
@@ -34,7 +34,7 @@ These changes were done for consistency, improved stability and to make room for
 
 ### Drop the legacy bundle
 
-The support for IE11 has been removed from all MUI X packages.
+The support for IE11 has been removed from all MUI X packages.
 The `legacy` bundle that used to support old browsers like IE11 is no longer included.
 
 :::info

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -98,7 +98,7 @@ Below are described the steps you need to make to migrate from v6 to v7.
 
 ### Drop the legacy bundle
 
-The support for IE11 has been removed from all MUI X packages.
+The support for IE11 has been removed from all MUI X packages.
 The `legacy` bundle that used to support old browsers like IE11 is no longer included.
 
 :::info

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -87,7 +87,7 @@ Feel free to [open an issue](https://github.com/mui/mui-x/issues/new/choose) for
 
 ## Drop the legacy bundle
 
-The support for IE11 has been removed from all MUI X packages.
+The support for IE11 has been removed from all MUI X packages.
 The `legacy` bundle that used to support old browsers like IE11 is no longer included.
 
 :::info

--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -34,7 +34,7 @@ These changes were done for consistency, improved stability and to make room for
 
 ### Drop the legacy bundle
 
-The support for IE11 has been removed from all MUI X packages.
+The support for IE11 has been removed from all MUI X packages.
 The `legacy` bundle that used to support old browsers like IE11 is no longer included.
 
 :::info


### PR DESCRIPTION
Closes #12141

Add mention of `legacy` bundle dropping in all package migration pages.