### PR TITLE
[charts] Fix `ticInterval` usage for y-axis

### DIFF
--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -68,6 +68,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
     slotProps,
     tickPlacement,
     tickLabelPlacement,
+    tickInterval,
   } = defaultizedProps;
 
   const theme = useTheme();
@@ -83,6 +84,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
     valueFormatter,
     tickPlacement,
     tickLabelPlacement,
+    tickInterval,
   });
 
   const positionSign = position === 'right' ? 1 : -1;


### PR DESCRIPTION
Discovered when doing demos for #12490 that the y axis was not reacting when providing the `ticInterval`