### PR TITLE
[docs-infra] Reuse the `SectionTitle`

### DIFF
--- a/docs/src/modules/components/InterfaceApiPage.js
+++ b/docs/src/modules/components/InterfaceApiPage.js
@@ -9,6 +9,7 @@ import { alpha } from '@mui/material/styles';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
 import { MarkdownElement } from '@mui/docs/MarkdownElement';
+import { SectionTitle } from '@mui/docs/SectionTitle';
 import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
 import PropertiesSection from 'docs/src/modules/components/ApiPage/sections/PropertiesSection';
 import { DEFAULT_API_LAYOUT_STORAGE_KEYS } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
@@ -32,21 +33,10 @@ export function getTranslatedHeader(t, header) {
 }
 
 function Heading(props) {
-  const { hash, level: Level = 'h2' } = props;
+  const { hash, level = 'h2' } = props;
   const t = useTranslate();
 
-  return (
-    <Level id={hash}>
-      <a aria-labelledby={hash} className="title-link-to-anchor" href={`#${hash}`} tabIndex={-1}>
-        {getTranslatedHeader(t, hash)}
-        <span className="anchor-icon">
-          <svg>
-            <use xlinkHref="#anchor-link-icon" />
-          </svg>
-        </span>
-      </a>
-    </Level>
-  );
+  return <SectionTitle title={getTranslatedHeader(t, hash)} hash={hash} level={level} />;
 }
 
 Heading.propTypes = {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@mui/icons-material": "^5.15.14",
     "@mui/internal-markdown": "^1.0.3",
     "@mui/material": "^5.15.14",
-    "@mui/monorepo": "github:mui/material-ui#40492b73c20822f2a6feba7a39aa0c43117828ff",
+    "@mui/monorepo": "github:mui/material-ui#3c888ed6cf0774815c32c6309e8cea2d8b5e684b",
     "@mui/utils": "^5.15.14",
     "@next/eslint-plugin-next": "14.2.3",
     "@octokit/plugin-retry": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^5.15.14
         version: 5.15.15(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.2.60)(react-dom@18.2.0)(react@18.2.0)
       '@mui/monorepo':
-        specifier: github:mui/material-ui#40492b73c20822f2a6feba7a39aa0c43117828ff
-        version: github.com/mui/material-ui/40492b73c20822f2a6feba7a39aa0c43117828ff(@opentelemetry/api@1.8.0)
+        specifier: github:mui/material-ui#3c888ed6cf0774815c32c6309e8cea2d8b5e684b
+        version: github.com/mui/material-ui/3c888ed6cf0774815c32c6309e8cea2d8b5e684b(@opentelemetry/api@1.8.0)
       '@mui/utils':
         specifier: ^5.15.14
         version: 5.15.14(@types/react@18.2.60)(react@18.2.0)
@@ -18296,9 +18296,9 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/mui/material-ui/40492b73c20822f2a6feba7a39aa0c43117828ff(@opentelemetry/api@1.8.0):
-    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/40492b73c20822f2a6feba7a39aa0c43117828ff}
-    id: github.com/mui/material-ui/40492b73c20822f2a6feba7a39aa0c43117828ff
+  github.com/mui/material-ui/3c888ed6cf0774815c32c6309e8cea2d8b5e684b(@opentelemetry/api@1.8.0):
+    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/3c888ed6cf0774815c32c6309e8cea2d8b5e684b}
+    id: github.com/mui/material-ui/3c888ed6cf0774815c32c6309e8cea2d8b5e684b
     name: '@mui/monorepo'
     version: 6.0.0-alpha.6
     requiresBuild: true


### PR DESCRIPTION
Bring https://github.com/mui/material-ui/pull/42236 to have better sync between the docs in core and X, and avoid this regression: 

https://mui-org.slack.com/archives/C04U3R2V9UK/p1715099605724209


To test: https://deploy-preview-13139--material-ui-x.netlify.app/x/api/data-grid/grid-col-def/