### PR TITLE
[DateTimeRangePicker] Fix views behavior regression

### DIFF
--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
@@ -105,7 +105,7 @@ const rendererInterceptor = function rendererInterceptor<
           viewRenderer as PickerViewRenderer<DateRange<TDate>, TimeViewWithMeridiem, any, {}>
         }
         view={view && isInternalTimeView(view) ? view : 'hours'}
-        views={finalProps.views.filter(isInternalTimeView)}
+        views={finalProps.views as TimeViewWithMeridiem[]}
         openTo={isInternalTimeView(openTo) ? openTo : 'hours'}
       />
     );


### PR DESCRIPTION
Fixes a regression where on mobile after selecting start time the view switches to end time instead of end date.

Caused by https://github.com/mui/mui-x/pull/12441/files#diff-3486b9e595ab1f393c7d593c337d48b0dfcde196e3d1f2b0fc641bba34f895abR108

Unblocking the release for now.
Will investigate why the test was not failing locally and reliably and how to make the view switching less fragile.