### PR TITLE
[core] Update supported browsers (browserlistrc)

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -7,34 +7,68 @@ node 14
 
 # Default/Fallback
 
-# `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, not IE 11"` when the last major is released.
-
-# Manually downgrading to ios_saf 12.4 for iPhone 6 and webpack 4 support.
+# `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, safari >= 15.4, ios_saf >= 15.4"` when the last major is released.
 
 # On update, sync references where "#stable-snapshot" is mentioned in the codebase.
 
 [stable]
-and_chr 91
-and_ff 89
-and_qq 10.4
-and_uc 12.12
-android 91
-baidu 7.12
-chrome 90
-edge 91
-firefox 78
-
-# 12.4 but 12.2-12.5 are treated equally in caniuse-lite.
-
-# Though caniuse-lite does not supporting finding an exact version in a range which is why `12.4` would result in "Unknown version 12.4 of ios_saf"
-
-ios_saf 12.2
+and_chr 122
+and_chr 121
+and_ff 123
+and_ff 122
+and_qq 14.9
+and_uc 15.5
+android 122
+android 121
+chrome 122
+chrome 121
+chrome 120
+chrome 119
+chrome 109
+edge 122
+edge 121
+firefox 123
+firefox 122
+firefox 115
+ios_saf 17.4
+ios_saf 17.3
+ios_saf 17.2
+ios_saf 17.1
+ios_saf 17.0
+ios_saf 16.6-16.7
+ios_saf 16.5
+ios_saf 16.4
+ios_saf 16.3
+ios_saf 16.2
+ios_saf 16.1
+ios_saf 16.0
+ios_saf 15.6-15.8
+ios_saf 15.5
+ios_saf 15.4
+kaios 3.0-3.1
 kaios 2.5
 op_mini all
-op_mob 73
-opera 76
-safari 14
-samsung 13.0
+op_mob 80
+opera 108
+opera 107
+opera 106
+safari 17.4
+safari 17.3
+safari 17.2
+safari 17.1
+safari 17.0
+safari 16.6
+safari 16.5
+safari 16.4
+safari 16.3
+safari 16.2
+safari 16.1
+safari 16.0
+safari 15.6
+safari 15.5
+safari 15.4
+samsung 23
+samsung 22
 
 # snapshot of `npx browserslist "maintained node versions"`
 

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -7,7 +7,8 @@ node 14
 
 # Default/Fallback
 
-# `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, safari >= 15.4, ios_saf >= 15.4"` when the last major is released.
+# Explicit safari versions are here based on the agreed terms in: https://github.com/mui/material-ui/issues/40958#issuecomment-1953215043
+# `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, safari >= 15.4, iOS >= 15.4"` when the last major is released.
 
 # On update, sync references where "#stable-snapshot" is mentioned in the codebase.
 

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -8,7 +8,9 @@ node 14
 # Default/Fallback
 
 # Explicit safari versions are here based on the agreed terms in: https://github.com/mui/material-ui/issues/40958#issuecomment-1953215043
-# `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, safari >= 15.4, iOS >= 15.4"` when the last major is released.
+# Run before a major release: `npx browserslist@latest --update-db && npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, safari >= 15.4, iOS >= 15.4"`.
+# Update the versions in the `stable` section with the output result.
+# Reference PR: https://github.com/mui/mui-x/pull/12521.
 
 # On update, sync references where "#stable-snapshot" is mentioned in the codebase.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5074,9 +5074,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001591"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz#16745e50263edc9f395895a7cd468b9f3767cf33"
-  integrity sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==
+  version "1.0.30001599"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz#571cf4f3f1506df9bf41fcbb6d10d5d017817bce"
+  integrity sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==
 
 chai-dom@^1.12.0:
   version "1.12.0"


### PR DESCRIPTION
Follow up on https://github.com/mui/mui-x/pull/12415#discussion_r1520254716.

The [coverage seems](https://browsersl.ist/#q=%3E0.5%25%2C+last+2+versions%2C+Firefox+ESR%2C+not+dead%2C+safari+%3E%3D+15.4%2C+iOS+%3E%3D+15.4) pretty good.

Respective Core PR: https://github.com/mui/material-ui/pull/41568

I omitted the `node` major bump (it could also be a separate PR as it's a bit different topic) until we have a green light from Core and we agree that this makes sense for us, where MUI-X v7 will be released quite a bit sooner than `@mui/material`.
WDYT @mui/x @mui/code-infra?

- Update `caniuse-lite` to benefit from latest data
- Run the command and update entries (including `safari >=15.4`)