### PR TITLE
[DataGrid] Limit panel width to not exceed screen width

### DIFF
--- a/packages/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.tsx
@@ -51,6 +51,8 @@ const GridPaperRoot = styled(Paper, {
   minWidth: 300,
   maxHeight: 450,
   display: 'flex',
+  maxWidth: `calc(100vw - ${theme.spacing(0.5)})`,
+  overflow: 'auto',
 }));
 
 const GridPanel = React.forwardRef<HTMLDivElement, GridPanelProps>((props, ref) => {


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/5183

| Before | After |
| ------ | ------ |
| <img width="284" src="https://github.com/mui/mui-x/assets/13808724/ddfe2072-4e41-4e81-89d0-55b1b1f61660"> | <img width="283" src="https://github.com/mui/mui-x/assets/13808724/c7cf67b0-5316-4d90-900a-275f0c1521bb"> | 
