### PR TITLE
[DataGrid] Fix `ElementType` usage

### DIFF
--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -32,12 +32,17 @@ const GridPaginationRoot = styled(TablePagination)(({ theme }) => ({
 
 type MutableArray<A> = A extends readonly (infer T)[] ? T[] : never;
 
+interface GridPaginationOwnProps {
+  component?: React.ElementType;
+}
+
 const GridPagination = React.forwardRef<
   unknown,
   Partial<
     // See https://github.com/mui/material-ui/issues/40427
-    Omit<TablePaginationProps, 'component'> & { component?: React.ElementType }
-  >
+    Omit<TablePaginationProps, 'component'>
+  > &
+    GridPaginationOwnProps
 >(function GridPagination(props, ref) {
   const apiRef = useGridApiContext();
   const rootProps = useGridRootProps();

--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -31,88 +31,92 @@ const GridPaginationRoot = styled(TablePagination)(({ theme }) => ({
 
 type MutableArray<A> = A extends readonly (infer T)[] ? T[] : never;
 
-export const GridPagination = React.forwardRef<unknown, Partial<TablePaginationProps>>(
-  function GridPagination(props, ref) {
-    const apiRef = useGridApiContext();
-    const rootProps = useGridRootProps();
-    const paginationModel = useGridSelector(apiRef, gridPaginationModelSelector);
-    const rowCount = useGridSelector(apiRef, gridPaginationRowCountSelector);
+export const GridPagination = React.forwardRef<
+  unknown,
+  Partial<
+    // See https://github.com/mui/material-ui/issues/40427
+    Omit<TablePaginationProps, 'component'> & { component: React.ElementType }
+  >
+>(function GridPagination(props, ref) {
+  const apiRef = useGridApiContext();
+  const rootProps = useGridRootProps();
+  const paginationModel = useGridSelector(apiRef, gridPaginationModelSelector);
+  const rowCount = useGridSelector(apiRef, gridPaginationRowCountSelector);
 
-    const lastPage = React.useMemo(() => {
-      const calculatedValue = Math.ceil(rowCount / (paginationModel.pageSize || 1)) - 1;
-      return Math.max(0, calculatedValue);
-    }, [rowCount, paginationModel.pageSize]);
+  const lastPage = React.useMemo(() => {
+    const calculatedValue = Math.ceil(rowCount / (paginationModel.pageSize || 1)) - 1;
+    return Math.max(0, calculatedValue);
+  }, [rowCount, paginationModel.pageSize]);
 
-    const handlePageSizeChange = React.useCallback(
-      (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-        const pageSize = Number(event.target.value);
-        apiRef.current.setPageSize(pageSize);
-      },
-      [apiRef],
-    );
+  const handlePageSizeChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      const pageSize = Number(event.target.value);
+      apiRef.current.setPageSize(pageSize);
+    },
+    [apiRef],
+  );
 
-    const handlePageChange = React.useCallback<TablePaginationProps['onPageChange']>(
-      (_, page) => {
-        apiRef.current.setPage(page);
-      },
-      [apiRef],
-    );
+  const handlePageChange = React.useCallback<TablePaginationProps['onPageChange']>(
+    (_, page) => {
+      apiRef.current.setPage(page);
+    },
+    [apiRef],
+  );
 
-    const isPageSizeIncludedInPageSizeOptions = (pageSize: number) => {
-      for (let i = 0; i < rootProps.pageSizeOptions.length; i += 1) {
-        const option = rootProps.pageSizeOptions[i];
-        if (typeof option === 'number') {
-          if (option === pageSize) {
-            return true;
-          }
-        } else if (option.value === pageSize) {
+  const isPageSizeIncludedInPageSizeOptions = (pageSize: number) => {
+    for (let i = 0; i < rootProps.pageSizeOptions.length; i += 1) {
+      const option = rootProps.pageSizeOptions[i];
+      if (typeof option === 'number') {
+        if (option === pageSize) {
           return true;
         }
-      }
-      return false;
-    };
-
-    if (process.env.NODE_ENV !== 'production') {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const warnedOnceMissingInPageSizeOptions = React.useRef(false);
-
-      const pageSize = rootProps.paginationModel?.pageSize ?? paginationModel.pageSize;
-      if (
-        !warnedOnceMissingInPageSizeOptions.current &&
-        !rootProps.autoPageSize &&
-        !isPageSizeIncludedInPageSizeOptions(pageSize)
-      ) {
-        console.warn(
-          [
-            `MUI X: The page size \`${paginationModel.pageSize}\` is not preset in the \`pageSizeOptions\`.`,
-            `Add it to show the pagination select.`,
-          ].join('\n'),
-        );
-
-        warnedOnceMissingInPageSizeOptions.current = true;
+      } else if (option.value === pageSize) {
+        return true;
       }
     }
+    return false;
+  };
 
-    const pageSizeOptions = isPageSizeIncludedInPageSizeOptions(paginationModel.pageSize)
-      ? rootProps.pageSizeOptions
-      : [];
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const warnedOnceMissingInPageSizeOptions = React.useRef(false);
 
-    return (
-      <GridPaginationRoot
-        ref={ref}
-        component="div"
-        count={rowCount}
-        page={paginationModel.page <= lastPage ? paginationModel.page : lastPage}
-        // TODO: Remove the cast once the type is fixed in Material UI and that the min Material UI version
-        // for x-data-grid is past the fix.
-        // Note that Material UI will not mutate the array, so this is safe.
-        rowsPerPageOptions={pageSizeOptions as MutableArray<typeof pageSizeOptions>}
-        rowsPerPage={paginationModel.pageSize}
-        onPageChange={handlePageChange}
-        onRowsPerPageChange={handlePageSizeChange}
-        {...apiRef.current.getLocaleText('MuiTablePagination')}
-        {...props}
-      />
-    );
-  },
-);
+    const pageSize = rootProps.paginationModel?.pageSize ?? paginationModel.pageSize;
+    if (
+      !warnedOnceMissingInPageSizeOptions.current &&
+      !rootProps.autoPageSize &&
+      !isPageSizeIncludedInPageSizeOptions(pageSize)
+    ) {
+      console.warn(
+        [
+          `MUI X: The page size \`${paginationModel.pageSize}\` is not preset in the \`pageSizeOptions\`.`,
+          `Add it to show the pagination select.`,
+        ].join('\n'),
+      );
+
+      warnedOnceMissingInPageSizeOptions.current = true;
+    }
+  }
+
+  const pageSizeOptions = isPageSizeIncludedInPageSizeOptions(paginationModel.pageSize)
+    ? rootProps.pageSizeOptions
+    : [];
+
+  return (
+    <GridPaginationRoot
+      ref={ref}
+      component="div"
+      count={rowCount}
+      page={paginationModel.page <= lastPage ? paginationModel.page : lastPage}
+      // TODO: Remove the cast once the type is fixed in Material UI and that the min Material UI version
+      // for x-data-grid is past the fix.
+      // Note that Material UI will not mutate the array, so this is safe.
+      rowsPerPageOptions={pageSizeOptions as MutableArray<typeof pageSizeOptions>}
+      rowsPerPage={paginationModel.pageSize}
+      onPageChange={handlePageChange}
+      onRowsPerPageChange={handlePageSizeChange}
+      {...apiRef.current.getLocaleText('MuiTablePagination')}
+      {...props}
+    />
+  );
+});

--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import TablePagination, {
   tablePaginationClasses,
   TablePaginationProps,
@@ -31,11 +32,11 @@ const GridPaginationRoot = styled(TablePagination)(({ theme }) => ({
 
 type MutableArray<A> = A extends readonly (infer T)[] ? T[] : never;
 
-export const GridPagination = React.forwardRef<
+const GridPagination = React.forwardRef<
   unknown,
   Partial<
     // See https://github.com/mui/material-ui/issues/40427
-    Omit<TablePaginationProps, 'component'> & { component: React.ElementType }
+    Omit<TablePaginationProps, 'component'> & { component?: React.ElementType }
   >
 >(function GridPagination(props, ref) {
   const apiRef = useGridApiContext();
@@ -120,3 +121,13 @@ export const GridPagination = React.forwardRef<
     />
   );
 });
+
+GridPagination.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // | To update them edit the TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  component: PropTypes.elementType,
+} as any;
+
+export { GridPagination };

--- a/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -83,6 +83,10 @@ GridActionsCellItem.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * from https://mui.com/material-ui/api/button-base/#ButtonBase-prop-component
+   */
+  component: PropTypes.elementType,
   icon: PropTypes.element,
   label: PropTypes.string.isRequired,
   showInMenu: PropTypes.bool,

--- a/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -5,23 +5,26 @@ import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 
-export type GridActionsCellItemProps = {
+interface GridActionsCellItemCommonProps {
   label: string;
   icon?: React.ReactElement;
   /** from https://mui.com/material-ui/api/button-base/#ButtonBase-prop-component */
   component?: React.ElementType;
-} & (
-  | ({ showInMenu?: false; icon: React.ReactElement } & IconButtonProps)
-  | ({
-      showInMenu: true;
-      /**
-       * If false, the menu will not close when this item is clicked.
-       * @default true
-       */
-      closeMenuOnClick?: boolean;
-      closeMenu?: () => void;
-    } & MenuItemProps)
-);
+}
+
+export type GridActionsCellItemProps = GridActionsCellItemCommonProps &
+  (
+    | ({ showInMenu?: false; icon: React.ReactElement } & Omit<IconButtonProps, 'component'>)
+    | ({
+        showInMenu: true;
+        /**
+         * If false, the menu will not close when this item is clicked.
+         * @default true
+         */
+        closeMenuOnClick?: boolean;
+        closeMenu?: () => void;
+      } & Omit<MenuItemProps, 'component'>)
+  );
 
 const GridActionsCellItem = React.forwardRef<HTMLElement, GridActionsCellItemProps>(
   (props, ref) => {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/40427 for the data grid

| Before | After |
| ------  | ----- |
| <img width="522" src="https://github.com/mui/mui-x/assets/13808724/0cc9b060-8bad-475d-8a7c-17b965b984d4"> | <img width="519" src="https://github.com/mui/mui-x/assets/13808724/7302f2f5-9cc6-4c82-9bdc-e408866b92dd"> |

In `GridPanel`, you can still see generics being passed to `React.ElementType`, but this was solved on the Core side in https://github.com/mui/material-ui/pull/41500

### Testing

It's hard to test because it requires a different version of `@types/react` than we use in our monorepo.
I've created a branch in https://github.com/cherniavskii/cra-data-grid-test/tree/react17

Before:

```sh
npx tsc --skipLibCheck false
node_modules/@mui/base/Unstable_Popup/Popup.d.ts:13:70 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

13 declare const Popup: React.ForwardRefExoticComponent<Omit<PopupProps<React.ElementType<any, keyof React.JSX.IntrinsicElements>>, "ref"> & React.RefAttributes<Element>>;
                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mui/x-data-grid/components/cell/GridActionsCellItem.d.ts:25:17 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

25     component?: React.ElementType<any, keyof React.JSX.IntrinsicElements> | undefined;
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mui/x-data-grid/components/cell/GridActionsCellItem.d.ts:32:17 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

32     component?: React.ElementType<any, keyof React.JSX.IntrinsicElements> | undefined;
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mui/x-data-grid/components/cell/GridActionsCellItem.d.ts:37:17 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

37     component?: React.ElementType<any, keyof React.JSX.IntrinsicElements> | undefined;
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mui/x-data-grid/components/cell/GridActionsCellItem.d.ts:49:17 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

49     component?: React.ElementType<any, keyof React.JSX.IntrinsicElements> | undefined;
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mui/x-data-grid/components/GridPagination.d.ts:3:17 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

3     component?: React.ElementType<any, keyof React.JSX.IntrinsicElements> | undefined;
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@mui/x-data-grid/components/GridPagination.d.ts:5:17 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

5     component?: React.ElementType<any, keyof React.JSX.IntrinsicElements> | undefined;
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@types/react/global.d.ts:157:11 - error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.

157 interface TrustedHTML {}
              ~~~~~~~~~~~

  node_modules/@types/trusted-types/index.d.ts:14:11
    14     const TrustedHTML: typeof lib.TrustedHTML;
                 ~~~~~~~~~~~
    'TrustedHTML' was also declared here.
  node_modules/@types/trusted-types/index.d.ts:15:10
    15     type TrustedHTML = lib.TrustedHTML;
                ~~~~~~~~~~~
    and here.

node_modules/@types/trusted-types/index.d.ts:14:11 - error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.

14     const TrustedHTML: typeof lib.TrustedHTML;
             ~~~~~~~~~~~

  node_modules/@types/react/global.d.ts:157:11
    157 interface TrustedHTML {}
                  ~~~~~~~~~~~
    'TrustedHTML' was also declared here.

node_modules/@types/trusted-types/index.d.ts:15:10 - error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.

15     type TrustedHTML = lib.TrustedHTML;
            ~~~~~~~~~~~

  node_modules/@types/react/global.d.ts:157:11
    157 interface TrustedHTML {}
                  ~~~~~~~~~~~
    'TrustedHTML' was also declared here.


Found 10 errors in 5 files.

Errors  Files
     1  node_modules/@mui/base/Unstable_Popup/Popup.d.ts:13
     4  node_modules/@mui/x-data-grid/components/cell/GridActionsCellItem.d.ts:25
     2  node_modules/@mui/x-data-grid/components/GridPagination.d.ts:3
     1  node_modules/@types/react/global.d.ts:157
     2  node_modules/@types/trusted-types/index.d.ts:14
```

After: 
```sh
npx tsc --skipLibCheck false         
node_modules/@mui/base/Unstable_Popup/Popup.d.ts:13:70 - error TS2707: Generic type 'ElementType' requires between 0 and 1 type arguments.

13 declare const Popup: React.ForwardRefExoticComponent<Omit<PopupProps<React.ElementType<any, keyof React.JSX.IntrinsicElements>>, "ref"> & React.RefAttributes<Element>>;
                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@types/react/global.d.ts:157:11 - error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.

157 interface TrustedHTML {}
              ~~~~~~~~~~~

  node_modules/@types/trusted-types/index.d.ts:14:11
    14     const TrustedHTML: typeof lib.TrustedHTML;
                 ~~~~~~~~~~~
    'TrustedHTML' was also declared here.
  node_modules/@types/trusted-types/index.d.ts:15:10
    15     type TrustedHTML = lib.TrustedHTML;
                ~~~~~~~~~~~
    and here.

node_modules/@types/trusted-types/index.d.ts:14:11 - error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.

14     const TrustedHTML: typeof lib.TrustedHTML;
             ~~~~~~~~~~~

  node_modules/@types/react/global.d.ts:157:11
    157 interface TrustedHTML {}
                  ~~~~~~~~~~~
    'TrustedHTML' was also declared here.

node_modules/@types/trusted-types/index.d.ts:15:10 - error TS2451: Cannot redeclare block-scoped variable 'TrustedHTML'.

15     type TrustedHTML = lib.TrustedHTML;
            ~~~~~~~~~~~

  node_modules/@types/react/global.d.ts:157:11
    157 interface TrustedHTML {}
                  ~~~~~~~~~~~
    'TrustedHTML' was also declared here.


Found 4 errors in 3 files.

Errors  Files
     1  node_modules/@mui/base/Unstable_Popup/Popup.d.ts:13
     1  node_modules/@types/react/global.d.ts:157
     2  node_modules/@types/trusted-types/index.d.ts:14
```