### PR TITLE
[charts] Allow `series.label` property to receive a function with the "location" it is going to be displayed on

### DIFF
--- a/docs/data/charts/label/BasicLabel.js
+++ b/docs/data/charts/label/BasicLabel.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+export default function BasicLabel() {
+  return (
+    <BarChart
+      {...props}
+      series={[
+        {
+          data: [2400, 1398, 9800],
+          label: 'label 1',
+        },
+      ]}
+    />
+  );
+}
+
+const props = {
+  width: 500,
+  height: 300,
+  xAxis: [{ data: ['A', 'B', 'C'], scaleType: 'band' }],
+};

--- a/docs/data/charts/label/BasicLabel.tsx
+++ b/docs/data/charts/label/BasicLabel.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+export default function BasicLabel() {
+  return (
+    <BarChart
+      {...props}
+      series={[
+        {
+          data: [2400, 1398, 9800],
+          label: 'label 1',
+        },
+      ]}
+    />
+  );
+}
+
+const props = {
+  width: 500,
+  height: 300,
+  xAxis: [{ data: ['A', 'B', 'C'], scaleType: 'band' as const }],
+};

--- a/docs/data/charts/label/BasicLabel.tsx.preview
+++ b/docs/data/charts/label/BasicLabel.tsx.preview
@@ -1,0 +1,9 @@
+<BarChart
+  {...props}
+  series={[
+    {
+      data: [2400, 1398, 9800],
+      label: 'label 1',
+    },
+  ]}
+/>

--- a/docs/data/charts/label/FunctionLabel.js
+++ b/docs/data/charts/label/FunctionLabel.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+export default function FunctionLabel() {
+  return (
+    <BarChart
+      {...props}
+      series={[
+        { data: [2400, 1398, 9800], label: 'simple label' },
+        { data: [500, 2398, 4300], label: (location) => `${location} label` },
+      ]}
+    />
+  );
+}
+
+const props = {
+  width: 500,
+  height: 300,
+  xAxis: [{ data: ['A', 'B', 'C'], scaleType: 'band' }],
+};

--- a/docs/data/charts/label/FunctionLabel.tsx
+++ b/docs/data/charts/label/FunctionLabel.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+export default function FunctionLabel() {
+  return (
+    <BarChart
+      {...props}
+      series={[
+        { data: [2400, 1398, 9800], label: 'simple label' },
+        { data: [500, 2398, 4300], label: (location) => `${location} label` },
+      ]}
+    />
+  );
+}
+
+const props = {
+  width: 500,
+  height: 300,
+  xAxis: [{ data: ['A', 'B', 'C'], scaleType: 'band' as const }],
+};

--- a/docs/data/charts/label/FunctionLabel.tsx.preview
+++ b/docs/data/charts/label/FunctionLabel.tsx.preview
@@ -1,0 +1,7 @@
+<BarChart
+  {...props}
+  series={[
+    { data: [2400, 1398, 9800], label: 'simple label' },
+    { data: [500, 2398, 4300], label: (location) => `${location} label` },
+  ]}
+/>

--- a/docs/data/charts/label/PieLabel.js
+++ b/docs/data/charts/label/PieLabel.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { PieChart } from '@mui/x-charts/PieChart';
+
+export default function PieLabel() {
+  return (
+    <PieChart
+      {...props}
+      series={[
+        {
+          data: [
+            { id: 0, value: 10, label: (v) => `${v}+A` },
+            { id: 1, value: 15, label: (v) => `${v}+B` },
+            { id: 2, value: 20, label: (v) => `${v}+C` },
+          ],
+          type: 'pie',
+          arcLabel: 'label',
+        },
+      ]}
+    />
+  );
+}
+
+const props = {
+  width: 500,
+  height: 200,
+};

