### PR TITLE
[DataGrid] Fix server-side filter demo not working

### DIFF
--- a/packages/x-data-grid-generator/src/hooks/useQuery.ts
+++ b/packages/x-data-grid-generator/src/hooks/useQuery.ts
@@ -100,7 +100,7 @@ const getFilteredRows = (
   return rows.filter((row: GridRowModel) =>
     filterModel.items.every((_, index) => {
       const value = valueGetters[index](row);
-      return filterFunctions[index] === null ? true : filterFunctions[index]({ value });
+      return filterFunctions[index] === null ? true : filterFunctions[index](value);
     }),
   );
 };


### PR DESCRIPTION
Fixes #12661

We updated the signature of ApplyFilterFunction in [this PR](https://github.com/mui/mui-x/pull/9254/files#diff-a5d39315fa266575b09805ca877789bd276c55b17ddb8ea3d271803bcd9eec29R12-R17) but didn't update it in `useQuery`. In v7, when we [removed](https://github.com/mui/mui-x/pull/10897) the legacy filter, the demo started to break.

I first spotted and fixed it in #12317, but a separate fix would be better.