### PR TITLE
[charts] Fix docs/translations/errors typos

### DIFF
--- a/docs/pages/x/api/charts/area-element.json
+++ b/docs/pages/x/api/charts/area-element.json
@@ -31,7 +31,7 @@
     {
       "key": "highlighted",
       "className": "MuiAreaElement-highlighted",
-      "description": "Styles applied to the root element when higlighted.",
+      "description": "Styles applied to the root element when highlighted.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/charts/charts-axis.json
+++ b/docs/pages/x/api/charts/charts-axis.json
@@ -86,7 +86,7 @@
     {
       "key": "tickContainer",
       "className": "MuiChartsAxis-tickContainer",
-      "description": "Styles applied to group ingruding the tick and its label.",
+      "description": "Styles applied to group including the tick and its label.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/charts/gauge.json
+++ b/docs/pages/x/api/charts/gauge.json
@@ -39,7 +39,7 @@
     {
       "key": "referenceArc",
       "className": "MuiGauge-referenceArc",
-      "description": "Styles applied to the arc diplaying the range of available values.",
+      "description": "Styles applied to the arc displaying the range of available values.",
       "isGlobal": false
     },
     {
@@ -51,7 +51,7 @@
     {
       "key": "valueArc",
       "className": "MuiGauge-valueArc",
-      "description": "Styles applied to the arc diplaying the value.",
+      "description": "Styles applied to the arc displaying the value.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/charts/line-element.json
+++ b/docs/pages/x/api/charts/line-element.json
@@ -31,7 +31,7 @@
     {
       "key": "highlighted",
       "className": "MuiLineElement-highlighted",
-      "description": "Styles applied to the root element when higlighted.",
+      "description": "Styles applied to the root element when highlighted.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/charts/mark-element.json
+++ b/docs/pages/x/api/charts/mark-element.json
@@ -25,7 +25,7 @@
     {
       "key": "highlighted",
       "className": "MuiMarkElement-highlighted",
-      "description": "Styles applied to the root element when higlighted.",
+      "description": "Styles applied to the root element when highlighted.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/charts/pie-arc-label.json
+++ b/docs/pages/x/api/charts/pie-arc-label.json
@@ -15,7 +15,7 @@
     {
       "key": "highlighted",
       "className": "MuiPieArcLabel-highlighted",
-      "description": "Styles applied to the root element when higlighted.",
+      "description": "Styles applied to the root element when highlighted.",
       "isGlobal": false
     },
     {

--- a/docs/pages/x/api/charts/pie-arc.json
+++ b/docs/pages/x/api/charts/pie-arc.json
@@ -15,7 +15,7 @@
     {
       "key": "highlighted",
       "className": "MuiPieArc-highlighted",
-      "description": "Styles applied to the root element when higlighted.",
+      "description": "Styles applied to the root element when highlighted.",
       "isGlobal": false
     },
     {

--- a/docs/translations/api-docs/charts/area-element/area-element.json
+++ b/docs/translations/api-docs/charts/area-element/area-element.json
@@ -14,7 +14,7 @@
     "highlighted": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "higlighted"
+      "conditions": "highlighted"
     },
     "root": { "description": "Styles applied to the root element." }
   },

--- a/docs/translations/api-docs/charts/bar-series-type.json
+++ b/docs/translations/api-docs/charts/bar-series-type.json
@@ -4,7 +4,7 @@
     "type": { "description": "" },
     "color": { "description": "" },
     "data": { "description": "Data associated to each bar." },
-    "dataKey": { "description": "The key used to retrive data from the dataset." },
+    "dataKey": { "description": "The key used to retrieve data from the dataset." },
     "highlightScope": { "description": "" },
     "id": { "description": "" },
     "label": { "description": "" },

--- a/docs/translations/api-docs/charts/charts-axis/charts-axis.json
+++ b/docs/translations/api-docs/charts/charts-axis/charts-axis.json
@@ -34,7 +34,7 @@
     "tick": { "description": "Styles applied to {{nodeName}}.", "nodeName": "ticks" },
     "tickContainer": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "group ingruding the tick and its label"
+      "nodeName": "group including the tick and its label"
     },
     "tickLabel": { "description": "Styles applied to {{nodeName}}.", "nodeName": "ticks label" },
     "top": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the top axis" }

--- a/docs/translations/api-docs/charts/charts-reference-line/charts-reference-line.json
+++ b/docs/translations/api-docs/charts/charts-reference-line/charts-reference-line.json
@@ -8,7 +8,7 @@
     "labelStyle": { "description": "The style applied to the label." },
     "lineStyle": { "description": "The style applied to the line." },
     "spacing": {
-      "description": "Additional space arround the label in px. Can be a number or an object <code>{ x, y }</code> to distinguish space with the reference line and space with axes."
+      "description": "Additional space around the label in px. Can be a number or an object <code>{ x, y }</code> to distinguish space with the reference line and space with axes."
     },
     "x": {
       "description": "The x value associated with the reference line. If defined the reference line will be vertical."

--- a/docs/translations/api-docs/charts/charts-tooltip/charts-tooltip.json
+++ b/docs/translations/api-docs/charts/charts-tooltip/charts-tooltip.json
@@ -2,11 +2,11 @@
   "componentDescription": "",
   "propDescriptions": {
     "axisContent": {
-      "description": "Component to override the tooltip content when triger is set to &#39;axis&#39;."
+      "description": "Component to override the tooltip content when trigger is set to &#39;axis&#39;."
     },
     "classes": { "description": "Override or extend the styles applied to the component." },
     "itemContent": {
-      "description": "Component to override the tooltip content when triger is set to &#39;item&#39;."
+      "description": "Component to override the tooltip content when trigger is set to &#39;item&#39;."
     },
     "slotProps": { "description": "The props used for each component slot." },
     "slots": { "description": "Overridable component slots." },

--- a/docs/translations/api-docs/charts/gauge-container/gauge-container.json
+++ b/docs/translations/api-docs/charts/gauge-container/gauge-container.json
@@ -18,7 +18,7 @@
       "description": "The height of the chart in px. If not defined, it takes the height of the parent element."
     },
     "innerRadius": {
-      "description": "The radius between circle center and the begining of the arc. Can be a number (in px) or a string with a percentage such as &#39;50%&#39;. The &#39;100%&#39; is the maximal radius that fit into the drawing area."
+      "description": "The radius between circle center and the beginning of the arc. Can be a number (in px) or a string with a percentage such as &#39;50%&#39;. The &#39;100%&#39; is the maximal radius that fit into the drawing area."
     },
     "margin": {
       "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>."

--- a/docs/translations/api-docs/charts/gauge/gauge.json
+++ b/docs/translations/api-docs/charts/gauge/gauge.json
@@ -18,7 +18,7 @@
       "description": "The height of the chart in px. If not defined, it takes the height of the parent element."
     },
     "innerRadius": {
-      "description": "The radius between circle center and the begining of the arc. Can be a number (in px) or a string with a percentage such as &#39;50%&#39;. The &#39;100%&#39; is the maximal radius that fit into the drawing area."
+      "description": "The radius between circle center and the beginning of the arc. Can be a number (in px) or a string with a percentage such as &#39;50%&#39;. The &#39;100%&#39; is the maximal radius that fit into the drawing area."
     },
     "margin": {
       "description": "The margin between the SVG and the drawing area. It&#39;s used for leaving some space for extra information such as the x- and y-axis or legend. Accepts an object with the optional properties: <code>top</code>, <code>bottom</code>, <code>left</code>, and <code>right</code>."
@@ -39,12 +39,12 @@
   "classDescriptions": {
     "referenceArc": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the arc diplaying the range of available values"
+      "nodeName": "the arc displaying the range of available values"
     },
     "root": { "description": "Styles applied to the root element." },
     "valueArc": {
       "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the arc diplaying the value"
+      "nodeName": "the arc displaying the value"
     },
     "valueText": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the value text" }
   }

--- a/docs/translations/api-docs/charts/line-element/line-element.json
+++ b/docs/translations/api-docs/charts/line-element/line-element.json
@@ -14,7 +14,7 @@
     "highlighted": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "higlighted"
+      "conditions": "highlighted"
     },
     "root": { "description": "Styles applied to the root element." }
   },

--- a/docs/translations/api-docs/charts/line-series-type.json
+++ b/docs/translations/api-docs/charts/line-series-type.json
@@ -9,7 +9,7 @@
     },
     "curve": { "description": "" },
     "data": { "description": "Data associated to the line." },
-    "dataKey": { "description": "The key used to retrive data from the dataset." },
+    "dataKey": { "description": "The key used to retrieve data from the dataset." },
     "disableHighlight": {
       "description": "Do not render the line highlight item if set to <code>true</code>."
     },

--- a/docs/translations/api-docs/charts/mark-element/mark-element.json
+++ b/docs/translations/api-docs/charts/mark-element/mark-element.json
@@ -14,7 +14,7 @@
     "highlighted": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "higlighted"
+      "conditions": "highlighted"
     },
     "root": { "description": "Styles applied to the root element." }
   }

--- a/docs/translations/api-docs/charts/pie-arc-label-plot/pie-arc-label-plot.json
+++ b/docs/translations/api-docs/charts/pie-arc-label-plot/pie-arc-label-plot.json
@@ -9,10 +9,10 @@
     "cornerRadius": {
       "description": "The radius applied to arc corners (similar to border radius)."
     },
-    "faded": { "description": "Override the arc attibutes when it is faded." },
-    "highlighted": { "description": "Override the arc attibutes when it is highlighted." },
+    "faded": { "description": "Override the arc attributes when it is faded." },
+    "highlighted": { "description": "Override the arc attributes when it is highlighted." },
     "innerRadius": {
-      "description": "The radius between circle center and the begining of the arc."
+      "description": "The radius between circle center and the beginning of the arc."
     },
     "outerRadius": { "description": "The radius between circle center and the end of the arc." },
     "paddingAngle": { "description": "The padding angle (deg) between two arcs." },

--- a/docs/translations/api-docs/charts/pie-arc-label/pie-arc-label.json
+++ b/docs/translations/api-docs/charts/pie-arc-label/pie-arc-label.json
@@ -10,7 +10,7 @@
     "highlighted": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "higlighted"
+      "conditions": "highlighted"
     },
     "root": { "description": "Styles applied to the root element." }
   }

