### PR TITLE
[docs-infra] Prepare infra to document charts interfaces

### DIFF
--- a/docs/scripts/api/buildApi.ts
+++ b/docs/scripts/api/buildApi.ts
@@ -1,13 +1,21 @@
+/* eslint-disable no-await-in-loop */
 import * as yargs from 'yargs';
 import path from 'path';
 import fs from 'fs';
 import * as prettier from 'prettier';
 import kebabCase from 'lodash/kebabCase';
-import buildInterfacesDocumentation from './buildInterfacesDocumentation';
+import {
+  buildApiInterfacesJson,
+  buildInterfacesDocumentationPage,
+} from './buildInterfacesDocumentation';
 import buildExportsDocumentation from './buildExportsDocumentation';
 import buildGridSelectorsDocumentation from './buildGridSelectorsDocumentation';
 import buildGridEventsDocumentation from './buildGridEventsDocumentation';
-import { createXTypeScriptProjects } from '../createXTypeScriptProjects';
+import {
+  XProjectNames,
+  XTypeScriptProjects,
+  createXTypeScriptProjects,
+} from '../createXTypeScriptProjects';
 import { DocumentedInterfaces } from './utils';
 
 const DEFAULT_PRETTIER_CONFIG_PATH = path.join(process.cwd(), 'prettier.config.js');
@@ -47,6 +55,7 @@ const bracketsRegexp = /\[\[([^\]]+)\]\]/g;
 export default async function linkifyTranslation(
   directory: string,
   documentedInterfaces: DocumentedInterfaces,
+  folder: string,
 ) {
   const items = fs.readdirSync(directory);
 
@@ -55,7 +64,7 @@ export default async function linkifyTranslation(
       const itemPath = path.resolve(directory, item);
 
       if (fs.statSync(itemPath).isDirectory()) {
-        await linkifyTranslation(itemPath, documentedInterfaces);
+        await linkifyTranslation(itemPath, documentedInterfaces, folder);
         return;
       }
 
@@ -69,7 +78,7 @@ export default async function linkifyTranslation(
         if (!documentedInterfaces.get(content)) {
           return content;
         }
-        const url = `/x/api/data-grid/${kebabCase(content)}/`;
+        const url = `/x/api/${folder}/${kebabCase(content)}/`;
         return `<a href='${url}'>${content}</a>`;
       });
 
@@ -78,29 +87,111 @@ export default async function linkifyTranslation(
   );
 }
 
