### PR TITLE
[fields] Allow empty `textField` slot placeholder value

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -166,20 +166,6 @@ describe('<DesktopDatePicker /> - Field', () => {
         const input = getTextbox();
         expectFieldPlaceholderV6(input, '');
       });
-
-      it('should render blank placeholder when prop is undefined', () => {
-        renderWithProps({
-          enableAccessibleFieldDOMStructure: false,
-          slotProps: {
-            textField: {
-              placeholder: undefined,
-            },
-          },
-        });
-
-        const input = getTextbox();
-        expectFieldPlaceholderV6(input, '');
-      });
     });
   });
 

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -138,18 +138,57 @@ describe('<DesktopDatePicker /> - Field', () => {
       Component: DesktopDatePicker,
     });
 
-    it('should allow to override the placeholder (v6 only)', () => {
-      renderWithProps({
-        enableAccessibleFieldDOMStructure: false,
-        slotProps: {
-          textField: {
-            placeholder: 'Custom placeholder',
+    describe('Placeholder override (v6 only)', () => {
+      it('should allow to override the placeholder', () => {
+        renderWithProps({
+          enableAccessibleFieldDOMStructure: false,
+          slotProps: {
+            textField: {
+              placeholder: 'Custom placeholder',
+            },
           },
-        },
+        });
+  
+        const input = getTextbox();
+        expectFieldPlaceholderV6(input, 'Custom placeholder');
       });
-
-      const input = getTextbox();
-      expectFieldPlaceholderV6(input, 'Custom placeholder');
+  
+      it('should show blank placeholder when prop is an empty string', () => {
+        renderWithProps({
+          enableAccessibleFieldDOMStructure: false,
+          slotProps: {
+            textField: {
+              placeholder: '',
+            },
+          },
+        });
+  
+        const input = getTextbox();
+        expectFieldPlaceholderV6(input, '');
+      });
+  
+      it('should show blank placeholder when prop is undefined', () => {
+        renderWithProps({
+          enableAccessibleFieldDOMStructure: false,
+          slotProps: {
+            textField: {
+              placeholder: undefined,
+            },
+          },
+        });
+  
+        const input = getTextbox();
+        expectFieldPlaceholderV6(input, '');
+      });
+  
+      it('should show default placeholder when no prop is received', () => {
+        renderWithProps({
+          enableAccessibleFieldDOMStructure: false,
+        });
+  
+        const input = getTextbox();
+        expectFieldPlaceholderV6(input, 'MM/DD/YYYY');
+      });
     });
   });
 

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -153,7 +153,7 @@ describe('<DesktopDatePicker /> - Field', () => {
         expectFieldPlaceholderV6(input, 'Custom placeholder');
       });
 
-      it('should show blank placeholder when prop is an empty string', () => {
+      it('should render blank placeholder when prop is an empty string', () => {
         renderWithProps({
           enableAccessibleFieldDOMStructure: false,
           slotProps: {
@@ -167,7 +167,7 @@ describe('<DesktopDatePicker /> - Field', () => {
         expectFieldPlaceholderV6(input, '');
       });
 
-      it('should show blank placeholder when prop is undefined', () => {
+      it('should render blank placeholder when prop is undefined', () => {
         renderWithProps({
           enableAccessibleFieldDOMStructure: false,
           slotProps: {
@@ -179,15 +179,6 @@ describe('<DesktopDatePicker /> - Field', () => {
 
         const input = getTextbox();
         expectFieldPlaceholderV6(input, '');
-      });
-
-      it('should show default placeholder when no prop is received', () => {
-        renderWithProps({
-          enableAccessibleFieldDOMStructure: false,
-        });
-
-        const input = getTextbox();
-        expectFieldPlaceholderV6(input, 'MM/DD/YYYY');
       });
     });
   });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -138,7 +138,7 @@ describe('<DesktopDatePicker /> - Field', () => {
       Component: DesktopDatePicker,
     });
 
-    describe('Placeholder override (v6 only)', () => {
+    describe('placeholder override (v6 only)', () => {
       it('should allow to override the placeholder', () => {
         renderWithProps({
           enableAccessibleFieldDOMStructure: false,

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -148,11 +148,11 @@ describe('<DesktopDatePicker /> - Field', () => {
             },
           },
         });
-  
+
         const input = getTextbox();
         expectFieldPlaceholderV6(input, 'Custom placeholder');
       });
-  
+
       it('should show blank placeholder when prop is an empty string', () => {
         renderWithProps({
           enableAccessibleFieldDOMStructure: false,
@@ -162,11 +162,11 @@ describe('<DesktopDatePicker /> - Field', () => {
             },
           },
         });
-  
+
         const input = getTextbox();
         expectFieldPlaceholderV6(input, '');
       });
-  
+
       it('should show blank placeholder when prop is undefined', () => {
         renderWithProps({
           enableAccessibleFieldDOMStructure: false,
@@ -176,16 +176,16 @@ describe('<DesktopDatePicker /> - Field', () => {
             },
           },
         });
-  
+
         const input = getTextbox();
         expectFieldPlaceholderV6(input, '');
       });
-  
+
       it('should show default placeholder when no prop is received', () => {
         renderWithProps({
           enableAccessibleFieldDOMStructure: false,
         });
-  
+
         const input = getTextbox();
         expectFieldPlaceholderV6(input, 'MM/DD/YYYY');
       });

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -400,7 +400,6 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
       isRTL,
     );
   }, [
-    params.forwardedProps,
     inPlaceholder,
     fieldValueManager,
     getSectionsFromValue,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -390,7 +390,7 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
   });
 
   const placeholder = React.useMemo(() => {
-    if (params.forwardedProps.hasOwnProperty('placeholder')) {
+    if (inPlaceholder !== undefined) {
       return inPlaceholder ?? '';
     }
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -390,8 +390,8 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
   });
 
   const placeholder = React.useMemo(() => {
-    if (inPlaceholder) {
-      return inPlaceholder;
+    if (params.forwardedProps.hasOwnProperty('placeholder')) {
+      return inPlaceholder ?? "";
     }
 
     return fieldValueManager.getV6InputValueFromSections(

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -391,7 +391,7 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
 
   const placeholder = React.useMemo(() => {
     if (params.forwardedProps.hasOwnProperty('placeholder')) {
-      return inPlaceholder ?? "";
+      return inPlaceholder ?? '';
     }
 
     return fieldValueManager.getV6InputValueFromSections(
@@ -400,6 +400,7 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
       isRTL,
     );
   }, [
+    params.forwardedProps,
     inPlaceholder,
     fieldValueManager,
     getSectionsFromValue,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -391,7 +391,7 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
 
   const placeholder = React.useMemo(() => {
     if (inPlaceholder !== undefined) {
-      return inPlaceholder ?? '';
+      return inPlaceholder;
     }
 
     return fieldValueManager.getV6InputValueFromSections(


### PR DESCRIPTION
Fixes [#12573](https://github.com/mui/mui-x/issues/12573).

Add some tests to prevent it in the future.

It should now be possible to pass the `placeholder` prop as either an empty string or undefined in order to achieve an empty placeholder in textField component. Sending no placeholder prop must fall into the default placeholder, generated specifically for each kind of picker.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
