### PR TITLE
[docs-infra] Fix custom API page headings

### DIFF
--- a/docs/src/modules/components/InterfaceApiPage.js
+++ b/docs/src/modules/components/InterfaceApiPage.js
@@ -37,11 +37,13 @@ function Heading(props) {
 
   return (
     <Level id={hash}>
-      {getTranslatedHeader(t, hash)}
-      <a aria-labelledby={hash} className="anchor-link" href={`#${hash}`} tabIndex={-1}>
-        <svg>
-          <use xlinkHref="#anchor-link-icon" />
-        </svg>
+      <a aria-labelledby={hash} className="title-link-to-anchor" href={`#${hash}`} tabIndex={-1}>
+        {getTranslatedHeader(t, hash)}
+        <span className="anchor-icon">
+          <svg>
+            <use xlinkHref="#anchor-link-icon" />
+          </svg>
+        </span>
       </a>
     </Level>
   );


### PR DESCRIPTION
Fix broken headings (too big SVG icons) in custom API pages:

## Before
- https://mui.com/x/api/charts/axis-config/
- https://mui.com/x/api/data-grid/grid-col-def/

![Screenshot 2024-05-10 at 11 00 20](https://github.com/mui/mui-x/assets/4941090/362228d8-bc8a-48ad-8b87-b9c643f777e6)


## After
- https://deploy-preview-13074--material-ui-x.netlify.app/x/api/charts/axis-config/
- https://deploy-preview-13074--material-ui-x.netlify.app/x/api/data-grid/grid-col-def/

![Screenshot 2024-05-10 at 11 13 40](https://github.com/mui/mui-x/assets/4941090/162e8329-2865-4f3c-8803-53df1e9a576a)

