### PR TITLE
[DataGrid] Fix throw error with onBlur at SVG element

### DIFF
--- a/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -331,7 +331,7 @@ export const useGridFocus = (
 
   const handleBlur = React.useCallback<GridEventListener<'columnHeaderBlur'>>(
     (_, event) => {
-      if (event.relatedTarget?.className.includes(gridClasses.columnHeader)) {
+      if (event.relatedTarget?.getAttribute('class')?.includes(gridClasses.columnHeader)) {
         return;
       }
       logger.debug(`Clearing focus`);


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/12955

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
In HTML, className is a string. In SVG it is an `SVGAnimatedString` object. I think It is better to get the className of an element using `elem.getAttribute`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
