### PR TITLE
[core] Use `describeTreeView` for selection tests

### DIFF
--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.test.tsx
@@ -22,20 +22,6 @@ describe('<SimpleTreeView />', () => {
   }));
 
   describe('warnings', () => {
-    it('should warn when switching from controlled to uncontrolled of the selectedItems prop', () => {
-      const { setProps } = render(
-        <SimpleTreeView selectedItems={null}>
-          <TreeItem itemId="1" label="one" />
-        </SimpleTreeView>,
-      );
-
-      expect(() => {
-        setProps({ selectedItems: undefined });
-      }).toErrorDev(
-        'MUI X: A component is changing the controlled selectedItems state of TreeView to be uncontrolled.',
-      );
-    });
-
     it('should not crash when shift clicking a clean tree', () => {
       render(
         <SimpleTreeView multiSelect>
@@ -143,70 +129,6 @@ describe('<SimpleTreeView />', () => {
     fireEvent.keyDown(getByTestId('one'), { key: 'Enter' });
 
     expect(getByTestId('one')).to.have.attribute('aria-selected');
-  });
-
-  it('should be able to be controlled with the selectedItems prop and singleSelect', () => {
-    function MyComponent() {
-      const [selectedState, setSelectedState] = React.useState(null);
-      const onSelectedItemsChange = (event, items) => {
-        setSelectedState(items);
-      };
-      return (
-        <SimpleTreeView selectedItems={selectedState} onSelectedItemsChange={onSelectedItemsChange}>
-          <TreeItem itemId="1" label="one" data-testid="one" />
-          <TreeItem itemId="2" label="two" data-testid="two" />
-        </SimpleTreeView>
-      );
-    }
-
-    const { getByTestId, getByText } = render(<MyComponent />);
-
-    expect(getByTestId('one')).not.to.have.attribute('aria-selected');
-    expect(getByTestId('two')).not.to.have.attribute('aria-selected');
-
-    fireEvent.click(getByText('one'));
-
-    expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-    expect(getByTestId('two')).not.to.have.attribute('aria-selected');
-
-    fireEvent.click(getByText('two'));
-
-    expect(getByTestId('one')).not.to.have.attribute('aria-selected');
-    expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-  });
-
-  it('should be able to be controlled with the selectedItems prop and multiSelect', () => {
-    function MyComponent() {
-      const [selectedState, setSelectedState] = React.useState([]);
-      const onSelectedItemsChange = (event, items) => {
-        setSelectedState(items);
-      };
-      return (
-        <SimpleTreeView
-          selectedItems={selectedState}
-          onSelectedItemsChange={onSelectedItemsChange}
-          multiSelect
-        >
-          <TreeItem itemId="1" label="one" data-testid="one" />
-          <TreeItem itemId="2" label="two" data-testid="two" />
-        </SimpleTreeView>
-      );
-    }
-
-    const { getByTestId, getByText } = render(<MyComponent />);
-
-    expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-    expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-
-    fireEvent.click(getByText('one'));
-
-    expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-    expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-
-    fireEvent.click(getByText('two'), { ctrlKey: true });
-
-    expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-    expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
   });
 
   it('should not error when component state changes', () => {
@@ -437,18 +359,6 @@ describe('<SimpleTreeView />', () => {
       const { getByRole } = render(<SimpleTreeView />);
 
       expect(getByRole('tree')).not.to.equal(null);
-    });
-
-    it('(TreeView) should have the attribute `aria-multiselectable=false if using single select`', () => {
-      const { getByRole } = render(<SimpleTreeView />);
-
-      expect(getByRole('tree')).to.have.attribute('aria-multiselectable', 'false');
-    });
-
-    it('(TreeView) should have the attribute `aria-multiselectable=true if using multi select`', () => {
-      const { getByRole } = render(<SimpleTreeView multiSelect />);
-
-      expect(getByRole('tree')).to.have.attribute('aria-multiselectable', 'true');
     });
   });
 });

--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -288,30 +288,6 @@ describe('<TreeItem />', () => {
       expect(getByRole('group')).to.contain(getByText('test2'));
     });
 
-    describe('aria-expanded', () => {
-      it('should have the attribute `aria-expanded=false` if collapsed', () => {
-        const { getByTestId } = render(
-          <SimpleTreeView>
-            <TreeItem itemId="test" label="test" data-testid="test">
-              <TreeItem itemId="test2" label="test2" />
-            </TreeItem>
-          </SimpleTreeView>,
-        );
-
-        expect(getByTestId('test')).to.have.attribute('aria-expanded', 'false');
-      });
-
-      it('should not have the attribute `aria-expanded` if no children are present', () => {
-        const { getByTestId } = render(
-          <SimpleTreeView>
-            <TreeItem itemId="test" label="test" data-testid="test" />
-          </SimpleTreeView>,
-        );
-
-        expect(getByTestId('test')).not.to.have.attribute('aria-expanded');
-      });
-    });
-
     describe('aria-disabled', () => {
       it('should not have the attribute `aria-disabled` if disabled is false', () => {
         const { getByTestId } = render(
@@ -331,62 +307,6 @@ describe('<TreeItem />', () => {
         );
 
         expect(getByTestId('one')).to.have.attribute('aria-disabled', 'true');
-      });
-    });
-
-    describe('aria-selected', () => {
-      describe('single-select', () => {
-        it('should not have the attribute `aria-selected` if not selected', () => {
-          const { getByTestId } = render(
-            <SimpleTreeView>
-              <TreeItem itemId="test" label="test" data-testid="test" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('test')).not.to.have.attribute('aria-selected');
-        });
-
-        it('should have the attribute `aria-selected={true}` if selected', () => {
-          const { getByTestId } = render(
-            <SimpleTreeView defaultSelectedItems={'test'}>
-              <TreeItem itemId="test" label="test" data-testid="test" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('test')).to.have.attribute('aria-selected', 'true');
-        });
-      });
-
-      describe('multi-select', () => {
-        it('should have the attribute `aria-selected=false` if not selected', () => {
-          const { getByTestId } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="test" label="test" data-testid="test" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('test')).to.have.attribute('aria-selected', 'false');
-        });
-
-        it('should have the attribute `aria-selected={true}` if selected', () => {
-          const { getByTestId } = render(
-            <SimpleTreeView multiSelect defaultSelectedItems={['test']}>
-              <TreeItem itemId="test" label="test" data-testid="test" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('test')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('should have the attribute `aria-selected` if disableSelection is true', () => {
-          const { getByTestId } = render(
-            <SimpleTreeView multiSelect disableSelection>
-              <TreeItem itemId="test" label="test" data-testid="test" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('test')).to.have.attribute('aria-selected', 'false');
-        });
       });
     });
 
@@ -1164,96 +1084,10 @@ describe('<TreeItem />', () => {
           expect(getByTestId('one')).to.have.attribute('aria-selected');
         });
       });
-
-      describe('mouse', () => {
-        it('should select an item when click', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('one')).not.to.have.attribute('aria-selected');
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('should not deselect an item when clicking a selected item', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView defaultSelectedItems="one">
-              <TreeItem itemId="one" label="one" data-testid="one" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('should not select an item when click and disableSelection', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView disableSelection>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).not.to.have.attribute('aria-selected');
-        });
-      });
     });
 
     describe('Multi Selection', () => {
       describe('deselection', () => {
-        describe('mouse behavior when multiple items are selected', () => {
-          it('clicking a selected item holding ctrl should deselect the item', () => {
-            const { getByText, getByTestId } = render(
-              <SimpleTreeView multiSelect defaultSelectedItems={['one', 'two']}>
-                <TreeItem itemId="one" label="one" data-testid="one" />
-                <TreeItem itemId="two" label="two" data-testid="two" />
-              </SimpleTreeView>,
-            );
-
-            expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-            expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-            fireEvent.click(getByText('one'), { ctrlKey: true });
-            expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-            expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-          });
-
-          it('clicking a selected item holding meta should deselect the item', () => {
-            const { getByText, getByTestId } = render(
-              <SimpleTreeView multiSelect defaultSelectedItems={['one', 'two']}>
-                <TreeItem itemId="one" label="one" data-testid="one" />
-                <TreeItem itemId="two" label="two" data-testid="two" />
-              </SimpleTreeView>,
-            );
-
-            expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-            expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-            fireEvent.click(getByText('one'), { metaKey: true });
-            expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-            expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-          });
-        });
-
-        describe('mouse behavior when one item is selected', () => {
-          it('clicking a selected item shout not deselect the item', () => {
-            const { getByText, getByTestId } = render(
-              <SimpleTreeView multiSelect defaultSelectedItems={['one']}>
-                <TreeItem itemId="one" label="one" data-testid="one" />
-                <TreeItem itemId="two" label="two" data-testid="two" />
-              </SimpleTreeView>,
-            );
-
-            expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-            expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-            fireEvent.click(getByText('one'));
-            expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-            expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          });
-        });
-
         it('should deselect the item when pressing space on a selected item', () => {
           const { getByTestId } = render(
             <SimpleTreeView multiSelect defaultSelectedItems={['one']}>
@@ -1529,93 +1363,6 @@ describe('<TreeItem />', () => {
 
           expect(queryAllByRole('treeitem', { selected: true })).to.have.length(0);
         });
-
-        it('mouse', () => {
-          const { getByTestId, getByText } = render(
-            <SimpleTreeView multiSelect defaultExpandedItems={['two']}>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two">
-                <TreeItem itemId="three" label="three" data-testid="three" />
-                <TreeItem itemId="four" label="four" data-testid="four" />
-              </TreeItem>
-              <TreeItem itemId="five" label="five" data-testid="five">
-                <TreeItem itemId="six" label="six" data-testid="six" />
-                <TreeItem itemId="seven" label="seven" data-testid="seven" />
-              </TreeItem>
-              <TreeItem itemId="eight" label="eight" data-testid="eight" />
-              <TreeItem itemId="nine" label="nine" data-testid="nine" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('five'));
-          fireEvent.click(getByText('nine'), { shiftKey: true });
-          expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('six')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('seven')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('eight')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('nine')).to.have.attribute('aria-selected', 'true');
-          fireEvent.click(getByText('one'), { shiftKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('four')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('mouse behavior after deselection', () => {
-          const { getByTestId, getByText } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two" />
-              <TreeItem itemId="three" label="three" data-testid="three" />
-              <TreeItem itemId="four" label="four" data-testid="four" />
-              <TreeItem itemId="five" label="five" data-testid="five" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('one'));
-          fireEvent.click(getByText('two'), { ctrlKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-          fireEvent.click(getByText('two'), { ctrlKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-
-          fireEvent.click(getByText('five'), { shiftKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('four')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
-          fireEvent.click(getByText('one'), { shiftKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('three')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('four')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('five')).to.have.attribute('aria-selected', 'false');
-        });
-
-        it('mouse does not range select when selectionDisabled', () => {
-          const { getByText, queryAllByRole } = render(
-            <SimpleTreeView disableSelection multiSelect defaultExpandedItems={['two']}>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two">
-                <TreeItem itemId="three" label="three" data-testid="three" />
-                <TreeItem itemId="four" label="four" data-testid="four" />
-              </TreeItem>
-              <TreeItem itemId="five" label="five" data-testid="five">
-                <TreeItem itemId="six" label="six" data-testid="six" />
-                <TreeItem itemId="seven" label="seven" data-testid="seven" />
-              </TreeItem>
-              <TreeItem itemId="eight" label="eight" data-testid="eight" />
-              <TreeItem itemId="nine" label="nine" data-testid="nine" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('five'));
-          fireEvent.click(getByText('nine'), { shiftKey: true });
-          expect(queryAllByRole('treeitem', { selected: true })).to.have.length(0);
-        });
       });
 
       describe('multi selection', () => {
@@ -1672,64 +1419,6 @@ describe('<TreeItem />', () => {
           expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
           expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
         });
-
-        it('mouse', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-
-          fireEvent.click(getByText('one'));
-
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-
-          fireEvent.click(getByText('two'));
-
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('mouse using ctrl', () => {
-          const { getByTestId, getByText } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          fireEvent.click(getByText('two'), { ctrlKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('mouse using meta', () => {
-          const { getByTestId, getByText } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two" />
-            </SimpleTreeView>,
-          );
-
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          fireEvent.click(getByText('two'), { metaKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'true');
-        });
       });
 
       it('ctrl + a selects all', () => {
@@ -1774,73 +1463,6 @@ describe('<TreeItem />', () => {
 
   describe('prop: disabled', () => {
     describe('selection', () => {
-      describe('mouse', () => {
-        it('should prevent selection by mouse', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView>
-              <TreeItem itemId="one" label="one" disabled data-testid="one" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('one'));
-          expect(getByTestId('one')).not.to.have.attribute('aria-selected');
-        });
-
-        it('should prevent item triggering start of range selection', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" disabled data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two" />
-              <TreeItem itemId="three" label="three" data-testid="three" />
-              <TreeItem itemId="four" label="four" data-testid="four" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('one'));
-          fireEvent.click(getByText('four'), { shiftKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('three')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('four')).to.have.attribute('aria-selected', 'false');
-        });
-
-        it('should prevent item being selected as part of range selection', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" disabled data-testid="two" />
-              <TreeItem itemId="three" label="three" data-testid="three" />
-              <TreeItem itemId="four" label="four" data-testid="four" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('one'));
-          fireEvent.click(getByText('four'), { shiftKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('four')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('should prevent item triggering end of range selection', () => {
-          const { getByText, getByTestId } = render(
-            <SimpleTreeView multiSelect>
-              <TreeItem itemId="one" label="one" data-testid="one" />
-              <TreeItem itemId="two" label="two" data-testid="two" />
-              <TreeItem itemId="three" label="three" data-testid="three" />
-              <TreeItem itemId="four" label="four" disabled data-testid="four" />
-            </SimpleTreeView>,
-          );
-
-          fireEvent.click(getByText('one'));
-          fireEvent.click(getByText('four'), { shiftKey: true });
-          expect(getByTestId('one')).to.have.attribute('aria-selected', 'true');
-          expect(getByTestId('two')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('three')).to.have.attribute('aria-selected', 'false');
-          expect(getByTestId('four')).to.have.attribute('aria-selected', 'false');
-        });
-      });
-
       describe('keyboard', () => {
         describe('`disabledItemsFocusable={true}`', () => {
           it('should prevent selection by keyboard', () => {
@@ -2232,19 +1854,6 @@ describe('<TreeItem />', () => {
           fireEvent.keyDown(getByTestId('two'), { key: 'ArrowLeft' });
           expect(getByTestId('two')).to.have.attribute('aria-expanded', 'true');
         });
-      });
-
-      it('should prevent expansion on click', () => {
-        const { getByText, getByTestId } = render(
-          <SimpleTreeView>
-            <TreeItem itemId="one" label="one" disabled data-testid="one">
-              <TreeItem itemId="two" label="two" />
-            </TreeItem>
-          </SimpleTreeView>,
-        );
-
-        fireEvent.click(getByText('one'));
-        expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
       });
     });
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.test.tsx
@@ -35,7 +35,7 @@ describeTreeView<UseTreeViewExpansionSignature>(
         expect(response.getAllItemRoots()).to.have.length(3);
       });
 
-      it('should use the control state when defined', () => {
+      it('should use the controlled state when defined', () => {
         const response = render({
           items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
           expandedItems: ['1'],
@@ -45,7 +45,7 @@ describeTreeView<UseTreeViewExpansionSignature>(
         expect(response.getItemRoot('1.1')).toBeVisible();
       });
 
-      it('should use the control state upon the default state when both are defined', () => {
+      it('should use the controlled state instead of the default state when both are defined', () => {
         const response = render({
           items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
           expandedItems: ['1'],
@@ -55,7 +55,7 @@ describeTreeView<UseTreeViewExpansionSignature>(
         expect(response.isItemExpanded('1')).to.equal(true);
       });
 
-      it('should react to control state update', () => {
+      it('should react to controlled state update', () => {
         const response = render({
           items: [{ id: '1', children: [{ id: '1.1' }] }],
           expandedItems: [],

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.test.tsx
@@ -1,15 +1,12 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { describeTreeView } from 'test/utils/tree-view/describeTreeView';
 import { UseTreeViewExpansionSignature } from '@mui/x-tree-view/internals';
-import { act, fireEvent } from '@mui-internal/test-utils';
-import {
-  TreeItem2,
-  TreeItem2Props,
-  UseTreeItem2ContentSlotOwnProps,
-  useTreeItem2Utils,
-} from '@mui/x-tree-view';
-import * as React from 'react';
+import { fireEvent } from '@mui-internal/test-utils';
+import { TreeItem2, TreeItem2Props } from '@mui/x-tree-view/TreeItem2';
+import { UseTreeItem2ContentSlotOwnProps } from '@mui/x-tree-view/useTreeItem2';
+import { useTreeItem2Utils } from '@mui/x-tree-view/hooks';
 
 /**
  * All tests related to keyboard navigation (e.g.: expanding using "Enter" and "ArrowRight")
@@ -77,15 +74,12 @@ describeTreeView<UseTreeViewExpansionSignature>(
         });
 
         fireEvent.click(response.getItemContent('1'));
-        act(() => {
-          response.getRoot().focus();
-        });
 
         expect(onExpandedItemsChange.callCount).to.equal(1);
         expect(onExpandedItemsChange.lastCall.args[1]).to.deep.equal(['1']);
       });
 
-      it('should call the onExpandedItemsChange callback when the model is updated (add expanded item no non-empty list)', () => {
+      it('should call the onExpandedItemsChange callback when the model is updated (add expanded item to non-empty list)', () => {
         const onExpandedItemsChange = spy();
 
         const response = render({
@@ -98,9 +92,6 @@ describeTreeView<UseTreeViewExpansionSignature>(
         });
 
         fireEvent.click(response.getItemContent('2'));
-        act(() => {
-          response.getRoot().focus();
-        });
 
         expect(onExpandedItemsChange.callCount).to.equal(1);
         expect(onExpandedItemsChange.lastCall.args[1]).to.deep.equal(['2', '1']);
@@ -119,9 +110,6 @@ describeTreeView<UseTreeViewExpansionSignature>(
         });
 
         fireEvent.click(response.getItemContent('1'));
-        act(() => {
-          response.getRoot().focus();
-        });
 
         expect(onExpandedItemsChange.callCount).to.equal(1);
         expect(onExpandedItemsChange.lastCall.args[1]).to.deep.equal([]);
@@ -156,7 +144,7 @@ describeTreeView<UseTreeViewExpansionSignature>(
       });
     });
 
-    describe('click interactions', () => {
+    describe('item click interaction', () => {
       it('should expand collapsed item when clicking on an item content', () => {
         const response = render({
           items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
@@ -267,6 +255,35 @@ describeTreeView<UseTreeViewExpansionSignature>(
         expect(response.isItemExpanded('1')).to.equal(false);
         fireEvent.click(response.getItemIconContainer('1'));
         expect(response.isItemExpanded('1')).to.equal(true);
+      });
+    });
+
+    // The `aria-expanded` attribute is used by the `response.isItemExpanded` method.
+    // This `describe` only tests basics scenarios, more complex scenarios are tested in this file's other `describe`.
+    describe('aria-expanded item attribute', () => {
+      it('should have the attribute `aria-expanded=false` if collapsed', () => {
+        const response = render({
+          items: [{ id: '1', children: [{ id: '1.1' }] }],
+        });
+
+        expect(response.getItemRoot('1')).to.have.attribute('aria-expanded', 'false');
+      });
+
+      it('should have the attribute `aria-expanded=true` if expanded', () => {
+        const response = render({
+          items: [{ id: '1', children: [{ id: '1.1' }] }],
+          defaultExpandedItems: ['1'],
+        });
+
+        expect(response.getItemRoot('1')).to.have.attribute('aria-expanded', 'true');
+      });
+
+      it('should not have the attribute `aria-expanded` if no children are present', () => {
+        const response = render({
+          items: [{ id: '1' }],
+        });
+
+        expect(response.getItemRoot('1')).not.to.have.attribute('aria-expanded');
       });
     });
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
@@ -1,0 +1,568 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { fireEvent } from '@mui-internal/test-utils';
+import { describeTreeView } from 'test/utils/tree-view/describeTreeView';
+import { UseTreeViewSelectionSignature } from '@mui/x-tree-view/internals';
+
+/**
+ * All tests related to keyboard navigation (e.g.: selection using "Space")
+ * are located in the `useTreeViewKeyboardNavigation.test.tsx` file.
+ */
+describeTreeView.only<UseTreeViewSelectionSignature>(
+  'useTreeViewSelection plugin',
+  ({ render, setup }) => {
+    describe('model props (selectedItems, defaultSelectedItems, onSelectedItemsChange)', () => {
+      it('should not select items when no default state and no control state are defined', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(false);
+      });
+
+      it('should use the default state when defined', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          defaultSelectedItems: ['1'],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(true);
+      });
+
+      it('should use the control state when defined', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          selectedItems: ['1'],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(true);
+      });
+
+      it('should use the control state upon the default state when both are defined', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          selectedItems: ['1'],
+          defaultSelectedItems: ['2'],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(true);
+      });
+
+      it('should react to control state update', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          selectedItems: [],
+        });
+
+        response.setProps({ selectedItems: ['1'] });
+        expect(response.isItemSelected('1')).to.equal(true);
+      });
+
+      it('should call the onSelectedItemsChange callback when the model is updated (single selection and add selected item)', () => {
+        const onSelectedItemsChange = spy();
+
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          onSelectedItemsChange,
+        });
+
+        fireEvent.click(response.getItemContent('1'));
+
+        expect(onSelectedItemsChange.callCount).to.equal(1);
+        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal('1');
+      });
+
+      // TODO: Re-enable this test if we have a way to un-select an item in single selection.
+      // eslint-disable-next-line mocha/no-skipped-tests
+      it.skip('should call onSelectedItemsChange callback when the model is updated (single selection and remove selected item', () => {
+        const onSelectedItemsChange = spy();
+
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          onSelectedItemsChange,
+          defaultSelectedItems: ['1'],
+        });
+
+        fireEvent.click(response.getItemContent('1'));
+
+        expect(onSelectedItemsChange.callCount).to.equal(1);
+        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal([]);
+      });
+
+      it('should call the onSelectedItemsChange callback when the model is updated (multi selection and add selected item to empty list)', () => {
+        const onSelectedItemsChange = spy();
+
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          onSelectedItemsChange,
+        });
+
+        fireEvent.click(response.getItemContent('1'));
+
+        expect(onSelectedItemsChange.callCount).to.equal(1);
+        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['1']);
+      });
+
+      it('should call the onSelectedItemsChange callback when the model is updated (multi selection and add selected item to non-empty list)', () => {
+        const onSelectedItemsChange = spy();
+
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          onSelectedItemsChange,
+          defaultSelectedItems: ['1'],
+        });
+
+        fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
+
+        expect(onSelectedItemsChange.callCount).to.equal(1);
+        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['2', '1']);
+      });
+
+      it('should call the onSelectedItemsChange callback when the model is updated (multi selection and remove selected item)', () => {
+        const onSelectedItemsChange = spy();
+
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          onSelectedItemsChange,
+          defaultSelectedItems: ['1'],
+        });
+
+        fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+
+        expect(onSelectedItemsChange.callCount).to.equal(1);
+        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal([]);
+      });
+
+      it('should warn when switching from controlled to uncontrolled', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          selectedItems: [],
+        });
+
+        expect(() => {
+          response.setProps({ selectedItems: undefined });
+        }).toErrorDev(
+          'MUI X: A component is changing the controlled selectedItems state of TreeView to be uncontrolled.',
+        );
+      });
+
+      it('should warn and not react to update when updating the default state', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          defaultSelectedItems: ['1'],
+        });
+
+        expect(() => {
+          response.setProps({ defaultSelectedItems: ['2'] });
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+        }).toErrorDev(
+          'MUI X: A component is changing the default selectedItems state of an uncontrolled TreeView after being initialized. To suppress this warning opt to use a controlled TreeView.',
+        );
+      });
+    });
+
+    describe('item click interaction', () => {
+      describe('single selection', () => {
+        it('should select un-selected item when clicking on an item content', () => {
+          const response = render({
+            items: [{ id: '1' }, { id: '2' }],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(true);
+        });
+
+        it('should not un-select selected item when clicking on an item content', () => {
+          const response = render({
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: '1',
+          });
+
+          expect(response.isItemSelected('1')).to.equal(true);
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(true);
+        });
+
+        it('should not select an item when click and disableSelection', () => {
+          const response = render({
+            items: [{ id: '1' }, { id: '2' }],
+            disableSelection: true,
+          });
+
+          expect(response.isItemSelected('1')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(false);
+        });
+
+        it('should not select an item when clicking on a disabled item content', () => {
+          const response = render({
+            items: [{ id: '1', disabled: true }, { id: '2' }],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(false);
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(false);
+        });
+      });
+
+      describe('multi selection', () => {
+        it('should select un-selected item when clicking on an item content', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: ['2'],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+        });
+
+        it('should not un-select selected item when clicking on an item content', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: ['1'],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(true);
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(true);
+        });
+
+        it('should un-select selected item when clicking on its content while holding Ctrl', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: ['1', '2'],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(true);
+          fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+        });
+
+        it('should un-select selected item when clicking on its content while holding Meta', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: ['1', '2'],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(true);
+
+          fireEvent.click(response.getItemContent('1'), { metaKey: true });
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+        });
+
+        it('should not select an item when click and disableSelection', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            disableSelection: true,
+          });
+
+          expect(response.isItemSelected('1')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(false);
+        });
+
+        it('should not select an item when clicking on a disabled item content', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1', disabled: true }, { id: '2' }],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(false);
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(false);
+        });
+
+        it('should select un-selected item when clicking on its content while holding Ctrl', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }, { id: '3' }],
+            defaultSelectedItems: ['1'],
+          });
+
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('3'), { ctrlKey: true });
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(true);
+        });
+
+        it('should expand the selection range when clicking on an item content below the last selected item while holding Shift', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
+          });
+
+          fireEvent.click(response.getItemContent('2'));
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(true);
+          expect(response.isItemSelected('3')).to.equal(true);
+          expect(response.isItemSelected('4')).to.equal(false);
+        });
+
+        it('should expand the selection range when clicking on an item content above the last selected item while holding Shift', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
+          });
+
+          fireEvent.click(response.getItemContent('3'));
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(true);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('2'), { shiftKey: true });
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(true);
+          expect(response.isItemSelected('3')).to.equal(true);
+          expect(response.isItemSelected('4')).to.equal(false);
+        });
+
+        it('should expand the selection range when clicking on an item content while holding Shift after un-selecting another item', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
+          });
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(true);
+          expect(response.isItemSelected('3')).to.equal(true);
+          expect(response.isItemSelected('4')).to.equal(false);
+        });
+
+        it('should not expand the selection range when clicking on a disabled item content then clicking on an item content while holding Shift', () => {
+          const response = render({
+            multiSelect: true,
+            items: [
+              { id: '1' },
+              { id: '2', disabled: true },
+              { id: '2.1' },
+              { id: '3' },
+              { id: '4' },
+            ],
+          });
+
+          fireEvent.click(response.getItemContent('2'));
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+        });
+
+        it('should not expand the selection range when clicking on an item content then clicking a disabled item content while holding Shift', () => {
+          const response = render({
+            multiSelect: true,
+            items: [
+              { id: '1' },
+              { id: '2' },
+              { id: '2.1' },
+              { id: '3', disabled: true },
+              { id: '4' },
+            ],
+          });
+
+          fireEvent.click(response.getItemContent('2'));
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+          expect(response.isItemSelected('1')).to.equal(false);
+          expect(response.isItemSelected('2')).to.equal(true);
+          expect(response.isItemSelected('2.1')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+          expect(response.isItemSelected('4')).to.equal(false);
+        });
+
+        it('should not select disabled item that are part of the selected range', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2', disabled: true }, { id: '3' }],
+          });
+
+          fireEvent.click(response.getItemContent('1'));
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(false);
+
+          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+          expect(response.isItemSelected('1')).to.equal(true);
+          expect(response.isItemSelected('2')).to.equal(false);
+          expect(response.isItemSelected('3')).to.equal(true);
+        });
+      });
+    });
+
+    describe('aria-multiselectable tree attribute', () => {
+      it('should have the attribute `aria-multiselectable=false if using single select`', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+        });
+
+        expect(response.getRoot()).to.have.attribute('aria-multiselectable', 'false');
+      });
+
+      it('should have the attribute `aria-multiselectable=true if using multi select`', () => {
+        const response = render({ items: [{ id: '1' }, { id: '2' }], multiSelect: true });
+
+        expect(response.getRoot()).to.have.attribute('aria-multiselectable', 'true');
+      });
+    });
+
+    // The `aria-selected` attribute is used by the `response.isItemSelected` method.
+    // This `describe` only tests basics scenarios, more complex scenarios are tested in this file's other `describe`.
+    describe('aria-selected item attribute', () => {
+      describe('single selection', () => {
+        it('should not have the attribute `aria-selected=false` if not selected', () => {
+          const response = render({
+            items: [{ id: '1' }, { id: '2' }],
+          });
+
+          expect(response.getItemRoot('1')).not.to.have.attribute('aria-selected');
+        });
+
+        it('should have the attribute `aria-selected=true` if selected', () => {
+          const response = render({
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: '1',
+          });
+
+          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'true');
+        });
+      });
+
+      describe('multi selection', () => {
+        it('should have the attribute `aria-selected=false` if not selected', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+          });
+
+          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'false');
+        });
+
+        it('should have the attribute `aria-selected=true` if selected', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            defaultSelectedItems: ['1'],
+          });
+
+          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'true');
+        });
+
+        it('should have the attribute `aria-selected=false` if disabledSelection is true', () => {
+          const response = render({
+            multiSelect: true,
+            items: [{ id: '1' }, { id: '2' }],
+            disableSelection: true,
+          });
+
+          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'false');
+        });
+      });
+    });
+
+    describe('onItemSelectionToggle prop', () => {
+      it('should call the onItemSelectionToggle callback when selecting an item', () => {
+        const onItemSelectionToggle = spy();
+
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          onItemSelectionToggle,
+        });
+
+        fireEvent.click(response.getItemContent('1'));
+        expect(onItemSelectionToggle.callCount).to.equal(1);
+        expect(onItemSelectionToggle.lastCall.args[1]).to.equal('1');
+        expect(onItemSelectionToggle.lastCall.args[2]).to.equal(true);
+      });
+
+      it('should call the onItemSelectionToggle callback when un-selecting an item', () => {
+        const onItemSelectionToggle = spy();
+
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          defaultSelectedItems: ['1'],
+          onItemSelectionToggle,
+        });
+
+        fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+        expect(onItemSelectionToggle.callCount).to.equal(1);
+        expect(onItemSelectionToggle.lastCall.args[1]).to.equal('1');
+        expect(onItemSelectionToggle.lastCall.args[2]).to.equal(false);
+      });
+    });
+  },
+);

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
@@ -8,561 +8,558 @@ import { UseTreeViewSelectionSignature } from '@mui/x-tree-view/internals';
  * All tests related to keyboard navigation (e.g.: selection using "Space")
  * are located in the `useTreeViewKeyboardNavigation.test.tsx` file.
  */
