### PR TITLE
[support-infra] Add release announcement to GitHub workflows (#11867)

### DIFF
--- a/.github/workflows/discord-release-announcement.yaml
+++ b/.github/workflows/discord-release-announcement.yaml
@@ -1,0 +1,20 @@
+name: Discord Release Announcement
+
+on:
+  release:
+    types: [prereleased, published]
+
+permissions: {}
+
+jobs:
+  delimiter-test:
+    runs-on: ubuntu-latest
+    name: Send message to discord
+    steps:
+      - name: parse and send message
+        uses: michelengelen/discord-message-action@02af30a15955ecf718049bc33b0efabf6f626e0b
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: MUI Releases
+          avatar-url: 'https://raw.githubusercontent.com/mui/material-ui/master/docs/public/static/logo.png'
+          separator: '<!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,11 @@ yarn release:changelog
    --release       The branch to release (default: master)
 ```
 
-You can also provide the GitHub token by setting `process.env.GITHUB_TOKEN` variable.
+> :warning: the script will add a separator string in form of a comment like this right after the highlights:
+> `<!--/ DO_NOT_REMOVE /-->`
+> This string needs to stay where it gets inserted for the automated discord announcement to work.
+
+You can also provide the github token by setting `process.env.GITHUB_TOKEN` variable.
 
 In case of a problem, another method to generate the changelog is available at the end of this page.
 

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -267,6 +267,8 @@ We'd like to offer a big thanks to the ${
 TODO INSERT HIGHLIGHTS
 ${changeLogMessages.length > 0 ? '\n\n' : ''}${changeLogMessages.join('\n')}
 
+<!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->
+
 ### Data Grid
 
 #### \`@mui/x-data-grid@__VERSION__\`


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

cherry picking the release announcement workflow since the original PR was targeted at next 🤦🏼 