### PR TITLE
[charts] Fix typescript error when using `sx` property on ChartsTooltip

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled, useThemeProps } from '@mui/material/styles';
-import Popper, { PopperProps } from '@mui/material/Popper';
+import { Popper, PopperProps as BasePopperProps } from '@mui/base/Popper';
 import { NoSsr } from '@mui/base/NoSsr';
 import { useSlotProps } from '@mui/base/utils';
+import { SxProps, Theme } from '@mui/system';
 import {
   AxisInteractionData,
   InteractionContext,
@@ -20,6 +21,13 @@ import { ChartSeriesType } from '../models/seriesType/config';
 import { ChartsItemContentProps, ChartsItemTooltipContent } from './ChartsItemTooltipContent';
 import { ChartsAxisContentProps, ChartsAxisTooltipContent } from './ChartsAxisTooltipContent';
 import { ChartsTooltipClasses, getChartsTooltipUtilityClass } from './chartsTooltipClasses';
+
+export type PopperProps = BasePopperProps & {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+};
 
 export interface ChartsTooltipSlots {
   /**

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
-import { styled, useThemeProps } from '@mui/material/styles';
+import { styled, useThemeProps, SxProps, Theme } from '@mui/material/styles';
 import { Popper, PopperProps as BasePopperProps } from '@mui/base/Popper';
 import { NoSsr } from '@mui/base/NoSsr';
 import { useSlotProps } from '@mui/base/utils';
-import { SxProps, Theme } from '@mui/system';
 import {
   AxisInteractionData,
   InteractionContext,

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
 import { styled, useThemeProps } from '@mui/material/styles';
-import { Popper, PopperProps } from '@mui/base/Popper';
+import Popper, { PopperProps } from '@mui/material/Popper';
 import { NoSsr } from '@mui/base/NoSsr';
 import { useSlotProps } from '@mui/base/utils';
 import {

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -227,6 +227,7 @@
   { "name": "PiePlotSlots", "kind": "Interface" },
   { "name": "PieSeriesType", "kind": "Interface" },
   { "name": "PieValueType", "kind": "TypeAlias" },
+  { "name": "PopperProps", "kind": "TypeAlias" },
   { "name": "referenceLineClasses", "kind": "Variable" },
   { "name": "ResponsiveChartContainer", "kind": "Variable" },
   { "name": "ResponsiveChartContainerProps", "kind": "Interface" },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The cause for this is that `@mui/base/Popper` doesn't seen to have the sx property.

I've re-exported a `PopperProps` property with the added `sx` prop. I decided on having the property be exported from the lib in order for users to be able to use it somewhere else.  

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