-describeTreeView.only<UseTreeViewSelectionSignature>(
-  'useTreeViewSelection plugin',
-  ({ render, setup }) => {
-    describe('model props (selectedItems, defaultSelectedItems, onSelectedItemsChange)', () => {
-      it('should not select items when no default state and no control state are defined', () => {
+describeTreeView<UseTreeViewSelectionSignature>('useTreeViewSelection plugin', ({ render }) => {
+  describe('model props (selectedItems, defaultSelectedItems, onSelectedItemsChange)', () => {
+    it('should not select items when no default state and no control state are defined', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+      });
+
+      expect(response.isItemSelected('1')).to.equal(false);
+    });
+
+    it('should use the default state when defined', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        defaultSelectedItems: ['1'],
+      });
+
+      expect(response.isItemSelected('1')).to.equal(true);
+    });
+
+    it('should use the control state when defined', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        selectedItems: ['1'],
+      });
+
+      expect(response.isItemSelected('1')).to.equal(true);
+    });
+
+    it('should use the control state upon the default state when both are defined', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        selectedItems: ['1'],
+        defaultSelectedItems: ['2'],
+      });
+
+      expect(response.isItemSelected('1')).to.equal(true);
+    });
+
+    it('should react to control state update', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        selectedItems: [],
+      });
+
+      response.setProps({ selectedItems: ['1'] });
+      expect(response.isItemSelected('1')).to.equal(true);
+    });
+
+    it('should call the onSelectedItemsChange callback when the model is updated (single selection and add selected item)', () => {
+      const onSelectedItemsChange = spy();
+
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        onSelectedItemsChange,
+      });
+
+      fireEvent.click(response.getItemContent('1'));
+
+      expect(onSelectedItemsChange.callCount).to.equal(1);
+      expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal('1');
+    });
+
+    // TODO: Re-enable this test if we have a way to un-select an item in single selection.
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('should call onSelectedItemsChange callback when the model is updated (single selection and remove selected item', () => {
+      const onSelectedItemsChange = spy();
+
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        onSelectedItemsChange,
+        defaultSelectedItems: ['1'],
+      });
+
+      fireEvent.click(response.getItemContent('1'));
+
+      expect(onSelectedItemsChange.callCount).to.equal(1);
+      expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal([]);
+    });
+
+    it('should call the onSelectedItemsChange callback when the model is updated (multi selection and add selected item to empty list)', () => {
+      const onSelectedItemsChange = spy();
+
+      const response = render({
+        multiSelect: true,
+        items: [{ id: '1' }, { id: '2' }],
+        onSelectedItemsChange,
+      });
+
+      fireEvent.click(response.getItemContent('1'));
+
+      expect(onSelectedItemsChange.callCount).to.equal(1);
+      expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['1']);
+    });
+
+    it('should call the onSelectedItemsChange callback when the model is updated (multi selection and add selected item to non-empty list)', () => {
+      const onSelectedItemsChange = spy();
+
+      const response = render({
+        multiSelect: true,
+        items: [{ id: '1' }, { id: '2' }],
+        onSelectedItemsChange,
+        defaultSelectedItems: ['1'],
+      });
+
+      fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
+
+      expect(onSelectedItemsChange.callCount).to.equal(1);
+      expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['2', '1']);
+    });
+
+    it('should call the onSelectedItemsChange callback when the model is updated (multi selection and remove selected item)', () => {
+      const onSelectedItemsChange = spy();
+
+      const response = render({
+        multiSelect: true,
+        items: [{ id: '1' }, { id: '2' }],
+        onSelectedItemsChange,
+        defaultSelectedItems: ['1'],
+      });
+
+      fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+
+      expect(onSelectedItemsChange.callCount).to.equal(1);
+      expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal([]);
+    });
+
+    it('should warn when switching from controlled to uncontrolled', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        selectedItems: [],
+      });
+
+      expect(() => {
+        response.setProps({ selectedItems: undefined });
+      }).toErrorDev(
+        'MUI X: A component is changing the controlled selectedItems state of TreeView to be uncontrolled.',
+      );
+    });
+
+    it('should warn and not react to update when updating the default state', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
+        defaultSelectedItems: ['1'],
+      });
+
+      expect(() => {
+        response.setProps({ defaultSelectedItems: ['2'] });
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+      }).toErrorDev(
+        'MUI X: A component is changing the default selectedItems state of an uncontrolled TreeView after being initialized. To suppress this warning opt to use a controlled TreeView.',
+      );
+    });
+  });
+
+  describe('item click interaction', () => {
+    describe('single selection', () => {
+      it('should select un-selected item when clicking on an item content', () => {
         const response = render({
           items: [{ id: '1' }, { id: '2' }],
         });
 
         expect(response.isItemSelected('1')).to.equal(false);
-      });
 
-      it('should use the default state when defined', () => {
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-          defaultSelectedItems: ['1'],
-        });
-
+        fireEvent.click(response.getItemContent('1'));
         expect(response.isItemSelected('1')).to.equal(true);
       });
 
-      it('should use the control state when defined', () => {
+      it('should not un-select selected item when clicking on an item content', () => {
         const response = render({
           items: [{ id: '1' }, { id: '2' }],
-          selectedItems: ['1'],
+          defaultSelectedItems: '1',
         });
 
         expect(response.isItemSelected('1')).to.equal(true);
+
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(true);
       });
 
-      it('should use the control state upon the default state when both are defined', () => {
+      it('should not select an item when click and disableSelection', () => {
         const response = render({
           items: [{ id: '1' }, { id: '2' }],
-          selectedItems: ['1'],
+          disableSelection: true,
+        });
+
+        expect(response.isItemSelected('1')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(false);
+      });
+
+      it('should not select an item when clicking on a disabled item content', () => {
+        const response = render({
+          items: [{ id: '1', disabled: true }, { id: '2' }],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(false);
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(false);
+      });
+    });
+
+    describe('multi selection', () => {
+      it('should select un-selected item when clicking on an item content', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
           defaultSelectedItems: ['2'],
         });
 
-        expect(response.isItemSelected('1')).to.equal(true);
-      });
-
-      it('should react to control state update', () => {
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-          selectedItems: [],
-        });
-
-        response.setProps({ selectedItems: ['1'] });
-        expect(response.isItemSelected('1')).to.equal(true);
-      });
-
-      it('should call the onSelectedItemsChange callback when the model is updated (single selection and add selected item)', () => {
-        const onSelectedItemsChange = spy();
-
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-          onSelectedItemsChange,
-        });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
 
         fireEvent.click(response.getItemContent('1'));
-
-        expect(onSelectedItemsChange.callCount).to.equal(1);
-        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal('1');
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
       });
 
-      // TODO: Re-enable this test if we have a way to un-select an item in single selection.
-      // eslint-disable-next-line mocha/no-skipped-tests
-      it.skip('should call onSelectedItemsChange callback when the model is updated (single selection and remove selected item', () => {
-        const onSelectedItemsChange = spy();
-
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-          onSelectedItemsChange,
-          defaultSelectedItems: ['1'],
-        });
-
-        fireEvent.click(response.getItemContent('1'));
-
-        expect(onSelectedItemsChange.callCount).to.equal(1);
-        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal([]);
-      });
-
-      it('should call the onSelectedItemsChange callback when the model is updated (multi selection and add selected item to empty list)', () => {
-        const onSelectedItemsChange = spy();
-
+      it('should not un-select selected item when clicking on an item content', () => {
         const response = render({
           multiSelect: true,
           items: [{ id: '1' }, { id: '2' }],
-          onSelectedItemsChange,
+          defaultSelectedItems: ['1'],
         });
 
-        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(true);
 
-        expect(onSelectedItemsChange.callCount).to.equal(1);
-        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['1']);
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(true);
       });
 
-      it('should call the onSelectedItemsChange callback when the model is updated (multi selection and add selected item to non-empty list)', () => {
-        const onSelectedItemsChange = spy();
-
+      it('should un-select selected item when clicking on its content while holding Ctrl', () => {
         const response = render({
           multiSelect: true,
           items: [{ id: '1' }, { id: '2' }],
-          onSelectedItemsChange,
+          defaultSelectedItems: ['1', '2'],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(true);
+        fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+      });
+
+      it('should un-select selected item when clicking on its content while holding Meta', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          defaultSelectedItems: ['1', '2'],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(true);
+
+        fireEvent.click(response.getItemContent('1'), { metaKey: true });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+      });
+
+      it('should not select an item when click and disableSelection', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          disableSelection: true,
+        });
+
+        expect(response.isItemSelected('1')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(false);
+      });
+
+      it('should not select an item when clicking on a disabled item content', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1', disabled: true }, { id: '2' }],
+        });
+
+        expect(response.isItemSelected('1')).to.equal(false);
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(false);
+      });
+
+      it('should select un-selected item when clicking on its content while holding Ctrl', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }, { id: '3' }],
           defaultSelectedItems: ['1'],
         });
