### PR TITLE
[DateTimeRangePicker] Fix selection on same day

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
@@ -1,13 +1,44 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen } from '@mui-internal/test-utils';
-import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
+import { screen, userEvent } from '@mui-internal/test-utils';
+import {
+  createPickerRenderer,
+  adapterToUse,
+  openPicker,
+  getFieldSectionsContainer,
+  expectFieldValueV7,
+} from 'test/utils/pickers';
 import { DesktopDateTimeRangePicker } from '../DesktopDateTimeRangePicker';
 
 describe('<DesktopDateTimeRangePicker />', () => {
   const { render } = createPickerRenderer({
     clock: 'fake',
     clockConfig: new Date(2018, 0, 10, 10, 16, 0),
+  });
+
+  describe('value selection', () => {
+    it('should allow to select range within the same day', () => {
+      render(<DesktopDateTimeRangePicker enableAccessibleFieldDOMStructure />);
+
+      openPicker({ type: 'date-time-range', variant: 'desktop', initialFocus: 'start' });
+
+      // select start date range
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '11' }));
+      userEvent.mousePress(screen.getByRole('option', { name: '4 hours' }));
+      userEvent.mousePress(screen.getByRole('option', { name: '5 minutes' }));
+      userEvent.mousePress(screen.getByRole('option', { name: 'PM' }));
+
+      // select end date range on the same day
+      userEvent.mousePress(screen.getByRole('gridcell', { name: '11' }));
+      userEvent.mousePress(screen.getByRole('option', { name: '5 hours' }));
+      userEvent.mousePress(screen.getByRole('option', { name: '10 minutes' }));
+      userEvent.mousePress(screen.getByRole('option', { name: 'PM' }));
+
+      const startSectionsContainer = getFieldSectionsContainer(0);
+      const endSectionsContainer = getFieldSectionsContainer(1);
+      expect(expectFieldValueV7(startSectionsContainer, '01/11/2018 04:05 PM'));
+      expect(expectFieldValueV7(endSectionsContainer, '01/11/2018 05:10 PM'));
+    });
   });
 
   describe('disabled dates', () => {

--- a/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.test.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.test.ts
@@ -4,6 +4,7 @@ import { calculateRangeChange, calculateRangePreview } from './date-range-manage
 import { DateRange } from '../../models';
 
 const start2018 = adapterToUse.date('2018-01-01');
+const start2018At4PM = adapterToUse.date('2018-01-01T16:00:00');
 const mid2018 = adapterToUse.date('2018-07-01');
 const end2019 = adapterToUse.date('2019-01-01');
 
@@ -87,6 +88,14 @@ describe('date-range-manager', () => {
       expectedRange: [start2018, mid2018],
       allowRangeFlip: true,
       expectedNextSelection: 'end' as const,
+    },
+    {
+      range: [start2018At4PM, null],
+      rangePosition: 'end' as const,
+      newDate: start2018,
+      expectedRange: [start2018At4PM, start2018],
+      allowRangeFlip: false,
+      expectedNextSelection: 'start' as const,
     },
   ].forEach(
     ({ range, rangePosition, newDate, expectedRange, allowRangeFlip, expectedNextSelection }) => {

--- a/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
@@ -53,7 +53,7 @@ export function calculateRangeChange<TDate extends PickerValidDate>({
   const truthyResult: CalculateRangeChangeResponse<TDate> = allowRangeFlip
     ? { nextSelection: 'end', newRange: [selectedDate, start!] }
     : { nextSelection: 'end', newRange: [selectedDate, null] };
-  return Boolean(start) && utils.isBefore(selectedDate!, start!)
+  return Boolean(start) && utils.isBeforeDay(selectedDate!, start!)
     ? truthyResult
     : { nextSelection: 'start', newRange: [start, selectedDate] };
 }


### PR DESCRIPTION
Fixes #12586

The problem was that we were using `isBefore` to compare the dates when calculating the new range.
This works for `DateRangePicker`, but in the case of `DateTimeRangePicker` its a problem, because it includes time in comparison.
Changed the comparison function to `isBeforeDay` instead.