### PR TITLE
[DataGrid] Reduce bundle size with error messages

### DIFF
--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -28,10 +28,11 @@ export type { GridPremiumSlotsComponent as GridSlots } from '../models';
 
 const releaseInfo = getReleaseInfo();
 
-const dataGridPremiumPropValidators: PropValidator<DataGridPremiumProcessedProps>[] = [
-  ...propValidatorsDataGrid,
-  ...propValidatorsDataGridPro,
-];
+let dataGridPremiumPropValidators: PropValidator<DataGridPremiumProcessedProps>[];
+
+if (process.env.NODE_ENV !== 'production') {
+  dataGridPremiumPropValidators = [...propValidatorsDataGrid, ...propValidatorsDataGridPro];
+}
 
 const DataGridPremiumRaw = React.forwardRef(function DataGridPremium<R extends GridValidRowModel>(
   inProps: DataGridPremiumProps<R>,

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -42,7 +42,9 @@ const DataGridPremiumRaw = React.forwardRef(function DataGridPremium<R extends G
 
   useLicenseVerifier('x-data-grid-premium', releaseInfo);
 
-  validateProps(props, dataGridPremiumPropValidators);
+  if (process.env.NODE_ENV !== 'production') {
+    validateProps(props, dataGridPremiumPropValidators);
+  }
   return (
     <GridContextProvider privateApiRef={privateApiRef} props={props}>
       <GridRoot

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -29,7 +29,9 @@ const DataGridProRaw = React.forwardRef(function DataGridPro<R extends GridValid
   const privateApiRef = useDataGridProComponent(props.apiRef, props);
   useLicenseVerifier('x-data-grid-pro', releaseInfo);
 
-  validateProps(props, propValidatorsDataGridPro);
+  if (process.env.NODE_ENV !== 'production') {
+    validateProps(props, propValidatorsDataGridPro);
+  }
   return (
     <GridContextProvider privateApiRef={privateApiRef} props={props}>
       <GridRoot

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -37,8 +37,9 @@ const DataGridRaw = React.forwardRef(function DataGrid<R extends GridValidRowMod
   const props = useDataGridProps(inProps);
   const privateApiRef = useDataGridComponent(props.apiRef, props);
 
-  validateProps(props, propValidators);
-
+  if (process.env.NODE_ENV !== 'production') {
+    validateProps(props, propValidators);
+  }
   return (
     <GridContextProvider privateApiRef={privateApiRef} props={props}>
       <GridRoot

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -15,20 +15,24 @@ import {
 
 export type { GridSlotsComponent as GridSlots } from '../models';
 
-const propValidators: PropValidator<DataGridProcessedProps>[] = [
-  ...propValidatorsDataGrid,
-  // Only validate in MIT version
-  (props) =>
-    (props.columns &&
-      props.columns.some((column) => column.resizable) &&
-      [
-        `MUI X: \`column.resizable = true\` is not a valid prop.`,
-        'Column resizing is not available in the MIT version.',
-        '',
-        'You need to upgrade to DataGridPro or DataGridPremium component to unlock this feature.',
-      ].join('\n')) ||
-    undefined,
-];
+let propValidators: PropValidator<DataGridProcessedProps>[];
+
+if (process.env.NODE_ENV !== 'production') {
+  propValidators = [
+    ...propValidatorsDataGrid,
+    // Only validate in MIT version
+    (props) =>
+      (props.columns &&
+        props.columns.some((column) => column.resizable) &&
+        [
+          `MUI X: \`column.resizable = true\` is not a valid prop.`,
+          'Column resizing is not available in the MIT version.',
+          '',
+          'You need to upgrade to DataGridPro or DataGridPremium component to unlock this feature.',
+        ].join('\n')) ||
+      undefined,
+  ];
+}
 
 const DataGridRaw = React.forwardRef(function DataGrid<R extends GridValidRowModel>(
   inProps: DataGridProps<R>,

--- a/packages/x-data-grid/src/internals/utils/propValidation.ts
+++ b/packages/x-data-grid/src/internals/utils/propValidation.ts
@@ -43,25 +43,22 @@ export const propValidatorsDataGrid: PropValidator<DataGridProcessedProps>[] = [
 ];
 
 const warnedOnceCache = new Set();
-const warnOnce = (message: string) => {
+function warnOnce(message: string) {
   if (!warnedOnceCache.has(message)) {
     console.error(message);
     warnedOnceCache.add(message);
   }
-};
+}
 
-export const validateProps = <TProps>(props: TProps, validators: PropValidator<TProps>[]) => {
-  if (process.env.NODE_ENV === 'production') {
-    return;
-  }
+export function validateProps<TProps>(props: TProps, validators: PropValidator<TProps>[]) {
   validators.forEach((validator) => {
     const warning = validator(props);
     if (warning) {
       warnOnce(warning);
     }
   });
-};
+}
 
-export const clearWarningsCache = () => {
+export function clearWarningsCache() {
   warnedOnceCache.clear();
-};
+}


### PR DESCRIPTION
### Problem

Open https://mui.com/x/react-data-grid/, see how we load unless code in the JS bundle:

<img width="743" alt="SCR-20240504-pnic" src="https://github.com/mui/mui-x/assets/3165635/4aca4f63-b1a0-4a23-a696-027ba5a4ce5d">

It increases the bundle size reported in https://bundlephobia.com/package/@mui/x-data-grid 🙃. 

### Solution

The most popular minifiers, esbuild seem to win https://npmtrends.com/esbuild-vs-terser-vs-uglify-js. A quick reproduction: https://esbuild.github.io/try/#YgAwLjIwLjIAeyBtaW5pZnk6IHRydWUsIGJ1bmRsZTogdHJ1ZSB9AABwcm9wVmFsaWRhdGlvbi5qcwBleHBvcnQgY29uc3QgcHJvcFZhbGlkYXRvcnMgPSBbKCkgPT4gJ2Vycm9yIG1lc3NhZ2UnXTsKCmV4cG9ydCBmdW5jdGlvbiB2YWxpZGF0ZVByb3BzKHByb3BzLCB2YWxpZGF0b3JzKSB7CiAgaWYgKHByb2Nlc3MuZW52Lk5PREVfRU5WID09PSAncHJvZHVjdGlvbicpIHsKICAgIHJldHVybjsKICB9CiAgdmFsaWRhdG9ycy5mb3JFYWNoKCh2YWxpZGF0b3IpID0+IHt9KTsKfQBlAERhdGFHcmlkLmpzAGltcG9ydCB7oHZhbGlkYXRlUHJvcHMsIHByb3BWYWxpZGF0b3JzIH0gZnJvbSAnLi9wcm9wVmFsaWRhdGlvbic7CgpleHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBEYXRhR3JpZChwcm9wcykgewogIHZhbGlkYXRlUHJvcHMocHJvcHMsIHByb3BWYWxpZGF0b3JzKTsKICByZXR1cm4gImZvbyI7Cn0

I thought it was because the function isn't treated as pure by default by minifiers, why our Babel transformers add those  `/*#__PURE__*/` in https://unpkg.com/browse/@mui/x-data-grid@7.3.2/DataGrid/DataGrid.js. But it doesn't seem to be this. So I went with the simplest solution.

Preview: https://deploy-preview-12992--material-ui-x.netlify.app/x/react-data-grid/

---

**Off-topic**: I think a reason why we need https://github.com/mui/mui-x/issues/5550. It would have been caught when we introduced this regression in #11303.