+
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('3'), { ctrlKey: true });
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(true);
+      });
+
+      it('should expand the selection range when clicking on an item content below the last selected item while holding Shift', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
+        });
+
+        fireEvent.click(response.getItemContent('2'));
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(true);
+        expect(response.isItemSelected('3')).to.equal(true);
+        expect(response.isItemSelected('4')).to.equal(false);
+      });
+
+      it('should expand the selection range when clicking on an item content above the last selected item while holding Shift', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
+        });
+
+        fireEvent.click(response.getItemContent('3'));
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(true);
+        expect(response.isItemSelected('4')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('2'), { shiftKey: true });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(true);
+        expect(response.isItemSelected('3')).to.equal(true);
+        expect(response.isItemSelected('4')).to.equal(false);
+      });
+
+      it('should expand the selection range when clicking on an item content while holding Shift after un-selecting another item', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
+        });
+
+        fireEvent.click(response.getItemContent('1'));
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
 
         fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
 
-        expect(onSelectedItemsChange.callCount).to.equal(1);
-        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['2', '1']);
+        fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(true);
+        expect(response.isItemSelected('3')).to.equal(true);
+        expect(response.isItemSelected('4')).to.equal(false);
       });
 
-      it('should call the onSelectedItemsChange callback when the model is updated (multi selection and remove selected item)', () => {
-        const onSelectedItemsChange = spy();
-
+      it('should not expand the selection range when clicking on a disabled item content then clicking on an item content while holding Shift', () => {
         const response = render({
           multiSelect: true,
-          items: [{ id: '1' }, { id: '2' }],
-          onSelectedItemsChange,
-          defaultSelectedItems: ['1'],
+          items: [
+            { id: '1' },
+            { id: '2', disabled: true },
+            { id: '2.1' },
+            { id: '3' },
+            { id: '4' },
+          ],
         });
 
-        fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+        fireEvent.click(response.getItemContent('2'));
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
 
-        expect(onSelectedItemsChange.callCount).to.equal(1);
-        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal([]);
+        fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
       });
 
-      it('should warn when switching from controlled to uncontrolled', () => {
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-          selectedItems: [],
-        });
-
-        expect(() => {
-          response.setProps({ selectedItems: undefined });
-        }).toErrorDev(
-          'MUI X: A component is changing the controlled selectedItems state of TreeView to be uncontrolled.',
-        );
-      });
-
-      it('should warn and not react to update when updating the default state', () => {
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-          defaultSelectedItems: ['1'],
-        });
-
-        expect(() => {
-          response.setProps({ defaultSelectedItems: ['2'] });
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-        }).toErrorDev(
-          'MUI X: A component is changing the default selectedItems state of an uncontrolled TreeView after being initialized. To suppress this warning opt to use a controlled TreeView.',
-        );
-      });
-    });
-
-    describe('item click interaction', () => {
-      describe('single selection', () => {
-        it('should select un-selected item when clicking on an item content', () => {
-          const response = render({
-            items: [{ id: '1' }, { id: '2' }],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(true);
-        });
-
-        it('should not un-select selected item when clicking on an item content', () => {
-          const response = render({
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: '1',
-          });
-
-          expect(response.isItemSelected('1')).to.equal(true);
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(true);
-        });
-
-        it('should not select an item when click and disableSelection', () => {
-          const response = render({
-            items: [{ id: '1' }, { id: '2' }],
-            disableSelection: true,
-          });
-
-          expect(response.isItemSelected('1')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(false);
-        });
-
-        it('should not select an item when clicking on a disabled item content', () => {
-          const response = render({
-            items: [{ id: '1', disabled: true }, { id: '2' }],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(false);
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(false);
-        });
-      });
-
-      describe('multi selection', () => {
-        it('should select un-selected item when clicking on an item content', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: ['2'],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-        });
-
-        it('should not un-select selected item when clicking on an item content', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: ['1'],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(true);
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(true);
-        });
-
-        it('should un-select selected item when clicking on its content while holding Ctrl', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: ['1', '2'],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(true);
-          fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-        });
-
-        it('should un-select selected item when clicking on its content while holding Meta', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: ['1', '2'],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(true);
-
-          fireEvent.click(response.getItemContent('1'), { metaKey: true });
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-        });
-
-        it('should not select an item when click and disableSelection', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            disableSelection: true,
-          });
-
-          expect(response.isItemSelected('1')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(false);
-        });
-
-        it('should not select an item when clicking on a disabled item content', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1', disabled: true }, { id: '2' }],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(false);
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(false);
-        });
-
-        it('should select un-selected item when clicking on its content while holding Ctrl', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }, { id: '3' }],
-            defaultSelectedItems: ['1'],
-          });
-
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('3'), { ctrlKey: true });
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(true);
-        });
-
-        it('should expand the selection range when clicking on an item content below the last selected item while holding Shift', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
-          });
-
-          fireEvent.click(response.getItemContent('2'));
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(true);
-          expect(response.isItemSelected('3')).to.equal(true);
-          expect(response.isItemSelected('4')).to.equal(false);
-        });
-
-        it('should expand the selection range when clicking on an item content above the last selected item while holding Shift', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
-          });
-
-          fireEvent.click(response.getItemContent('3'));
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(true);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('2'), { shiftKey: true });
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(true);
-          expect(response.isItemSelected('3')).to.equal(true);
-          expect(response.isItemSelected('4')).to.equal(false);
-        });
-
-        it('should expand the selection range when clicking on an item content while holding Shift after un-selecting another item', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }, { id: '2.1' }, { id: '3' }, { id: '4' }],
-          });
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('2'), { ctrlKey: true });
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(true);
-          expect(response.isItemSelected('3')).to.equal(true);
-          expect(response.isItemSelected('4')).to.equal(false);
-        });
-
-        it('should not expand the selection range when clicking on a disabled item content then clicking on an item content while holding Shift', () => {
-          const response = render({
-            multiSelect: true,
-            items: [
-              { id: '1' },
-              { id: '2', disabled: true },
-              { id: '2.1' },
-              { id: '3' },
-              { id: '4' },
-            ],
-          });
-
-          fireEvent.click(response.getItemContent('2'));
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-        });
-
-        it('should not expand the selection range when clicking on an item content then clicking a disabled item content while holding Shift', () => {
-          const response = render({
-            multiSelect: true,
-            items: [
-              { id: '1' },
-              { id: '2' },
-              { id: '2.1' },
-              { id: '3', disabled: true },
-              { id: '4' },
-            ],
-          });
-
-          fireEvent.click(response.getItemContent('2'));
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
-          expect(response.isItemSelected('1')).to.equal(false);
-          expect(response.isItemSelected('2')).to.equal(true);
-          expect(response.isItemSelected('2.1')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-          expect(response.isItemSelected('4')).to.equal(false);
-        });
-
-        it('should not select disabled item that are part of the selected range', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2', disabled: true }, { id: '3' }],
-          });
-
-          fireEvent.click(response.getItemContent('1'));
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(false);
-
-          fireEvent.click(response.getItemContent('3'), { shiftKey: true });
-          expect(response.isItemSelected('1')).to.equal(true);
-          expect(response.isItemSelected('2')).to.equal(false);
-          expect(response.isItemSelected('3')).to.equal(true);
-        });
-      });
-    });
-
-    describe('aria-multiselectable tree attribute', () => {
-      it('should have the attribute `aria-multiselectable=false if using single select`', () => {
-        const response = render({
-          items: [{ id: '1' }, { id: '2' }],
-        });
-
-        expect(response.getRoot()).to.have.attribute('aria-multiselectable', 'false');
-      });
-
-      it('should have the attribute `aria-multiselectable=true if using multi select`', () => {
-        const response = render({ items: [{ id: '1' }, { id: '2' }], multiSelect: true });
-
-        expect(response.getRoot()).to.have.attribute('aria-multiselectable', 'true');
-      });
-    });
-
-    // The `aria-selected` attribute is used by the `response.isItemSelected` method.
-    // This `describe` only tests basics scenarios, more complex scenarios are tested in this file's other `describe`.
-    describe('aria-selected item attribute', () => {
-      describe('single selection', () => {
-        it('should not have the attribute `aria-selected=false` if not selected', () => {
-          const response = render({
-            items: [{ id: '1' }, { id: '2' }],
-          });
-
-          expect(response.getItemRoot('1')).not.to.have.attribute('aria-selected');
-        });
-
-        it('should have the attribute `aria-selected=true` if selected', () => {
-          const response = render({
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: '1',
-          });
-
-          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'true');
-        });
-      });
-
-      describe('multi selection', () => {
-        it('should have the attribute `aria-selected=false` if not selected', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-          });
-
-          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'false');
-        });
-
-        it('should have the attribute `aria-selected=true` if selected', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            defaultSelectedItems: ['1'],
-          });
-
-          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'true');
-        });
-
-        it('should have the attribute `aria-selected=false` if disabledSelection is true', () => {
-          const response = render({
-            multiSelect: true,
-            items: [{ id: '1' }, { id: '2' }],
-            disableSelection: true,
-          });
-
-          expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'false');
-        });
-      });
-    });
-
-    describe('onItemSelectionToggle prop', () => {
-      it('should call the onItemSelectionToggle callback when selecting an item', () => {
-        const onItemSelectionToggle = spy();
-
+      it('should not expand the selection range when clicking on an item content then clicking a disabled item content while holding Shift', () => {
         const response = render({
           multiSelect: true,
-          items: [{ id: '1' }, { id: '2' }],
-          onItemSelectionToggle,
+          items: [
+            { id: '1' },
+            { id: '2' },
+            { id: '2.1' },
+            { id: '3', disabled: true },
+            { id: '4' },
+          ],
+        });
+
+        fireEvent.click(response.getItemContent('2'));
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+        expect(response.isItemSelected('1')).to.equal(false);
+        expect(response.isItemSelected('2')).to.equal(true);
+        expect(response.isItemSelected('2.1')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+        expect(response.isItemSelected('4')).to.equal(false);
+      });
+
+      it('should not select disabled item that are part of the selected range', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2', disabled: true }, { id: '3' }],
         });
 
         fireEvent.click(response.getItemContent('1'));
-        expect(onItemSelectionToggle.callCount).to.equal(1);
-        expect(onItemSelectionToggle.lastCall.args[1]).to.equal('1');
-        expect(onItemSelectionToggle.lastCall.args[2]).to.equal(true);
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(false);
+
+        fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+        expect(response.isItemSelected('1')).to.equal(true);
+        expect(response.isItemSelected('2')).to.equal(false);
+        expect(response.isItemSelected('3')).to.equal(true);
+      });
+    });
+  });
+
+  describe('aria-multiselectable tree attribute', () => {
+    it('should have the attribute `aria-multiselectable=false if using single select`', () => {
+      const response = render({
+        items: [{ id: '1' }, { id: '2' }],
       });
 
-      it('should call the onItemSelectionToggle callback when un-selecting an item', () => {
-        const onItemSelectionToggle = spy();
+      expect(response.getRoot()).to.have.attribute('aria-multiselectable', 'false');
+    });
 
+    it('should have the attribute `aria-multiselectable=true if using multi select`', () => {
+      const response = render({ items: [{ id: '1' }, { id: '2' }], multiSelect: true });
+
+      expect(response.getRoot()).to.have.attribute('aria-multiselectable', 'true');
+    });
+  });
+
+  // The `aria-selected` attribute is used by the `response.isItemSelected` method.
+  // This `describe` only tests basics scenarios, more complex scenarios are tested in this file's other `describe`.
+  describe('aria-selected item attribute', () => {
+    describe('single selection', () => {
+      it('should not have the attribute `aria-selected=false` if not selected', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+        });
+
+        expect(response.getItemRoot('1')).not.to.have.attribute('aria-selected');
+      });
+
+      it('should have the attribute `aria-selected=true` if selected', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+          defaultSelectedItems: '1',
+        });
+
+        expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'true');
+      });
+    });
+
+    describe('multi selection', () => {
+      it('should have the attribute `aria-selected=false` if not selected', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+        });
+
+        expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'false');
+      });
+
+      it('should have the attribute `aria-selected=true` if selected', () => {
         const response = render({
           multiSelect: true,
           items: [{ id: '1' }, { id: '2' }],
           defaultSelectedItems: ['1'],
-          onItemSelectionToggle,
         });
 
-        fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
-        expect(onItemSelectionToggle.callCount).to.equal(1);
-        expect(onItemSelectionToggle.lastCall.args[1]).to.equal('1');
-        expect(onItemSelectionToggle.lastCall.args[2]).to.equal(false);
+        expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'true');
+      });
+
+      it('should have the attribute `aria-selected=false` if disabledSelection is true', () => {
+        const response = render({
+          multiSelect: true,
+          items: [{ id: '1' }, { id: '2' }],
+          disableSelection: true,
+        });
+
+        expect(response.getItemRoot('1')).to.have.attribute('aria-selected', 'false');
       });
     });
