### PR TITLE
[docs] These API don't exist in MUI X v6

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -5,7 +5,7 @@
     "localeName": "Arabic (Sudan)",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/arSD.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/arSD.ts"
   },
   {
     "languageTag": "be-BY",
@@ -13,7 +13,7 @@
     "localeName": "Belarusian",
     "missingKeysCount": 26,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/beBY.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/beBY.ts"
   },
   {
     "languageTag": "bg-BG",
@@ -21,7 +21,7 @@
     "localeName": "Bulgarian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/bgBG.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/bgBG.ts"
   },
   {
     "languageTag": "zh-HK",
@@ -29,7 +29,7 @@
     "localeName": "Chinese (Hong Kong)",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/zhHK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/zhHK.ts"
   },
   {
     "languageTag": "zh-CN",
@@ -37,7 +37,7 @@
     "localeName": "Chinese (Simplified)",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/zhCN.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/zhCN.ts"
   },
   {
     "languageTag": "zh-TW",
@@ -45,7 +45,7 @@
     "localeName": "Chinese (Taiwan)",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/zhTW.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/zhTW.ts"
   },
   {
     "languageTag": "hr-HR",
@@ -53,7 +53,7 @@
     "localeName": "Croatian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/hrHR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/hrHR.ts"
   },
   {
     "languageTag": "cs-CZ",
@@ -61,7 +61,7 @@
     "localeName": "Czech",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/csCZ.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/csCZ.ts"
   },
   {
     "languageTag": "da-DK",
@@ -69,7 +69,7 @@
     "localeName": "Danish",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/daDK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/daDK.ts"
   },
   {
     "languageTag": "nl-NL",
@@ -77,7 +77,7 @@
     "localeName": "Dutch",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/nlNL.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/nlNL.ts"
   },
   {
     "languageTag": "fi-FI",
@@ -85,7 +85,7 @@
     "localeName": "Finnish",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/fiFI.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/fiFI.ts"
   },
   {
     "languageTag": "fr-FR",
@@ -93,7 +93,7 @@
     "localeName": "French",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/frFR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/frFR.ts"
   },
   {
     "languageTag": "de-DE",
@@ -101,7 +101,7 @@
     "localeName": "German",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/deDE.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/deDE.ts"
   },
   {
     "languageTag": "el-GR",
@@ -109,7 +109,7 @@
     "localeName": "Greek",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/elGR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/elGR.ts"
   },
   {
     "languageTag": "he-IL",
@@ -117,7 +117,7 @@
     "localeName": "Hebrew",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/heIL.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/heIL.ts"
   },
   {
     "languageTag": "hu-HU",
@@ -125,7 +125,7 @@
     "localeName": "Hungarian",
     "missingKeysCount": 2,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/huHU.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/huHU.ts"
   },
   {
     "languageTag": "it-IT",
@@ -133,7 +133,7 @@
     "localeName": "Italian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/itIT.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/itIT.ts"
   },
   {
     "languageTag": "ja-JP",
@@ -141,7 +141,7 @@
     "localeName": "Japanese",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/jaJP.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/jaJP.ts"
   },
   {
     "languageTag": "ko-KR",
@@ -149,7 +149,7 @@
     "localeName": "Korean",
     "missingKeysCount": 27,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/koKR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/koKR.ts"
   },
   {
     "languageTag": "nb-NO",
@@ -157,7 +157,7 @@
     "localeName": "Norwegian (Bokmål)",
     "missingKeysCount": 25,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/nbNO.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/nbNO.ts"
   },
   {
     "languageTag": "fa-IR",
@@ -165,7 +165,7 @@
     "localeName": "Persian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/faIR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/faIR.ts"
   },
   {
     "languageTag": "pl-PL",
@@ -173,7 +173,7 @@
     "localeName": "Polish",
     "missingKeysCount": 27,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/plPL.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/plPL.ts"
   },
   {
     "languageTag": "pt-PT",
@@ -181,7 +181,7 @@
     "localeName": "Portuguese",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ptPT.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/ptPT.ts"
   },
   {
     "languageTag": "pt-BR",
@@ -189,7 +189,7 @@
     "localeName": "Portuguese (Brazil)",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ptBR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/ptBR.ts"
   },
   {
     "languageTag": "ro-RO",
@@ -197,7 +197,7 @@
     "localeName": "Romanian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/roRO.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/roRO.ts"
   },
   {
     "languageTag": "ru-RU",
@@ -205,7 +205,7 @@
     "localeName": "Russian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ruRU.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/ruRU.ts"
   },
   {
     "languageTag": "sk-SK",
@@ -213,7 +213,7 @@
     "localeName": "Slovak",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/skSK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/skSK.ts"
   },
   {
     "languageTag": "es-ES",
@@ -221,7 +221,7 @@
     "localeName": "Spanish",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/esES.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/esES.ts"
   },
   {
     "languageTag": "sv-SE",
@@ -229,7 +229,7 @@
     "localeName": "Swedish",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/svSE.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/svSE.ts"
   },
   {
     "languageTag": "tr-TR",
@@ -237,7 +237,7 @@
     "localeName": "Turkish",
     "missingKeysCount": 15,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/trTR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/trTR.ts"
   },
   {
     "languageTag": "uk-UA",
@@ -245,7 +245,7 @@
     "localeName": "Ukrainian",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/ukUA.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/ukUA.ts"
   },
   {
     "languageTag": "ur-PK",
@@ -253,7 +253,7 @@
     "localeName": "Urdu (Pakistan)",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/urPK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/urPK.ts"
   },
   {
     "languageTag": "vi-VN",
@@ -261,6 +261,6 @@
     "localeName": "Vietnamese",
     "missingKeysCount": 0,
     "totalKeysCount": 119,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/locales/viVN.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/grid/x-data-grid/src/locales/viVN.ts"
   }
 ]

