### PR TITLE
[docs] Add grid cell display example to the migration guide

### DIFF
--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -509,7 +509,8 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
 - You can now style a row's hover state using just `:hover` instead of `.Mui-hovered`.
 - The `.MuiDataGrid--pinnedColumns-(left\|right)` class for pinned columns has been removed.
 - The `.MuiDataGrid-cell--withRenderer` class has been removed.
-- The cell element isn't `display: flex` by default. You can add `display: 'flex'` on the column definition to restore the behavior.  
+- The cell element isn't `display: flex` by default. You can add `display: 'flex'` on the column definition to restore the behavior.
+
   **NOTE**: If you're using **dynamic row height**, this also means cells aren't vertically centered by default anymore, you might want to set the `display: 'flex'` for all non-dynamic columns. This may also affect text-ellipsis, which you can restore by adding your own wrapper with `text-overflow: ellipsis`.
   ```tsx
   {

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -513,9 +513,9 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
   **NOTE**: If you're using **dynamic row height**, this also means cells aren't vertically centered by default anymore, you might want to set the `display: 'flex'` for all non-dynamic columns. This may also affect text-ellipsis, which you can restore by adding your own wrapper with `text-overflow: ellipsis`.
   ```tsx
   {
-    display: "flex",
+    display: 'flex',
     renderCell: ({ value }) => (
-      <div style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         {value}
       </div>
     ),

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -509,8 +509,18 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
 - You can now style a row's hover state using just `:hover` instead of `.Mui-hovered`.
 - The `.MuiDataGrid--pinnedColumns-(left\|right)` class for pinned columns has been removed.
 - The `.MuiDataGrid-cell--withRenderer` class has been removed.
-- The cell element isn't `display: flex` by default. You can add `display: 'flex'` on the column definition to restore the behavior.
-  NOTE: If you're using **dynamic row height**, this also means cells aren't vertically centered by default anymore, you might want to set the `display: 'flex'` for all non-dynamic columns. This may also affect text-ellipsis, which you can restore by adding your own wrapper with `text-overflow: ellipsis;`.
+- The cell element isn't `display: flex` by default. You can add `display: 'flex'` on the column definition to restore the behavior.  
+  **NOTE**: If you're using **dynamic row height**, this also means cells aren't vertically centered by default anymore, you might want to set the `display: 'flex'` for all non-dynamic columns. This may also affect text-ellipsis, which you can restore by adding your own wrapper with `text-overflow: ellipsis`.
+  ```tsx
+  {
+    display: "flex",
+    renderCell: ({ value }) => (
+      <div style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+        {value}
+      </div>
+    ),
+  },
+  ```
 - The `columnHeader--showColumnBorder` class was replaced by `columnHeader--withLeftBorder` and `columnHeader--withRightBorder`.
 - The `columnHeadersInner`, `columnHeadersInner--scrollable`, and `columnHeaderDropZone` classes were removed since the inner wrapper was removed in our effort to simplify the DOM structure and improve accessibility.
 - The `pinnedColumnHeaders`, `pinnedColumnHeaders--left`, and `pinnedColumnHeaders--right` classes were removed along with the element they were applied to.

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -512,6 +512,7 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
 - The cell element isn't `display: flex` by default. You can add `display: 'flex'` on the column definition to restore the behavior.
 
   **NOTE**: If you're using **dynamic row height**, this also means cells aren't vertically centered by default anymore, you might want to set the `display: 'flex'` for all non-dynamic columns. This may also affect text-ellipsis, which you can restore by adding your own wrapper with `text-overflow: ellipsis`.
+
   ```tsx
   {
     display: 'flex',
@@ -522,6 +523,7 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
     ),
   },
   ```
+
 - The `columnHeader--showColumnBorder` class was replaced by `columnHeader--withLeftBorder` and `columnHeader--withRightBorder`.
 - The `columnHeadersInner`, `columnHeadersInner--scrollable`, and `columnHeaderDropZone` classes were removed since the inner wrapper was removed in our effort to simplify the DOM structure and improve accessibility.
 - The `pinnedColumnHeaders`, `pinnedColumnHeaders--left`, and `pinnedColumnHeaders--right` classes were removed along with the element they were applied to.


### PR DESCRIPTION
Follow-up of https://github.com/mui/mui-x/pull/12683#discussion_r1560772877