-  },
-);
+  });
+
+  describe('onItemSelectionToggle prop', () => {
+    it('should call the onItemSelectionToggle callback when selecting an item', () => {
+      const onItemSelectionToggle = spy();
+
+      const response = render({
+        multiSelect: true,
+        items: [{ id: '1' }, { id: '2' }],
+        onItemSelectionToggle,
+      });
+
+      fireEvent.click(response.getItemContent('1'));
+      expect(onItemSelectionToggle.callCount).to.equal(1);
+      expect(onItemSelectionToggle.lastCall.args[1]).to.equal('1');
+      expect(onItemSelectionToggle.lastCall.args[2]).to.equal(true);
+    });
+
+    it('should call the onItemSelectionToggle callback when un-selecting an item', () => {
+      const onItemSelectionToggle = spy();
+
+      const response = render({
+        multiSelect: true,
+        items: [{ id: '1' }, { id: '2' }],
+        defaultSelectedItems: ['1'],
+        onItemSelectionToggle,
+      });
+
+      fireEvent.click(response.getItemContent('1'), { ctrlKey: true });
+      expect(onItemSelectionToggle.callCount).to.equal(1);
+      expect(onItemSelectionToggle.lastCall.args[1]).to.equal('1');
+      expect(onItemSelectionToggle.lastCall.args[2]).to.equal(false);
+    });
+  });
+});

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
@@ -27,7 +27,7 @@ describeTreeView<UseTreeViewSelectionSignature>('useTreeViewSelection plugin', (
       expect(response.isItemSelected('1')).to.equal(true);
     });
 