--- a/docs/data/date-pickers/localization/data.json
+++ b/docs/data/date-pickers/localization/data.json
@@ -5,7 +5,7 @@
     "localeName": "Basque",
     "missingKeysCount": 0,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/eu.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/eu.ts"
   },
   {
     "languageTag": "be-BY",
@@ -13,7 +13,7 @@
     "localeName": "Belarusian",
     "missingKeysCount": 2,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/beBY.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/beBY.ts"
   },
   {
     "languageTag": "ca-ES",
@@ -21,7 +21,7 @@
     "localeName": "Catalan",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/caES.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/caES.ts"
   },
   {
     "languageTag": "zh-HK",
@@ -29,7 +29,7 @@
     "localeName": "Chinese (Hong Kong)",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/zhHK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/zhHK.ts"
   },
   {
     "languageTag": "zh-CN",
@@ -37,7 +37,7 @@
     "localeName": "Chinese (Simplified)",
     "missingKeysCount": 0,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/zhCN.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/zhCN.ts"
   },
   {
     "languageTag": "cs-CZ",
@@ -45,7 +45,7 @@
     "localeName": "Czech",
     "missingKeysCount": 2,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/csCZ.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/csCZ.ts"
   },
   {
     "languageTag": "da-DK",
@@ -53,7 +53,7 @@
     "localeName": "Danish",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/daDK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/daDK.ts"
   },
   {
     "languageTag": "nl-NL",
@@ -61,7 +61,7 @@
     "localeName": "Dutch",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/nlNL.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/nlNL.ts"
   },
   {
     "languageTag": "fi-FI",
@@ -69,7 +69,7 @@
     "localeName": "Finnish",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/fiFI.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/fiFI.ts"
   },
   {
     "languageTag": "fr-FR",
@@ -77,7 +77,7 @@
     "localeName": "French",
     "missingKeysCount": 2,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/frFR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/frFR.ts"
   },
   {
     "languageTag": "de-DE",
@@ -85,7 +85,7 @@
     "localeName": "German",
     "missingKeysCount": 0,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/deDE.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/deDE.ts"
   },
   {
     "languageTag": "el-GR",
@@ -93,7 +93,7 @@
     "localeName": "Greek",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/elGR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/elGR.ts"
   },
   {
     "languageTag": "he-IL",
@@ -101,7 +101,7 @@
     "localeName": "Hebrew",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/heIL.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/heIL.ts"
   },
   {
     "languageTag": "hu-HU",
@@ -109,7 +109,7 @@
     "localeName": "Hungarian",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/huHU.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/huHU.ts"
   },
   {
     "languageTag": "is-IS",
@@ -117,7 +117,7 @@
     "localeName": "Icelandic",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/isIS.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/isIS.ts"
   },
   {
     "languageTag": "it-IT",
@@ -125,7 +125,7 @@
     "localeName": "Italian",
     "missingKeysCount": 2,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/itIT.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/itIT.ts"
   },
   {
     "languageTag": "ja-JP",
@@ -133,7 +133,7 @@
     "localeName": "Japanese",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/jaJP.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/jaJP.ts"
   },
   {
     "languageTag": "kz-KZ",
@@ -141,7 +141,7 @@
     "localeName": "Kazakh",
     "missingKeysCount": 2,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/kzKZ.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/kzKZ.ts"
   },
   {
     "languageTag": "ko-KR",
@@ -149,7 +149,7 @@
     "localeName": "Korean",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/koKR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/koKR.ts"
   },
   {
     "languageTag": "mk",
@@ -157,7 +157,7 @@
     "localeName": "Macedonian",
     "missingKeysCount": 0,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/mk.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/mk.ts"
   },
   {
     "languageTag": "nb-NO",
@@ -165,7 +165,7 @@
     "localeName": "Norwegian (Bokmål)",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/nbNO.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/nbNO.ts"
   },
   {
     "languageTag": "fa-IR",
@@ -173,7 +173,7 @@
     "localeName": "Persian",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/faIR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/faIR.ts"
   },
   {
     "languageTag": "pl-PL",
@@ -181,7 +181,7 @@
     "localeName": "Polish",
     "missingKeysCount": 9,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/plPL.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/plPL.ts"
   },
   {
     "languageTag": "pt-BR",
@@ -189,7 +189,7 @@
     "localeName": "Portuguese (Brazil)",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/ptBR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/ptBR.ts"
   },
   {
     "languageTag": "ro-RO",
@@ -197,7 +197,7 @@
     "localeName": "Romanian",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/roRO.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/roRO.ts"
   },
   {
     "languageTag": "ru-RU",
@@ -205,7 +205,7 @@
     "localeName": "Russian",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/ruRU.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/ruRU.ts"
   },
   {
     "languageTag": "sk-SK",
@@ -213,7 +213,7 @@
     "localeName": "Slovak",
     "missingKeysCount": 2,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/skSK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/skSK.ts"
   },
   {
     "languageTag": "es-ES",
@@ -221,7 +221,7 @@
     "localeName": "Spanish",
     "missingKeysCount": 0,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/esES.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/esES.ts"
   },
   {
     "languageTag": "sv-SE",
@@ -229,7 +229,7 @@
     "localeName": "Swedish",
     "missingKeysCount": 9,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/svSE.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/svSE.ts"
   },
   {
     "languageTag": "tr-TR",
@@ -237,7 +237,7 @@
     "localeName": "Turkish",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/trTR.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/trTR.ts"
   },
   {
     "languageTag": "uk-UA",
@@ -245,7 +245,7 @@
     "localeName": "Ukrainian",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/ukUA.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/ukUA.ts"
   },
   {
     "languageTag": "ur-PK",
@@ -253,7 +253,7 @@
     "localeName": "Urdu (Pakistan)",
     "missingKeysCount": 9,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/urPK.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/urPK.ts"
   },
   {
     "languageTag": "vi-VN",
@@ -261,6 +261,6 @@
     "localeName": "Vietnamese",
     "missingKeysCount": 1,
     "totalKeysCount": 37,
-    "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/viVN.ts"
+    "githubLink": "https://github.com/mui/mui-x/blob/v6.x/packages/x-date-pickers/src/locales/viVN.ts"
   }
 ]

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -25,7 +25,7 @@ module.exports = withDocsInfra({
     FEEDBACK_URL: process.env.FEEDBACK_URL,
     CONTEXT: process.env.CONTEXT,
     // #default-branch-switch
-    SOURCE_GITHUB_BRANCH: 'master',
+    SOURCE_GITHUB_BRANCH: 'v6.x',
     SOURCE_CODE_REPO: 'https://github.com/mui/mui-x',
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '6.docs-feedback.yml',
   },


### PR DESCRIPTION
Links to github translation are wrong, because the grid flatten it's folder path from `/grid/x-data-grid` to `/x-data-grid`

But I assume other links will probably break if we don't update the nextjs config