### PR TITLE
[core] Limit `test-types` CI step allowed memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
           name: Tests TypeScript definitions
           command: yarn typescript:ci
           environment:
-            NODE_OPTIONS: --max-old-space-size=3072
+            NODE_OPTIONS: --max-old-space-size=2048
   test_e2e:
     <<: *default-job
     docker:


### PR DESCRIPTION
This is a continuation of https://github.com/mui/mui-x/pull/8796.

We again started occasionally seeing 137 errors: https://app.circleci.com/pipelines/github/mui/mui-x/55996/workflows/3785ca42-1a35-41fb-945a-6672ab60ff50/jobs/320388/steps

I assume that the memory limit applies to a single node instance.
Given that Lerna runs 3 concurrent instances at a single point in time, it would mean that theoretically we currently allow a maximum of 9GB of RAM to be used. 🙈 

It doesn't seem to impact the step runtime in a significant way that couldn't be attributed to a difference between runs:

| Before | After |
| ------- | ----- |
| ![Screenshot 2024-04-03 at 17 52 28](https://github.com/mui/mui-x/assets/4941090/368dbf7d-79a0-4345-9573-fb5f31c36280) | ![Screenshot 2024-04-03 at 17 52 19](https://github.com/mui/mui-x/assets/4941090/fb2ae355-3a2d-4116-9987-8224dc486098) |
| https://app.circleci.com/pipelines/github/mui/mui-x/56008/workflows/c845e1fa-28a7-44bf-8d98-a93a4705ae36/jobs/320441/steps | https://app.circleci.com/pipelines/github/mui/mui-x/56001/workflows/74d23679-f599-4320-a60d-30b0d195376f/jobs/320419/steps |

