### PR TITLE
[DataGrid] Fix `ColDefChangesGridNoSnap` demo crash

### DIFF
--- a/docs/data/migration/migration-data-grid-v6/ColDefChangesGridNoSnap.js
+++ b/docs/data/migration/migration-data-grid-v6/ColDefChangesGridNoSnap.js
@@ -115,6 +115,7 @@ export default function ColDefChangesGridNoSnap() {
     <div style={{ width: '100%' }}>
       <DataGridPremium
         hideFooter
+        disableColumnMenu
         autoHeight
         columns={columns}
         rows={rows}


### PR DESCRIPTION
Fixes #12628

No need to allow column menu operations on this demo, since this is mostly meant for informational purposes