### PR TITLE
[pickers] Fix desktop date time Pickers grid layout

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
@@ -91,8 +91,9 @@ const rendererInterceptor = function rendererInterceptor<
         availableRangePositions: [rangePosition],
         view: !isTimeViewActive ? popperView : 'day',
         views: rendererProps.views.filter(isDatePickerView),
+        sx: [{ gridColumn: 1 }, ...finalProps.sx],
       })}
-      <Divider orientation="vertical" />
+      <Divider orientation="vertical" sx={{ gridColumn: 2 }} />
       <DateTimeRangePickerTimeWrapper
         {...finalProps}
         view={isTimeViewActive ? popperView : 'hours'}
@@ -106,6 +107,7 @@ const rendererInterceptor = function rendererInterceptor<
             {}
           >
         }
+        sx={[{ gridColumn: 3 }, ...finalProps.sx]}
       />
     </React.Fragment>
   );

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -90,16 +90,18 @@ const rendererInterceptor = function rendererInterceptor<
         view: !isTimeViewActive ? popperView : 'day',
         focusedView: focusedView && isDatePickerView(focusedView) ? focusedView : null,
         views: rendererProps.views.filter(isDatePickerView),
+        sx: [{ gridColumn: 1 }, ...finalProps.sx],
       })}
       {timeViewsCount > 0 && (
         <React.Fragment>
-          <Divider orientation="vertical" />
+          <Divider orientation="vertical" sx={{ gridColumn: 2 }} />
           {inViewRenderers[isTimeViewActive ? popperView : 'hours']?.({
             ...finalProps,
             view: isTimeViewActive ? popperView : 'hours',
             focusedView: focusedView && isInternalTimeView(focusedView) ? focusedView : null,
             openTo: isInternalTimeView(openTo) ? openTo : 'hours',
             views: rendererProps.views.filter(isInternalTimeView),
+            sx: [{ gridColumn: 3 }, ...finalProps.sx],
           })}
         </React.Fragment>
       )}


### PR DESCRIPTION
Fixes #12726

This was a problem for both `DesktopDateTimePicker` (a regression as compared to v6) and the `DesktopDateTimeRangePicker`.

The `Layout.contentWrapper` element has a `display: grid` style in case of Desktop Date Time (Range) Pickers.
It causes the layout to behave differently, on what kind of children are added.

With this change, all the grid children have explicitly specified `gridColumn` property to be aware of the position they should be placed in.