-    it('should use the control state when defined', () => {
+    it('should use the controlled state when defined', () => {
       const response = render({
         items: [{ id: '1' }, { id: '2' }],
         selectedItems: ['1'],
@@ -36,7 +36,7 @@ describeTreeView<UseTreeViewSelectionSignature>('useTreeViewSelection plugin', (
       expect(response.isItemSelected('1')).to.equal(true);
     });
 
-    it('should use the control state upon the default state when both are defined', () => {
+    it('should use the controlled state instead of the default state when both are defined', () => {
       const response = render({
         items: [{ id: '1' }, { id: '2' }],
         selectedItems: ['1'],
@@ -46,7 +46,7 @@ describeTreeView<UseTreeViewSelectionSignature>('useTreeViewSelection plugin', (
       expect(response.isItemSelected('1')).to.equal(true);
     });
 
-    it('should react to control state update', () => {
+    it('should react to controlled state update', () => {
       const response = render({
         items: [{ id: '1' }, { id: '2' }],
         selectedItems: [],
@@ -441,7 +441,7 @@ describeTreeView<UseTreeViewSelectionSignature>('useTreeViewSelection plugin', (
         expect(response.isItemSelected('4')).to.equal(false);
       });
 
-      it('should not select disabled item that are part of the selected range', () => {
+      it('should not select disabled items that are part of the selected range', () => {
         const response = render({
           multiSelect: true,
           items: [{ id: '1' }, { id: '2', disabled: true }, { id: '3' }],

--- a/test/utils/tree-view/describeTreeView/describeTreeView.tsx
+++ b/test/utils/tree-view/describeTreeView/describeTreeView.tsx
@@ -40,6 +40,8 @@ const innerDescribeTreeView = <TPlugin extends TreeViewAnyPluginSignature>(
 
     const isItemExpanded = (id: string) => getItemRoot(id).getAttribute('aria-expanded') === 'true';
 
+    const isItemSelected = (id: string) => getItemRoot(id).getAttribute('aria-selected') === 'true';
+
     return {
       getRoot,
       getAllItemRoots,
@@ -48,6 +50,7 @@ const innerDescribeTreeView = <TPlugin extends TreeViewAnyPluginSignature>(
       getItemLabel,
       getItemIconContainer,
       isItemExpanded,
+      isItemSelected,
     };
   };
 

--- a/test/utils/tree-view/describeTreeView/describeTreeView.types.ts
+++ b/test/utils/tree-view/describeTreeView/describeTreeView.types.ts
@@ -54,6 +54,13 @@ export interface DescribeTreeViewRendererReturnValue<TPlugin extends TreeViewAny
    * @returns {boolean} `true` if the item is expanded, `false` otherwise.
    */
   isItemExpanded: (id: string) => boolean;
+  /**
+   * Checks if an item is selected.
+   * Uses the `aria-selected` attribute to check the selected.
+   * @param {string} id The id of the item to check.
+   * @returns {boolean} `true` if the item is selected, `false` otherwise.
+   */
+  isItemSelected: (id: string) => boolean;
 }
 
 export type DescribeTreeViewRenderer<TPlugin extends TreeViewAnyPluginSignature> = <


### PR DESCRIPTION
Part of #12433

Most tests are just migration with unified API from existing tests.
I did not remove any test.

I have doubt about some of the current behaviors, which IMHO are not what the ARIA spec describes (clicking on a selected item in single selection does not un-select it, but the specs say that it should "toggle" the selection). But for now I migrated all the tests without touching the behaviors to avoid mixing the two.