### PR TITLE
[charts] Add Legend actions

### DIFF
--- a/docs/pages/x/api/charts/charts-legend.json
+++ b/docs/pages/x/api/charts/charts-legend.json
@@ -38,6 +38,12 @@
       "isGlobal": false
     },
     {
+      "key": "itemBackground",
+      "className": "MuiChartsLegend-itemBackground",
+      "description": "Styles applied to the item background.",
+      "isGlobal": false
+    },
+    {
       "key": "label",
       "className": "MuiChartsLegend-label",
       "description": "Styles applied to the series label.",

--- a/docs/pages/x/api/charts/default-charts-legend.json
+++ b/docs/pages/x/api/charts/default-charts-legend.json
@@ -18,6 +18,14 @@
     "itemMarkWidth": { "type": { "name": "number" }, "default": "20" },
     "labelStyle": { "type": { "name": "object" }, "default": "theme.typography.subtitle1" },
     "markGap": { "type": { "name": "number" }, "default": "5" },
+    "onClick": {
+      "type": { "name": "func" },
+      "default": "undefined",
+      "signature": {
+        "type": "function(legend: LegendItemParams, dataIndex: number) => void",
+        "describedArgs": ["legend", "dataIndex"]
+      }
+    },
     "padding": {
       "type": {
         "name": "union",
@@ -34,21 +42,33 @@
   ],
   "classes": [
     {
+      "key": "itemBackground",
+      "className": "MuiDefaultChartsLegend-itemBackground",
+      "description": "Styles applied to the item background.",
+      "isGlobal": false
+    },
+    {
+      "key": "label",
+      "className": "MuiDefaultChartsLegend-label",
+      "description": "Styles applied to the series label.",
+      "isGlobal": false
+    },
+    {
       "key": "mark",
       "className": "MuiDefaultChartsLegend-mark",
-      "description": "",
+      "description": "Styles applied to series mark element.",
       "isGlobal": false
     },
     {
       "key": "root",
       "className": "MuiDefaultChartsLegend-root",
-      "description": "",
+      "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "series",
       "className": "MuiDefaultChartsLegend-series",
-      "description": "",
+      "description": "Styles applied to a series element.",
       "isGlobal": false
     }
   ],

--- a/docs/pages/x/api/charts/piecewise-color-legend.json
+++ b/docs/pages/x/api/charts/piecewise-color-legend.json
@@ -36,6 +36,14 @@
     },
     "labelStyle": { "type": { "name": "object" }, "default": "theme.typography.subtitle1" },
     "markGap": { "type": { "name": "number" }, "default": "5" },
+    "onClick": {
+      "type": { "name": "func" },
+      "default": "undefined",
+      "signature": {
+        "type": "function(legend: LegendItemParams, dataIndex: number) => void",
+        "describedArgs": ["legend", "dataIndex"]
+      }
+    },
     "padding": {
       "type": {
         "name": "union",
@@ -52,21 +60,33 @@
   ],
   "classes": [
     {
+      "key": "itemBackground",
+      "className": "MuiPiecewiseColorLegend-itemBackground",
+      "description": "Styles applied to the item background.",
+      "isGlobal": false
+    },
+    {
+      "key": "label",
+      "className": "MuiPiecewiseColorLegend-label",
+      "description": "Styles applied to the series label.",
+      "isGlobal": false
+    },
+    {
       "key": "mark",
       "className": "MuiPiecewiseColorLegend-mark",
-      "description": "",
+      "description": "Styles applied to series mark element.",
       "isGlobal": false
     },
     {
       "key": "root",
       "className": "MuiPiecewiseColorLegend-root",
-      "description": "",
+      "description": "Styles applied to the root element.",
       "isGlobal": false
     },
     {
       "key": "series",
       "className": "MuiPiecewiseColorLegend-series",
-      "description": "",
+      "description": "Styles applied to a series element.",
       "isGlobal": false
     }
   ],

--- a/docs/translations/api-docs/charts/charts-legend/charts-legend.json
+++ b/docs/translations/api-docs/charts/charts-legend/charts-legend.json
@@ -15,6 +15,10 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the legend with column layout"
     },
+    "itemBackground": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the item background"
+    },
     "label": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the series label" },
     "mark": { "description": "Styles applied to {{nodeName}}.", "nodeName": "series mark element" },
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/charts/default-charts-legend/default-charts-legend.json
+++ b/docs/translations/api-docs/charts/default-charts-legend/default-charts-legend.json
@@ -11,14 +11,26 @@
     "itemMarkWidth": { "description": "Width of the item mark (in px)." },
     "labelStyle": { "description": "Style applied to legend labels." },
     "markGap": { "description": "Space between the mark and the label (in px)." },
