### PR TITLE
[DataGrid] Fix `rowModesModel` controlled prop

### DIFF
--- a/packages/x-data-grid-pro/src/tests/rowEditing.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowEditing.DataGridPro.test.tsx
@@ -1260,6 +1260,15 @@ describe('<DataGridPro /> - Row editing', () => {
         expect(getCell(0, 1)).not.to.have.class('MuiDataGrid-cell--editing');
       });
 
+      it('should stop edit mode when rowModesModel empty', () => {
+        const { setProps } = render(
+          <TestCase rowModesModel={{ 0: { mode: GridRowModes.Edit } }} />,
+        );
+        expect(getCell(0, 1)).to.have.class('MuiDataGrid-cell--editing');
+        setProps({ rowModesModel: {} });
+        expect(getCell(0, 1)).not.to.have.class('MuiDataGrid-cell--editing');
+      });
+
       it('should ignode modifications if ignoreModifications=true', async () => {
         const { setProps } = render(
           <TestCase rowModesModel={{ 0: { mode: GridRowModes.Edit } }} />,

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -718,7 +718,9 @@ export const useGridRowEditing = (
     const copyOfPrevRowModesModel = prevRowModesModel.current;
     prevRowModesModel.current = deepClone(rowModesModel); // Do a deep-clone because the attributes might be changed later
 
-    Object.entries(rowModesModel).forEach(([id, params]) => {
+    const ids = new Set([...Object.keys(rowModesModel), ...Object.keys(copyOfPrevRowModesModel)]);
+    Array.from(ids).forEach((id) => {
+      const params = rowModesModel[id] ?? { mode: GridRowModes.View };
       const prevMode = copyOfPrevRowModesModel[id]?.mode || GridRowModes.View;
       const originalId = idToIdLookup[id] ?? id;
       if (params.mode === GridRowModes.Edit && prevMode === GridRowModes.View) {


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/11423

I need this to work for Toolpad. Instead of creating [workarounds](https://stackblitz.com/edit/react-m6fhje-31blaf?file=Demo.tsx), might as well just fix it at the root.

The problem seems to be that `updateStateToStopRowEditMode` in the loop doesn't run. `rowModesModel` is an empty object and thus the `.forEach` doesn't run. This PR adjusts the logic and runs the loop for each property of both previous and current `rowModesModel`. If the current one doesn't contain a model for a row, it assumes it's in view mode.