--- a/docs/translations/api-docs/charts/pie-arc-plot/pie-arc-plot.json
+++ b/docs/translations/api-docs/charts/pie-arc-plot/pie-arc-plot.json
@@ -7,10 +7,10 @@
     "cornerRadius": {
       "description": "The radius applied to arc corners (similar to border radius)."
     },
-    "faded": { "description": "Override the arc attibutes when it is faded." },
-    "highlighted": { "description": "Override the arc attibutes when it is highlighted." },
+    "faded": { "description": "Override the arc attributes when it is faded." },
+    "highlighted": { "description": "Override the arc attributes when it is highlighted." },
     "innerRadius": {
-      "description": "The radius between circle center and the begining of the arc."
+      "description": "The radius between circle center and the beginning of the arc."
     },
     "onItemClick": {
       "description": "Callback fired when a pie item is clicked.",

--- a/docs/translations/api-docs/charts/pie-arc/pie-arc.json
+++ b/docs/translations/api-docs/charts/pie-arc/pie-arc.json
@@ -10,7 +10,7 @@
     "highlighted": {
       "description": "Styles applied to {{nodeName}} when {{conditions}}.",
       "nodeName": "the root element",
-      "conditions": "higlighted"
+      "conditions": "highlighted"
     },
     "root": { "description": "Styles applied to the root element." }
   }

