### PR TITLE
[DataGrid] Remove baseSwitch

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -768,12 +768,6 @@
       "class": null
     },
     {
-      "name": "baseSwitch",
-      "description": "The custom Switch component used in the grid.",
-      "default": "Switch",
-      "class": null
-    },
-    {
       "name": "baseButton",
       "description": "The custom Button component used in the grid.",
       "default": "Button",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -707,12 +707,6 @@
       "class": null
     },
     {
-      "name": "baseSwitch",
-      "description": "The custom Switch component used in the grid.",
-      "default": "Switch",
-      "class": null
-    },
-    {
       "name": "baseButton",
       "description": "The custom Button component used in the grid.",
       "default": "Button",

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -580,12 +580,6 @@
       "class": null
     },
     {
-      "name": "baseSwitch",
-      "description": "The custom Switch component used in the grid.",
-      "default": "Switch",
-      "class": null
-    },
-    {
       "name": "baseButton",
       "description": "The custom Button component used in the grid.",
       "default": "Button",

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -1235,7 +1235,6 @@
     "basePopper": "The custom Popper component used in the grid.",
     "baseSelect": "The custom Select component used in the grid.",
     "baseSelectOption": "The custom SelectOption component used in the grid.",
-    "baseSwitch": "The custom Switch component used in the grid.",
     "baseTextField": "The custom TextField component used in the grid.",
     "baseTooltip": "The custom Tooltip component used in the grid.",
     "booleanCellFalseIcon": "Icon displayed on the boolean cell to represent the false value.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -1177,7 +1177,6 @@
     "basePopper": "The custom Popper component used in the grid.",
     "baseSelect": "The custom Select component used in the grid.",
     "baseSelectOption": "The custom SelectOption component used in the grid.",
-    "baseSwitch": "The custom Switch component used in the grid.",
     "baseTextField": "The custom TextField component used in the grid.",
     "baseTooltip": "The custom Tooltip component used in the grid.",
     "booleanCellFalseIcon": "Icon displayed on the boolean cell to represent the false value.",

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -1043,7 +1043,6 @@
     "basePopper": "The custom Popper component used in the grid.",
     "baseSelect": "The custom Select component used in the grid.",
     "baseSelectOption": "The custom SelectOption component used in the grid.",
-    "baseSwitch": "The custom Switch component used in the grid.",
     "baseTextField": "The custom TextField component used in the grid.",
     "baseTooltip": "The custom Tooltip component used in the grid.",
     "booleanCellFalseIcon": "Icon displayed on the boolean cell to represent the false value.",

--- a/packages/x-data-grid/src/joy/joySlots.tsx
+++ b/packages/x-data-grid/src/joy/joySlots.tsx
@@ -7,7 +7,6 @@ import JoyFormControl from '@mui/joy/FormControl';
 import JoyFormLabel from '@mui/joy/FormLabel';
 import JoyButton from '@mui/joy/Button';
 import JoyIconButton from '@mui/joy/IconButton';
-import JoySwitch, { SwitchProps as JoySwitchProps } from '@mui/joy/Switch';
 import JoySelect, { SelectProps as JoySelectProps } from '@mui/joy/Select';
 import JoyOption, { OptionProps as JoyOptionProps } from '@mui/joy/Option';
 import JoyBox from '@mui/joy/Box';
@@ -146,57 +145,6 @@ const IconButton = React.forwardRef<
       variant="plain"
       ref={ref}
       sx={sx as SxProps<Theme>}
-    />
-  );
-});
-
-const Switch = React.forwardRef<any, GridSlotProps['baseSwitch']>(function Switch(
-  {
-    name,
-    checkedIcon,
-    color: colorProp,
-    disableRipple,
-    disableFocusRipple,
-    disableTouchRipple,
-    edge,
-    icon,
-    inputProps,
-    inputRef,
-    size,
-    sx,
-    onChange,
-    onClick,
-    ...props
-  },
-  ref,
-) {
-  return (
-    <JoySwitch
-      {...(props as JoySwitchProps)}
-      onChange={onChange as JoySwitchProps['onChange']}
-      size={convertSize(size)}
-      color={convertColor(colorProp)}
-      ref={ref}
-      slotProps={{
-        input: {
-          ...inputProps,
-          name,
-          onClick: onClick as React.JSX.IntrinsicElements['input']['onClick'],
-          ref: inputRef,
-        },
-        thumb: {
-          children: icon,
-        },
-      }}
-      sx={
-        [
-          {
-            ...(edge === 'start' && { ml: '-8px' }),
-            ...(edge === 'end' && { mr: '-8px' }),
-          },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ] as SxProps<Theme>
-      }
     />
   );
 });
@@ -430,7 +378,6 @@ const joySlots: Partial<GridSlotsComponent> = {
   baseTextField: TextField,
   baseButton: Button,
   baseIconButton: IconButton,
-  baseSwitch: Switch,
   baseSelect: Select,
   baseSelectOption: Option,
   baseInputLabel: InputLabel,

--- a/packages/x-data-grid/src/material/index.ts
+++ b/packages/x-data-grid/src/material/index.ts
@@ -2,7 +2,6 @@ import MUICheckbox from '@mui/material/Checkbox';
 import MUITextField from '@mui/material/TextField';
 import MUIFormControl from '@mui/material/FormControl';
 import MUISelect from '@mui/material/Select';
-import MUISwitch from '@mui/material/Switch';
 import MUIButton from '@mui/material/Button';
 import MUIIconButton from '@mui/material/IconButton';
 import MUIInputAdornment from '@mui/material/InputAdornment';
@@ -86,7 +85,6 @@ const materialSlots: GridBaseSlots & GridIconSlotsComponent = {
   baseTextField: MUITextField,
   baseFormControl: MUIFormControl,
   baseSelect: MUISelect,
-  baseSwitch: MUISwitch,
   baseButton: MUIButton,
   baseIconButton: MUIIconButton,
   baseInputAdornment: MUIInputAdornment,

--- a/packages/x-data-grid/src/models/gridSlotsComponent.ts
+++ b/packages/x-data-grid/src/models/gridSlotsComponent.ts
@@ -36,11 +36,6 @@ export interface GridBaseSlots {
    */
   baseSelect: React.JSXElementConstructor<GridSlotProps['baseSelect']>;
   /**
-   * The custom Switch component used in the grid.
-   * @default Switch
-   */
-  baseSwitch: React.JSXElementConstructor<GridSlotProps['baseSwitch']>;
-  /**
    * The custom Button component used in the grid.
    * @default Button
    */


### PR DESCRIPTION
Following the column management panels refactor, we don't use the switch anymore.