### PR TITLE
[test] Increase timeout for test that sometimes fail on DateTimeRangePicker

### DIFF
--- a/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
+++ b/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
@@ -180,7 +180,7 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<any, 'picker'>
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should not call onClose or onAccept when selecting a date and `props.closeOnSelect` is false', function () {
+    it('should not call onClose or onAccept when selecting a date and `props.closeOnSelect` is false', function test() {
       // increase the timeout of this test as it tends to sometimes fail on CI with `DesktopDateTimeRangePicker` or `MobileDateTimeRangePicker`
       this.timeout(10000);
       const onChange = spy();

--- a/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
+++ b/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
@@ -180,7 +180,9 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<any, 'picker'>
       expect(onClose.callCount).to.equal(1);
     });
 
-    it('should not call onClose or onAccept when selecting a date and `props.closeOnSelect` is false', () => {
+    it('should not call onClose or onAccept when selecting a date and `props.closeOnSelect` is false', function () {
+      // increase the timeout of this test as it tends to sometimes fail on CI with `DesktopDateTimeRangePicker` or `MobileDateTimeRangePicker`
+      this.timeout(10000);
       const onChange = spy();
       const onAccept = spy();
       const onClose = spy();


### PR DESCRIPTION
This test sometimes fails locally with a `1s` timeout.
Given how much CI VMs are slower, it could simply be an actual flaky timeout. 🙈 
Increase timeout of the test that occasionally fails on CI with `DesktopDateTimeRangePicker` or `MobileDateTimeRangePicker`.

### Failure examples
- https://app.circleci.com/pipelines/github/mui/mui-x/56644/workflows/3fad6689-5a66-4c52-b9ad-129f0aa7c708/jobs/324060
- https://app.circleci.com/pipelines/github/mui/mui-x/55241/workflows/48a5768d-15c0-44fc-affb-0ffebdbe3a71/jobs/315947
- https://app.circleci.com/pipelines/github/mui/mui-x/56639/workflows/8293160a-8444-48a3-b61e-053e5a040908/jobs/324035
- https://app.circleci.com/pipelines/github/mui/mui-x/55868/workflows/d44dc6ca-55af-404b-a73d-4d364dfe9582/jobs/320203