### PR TITLE
[docs] Fix type arguments in Custom Field page

### DIFF
--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -173,20 +173,22 @@ On the examples below, you can see that the typing of the props received by a cu
 
 ```tsx
 interface JoyDateFieldProps
-  extends UseDateFieldProps<Dayjs>, // The headless field props
+  extends UseDateFieldProps<Dayjs, false>, // The headless field props
     BaseSingleInputFieldProps<
       Dayjs | null,
       Dayjs,
       FieldSection,
+      false, // `true` for `enableAccessibleFieldDOMStructure`
       DateValidationError
     > {} // The DOM field props
 
 interface JoyDateTimeFieldProps
-  extends UseDateTimeFieldProps<Dayjs>, // The headless field props
+  extends UseDateTimeFieldProps<Dayjs, false>, // The headless field props
     BaseSingleInputFieldProps<
       Dayjs | null,
       Dayjs,
       FieldSection,
+      false, // `true` for `enableAccessibleFieldDOMStructure`
       DateTimeValidationError
     > {} // The DOM field props
 ```


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

In v7, the `UseDateFieldProps` and `BaseSingleInputFieldProps` require an additional `TEnableAccessibleFieldDOMStructure extends boolean` type argument.

https://github.com/mui/mui-x/blob/ef40e06213d4721c51d498328f4fadf8e545b3e7/packages/x-date-pickers/src/DateField/DateField.types.ts#L24-L27

https://github.com/mui/mui-x/blob/ef40e06213d4721c51d498328f4fadf8e545b3e7/packages/x-date-pickers/src/models/fields.ts#L168-L174

The latest ["Custom field" documentation page](https://mui.com/x/react-date-pickers/custom-field/#how-to-build-a-custom-field) is still using the old v6 version.  TypeScript reports the following errors:

```
TS2314: Generic type 'UseDateFieldProps<TDate, TEnableAccessibleFieldDOMStructure>' requires 2 type argument(s).
TS2314: Generic type BaseSingleInputFieldProps requires 5 type argument(s).
```

![image](https://github.com/mui/mui-x/assets/20135478/7b95fdbc-53a8-4748-8974-6309189e0870)
