### PR TITLE
[charts] Round y values for bar chart

### DIFF
--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -55,7 +55,6 @@ export const BarElementPath = styled(animated.rect, {
   overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: BarElementOwnerState }>(({ ownerState }) => ({
   stroke: 'none',
-  shapeRendering: 'crispEdges',
   fill: ownerState.isHighlighted
     ? d3Color(ownerState.color)!.brighter(0.5).formatHex()
     : ownerState.color,

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -180,8 +180,8 @@ const useAggregatedData = (): CompletedBarData[] => {
       return stackedData.map((values, dataIndex: number) => {
         const valueCoordinates = values.map((v) => (verticalLayout ? yScale(v)! : xScale(v)!));
 
-        const minValueCoord = Math.min(...valueCoordinates);
-        const maxValueCoord = Math.max(...valueCoordinates);
+        const minValueCoord = Math.round(Math.min(...valueCoordinates));
+        const maxValueCoord = Math.round(Math.max(...valueCoordinates));
 
         return {
           seriesId,


### PR DESCRIPTION
Seems that rounding the px coordinate of the stack bars is better to avoid weird overlapping
