### PR TITLE
[docs-infra] Fix Netlify PR preview path

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,7 +1,7 @@
 / /x/introduction/ 301
 /x/ https://mui.com/x/ 302
 # Avoid conflicts with the other Next.js apps hosted under https://mui.com/
-/x/_next/* /_next/:splat
+/x/_next/* /_next/:splat 200
 
 # For links that we can't edit later on, for example hosted in the code published on npm or sent by email
 


### PR DESCRIPTION
I noticed this in #12992. PR preview JS loading is all broken 🙈 

<img width="417" alt="SCR-20240504-qgra" src="https://github.com/mui/mui-x/assets/3165635/341041aa-d4bd-4564-bf48-99734fa794d9">

