### PR TITLE
[Data Grid][core] fix: Entering in edit mode, reload column configuration #12429

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -258,9 +258,9 @@ export const applyInitialState = (
     cleanOrderedFields.length === 0
       ? columnsState.orderedFields
       : [
-          ...cleanOrderedFields,
-          ...columnsState.orderedFields.filter((field) => !orderedFieldsLookup[field]),
-        ];
+        ...cleanOrderedFields,
+        ...columnsState.orderedFields.filter((field) => !orderedFieldsLookup[field]),
+      ];
 
   const newColumnLookup: GridColumnRawLookup = { ...columnsState.lookup };
   for (let i = 0; i < columnsWithUpdatedDimensions.length; i += 1) {
@@ -310,9 +310,12 @@ export const createColumnsState = ({
 }) => {
   const isInsideStateInitializer = !apiRef.current.state.columns;
 
+
   let columnsState: Omit<GridColumnsRawState, 'lookup'> & {
     lookup: { [field: string]: Omit<GridStateColDef, 'computedWidth'> };
+    desiredOrderedFields?: string[];
   };
+
   if (isInsideStateInitializer) {
     columnsState = {
       orderedFields: [],
@@ -325,6 +328,7 @@ export const createColumnsState = ({
       orderedFields: keepOnlyColumnsToUpsert ? [] : [...currentState.orderedFields],
       lookup: { ...currentState.lookup }, // Will be cleaned later if keepOnlyColumnsToUpsert=true
       columnVisibilityModel,
+      desiredOrderedFields: currentState.orderedFields, // Will be cleaned later
     };
   }
 
@@ -379,6 +383,14 @@ export const createColumnsState = ({
       hasBeenResized,
     };
   });
+
+  if (columnsState.desiredOrderedFields) {
+    columnsState.orderedFields.sort((fieldA, fieldB) =>
+      columnsState.desiredOrderedFields!.indexOf(fieldA) - columnsState.desiredOrderedFields!.indexOf(fieldB)
+    );
+
+    delete columnsState.desiredOrderedFields;
+  }
 
   if (keepOnlyColumnsToUpsert && !isInsideStateInitializer) {
     Object.keys(columnsState.lookup).forEach((field) => {

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -405,9 +405,18 @@ export const createColumnsState = ({
   });
 
   if (columnsState.desiredOrderedFields) {
-    columnsState.orderedFields.sort((fieldA, fieldB) =>
-      columnsState.desiredOrderedFields!.indexOf(fieldA) - columnsState.desiredOrderedFields!.indexOf(fieldB)
-    );
+    columnsState.orderedFields.sort((fieldA, fieldB) => {
+      const indexA = columnsState.desiredOrderedFields!.indexOf(fieldA);
+      const indexB = columnsState.desiredOrderedFields!.indexOf(fieldB);
+      if (indexA === -1 && indexB !== -1) {
+        return 1;
+      }
+      if (indexB === -1 && indexA !== -1) {
+        return -1;
+      }
+
+      return indexA - indexB
+    });
 
     delete columnsState.desiredOrderedFields;
   }

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -384,11 +384,22 @@ export const createColumnsState = ({
       }
     });
 
+    // Do not override column dimension properties on re-render if not desired
+    const previousDimensions = columnsState.lookup[field]
+      ? columnDimensionProperties(columnsState.lookup[field])
+      : {};
+
+    // check if new dimensions are specified
+    const newDimensions = {
+      ...previousDimensions,
+      ...columnDimensionProperties(newColumn),
+    }
+
+
     columnsState.lookup[field] = {
       ...existingState,
       ...newColumn,
-      // Do not override column dimension properties on re-render
-      ...(columnsState.lookup[field] ? columnDimensionProperties(columnsState.lookup[field]) : {}),
+      ...newDimensions,
       hasBeenResized,
     };
   });

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -331,11 +331,18 @@ export const createColumnsState = ({
     };
   } else {
     const currentState = gridColumnsStateSelector(apiRef.current.state);
+
+    const pinnedColumns = apiRef.current.state.pinnedColumns;
+    // Remove pinned columns
+    const desiredOrderedFields = currentState.orderedFields.filter(field => {
+      return !(pinnedColumns.left?.includes(field) || pinnedColumns.right?.includes(field))
+    });
+
     columnsState = {
       orderedFields: keepOnlyColumnsToUpsert ? [] : [...currentState.orderedFields],
       lookup: { ...currentState.lookup }, // Will be cleaned later if keepOnlyColumnsToUpsert=true
       columnVisibilityModel,
-      desiredOrderedFields: currentState.orderedFields, // Will be cleaned later
+      desiredOrderedFields, // Will be cleaned later
     };
   }
 

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -24,11 +24,18 @@ import { gridHeaderFilteringEnabledSelector } from '../headerFiltering/gridHeade
 import { gridColumnGroupsHeaderMaxDepthSelector } from '../columnGrouping/gridColumnGroupsSelector';
 import type { GridDimensions } from '../dimensions/gridDimensionsApi';
 
+type ArrayElement<ArrayType extends readonly unknown[]> =
+  ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
 export const COLUMNS_DIMENSION_PROPERTIES = ['maxWidth', 'minWidth', 'width', 'flex'] as const;
 
 export type GridColumnDimensionProperties = (typeof COLUMNS_DIMENSION_PROPERTIES)[number];
 
 const COLUMN_TYPES = getGridDefaultColumnTypes();
+
+const columnDimensionProperties = (column: GridColDef): Partial<Pick<GridColDef, ArrayElement<typeof COLUMNS_DIMENSION_PROPERTIES>>> => COLUMNS_DIMENSION_PROPERTIES.reduce((columnDimensionPros, dimensionKey) => dimensionKey in column ?
+  Object.assign(columnDimensionPros, { [dimensionKey]: column[dimensionKey] })
+  : columnDimensionPros, {})
 
 /**
  * Computes width for flex columns.
@@ -380,6 +387,8 @@ export const createColumnsState = ({
     columnsState.lookup[field] = {
       ...existingState,
       ...newColumn,
+      // Do not override column dimension properties on re-render
+      ...(columnsState.lookup[field] ? columnDimensionProperties(columnsState.lookup[field]) : {}),
       hasBeenResized,
     };
   });


### PR DESCRIPTION
As exposed in #12429, their is an issue during rerendering columns : the user column position was reset and also the columns size. 

I hope it will satisfy you and will merge soon. Don't hesitate if you have any remarks.

https://github.com/mui/mui-x/assets/617780/14121eea-4f45-47c9-9688-7f9d11412eda

