### PR TITLE
[charts] Fix TS bottle neck

### DIFF
--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -6,7 +6,7 @@ import generateUtilityClass from '@mui/utils/generateUtilityClass';
 import { styled } from '@mui/material/styles';
 import { color as d3Color } from 'd3-color';
 import generateUtilityClasses from '@mui/utils/generateUtilityClasses';
-import { animated } from '@react-spring/web';
+import { AnimatedProps, animated } from '@react-spring/web';
 import {
   getIsFaded,
   getIsHighlighted,
@@ -60,11 +60,20 @@ export const BarElementPath = styled(animated.rect, {
     : ownerState.color,
   transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',
   opacity: (ownerState.isFaded && 0.3) || 1,
-}));
+})) as React.ElementType<BarProps>;
 
-interface BarProps extends Omit<React.ComponentPropsWithoutRef<'path'>, 'id' | 'color'> {
+interface BarProps
+  extends Omit<
+      React.SVGProps<SVGRectElement>,
+      'id' | 'color' | 'ref' | 'x' | 'y' | 'height' | 'width'
+    >,
+    AnimatedProps<{
+      x?: string | number | undefined;
+      y?: string | number | undefined;
+      height?: string | number | undefined;
+      width?: string | number | undefined;
+    }> {
   highlightScope?: Partial<HighlightScope>;
-  onClick?: (event: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
   ownerState: BarElementOwnerState;
 }
 
@@ -73,7 +82,7 @@ export interface BarElementSlots {
    * The component that renders the bar.
    * @default BarElementPath
    */
-  bar?: React.JSXElementConstructor<BarProps>;
+  bar?: React.ElementType<BarProps>;
 }
 
 export interface BarElementSlotProps {

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -60,7 +60,7 @@ export const BarElementPath = styled(animated.rect, {
     : ownerState.color,
   transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',
   opacity: (ownerState.isFaded && 0.3) || 1,
-})) as React.ElementType<BarProps>;
+}));
 
 interface BarProps
   extends Omit<
@@ -139,7 +139,7 @@ function BarElement(props: BarElementProps) {
   };
   const classes = useUtilityClasses(ownerState);
 
-  const Bar = slots?.bar ?? BarElementPath;
+  const Bar = slots?.bar ?? (BarElementPath as React.ElementType<BarProps>);
 
   const barProps = useSlotProps({
     elementType: Bar,


### PR DESCRIPTION
Fix #12921

The issue seems to come from the `useSlotProps` which try to guess props types from the component `Bar`

Wich can be a `styled(animated.rect)` or a `rect` component with some additional props.

To simplify all that:

- I updated `BarProps` such that it knows it needs to expect props `x`, `y`, `width`, and `height` to be animated ones
- Override the type of `BarElementPath` such that `styles only get access the the `BarProps`