### PR TITLE
[TreeView] Use the order in which the items are displayed for type-ahead

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
@@ -18,15 +18,6 @@ function isPrintableCharacter(string: string) {
   return !!string && string.length === 1 && !!string.match(/\S/);
 }
 
-function findNextFirstChar(firstChars: string[], startIndex: number, char: string) {
-  for (let i = startIndex; i < firstChars.length; i += 1) {
-    if (char === firstChars[i]) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 export const useTreeViewKeyboardNavigation: TreeViewPlugin<
   UseTreeViewKeyboardNavigationSignature
 > = ({ instance, params, state }) => {
@@ -55,47 +46,31 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
     firstCharMap.current = newFirstCharMap;
   }, [state.items.itemMetaMap, params.getItemId, instance]);
 
-  const getFirstMatchingItem = (itemId: string, firstChar: string) => {
-    let start: number;
-    let index: number;
-    const lowercaseChar = firstChar.toLowerCase();
+  const getFirstMatchingItem = (itemId: string, query: string) => {
+    const cleanQuery = query.toLowerCase();
 
-    const firstCharIds: string[] = [];
-    const firstChars: string[] = [];
-    // This really only works since the ids are strings
-    Object.keys(firstCharMap.current).forEach((mapItemId) => {
-      const map = instance.getItemMeta(mapItemId);
-      const visible = map.parentId ? instance.isItemExpanded(map.parentId) : true;
-      const shouldBeSkipped = params.disabledItemsFocusable
-        ? false
-        : instance.isItemDisabled(mapItemId);
-
-      if (visible && !shouldBeSkipped) {
-        firstCharIds.push(mapItemId);
-        firstChars.push(firstCharMap.current[mapItemId]);
+    const getNextItem = (itemIdToCheck: string) => {
+      const nextItemId = getNextNavigableItem(instance, itemIdToCheck);
+      // We reached the end of the tree, check from the beginning
+      if (nextItemId == null) {
+        return getFirstNavigableItem(instance);
       }
-    });
 
-    // Get start index for search based on position of currentItem
-    start = firstCharIds.indexOf(itemId) + 1;
-    if (start >= firstCharIds.length) {
-      start = 0;
+      return nextItemId;
+    };
+
+    let matchingItemId: string | null = null;
+    let currentItemId: string = getNextItem(itemId);
+    // The "currentItemId !== itemId" condition is to avoid an infinite loop when there is no matching item.
+    while (matchingItemId == null && currentItemId !== itemId) {
+      if (firstCharMap.current[currentItemId] === cleanQuery) {
+        matchingItemId = currentItemId;
+      } else {
+        currentItemId = getNextItem(currentItemId);
+      }
     }
 
-    // Check remaining slots in the menu
-    index = findNextFirstChar(firstChars, start, lowercaseChar);
-
-    // If not found in remaining slots, check from beginning
-    if (index === -1) {
-      index = findNextFirstChar(firstChars, 0, lowercaseChar);
-    }
-
-    // If a match was found...
-    if (index > -1) {
-      return firstCharIds[index];
-    }
-
-    return null;
+    return matchingItemId;
   };
 
   const canToggleItemSelection = (itemId: string) =>

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
@@ -52,7 +52,7 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
     const getNextItem = (itemIdToCheck: string) => {
       const nextItemId = getNextNavigableItem(instance, itemIdToCheck);
       // We reached the end of the tree, check from the beginning
-      if (nextItemId == null) {
+      if (nextItemId === null) {
         return getFirstNavigableItem(instance);
       }
 


### PR DESCRIPTION
Fixes #12826 

Not sure if this is a bug fix or just a behavior change.
The current type-ahead was alphabetical, if you have the items `["A3", "A2", "A1"]`, you focus `"A3"` and press `"a"`, the focus goes to `"A1"` because it's the 1st matching item alphabetically. 
This PR switches for a search based on the displayed order (you focus `"A2"` because it is the 1st matching item below the currently focused one.

IMHO this is a lot more consistent, it's the approach taken by [this TreeView](https://clarity.design/documentation/tree-view) for instance.

Nice side-effect, we no longer generate the list of the 1st letter of **every item** on each keystroke 
Now that `getNextNavigableItem` is cheap it's a lot more efficient that way


### Follow up

Add test in #12811