+    "onClick": {
+      "description": "Callback fired when a legend item is clicked.",
+      "typeDescriptions": {
+        "legend": "The legend item data.",
+        "dataIndex": "The index of the clicked legend item."
+      }
+    },
     "padding": {
       "description": "Legend padding (in px). Can either be a single number, or an object with top, left, bottom, right properties."
     },
     "position": { "description": "The position of the legend." }
   },
   "classDescriptions": {
-    "mark": { "description": "" },
-    "root": { "description": "" },
-    "series": { "description": "" }
+    "itemBackground": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the item background"
+    },
+    "label": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the series label" },
+    "mark": { "description": "Styles applied to {{nodeName}}.", "nodeName": "series mark element" },
+    "root": { "description": "Styles applied to the root element." },
+    "series": { "description": "Styles applied to {{nodeName}}.", "nodeName": "a series element" }
   }
 }

--- a/docs/translations/api-docs/charts/piecewise-color-legend/piecewise-color-legend.json
+++ b/docs/translations/api-docs/charts/piecewise-color-legend/piecewise-color-legend.json
@@ -30,14 +30,26 @@
     },
     "labelStyle": { "description": "Style applied to legend labels." },
     "markGap": { "description": "Space between the mark and the label (in px)." },
+    "onClick": {
+      "description": "Callback fired when a legend item is clicked.",
+      "typeDescriptions": {
+        "legend": "The legend item data.",
+        "dataIndex": "The index of the clicked legend item."
+      }
+    },
     "padding": {
       "description": "Legend padding (in px). Can either be a single number, or an object with top, left, bottom, right properties."
     },
     "position": { "description": "The position of the legend." }
   },
   "classDescriptions": {
-    "mark": { "description": "" },
-    "root": { "description": "" },
-    "series": { "description": "" }
+    "itemBackground": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the item background"
+    },
+    "label": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the series label" },
+    "mark": { "description": "Styles applied to {{nodeName}}.", "nodeName": "series mark element" },
+    "root": { "description": "Styles applied to the root element." },
+    "series": { "description": "Styles applied to {{nodeName}}.", "nodeName": "a series element" }
   }
 }

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -54,6 +54,7 @@ const useUtilityClasses = (ownerState: DefaultizedChartsLegendProps & { theme: T
     mark: ['mark'],
     label: ['label'],
     series: ['series'],
+    itemBackground: ['itemBackground'],
   };
 
   return composeClasses(slots, getLegendUtilityClass, classes);

--- a/packages/x-charts/src/ChartsLegend/ChartsLegendItem.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegendItem.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import { useTheme } from '@mui/material/styles';
+import { ChartsText, ChartsTextStyle } from '../ChartsText';
+import { SeriesId } from '../models/seriesType/common';
+import { LegendItemParams } from './chartsLegend.types';
+import { ChartsLegendClasses } from './chartsLegendClasses';
+
+export interface ChartsLegendItemProps {
+  id: SeriesId;
+  index: number;
+  positionY: number;
+  label: string;
+  positionX: number;
+  innerHeight: number;
+  innerWidth: number;
+  color: string;
+  gapX: number;
+  gapY: number;
+  legendWidth: number;
+  itemMarkHeight: number;
+  itemMarkWidth: number;
+  markGap: number;
+  labelStyle: ChartsTextStyle;
+  classes?: Omit<Partial<ChartsLegendClasses>, 'column' | 'row' | 'label'>;
+  onClick?: (legend: LegendItemParams, index: number) => void;
+}
+
+/**
+ * @ignore - internal component.
+ */
+function ChartsLegendItem(props: ChartsLegendItemProps) {
+  const theme = useTheme();
+  const isRTL = theme.direction === 'rtl';
+  const {
+    id,
+    positionY,
+    label,
+    positionX,
+    innerHeight,
+    innerWidth,
+    legendWidth,
+    color,
+    gapX,
+    gapY,
+    itemMarkHeight,
+    itemMarkWidth,
+    markGap,
+    labelStyle,
+    classes,
+    index,
+    onClick,
+  } = props;
+
+  return (
+    <g
+      className={clsx(classes?.series, `${classes?.series}-${id}`)}
+      transform={`translate(${gapX + (isRTL ? legendWidth - positionX : positionX)} ${gapY + positionY})`}
+    >
+      <rect
+        x={isRTL ? -(innerWidth + 2) : -2}
+        y={-itemMarkHeight / 2 - 2}
+        width={innerWidth + 4}
+        height={innerHeight + 4}
+        fill="transparent"
+        className={classes?.itemBackground}
+        onClick={onClick ? () => onClick({ id, label, color }, index) : undefined}
+        style={{
+          pointerEvents: onClick ? 'all' : 'none',
+          cursor: onClick ? 'pointer' : 'unset',
+        }}
+      />
+      <rect
+        className={classes?.mark}
+        x={isRTL ? -itemMarkWidth : 0}
+        y={-itemMarkHeight / 2}
+        width={itemMarkWidth}
+        height={itemMarkHeight}
+        fill={color}
+        style={{ pointerEvents: 'none' }}
+      />
+      <ChartsText
+        style={{ ...labelStyle, pointerEvents: 'none' }}
+        text={label}
+        x={(isRTL ? -1 : 1) * (itemMarkWidth + markGap)}
+        y={0}
+      />
+    </g>
+  );
+}
+
+export { ChartsLegendItem };

--- a/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
@@ -75,6 +75,13 @@ DefaultChartsLegend.propTypes = {
    */
   markGap: PropTypes.number,
   /**
+   * Callback fired when a legend item is clicked.
+   * @param {LegendItemParams} legend The legend item data.
+   * @param {number} dataIndex The index of the clicked legend item.
+   * @default undefined
+   */
+  onClick: PropTypes.func,
+  /**
    * Legend padding (in px).
    * Can either be a single number, or an object with top, left, bottom, right properties.
    * @default 10

--- a/packages/x-charts/src/ChartsLegend/LegendPerItem.tsx
+++ b/packages/x-charts/src/ChartsLegend/LegendPerItem.tsx
@@ -3,7 +3,7 @@ import NoSsr from '@mui/material/NoSsr';
 import { useTheme, styled } from '@mui/material/styles';
 import { DrawingArea } from '../context/DrawingProvider';
 import { DefaultizedProps } from '../models/helpers';
-import { ChartsText, ChartsTextStyle } from '../ChartsText';
+import { ChartsTextStyle } from '../ChartsText';
 import { CardinalDirections } from '../models/layout';
 import { getWordsByLines } from '../internals/getWordsByLines';
 import type { ChartsLegendProps } from './ChartsLegend';
@@ -11,6 +11,8 @@ import { GetItemSpaceType, LegendItemParams } from './chartsLegend.types';
 import { legendItemPlacements } from './legendItemsPlacement';
 import { useDrawingArea } from '../hooks/useDrawingArea';
 import { AnchorPosition, Direction } from './legend.types';
+import { ChartsLegendItem } from './ChartsLegendItem';
+import { ChartsLegendClasses } from './chartsLegendClasses';
 
 export type ChartsLegendRootOwnerState = {
   position: AnchorPosition;
@@ -36,7 +38,7 @@ export interface LegendPerItemProps
    * The ordered array of item to display in the legend.
    */
   itemsToDisplay: LegendItemParams[];
-  classes?: Record<'mark' | 'series' | 'root', string>;
+  classes?: Omit<Partial<ChartsLegendClasses>, 'column' | 'row'>;
   /**
    * Style applied to legend labels.
    * @default theme.typography.subtitle1
@@ -68,6 +70,13 @@ export interface LegendPerItemProps
    * @default 10
    */
   padding?: number | Partial<CardinalDirections<number>>;
+  /**
+   * Callback fired when a legend item is clicked.
+   * @param {LegendItemParams} legend The legend item data.
+   * @param {number} dataIndex The index of the clicked legend item.
+   * @default undefined
+   */
+  onClick?: (legend: LegendItemParams, dataIndex: number) => void;
 }
 
 /**
@@ -109,9 +118,9 @@ export function LegendPerItem(props: LegendPerItemProps) {
     itemGap = 10,
     padding: paddingProps = 10,
     labelStyle: inLabelStyle,
+    onClick,
   } = props;
   const theme = useTheme();
-  const isRTL = theme.direction === 'rtl';
   const drawingArea = useDrawingArea();
 
   const labelStyle = React.useMemo(
@@ -196,27 +205,21 @@ export function LegendPerItem(props: LegendPerItemProps) {
   return (
     <NoSsr>
       <ChartsLegendRoot className={classes?.root}>
-        {itemsWithPosition.map(({ id, label, color, positionX, positionY }) => (
-          <g
-            key={id}
-            className={classes?.series}
-            transform={`translate(${gapX + (isRTL ? legendWidth - positionX : positionX)} ${gapY + positionY})`}
-          >
-            <rect
-              className={classes?.mark}
-              x={isRTL ? -itemMarkWidth : 0}
-              y={-itemMarkHeight / 2}
-              width={itemMarkWidth}
-              height={itemMarkHeight}
-              fill={color}
-            />
-            <ChartsText
-              style={labelStyle}
-              text={label}
-              x={(isRTL ? -1 : 1) * (itemMarkWidth + markGap)}
-              y={0}
-            />
-          </g>
+        {itemsWithPosition.map((item, i) => (
+          <ChartsLegendItem
+            {...item}
+            key={item.id}
+            index={i}
+            gapX={gapX}
+            gapY={gapY}
+            legendWidth={legendWidth}
+            itemMarkHeight={itemMarkHeight}
+            itemMarkWidth={itemMarkWidth}
+            markGap={markGap}
+            labelStyle={labelStyle}
+            classes={classes}
+            onClick={onClick}
+          />
         ))}
       </ChartsLegendRoot>
     </NoSsr>

--- a/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.tsx
@@ -158,6 +158,13 @@ PiecewiseColorLegend.propTypes = {
    */
   markGap: PropTypes.number,
   /**
+   * Callback fired when a legend item is clicked.
+   * @param {LegendItemParams} legend The legend item data.
+   * @param {number} dataIndex The index of the clicked legend item.
+   * @default undefined
+   */
+  onClick: PropTypes.func,
+  /**
    * Legend padding (in px).
    * Can either be a single number, or an object with top, left, bottom, right properties.
    * @default 10

--- a/packages/x-charts/src/ChartsLegend/chartsLegendClasses.ts
+++ b/packages/x-charts/src/ChartsLegend/chartsLegendClasses.ts
@@ -8,6 +8,8 @@ export interface ChartsLegendClasses {
   root: string;
   /** Styles applied to a series element. */
   series: string;
+  /** Styles applied to the item background. */
+  itemBackground: string;
   /** Styles applied to series mark element. */
   mark: string;
   /** Styles applied to the series label. */
@@ -27,6 +29,7 @@ export function getLegendUtilityClass(slot: string) {
 export const legendClasses: ChartsLegendClasses = generateUtilityClasses('MuiChartsLegend', [
   'root',
   'series',
+  'itemBackground',
   'mark',
   'label',
   'column',

--- a/packages/x-charts/src/themeAugmentation/overrides.d.ts
+++ b/packages/x-charts/src/themeAugmentation/overrides.d.ts
@@ -8,7 +8,7 @@ import { ChartsTooltipClassKey } from '../ChartsTooltip';
 import { AreaElementClassKey, LineElementClassKey, MarkElementClassKey } from '../LineChart';
 
 // prettier-ignore
-export interface PickersComponentNameToClassKey {
+export interface ChartsComponentNameToClassKey {
   MuiChartsAxis: ChartsAxisClassKey;
   MuiChartsAxisHighlight: ChartsAxisHighlightClassKey;
   MuiChartsGrid: ChartsGridClassKey;
@@ -29,7 +29,7 @@ export interface PickersComponentNameToClassKey {
 }
 
 declare module '@mui/material/styles' {
-  interface ComponentNameToClassKey extends PickersComponentNameToClassKey {}
+  interface ComponentNameToClassKey extends ChartsComponentNameToClassKey {}
 }
 
 // disable automatic export


### PR DESCRIPTION
## Event Handlers Approach (current)

The current implementation is a naive approach where I simply added a `onClick` handler to each of the labels, and let the users manually handle the changes they want. 

<details>

<summary>You should be able to test it with the code below.</summary>

```tsx
import * as React from 'react';
import { BarChart } from '@mui/x-charts/BarChart';
import { Box } from '@mui/material';

const chartSetting = {
  yAxis: [{ label: 'rainfall (mm)' }],
  height: 300,
};

const dataset = [
  [59, 57, 86, 21, 'Jan'],
  [50, 52, 78, 28, 'Fev'],
  [47, 53, 106, 41, 'Mar'],
  [54, 56, 92, 73, 'Apr'],
  [57, 69, 92, 99, 'May'],
  [60, 63, 103, 144, 'June'],
  [59, 60, 105, 319, 'July'],
  [65, 60, 106, 249, 'Aug'],
  [51, 51, 95, 131, 'Sept'],
  [60, 65, 97, 55, 'Oct'],
  [67, 64, 76, 48, 'Nov'],
  [61, 70, 103, 25, 'Dec'],
].map(([london, paris, newYork, seoul, month]) => ({ london, paris, newYork, seoul, month }));

const valueFormatter = (value: number | null) => `${value}mm`;

function BarsDataset() {
  const [series, setSeries] = React.useState([
    { dataKey: 'london', label: 'London', valueFormatter, color: 'rgba(255, 0, 0, 1)' },
    { dataKey: 'paris', label: 'Paris', valueFormatter, color: 'rgba(0, 255, 0, 1)' },
    { dataKey: 'newYork', label: 'New York', valueFormatter, color: 'rgba(0, 0, 255, 1)' },
    { dataKey: 'seoul', label: 'Seoul', valueFormatter, color: 'rgba(255, 0, 255, 1)' },
  ]);

  return (
    <Box
      sx={{
        [`& .MuiChartsLegend-seriesBackground:hover`]: {
          fill: 'rgba(10,10,50,0.3)',
        },
      }}
    >
      <BarChart
        dataset={dataset}
        xAxis={[{ scaleType: 'band', dataKey: 'month' }]}
        series={series}
        slotProps={{
          legend: {
            onClick: (item, index) => {
              console.log(item, index);
              setSeries((prev) => {
                const newSeries = [...prev];
                if (newSeries[index].color.endsWith('1)')) {
                  newSeries[index] = {
                    ...newSeries[index],
                    color: newSeries[index].color.replace('1)', '0.3)'),
                  };
                } else {
                  newSeries[index] = {
                    ...newSeries[index],
                    color: newSeries[index].color.replace('0.3)', '1)'),
                  };
                }
                return newSeries;
              });
            },
          },
        }}
        {...chartSetting}
      />
    </Box>
  );
}
export default function Page() {
  return <BarsDataset />;
}

```

</details>

https://codesandbox.io/p/sandbox/bold-leftpad-knlpjp?file=%2Fsrc%2FDemo.tsx%3A74%2C21

It should eventually also have events for `mouseover/enter/leave/etc`

## Class approach

We could build on top of the current approach by also adding classes to both the legends and data(bar/point/line/etc) related to the series.

Eg: `mouseover` legend for series `"london"`. We add a `MuiCharts(tdb)-hover` to all legends and data related to that series. On `click` we would add an `active` class, while removing it from the previous elements if any.

This would allow users to control these behaviours by simply implementing their own css.

## Fully managed

We could work on top of both previous ideas and "fully manage" the changes, if we change the `dataset[].color` to something akin to `dataset[].colors:{hover,active,etc}`

This way we would be able to handle all the changes ourselves with the data provided

## Question

- How flexible we want this feature to be?

## References

[chartjs](https://www.chartjs.org/docs/latest/samples/legend/events.html)
[recharts](https://recharts.org/en-US/examples/LegendEffectOpacity)
[visx](https://airbnb.io/visx/legends)
