### PR TITLE
[charts] Fix Scatter series highlight when id is a `number`

### DIFF
--- a/docs/translations/api-docs/charts/charts-voronoi-handler/charts-voronoi-handler.json
+++ b/docs/translations/api-docs/charts/charts-voronoi-handler/charts-voronoi-handler.json
@@ -4,8 +4,8 @@
     "onItemClick": {
       "description": "Callback fired when clicking on a scatter item.",
       "typeDescriptions": {
-        "event": "Mouse event catched at the svg level",
-        "scatterItemIdentifier": "Identify whihc item got clicked"
+        "event": "Mouse event caught at the svg level",
+        "scatterItemIdentifier": "Identify which item got clicked"
       }
     },
     "voronoiMaxRadius": {

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -19,8 +19,8 @@ export type ChartsVoronoiHandlerProps = {
   voronoiMaxRadius?: number | undefined;
   /**
    * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event Mouse event catched at the svg level
-   * @param {ScatterItemIdentifier} scatterItemIdentifier Identify whihc item got clicked
+   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick?: (event: MouseEvent, scatterItemIdentifier: ScatterItemIdentifier) => void;
 };
@@ -85,7 +85,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       return undefined;
     }
 
-    // TODO: A perf optimisation of voronoi could be to use the last point as the intial point for the next search.
+    // TODO: A perf optimisation of voronoi could be to use the last point as the initial point for the next search.
     function getClosestPoint(
       event: MouseEvent,
     ):
@@ -191,8 +191,8 @@ ChartsVoronoiHandler.propTypes = {
   // ----------------------------------------------------------------------
   /**
    * Callback fired when clicking on a scatter item.
-   * @param {MouseEvent} event Mouse event catched at the svg level
-   * @param {ScatterItemIdentifier} scatterItemIdentifier Identify whihc item got clicked
+   * @param {MouseEvent} event Mouse event caught at the svg level
+   * @param {ScatterItemIdentifier} scatterItemIdentifier Identify which item got clicked
    */
   onItemClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -26,7 +26,7 @@ export type ChartsVoronoiHandlerProps = {
 };
 
 type VoronoiSeries = { seriesId: SeriesId; startIndex: number; endIndex: number };
-export const isSeries = (obj: any): obj is VoronoiSeries => 'seriesId' in obj;
+const isSeries = (obj: any): obj is VoronoiSeries => 'seriesId' in obj;
 
 function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
   const { voronoiMaxRadius, onItemClick } = props;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Issue was due to `Object.keys()` returning an array of strings even if the keys are numbers.

This fix stores the `seriesId` as a property inside the series object to avoid the issue mentioned above.

Fixes #12603 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
