### PR TITLE
export GridAggregationParams for use with custom aggregators

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationInterfaces.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationInterfaces.ts
@@ -82,7 +82,7 @@ export interface GridAggregationFunction<V = any, AV = V, FAV = AV> {
   getCellValue?: (params: GridAggregationGetCellValueParams) => V;
 }
 
-interface GridAggregationParams<V = any> {
+export interface GridAggregationParams<V = any> {
   values: (V | undefined)[];
   groupId: GridRowId;
   field: GridColDef['field'];

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -94,6 +94,7 @@
   { "name": "gridAggregationLookupSelector", "kind": "Variable" },
   { "name": "GridAggregationModel", "kind": "TypeAlias" },
   { "name": "gridAggregationModelSelector", "kind": "Variable" },
+  { "name": "GridAggregationParams", "kind": "Interface" },
   { "name": "GridAggregationPosition", "kind": "TypeAlias" },
   { "name": "GridAggregationRule", "kind": "Interface" },
   { "name": "GridAggregationRules", "kind": "TypeAlias" },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #12805 

This is simply exporting a type to make creating custom aggregators easier from a typing perspective.