### PR TITLE
[l10n] Improve Swedish (sv-SE) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -227,7 +227,7 @@
     "languageTag": "sv-SE",
     "importName": "svSE",
     "localeName": "Swedish",
-    "missingKeysCount": 3,
+    "missingKeysCount": 0,
     "totalKeysCount": 117,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/svSE.ts"
   },

--- a/docs/data/date-pickers/localization/data.json
+++ b/docs/data/date-pickers/localization/data.json
@@ -227,7 +227,7 @@
     "languageTag": "sv-SE",
     "importName": "svSE",
     "localeName": "Swedish",
-    "missingKeysCount": 22,
+    "missingKeysCount": 0,
     "totalKeysCount": 50,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/locales/svSE.ts"
   },

--- a/packages/x-data-grid/src/locales/svSE.ts
+++ b/packages/x-data-grid/src/locales/svSE.ts
@@ -39,9 +39,9 @@ const svSEGrid: Partial<GridLocaleText> = {
   toolbarExportExcel: 'Ladda ner som Excel',
 
   // Columns management text
-  // columnsManagementSearchTitle: 'Search',
-  // columnsManagementNoColumns: 'No columns',
-  // columnsManagementShowHideAllText: 'Show/Hide All',
+  columnsManagementSearchTitle: 'Sök',
+  columnsManagementNoColumns: 'Inga kolumner',
+  columnsManagementShowHideAllText: 'Visa/Dölj alla',
 
   // Filter panel text
   filterPanelAddFilter: 'Lägg till filter',

--- a/packages/x-date-pickers/src/locales/svSE.ts
+++ b/packages/x-date-pickers/src/locales/svSE.ts
@@ -25,10 +25,10 @@ const svSEPickers: Partial<PickersLocaleText<any>> = {
   // DateRange labels
   start: 'Start',
   end: 'Slut',
-  // startDate: 'Start date',
-  // startTime: 'Start time',
-  // endDate: 'End date',
-  // endTime: 'End time',
+  startDate: 'Startdatum',
+  startTime: 'Starttid',
+  endDate: 'Slutdatum',
+  endTime: 'Sluttid',
 
   // Action bar
   cancelButtonLabel: 'Avbryt',
@@ -67,34 +67,34 @@ const svSEPickers: Partial<PickersLocaleText<any>> = {
     value !== null && utils.isValid(value)
       ? `Välj tid, vald tid är ${utils.format(value, 'fullTime')}`
       : 'Välj tid',
-  // fieldClearLabel: 'Clear value',
+  fieldClearLabel: 'Rensa värde',
 
   // Table labels
   timeTableLabel: 'välj tid',
   dateTableLabel: 'välj datum',
 
   // Field section placeholders
-  // fieldYearPlaceholder: params => 'Y'.repeat(params.digitAmount),
-  // fieldMonthPlaceholder: params => params.contentType === 'letter' ? 'MMMM' : 'MM',
-  // fieldDayPlaceholder: () => 'DD',
-  // fieldWeekDayPlaceholder: params => params.contentType === 'letter' ? 'EEEE' : 'EE',
-  // fieldHoursPlaceholder: () => 'hh',
-  // fieldMinutesPlaceholder: () => 'mm',
-  // fieldSecondsPlaceholder: () => 'ss',
-  // fieldMeridiemPlaceholder: () => 'aa',
+  fieldYearPlaceholder: (params) => 'Å'.repeat(params.digitAmount),
+  fieldMonthPlaceholder: (params) => (params.contentType === 'letter' ? 'MMMM' : 'MM'),
+  fieldDayPlaceholder: () => 'DD',
+  fieldWeekDayPlaceholder: (params) => (params.contentType === 'letter' ? 'EEEE' : 'EE'),
+  fieldHoursPlaceholder: () => 'tt',
+  fieldMinutesPlaceholder: () => 'mm',
+  fieldSecondsPlaceholder: () => 'ss',
+  fieldMeridiemPlaceholder: () => 'aa',
 
   // View names
-  // year: 'Year',
-  // month: 'Month',
-  // day: 'Day',
-  // weekDay: 'Week day',
-  // hours: 'Hours',
-  // minutes: 'Minutes',
-  // seconds: 'Seconds',
-  // meridiem: 'Meridiem',
+  year: 'År',
+  month: 'Månad',
+  day: 'Dag',
+  weekDay: 'Veckodag',
+  hours: 'Timmar',
+  minutes: 'Minuter',
+  seconds: 'Sekunder',
+  meridiem: 'Meridiem',
 
   // Common
-  // empty: 'Empty',
+  empty: 'Tom',
 };
 
 export const svSE = getPickersLocalization(svSEPickers);


### PR DESCRIPTION
This PR adds the missing translation for the Swedish (sv-SE) locale - https://github.com/mui/mui-x/issues/3211.