### PR TITLE
[docs] Adds a recipe for the `checkboxSelectionVisibleOnly` prop

### DIFF
--- a/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.js
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.js
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+import { useDemoData } from '@mui/x-data-grid-generator';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
+import Box from '@mui/material/Box';
+
+export default function CheckboxSelectionVisibleOnlyGrid() {
+  const [checkboxSelectionVisibleOnly, setCheckboxSelectionVisibleOnly] =
+    React.useState(false);
+
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 300,
+    maxColumns: 5,
+  });
+
+  return (
+    <div style={{ width: '100%' }}>
+      <Box sx={{ mb: 1 }}>
+        <FormControlLabel
+          label="disableMultipleRowSelection"
+          control={
+            <Switch
+              checked={checkboxSelectionVisibleOnly}
+              onChange={(event) =>
+                setCheckboxSelectionVisibleOnly(event.target.checked)
+              }
+            />
+          }
+        />
+      </Box>
+      <div style={{ height: 400 }}>
+        <DataGridPro
+          {...data}
+          checkboxSelectionVisibleOnly={checkboxSelectionVisibleOnly}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.js
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.js
@@ -19,7 +19,7 @@ export default function CheckboxSelectionVisibleOnlyGrid() {
     <div style={{ width: '100%' }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
-          label="disableMultipleRowSelection"
+          label="checkboxSelectionVisibleOnly"
           control={
             <Switch
               checked={checkboxSelectionVisibleOnly}
@@ -33,6 +33,13 @@ export default function CheckboxSelectionVisibleOnlyGrid() {
       <div style={{ height: 400 }}>
         <DataGridPro
           {...data}
+          initialState={{
+            ...data.initialState,
+            pagination: { paginationModel: { pageSize: 50 } },
+          }}
+          pageSizeOptions={[5, 10, 25, 50, 100]}
+          pagination
+          checkboxSelection
           checkboxSelectionVisibleOnly={checkboxSelectionVisibleOnly}
         />
       </div>

--- a/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.tsx
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.tsx
@@ -33,6 +33,12 @@ export default function CheckboxSelectionVisibleOnlyGrid() {
       <div style={{ height: 400 }}>
         <DataGridPro
           {...data}
+          initialState={{
+            ...data.initialState,
+            pagination: { paginationModel: { pageSize: 50 } },
+          }}
+          pageSizeOptions={[5, 10, 25, 50, 100]}
+          pagination
           checkboxSelection
           checkboxSelectionVisibleOnly={checkboxSelectionVisibleOnly}
         />

--- a/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.tsx
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+import { useDemoData } from '@mui/x-data-grid-generator';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
+import Box from '@mui/material/Box';
+
+export default function CheckboxSelectionVisibleOnlyGrid() {
+  const [checkboxSelectionVisibleOnly, setCheckboxSelectionVisibleOnly] =
+    React.useState(false);
+
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 300,
+    maxColumns: 5,
+  });
+
+  return (
+    <div style={{ width: '100%' }}>
+      <Box sx={{ mb: 1 }}>
+        <FormControlLabel
+          label="disableMultipleRowSelection"
+          control={
+            <Switch
+              checked={checkboxSelectionVisibleOnly}
+              onChange={(event) =>
+                setCheckboxSelectionVisibleOnly(event.target.checked)
+              }
+            />
+          }
+        />
+      </Box>
+      <div style={{ height: 400 }}>
+        <DataGridPro
+          {...data}
+          checkboxSelectionVisibleOnly={checkboxSelectionVisibleOnly}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.tsx
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionVisibleOnlyGrid.tsx
@@ -19,7 +19,7 @@ export default function CheckboxSelectionVisibleOnlyGrid() {
     <div style={{ width: '100%' }}>
       <Box sx={{ mb: 1 }}>
         <FormControlLabel
-          label="disableMultipleRowSelection"
+          label="checkboxSelectionVisibleOnly"
           control={
             <Switch
               checked={checkboxSelectionVisibleOnly}
@@ -33,6 +33,7 @@ export default function CheckboxSelectionVisibleOnlyGrid() {
       <div style={{ height: 400 }}>
         <DataGridPro
           {...data}
+          checkboxSelection
           checkboxSelectionVisibleOnly={checkboxSelectionVisibleOnly}
         />
       </div>

--- a/docs/data/data-grid/row-selection/row-selection.md
+++ b/docs/data/data-grid/row-selection/row-selection.md
@@ -49,13 +49,6 @@ To activate checkbox selection set `checkboxSelection={true}`.
 
 {{"demo": "CheckboxSelectionGrid.js", "bg": "inline"}}
 
-### Select only visible rows [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
-
-By default, when you click the "Select All" checkbox, all rows in the data grid are selected.
-If you want to change this behavior and only select the rows that are currently visible on the page, you can use the `checkboxSelectionVisibleOnly` prop.
-
-{{"demo": "CheckboxSelectionVisibleOnlyGrid.js", "bg": "inline"}}
-
 ### Custom checkbox column
 
 If you provide a custom checkbox column to the data grid with the `GRID_CHECKBOX_SELECTION_FIELD` field, the data grid will not add its own.
@@ -70,6 +63,13 @@ In the following demo, the checkbox column has been moved to the right and its w
 Always set the `checkboxSelection` prop to `true` even when providing a custom checkbox column.
 Otherwise, the data grid might remove your column.
 :::
+
+### Visible rows selection [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+
+By default, when you click the "Select All" checkbox, all rows in the data grid are selected.
+If you want to change this behavior and only select the rows that are currently visible on the page, you can use the `checkboxSelectionVisibleOnly` prop.
+
+{{"demo": "CheckboxSelectionVisibleOnlyGrid.js", "bg": "inline"}}
 
 ## Usage with server-side pagination
 

--- a/docs/data/data-grid/row-selection/row-selection.md
+++ b/docs/data/data-grid/row-selection/row-selection.md
@@ -49,6 +49,13 @@ To activate checkbox selection set `checkboxSelection={true}`.
 
 {{"demo": "CheckboxSelectionGrid.js", "bg": "inline"}}
 
+### Select only visible rows [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+
+By default, when you click the "Select All" checkbox, all rows in the data grid are selected.
+If you want to change this behavior and only select the rows that are currently visible on the page, you can use the `checkboxSelectionVisibleOnly` prop.
+
+{{"demo": "CheckboxSelectionVisibleOnlyGrid.js", "bg": "inline"}}
+
 ### Custom checkbox column
 
 If you provide a custom checkbox column to the data grid with the `GRID_CHECKBOX_SELECTION_FIELD` field, the data grid will not add its own.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
---

This adds a new demo to the selection page in the docs to show the behaviour of the `checkboxSelectionVisibleOnly` prop.

This came up in #12625 