### PR TITLE
[support-infra] fixes user permission check

### DIFF
--- a/.github/workflows/closed-issue-message.yaml
+++ b/.github/workflows/closed-issue-message.yaml
@@ -29,6 +29,7 @@ jobs:
         id: checkUser
         with:
           require: 'write'
+          username: ${{ github.event.issue.user.login }}
       - name: Add comment for outside contributors
         if: steps.checkUser.outputs.check-result == 'false'
         run: gh issue comment "$NUMBER" --body "$BODY $APPENDIX"

--- a/.github/workflows/closed-issue-message.yaml
+++ b/.github/workflows/closed-issue-message.yaml
@@ -31,8 +31,8 @@ jobs:
           require: 'write'
           username: ${{ github.event.issue.user.login }}
       - name: Add comment for outside contributors
-        if: steps.checkUser.outputs.check-result == 'false'
+        if: steps.checkUser.outputs.check-result == false
         run: gh issue comment "$NUMBER" --body "$BODY $APPENDIX"
       - name: Add comment for maintainers
-        if: steps.checkUser.outputs.check-result == 'true'
+        if: steps.checkUser.outputs.check-result == true
         run: gh issue comment "$NUMBER" --body "$BODY"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
---
the default username that gets checked is the one that triggered the state change (closed the issue), but for this we need to check if the user that opened the issue has the required permissions.

It also fixes the result check to use booleans