### PR TITLE
[DataGrid] Remove GridFormatterParams completely

### DIFF
--- a/docs/data/data-grid/aggregation/AggregationValueFormatter.js
+++ b/docs/data/data-grid/aggregation/AggregationValueFormatter.js
@@ -45,7 +45,7 @@ const firstAlphabeticalAggregation = {
     return sortedValue[0];
   },
   label: 'first alphabetical',
-  valueFormatter: (params) => `Agg: ${params.value}`,
+  valueFormatter: (value) => `Agg: ${value}`,
   columnTypes: ['string'],
 };
 

--- a/docs/data/data-grid/aggregation/AggregationValueFormatter.tsx
+++ b/docs/data/data-grid/aggregation/AggregationValueFormatter.tsx
@@ -48,7 +48,7 @@ const firstAlphabeticalAggregation: GridAggregationFunction<string, string | nul
       return sortedValue[0];
     },
     label: 'first alphabetical',
-    valueFormatter: (params) => `Agg: ${params.value}`,
+    valueFormatter: (value) => `Agg: ${value}`,
     columnTypes: ['string'],
   };
 

--- a/docs/pages/x/api/data-grid/grid-aggregation-function.json
+++ b/docs/pages/x/api/data-grid/grid-aggregation-function.json
@@ -25,9 +25,6 @@
       "default": "apiRef.current.getLocaleText('aggregationFunctionLabel{capitalize(name)})",
       "isPremiumPlan": true
     },
-    "valueFormatter": {
-      "type": { "description": "(params: GridValueFormatterParams&lt;AV&gt;) =&gt; FAV" },
-      "isPremiumPlan": true
-    }
+    "valueFormatter": { "type": { "description": "GridValueFormatter" }, "isPremiumPlan": true }
   }
 }

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationFunctions.ts
@@ -1,4 +1,3 @@
-import { GridValueFormatterParams } from '@mui/x-data-grid-pro';
 import { isNumber } from '@mui/x-data-grid-pro/internals';
 import { GridAggregationFunction } from './gridAggregationInterfaces';
 
