### PR TITLE
[charts][PieChart] Fix `prop.slots` and `prop.slotProps` not passed to `<ChartsTooltip />`

### DIFF
--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -194,7 +194,7 @@ function PieChart(props: PieChartProps) {
       <ChartsOverlay loading={loading} slots={slots} slotProps={slotProps} />
       <ChartsLegend {...legend} slots={slots} slotProps={slotProps} />
       <ChartsAxisHighlight {...axisHighlight} />
-      {!loading && <ChartsTooltip {...tooltip} />}
+      {!loading && <ChartsTooltip {...tooltip} slots={slots} slotProps={slotProps} />}
       {children}
     </ResponsiveChartContainer>
   );


### PR DESCRIPTION
Fixes #12926 

[working example](https://codesandbox.io/p/sandbox/heuristic-hawking-w98gzj?file=%2Fsrc%2FDemo.tsx%3A9%2C12)
