### PR TITLE
[core] Fix `l10n` script on Windows

### DIFF
--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -442,7 +442,11 @@ async function run(argv: yargs.ArgumentsCamelCase<HandlerArgv>) {
           }
           if (!missingTranslations[localeCode][packageInfo.key]) {
             missingTranslations[localeCode][packageInfo.key] = {
-              path: localePath.replace(workspaceRoot, '').slice(1), // Remove leading slash
+              path: localePath
+                .replace(workspaceRoot, '')
+                .slice(1) // Remove leading slash
+                .split(path.sep)
+                .join('/'), // Ensure the path is using forward slashes even on Windows machines
               missingKeys: [],
             };
           }

--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -442,11 +442,10 @@ async function run(argv: yargs.ArgumentsCamelCase<HandlerArgv>) {
           }
           if (!missingTranslations[localeCode][packageInfo.key]) {
             missingTranslations[localeCode][packageInfo.key] = {
+              // prettier-ignore
               path: localePath
-                .replace(workspaceRoot, '')
-                .slice(1) // Remove leading slash
-                .split(path.sep)
-                .join('/'), // Ensure the path is using forward slashes even on Windows machines
+                .replace(workspaceRoot, '').slice(1) // Remove leading slash
+                .split(path.sep).join('/'), // Ensure the path is using forward slashes even on Windows machines
               missingKeys: [],
             };
           }


### PR DESCRIPTION
Avoids incorrect path building on Windows.
Example: https://github.com/mui/mui-x/pull/12547/commits/da87e358d0c37462c1e53ca7659deff15b6e9aba

P.S. Tested on a local Windows machine.