### PR TITLE
[core] Add cherry-pick `master` to `v6` action

### DIFF
--- a/.github/workflows/cherry-pick-master-to-v6.yml
+++ b/.github/workflows/cherry-pick-master-to-v6.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && contains(github.event.pull_request.labels.*.name, 'v6.x') && github.event.pull_request.merged == true }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/cherry-pick-master-to-v6.yml
+++ b/.github/workflows/cherry-pick-master-to-v6.yml
@@ -1,0 +1,34 @@
+name: Cherry pick master to v6
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: ['closed']
+
+permissions: {}
+
+jobs:
+  cherry_pick_to_v6:
+    runs-on: ubuntu-latest
+    name: Cherry pick into v6
+    permissions:
+      pull-requests: write
+      contents: write
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && contains(github.event.pull_request.labels.*.name, 'v6.x') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Cherry pick and create the new PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: carloscastrojumo/github-cherry-pick-action@a145da1b8142e752d3cbc11aaaa46a535690f0c5 # v1.0.9
+        with:
+          branch: v6.x
+          body: 'Cherry-pick of #{old_pull_request_id}'
+          cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
+          title: '{old_title} (@${{ github.event.pull_request.user.login }})'
+          labels: |
+            cherry-pick


### PR DESCRIPTION
Add an action, which would cherry-pick a PR merged to master into a `v6.x` branch if it would have a `needs cherry-pick` label.

Could be useful for bug fixes during the v7 development / v6 maintenance mode.