--- a/docs/data/charts/label/PieLabel.js
+++ b/docs/data/charts/label/PieLabel.js
@@ -8,9 +8,9 @@ export default function PieLabel() {
       series={[
         {
           data: [
-            { id: 0, value: 10, label: (v) => `${v}+A` },
-            { id: 1, value: 15, label: (v) => `${v}+B` },
-            { id: 2, value: 20, label: (v) => `${v}+C` },
+            { id: 0, value: 10, label: (location) => `${location}+A` },
+            { id: 1, value: 15, label: (location) => `${location}+B` },
+            { id: 2, value: 20, label: (location) => `${location}+C` },
           ],
           type: 'pie',
           arcLabel: 'label',

--- a/docs/data/charts/label/PieLabel.tsx
+++ b/docs/data/charts/label/PieLabel.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { PieChart } from '@mui/x-charts/PieChart';
+
+export default function PieLabel() {
+  return (
+    <PieChart
+      {...props}
+      series={[
+        {
+          data: [
+            { id: 0, value: 10, label: (v) => `${v}+A` },
+            { id: 1, value: 15, label: (v) => `${v}+B` },
+            { id: 2, value: 20, label: (v) => `${v}+C` },
+          ],
+          type: 'pie',
+          arcLabel: 'label',
+        },
+      ]}
+    />
+  );
+}
+
+const props = {
+  width: 500,
+  height: 200,
+};

--- a/docs/data/charts/label/PieLabel.tsx
+++ b/docs/data/charts/label/PieLabel.tsx
@@ -8,9 +8,9 @@ export default function PieLabel() {
       series={[
         {
           data: [
-            { id: 0, value: 10, label: (v) => `${v}+A` },
-            { id: 1, value: 15, label: (v) => `${v}+B` },
-            { id: 2, value: 20, label: (v) => `${v}+C` },
+            { id: 0, value: 10, label: (location) => `${location}+A` },
+            { id: 1, value: 15, label: (location) => `${location}+B` },
+            { id: 2, value: 20, label: (location) => `${location}+C` },
           ],
           type: 'pie',
           arcLabel: 'label',

--- a/docs/data/charts/label/PieLabel.tsx.preview
+++ b/docs/data/charts/label/PieLabel.tsx.preview
@@ -1,0 +1,14 @@
+<PieChart
+  {...props}
+  series={[
+    {
+      data: [
+        { id: 0, value: 10, label: (v) => `${v}+A` },
+        { id: 1, value: 15, label: (v) => `${v}+B` },
+        { id: 2, value: 20, label: (v) => `${v}+C` },
+      ],
+      type: 'pie',
+      arcLabel: 'label',
+    },
+  ]}
+/>

--- a/docs/data/charts/label/PieLabel.tsx.preview
+++ b/docs/data/charts/label/PieLabel.tsx.preview
@@ -3,9 +3,9 @@
   series={[
     {
       data: [
-        { id: 0, value: 10, label: (v) => `${v}+A` },
-        { id: 1, value: 15, label: (v) => `${v}+B` },
-        { id: 2, value: 20, label: (v) => `${v}+C` },
+        { id: 0, value: 10, label: (location) => `${location}+A` },
+        { id: 1, value: 15, label: (location) => `${location}+B` },
+        { id: 2, value: 20, label: (location) => `${location}+C` },
       ],
       type: 'pie',
       arcLabel: 'label',

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -39,7 +39,7 @@ Instead of receiving the `label` as part of the series. It instead receives it a
 
 Its `location` argument can have the following values:
 
-- `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
+- `'legend'` to format the label to display in the [Legend](/x/react-charts/legend/)
 - `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
 - `'arc'` to format the [Arc](http://localhost:3001/x/react-charts/pie/#labels) label when `arcLabel` is set to `'label'`
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -38,7 +38,9 @@ The function receives `location` as its first argument which can have the follow
 
 ### Pie
 
-The [Pie](/x/react-charts/pie/) chart behaves a little differently due to its nature. It also has one more place where the label can be rendered.
+The [Pie](/x/react-charts/pie/) chart behaves differently due to its nature.
+It has labels per slice instead of per series.
+It also has one more place where the label can be rendered.
 
 Instead of receiving the `label` as part of the series. It instead receives it as part of the `data` set inside a series.
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -31,7 +31,7 @@ Each of the `series` can receive a different `function` or `string` as their `la
 
 The function receives `location` as its first argument which can have the following values:
 
-- `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
+- `'legend'` to format the label in the [Legend](/x/react-charts/legend/)
 - `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
 
 {{"demo": "FunctionLabel.js"}}

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -41,6 +41,6 @@ And its `location` argument can have the following values:
 
 - `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
 - `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
-- `'arc'` for formatting the [Arc](http://localhost:3001/x/react-charts/pie/#labels) label when `arcLabel` is set to `'label'`
+- `'arc'` to format the [Arc](http://localhost:3001/x/react-charts/pie/#labels) label when `arcLabel` is set to `'label'`
 
 {{"demo": "PieLabel.js"}}

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -14,7 +14,7 @@ In the most basic example, you can pass in a `string` as a series' label, and it
 
 {{"demo": "BasicLabel.js"}}
 
-## Conditional Formatting
+## Conditional formatting
 
 In order to change the content of the label based on where it is being displayed. You can pass a function to the `label` property of the [BarSeriesType](/x/api/charts/bar-series-type/), [LineSeriesType](/x/api/charts/line-series-type/) and [ScatterSeriesType](/x/api/charts/scatter-series-type/) or [PieSeriesType](/x/api/charts/pie-series-type/)`.data.label` in case of a pie chart.
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -33,7 +33,7 @@ The function receives `location` as its first argument, and it can have the foll
 
 ### Pie
 
-The [Pie](/x/react-charts/pie/) charts however, behave a little different due to their nature. They also have one more place where the label can be rendered.
+The [Pie](/x/react-charts/pie/) chart behaves a little differently due to its nature. It also has one more place where the label can be rendered.
 
 Instead of receiving the `label` as part of the series. It instead receives it as part of the `data` set inside a series.
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -21,7 +21,7 @@ The Pie chart has some specificity described in its [own section](#pie).
 
 ## Conditional formatting
 
-In order to change the content of the label based on where it is being displayed. You can pass a function to the `label` property of the [BarSeriesType](/x/api/charts/bar-series-type/), [LineSeriesType](/x/api/charts/line-series-type/) and [ScatterSeriesType](/x/api/charts/scatter-series-type/) or [PieSeriesType](/x/api/charts/pie-series-type/)`.data.label` in case of a pie chart.
+The `label` property also accepts a function allowing you to change the label content based on location.
 
 ### Bars, Lines and Scatter
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -42,7 +42,8 @@ The [Pie](/x/react-charts/pie/) chart behaves differently due to its nature.
 It has labels per slice instead of per series.
 It also has one more place where the label can be rendered.
 
-Instead of receiving the `label` as part of the series. It instead receives it as part of the `data` set inside a series.
+Instead of receiving the `label` as part of the series.
+It instead receives it as part of the `data` set inside a series.
 
 Its `location` argument can have the following values:
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -6,11 +6,11 @@ components: BarChart, ScatterChart, LineChart, PieChart
 
 # Charts - Label
 
-<p class="description">Label refers to the text reference of a series or data.</p>
+<p class="description">Label is the text reference of a series or data.</p>
 
 ## Basic display
 
-To set series' label, you can pass in a `string` as a series' property `label`.
+To set a series' label, you can pass in a `string` as a series' property `label`.
 The provided label will be visible at different locations such as the legend, or the tooltip.
 
 :::info
@@ -21,18 +21,12 @@ The Pie chart has some specificity described in its [own section](#pie).
 
 ## Conditional formatting
 
-The `label` property also accepts a function allowing you to change the label content based on location.
-
-### Bars, Lines and Scatter
-
-The [Bars](/x/react-charts/bars/), [Lines](/x/react-charts/lines/) and [Scatter](/x/react-charts/scatter/) charts all work in the same way regarding the `label` property.
-
-Each of the `series` can receive a different `function` or `string` as their `label`.
+The `label` property also accepts a `function` allowing you to change the label content based on location.
 
 The function receives `location` as its first argument which can have the following values:
 
 - `'legend'` to format the label in the [Legend](/x/react-charts/legend/)
-- `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
+- `'tooltip'` to format the label in the [Tooltip](/x/react-charts/tooltip/)
 
 {{"demo": "FunctionLabel.js"}}
 
@@ -47,8 +41,8 @@ It instead receives it as part of the `data` set inside a series.
 
 Its `location` argument can have the following values:
 
-- `'legend'` to format the label to display in the [Legend](/x/react-charts/legend/)
-- `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
+- `'legend'` to format the label in the [Legend](/x/react-charts/legend/)
+- `'tooltip'` to format the label in the [Tooltip](/x/react-charts/tooltip/)
 - `'arc'` to format the [Arc label](/x/react-charts/pie/#labels) when `arcLabel` is set to `'label'`
 
 {{"demo": "PieLabel.js"}}

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -6,7 +6,7 @@ components: BarChart, ScatterChart, LineChart, PieChart
 
 # Charts - Label
 
-<p class="description">Label refers to the text reference of a series or data. In the UI it is used in many components like the `legend`, `tooltip` and inside an `arc` of a pie chart.</p>
+<p class="description">Label refers to the text reference of a series or data. It is used in many components like the "legend", "tooltip",  and inside an "arc" of a pie chart.</p>
 
 ## Basic display
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -37,7 +37,7 @@ The [Pie](/x/react-charts/pie/) chart behaves a little differently due to its na
 
 Instead of receiving the `label` as part of the series. It instead receives it as part of the `data` set inside a series.
 
-And its `location` argument can have the following values:
+Its `location` argument can have the following values:
 
 - `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
 - `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -6,7 +6,7 @@ components: BarChart, ScatterChart, LineChart, PieChart
 
 # Charts - Label
 
-<p class="description">Label refers to the text reference of a series or data. It is used in many components like the "legend", "tooltip",  and inside an "arc" of a pie chart.</p>
+<p class="description">Label refers to the text reference of a series or data.</p>
 
 ## Basic display
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -29,7 +29,7 @@ The [Bars](/x/react-charts/bars/), [Lines](/x/react-charts/lines/) and [Scatter]
 
 Each of the `series` can receive a different `function` or `string` as their `label`.
 
-The function receives `location` as its first argument, and it can have the following values:
+The function receives `location` as its first argument which can have the following values:
 
 - `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
 - `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -46,6 +46,6 @@ Its `location` argument can have the following values:
 
 - `'legend'` to format the label to display in the [Legend](/x/react-charts/legend/)
 - `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
-- `'arc'` to format the [Arc](http://localhost:3001/x/react-charts/pie/#labels) label when `arcLabel` is set to `'label'`
+- `'arc'` to format the [Arc label](/x/react-charts/pie/#labels) when `arcLabel` is set to `'label'`
 
 {{"demo": "PieLabel.js"}}

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -30,7 +30,7 @@ The function receives `location` as its first argument which can have the follow
 
 {{"demo": "FunctionLabel.js"}}
 
-### Pie
+## Pie
 
 The [Pie](/x/react-charts/pie/) chart behaves differently due to its nature.
 It has labels per slice instead of per series.

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -10,7 +10,12 @@ components: BarChart, ScatterChart, LineChart, PieChart
 
 ## Basic display
 
-In the most basic example, you can pass in a `string` as a series' label, and it will be rendered like that by all the different components that use it in order to differentiate each series.
+To set series' label, you can pass in a `string` as a series' property `label`.
+The provided label will be visible at different locations such as the legend, or the tooltip.
+
+:::info
+The Pie chart has some specificity described in its [own section](#pie).
+:::
 
 {{"demo": "BasicLabel.js"}}
 

--- a/docs/data/charts/label/label.md
+++ b/docs/data/charts/label/label.md
@@ -1,0 +1,46 @@
+---
+title: Charts - Label
+productId: x-charts
+components: BarChart, ScatterChart, LineChart, PieChart
+---
+
+# Charts - Label
+
+<p class="description">Label refers to the text reference of a series or data. In the UI it is used in many components like the `legend`, `tooltip` and inside an `arc` of a pie chart.</p>
+
+## Basic display
+
+In the most basic example, you can pass in a `string` as a series' label, and it will be rendered like that by all the different components that use it in order to differentiate each series.
+
+{{"demo": "BasicLabel.js"}}
+
+## Conditional Formatting
+
+In order to change the content of the label based on where it is being displayed. You can pass a function to the `label` property of the [BarSeriesType](/x/api/charts/bar-series-type/), [LineSeriesType](/x/api/charts/line-series-type/) and [ScatterSeriesType](/x/api/charts/scatter-series-type/) or [PieSeriesType](/x/api/charts/pie-series-type/)`.data.label` in case of a pie chart.
+
+### Bars, Lines and Scatter
+
+The [Bars](/x/react-charts/bars/), [Lines](/x/react-charts/lines/) and [Scatter](/x/react-charts/scatter/) charts all work in the same way regarding the `label` property.
+
+Each of the `series` can receive a different `function` or `string` as their `label`.
+
+The function receives `location` as its first argument, and it can have the following values:
+
+- `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
+- `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
+
+{{"demo": "FunctionLabel.js"}}
+
+### Pie
+
+The [Pie](/x/react-charts/pie/) charts however, behave a little different due to their nature. They also have one more place where the label can be rendered.
+
+Instead of receiving the `label` as part of the series. It instead receives it as part of the `data` set inside a series.
+
+And its `location` argument can have the following values:
+
+- `'legend'` in order to format the label to display in the [Legend](/x/react-charts/legend/)
+- `'tooltip'` to format for displaying in the [Tooltip](/x/react-charts/tooltip/)
+- `'arc'` for formatting the [Arc](http://localhost:3001/x/react-charts/pie/#labels) label when `arcLabel` is set to `'label'`
+
+{{"demo": "PieLabel.js"}}

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -444,6 +444,7 @@ const pages: MuiPage[] = [
               { pathname: '/x/react-charts/axis', title: 'Axis' },
               { pathname: '/x/react-charts/components', title: 'Custom components' },
               { pathname: '/x/react-charts/composition', title: 'Composition' },
+              { pathname: '/x/react-charts/label', title: 'Label' },
               { pathname: '/x/react-charts/legend', title: 'Legend' },
               { pathname: '/x/react-charts/stacking', title: 'Stacking' },
               { pathname: '/x/react-charts/styling', title: 'Styling' },

--- a/docs/package.json
+++ b/docs/package.json
@@ -100,7 +100,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@mui/internal-docs-utils": "^1.0.4",
     "@mui/internal-scripts": "^1.0.3",
-    "@types/chance": "^1.0.3",
+    "@types/chance": "^1.1.11",
     "@types/d3-scale": "^4.0.8",
     "@types/doctrine": "^0.0.9",
     "@types/lodash": "^4.17.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -100,7 +100,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@mui/internal-docs-utils": "^1.0.4",
     "@mui/internal-scripts": "^1.0.3",
-    "@types/chance": "^1.1.11",
+    "@types/chance": "^1.1.6",
     "@types/d3-scale": "^4.0.8",
     "@types/doctrine": "^0.0.9",
     "@types/lodash": "^4.17.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -100,6 +100,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@mui/internal-docs-utils": "^1.0.4",
     "@mui/internal-scripts": "^1.0.3",
+    "@types/chance": "^1.0.3",
     "@types/d3-scale": "^4.0.8",
     "@types/doctrine": "^0.0.9",
     "@types/lodash": "^4.17.1",

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -172,6 +172,6 @@
   "muiName": "MuiBarChart",
   "filename": "/packages/x-charts/src/BarChart/BarChart.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-charts/bar-demo/\">Charts - Bar demonstration</a></li>\n<li><a href=\"/x/react-charts/bars/\">Charts - Bars</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-charts/bar-demo/\">Charts - Bar demonstration</a></li>\n<li><a href=\"/x/react-charts/bars/\">Charts - Bars</a></li>\n<li><a href=\"/x/react-charts/label/\">Charts - Label</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/x/api/charts/bar-series-type.json
+++ b/docs/pages/x/api/charts/bar-series-type.json
@@ -8,7 +8,9 @@
     "dataKey": { "type": { "description": "string" } },
     "highlightScope": { "type": { "description": "Partial&lt;HighlightScope&gt;" } },
     "id": { "type": { "description": "SeriesId" } },
-    "label": { "type": { "description": "string" } },
+    "label": {
+      "type": { "description": "string | ((location: 'tooltip' | 'legend') =&gt; string)" }
+    },
     "layout": { "type": { "description": "'horizontal' | 'vertical'" }, "default": "'vertical'" },
     "stack": { "type": { "description": "string" } },
     "stackOffset": { "type": { "description": "StackOffsetType" }, "default": "'diverging'" },

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -174,6 +174,6 @@
   "muiName": "MuiLineChart",
   "filename": "/packages/x-charts/src/LineChart/LineChart.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-charts/areas-demo/\">Charts - Areas demonstration</a></li>\n<li><a href=\"/x/react-charts/line-demo/\">Charts - Line demonstration</a></li>\n<li><a href=\"/x/react-charts/lines/\">Charts - Lines</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-charts/areas-demo/\">Charts - Areas demonstration</a></li>\n<li><a href=\"/x/react-charts/label/\">Charts - Label</a></li>\n<li><a href=\"/x/react-charts/line-demo/\">Charts - Line demonstration</a></li>\n<li><a href=\"/x/react-charts/lines/\">Charts - Lines</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/x/api/charts/line-series-type.json
+++ b/docs/pages/x/api/charts/line-series-type.json
@@ -12,7 +12,9 @@
     "disableHighlight": { "type": { "description": "boolean" }, "default": "false" },
     "highlightScope": { "type": { "description": "Partial&lt;HighlightScope&gt;" } },
     "id": { "type": { "description": "SeriesId" } },
-    "label": { "type": { "description": "string" } },
+    "label": {
+      "type": { "description": "string | ((location: 'tooltip' | 'legend') =&gt; string)" }
+    },
     "showMark": { "type": { "description": "boolean | ((params: ShowMarkParams) =&gt; boolean)" } },
     "stack": { "type": { "description": "string" } },
     "stackOffset": { "type": { "description": "StackOffsetType" }, "default": "'none'" },

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -158,6 +158,6 @@
   "muiName": "MuiPieChart",
   "filename": "/packages/x-charts/src/PieChart/PieChart.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-charts/pie/\">Charts - Pie</a></li>\n<li><a href=\"/x/react-charts/pie-demo/\">Charts - Pie demonstration</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-charts/label/\">Charts - Label</a></li>\n<li><a href=\"/x/react-charts/pie/\">Charts - Pie</a></li>\n<li><a href=\"/x/react-charts/pie-demo/\">Charts - Pie demonstration</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/x/api/charts/pie-series-type.json
+++ b/docs/pages/x/api/charts/pie-series-type.json
@@ -6,7 +6,7 @@
     "type": { "type": { "description": "'pie'" }, "required": true },
     "arcLabel": {
       "type": {
-        "description": "'formattedValue' | 'label' | 'value' | ((item: DefaultizedPieValueType) =&gt; string)"
+        "description": "'formattedValue' | 'label' | 'value' | ((item: Omit&lt;DefaultizedPieValueType, 'label'&gt; & { label?: string }) =&gt; string)"
       }
     },
     "arcLabelMinAngle": { "type": { "description": "number" }, "default": "0" },

--- a/docs/pages/x/api/charts/pie-series-type.json
+++ b/docs/pages/x/api/charts/pie-series-type.json
@@ -2,7 +2,7 @@
   "name": "PieSeriesType",
   "imports": ["import { PieSeriesType } from '@mui/x-charts'"],
   "properties": {
-    "data": { "type": { "description": "Tdata[]" }, "required": true },
+    "data": { "type": { "description": "TData[]" }, "required": true },
     "type": { "type": { "description": "'pie'" }, "required": true },
     "arcLabel": {
       "type": {

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -164,6 +164,6 @@
   "muiName": "MuiScatterChart",
   "filename": "/packages/x-charts/src/ScatterChart/ScatterChart.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-charts/scatter/\">Charts - Scatter</a></li>\n<li><a href=\"/x/react-charts/scatter-demo/\">Charts - Scatter demonstration</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-charts/label/\">Charts - Label</a></li>\n<li><a href=\"/x/react-charts/scatter/\">Charts - Scatter</a></li>\n<li><a href=\"/x/react-charts/scatter-demo/\">Charts - Scatter demonstration</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/x/api/charts/scatter-series-type.json
+++ b/docs/pages/x/api/charts/scatter-series-type.json
@@ -8,7 +8,9 @@
     "disableHover": { "type": { "description": "boolean" }, "default": "false" },
     "highlightScope": { "type": { "description": "Partial&lt;HighlightScope&gt;" } },
     "id": { "type": { "description": "SeriesId" } },
-    "label": { "type": { "description": "string" } },
+    "label": {
+      "type": { "description": "string | ((location: 'tooltip' | 'legend') =&gt; string)" }
+    },
     "markerSize": { "type": { "description": "number" } },
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisKey": { "type": { "description": "string" } },

--- a/docs/pages/x/react-charts/label.js
+++ b/docs/pages/x/react-charts/label.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docsx/data/charts/label/label.md?muiMarkdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/translations/api-docs/charts/bar-series-type.json
+++ b/docs/translations/api-docs/charts/bar-series-type.json
@@ -7,7 +7,9 @@
     "dataKey": { "description": "The key used to retrieve data from the dataset." },
     "highlightScope": { "description": "" },
     "id": { "description": "" },
-    "label": { "description": "" },
+    "label": {
+      "description": "The label to display on the tooltip or the legend. It can be a string or a function."
+    },
     "layout": { "description": "Layout of the bars. All bar should have the same layout." },
     "stack": {
       "description": "The key that identifies the stacking group.<br />Series with the same <code>stack</code> property will be stacked together."

--- a/docs/translations/api-docs/charts/line-series-type.json
+++ b/docs/translations/api-docs/charts/line-series-type.json
@@ -15,7 +15,9 @@
     },
     "highlightScope": { "description": "" },
     "id": { "description": "" },
-    "label": { "description": "" },
+    "label": {
+      "description": "The label to display on the tooltip or the legend. It can be a string or a function."
+    },
     "showMark": {
       "description": "Define which items of the series should display a mark.<br />If can be a boolean that applies to all items.<br />Or a callback that gets some item properties and returns true if the item should be displayed."
     },

--- a/docs/translations/api-docs/charts/scatter-series-type.json
+++ b/docs/translations/api-docs/charts/scatter-series-type.json
@@ -9,7 +9,9 @@
     },
     "highlightScope": { "description": "" },
     "id": { "description": "" },
-    "label": { "description": "" },
+    "label": {
+      "description": "The label to display on the tooltip or the legend. It can be a string or a function."
+    },
     "markerSize": { "description": "" },
     "valueFormatter": {
       "description": "Formatter used to render values in tooltip or other data display."

--- a/packages/x-charts/src/BarChart/legend.ts
+++ b/packages/x-charts/src/BarChart/legend.ts
@@ -1,13 +1,22 @@
+import { getLabel } from '../internals/getLabel';
 import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'bar'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => ({
-    color: series[seriesId].color,
-    label: series[seriesId].label,
-    id: seriesId,
-  }));
-  return data.filter((item) => item.label !== undefined) as LegendParams[];
+  return seriesOrder.reduce((acc, seriesId) => {
+    const formattedLabel = getLabel(series[seriesId].label, 'legend');
+
+    if (formattedLabel === undefined) {
+      return acc;
+    }
+
+    acc.push({
+      color: series[seriesId].color,
+      label: formattedLabel,
+      id: seriesId,
+    });
+    return acc;
+  }, [] as LegendParams[]);
 };
 
 export default legendGetter;

--- a/packages/x-charts/src/BarChart/legend.ts
+++ b/packages/x-charts/src/BarChart/legend.ts
@@ -2,11 +2,15 @@ import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'bar'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => ({
-    color: series[seriesId].color,
-    label: series[seriesId].label,
-    id: seriesId,
-  }));
+  const data = seriesOrder.map((seriesId) => {
+    const label = series[seriesId].label;
+    const labelFormatter = series[seriesId].labelFormatter;
+    return {
+      color: series[seriesId].color,
+      label: label ? labelFormatter?.(label, { location: 'legend' }) ?? label : undefined,
+      id: seriesId,
+    };
+  });
   return data.filter((item) => item.label !== undefined) as LegendParams[];
 };
 

--- a/packages/x-charts/src/BarChart/legend.ts
+++ b/packages/x-charts/src/BarChart/legend.ts
@@ -2,15 +2,11 @@ import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'bar'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => {
-    const label = series[seriesId].label;
-    const labelFormatter = series[seriesId].labelFormatter;
-    return {
-      color: series[seriesId].color,
-      label: label ? labelFormatter?.(label, { location: 'legend' }) ?? label : undefined,
-      id: seriesId,
-    };
-  });
+  const data = seriesOrder.map((seriesId) => ({
+    color: series[seriesId].color,
+    label: series[seriesId].label,
+    id: seriesId,
+  }));
   return data.filter((item) => item.label !== undefined) as LegendParams[];
 };
 

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsAxisTooltipContent.tsx
@@ -11,6 +11,7 @@ import {
 } from './ChartsTooltipTable';
 import type { ChartsAxisContentProps } from './ChartsAxisTooltipContent';
 import { isCartesianSeries, utcFormatter } from './utils';
+import { getLabel } from '../internals/getLabel';
 
 function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
   const { series, axis, dataIndex, axisValue, sx, classes } = props;
@@ -46,6 +47,7 @@ function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
               if (formattedValue == null) {
                 return null;
               }
+              const formattedLabel = getLabel(label, 'tooltip');
               return (
                 <ChartsTooltipRow key={id} className={classes.row}>
                   <ChartsTooltipCell className={clsx(classes.markCell, classes.cell)}>
@@ -55,7 +57,7 @@ function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
                     />
                   </ChartsTooltipCell>
                   <ChartsTooltipCell className={clsx(classes.labelCell, classes.cell)}>
-                    {label ? <Typography>{label}</Typography> : null}
+                    {formattedLabel ? <Typography>{formattedLabel}</Typography> : null}
                   </ChartsTooltipCell>
                   <ChartsTooltipCell className={clsx(classes.valueCell, classes.cell)}>
                     <Typography>{formattedValue}</Typography>

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsAxisTooltipContent.tsx
@@ -40,7 +40,7 @@ function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
         <tbody>
           {series
             .filter(isCartesianSeries)
-            .map(({ color, id, label, valueFormatter, data, getColor, labelFormatter }) => {
+            .map(({ color, id, label, valueFormatter, data, getColor }) => {
               // @ts-ignore
               const formattedValue = valueFormatter(data[dataIndex] ?? null, { dataIndex });
               if (formattedValue == null) {
@@ -55,11 +55,7 @@ function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
                     />
                   </ChartsTooltipCell>
                   <ChartsTooltipCell className={clsx(classes.labelCell, classes.cell)}>
-                    {label ? (
-                      <Typography>
-                        {labelFormatter?.(label, { location: 'tooltip' }) ?? label}
-                      </Typography>
-                    ) : null}
+                    {label ? <Typography>{label}</Typography> : null}
                   </ChartsTooltipCell>
                   <ChartsTooltipCell className={clsx(classes.valueCell, classes.cell)}>
                     <Typography>{formattedValue}</Typography>

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsAxisTooltipContent.tsx
@@ -40,7 +40,7 @@ function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
         <tbody>
           {series
             .filter(isCartesianSeries)
-            .map(({ color, id, label, valueFormatter, data, getColor }) => {
+            .map(({ color, id, label, valueFormatter, data, getColor, labelFormatter }) => {
               // @ts-ignore
               const formattedValue = valueFormatter(data[dataIndex] ?? null, { dataIndex });
               if (formattedValue == null) {
@@ -55,7 +55,11 @@ function DefaultChartsAxisTooltipContent(props: ChartsAxisContentProps) {
                     />
                   </ChartsTooltipCell>
                   <ChartsTooltipCell className={clsx(classes.labelCell, classes.cell)}>
-                    {label ? <Typography>{label}</Typography> : null}
+                    {label ? (
+                      <Typography>
+                        {labelFormatter?.(label, { location: 'tooltip' }) ?? label}
+                      </Typography>
+                    ) : null}
                   </ChartsTooltipCell>
                   <ChartsTooltipCell className={clsx(classes.valueCell, classes.cell)}>
                     <Typography>{formattedValue}</Typography>

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
@@ -11,6 +11,7 @@ import {
 } from './ChartsTooltipTable';
 import type { ChartsItemContentProps } from './ChartsItemTooltipContent';
 import { CommonSeriesType } from '../models/seriesType/common';
+import { getLabel } from '../internals/getLabel';
 
 function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeriesType>(
   props: ChartsItemContentProps<T>,
@@ -24,14 +25,20 @@ function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeries
     series.type === 'pie'
       ? {
           color: getColor(itemData.dataIndex),
-          displayedLabel: series.data[itemData.dataIndex].label,
+          displayedLabel: getLabel(series.data[itemData.dataIndex].label, 'tooltip'),
         }
       : {
           color: getColor(itemData.dataIndex) ?? series.color,
-          displayedLabel: series.label,
+          displayedLabel: getLabel(series.label, 'tooltip'),
         };
 
-  const value = series.data[itemData.dataIndex];
+  const value =
+    series.type === 'pie'
+      ? {
+          ...series.data[itemData.dataIndex],
+          label: getLabel(series.data[itemData.dataIndex].label, 'tooltip'),
+        }
+      : series.data[itemData.dataIndex];
   const formattedValue = (
     series.valueFormatter as CommonSeriesType<typeof value>['valueFormatter']
   )?.(value, { dataIndex: itemData.dataIndex });

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
@@ -20,11 +20,16 @@ function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeries
   if (itemData.dataIndex === undefined || !series.data[itemData.dataIndex]) {
     return null;
   }
-
-  const color = series.type === 'pie' ? getColor(itemData.dataIndex) : series.color;
-  const label = series.type === 'pie' ? series.data[itemData.dataIndex].label : series.label;
-  const displayedLabel =
-    (label && series.labelFormatter?.(label, { location: 'tooltip' })) ?? label;
+  const { displayedLabel, color } =
+    series.type === 'pie'
+      ? {
+          color: getColor(itemData.dataIndex),
+          displayedLabel: series.data[itemData.dataIndex].label,
+        }
+      : {
+          color: getColor(itemData.dataIndex) ?? series.color,
+          displayedLabel: series.label,
+        };
 
   const value = series.data[itemData.dataIndex];
   const formattedValue = (

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
@@ -20,16 +20,11 @@ function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeries
   if (itemData.dataIndex === undefined || !series.data[itemData.dataIndex]) {
     return null;
   }
-  const { displayedLabel, color } =
-    series.type === 'pie'
-      ? {
-          color: getColor(itemData.dataIndex),
-          displayedLabel: series.data[itemData.dataIndex].label,
-        }
-      : {
-          color: getColor(itemData.dataIndex) ?? series.color,
-          displayedLabel: series.label,
-        };
+
+  const color = series.type === 'pie' ? getColor(itemData.dataIndex) : series.color;
+  const label = series.type === 'pie' ? series.data[itemData.dataIndex].label : series.label;
+  const displayedLabel =
+    (label && series.labelFormatter?.(label, { location: 'tooltip' })) ?? label;
 
   const value = series.data[itemData.dataIndex];
   const formattedValue = (

--- a/packages/x-charts/src/LineChart/legend.ts
+++ b/packages/x-charts/src/LineChart/legend.ts
@@ -1,13 +1,22 @@
+import { getLabel } from '../internals/getLabel';
 import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'line'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => ({
-    color: series[seriesId].color,
-    label: series[seriesId].label,
-    id: seriesId,
-  }));
-  return data.filter((item) => item.label !== undefined) as LegendParams[];
+  return seriesOrder.reduce((acc, seriesId) => {
+    const formattedLabel = getLabel(series[seriesId].label, 'legend');
+
+    if (formattedLabel === undefined) {
+      return acc;
+    }
+
+    acc.push({
+      color: series[seriesId].color,
+      label: formattedLabel,
+      id: seriesId,
+    });
+    return acc;
+  }, [] as LegendParams[]);
 };
 
 export default legendGetter;

--- a/packages/x-charts/src/LineChart/legend.ts
+++ b/packages/x-charts/src/LineChart/legend.ts
@@ -2,11 +2,15 @@ import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'line'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => ({
-    color: series[seriesId].color,
-    label: series[seriesId].label,
-    id: seriesId,
-  }));
+  const data = seriesOrder.map((seriesId) => {
+    const label = series[seriesId].label;
+    const labelFormatter = series[seriesId].labelFormatter;
+    return {
+      color: series[seriesId].color,
+      label: label ? labelFormatter?.(label, { location: 'legend' }) ?? label : undefined,
+      id: seriesId,
+    };
+  });
   return data.filter((item) => item.label !== undefined) as LegendParams[];
 };
 

--- a/packages/x-charts/src/LineChart/legend.ts
+++ b/packages/x-charts/src/LineChart/legend.ts
@@ -2,15 +2,11 @@ import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'line'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => {
-    const label = series[seriesId].label;
-    const labelFormatter = series[seriesId].labelFormatter;
-    return {
-      color: series[seriesId].color,
-      label: label ? labelFormatter?.(label, { location: 'legend' }) ?? label : undefined,
-      id: seriesId,
-    };
-  });
+  const data = seriesOrder.map((seriesId) => ({
+    color: series[seriesId].color,
+    label: series[seriesId].label,
+    id: seriesId,
+  }));
   return data.filter((item) => item.label !== undefined) as LegendParams[];
 };
 

--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -54,6 +54,7 @@ const PieArcLabelRoot = styled(animated.text, {
   fill: (theme.vars || theme).palette.text.primary,
   textAnchor: 'middle',
   dominantBaseline: 'middle',
+  pointerEvents: 'none',
 }));
 
 export type PieArcLabelProps = PieArcLabelOwnerState &

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -14,6 +14,7 @@ import {
   useTransformData,
 } from './dataTransform/useTransformData';
 import { PieArcLabel, PieArcLabelProps } from './PieArcLabel';
+import { getLabel } from '../internals/getLabel';
 
 const RATIO = 180 / Math.PI;
 
@@ -30,11 +31,22 @@ function getItemLabel(
     return null;
   }
 
-  if (typeof arcLabel === 'string') {
-    return item[arcLabel]?.toString();
+  if (arcLabel === 'label') {
+    return getLabel(item.label, 'arc');
   }
 
-  return arcLabel(item);
+  if (arcLabel === 'value') {
+    return item.value?.toString();
+  }
+
+  if (arcLabel === 'formattedValue') {
+    return item.formattedValue;
+  }
+
+  return arcLabel({
+    ...item,
+    label: getLabel(item.label, 'arc'),
+  });
 }
 
 export interface PieArcLabelPlotSlots {

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -210,7 +210,7 @@ PieArcLabelPlot.propTypes = {
       formattedValue: PropTypes.string.isRequired,
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
       index: PropTypes.number.isRequired,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
       padAngle: PropTypes.number.isRequired,
       startAngle: PropTypes.number.isRequired,
       value: PropTypes.number.isRequired,

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -31,22 +31,19 @@ function getItemLabel(
     return null;
   }
 
-  if (arcLabel === 'label') {
-    return getLabel(item.label, 'arc');
+  switch (arcLabel) {
+    case 'label':
+      return getLabel(item.label, 'arc');
+    case 'value':
+      return item.value?.toString();
+    case 'formattedValue':
+      return item.formattedValue;
+    default:
+      return arcLabel({
+        ...item,
+        label: getLabel(item.label, 'arc'),
+      });
   }
-
-  if (arcLabel === 'value') {
-    return item.value?.toString();
-  }
-
-  if (arcLabel === 'formattedValue') {
-    return item.formattedValue;
-  }
-
-  return arcLabel({
-    ...item,
-    label: getLabel(item.label, 'arc'),
-  });
 }
 
 export interface PieArcLabelPlotSlots {

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -172,7 +172,7 @@ PieArcPlot.propTypes = {
       formattedValue: PropTypes.string.isRequired,
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
       index: PropTypes.number.isRequired,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
       padAngle: PropTypes.number.isRequired,
       startAngle: PropTypes.number.isRequired,
       value: PropTypes.number.isRequired,

--- a/packages/x-charts/src/PieChart/formatter.ts
+++ b/packages/x-charts/src/PieChart/formatter.ts
@@ -2,6 +2,7 @@ import { pie as d3Pie } from 'd3-shape';
 import { ChartSeriesDefaultized, Formatter } from '../models/seriesType/config';
 import { ChartsPieSorting, PieValueType } from '../models/seriesType/pie';
 import { SeriesId } from '../models/seriesType/common';
+import { getLabel } from '../internals/getLabel';
 
 const getSortingComparator = (comparator: ChartsPieSorting = 'none') => {
   if (typeof comparator === 'function') {
@@ -43,8 +44,10 @@ const formatter: Formatter<'pie'> = (params) => {
         .map((item, index) => ({
           ...item,
           formattedValue:
-            series[seriesId].valueFormatter?.(item, { dataIndex: index }) ??
-            item.value.toLocaleString(),
+            series[seriesId].valueFormatter?.(
+              { ...item, label: getLabel(item.label, 'arc') },
+              { dataIndex: index },
+            ) ?? item.value.toLocaleString(),
         })),
     };
   });

--- a/packages/x-charts/src/PieChart/legend.ts
+++ b/packages/x-charts/src/PieChart/legend.ts
@@ -1,17 +1,24 @@
+import { getLabel } from '../internals/getLabel';
 import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'pie'> = (params) => {
   const { seriesOrder, series } = params;
-  return seriesOrder.flatMap(
-    (seriesId) =>
-      series[seriesId].data
-        .map((item) => ({
-          color: item.color,
-          label: item.label,
-          id: item.id,
-        }))
-        .filter((item) => item.label !== undefined) as LegendParams[],
-  );
+  return seriesOrder.reduce((acc, seriesId) => {
+    series[seriesId].data.forEach((item) => {
+      const formattedLabel = getLabel(item.label, 'legend');
+
+      if (formattedLabel === undefined) {
+        return;
+      }
+
+      acc.push({
+        color: item.color,
+        label: formattedLabel,
+        id: item.id,
+      });
+    });
+    return acc;
+  }, [] as LegendParams[]);
 };
 
 export default legendGetter;

--- a/packages/x-charts/src/PieChart/legend.ts
+++ b/packages/x-charts/src/PieChart/legend.ts
@@ -7,9 +7,7 @@ const legendGetter: LegendGetter<'pie'> = (params) => {
       series[seriesId].data
         .map((item) => ({
           color: item.color,
-          label: item.label
-            ? series[seriesId].labelFormatter?.(item.label, { location: 'legend' }) ?? item.label
-            : undefined,
+          label: item.label,
           id: item.id,
         }))
         .filter((item) => item.label !== undefined) as LegendParams[],

--- a/packages/x-charts/src/PieChart/legend.ts
+++ b/packages/x-charts/src/PieChart/legend.ts
@@ -7,7 +7,9 @@ const legendGetter: LegendGetter<'pie'> = (params) => {
       series[seriesId].data
         .map((item) => ({
           color: item.color,
-          label: item.label,
+          label: item.label
+            ? series[seriesId].labelFormatter?.(item.label, { location: 'legend' }) ?? item.label
+            : undefined,
           id: item.id,
         }))
         .filter((item) => item.label !== undefined) as LegendParams[],

--- a/packages/x-charts/src/ScatterChart/legend.ts
+++ b/packages/x-charts/src/ScatterChart/legend.ts
@@ -1,13 +1,22 @@
+import { getLabel } from '../internals/getLabel';
 import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'scatter'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => ({
-    color: series[seriesId].color,
-    label: series[seriesId].label,
-    id: seriesId,
-  }));
-  return data.filter((item) => item.label !== undefined) as LegendParams[];
+  return seriesOrder.reduce((acc, seriesId) => {
+    const formattedLabel = getLabel(series[seriesId].label, 'legend');
+
+    if (formattedLabel === undefined) {
+      return acc;
+    }
+
+    acc.push({
+      color: series[seriesId].color,
+      label: formattedLabel,
+      id: seriesId,
+    });
+    return acc;
+  }, [] as LegendParams[]);
 };
 
 export default legendGetter;

--- a/packages/x-charts/src/ScatterChart/legend.ts
+++ b/packages/x-charts/src/ScatterChart/legend.ts
@@ -2,15 +2,11 @@ import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'scatter'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => {
-    const label = series[seriesId].label;
-    const labelFormatter = series[seriesId].labelFormatter;
-    return {
-      color: series[seriesId].color,
-      label: label ? labelFormatter?.(label, { location: 'legend' }) ?? label : undefined,
-      id: seriesId,
-    };
-  });
+  const data = seriesOrder.map((seriesId) => ({
+    color: series[seriesId].color,
+    label: series[seriesId].label,
+    id: seriesId,
+  }));
   return data.filter((item) => item.label !== undefined) as LegendParams[];
 };
 

--- a/packages/x-charts/src/ScatterChart/legend.ts
+++ b/packages/x-charts/src/ScatterChart/legend.ts
@@ -2,11 +2,15 @@ import { LegendGetter, LegendParams } from '../models/seriesType/config';
 
 const legendGetter: LegendGetter<'scatter'> = (params) => {
   const { seriesOrder, series } = params;
-  const data = seriesOrder.map((seriesId) => ({
-    color: series[seriesId].color,
-    label: series[seriesId].label,
-    id: seriesId,
-  }));
+  const data = seriesOrder.map((seriesId) => {
+    const label = series[seriesId].label;
+    const labelFormatter = series[seriesId].labelFormatter;
+    return {
+      color: series[seriesId].color,
+      label: label ? labelFormatter?.(label, { location: 'legend' }) ?? label : undefined,
+      id: seriesId,
+    };
+  });
   return data.filter((item) => item.label !== undefined) as LegendParams[];
 };
 

--- a/packages/x-charts/src/internals/getLabel.ts
+++ b/packages/x-charts/src/internals/getLabel.ts
@@ -1,0 +1,6 @@
+export function getLabel<Location extends string>(
+  value: string | ((location: Location) => string) | undefined,
+  location: Location,
+): string | undefined {
+  return typeof value === 'function' ? value(location) : value;
+}

--- a/packages/x-charts/src/models/seriesType/bar.ts
+++ b/packages/x-charts/src/models/seriesType/bar.ts
@@ -20,7 +20,10 @@ export interface BarSeriesType
    * The key used to retrieve data from the dataset.
    */
   dataKey?: string;
-  label?: string;
+  /**
+   * The label to display on the tooltip or the legend. It can be a string or a function.
+   */
+  label?: string | ((location: 'tooltip' | 'legend') => string);
   /**
    * Layout of the bars. All bar should have the same layout.
    * @default 'vertical'

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -10,10 +10,21 @@ export type SeriesValueFormatterContext = {
   dataIndex: number;
 };
 
+export type SeriesLabelFormatterContext = {
+  /**
+   * The location where the value is being rendered.
+   * - `'tooltip'`: The value is displayed in the tooltip when hovering the chart.
+   * - `'legend'`: The value is displayed on the legend.
+   */
+  location: 'tooltip' | 'legend';
+};
+
 export type SeriesValueFormatter<TValue> = (
   value: TValue,
   context: SeriesValueFormatterContext,
 ) => string;
+
+export type SeriesLabelFormatter = (label: string, context: SeriesLabelFormatterContext) => string;
 
 export type CommonSeriesType<TValue> = {
   id?: SeriesId;
@@ -25,6 +36,13 @@ export type CommonSeriesType<TValue> = {
    * @returns {string} The string to display.
    */
   valueFormatter?: SeriesValueFormatter<TValue>;
+  /**
+   * Formatter used to render labels in tooltip or legend.
+   * @param {string} label The series' value to render.
+   * @param {SeriesLabelFormatterContext} context The rendering context of the value.
+   * @returns {string} The string to display.
+   */
+  labelFormatter?: SeriesLabelFormatter;
   highlightScope?: Partial<HighlightScope>;
 };
 

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -10,21 +10,10 @@ export type SeriesValueFormatterContext = {
   dataIndex: number;
 };
 
-export type SeriesLabelFormatterContext = {
-  /**
-   * The location where the value is being rendered.
-   * - `'tooltip'`: The value is displayed in the tooltip when hovering the chart.
-   * - `'legend'`: The value is displayed on the legend.
-   */
-  location: 'tooltip' | 'legend';
-};
-
 export type SeriesValueFormatter<TValue> = (
   value: TValue,
   context: SeriesValueFormatterContext,
 ) => string;
-
-export type SeriesLabelFormatter = (label: string, context: SeriesLabelFormatterContext) => string;
 
 export type CommonSeriesType<TValue> = {
   id?: SeriesId;
@@ -36,13 +25,6 @@ export type CommonSeriesType<TValue> = {
    * @returns {string} The string to display.
    */
   valueFormatter?: SeriesValueFormatter<TValue>;
-  /**
-   * Formatter used to render labels in tooltip or legend.
-   * @param {string} label The series' value to render.
-   * @param {SeriesLabelFormatterContext} context The rendering context of the value.
-   * @returns {string} The string to display.
-   */
-  labelFormatter?: SeriesLabelFormatter;
   highlightScope?: Partial<HighlightScope>;
 };
 

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -56,7 +56,10 @@ export interface LineSeriesType
   dataKey?: string;
   stack?: string;
   area?: boolean;
-  label?: string;
+  /**
+   * The label to display on the tooltip or the legend. It can be a string or a function.
+   */
+  label?: string | ((location: 'tooltip' | 'legend') => string);
   curve?: CurveType;
   /**
    * Define which items of the series should display a mark.

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -11,7 +11,7 @@ export type PieValueType = {
   id: PieItemId;
   value: number;
   /**
-   * The label to display on the tooltip or the legend. It can be a string or a function.
+   * The label to display on the tooltip, arc, or the legend. It can be a string or a function.
    */
   label?: string | ((location: 'tooltip' | 'legend' | 'arc') => string);
   color?: string;

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -10,7 +10,10 @@ export type PieValueType = {
    */
   id: PieItemId;
   value: number;
-  label?: string;
+  /**
+   * The label to display on the tooltip or the legend. It can be a string or a function.
+   */
+  label?: string | ((location: 'tooltip' | 'legend' | 'arc') => string);
   color?: string;
 };
 

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -75,7 +75,11 @@ export interface PieSeriesType<TData = PieValueType> extends CommonSeriesType<TD
   /**
    * The label displayed into the arc.
    */
-  arcLabel?: 'formattedValue' | 'label' | 'value' | ((item: DefaultizedPieValueType) => string);
+  arcLabel?:
+    | 'formattedValue'
+    | 'label'
+    | 'value'
+    | ((item: Omit<DefaultizedPieValueType, 'label'> & { label?: string }) => string);
   /**
    * The minimal angle required to display the arc label.
    * @default 0

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -22,9 +22,9 @@ export type DefaultizedPieValueType = PieValueType &
 
 export type ChartsPieSorting = 'none' | 'asc' | 'desc' | ((a: number, b: number) => number);
 
-export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Tdata> {
+export interface PieSeriesType<TData = PieValueType> extends CommonSeriesType<TData> {
   type: 'pie';
-  data: Tdata[];
+  data: TData[];
   /**
    * The radius between circle center and the beginning of the arc.
    * Can be a number (in px) or a string with a percentage such as '50%'.

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -15,7 +15,10 @@ export interface ScatterSeriesType extends CommonSeriesType<ScatterValueType>, C
   type: 'scatter';
   data: ScatterValueType[];
   markerSize?: number;
-  label?: string;
+  /**
+   * The label to display on the tooltip or the legend. It can be a string or a function.
+   */
+  label?: string | ((location: 'tooltip' | 'legend') => string);
   /**
    * If true, the interaction will not use element hover for this series.
    * @default false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       '@mui/internal-scripts':
         specifier: ^1.0.3
         version: 1.0.3
+      '@types/chance':
+        specifier: ^1.0.3
+        version: 1.1.6
       '@types/d3-scale':
         specifier: ^4.0.8
         version: 4.0.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,7 +631,7 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@types/chance':
-        specifier: ^1.0.3
+        specifier: ^1.1.6
         version: 1.1.6
       '@types/d3-scale':
         specifier: ^4.0.8


### PR DESCRIPTION
- Allow `series.label` property to receive a function with the "location" it is going to be displayed on 
- `location` options are `legend` | `tooltip` for Series, Scatter and Line
- And `legend` | `tooltip` | `arc` for Pie
- Small typos fixed
- Added `label` documentation as a standalone page

resolves #12482

### Todo:

- [x] Example usage
- [x] Typings documentation