### PR TITLE
[TreeView] Remove state.items.itemTree

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
@@ -81,14 +81,8 @@ interface UseTreeViewItemsEventLookup {
   };
 }
 
-export interface TreeViewItemIdAndChildren {
-  id: TreeViewItemId;
-  children?: TreeViewItemIdAndChildren[];
-}
-
 export interface UseTreeViewItemsState<R extends {}> {
   items: {
-    itemTree: TreeViewItemIdAndChildren[];
     itemMetaMap: TreeViewItemMetaMap;
     itemMap: TreeViewItemMap<R>;
     itemOrderedChildrenIds: { [parentItemId: string]: string[] };


### PR DESCRIPTION
While working on #12213, I noticed that `itemTree` was now totally redundant with `orderedItemChildren`.