### PR TITLE
[infra] Polish support survey experience

### DIFF
--- a/.github/workflows/closed-issue-message.yaml
+++ b/.github/workflows/closed-issue-message.yaml
@@ -14,13 +14,11 @@ jobs:
       GH_REPO: ${{ github.repository }}
       NUMBER: ${{ github.event.issue.number }}
       BODY: |
-        :warning: **This issue has been closed.**
-        If you have a similar problem, please open a [new issue](https://github.com/mui/mui-x/issues/new/choose) and provide details about your specific problem.
-        If you can provide additional information related to this topic that could help future readers, please feel free to leave a comment.
+        :warning: **This issue has been closed.** If you have a similar problem but not exactly the same, please open a [new issue](https://github.com/mui/mui-x/issues/new/choose).
+        Now, if you have additional information related to this issue or things that could help future readers, feel free to leave a comment.
       APPENDIX: |
 
-        **How did we do @${{ github.event.issue.user.login }}?**
-        Your experience with our support team matters to us. If you have a moment, please share your thoughts through our [brief survey](https://tally.so/r/w4r5Mk?issue=${{ github.event.issue.number }}).
+        @${{ github.event.issue.user.login }}: How did we do? Your experience with our support team matters to us. If you have a moment, please share your thoughts in this short [Support Satisfaction survey](https://tally.so/r/w4r5Mk?issue=${{ github.event.issue.number }}&productId=x).
 
     if: github.event.issue.state_reason != 'inactivity'
     runs-on: ubuntu-latest


### PR DESCRIPTION
I did a quick dive into the comment experience with this PR:

1. Output tested in https://github.com/mui/mui-x/issues/12594#issuecomment-2025413729. This feels easier to parse and understand.

2. Also made it so that we can use https://tally.so/forms/w4r5Mk/edit with other products.

<img width="679" alt="SCR-20240331-rgam" src="https://github.com/mui/mui-x/assets/3165635/6cfce22b-2f85-4ef7-b611-d0f5d4e9d9ed">

3. And did a quick-win when the rating left is equal to 5:

<img width="841" alt="SCR-20240331-rgch" src="https://github.com/mui/mui-x/assets/3165635/859089e4-10ae-458c-9f96-711c9af4b8db">

https://tally.so/forms/w4r5Mk. This executes https://www.notion.so/mui-org/mui-x-Gather-reviews-on-a-third-party-website-8be4fc85bcb34974a7d62cd74750e383?pvs=4#65c912f218a041c8958e7f84947ac8c2.

4. I have also documented the thing in https://www.notion.so/mui-org/Technical-Support-80c9c7e0af614af68c1abb7120f634c8?pvs=4#d0e2a3e120fe415b869506fa3ed88748. 

---

Going forward, I think that it would be great to invest in metrics. I have added these ideas to https://www.notion.so/mui-org/support-Create-CSAT-on-GitHub-issues-001c3ed8da9340f0a04bb3c5075e6086?pvs=4#445e2fba505749e097c404464d940400. I'm not sure how to implement this. We could either use Google Sheet's integration, https://drive.google.com/drive/u/0/folders/1pxUWDoTCBA06Igl0p030w5GaMWwObuln, or use Notion's integration. Toolpad has native integration with Google Sheets so maybe it's simpler cc @prakhargupta1, no idea 🤷‍♂️. The problem is that Tally doesn't expose the data directly: https://tally.so/feedback/p/developer-api.