### PR TITLE
[code-infra] Bump node image used by CI in docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ default-job: &default-job
     REACT_DIST_TAG: << parameters.react-dist-tag >>
   working_directory: /tmp/mui
   docker:
-    - image: cimg/node:18.19
+    - image: cimg/node:18.20
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.


### PR DESCRIPTION
Bumping to use latest LTS (v18.x) version to benefit from updates and security fixes.

https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md