### PR TITLE
[charts] Add support mobile tooltip

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -52,22 +52,27 @@ export function useMouseTracker() {
       return () => {};
     }
 
-    const handleMouseOut = () => {
+    const handleOut = () => {
       setMousePosition(null);
     };
 
-    const handleMouseMove = (event: MouseEvent) => {
+    const handleMove = (event: MouseEvent | TouchEvent) => {
+      const target = 'targetTouches' in event ? event.targetTouches[0] : event;
       setMousePosition({
-        x: event.clientX,
-        y: event.clientY,
+        x: target.clientX,
+        y: target.clientY,
       });
     };
 
-    element.addEventListener('mouseout', handleMouseOut);
-    element.addEventListener('mousemove', handleMouseMove);
+    element.addEventListener('mouseout', handleOut);
+    element.addEventListener('mousemove', handleMove);
+    element.addEventListener('touchend', handleOut);
+    element.addEventListener('touchmove', handleMove);
     return () => {
-      element.removeEventListener('mouseout', handleMouseOut);
-      element.removeEventListener('mousemove', handleMouseMove);
+      element.removeEventListener('mouseout', handleOut);
+      element.removeEventListener('mousemove', handleMove);
+      element.addEventListener('touchend', handleOut);
+      element.addEventListener('touchmove', handleMove);
     };
   }, [svgRef]);
 

--- a/packages/x-charts/src/hooks/useAxisEvents.ts
+++ b/packages/x-charts/src/hooks/useAxisEvents.ts
@@ -95,7 +95,7 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
       };
     };
 
-    const handleMouseOut = () => {
+    const handleOut = () => {
       mousePosition.current = {
         x: -1,
         y: -1,
@@ -103,8 +103,9 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
       dispatch({ type: 'exitChart' });
     };
 
-    const handleMouseMove = (event: MouseEvent) => {
-      const svgPoint = getSVGPoint(svgRef.current!, event);
+    const handleMove = (event: MouseEvent | TouchEvent) => {
+      const target = 'targetTouches' in event ? event.targetTouches[0] : event;
+      const svgPoint = getSVGPoint(svgRef.current!, target);
 
       mousePosition.current = {
         x: svgPoint.x,
@@ -123,11 +124,15 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
       dispatch({ type: 'updateAxis', data: { x: newStateX, y: newStateY } });
     };
 
-    element.addEventListener('mouseout', handleMouseOut);
-    element.addEventListener('mousemove', handleMouseMove);
+    element.addEventListener('mouseout', handleOut);
+    element.addEventListener('mousemove', handleMove);
+    element.addEventListener('touchend', handleOut);
+    element.addEventListener('touchmove', handleMove);
     return () => {
-      element.removeEventListener('mouseout', handleMouseOut);
-      element.removeEventListener('mousemove', handleMouseMove);
+      element.removeEventListener('mouseout', handleOut);
+      element.removeEventListener('mousemove', handleMove);
+      element.removeEventListener('touchend', handleOut);
+      element.removeEventListener('touchmove', handleMove);
     };
   }, [
     svgRef,

--- a/packages/x-charts/src/internals/utils.ts
+++ b/packages/x-charts/src/internals/utils.ts
@@ -14,7 +14,7 @@ export type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U,
  * @param svg The SVG element
  * @param event The mouseEvent to transform
  */
-export function getSVGPoint(svg: SVGSVGElement, event: MouseEvent) {
+export function getSVGPoint(svg: SVGSVGElement, event: Pick<MouseEvent, 'clientX' | 'clientY'>) {
   const pt = svg.createSVGPoint();
   pt.x = event.clientX;
   pt.y = event.clientY;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Resolves: https://github.com/mui/mui-x/issues/13041



Added tracking of touch events for correct operation on mobile devices. This works in case of an `axis` trigger.

This solution does not work for an `item` trigger. It is necessary to come up with a solution for this case.

**Preview:** https://deploy-preview-13043--material-ui-x.netlify.app/x/react-charts/tooltip/





- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
