### PR TITLE
Update validation.md

### DIFF
--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -45,6 +45,9 @@ On the calendar and clock views—the invalid values are displayed as disabled t
 
 {{"demo": "ValidationBehaviorView.js", "defaultCodeOpen": false}}
 
+### Empty string considered invalid
+Empty string (`''`) values will be considered invalid.  Pass `null` instead if you want a blank date-picker.
+
 ## Past and future validation
 
 All pickers support the past and future validation.


### PR DESCRIPTION
Clarified that the component requires a `null` value for the validation to treat it as acceptable.  As I discovered, a blank string makes the component go into the invalid validation state ... but there's currently no explanation of this behavior in the docs (that I could find).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
