### PR TITLE
[docs] Use MUI X v6 in Codesandbox and Stackblitz demos

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -27,7 +27,7 @@ LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
     // #default-branch-switch with latest for the master branch
-    return 'latest';
+    return '^6';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui/mui-x/commit/${shortSha}/@mui/${packageName}`;


### PR DESCRIPTION
Use v6 versions of MUI X packages in Codesandbox and Stackblitz demos opened from https://v6.mui.com/x/react-data-grid.