--- a/docs/translations/api-docs/charts/pie-series-type.json
+++ b/docs/translations/api-docs/charts/pie-series-type.json
@@ -19,12 +19,12 @@
       "description": "The y coordinate of the pie center.<br />Can be a number (in px) or a string with a percentage such as &#39;50%&#39;.<br />The &#39;100%&#39; is the height the drawing area."
     },
     "endAngle": { "description": "The end angle (deg) of the last item." },
-    "faded": { "description": "Override the arc attibutes when it is faded." },
-    "highlighted": { "description": "Override the arc attibutes when it is highlighted." },
+    "faded": { "description": "Override the arc attributes when it is faded." },
+    "highlighted": { "description": "Override the arc attributes when it is highlighted." },
     "highlightScope": { "description": "" },
     "id": { "description": "" },
     "innerRadius": {
-      "description": "The radius between circle center and the begining of the arc.<br />Can be a number (in px) or a string with a percentage such as &#39;50%&#39;.<br />The &#39;100%&#39; is the maximal radius that fit into the drawing area."
+      "description": "The radius between circle center and the beginning of the arc.<br />Can be a number (in px) or a string with a percentage such as &#39;50%&#39;.<br />The &#39;100%&#39; is the maximal radius that fit into the drawing area."
     },
     "outerRadius": {
       "description": "The radius between circle center and the end of the arc.<br />Can be a number (in px) or a string with a percentage such as &#39;50%&#39;.<br />The &#39;100%&#39; is the maximal radius that fit into the drawing area."

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -108,7 +108,7 @@ const useAggregatedData = (): CompletedBarData[] => {
               xAxisKey === DEFAULT_X_AXIS_KEY
                 ? 'The first `xAxis`'
                 : `The x-axis with id "${xAxisKey}"`
-            } shoud be of type "band" to display the bar series of id "${seriesId}".`,
+            } should be of type "band" to display the bar series of id "${seriesId}".`,
           );
         }
         if (xAxis[xAxisKey].data === undefined) {
@@ -117,7 +117,7 @@ const useAggregatedData = (): CompletedBarData[] => {
               xAxisKey === DEFAULT_X_AXIS_KEY
                 ? 'The first `xAxis`'
                 : `The x-axis with id "${xAxisKey}"`
-            } shoud have data property.`,
+            } should have data property.`,
           );
         }
         baseScaleConfig = xAxisConfig as AxisDefaultized<'band'>;
