### PR TITLE
[DataGrid] Do not escape double quotes when copying to clipboard

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
@@ -561,7 +561,7 @@ export const useGridCellSelection = (
             cellData = serializeCellValue(cellParams, {
               delimiterCharacter: clipboardCopyCellDelimiter,
               ignoreValueFormatter,
-              shouldAppendQuotes: true,
+              shouldAppendQuotes: false,
             });
           } else {
             cellData = '';

--- a/packages/x-data-grid-premium/src/tests/clipboard.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/clipboard.DataGridPremium.test.tsx
@@ -140,6 +140,30 @@ describe('<DataGridPremium /> - Clipboard', () => {
       fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
       expect(writeText.lastCall.firstArg).to.equal(['Adidas', 'Nike', 'Puma'].join('\r\n'));
     });
+
+    it('should not escape double quotes when copying multiple cells to clipboard', () => {
+      render(
+        <DataGridPremium
+          columns={[{ field: 'value' }]}
+          rows={[
+            { id: 0, value: '1 " 1' },
+            { id: 1, value: '2' },
+          ]}
+          cellSelection
+          disableRowSelectionOnClick
+        />,
+      );
+
+      const cell = getCell(0, 0);
+      cell.focus();
+      userEvent.mousePress(cell);
+
+      fireEvent.keyDown(cell, { key: 'Ctrl' });
+      fireEvent.click(getCell(1, 0), { ctrlKey: true });
+
+      fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
+      expect(writeText.lastCall.firstArg).to.equal(['1 " 1', '2'].join('\r\n'));
+    });
   });
 
   describe('paste', () => {

--- a/packages/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/clipboard.DataGridPro.test.tsx
@@ -28,18 +28,9 @@ describe('<DataGridPro /> - Clipboard', () => {
           apiRef={apiRef}
           columns={columns}
           rows={[
-            {
-              id: 0,
-              brand: 'Nike',
-            },
-            {
-              id: 1,
-              brand: 'Adidas',
-            },
-            {
-              id: 2,
-              brand: 'Puma',
-            },
+            { id: 0, brand: 'Nike' },
+            { id: 1, brand: 'Adidas' },
+            { id: 2, brand: 'Puma' },
           ]}
           {...props}
         />
@@ -47,7 +38,7 @@ describe('<DataGridPro /> - Clipboard', () => {
     );
   }
 
-  describe('copySelectedRowsToClipboard', () => {
+  describe('copy to clipboard', () => {
     let writeText: SinonStub;
     const originalClipboard = navigator.clipboard;
 
@@ -73,6 +64,42 @@ describe('<DataGridPro /> - Clipboard', () => {
         fireEvent.keyDown(cell, { key: 'c', keyCode: 67, [key]: true });
         expect(writeText.firstCall.args[0]).to.equal(['0\tNike', '1\tAdidas'].join('\r\n'));
       });
+    });
+
+    it('should not escape double quotes when copying a single cell to clipboard', () => {
+      render(
+        <Test
+          columns={[{ field: 'value' }]}
+          rows={[{ id: 0, value: '1 " 1' }]}
+          disableRowSelectionOnClick
+        />,
+      );
+
+      const cell = getCell(0, 0);
+      cell.focus();
+      userEvent.mousePress(cell);
+
+      fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
+      expect(writeText.lastCall.firstArg).to.equal('1 " 1');
+    });
+
+    it('should not escape double quotes when copying rows to clipboard', () => {
+      render(
+        <Test
+          columns={[{ field: 'value' }]}
+          rows={[
+            { id: 0, value: '1 " 1' },
+            { id: 1, value: '2' },
+          ]}
+          disableRowSelectionOnClick
+        />,
+      );
+
+      act(() => apiRef.current.selectRows([0, 1]));
+      const cell = getCell(0, 0);
+      userEvent.mousePress(cell);
+      fireEvent.keyDown(cell, { key: 'c', keyCode: 67, ctrlKey: true });
+      expect(writeText.firstCall.args[0]).to.equal(['1 " 1', '2'].join('\r\n'));
     });
   });
 });

--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -7,12 +7,13 @@ import { buildWarning } from '../../../../utils/warning';
 
 function sanitizeCellValue(value: any, delimiterCharacter: string, shouldAppendQuotes: boolean) {
   if (typeof value === 'string') {
-    // Make sure value containing delimiter or line break won't be split into multiple rows
-    if ([delimiterCharacter, '\n', '\r', '"'].some((delimiter) => value.includes(delimiter))) {
-      if (shouldAppendQuotes) {
-        return `"${value.replace(/"/g, '""')}"`;
+    if (shouldAppendQuotes) {
+      const escapedValue = value.replace(/"/g, '""');
+      // Make sure value containing delimiter or line break won't be split into multiple rows
+      if ([delimiterCharacter, '\n', '\r', '"'].some((delimiter) => value.includes(delimiter))) {
+        return `"${escapedValue}"`;
       }
-      return `${value.replace(/"/g, '""')}`;
+      return escapedValue;
     }
 
     return value;


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/12456

[Escaping double quotes is specific to CSV format](https://techterms.com/definition/csv) and shouldn't be done when copying to clipboard.