@@ -80,12 +79,12 @@ const sizeAgg: GridAggregationFunction<unknown, number> = {
   apply: ({ values }) => {
     return values.filter((value) => typeof value !== 'undefined').length;
   },
-  valueFormatter: (params: GridValueFormatterParams) => {
-    if (params.value == null || !isNumber(params.value)) {
-      return params.value;
+  valueFormatter: (value: number | string | null) => {
+    if (value == null || !isNumber(value)) {
+      return value;
     }
 
-    return params.value.toLocaleString();
+    return value.toLocaleString();
   },
   hasCellUnit: false,
 };

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationInterfaces.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationInterfaces.ts
@@ -1,9 +1,4 @@
-import {
-  GridValueFormatterParams,
-  GridRowId,
-  GridRowModel,
-  GridColDef,
-} from '@mui/x-data-grid-pro';
+import { GridRowId, GridRowModel, GridColDef, GridValueFormatter } from '@mui/x-data-grid-pro';
 
 export interface GridAggregationState {
   model: GridAggregationModel;
@@ -39,7 +34,7 @@ export interface GridAggregationGetCellValueParams {
  * @demos
  *   - [Aggregation functions](/x/react-data-grid/aggregation/#aggregation-functions)
  */
-export interface GridAggregationFunction<V = any, AV = V, FAV = AV> {
+export interface GridAggregationFunction<V = any, AV = V> {
   /**
    * Function that takes the current cell values and generates the aggregated value.
    * @template V, AV
@@ -61,11 +56,8 @@ export interface GridAggregationFunction<V = any, AV = V, FAV = AV> {
   /**
    * Function that allows to apply a formatter to the aggregated value.
    * If not defined, the grid will use the formatter of the column.
-   * @template AV, F
-   * @param {GridValueFormatterParams<AV>} params Object containing parameters for the formatter.
-   * @returns {F} The formatted value.
    */
-  valueFormatter?: (params: GridValueFormatterParams<AV>) => FAV;
+  valueFormatter?: GridValueFormatter;
   /**
    * Indicates if the aggregated value have the same unit as the cells used to generate it.
    * It can be used to apply a custom cell renderer only if the aggregated value has the same unit.

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/wrapColumnWithAggregation.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/wrapColumnWithAggregation.tsx
@@ -78,12 +78,7 @@ const getAggregationValueWrappedValueFormatter: ColumnPropertyWrapper<'valueForm
     if (rowId != null) {
       const cellAggregationResult = getCellAggregationResult(rowId, column.field);
       if (cellAggregationResult != null) {
-        return aggregationRule.aggregationFunction.valueFormatter?.({
-          id: rowId,
-          field: column.field,
-          value,
-          api: apiRef.current,
-        });
+        return aggregationRule.aggregationFunction.valueFormatter?.(value, row, column, apiRef);
       }
     }
 

--- a/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -641,7 +641,7 @@ describe('<DataGridPremium /> - Aggregation', () => {
     it('should use the aggregation function valueFormatter if defined', () => {
       const customAggregationFunction: GridAggregationFunction = {
         apply: () => 'Agg value',
-        valueFormatter: (params) => `+ ${params.value}`,
+        valueFormatter: (value) => `+ ${value}`,
       };
 
       render(

--- a/packages/x-data-grid/src/models/params/gridCellParams.ts
+++ b/packages/x-data-grid/src/models/params/gridCellParams.ts
@@ -109,29 +109,6 @@ export interface GridRenderEditCellParams<
 }
 
 /**
- * Object passed as parameter in the column [[GridColDef]] value formatter callback.
- */
-export interface GridValueFormatterParams<V = any> {
-  /**
-   * The grid row id.
-   * It is not available when the value formatter is called by the filter panel.
-   */
-  id?: GridRowId;
-  /**
-   * The column field of the cell that triggered the event.
-   */
-  field: string;
-  /**
-   * The cell value, if the column has valueGetter it is the value returned by it.
-   */
-  value: V;
-  /**
-   * GridApi that let you manipulate the grid.
-   */
-  api: GridApiCommunity;
-}
-
-/**
  * Object passed as parameter in the column [[GridColDef]] edit cell props change callback.
  */
 export interface GridPreProcessEditCellProps<V = any, R extends GridValidRowModel = any> {

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -588,7 +588,6 @@
   { "name": "GridUpdateAction", "kind": "TypeAlias" },
   { "name": "GridValidRowModel", "kind": "TypeAlias" },
   { "name": "GridValueFormatter", "kind": "TypeAlias" },
-  { "name": "GridValueFormatterParams", "kind": "Interface" },
   { "name": "GridValueGetter", "kind": "TypeAlias" },
   { "name": "GridValueOptionsParams", "kind": "Interface" },
   { "name": "GridValueParser", "kind": "TypeAlias" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -542,7 +542,6 @@
   { "name": "GridUpdateAction", "kind": "TypeAlias" },
   { "name": "GridValidRowModel", "kind": "TypeAlias" },
   { "name": "GridValueFormatter", "kind": "TypeAlias" },
-  { "name": "GridValueFormatterParams", "kind": "Interface" },
   { "name": "GridValueGetter", "kind": "TypeAlias" },
   { "name": "GridValueOptionsParams", "kind": "Interface" },
   { "name": "GridValueParser", "kind": "TypeAlias" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -501,7 +501,6 @@
   { "name": "GridUpdateAction", "kind": "TypeAlias" },
   { "name": "GridValidRowModel", "kind": "TypeAlias" },
   { "name": "GridValueFormatter", "kind": "TypeAlias" },
-  { "name": "GridValueFormatterParams", "kind": "Interface" },
   { "name": "GridValueGetter", "kind": "TypeAlias" },
   { "name": "GridValueOptionsParams", "kind": "Interface" },
   { "name": "GridValueParser", "kind": "TypeAlias" },


### PR DESCRIPTION
Closes #12658 

We didn't complete this breaking change. This is now a bug at runtime for users, so we need to remove it even if we didn't do it at v7 release.