### PR TITLE
[docs] Cover webpack 4 support in migration guide

### DIFF
--- a/docs/data/migration/migration-charts-v6/migration-charts-v6.md
+++ b/docs/data/migration/migration-charts-v6/migration-charts-v6.md
@@ -47,7 +47,7 @@ Dropping old browsers support also means that we no longer transpile some featur
 
 These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
 
-Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` preset:
 
 ```diff
  // webpack.config.js

--- a/docs/data/migration/migration-charts-v6/migration-charts-v6.md
+++ b/docs/data/migration/migration-charts-v6/migration-charts-v6.md
@@ -41,6 +41,36 @@ The `legacy` bundle that used to support old browsers like IE 11 is no longer i
 If you need support for IE 11, you will need to keep using the latest version of the `v6` release.
 :::
 
+### Drop Webpack 4 support
+
+Dropping old browsers support also means that we no longer transpile some features that are natively supported by modern browsers – like [Nullish Coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and [Optional Chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
+
+These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
+
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+
+```diff
+ // webpack.config.js
+
+ module.exports = (env) => ({
+   // ...
+   module: {
+     rules: [
+       {
+         test: /\.[jt]sx?$/,
+-        exclude: /node_modules/,
++        exclude: [
++          {
++            test: path.resolve(__dirname, 'node_modules'),
++            exclude: [path.resolve(__dirname, 'node_modules/@mui/x-charts')],
++          },
++        ],
+       },
+     ],
+   },
+ });
+```
+
 ### Renaming
 
 #### Types

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -130,6 +130,7 @@ Here is an example of how you can transpile these features on Webpack 4 using th
 +          {
 +            test: path.resolve(__dirname, 'node_modules'),
 +            exclude: [
++              // Covers @mui/x-data-grid, @mui/x-data-grid-pro, and @mui/x-data-grid-premium
 +              path.resolve(__dirname, 'node_modules/@mui/x-data-grid'),
 +              path.resolve(__dirname, 'node_modules/@mui/x-license'),
 +            ],

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -108,13 +108,13 @@ The `legacy` bundle that used to support old browsers like IE 11 is no longer i
 If you need support for IE 11, you will need to keep using the latest version of the `v6` release.
 :::
 
-### Drop webpack 4 support
+### Drop Webpack 4 support
 
 Dropping old browsers support also means that we no longer transpile some features that are natively supported by modern browsers – like [Nullish Coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and [Optional Chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
 
-These features are not supported by webpack 4, so if you are using webpack 4, you will need to transpile these features yourself or upgrade to webpack 5.
+These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
 
-Here is an example of how you can transpile these features for webpack 4 using `@babel/preset-env` plugin:
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
 
 ```diff
  // webpack.config.js

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -135,14 +135,6 @@ Here is an example of how you can transpile these features on Webpack 4 using th
 +            ],
 +          },
 +        ],
-         use: [
-           {
-             loader: 'babel-loader',
-             options: {
-               presets: ['@babel/preset-env', '@babel/preset-react'],
-             },
-           },
-         ],
        },
      ],
    },

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -108,6 +108,47 @@ The `legacy` bundle that used to support old browsers like IE 11 is no longer i
 If you need support for IE 11, you will need to keep using the latest version of the `v6` release.
 :::
 
+### Drop webpack 4 support
+
+Dropping old browsers support also means that we no longer transpile some features that are natively supported by modern browsers – like [Nullish Coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and [Optional Chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
+
+These features are not supported by webpack 4, so if you are using webpack 4, you will need to transpile these features yourself or upgrade to webpack 5.
+
+Here is an example of how you can transpile these features for webpack 4 using `@babel/preset-env` plugin:
+
+```diff
+ // webpack.config.js
+
+ module.exports = (env) => ({
+   // ...
+   module: {
+     rules: [
+       {
+         test: /\.[jt]sx?$/,
+-        exclude: /node_modules/,
++        exclude: [
++          {
++            test: path.resolve(__dirname, 'node_modules'),
++            exclude: [
++              path.resolve(__dirname, 'node_modules/@mui/x-data-grid'),
++              path.resolve(__dirname, 'node_modules/@mui/x-license'),
++            ],
++          },
++        ],
+         use: [
+           {
+             loader: 'babel-loader',
+             options: {
+               presets: ['@babel/preset-env', '@babel/preset-react'],
+             },
+           },
+         ],
+       },
+     ],
+   },
+ });
+```
+
 ### DOM changes
 
 The Data Grid's layout has been substantially altered to use CSS sticky positioned elements.

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -114,7 +114,7 @@ Dropping old browsers support also means that we no longer transpile some featur
 
 These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
 
-Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` preset:
 
 ```diff
  // webpack.config.js

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -106,7 +106,7 @@ Dropping old browsers support also means that we no longer transpile some featur
 
 These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
 
-Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` preset:
 
 ```diff
  // webpack.config.js

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -122,6 +122,7 @@ Here is an example of how you can transpile these features on Webpack 4 using th
 +          {
 +            test: path.resolve(__dirname, 'node_modules'),
 +            exclude: [
++              // Covers @mui/x-date-pickers and @mui/x-date-pickers-pro
 +              path.resolve(__dirname, 'node_modules/@mui/x-date-pickers'),
 +              path.resolve(__dirname, 'node_modules/@mui/x-license'),
 +            ],

--- a/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
+++ b/docs/data/migration/migration-pickers-v6/migration-pickers-v6.md
@@ -86,7 +86,12 @@ After running the codemods, make sure to test your application and that you don'
 Feel free to [open an issue](https://github.com/mui/mui-x/issues/new/choose) for support if you need help to proceed with your migration.
 :::
 
-## Drop the legacy bundle
+## Breaking changes
+
+Since v7 is a major release, it contains some changes that affect the public API.
+These changes were done for consistency, improve stability and make room for new features.
+
+### Drop the legacy bundle
 
 The support for IE 11 has been removed from all MUI X packages.
 The `legacy` bundle that used to support old browsers like IE 11 is no longer included.
@@ -94,6 +99,39 @@ The `legacy` bundle that used to support old browsers like IE 11 is no longer i
 :::info
 If you need support for IE 11, you will need to keep using the latest version of the `v6` release.
 :::
+
+### Drop Webpack 4 support
+
+Dropping old browsers support also means that we no longer transpile some features that are natively supported by modern browsers – like [Nullish Coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and [Optional Chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
+
+These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
+
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+
+```diff
+ // webpack.config.js
+
+ module.exports = (env) => ({
+   // ...
+   module: {
+     rules: [
+       {
+         test: /\.[jt]sx?$/,
+-        exclude: /node_modules/,
++        exclude: [
++          {
++            test: path.resolve(__dirname, 'node_modules'),
++            exclude: [
++              path.resolve(__dirname, 'node_modules/@mui/x-date-pickers'),
++              path.resolve(__dirname, 'node_modules/@mui/x-license'),
++            ],
++          },
++        ],
+       },
+     ],
+   },
+ });
+```
 
 ## Component slots
 

--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -40,6 +40,36 @@ The `legacy` bundle that used to support old browsers like IE 11 is no longer i
 If you need support for IE 11, you will need to keep using the latest version of the `v6` release.
 :::
 
+### Drop Webpack 4 support
+
+Dropping old browsers support also means that we no longer transpile some features that are natively supported by modern browsers – like [Nullish Coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and [Optional Chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
+
+These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
+
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+
+```diff
+ // webpack.config.js
+
+ module.exports = (env) => ({
+   // ...
+   module: {
+     rules: [
+       {
+         test: /\.[jt]sx?$/,
+-        exclude: /node_modules/,
++        exclude: [
++          {
++            test: path.resolve(__dirname, 'node_modules'),
++            exclude: [path.resolve(__dirname, 'node_modules/@mui/x-tree-view')],
++          },
++        ],
+       },
+     ],
+   },
+ });
+```
+
 ### ✅ Rename `nodeId` to `itemId`
 
 The required `nodeId` prop used by the `TreeItem` has been renamed to `itemId` for consistency:

--- a/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
+++ b/docs/data/migration/migration-tree-view-v6/migration-tree-view-v6.md
@@ -46,7 +46,7 @@ Dropping old browsers support also means that we no longer transpile some featur
 
 These features are not supported by Webpack 4, so if you are using Webpack 4, you will need to transpile these features yourself or upgrade to Webpack 5.
 
-Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` plugin:
+Here is an example of how you can transpile these features on Webpack 4 using the `@babel/preset-env` preset:
 
 ```diff
  // webpack.config.js


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/12612

Preview: https://deploy-preview-12710--material-ui-x.netlify.app/x/migration/migration-data-grid-v6/#drop-webpack-4-support