### PR TITLE
[core] Remove redundant `setupFiles` entries in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,9 +188,6 @@
     "webpack-cli": "^5.1.4",
     "yargs": "^17.7.2"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "resolutions": {
     "react-is": "^18.2.0",
     "@types/node": "^18.19.23"

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -92,9 +92,6 @@
       "default": "./esm/*/index.js"
     }
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -50,9 +50,6 @@
     "@mui/material": "^5.15.14",
     "react": "^17.0.0 || ^18.0.0"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -65,9 +65,6 @@
     "date-fns": "^2.30.0",
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -62,9 +62,6 @@
     "@types/prop-types": "^15.7.11",
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -65,9 +65,6 @@
     "@types/prop-types": "^15.7.11",
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -104,9 +104,6 @@
     "moment": "^2.30.1",
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -112,9 +112,6 @@
     "moment-timezone": "^0.5.44",
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -43,9 +43,6 @@
   "devDependencies": {
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -64,9 +64,6 @@
   "devDependencies": {
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -63,9 +63,6 @@
     "@types/prop-types": "^15.7.11",
     "rimraf": "^5.0.5"
   },
-  "setupFiles": [
-    "<rootDir>/src/setupTests.js"
-  ],
   "engines": {
     "node": ">=14.0.0"
   }


### PR DESCRIPTION
I noticed it while working on the `pnpm` migration.
These files do not seem to exist anymore and the config is located in respective test framework setup files.