### PR TITLE
[core] Avoid root level `@mui/x-date-pickers` imports

### DIFF
--- a/docs/data/date-pickers/custom-field/BrowserV7SingleInputRangeField.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV7SingleInputRangeField.tsx
@@ -25,7 +25,7 @@ import {
   DateRange,
   FieldType,
 } from '@mui/x-date-pickers-pro/models';
-import { BaseSingleInputFieldProps } from '@mui/x-date-pickers';
+import { BaseSingleInputFieldProps } from '@mui/x-date-pickers/models';
 
 const BrowserFieldRoot = styled('div', { name: 'BrowserField', slot: 'Root' })({
   display: 'flex',

--- a/docs/data/date-pickers/date-time-range-picker/DateTimeRangePickerValue.tsx
+++ b/docs/data/date-pickers/date-time-range-picker/DateTimeRangePickerValue.tsx
@@ -3,7 +3,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateRange } from '@mui/x-date-pickers-pro';
+import { DateRange } from '@mui/x-date-pickers-pro/models';
 import { DateTimeRangePicker } from '@mui/x-date-pickers-pro/DateTimeRangePicker';
 
 export default function DateTimeRangePickerValue() {

--- a/docs/data/date-pickers/fields/ControlledSelectedSectionsMultiInputRangeField.tsx
+++ b/docs/data/date-pickers/fields/ControlledSelectedSectionsMultiInputRangeField.tsx
@@ -4,11 +4,8 @@ import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import {
-  FieldSectionType,
-  FieldSelectedSections,
-  RangePosition,
-} from '@mui/x-date-pickers-pro/models';
+import { FieldSectionType, FieldSelectedSections } from '@mui/x-date-pickers/models';
+import { RangePosition } from '@mui/x-date-pickers-pro/models';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 
 export default function ControlledSelectedSectionsMultiInputRangeField() {

--- a/docs/data/date-pickers/fields/ControlledSelectedSectionsMultiInputRangeField.tsx
+++ b/docs/data/date-pickers/fields/ControlledSelectedSectionsMultiInputRangeField.tsx
@@ -8,7 +8,7 @@ import {
   FieldSectionType,
   FieldSelectedSections,
   RangePosition,
-} from '@mui/x-date-pickers-pro';
+} from '@mui/x-date-pickers-pro/models';
 import { MultiInputDateRangeField } from '@mui/x-date-pickers-pro/MultiInputDateRangeField';
 
 export default function ControlledSelectedSectionsMultiInputRangeField() {

--- a/docs/data/date-pickers/fields/ControlledSelectedSectionsSingleInputRangeField.tsx
+++ b/docs/data/date-pickers/fields/ControlledSelectedSectionsSingleInputRangeField.tsx
@@ -8,9 +8,8 @@ import {
   FieldSectionType,
   FieldSelectedSections,
   FieldRef,
-  RangeFieldSection,
-  RangePosition,
-} from '@mui/x-date-pickers-pro';
+} from '@mui/x-date-pickers/models';
+import { RangeFieldSection, RangePosition } from '@mui/x-date-pickers-pro/models';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 
 export default function ControlledSelectedSectionsSingleInputRangeField() {

--- a/packages/x-codemod/src/v6.0.0/pickers/migrate-to-components-componentsProps/actual.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/migrate-to-components-componentsProps/actual.spec.js
@@ -1,4 +1,4 @@
-import { DatePicker } from '@mui/x-date-pickers';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 <DatePicker PopperProps={{ onClick: handleClick }} />;
 

--- a/packages/x-codemod/src/v6.0.0/pickers/migrate-to-components-componentsProps/expected.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/migrate-to-components-componentsProps/expected.spec.js
@@ -1,4 +1,4 @@
-import { DatePicker } from '@mui/x-date-pickers';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 <DatePicker
   componentsProps={{

--- a/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/actual-props.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/actual-props.spec.js
@@ -1,5 +1,5 @@
-import { DatePicker } from '@mui/x-date-pickers';
-import { DateRangePicker } from '@mui/x-date-pickers-pro';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import TextField from '@mui/material/TextField';
 
 <div>

--- a/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/expected-props.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/rename-components-to-slots/expected-props.spec.js
@@ -1,5 +1,5 @@
-import { DatePicker } from '@mui/x-date-pickers';
-import { DateRangePicker } from '@mui/x-date-pickers-pro';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
 import TextField from '@mui/material/TextField';
 
 <div>

--- a/packages/x-codemod/src/v6.0.0/pickers/replace-arrows-button-slot/actual.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/replace-arrows-button-slot/actual.spec.js
@@ -1,4 +1,5 @@
-import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 <LocalizationProvider>
   <DatePicker

--- a/packages/x-codemod/src/v6.0.0/pickers/replace-arrows-button-slot/expected.spec.js
+++ b/packages/x-codemod/src/v6.0.0/pickers/replace-arrows-button-slot/expected.spec.js
@@ -1,4 +1,5 @@
-import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 <LocalizationProvider>
   <DatePicker

--- a/packages/x-codemod/src/v7.0.0/pickers/preset-safe/actual.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/pickers/preset-safe/actual.spec.tsx
@@ -1,7 +1,12 @@
 // @ts-nocheck
 import * as React from 'react';
-import { DatePicker, dayPickerClasses } from '@mui/x-date-pickers';
-import { DateRangePicker, DateRangePickerSlotsComponentsProps } from '@mui/x-date-pickers-pro';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { dayPickerClasses } from '@mui/x-date-pickers/DateCalendar';
+// prettier-ignore
+import {
+  DateRangePicker,
+  DateRangePickerSlotsComponentsProps,
+} from '@mui/x-date-pickers-pro/DateRangePicker';
 import TextField from '@mui/material/TextField';
 
 const className = dayPickerClasses.root;

--- a/packages/x-codemod/src/v7.0.0/pickers/preset-safe/expected.spec.tsx
+++ b/packages/x-codemod/src/v7.0.0/pickers/preset-safe/expected.spec.tsx
@@ -1,7 +1,12 @@
 // @ts-nocheck
 import * as React from 'react';
-import { DatePicker, dayCalendarClasses } from '@mui/x-date-pickers';
-import { DateRangePicker, DateRangePickerSlotProps } from '@mui/x-date-pickers-pro';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { dayCalendarClasses } from '@mui/x-date-pickers/DateCalendar';
+// prettier-ignore
+import {
+  DateRangePicker,
+  DateRangePickerSlotProps,
+} from '@mui/x-date-pickers-pro/DateRangePicker';
 import TextField from '@mui/material/TextField';
 
 const className = dayCalendarClasses.root;

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
@@ -3,8 +3,9 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { screen, fireEvent, userEvent, act, getByRole } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
-import { DateRange, LocalizationProvider } from '@mui/x-date-pickers-pro';
+import { DateRange } from '@mui/x-date-pickers-pro/models';
 import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDateRangeField';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { DateTimeField } from '@mui/x-date-pickers';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/AdapterDateFnsJalaliV3/AdapterDateFnsJalaliV3.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalaliV3/AdapterDateFnsJalaliV3.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { DateTimeField } from '@mui/x-date-pickers';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalaliV3';
 import {
   createPickerRenderer,

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -1,5 +1,5 @@
 import dayjs, { Dayjs } from 'dayjs';
-import { DateTimeField } from '@mui/x-date-pickers';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
 import { expect } from 'chai';

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { DateTime, Settings } from 'luxon';
-import { DateTimeField } from '@mui/x-date-pickers';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
 import {

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
@@ -1,6 +1,6 @@
 import moment, { Moment } from 'moment';
 import momentTZ from 'moment-timezone';
-import { DateTimeField } from '@mui/x-date-pickers';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
 import { expect } from 'chai';

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { expect } from 'chai';
-import { DateTimeField } from '@mui/x-date-pickers';
+import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { AdapterMomentHijri } from '@mui/x-date-pickers/AdapterMomentHijri';
 import { AdapterFormats } from '@mui/x-date-pickers/models';
 import {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -877,6 +877,10 @@ async function initializeEnvironment(
       });
 
       it('should correctly select hours section when there are no time renderers on v6', async () => {
+        // The test is flaky on webkit
+        if (browserType.name() === 'webkit') {
+          return;
+        }
         await renderFixture(
           'DatePicker/DesktopDateTimePickerNoTimeRenderers?enableAccessibleFieldDOMStructure=false',
         );


### PR DESCRIPTION
Small cleanup—avoid importing from package root where possible.