### PR TITLE
[core] Remove explicit `express` package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -57,7 +57,6 @@
     "dayjs": "^1.11.10",
     "doctrine": "^3.0.0",
     "exceljs": "^4.4.0",
-    "express": "^4.18.3",
     "fg-loadcss": "^3.1.0",
     "fs-extra": "^11.2.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7280,7 +7280,7 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
-express@^4.16.4, express@^4.18.3:
+express@^4.16.4:
   version "4.18.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.3.tgz#6870746f3ff904dee1819b82e4b51509afffb0d4"
   integrity sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==


### PR DESCRIPTION
Checked https://github.com/mui/mui-x/pull/12598 and noticed that this package is not used anywhere explicitly.
I think that we can keep it as a transitive dependency of `@slack/bolt` unless I'm missing something.