### PR TITLE
[charts] Fix area order when overlapping

### DIFF
--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -48,7 +48,7 @@ const useAggregatedData = () => {
 
   return stackingGroups.flatMap(({ ids: groupIds }) => {
     return [...groupIds]
-      .reverse() // Revert staked area for a more pleasant animation
+      .reverse() // Revert stacked area for a more pleasant animation
       .map((seriesId) => {
         const {
           xAxisKey = defaultXAxisId,

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -47,62 +47,66 @@ const useAggregatedData = () => {
   const defaultYAxisId = yAxisIds[0];
 
   return stackingGroups.flatMap(({ ids: groupIds }) => {
-    return groupIds.flatMap((seriesId) => {
-      const {
-        xAxisKey = defaultXAxisId,
-        yAxisKey = defaultYAxisId,
-        stackedData,
-        data,
-        connectNulls,
-      } = series[seriesId];
+    return [...groupIds]
+      .reverse() // Revert staked area for a more pleasant animation
+      .map((seriesId) => {
+        const {
+          xAxisKey = defaultXAxisId,
+          yAxisKey = defaultYAxisId,
+          stackedData,
+          data,
+          connectNulls,
+        } = series[seriesId];
 
-      const xScale = getValueToPositionMapper(xAxis[xAxisKey].scale);
-      const yScale = yAxis[yAxisKey].scale;
-      const xData = xAxis[xAxisKey].data;
+        const xScale = getValueToPositionMapper(xAxis[xAxisKey].scale);
+        const yScale = yAxis[yAxisKey].scale;
+        const xData = xAxis[xAxisKey].data;
 
-      const gradientUsed: [string, 'x' | 'y'] | undefined =
-        (yAxis[yAxisKey].colorScale && [yAxisKey, 'y']) ||
-        (xAxis[xAxisKey].colorScale && [xAxisKey, 'x']) ||
-        undefined;
+        const gradientUsed: [string, 'x' | 'y'] | undefined =
+          (yAxis[yAxisKey].colorScale && [yAxisKey, 'y']) ||
+          (xAxis[xAxisKey].colorScale && [xAxisKey, 'x']) ||
+          undefined;
 
-      if (process.env.NODE_ENV !== 'production') {
-        if (xData === undefined) {
-          throw new Error(
-            `MUI X Charts: ${
-              xAxisKey === DEFAULT_X_AXIS_KEY
-                ? 'The first `xAxis`'
-                : `The x-axis with id "${xAxisKey}"`
-            } should have data property to be able to display a line plot.`,
-          );
+        if (process.env.NODE_ENV !== 'production') {
+          if (xData === undefined) {
+            throw new Error(
+              `MUI X Charts: ${
+                xAxisKey === DEFAULT_X_AXIS_KEY
+                  ? 'The first `xAxis`'
+                  : `The x-axis with id "${xAxisKey}"`
+              } should have data property to be able to display a line plot.`,
+            );
+          }
+          if (xData.length < stackedData.length) {
+            throw new Error(
+              `MUI X Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items).`,
+            );
+          }
         }
-        if (xData.length < stackedData.length) {
-          throw new Error(
-            `MUI X Charts: The data length of the x axis (${xData.length} items) is lower than the length of series (${stackedData.length} items).`,
-          );
-        }
-      }
 
-      const areaPath = d3Area<{
-        x: any;
-        y: [number, number];
-      }>()
-        .x((d) => xScale(d.x))
-        .defined((_, i) => connectNulls || data[i] != null)
-        .y0((d) => d.y && yScale(d.y[0])!)
-        .y1((d) => d.y && yScale(d.y[1])!);
+        const areaPath = d3Area<{
+          x: any;
+          y: [number, number];
+        }>()
+          .x((d) => xScale(d.x))
+          .defined((_, i) => connectNulls || data[i] != null)
+          .y0((d) => d.y && yScale(d.y[0])!)
+          .y1((d) => d.y && yScale(d.y[1])!);
 
-      const curve = getCurveFactory(series[seriesId].curve);
-      const formattedData = xData?.map((x, index) => ({ x, y: stackedData[index] })) ?? [];
-      const d3Data = connectNulls ? formattedData.filter((_, i) => data[i] != null) : formattedData;
+        const curve = getCurveFactory(series[seriesId].curve);
+        const formattedData = xData?.map((x, index) => ({ x, y: stackedData[index] })) ?? [];
+        const d3Data = connectNulls
+          ? formattedData.filter((_, i) => data[i] != null)
+          : formattedData;
 
-      const d = areaPath.curve(curve)(d3Data) || '';
-      return {
-        ...series[seriesId],
-        gradientUsed,
-        d,
-        seriesId,
-      };
-    });
+        const d = areaPath.curve(curve)(d3Data) || '';
+        return {
+          ...series[seriesId],
+          gradientUsed,
+          d,
+          seriesId,
+        };
+      });
   });
 };
 
@@ -125,25 +129,23 @@ function AreaPlot(props: AreaPlotProps) {
 
   return (
     <g {...other}>
-      {completedData
-        .reverse()
-        .map(
-          ({ d, seriesId, color, highlightScope, area, gradientUsed }) =>
-            !!area && (
-              <AreaElement
-                key={seriesId}
-                id={seriesId}
-                d={d}
-                color={color}
-                gradientId={gradientUsed && getGradientId(...gradientUsed)}
-                highlightScope={highlightScope}
-                slots={slots}
-                slotProps={slotProps}
-                onClick={onItemClick && ((event) => onItemClick(event, { type: 'line', seriesId }))}
-                skipAnimation={skipAnimation}
-              />
-            ),
-        )}
+      {completedData.map(
+        ({ d, seriesId, color, highlightScope, area, gradientUsed }) =>
+          !!area && (
+            <AreaElement
+              key={seriesId}
+              id={seriesId}
+              d={d}
+              color={color}
+              gradientId={gradientUsed && getGradientId(...gradientUsed)}
+              highlightScope={highlightScope}
+              slots={slots}
+              slotProps={slotProps}
+              onClick={onItemClick && ((event) => onItemClick(event, { type: 'line', seriesId }))}
+              skipAnimation={skipAnimation}
+            />
+          ),
+      )}
     </g>
   );
 }


### PR DESCRIPTION
Fix #13067

I would still discourage the use of overlapping areas except for very specific edge case (such the one in the issue) 🙈

With no structure

![image](https://github.com/mui/mui-x/assets/45398769/1bea5b1d-5e56-47c9-9ce1-b47eee1ee97b)

With guarantee some series are always smaller than others

![image](https://github.com/mui/mui-x/assets/45398769/9fe44366-99a7-411b-962e-34fa462146a9)


I introduced this `reverse` when creating the animation, otherwise you get a weird state with the line and the area not in sync, just because the area on top of you is overlapping  (the time it finishes its animation too)

This fix applies the reverse on staking groups instead of all series.
- For staked series, they do not overflow so we can reverse the series order
- For non-stacked series, we do not apply the reverse and so they overlap correctly