### PR TITLE
[fields] Fix `autoComplete` attribute propagation

### DIFF
--- a/docs/pages/x/api/date-pickers/date-field.json
+++ b/docs/pages/x/api/date-pickers/date-field.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "areAllSectionsEmpty": { "type": { "name": "bool" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "clearable": { "type": { "name": "bool" }, "default": "false" },
     "clearButtonPosition": {

--- a/docs/pages/x/api/date-pickers/date-time-field.json
+++ b/docs/pages/x/api/date-pickers/date-time-field.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "adapter.is12HourCycleInCurrentLocale()" },
     "areAllSectionsEmpty": { "type": { "name": "bool" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "clearable": { "type": { "name": "bool" }, "default": "false" },
     "clearButtonPosition": {

--- a/docs/pages/x/api/date-pickers/pickers-text-field.json
+++ b/docs/pages/x/api/date-pickers/pickers-text-field.json
@@ -9,6 +9,7 @@
       },
       "required": true
     },
+    "autoComplete": { "type": { "name": "string" } },
     "color": {
       "type": {
         "name": "enum",

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "areAllSectionsEmpty": { "type": { "name": "bool" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "clearable": { "type": { "name": "bool" }, "default": "false" },
     "clearButtonPosition": {

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "adapter.is12HourCycleInCurrentLocale()" },
     "areAllSectionsEmpty": { "type": { "name": "bool" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "clearable": { "type": { "name": "bool" }, "default": "false" },
     "clearButtonPosition": {

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "adapter.is12HourCycleInCurrentLocale()" },
     "areAllSectionsEmpty": { "type": { "name": "bool" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "clearable": { "type": { "name": "bool" }, "default": "false" },
     "clearButtonPosition": {

--- a/docs/pages/x/api/date-pickers/time-field.json
+++ b/docs/pages/x/api/date-pickers/time-field.json
@@ -2,6 +2,7 @@
   "props": {
     "ampm": { "type": { "name": "bool" }, "default": "adapter.is12HourCycleInCurrentLocale()" },
     "areAllSectionsEmpty": { "type": { "name": "bool" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "clearable": { "type": { "name": "bool" }, "default": "false" },
     "clearButtonPosition": {

--- a/docs/translations/api-docs/date-pickers/date-field/date-field.json
+++ b/docs/translations/api-docs/date-pickers/date-field/date-field.json
@@ -4,6 +4,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
     },

--- a/docs/translations/api-docs/date-pickers/date-time-field/date-time-field.json
+++ b/docs/translations/api-docs/date-pickers/date-time-field/date-time-field.json
@@ -5,6 +5,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
     },

--- a/docs/translations/api-docs/date-pickers/pickers-text-field/pickers-text-field.json
+++ b/docs/translations/api-docs/date-pickers/pickers-text-field/pickers-text-field.json
@@ -4,6 +4,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "color": {
       "description": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#custom-colors\">palette customization guide</a>."
     },

--- a/docs/translations/api-docs/date-pickers/single-input-date-range-field/single-input-date-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-range-field/single-input-date-range-field.json
@@ -4,6 +4,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
     },

--- a/docs/translations/api-docs/date-pickers/single-input-date-time-range-field/single-input-date-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-date-time-range-field/single-input-date-time-range-field.json
@@ -5,6 +5,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
     },

--- a/docs/translations/api-docs/date-pickers/single-input-time-range-field/single-input-time-range-field.json
+++ b/docs/translations/api-docs/date-pickers/single-input-time-range-field/single-input-time-range-field.json
@@ -5,6 +5,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
     },

--- a/docs/translations/api-docs/date-pickers/time-field/time-field.json
+++ b/docs/translations/api-docs/date-pickers/time-field/time-field.json
@@ -5,6 +5,9 @@
     "areAllSectionsEmpty": {
       "description": "Is <code>true</code> if the current values equals the empty value. For a single item value, it means that <code>value === null</code> For a range value, it means that <code>value === [null, null]</code>"
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
     },

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -67,6 +67,12 @@ SingleInputDateRangeField.propTypes /* remove-proptypes */ = {
    */
   areAllSectionsEmpty: PropTypes.bool,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
    */

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -72,6 +72,12 @@ SingleInputDateTimeRangeField.propTypes /* remove-proptypes */ = {
    */
   areAllSectionsEmpty: PropTypes.bool,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
    */

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
@@ -72,6 +72,12 @@ SingleInputTimeRangeField.propTypes /* remove-proptypes */ = {
    */
   areAllSectionsEmpty: PropTypes.bool,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
    */

--- a/packages/x-date-pickers/src/DateField/DateField.tsx
+++ b/packages/x-date-pickers/src/DateField/DateField.tsx
@@ -64,6 +64,12 @@ DateField.propTypes /* remove-proptypes */ = {
    */
   areAllSectionsEmpty: PropTypes.bool,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
    */

--- a/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
@@ -24,6 +24,14 @@ describe('<DateField />', () => {
       expect(screen.getByRole('group', { description: 'field-helper' })).not.to.equal(null);
     });
 
+    it('should forward `slotProps.textField.autoComplete` to the hidden <input>', () => {
+      render(<DateField slotProps={{ textField: { autoComplete: 'bday' } }} />);
+
+      expect(screen.getByRole('textbox', { hidden: true }))
+        .attribute('autocomplete')
+        .to.equal('bday');
+    });
+
     it('should respect the `slotProps.textField.slotProps.htmlInput`', () => {
       render(
         <DateField

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
@@ -69,6 +69,12 @@ DateTimeField.propTypes /* remove-proptypes */ = {
    */
   areAllSectionsEmpty: PropTypes.bool,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
    */

--- a/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
@@ -275,6 +275,12 @@ PickersFilledInput.propTypes /* remove-proptypes */ = {
    * For a range value, it means that `value === [null, null]`
    */
   areAllSectionsEmpty: PropTypes.bool.isRequired,
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
   classes: PropTypes.object,
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
@@ -192,6 +192,12 @@ PickersInput.propTypes /* remove-proptypes */ = {
    * For a range value, it means that `value === [null, null]`
    */
   areAllSectionsEmpty: PropTypes.bool.isRequired,
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
   classes: PropTypes.object,
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -340,6 +340,7 @@ const PickersInputBase = React.forwardRef(function PickersInputBase(
     onKeyDown,
     fullWidth,
     name,
+    autoComplete,
     readOnly,
     inputRef,
     sectionListRef,
@@ -499,6 +500,7 @@ const PickersInputBase = React.forwardRef(function PickersInputBase(
         : null}
       <HtmlInputComponent
         name={name}
+        autoComplete={autoComplete}
         className={classes.input}
         value={value}
         onChange={onChange}
@@ -536,6 +538,12 @@ PickersInputBase.propTypes /* remove-proptypes */ = {
    * For a range value, it means that `value === [null, null]`
    */
   areAllSectionsEmpty: PropTypes.bool.isRequired,
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
   classes: PropTypes.object,
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
@@ -51,6 +51,12 @@ export interface PickersInputPropsUsedByField extends Pick<
    * Name attribute of the `input` element.
    */
   name?: string;
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete?: string;
 
   /**
    * Pass a ref to the `input` element.

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
@@ -176,6 +176,12 @@ PickersOutlinedInput.propTypes /* remove-proptypes */ = {
    * For a range value, it means that `value === [null, null]`
    */
   areAllSectionsEmpty: PropTypes.bool.isRequired,
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
   classes: PropTypes.object,
   className: PropTypes.string,
   /**

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.test.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.test.tsx
@@ -30,6 +30,24 @@ describe('<PickersTextField /> - slot forwarding', () => {
     expect(screen.getByTestId('html-input')).not.to.equal(null);
   });
 
+  it('should forward the `autoComplete` prop to the underlying <input>', () => {
+    render(<PickersTextField {...STUB_PROPS} autoComplete="bday" />);
+
+    expect(document.querySelector('input')).to.have.attribute('autocomplete', 'bday');
+  });
+
+  it('should let `slotProps.htmlInput.autoComplete` override the `autoComplete` prop', () => {
+    render(
+      <PickersTextField
+        {...STUB_PROPS}
+        autoComplete="bday"
+        slotProps={{ htmlInput: { autoComplete: 'off' } as any }}
+      />,
+    );
+
+    expect(document.querySelector('input')).to.have.attribute('autocomplete', 'off');
+  });
+
   it('should merge `slotProps.input.slotProps.sectionContent` onto each section content element', () => {
     render(
       <PickersTextField

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
@@ -119,6 +119,7 @@ const PickersTextField = React.forwardRef(function PickersTextField(
     fullWidth,
     id: idProp,
     name,
+    autoComplete,
     // Props used by FormHelperText
     helperText,
     // Props used by InputLabel
@@ -242,6 +243,7 @@ const PickersTextField = React.forwardRef(function PickersTextField(
           sectionListRef={sectionListRef}
           label={label}
           name={name}
+          autoComplete={autoComplete}
           role="group"
           aria-labelledby={inputLabelId}
           aria-describedby={helperTextId}
@@ -279,6 +281,12 @@ PickersTextField.propTypes /* remove-proptypes */ = {
    * For a range value, it means that `value === [null, null]`
    */
   areAllSectionsEmpty: PropTypes.bool.isRequired,
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
   className: PropTypes.string,
   /**
    * The color of the component.

--- a/packages/x-date-pickers/src/TimeField/TimeField.tsx
+++ b/packages/x-date-pickers/src/TimeField/TimeField.tsx
@@ -69,6 +69,12 @@ TimeField.propTypes /* remove-proptypes */ = {
    */
   areAllSectionsEmpty: PropTypes.bool,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the `input` element is focused during the first mount.
    * @default false
    */


### PR DESCRIPTION
Part of #12218

Propagate a user-supplied `slotProps.textField.autoComplete` down to the field's underlying hidden `<input>`, matching how `@mui/material` `TextField` threads `autoComplete` through `InputBase` to the input. Previously the prop was dropped onto the field root `<div>` (via `...other`) and never reached the input.

## What changed

- Declared `autoComplete` once on `PickersInputPropsUsedByField`, so it flows to the field components (`DateField`, `TimeField`, ...), `PickersTextField` and `PickersInputBase`.
- `PickersTextField` forwards it to the input component; `PickersInputBase` sets it on the hidden `<input>`, placed before `slotProps.htmlInput` so the existing escape hatch still overrides it.
- Added regression tests at the `PickersTextField` and `DateField` levels.

## Note on autofill

This restores prop propagation (parity with `TextField`), but does not on its own guarantee browser/OS autofill of date values. The editable surface is now contentEditable section spans, and the only real `<input>` is `aria-hidden` / `tabIndex={-1}` (used for form submission), so whether autofill targets this DOM still needs separate verification. The old v6/v7 hardcoded `autoComplete: 'off'` no longer exists (it was removed together with the legacy DOM structure), so there is nothing left to override - the prop simply needs to flow through.