@@ -127,7 +127,7 @@ const useAggregatedData = (): CompletedBarData[] => {
               yAxisKey === DEFAULT_Y_AXIS_KEY
                 ? 'The first `yAxis`'
                 : `The y-axis with id "${yAxisKey}"`
-            } shoud be a continuous type to display the bar series of id "${seriesId}".`,
+            } should be a continuous type to display the bar series of id "${seriesId}".`,
           );
         }
       } else {
@@ -137,7 +137,7 @@ const useAggregatedData = (): CompletedBarData[] => {
               yAxisKey === DEFAULT_Y_AXIS_KEY
                 ? 'The first `yAxis`'
                 : `The y-axis with id "${yAxisKey}"`
-            } shoud be of type "band" to display the bar series of id "${seriesId}".`,
+            } should be of type "band" to display the bar series of id "${seriesId}".`,
           );
         }
 
@@ -147,7 +147,7 @@ const useAggregatedData = (): CompletedBarData[] => {
               yAxisKey === DEFAULT_Y_AXIS_KEY
                 ? 'The first `yAxis`'
                 : `The y-axis with id "${yAxisKey}"`
-            } shoud have data property.`,
+            } should have data property.`,
           );
         }
         baseScaleConfig = yAxisConfig as AxisDefaultized<'band'>;
@@ -157,7 +157,7 @@ const useAggregatedData = (): CompletedBarData[] => {
               xAxisKey === DEFAULT_X_AXIS_KEY
                 ? 'The first `xAxis`'
                 : `The x-axis with id "${xAxisKey}"`
-            } shoud be a continuous type to display the bar series of id "${seriesId}".`,
+            } should be a continuous type to display the bar series of id "${seriesId}".`,
           );
         }
       }