+const specialAPIs: { folder: string; packages: XProjectNames[]; documentedInterfaces: string[] }[] =
+  [
+    {
+      folder: 'data-grid',
+      packages: ['x-data-grid', 'x-data-grid-pro', 'x-data-grid-premium', 'x-data-grid-generator'],
+      documentedInterfaces: [
+        // apiRef
+        'GridApi',
+
+        // Params
+        'GridCellParams',
+        'GridRowParams',
+        'GridRowClassNameParams',
+        'GridRowSpacingParams',
+        'GridExportStateParams',
+
+        // Others
+        'GridColDef',
+        'GridSingleSelectColDef',
+        'GridActionsColDef',
+        'GridCsvExportOptions',
+        'GridPrintExportOptions',
+        'GridExcelExportOptions',
+
+        // Filters
+        'GridFilterModel',
+        'GridFilterItem',
+        'GridFilterOperator',
+
+        // Aggregation
+        'GridAggregationFunction',
+      ],
+    },
+    // {
+    //   folder: 'charts',
+    //   packages: ['x-charts'],
+    // },
+  ];
 async function run() {
   const projects = createXTypeScriptProjects();
 
   // Create documentation folder if it does not exist
   const apiPagesFolder = path.resolve('./docs/pages/x/api');
-  const dataGridTranslationFolder = path.resolve('./docs/translations/api-docs/data-grid/');
 
-  const documentedInterfaces = await buildInterfacesDocumentation({
-    projects,
-    apiPagesFolder,
-  });
+  // eslint-disable-next-line no-restricted-syntax
+  for (const { folder, packages, documentedInterfaces } of specialAPIs) {
+    const subProjects: XTypeScriptProjects = new Map();
 
-  await linkifyTranslation(dataGridTranslationFolder, documentedInterfaces);
+    packages.forEach((pck) => {
+      subProjects.set(pck, projects.get(pck)!);
+    });
 
-  await buildGridEventsDocumentation({
-    projects,
-    documentedInterfaces,
-  });
+    // Create translation folder if it does not exist
+    const translationFolder = path.resolve(`./docs/translations/api-docs/${folder}/`);
 
-  await buildGridSelectorsDocumentation({
-    project: projects.get('x-data-grid-premium')!,
-    apiPagesFolder,
-  });
+    const interfacesWithDedicatedPage = await buildInterfacesDocumentationPage({
+      projects: subProjects,
+      translationPagesDirectory: `docs/translations/api-docs/${folder}`,
+      importTranslationPagesDirectory: `docsx/translations/api-docs/${folder}`,
+      apiPagesDirectory: path.join(process.cwd(), `docs/pages/x/api/${folder}`),
+      folder,
+      interfaces: documentedInterfaces,
+    });
+
+    await linkifyTranslation(translationFolder, interfacesWithDedicatedPage, folder);
+
+    if (folder === 'data-grid') {
+      // Generate JSON for some API inerfaces rendered in the `<ApiDocs />` components.
+      // This is API insterted inside some demo pages, and not dedicated pages.
+      await buildApiInterfacesJson({
+        projects: subProjects,
+        apiPagesFolder,
+        folder,
+        interfaces: [
+          'GridCellSelectionApi',
+          'GridColumnPinningApi',
+          'GridColumnResizeApi',
+          'GridCsvExportApi',
+          'GridDetailPanelApi',
+          'GridEditingApi',
+          'GridExcelExportApi',
+          'GridFilterApi',
+          'GridPaginationApi',
+          'GridPrintExportApi',
+          'GridRowGroupingApi',
+          'GridRowMultiSelectionApi',
+          'GridRowSelectionApi',
+          'GridScrollApi',
+          'GridSortApi',
+          'GridVirtualizationApi',
+        ],
+        interfacesWithDedicatedPage,
+      });
+
+      await buildGridEventsDocumentation({
+        projects: subProjects,
+        interfacesWithDedicatedPage,
+      });
+
+      await buildGridSelectorsDocumentation({
+        project: projects.get('x-data-grid-premium')!,
+        apiPagesFolder,
+      });
+    }
+  }
 
   buildExportsDocumentation({
     projects,

--- a/docs/scripts/api/buildApi.ts
+++ b/docs/scripts/api/buildApi.ts
@@ -12,9 +12,10 @@ import buildExportsDocumentation from './buildExportsDocumentation';
 import buildGridSelectorsDocumentation from './buildGridSelectorsDocumentation';
 import buildGridEventsDocumentation from './buildGridEventsDocumentation';
 import {
-  XProjectNames,
   XTypeScriptProjects,
   createXTypeScriptProjects,
+  datagridApiToDocument,
+  interfacesToDocument,
 } from '../createXTypeScriptProjects';
 import { DocumentedInterfaces } from './utils';
 
@@ -87,44 +88,6 @@ export default async function linkifyTranslation(
   );
 }
 
-const specialAPIs: { folder: string; packages: XProjectNames[]; documentedInterfaces: string[] }[] =
-  [
-    {
-      folder: 'data-grid',
-      packages: ['x-data-grid', 'x-data-grid-pro', 'x-data-grid-premium', 'x-data-grid-generator'],
-      documentedInterfaces: [
-        // apiRef
-        'GridApi',
-
-        // Params
-        'GridCellParams',
-        'GridRowParams',
-        'GridRowClassNameParams',
-        'GridRowSpacingParams',
-        'GridExportStateParams',
-
-        // Others
-        'GridColDef',
-        'GridSingleSelectColDef',
-        'GridActionsColDef',
-        'GridCsvExportOptions',
-        'GridPrintExportOptions',
-        'GridExcelExportOptions',
-
-        // Filters
-        'GridFilterModel',
-        'GridFilterItem',
-        'GridFilterOperator',
-
-        // Aggregation
-        'GridAggregationFunction',
-      ],
-    },
-    // {
-    //   folder: 'charts',
-    //   packages: ['x-charts'],
-    // },
-  ];
 async function run() {
   const projects = createXTypeScriptProjects();
 
@@ -132,7 +95,7 @@ async function run() {
   const apiPagesFolder = path.resolve('./docs/pages/x/api');
 
   // eslint-disable-next-line no-restricted-syntax
-  for (const { folder, packages, documentedInterfaces } of specialAPIs) {
+  for (const { folder, packages, documentedInterfaces } of interfacesToDocument) {
     const subProjects: XTypeScriptProjects = new Map();
 
     packages.forEach((pck) => {
@@ -160,24 +123,7 @@ async function run() {
         projects: subProjects,
         apiPagesFolder,
         folder,
-        interfaces: [
-          'GridCellSelectionApi',
-          'GridColumnPinningApi',
-          'GridColumnResizeApi',
-          'GridCsvExportApi',
-          'GridDetailPanelApi',
-          'GridEditingApi',
-          'GridExcelExportApi',
-          'GridFilterApi',
-          'GridPaginationApi',
-          'GridPrintExportApi',
-          'GridRowGroupingApi',
-          'GridRowMultiSelectionApi',
-          'GridRowSelectionApi',
-          'GridScrollApi',
-          'GridSortApi',
-          'GridVirtualizationApi',
-        ],
+        interfaces: datagridApiToDocument,
         interfacesWithDedicatedPage,
       });
 

--- a/docs/scripts/api/buildGridEventsDocumentation.ts
+++ b/docs/scripts/api/buildGridEventsDocumentation.ts
@@ -13,7 +13,7 @@ import { XProjectNames, XTypeScriptProjects } from '../createXTypeScriptProjects
 
 interface BuildEventsDocumentationOptions {
   projects: XTypeScriptProjects;
-  documentedInterfaces: DocumentedInterfaces;
+  interfacesWithDedicatedPage: DocumentedInterfaces;
 }
 
 const GRID_PROJECTS: XProjectNames[] = ['x-data-grid', 'x-data-grid-pro', 'x-data-grid-premium'];
@@ -21,7 +21,7 @@ const GRID_PROJECTS: XProjectNames[] = ['x-data-grid', 'x-data-grid-pro', 'x-dat
 export default async function buildGridEventsDocumentation(
   options: BuildEventsDocumentationOptions,
 ) {
-  const { projects, documentedInterfaces } = options;
+  const { projects, interfacesWithDedicatedPage } = options;
 
   const events: {
     [eventName: string]: {
@@ -61,8 +61,9 @@ export default async function buildGridEventsDocumentation(
 
           const description = linkify(
             getSymbolDescription(event, project),
-            documentedInterfaces,
+            interfacesWithDedicatedPage,
             'html',
+            'data-grid',
           );
 
           const eventParams: { [key: string]: string } = {};
@@ -80,7 +81,7 @@ export default async function buildGridEventsDocumentation(
             projects: [project.name],
             name: event.name,
             description: renderMarkdown(description),
-            params: linkify(eventParams.params, documentedInterfaces, 'html'),
+            params: linkify(eventParams.params, interfacesWithDedicatedPage, 'html', 'data-grid'),
             event: `MuiEvent<${eventParams.event ?? '{}'}>`,
           };
         }

--- a/docs/scripts/api/buildInterfacesDocumentation.ts
+++ b/docs/scripts/api/buildInterfacesDocumentation.ts
@@ -39,57 +39,6 @@ interface ParsedProperty {
   projects: XProjectNames[];
 }
 
-const translationPagesDirectory = 'docs/translations/api-docs/data-grid';
-const importTranslationPagesDirectory = 'docsx/translations/api-docs/data-grid';
-const apiPagesDirectory = path.join(process.cwd(), `docs/pages/x/api/data-grid`);
-
-const GRID_API_INTERFACES_WITH_DEDICATED_PAGES = [
-  'GridCellSelectionApi',
-  'GridColumnPinningApi',
-  'GridColumnResizeApi',
-  'GridCsvExportApi',
-  'GridDetailPanelApi',
-  'GridEditingApi',
-  'GridExcelExportApi',
-  'GridFilterApi',
-  'GridPaginationApi',
-  'GridPrintExportApi',
-  'GridRowGroupingApi',
-  'GridRowMultiSelectionApi',
-  'GridRowSelectionApi',
-  'GridScrollApi',
-  'GridSortApi',
-  'GridVirtualizationApi',
-];
-
-const OTHER_GRID_INTERFACES_WITH_DEDICATED_PAGES = [
-  // apiRef
-  'GridApi',
-
-  // Params
-  'GridCellParams',
-  'GridRowParams',
-  'GridRowClassNameParams',
-  'GridRowSpacingParams',
-  'GridExportStateParams',
-
-  // Others
-  'GridColDef',
-  'GridSingleSelectColDef',
-  'GridActionsColDef',
-  'GridCsvExportOptions',
-  'GridPrintExportOptions',
-  'GridExcelExportOptions',
-
-  // Filters
-  'GridFilterModel',
-  'GridFilterItem',
-  'GridFilterOperator',
-
-  // Aggregation
-  'GridAggregationFunction',
-];
-
 const parseProperty = async (
   propertySymbol: ts.Symbol,
   project: XTypeScriptProject,
@@ -111,11 +60,10 @@ interface ProjectInterface {
 
 const parseInterfaceSymbol = async (
   interfaceName: string,
-  documentedInterfaces: DocumentedInterfaces,
+  packagesWithThisInterface: XProjectNames[],
   projects: XTypeScriptProjects,
 ): Promise<ParsedObject | null> => {
-  const projectInterfaces = documentedInterfaces
-    .get(interfaceName)!
+  const projectInterfaces = packagesWithThisInterface
     .map((projectName) => {
       const project = projects.get(projectName)!;
 
@@ -177,14 +125,17 @@ const parseInterfaceSymbol = async (
   return parsedInterface;
 };
 
+const isPro = (project: string) => project.includes('-pro');
+const isPremium = (project: string) => project.includes('-premium');
+
 function getPlanLevel(property: ParsedProperty) {
-  if (property.projects.includes('x-data-grid')) {
+  if (property.projects.some((project) => !isPro(project) && !isPremium(project))) {
     return '';
   }
-  if (property.projects.includes('x-data-grid-pro')) {
+  if (property.projects.some(isPro)) {
     return 'pro';
   }
-  if (property.projects.includes('x-data-grid-premium')) {
+  if (property.projects.some(isPremium)) {
     return 'premium';
   }
   throw new Error(`No valid plan found for ${property.name} property`);
@@ -228,23 +179,99 @@ function extractDemos(tagInfo: ts.JSDocTagInfo): { demos?: string } {
   return { demos: `<ul>${demos.join('\n')}</ul>` };
 }
 
-interface BuildInterfacesDocumentationOptions {
+interface BuildInterfacesCommonOptions {
   projects: XTypeScriptProjects;
-  apiPagesFolder: string;
+  folder: string;
+  /**
+   * An array of the interfaces to process.
+   */
+  interfaces: string[];
 }
 
-export default async function buildInterfacesDocumentation(
-  options: BuildInterfacesDocumentationOptions,
+type BuildApiInterfacesJsonOptions = BuildInterfacesCommonOptions & {
+  apiPagesFolder: string;
+  interfacesWithDedicatedPage: DocumentedInterfaces;
+};
+
+export async function buildApiInterfacesJson(options: BuildApiInterfacesJsonOptions) {
+  const { projects, apiPagesFolder, folder, interfaces, interfacesWithDedicatedPage } = options;
+
+  const allProjectsName = Array.from(projects.keys());
+
+  await Promise.all(
+    interfaces.map(async (interfaceName) => {
+      const packagesWithThisInterface = allProjectsName.filter(
+        (projectName) => !!projects.get(projectName)!.exports[interfaceName],
+      );
+
+      if (packagesWithThisInterface.length === 0) {
+        throw new Error(`Can't find symbol for ${interfaceName}`);
+      }
+
+      const project = projects.get(packagesWithThisInterface[0])!;
+      // eslint-disable-next-line no-await-in-loop
+      const parsedInterface = await parseInterfaceSymbol(
+        interfaceName,
+        packagesWithThisInterface,
+        projects,
+      );
+      if (!parsedInterface) {
+        return;
+      }
+
+      const slug = kebabCase(parsedInterface.name);
+
+      const json = {
+        name: parsedInterface.name,
+        description: linkify(
+          parsedInterface.description,
+          interfacesWithDedicatedPage,
+          'html',
+          folder,
+        ),
+        properties: parsedInterface.properties.map((property) => ({
+          name: property.name,
+          description: renderMarkdown(
+            linkify(property.description, interfacesWithDedicatedPage, 'html', folder),
+          ),
+          type: property.typeStr,
+        })),
+      };
+      // eslint-disable-next-line no-await-in-loop
+      await writePrettifiedFile(
+        path.resolve(apiPagesFolder, project.documentationFolderName, `${slug}.json`),
+        JSON.stringify(json),
+        project,
+      );
+      // eslint-disable-next-line no-console
+      console.log('Built JSON file for', parsedInterface.name);
+    }),
+  );
+}
+
+type BuildInterfacesDocumentationPageOptions = BuildInterfacesCommonOptions & {
+  apiPagesDirectory: string;
+  translationPagesDirectory: string;
+  importTranslationPagesDirectory: string;
+};
+
+export async function buildInterfacesDocumentationPage(
+  options: BuildInterfacesDocumentationPageOptions,
 ) {
-  const { projects, apiPagesFolder } = options;
+  const {
+    projects,
+    apiPagesDirectory,
+    translationPagesDirectory,
+    importTranslationPagesDirectory,
+    folder,
+    interfaces,
+  } = options;
 
   const allProjectsName = Array.from(projects.keys());
 
   const documentedInterfaces: DocumentedInterfaces = new Map();
-  [
-    ...OTHER_GRID_INTERFACES_WITH_DEDICATED_PAGES,
-    ...GRID_API_INTERFACES_WITH_DEDICATED_PAGES,
-  ].forEach((interfaceName) => {
+
+  interfaces.forEach((interfaceName) => {
     const packagesWithThisInterface = allProjectsName.filter(
       (projectName) => !!projects.get(projectName)!.exports[interfaceName],
     );
@@ -264,7 +291,7 @@ export default async function buildInterfacesDocumentation(
     // eslint-disable-next-line no-await-in-loop
     const parsedInterface = await parseInterfaceSymbol(
       interfaceName,
-      documentedInterfaces,
+      packagesWithThisInterface,
       projects,
     );
     if (!parsedInterface) {
@@ -273,94 +300,80 @@ export default async function buildInterfacesDocumentation(
 
     const slug = kebabCase(parsedInterface.name);
 
-    if (GRID_API_INTERFACES_WITH_DEDICATED_PAGES.includes(parsedInterface.name)) {
-      const json = {
-        name: parsedInterface.name,
-        description: linkify(parsedInterface.description, documentedInterfaces, 'html'),
-        properties: parsedInterface.properties.map((property) => ({
-          name: property.name,
-          description: renderMarkdown(linkify(property.description, documentedInterfaces, 'html')),
-          type: property.typeStr,
-        })),
-      };
-      // eslint-disable-next-line no-await-in-loop
-      await writePrettifiedFile(
-        path.resolve(apiPagesFolder, project.documentationFolderName, `${slug}.json`),
-        JSON.stringify(json),
-        project,
-      );
-      // eslint-disable-next-line no-console
-      console.log('Built JSON file for', parsedInterface.name);
-    } else {
-      const content = {
-        name: parsedInterface.name,
-        imports: generateImportStatement(parsedInterface, projects),
-        ...extractDemos(parsedInterface.tags.demos),
-        properties: {},
-      };
+    const content = {
+      name: parsedInterface.name,
+      imports: generateImportStatement(parsedInterface, projects),
+      ...extractDemos(parsedInterface.tags.demos),
+      properties: {},
+    };
 
-      const translations = {
-        interfaceDescription: renderMarkdown(
-          linkify(escapeCell(parsedInterface.description || ''), documentedInterfaces, 'html'),
+    const translations = {
+      interfaceDescription: renderMarkdown(
+        linkify(
+          escapeCell(parsedInterface.description || ''),
+          documentedInterfaces,
+          'html',
+          folder,
         ),
-        propertiesDescriptions: {},
-      };
+      ),
+      propertiesDescriptions: {},
+    };
 
-      parsedInterface.properties
-        .map((property) => ({
-          name: property.name,
-          description: renderMarkdown(
-            linkify(escapeCell(property.description), documentedInterfaces, 'html'),
-          ),
-          type: { description: escapeCell(property.typeStr) },
-          default: getDefaultValue(property),
-          planLevel: getPlanLevel(property),
-          required: property.required,
-        }))
-        .sort((a, b) => {
-          if ((a.required && b.required) || (!a.required && !b.required)) {
-            return a.name.localeCompare(b.name);
-          }
-          if (a.required) {
-            return -1;
-          }
-          return 1;
-        })
-        .forEach(({ name, description, type, default: defaultValue, required, planLevel }) => {
-          content.properties[name] = { type };
-          if (defaultValue) {
-            content.properties[name].default = defaultValue;
-          }
-          if (required) {
-            content.properties[name].required = required;
-          }
-          if (planLevel === 'pro') {
-            content.properties[name].isProPlan = true;
-          }
-          if (planLevel === 'premium') {
-            content.properties[name].isPremiumPlan = true;
-          }
-          translations.propertiesDescriptions[name] = { description };
-        });
+    parsedInterface.properties
+      .map((property) => ({
+        name: property.name,
+        description: renderMarkdown(
+          linkify(escapeCell(property.description), documentedInterfaces, 'html', folder),
+        ),
+        type: { description: escapeCell(property.typeStr) },
+        default: getDefaultValue(property),
+        planLevel: getPlanLevel(property),
+        required: property.required,
+      }))
+      .sort((a, b) => {
+        if ((a.required && b.required) || (!a.required && !b.required)) {
+          return a.name.localeCompare(b.name);
+        }
+        if (a.required) {
+          return -1;
+        }
+        return 1;
+      })
+      .forEach(({ name, description, type, default: defaultValue, required, planLevel }) => {
+        content.properties[name] = { type };
+        if (defaultValue) {
+          content.properties[name].default = defaultValue;
+        }
+        if (required) {
+          content.properties[name].required = required;
+        }
+        if (planLevel === 'pro') {
+          content.properties[name].isProPlan = true;
+        }
+        if (planLevel === 'premium') {
+          content.properties[name].isPremiumPlan = true;
+        }
+        translations.propertiesDescriptions[name] = { description };
+      });
 
-      // eslint-disable-next-line no-await-in-loop
-      await writePrettifiedFile(
-        path.resolve(apiPagesDirectory, `${slug}.json`),
-        JSON.stringify(content),
-        project,
-      );
+    // eslint-disable-next-line no-await-in-loop
+    await writePrettifiedFile(
+      path.resolve(apiPagesDirectory, `${slug}.json`),
+      JSON.stringify(content),
+      project,
+    );
 
-      // eslint-disable-next-line no-await-in-loop
-      await writePrettifiedFile(
-        path.resolve(translationPagesDirectory, `${slug}.json`),
-        JSON.stringify(translations),
-        project,
-      );
+    // eslint-disable-next-line no-await-in-loop
+    await writePrettifiedFile(
+      path.resolve(translationPagesDirectory, `${slug}.json`),
+      JSON.stringify(translations),
+      project,
+    );
 
-      // eslint-disable-next-line no-await-in-loop
-      await writePrettifiedFile(
-        path.resolve(apiPagesDirectory, `${slug}.js`),
-        `import * as React from 'react';
+    // eslint-disable-next-line no-await-in-loop
+    await writePrettifiedFile(
+      path.resolve(apiPagesDirectory, `${slug}.js`),
+      `import * as React from 'react';
     import InterfaceApiPage from 'docsx/src/modules/components/InterfaceApiPage';
     import layoutConfig from 'docsx/src/modules/utils/dataGridLayoutConfig';
     import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
@@ -385,12 +398,11 @@ export default async function buildInterfacesDocumentation(
       };
     };
     `.replace(/\r?\n/g, EOL),
-        project,
-      );
+      project,
+    );
 
-      // eslint-disable-next-line no-console
-      console.log('Built API docs for', parsedInterface.name);
-    }
+    // eslint-disable-next-line no-console
+    console.log('Built API docs for', parsedInterface.name);
   }
 
   return documentedInterfaces;

--- a/docs/scripts/api/buildInterfacesDocumentation.ts
+++ b/docs/scripts/api/buildInterfacesDocumentation.ts
@@ -209,7 +209,7 @@ export async function buildApiInterfacesJson(options: BuildApiInterfacesJsonOpti
       }
 
       const project = projects.get(packagesWithThisInterface[0])!;
-      // eslint-disable-next-line no-await-in-loop
+
       const parsedInterface = await parseInterfaceSymbol(
         interfaceName,
         packagesWithThisInterface,
@@ -237,7 +237,7 @@ export async function buildApiInterfacesJson(options: BuildApiInterfacesJsonOpti
           type: property.typeStr,
         })),
       };
-      // eslint-disable-next-line no-await-in-loop
+
       await writePrettifiedFile(
         path.resolve(apiPagesFolder, project.documentationFolderName, `${slug}.json`),
         JSON.stringify(json),

--- a/docs/scripts/api/utils.ts
+++ b/docs/scripts/api/utils.ts
@@ -69,6 +69,7 @@ export function linkify(
   text: string | undefined,
   documentedInterfaces: DocumentedInterfaces,
   format: 'markdown' | 'html',
+  folder: string,
 ) {
   if (text == null) {
     return '';
@@ -79,7 +80,7 @@ export function linkify(
     if (!documentedInterfaces.get(content)) {
       return content;
     }
-    const url = `/x/api/data-grid/${kebabCase(content)}/`;
+    const url = `/x/api/${folder}/${kebabCase(content)}/`;
     return format === 'markdown' ? `[${content}](${url})` : `<a href="${url}">${content}</a>`;
   });
 }

--- a/docs/scripts/createXTypeScriptProjects.ts
+++ b/docs/scripts/createXTypeScriptProjects.ts
@@ -114,6 +114,69 @@ const getComponentPaths =
     return paths;
   };
 
+type InterfacesToDocumentType = {
+  folder: string;
+  packages: XProjectNames[];
+  documentedInterfaces: string[];
+};
+
+export const interfacesToDocument: InterfacesToDocumentType[] = [
+  {
+    folder: 'data-grid',
+    packages: ['x-data-grid', 'x-data-grid-pro', 'x-data-grid-premium', 'x-data-grid-generator'],
+    documentedInterfaces: [
+      // apiRef
+      'GridApi',
+
+      // Params
+      'GridCellParams',
+      'GridRowParams',
+      'GridRowClassNameParams',
+      'GridRowSpacingParams',
+      'GridExportStateParams',
+
+      // Others
+      'GridColDef',
+      'GridSingleSelectColDef',
+      'GridActionsColDef',
+      'GridCsvExportOptions',
+      'GridPrintExportOptions',
+      'GridExcelExportOptions',
+
+      // Filters
+      'GridFilterModel',
+      'GridFilterItem',
+      'GridFilterOperator',
+
+      // Aggregation
+      'GridAggregationFunction',
+    ],
+  },
+  // {
+  //   folder: 'charts',
+  //   packages: ['x-charts'],
+  // },
+];
+
+export const datagridApiToDocument = [
+  'GridCellSelectionApi',
+  'GridColumnPinningApi',
+  'GridColumnResizeApi',
+  'GridCsvExportApi',
+  'GridDetailPanelApi',
+  'GridEditingApi',
+  'GridExcelExportApi',
+  'GridFilterApi',
+  'GridPaginationApi',
+  'GridPrintExportApi',
+  'GridRowGroupingApi',
+  'GridRowMultiSelectionApi',
+  'GridRowSelectionApi',
+  'GridScrollApi',
+  'GridSortApi',
+  'GridVirtualizationApi',
+];
+
 export const createXTypeScriptProjects = () => {
   const projects: XTypeScriptProjects = new Map();
 


### PR DESCRIPTION
1.Isolate the interfaces docs pages from the API JSON generation
2. Allow to get interfaces from some specific packages
3. Remove most of the hard coded values specific to the data grid 

This PR is used to add interfaces for x-charts in https://github.com/mui/mui-x/pull/12656

Could be used the same way to add interfaces pages for tree view