### PR TITLE
[charts] Fix line animation

### DIFF
--- a/packages/x-charts/src/internals/useAnimatedPath.ts
+++ b/packages/x-charts/src/internals/useAnimatedPath.ts
@@ -33,11 +33,12 @@ export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
     },
   });
 
-  const interpolation = (t: number) => {
+  const interpolation = React.useMemo(() => {
     if (previousPathRef.current === null) {
-      return path;
+      return () => path;
     }
-    return interpolateString(previousPathRef.current, path)(t);
-  };
+    return interpolateString(previousPathRef.current, path);
+  }, [path]);
+
   return spring.value.to(interpolation);
 };

--- a/packages/x-charts/src/internals/useAnimatedPath.ts
+++ b/packages/x-charts/src/internals/useAnimatedPath.ts
@@ -1,27 +1,18 @@
 import * as React from 'react';
 import { interpolateString } from 'd3-interpolate';
-import { useSpringRef, useSpring } from '@react-spring/web';
+import { useSpring } from '@react-spring/web';
 
 // Taken from Nivo
 export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
   const previousPathRef = React.useRef<string | null>(null);
   const currentPathRef = React.useRef<string | null>(path);
 
-  const api = useSpringRef();
-
   React.useEffect(() => {
-    if (previousPathRef.current !== path) {
-      // Only start the animation if the previouse path is different.
-      // Avoid re-animating if the props is updated with the same value.
-      api.start();
-    }
-
     previousPathRef.current = currentPathRef.current;
     currentPathRef.current = path;
-  }, [api, path]);
+  }, [path]);
 
   const spring = useSpring({
-    ref: api,
     from: { value: 0 },
     to: { value: 1 },
     reset: true,

--- a/packages/x-charts/src/internals/useAnimatedPath.ts
+++ b/packages/x-charts/src/internals/useAnimatedPath.ts
@@ -1,29 +1,40 @@
 import * as React from 'react';
 import { interpolateString } from 'd3-interpolate';
-import { useSpring, to } from '@react-spring/web';
-
-function usePrevious<T>(value: T) {
-  const ref = React.useRef<T | null>(null);
-  React.useEffect(() => {
-    ref.current = value;
-  }, [value]);
-  return ref.current;
-}
+import { useSpringRef, useSpring, to } from '@react-spring/web';
 
 // Taken from Nivo
 export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
-  const previousPath = usePrevious(path);
-  const interpolator = React.useMemo(
-    () => (previousPath ? interpolateString(previousPath, path) : () => path),
-    [previousPath, path],
-  );
+  const previousPathRef = React.useRef<string | null>(null);
+  const currentPathRef = React.useRef<string | null>(path);
+
+  const api = useSpringRef();
+
+  React.useEffect(() => {
+    if (previousPathRef.current !== path) {
+      // Only start the animation if the previouse path is different.
+      // Avoid re-animating if the props is updated with the same value.u
+      api.start();
+    }
+    if (currentPathRef.current !== path) {
+      previousPathRef.current = currentPathRef.current;
+      currentPathRef.current = path;
+    }
+  }, [api, path]);
 
   const { value } = useSpring({
+    ref: api,
     from: { value: 0 },
     to: { value: 1 },
     reset: true,
     immediate: skipAnimation,
   });
 
-  return to([value], interpolator);
+  const interpolation = (t: number) => {
+    if (previousPathRef.current === null) {
+      return path;
+    }
+    return interpolateString(previousPathRef.current, path)(t);
+  };
+
+  return to([value], interpolation);
 };

--- a/packages/x-charts/src/internals/useAnimatedPath.ts
+++ b/packages/x-charts/src/internals/useAnimatedPath.ts
@@ -12,13 +12,12 @@ export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
   React.useEffect(() => {
     if (previousPathRef.current !== path) {
       // Only start the animation if the previouse path is different.
-      // Avoid re-animating if the props is updated with the same value.u
+      // Avoid re-animating if the props is updated with the same value.
       api.start();
     }
-    if (currentPathRef.current !== path) {
-      previousPathRef.current = currentPathRef.current;
-      currentPathRef.current = path;
-    }
+
+    previousPathRef.current = currentPathRef.current;
+    currentPathRef.current = path;
   }, [api, path]);
 
   const spring = useSpring({

--- a/packages/x-charts/src/internals/useAnimatedPath.ts
+++ b/packages/x-charts/src/internals/useAnimatedPath.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { interpolateString } from 'd3-interpolate';
-import { useSpringRef, useSpring, to } from '@react-spring/web';
+import { useSpringRef, useSpring } from '@react-spring/web';
 
 // Taken from Nivo
 export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
@@ -21,12 +21,16 @@ export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
     }
   }, [api, path]);
 
-  const { value } = useSpring({
+  const spring = useSpring({
     ref: api,
     from: { value: 0 },
     to: { value: 1 },
     reset: true,
     immediate: skipAnimation,
+    onResolve() {
+      previousPathRef.current = path;
+      currentPathRef.current = path;
+    },
   });
 
   const interpolation = (t: number) => {
@@ -35,6 +39,5 @@ export const useAnimatedPath = (path: string, skipAnimation?: boolean) => {
     }
     return interpolateString(previousPathRef.current, path)(t);
   };
-
-  return to([value], interpolation);
+  return spring.value.to(interpolation);
 };


### PR DESCRIPTION
Fix #12873

Here is the codesandbox with the fix:

https://codesandbox.io/p/sandbox/priceless-shaw-g23c8w?file=%2Fsrc%2FDemo.tsx%3A57%2C24

It remains an edge case if you toggle before the animation is resolved. It that case, the animation is not played and the chars goes directly to the final state. Which is less problematic than stopping wright in the middle.


I don't know why animation stopped. I opened an issue on this topic: https://github.com/pmndrs/react-spring/issues/2273

The current workaround make sure to keep the last **different** value in memory