--- a/packages/x-charts/src/ChartsAxis/axisClasses.ts
+++ b/packages/x-charts/src/ChartsAxis/axisClasses.ts
@@ -8,7 +8,7 @@ export interface ChartsAxisClasses {
   root: string;
   /** Styles applied to the main line element. */
   line: string;
-  /** Styles applied to group ingruding the tick and its label. */
+  /** Styles applied to group including the tick and its label. */
   tickContainer: string;
   /** Styles applied to ticks. */
   tick: string;

--- a/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
+++ b/packages/x-charts/src/ChartsReferenceLine/ChartsReferenceLine.tsx
@@ -61,7 +61,7 @@ ChartsReferenceLine.propTypes = {
    */
   lineStyle: PropTypes.object,
   /**
-   * Additional space arround the label in px.
+   * Additional space around the label in px.
    * Can be a number or an object `{ x, y }` to distinguish space with the reference line and space with axes.
    * @default 5
    */

--- a/packages/x-charts/src/ChartsReferenceLine/common.tsx
+++ b/packages/x-charts/src/ChartsReferenceLine/common.tsx
@@ -14,7 +14,7 @@ export type CommonChartsReferenceLineProps = {
    */
   label?: string;
   /**
-   * Additional space arround the label in px.
+   * Additional space around the label in px.
    * Can be a number or an object `{ x, y }` to distinguish space with the reference line and space with axes.
    * @default 5
    */

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -62,12 +62,12 @@ export type ChartsTooltipProps = {
    */
   trigger?: TriggerOptions;
   /**
-   * Component to override the tooltip content when triger is set to 'item'.
+   * Component to override the tooltip content when trigger is set to 'item'.
    * @deprecated Use slots.itemContent instead
    */
   itemContent?: React.ElementType<ChartsItemContentProps<any>>;
   /**
-   * Component to override the tooltip content when triger is set to 'axis'.
+   * Component to override the tooltip content when trigger is set to 'axis'.
    * @deprecated Use slots.axisContent instead
    */
   axisContent?: React.ElementType<ChartsAxisContentProps>;
@@ -189,7 +189,7 @@ ChartsTooltip.propTypes = {
   // | To update them edit the TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * Component to override the tooltip content when triger is set to 'axis'.
+   * Component to override the tooltip content when trigger is set to 'axis'.
    * @deprecated Use slots.axisContent instead
    */
   axisContent: PropTypes.elementType,
@@ -198,7 +198,7 @@ ChartsTooltip.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * Component to override the tooltip content when triger is set to 'item'.
+   * Component to override the tooltip content when trigger is set to 'item'.
    * @deprecated Use slots.itemContent instead
    */
   itemContent: PropTypes.elementType,

--- a/packages/x-charts/src/Gauge/Gauge.tsx
+++ b/packages/x-charts/src/Gauge/Gauge.tsx
@@ -81,7 +81,7 @@ Gauge.propTypes = {
    */
   height: PropTypes.number,
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the maximal radius that fit into the drawing area.
    * @default '80%'

--- a/packages/x-charts/src/Gauge/GaugeContainer.tsx
+++ b/packages/x-charts/src/Gauge/GaugeContainer.tsx
@@ -158,7 +158,7 @@ GaugeContainer.propTypes = {
    */
   height: PropTypes.number,
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the maximal radius that fit into the drawing area.
    * @default '80%'

--- a/packages/x-charts/src/Gauge/GaugeProvider.tsx
+++ b/packages/x-charts/src/Gauge/GaugeProvider.tsx
@@ -16,7 +16,7 @@ interface CircularConfig {
    */
   endAngle?: number;
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the maximal radius that fit into the drawing area.
    * @default '80%'
@@ -59,7 +59,7 @@ interface ProcessedCircularConfig {
    */
   endAngle: number;
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    */
   innerRadius: number;
   /**
@@ -160,7 +160,7 @@ export function GaugeProvider(props: GaugeProviderProps) {
 
   const maxRadius = getAvailableRadius(innerCx, innerCy, width, height, ratios);
 
-  // If the center is not defined, after computation of the available radius, udpate the center to use the remaining space.
+  // If the center is not defined, after computation of the available radius, update the center to use the remaining space.
   if (cxParam === undefined) {
     const usedWidth = maxRadius * (ratios.maxX - ratios.minX);
     cx = left + (width - usedWidth) / 2 + ratios.cx * usedWidth;

--- a/packages/x-charts/src/Gauge/gaugeClasses.ts
+++ b/packages/x-charts/src/Gauge/gaugeClasses.ts
@@ -4,9 +4,9 @@ import generateUtilityClass from '@mui/utils/generateUtilityClass';
 export interface GaugeClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the arc diplaying the value. */
+  /** Styles applied to the arc displaying the value. */
   valueArc: string;
-  /** Styles applied to the arc diplaying the range of available values. */
+  /** Styles applied to the arc displaying the range of available values. */
   referenceArc: string;
   /** Styles applied to the value text. */
   valueText: string;

--- a/packages/x-charts/src/Gauge/utils.ts
+++ b/packages/x-charts/src/Gauge/utils.ts
@@ -7,7 +7,7 @@ function getPoint(angle: number): [number, number] {
 }
 
 /**
- * Retruns the ratio of the arc bounding box and its center.
+ * Returns the ratio of the arc bounding box and its center.
  * @param startAngle The start angle (in deg)
  * @param endAngle The end angle (in deg)
  */
@@ -22,9 +22,9 @@ export function getArcRatios(startAngle: number, endAngle: number) {
   const initialAngle = Math.floor(minAngle / 90) * 90;
 
   for (let step = 1; step <= 4; step += 1) {
-    const cartinalAngle = initialAngle + step * 90;
-    if (cartinalAngle < maxAngle) {
-      points.push(getPoint(cartinalAngle));
+    const cardinalAngle = initialAngle + step * 90;
+    if (cardinalAngle < maxAngle) {
+      points.push(getPoint(cardinalAngle));
     }
   }
 

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -17,7 +17,7 @@ import { SeriesId } from '../models/seriesType/common';
 export interface AreaElementClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element when higlighted. */
+  /** Styles applied to the root element when highlighted. */
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;

--- a/packages/x-charts/src/LineChart/LineElement.tsx
+++ b/packages/x-charts/src/LineChart/LineElement.tsx
@@ -17,7 +17,7 @@ import { SeriesId } from '../models/seriesType/common';
 export interface LineElementClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element when higlighted. */
+  /** Styles applied to the root element when highlighted. */
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;

--- a/packages/x-charts/src/LineChart/MarkElement.tsx
+++ b/packages/x-charts/src/LineChart/MarkElement.tsx
@@ -19,7 +19,7 @@ import { SeriesId } from '../models/seriesType/common';
 export interface MarkElementClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element when higlighted. */
+  /** Styles applied to the root element when highlighted. */
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;

--- a/packages/x-charts/src/LineChart/formatter.test.ts
+++ b/packages/x-charts/src/LineChart/formatter.test.ts
@@ -9,7 +9,7 @@ const seriesDataset: FormatterParams<'line'>['series'] = {
     type: 'line',
     id: 'id1',
     color: 'red',
-    // usefull info
+    // useful info
     dataKey: 'k',
   },
 };

--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -13,7 +13,7 @@ import { PieItemId } from '../models';
 export interface PieArcClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element when higlighted. */
+  /** Styles applied to the root element when highlighted. */
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;

--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -11,7 +11,7 @@ import { PieItemId } from '../models/seriesType/pie';
 export interface PieArcLabelClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element when higlighted. */
+  /** Styles applied to the root element when highlighted. */
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;
@@ -71,7 +71,7 @@ export type PieArcLabelProps = PieArcLabelOwnerState &
 
 /**
  * Helper to compute label position.
- * It's not an inline function because we need it in inerpolation.
+ * It's not an inline function because we need it in interpolation.
  */
 const getLabelPosition =
   (formattedArcLabel: string | null | undefined, variable: 'x' | 'y') =>

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -60,7 +60,7 @@ export interface PieArcLabelPlotProps
     >,
     ComputedPieRadius {
   /**
-   * Override the arc attibutes when it is faded.
+   * Override the arc attributes when it is faded.
    * @default { additionalRadius: -5 }
    */
   faded?: DefaultizedPieSeriesType['faded'];
@@ -205,7 +205,7 @@ PieArcLabelPlot.propTypes = {
     }),
   ).isRequired,
   /**
-   * Override the arc attibutes when it is faded.
+   * Override the arc attributes when it is faded.
    * @default { additionalRadius: -5 }
    */
   faded: PropTypes.shape({
@@ -218,7 +218,7 @@ PieArcLabelPlot.propTypes = {
     paddingAngle: PropTypes.number,
   }),
   /**
-   * Override the arc attibutes when it is highlighted.
+   * Override the arc attributes when it is highlighted.
    */
   highlighted: PropTypes.shape({
     additionalRadius: PropTypes.number,
@@ -235,7 +235,7 @@ PieArcLabelPlot.propTypes = {
   }),
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * @default 0
    */
   innerRadius: PropTypes.number,

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -30,7 +30,7 @@ export interface PieArcPlotProps
     >,
     ComputedPieRadius {
   /**
-   * Override the arc attibutes when it is faded.
+   * Override the arc attributes when it is faded.
    * @default { additionalRadius: -5 }
    */
   faded?: DefaultizedPieSeriesType['faded'];
@@ -179,7 +179,7 @@ PieArcPlot.propTypes = {
     }),
   ).isRequired,
   /**
-   * Override the arc attibutes when it is faded.
+   * Override the arc attributes when it is faded.
    * @default { additionalRadius: -5 }
    */
   faded: PropTypes.shape({
@@ -192,7 +192,7 @@ PieArcPlot.propTypes = {
     paddingAngle: PropTypes.number,
   }),
   /**
-   * Override the arc attibutes when it is highlighted.
+   * Override the arc attributes when it is highlighted.
    */
   highlighted: PropTypes.shape({
     additionalRadius: PropTypes.number,
@@ -209,7 +209,7 @@ PieArcPlot.propTypes = {
   }),
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * @default 0
    */
   innerRadius: PropTypes.number,

--- a/packages/x-charts/src/context/SeriesContextProvider.tsx
+++ b/packages/x-charts/src/context/SeriesContextProvider.tsx
@@ -76,7 +76,7 @@ const formatSeries = (series: AllSeriesType[], colors: string[], dataset?: Datas
   });
 
   const formattedSeries: FormattedSeries = {};
-  // Apply formater on a type group
+  // Apply formatter on a type group
   (Object.keys(seriesTypeFormatter) as ChartSeriesType[]).forEach((type) => {
     if (seriesGroups[type] !== undefined) {
       formattedSeries[type] =

--- a/packages/x-charts/src/hooks/useReducedMotion.ts
+++ b/packages/x-charts/src/hooks/useReducedMotion.ts
@@ -5,7 +5,7 @@ import { useIsomorphicLayoutEffect, Globals } from '@react-spring/web';
  * set skipAnimations to the value of the user's
  * `prefers-reduced-motion` query.
  *
- * The return value, post-effect, is the value of their prefered setting
+ * The return value, post-effect, is the value of their preferred setting
  */
 export const useReducedMotion = () => {
   // Taken from: https://github.com/pmndrs/react-spring/blob/02ec877bbfab0df46da0e4a47d5f68d3e731206a/packages/shared/src/hooks/useReducedMotion.ts#L13

--- a/packages/x-charts/src/hooks/useScale.ts
+++ b/packages/x-charts/src/hooks/useScale.ts
@@ -5,7 +5,7 @@ import { AxisScaleConfig, D3Scale, ScaleName } from '../models/axis';
 
 /**
  * For a given scale return a function that map value to their position.
- * Usefull when dealing with specific scale such as band.
+ * Useful when dealing with specific scale such as band.
  * @param scale The scale to use
  * @returns (value: any) => number
  */

--- a/packages/x-charts/src/internals/components/ChartsAxesGradients/ChartsAxesGradients.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAxesGradients/ChartsAxesGradients.tsx
@@ -8,7 +8,7 @@ import ChartsContinuousGradient from './ChartsContinuousGradient';
 export function useChartGradient() {
   const { chartId } = React.useContext(DrawingContext);
   return React.useCallback(
-    (axisId: string, direction: 'x' | 'y') => `${chartId}-graient-${direction}-${axisId}`,
+    (axisId: string, direction: 'x' | 'y') => `${chartId}-gradient-${direction}-${axisId}`,
     [chartId],
   );
 }
@@ -32,7 +32,7 @@ export function ChartsAxesGradients() {
             return (
               <ChartsPiecewiseGradient
                 key={gradientId}
-                isReveresed={!reverse}
+                isReversed={!reverse}
                 scale={scale}
                 colorMap={colorMap}
                 size={svgHeight}
@@ -45,7 +45,7 @@ export function ChartsAxesGradients() {
             return (
               <ChartsContinuousGradient
                 key={gradientId}
-                isReveresed={!reverse}
+                isReversed={!reverse}
                 scale={scale}
                 colorScale={colorScale!}
                 colorMap={colorMap}
@@ -66,7 +66,7 @@ export function ChartsAxesGradients() {
             return (
               <ChartsPiecewiseGradient
                 key={gradientId}
-                isReveresed={reverse}
+                isReversed={reverse}
                 scale={scale}
                 colorMap={colorMap}
                 size={svgWidth}
@@ -79,7 +79,7 @@ export function ChartsAxesGradients() {
             return (
               <ChartsContinuousGradient
                 key={gradientId}
-                isReveresed={reverse}
+                isReversed={reverse}
                 scale={scale}
                 colorScale={colorScale!}
                 colorMap={colorMap}

--- a/packages/x-charts/src/internals/components/ChartsAxesGradients/ChartsContinuousGradient.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAxesGradients/ChartsContinuousGradient.tsx
@@ -5,7 +5,7 @@ import { ContinuousColorConfig } from '../../../models/colorMapping';
 const PX_PRECISION = 10;
 
 type ChartsContinuousGradientProps = {
-  isReveresed?: boolean;
+  isReversed?: boolean;
   gradientId: string;
   size: number;
   direction: 'x' | 'y';
@@ -15,7 +15,7 @@ type ChartsContinuousGradientProps = {
 };
 
 export default function ChartsContinuousGradient(props: ChartsContinuousGradientProps) {
-  const { isReveresed, gradientId, size, direction, scale, colorScale, colorMap } = props;
+  const { isReversed, gradientId, size, direction, scale, colorScale, colorMap } = props;
 
   const extremValues = [colorMap.min ?? 0, colorMap.max ?? 100] as [number, number] | [Date, Date];
   const extremPositions = extremValues.map(scale).filter((p): p is number => p !== undefined);
@@ -40,7 +40,7 @@ export default function ChartsContinuousGradient(props: ChartsContinuousGradient
       x2="0"
       y1="0"
       y2="0"
-      {...{ [`${direction}${isReveresed ? 1 : 2}`]: `${size}px` }}
+      {...{ [`${direction}${isReversed ? 1 : 2}`]: `${size}px` }}
       gradientUnits="userSpaceOnUse" // Use the SVG coordinate instead of the component ones.
     >
       {Array.from({ length: numberOfPoints + 1 }, (_, index) => {
@@ -52,7 +52,7 @@ export default function ChartsContinuousGradient(props: ChartsContinuousGradient
         if (x === undefined) {
           return null;
         }
-        const offset = isReveresed ? 1 - x / size : x / size;
+        const offset = isReversed ? 1 - x / size : x / size;
         const color = colorScale(value);
 
         if (color === null) {

--- a/packages/x-charts/src/internals/components/ChartsAxesGradients/ChartsPiecewiseGradient.tsx
+++ b/packages/x-charts/src/internals/components/ChartsAxesGradients/ChartsPiecewiseGradient.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { PiecewiseColorConfig } from '../../../models/colorMapping';
 
 type ChartsPiecewiseGradientProps = {
-  isReveresed?: boolean;
+  isReversed?: boolean;
   gradientId: string;
   size: number;
   direction: 'x' | 'y';
@@ -11,7 +11,7 @@ type ChartsPiecewiseGradientProps = {
 };
 
 export default function ChartsPiecewiseGradient(props: ChartsPiecewiseGradientProps) {
-  const { isReveresed, gradientId, size, direction, scale, colorMap } = props;
+  const { isReversed, gradientId, size, direction, scale, colorMap } = props;
 
   return (
     <linearGradient
@@ -20,7 +20,7 @@ export default function ChartsPiecewiseGradient(props: ChartsPiecewiseGradientPr
       x2="0"
       y1="0"
       y2="0"
-      {...{ [`${direction}${isReveresed ? 1 : 2}`]: `${size}px` }}
+      {...{ [`${direction}${isReversed ? 1 : 2}`]: `${size}px` }}
       gradientUnits="userSpaceOnUse" // Use the SVG coordinate instead of the component ones.
     >
       {colorMap.thresholds.map((threshold, index) => {
@@ -29,7 +29,7 @@ export default function ChartsPiecewiseGradient(props: ChartsPiecewiseGradientPr
         if (x === undefined) {
           return null;
         }
-        const offset = isReveresed ? 1 - x / size : x / size;
+        const offset = isReversed ? 1 - x / size : x / size;
 
         return (
           <React.Fragment key={threshold.toString() + index}>

--- a/packages/x-charts/src/internals/utils.ts
+++ b/packages/x-charts/src/internals/utils.ts
@@ -10,7 +10,7 @@ type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U;
 
 /**
- * Transform mouse event position to corrdinates inside the SVG.
+ * Transform mouse event position to coordinates inside the SVG.
  * @param svg The SVG element
  * @param event The mouseEvent to transform
  */

--- a/packages/x-charts/src/models/seriesType/bar.ts
+++ b/packages/x-charts/src/models/seriesType/bar.ts
@@ -17,7 +17,7 @@ export interface BarSeriesType
    */
   data?: (number | null)[];
   /**
-   * The key used to retrive data from the dataset.
+   * The key used to retrieve data from the dataset.
    */
   dataKey?: string;
   label?: string;

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -51,7 +51,7 @@ export interface LineSeriesType
    */
   data?: (number | null)[];
   /**
-   * The key used to retrive data from the dataset.
+   * The key used to retrieve data from the dataset.
    */
   dataKey?: string;
   stack?: string;

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -23,7 +23,7 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
   type: 'pie';
   data: Tdata[];
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * Can be a number (in px) or a string with a percentage such as '50%'.
    * The '100%' is the maximal radius that fit into the drawing area.
    * @default 0
@@ -93,7 +93,7 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
    */
   cy?: number | string;
   /**
-   * Override the arc attibutes when it is highlighted.
+   * Override the arc attributes when it is highlighted.
    */
   highlighted?: {
     /**
@@ -109,7 +109,7 @@ export interface PieSeriesType<Tdata = PieValueType> extends CommonSeriesType<Td
     color?: string;
   };
   /**
-   * Override the arc attibutes when it is faded.
+   * Override the arc attributes when it is faded.
    */
   faded?: {
     /**
@@ -146,7 +146,7 @@ export interface DefaultizedPieSeriesType
  */
 export interface ComputedPieRadius {
   /**
-   * The radius between circle center and the begining of the arc.
+   * The radius between circle center and the beginning of the arc.
    * @default 0
    */
   innerRadius?: number;


### PR DESCRIPTION
I just ran [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell) on the x-charts folder and fixed what didn't look like intentional 😅 