### PR TITLE
[core] Bump monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
-    "@mui/monorepo": "https://github.com/mui/material-ui.git#master",
+    "@mui/monorepo": "https://github.com/mui/material-ui.git#next",
     "@mui/utils": "^5.15.14",
     "@next/eslint-plugin-next": "14.0.4",
     "@octokit/plugin-retry": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,9 +2016,9 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
-"@mui/monorepo@https://github.com/mui/material-ui.git#master":
-  version "5.15.14"
-  resolved "https://github.com/mui/material-ui.git#39fe215ce8bb1ed215e9a274f63b979714876e61"
+"@mui/monorepo@https://github.com/mui/material-ui.git#next":
+  version "6.0.0-alpha.0"
+  resolved "https://github.com/mui/material-ui.git#e1d94d5ce097815bcd738352e69bb43ce03bd266"
   dependencies:
     "@googleapis/sheets" "^5.0.5"
     "@netlify/functions" "^2.6.0"


### PR DESCRIPTION
Tried installing the project after clearing the `yarn cache` and got an error regarding the `monorepo` hash version (because the default branch changed).
Looked into bumping the monorepo, but I thought that we should also switch to the `next` branch, shouldn't we? 🤔 
It's going to be the branch that will receive all the new changes regarding docs-infra and other stuff, isn't it? 🤔 