### PR TITLE
[test] Use `describeTreeView` for items rendering edge-case tests

### DIFF
--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -112,56 +112,6 @@ describe('<TreeItem />', () => {
     expect(handleClick.callCount).to.equal(1);
   });
 
-  it('should treat multiple empty conditional arrays as empty', () => {
-    const { getByTestId } = render(
-      <SimpleTreeView defaultExpandedItems={['1']}>
-        <TreeItem itemId="1" label="1" data-testid="1">
-          <TreeItem itemId="2" label="2" data-testid="2">
-            {[].map((_, index) => (
-              <React.Fragment key={index}>a child</React.Fragment>
-            ))}
-            {[].map((_, index) => (
-              <React.Fragment key={index}>a child</React.Fragment>
-            ))}
-          </TreeItem>
-        </TreeItem>
-      </SimpleTreeView>,
-    );
-
-    expect(getByTestId('2')).not.to.have.attribute('aria-expanded');
-  });
-
-  it('should treat one conditional empty and one conditional with results as expandable', () => {
-    const { getByTestId } = render(
-      <SimpleTreeView defaultExpandedItems={['1', '2']}>
-        <TreeItem itemId="1" label="1" data-testid="1">
-          <TreeItem itemId="2" label="2" data-testid="2">
-            {[]}
-            {[1].map((_, index) => (
-              <React.Fragment key={index}>a child</React.Fragment>
-            ))}
-          </TreeItem>
-        </TreeItem>
-      </SimpleTreeView>,
-    );
-
-    expect(getByTestId('2')).to.have.attribute('aria-expanded', 'true');
-  });
-
-  it('should handle edge case of nested array of array', () => {
-    const { getByTestId } = render(
-      <SimpleTreeView defaultExpandedItems={['1', '2']}>
-        <TreeItem itemId="1" label="1" data-testid="1">
-          <TreeItem itemId="2" label="2" data-testid="2">
-            {[[]]}
-          </TreeItem>
-        </TreeItem>
-      </SimpleTreeView>,
-    );
-
-    expect(getByTestId('2')).not.to.have.attribute('aria-expanded');
-  });
-
   it('should not call onClick when children are clicked', () => {
     const handleClick = spy();
 

--- a/packages/x-tree-view/src/hooks/useTreeItem2Utils/useTreeItem2Utils.tsx
+++ b/packages/x-tree-view/src/hooks/useTreeItem2Utils/useTreeItem2Utils.tsx
@@ -14,6 +14,13 @@ interface UseTreeItem2UtilsReturnValue {
   status: UseTreeItem2Status;
 }
 
+const isItemExpandable = (reactChildren: React.ReactNode) => {
+  if (Array.isArray(reactChildren)) {
+    return reactChildren.length > 0 && reactChildren.some(isItemExpandable);
+  }
+  return Boolean(reactChildren);
+};
+
 export const useTreeItem2Utils = ({
   itemId,
   children,
@@ -27,7 +34,7 @@ export const useTreeItem2Utils = ({
   } = useTreeViewContext<DefaultTreeViewPlugins>();
 
   const status: UseTreeItem2Status = {
-    expandable: Boolean(Array.isArray(children) ? children.length : children),
+    expandable: isItemExpandable(children),
     expanded: instance.isItemExpanded(itemId),
     focused: instance.isItemFocused(itemId),
     selected: instance.isItemSelected(itemId),

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewIcons/useTreeViewIcons.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewIcons/useTreeViewIcons.test.tsx
@@ -13,7 +13,7 @@ describeTreeView<[UseTreeViewIconsSignature, UseTreeViewExpansionSignature]>(
   'useTreeViewIcons plugin',
   ({ render }) => {
     describe('slots (expandIcon, collapseIcon, endIcon, icon)', () => {
-      const getIconTestId = (response: DescribeTreeViewRendererReturnValue<[]>, itemId: string) =>
+      const getIconTestId = (response: DescribeTreeViewRendererReturnValue<any>, itemId: string) =>
         response.getItemIconContainer(itemId).querySelector(`div`)?.dataset.testid;
 
       it('should render the expandIcon slot defined on the tree if no icon slot is defined on the item and the item is collapsed', () => {

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { fireEvent } from '@mui-internal/test-utils';
@@ -10,123 +11,176 @@ import {
 
 describeTreeView<
   [UseTreeViewItemsSignature, UseTreeViewExpansionSignature, UseTreeViewSelectionSignature]
->('useTreeViewItems plugin', ({ render, treeViewComponent }) => {
-  it('should throw an error when two items have the same ID', function test() {
-    // TODO is this fixed?
-    if (!/jsdom/.test(window.navigator.userAgent)) {
-      // can't catch render errors in the browser for unknown reason
-      // tried try-catch + error boundary + window onError preventDefault
-      this.skip();
-    }
+>(
+  'useTreeViewItems plugin',
+  ({ render, renderFromJSX, treeViewComponentName, TreeViewComponent, TreeItemComponent }) => {
+    it('should throw an error when two items have the same ID', function test() {
+      // TODO is this fixed?
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        // can't catch render errors in the browser for unknown reason
+        // tried try-catch + error boundary + window onError preventDefault
+        this.skip();
+      }
 
-    expect(() => render({ items: [{ id: '1' }, { id: '1' }], withErrorBoundary: true })).toErrorDev(
-      [
-        ...(treeViewComponent === 'SimpleTreeView'
+      expect(() =>
+        render({ items: [{ id: '1' }, { id: '1' }], withErrorBoundary: true }),
+      ).toErrorDev([
+        ...(treeViewComponentName === 'SimpleTreeView'
           ? ['Encountered two children with the same key']
           : []),
         'MUI X: The Tree View component requires all items to have a unique `id` property.',
         'MUI X: The Tree View component requires all items to have a unique `id` property.',
-        `The above error occurred in the <ForwardRef(${treeViewComponent})> component`,
-      ],
-    );
-  });
-
-  it('should be able to use a custom id attribute', function test() {
-    // For now, only SimpleTreeView can use custom id attributes
-    if (treeViewComponent.startsWith('RichTreeView')) {
-      this.skip();
-    }
-
-    const response = render({
-      items: [{ id: '1' }],
-      slotProps: {
-        item: {
-          id: 'customId',
-        },
-      },
+        `The above error occurred in the <ForwardRef(${treeViewComponentName})> component`,
+      ]);
     });
 
-    expect(response.getItemRoot('1')).to.have.attribute('id', 'customId');
-  });
+    it('should be able to use a custom id attribute', function test() {
+      // For now, only SimpleTreeView can use custom id attributes
+      if (treeViewComponentName.startsWith('RichTreeView')) {
+        this.skip();
+      }
 
-  describe('items prop / JSX Tree Item', () => {
-    it('should support removing an item', () => {
-      const response = render({
-        items: [{ id: '1' }, { id: '2' }],
-      });
-
-      response.setItems([{ id: '1' }]);
-      expect(response.getAllTreeItemIds()).to.deep.equal(['1']);
-    });
-
-    it('should support adding an item at the end', () => {
       const response = render({
         items: [{ id: '1' }],
+        slotProps: {
+          item: {
+            id: 'customId',
+          },
+        },
       });
 
-      response.setItems([{ id: '1' }, { id: '2' }]);
-      expect(response.getAllTreeItemIds()).to.deep.equal(['1', '2']);
+      expect(response.getItemRoot('1')).to.have.attribute('id', 'customId');
     });
 
-    it('should support adding an item at the beginning', () => {
-      const response = render({
-        items: [{ id: '2' }],
+    describe('items prop / JSX Tree Item', () => {
+      it('should support removing an item', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }],
+        });
+
+        response.setItems([{ id: '1' }]);
+        expect(response.getAllTreeItemIds()).to.deep.equal(['1']);
       });
 
-      response.setItems([{ id: '1' }, { id: '2' }]);
-      expect(response.getAllTreeItemIds()).to.deep.equal(['1', '2']);
-    });
+      it('should support adding an item at the end', () => {
+        const response = render({
+          items: [{ id: '1' }],
+        });
 
-    it('should update indexes when two items are swapped', () => {
-      const onSelectedItemsChange = spy();
-
-      const response = render({
-        items: [{ id: '1' }, { id: '2' }, { id: '3' }],
-        multiSelect: true,
-        onSelectedItemsChange,
+        response.setItems([{ id: '1' }, { id: '2' }]);
+        expect(response.getAllTreeItemIds()).to.deep.equal(['1', '2']);
       });
 
-      response.setItems([{ id: '1' }, { id: '3' }, { id: '2' }]);
-      expect(response.getAllTreeItemIds()).to.deep.equal(['1', '3', '2']);
+      it('should support adding an item at the beginning', () => {
+        const response = render({
+          items: [{ id: '2' }],
+        });
 
-      // Check if the internal state is updated by running a range selection
-      fireEvent.click(response.getItemContent('1'));
-      fireEvent.click(response.getItemContent('3'), { shiftKey: true });
-      expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['1', '3']);
-    });
-
-    it('should not mark an item as expandable if its children is an empty array', () => {
-      const response = render({
-        items: [{ id: '1', children: [] }],
-        defaultExpandedItems: ['1'],
+        response.setItems([{ id: '1' }, { id: '2' }]);
+        expect(response.getAllTreeItemIds()).to.deep.equal(['1', '2']);
       });
 
-      expect(response.getItemRoot('1')).not.to.have.attribute('aria-expanded');
-    });
-  });
+      it('should update indexes when two items are swapped', () => {
+        const onSelectedItemsChange = spy();
 
-  describe('disabled prop', () => {
-    it('should not have the attribute `aria-disabled` if disabled is not defined', () => {
-      const response = render({
-        items: [{ id: '1' }, { id: '2', disabled: false }, { id: '3', disabled: true }],
+        const response = render({
+          items: [{ id: '1' }, { id: '2' }, { id: '3' }],
+          multiSelect: true,
+          onSelectedItemsChange,
+        });
+
+        response.setItems([{ id: '1' }, { id: '3' }, { id: '2' }]);
+        expect(response.getAllTreeItemIds()).to.deep.equal(['1', '3', '2']);
+
+        // Check if the internal state is updated by running a range selection
+        fireEvent.click(response.getItemContent('1'));
+        fireEvent.click(response.getItemContent('3'), { shiftKey: true });
+        expect(onSelectedItemsChange.lastCall.args[1]).to.deep.equal(['1', '3']);
       });
 
-      expect(response.getItemRoot('1')).not.to.have.attribute('aria-disabled');
-      expect(response.getItemRoot('2')).not.to.have.attribute('aria-disabled');
-      expect(response.getItemRoot('3')).to.have.attribute('aria-disabled');
-    });
+      it('should not mark an item as expandable if its children is an empty array', () => {
+        const response = render({
+          items: [{ id: '1', children: [] }],
+          defaultExpandedItems: ['1'],
+        });
 
-    it('should disable all descendants of a disabled item', () => {
-      const response = render({
-        items: [
-          { id: '1', disabled: true, children: [{ id: '1.1', children: [{ id: '1.1.1' }] }] },
-        ],
-        defaultExpandedItems: ['1', '1.1'],
+        expect(response.getItemRoot('1')).not.to.have.attribute('aria-expanded');
       });
 
-      expect(response.getItemRoot('1')).to.have.attribute('aria-disabled', 'true');
-      expect(response.getItemRoot('1.1')).to.have.attribute('aria-disabled', 'true');
-      expect(response.getItemRoot('1.1.1')).to.have.attribute('aria-disabled', 'true');
+      it('should mark an item as not expandable if it has only empty conditional arrays', function test() {
+        if (treeViewComponentName.startsWith('RichTreeView')) {
+          this.skip();
+        }
+
+        const response = renderFromJSX(
+          <TreeViewComponent defaultExpandedItems={['1']}>
+            <TreeItemComponent itemId="1" label="1" data-testid="1">
+              {[]}
+              {[]}
+            </TreeItemComponent>
+          </TreeViewComponent>,
+        );
+
+        expect(response.isItemExpanded('1')).to.equal(false);
+      });
+
+      it('should mark an item as expandable if it has two array as children, one of which is empty (SimpleTreeView only)', function test() {
+        if (treeViewComponentName.startsWith('RichTreeView')) {
+          this.skip();
+        }
+
+        const response = renderFromJSX(
+          <TreeViewComponent defaultExpandedItems={['1']}>
+            <TreeItemComponent itemId="1" label="1" data-testid="1">
+              {[]}
+              {[<TreeItemComponent key="1.1" itemId="1.1" />]}
+            </TreeItemComponent>
+          </TreeViewComponent>,
+        );
+
+        expect(response.isItemExpanded('1')).to.equal(true);
+      });
+
+      it('should mark an item as not expandable if it has one array containing an empty array as a children (SimpleTreeView only)', function test() {
+        if (treeViewComponentName.startsWith('RichTreeView')) {
+          this.skip();
+        }
+
+        const response = renderFromJSX(
+          <TreeViewComponent defaultExpandedItems={['1']}>
+            <TreeItemComponent itemId="1" label="1" data-testid="1">
+              {[[]]}
+            </TreeItemComponent>
+          </TreeViewComponent>,
+        );
+
+        expect(response.isItemExpanded('1')).to.equal(false);
+      });
     });
-  });
-});
+
+    describe('disabled prop', () => {
+      it('should not have the attribute `aria-disabled` if disabled is not defined', () => {
+        const response = render({
+          items: [{ id: '1' }, { id: '2', disabled: false }, { id: '3', disabled: true }],
+        });
+
+        expect(response.getItemRoot('1')).not.to.have.attribute('aria-disabled');
+        expect(response.getItemRoot('2')).not.to.have.attribute('aria-disabled');
+        expect(response.getItemRoot('3')).to.have.attribute('aria-disabled');
+      });
+
+      it('should disable all descendants of a disabled item', () => {
+        const response = render({
+          items: [
+            { id: '1', disabled: true, children: [{ id: '1.1', children: [{ id: '1.1.1' }] }] },
+          ],
+          defaultExpandedItems: ['1', '1.1'],
+        });
+
+        expect(response.getItemRoot('1')).to.have.attribute('aria-disabled', 'true');
+        expect(response.getItemRoot('1.1')).to.have.attribute('aria-disabled', 'true');
+        expect(response.getItemRoot('1.1.1')).to.have.attribute('aria-disabled', 'true');
+      });
+    });
+  },
+);

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.test.tsx
@@ -16,7 +16,7 @@ describeTreeView<
     UseTreeViewExpansionSignature,
     UseTreeViewSelectionSignature,
   ]
->('useTreeViewKeyboardNavigation', ({ render, treeViewComponent }) => {
+>('useTreeViewKeyboardNavigation', ({ render, treeViewComponentName }) => {
   describe('Navigation (focus and expansion)', () => {
     describe('key: ArrowDown', () => {
       it('should move the focus to a sibling item', () => {
@@ -825,7 +825,7 @@ describeTreeView<
 
     it('should work with ReactElement label', function test() {
       // Only the SimpleTreeView can have React Element labels.
-      if (treeViewComponent !== 'SimpleTreeView') {
+      if (treeViewComponentName !== 'SimpleTreeView') {
         this.skip();
       }
 

--- a/test/utils/tree-view/describeTreeView/describeTreeView.tsx
+++ b/test/utils/tree-view/describeTreeView/describeTreeView.tsx
@@ -11,8 +11,9 @@ import { MuiRenderResult } from '@mui-internal/test-utils/createRenderer';
 import {
   DescribeTreeViewTestRunner,
   DescribeTreeViewRenderer,
-  DescribeTreeViewRendererReturnValue,
+  DescribeTreeViewJSXRenderer,
   DescribeTreeViewItem,
+  DescribeTreeViewRendererUtils,
 } from './describeTreeView.types';
 
 const innerDescribeTreeView = <TPlugins extends TreeViewAnyPluginSignature[]>(
@@ -21,9 +22,7 @@ const innerDescribeTreeView = <TPlugins extends TreeViewAnyPluginSignature[]>(
 ): void => {
   const { render } = createRenderer();
 
-  const getUtils = (
-    result: MuiRenderResult,
-  ): Omit<DescribeTreeViewRendererReturnValue<TPlugins>, 'setProps' | 'setItems' | 'apiRef'> => {
+  const getUtils = (result: MuiRenderResult): DescribeTreeViewRendererUtils => {
     const getRoot = () => result.getByRole('tree');
 
     const getAllTreeItemIds = () =>
@@ -81,11 +80,16 @@ const innerDescribeTreeView = <TPlugins extends TreeViewAnyPluginSignature[]>(
     };
   };
 
+  const jsxRenderer: DescribeTreeViewJSXRenderer = (element) => {
+    const result = render(element);
+    return getUtils(result);
+  };
+
   const createRendererForComponentWithItemsProp = (
     TreeViewComponent: typeof RichTreeView,
     TreeItemComponent: typeof TreeItem | typeof TreeItem2,
   ) => {
-    const wrappedRenderer: DescribeTreeViewRenderer<TPlugins> = ({
+    const objectRenderer: DescribeTreeViewRenderer<TPlugins> = ({
       items: rawItems,
       withErrorBoundary,
       slotProps,
@@ -133,14 +137,17 @@ const innerDescribeTreeView = <TPlugins extends TreeViewAnyPluginSignature[]>(
       };
     };
 
-    return wrappedRenderer;
+    return {
+      render: objectRenderer,
+      renderFromJSX: jsxRenderer,
+    };
   };
 
-  const createRendererForComponentWithJSXItems = (
+  const createRenderersForComponentWithJSXItems = (
     TreeViewComponent: typeof SimpleTreeView,
     TreeItemComponent: typeof TreeItem | typeof TreeItem2,
   ) => {
-    const wrappedRenderer: DescribeTreeViewRenderer<TPlugins> = ({
+    const objectRenderer: DescribeTreeViewRenderer<TPlugins> = ({
       items: rawItems,
       withErrorBoundary,
       slots,
@@ -180,61 +187,76 @@ const innerDescribeTreeView = <TPlugins extends TreeViewAnyPluginSignature[]>(
       };
     };
 
-    return wrappedRenderer;
+    return {
+      render: objectRenderer,
+      renderFromJSX: jsxRenderer,
+    };
   };
 
   describe(message, () => {
     describe('RichTreeView + TreeItem', () => {
       testRunner({
-        render: createRendererForComponentWithItemsProp(RichTreeView, TreeItem),
+        ...createRendererForComponentWithItemsProp(RichTreeView, TreeItem),
         setup: 'RichTreeView + TreeItem',
-        treeViewComponent: 'RichTreeView',
-        treeItemComponent: 'TreeItem',
+        treeViewComponentName: 'RichTreeView',
+        treeItemComponentName: 'TreeItem',
+        TreeViewComponent: RichTreeView,
+        TreeItemComponent: TreeItem,
       });
     });
 
     describe('RichTreeView + TreeItem2', () => {
       testRunner({
-        render: createRendererForComponentWithItemsProp(RichTreeView, TreeItem2),
+        ...createRendererForComponentWithItemsProp(RichTreeView, TreeItem2),
         setup: 'RichTreeView + TreeItem2',
-        treeViewComponent: 'RichTreeView',
-        treeItemComponent: 'TreeItem2',
+        treeViewComponentName: 'RichTreeView',
+        treeItemComponentName: 'TreeItem2',
+        TreeViewComponent: RichTreeView,
+        TreeItemComponent: TreeItem2,
       });
     });
 
     describe('RichTreeViewPro + TreeItem', () => {
       testRunner({
-        render: createRendererForComponentWithItemsProp(RichTreeViewPro, TreeItem),
+        ...createRendererForComponentWithItemsProp(RichTreeViewPro, TreeItem),
         setup: 'RichTreeViewPro + TreeItem',
-        treeViewComponent: 'RichTreeViewPro',
-        treeItemComponent: 'TreeItem',
+        treeViewComponentName: 'RichTreeViewPro',
+        treeItemComponentName: 'TreeItem',
+        TreeViewComponent: RichTreeViewPro,
+        TreeItemComponent: TreeItem,
       });
     });
 
     describe('RichTreeViewPro + TreeItem2', () => {
       testRunner({
-        render: createRendererForComponentWithItemsProp(RichTreeViewPro, TreeItem2),
+        ...createRendererForComponentWithItemsProp(RichTreeViewPro, TreeItem2),
         setup: 'RichTreeViewPro + TreeItem2',
-        treeViewComponent: 'RichTreeViewPro',
-        treeItemComponent: 'TreeItem2',
+        treeViewComponentName: 'RichTreeViewPro',
+        treeItemComponentName: 'TreeItem2',
+        TreeViewComponent: RichTreeViewPro,
+        TreeItemComponent: TreeItem2,
       });
     });
 
     describe('SimpleTreeView + TreeItem', () => {
       testRunner({
-        render: createRendererForComponentWithJSXItems(SimpleTreeView, TreeItem),
+        ...createRenderersForComponentWithJSXItems(SimpleTreeView, TreeItem),
         setup: 'SimpleTreeView + TreeItem',
-        treeViewComponent: 'SimpleTreeView',
-        treeItemComponent: 'TreeItem',
+        treeViewComponentName: 'SimpleTreeView',
+        treeItemComponentName: 'TreeItem',
+        TreeViewComponent: SimpleTreeView,
+        TreeItemComponent: TreeItem,
       });
     });
 
     describe('SimpleTreeView + TreeItem2', () => {
       testRunner({
-        render: createRendererForComponentWithJSXItems(SimpleTreeView, TreeItem2),
+        ...createRenderersForComponentWithJSXItems(SimpleTreeView, TreeItem2),
         setup: 'SimpleTreeView + TreeItem2',
-        treeViewComponent: 'SimpleTreeView',
-        treeItemComponent: 'TreeItem2',
+        treeViewComponentName: 'SimpleTreeView',
+        treeItemComponentName: 'TreeItem2',
+        TreeViewComponent: SimpleTreeView,
+        TreeItemComponent: TreeItem2,
       });
     });
   });

--- a/test/utils/tree-view/describeTreeView/describeTreeView.types.ts
+++ b/test/utils/tree-view/describeTreeView/describeTreeView.types.ts
@@ -159,7 +159,7 @@ interface DescribeTreeViewTestRunnerParams<TPlugins extends TreeViewAnyPluginSig
    * (most likely to advanced testing of the children rendering aspect on the SimpleTreeView)
    *
    * Warning: If you want to use the utils returned by the `renderFromJSX` function,
-   * each item should receive a `label` and a `data-testid` equals to its `id`.
+   * each item should receive a `label` and a `data-testid` equal to its `id`.
    */
   renderFromJSX: DescribeTreeViewJSXRenderer;
   setup: `${TreeViewComponentName} + ${TreeItemComponentName}`;

--- a/test/utils/tree-view/describeTreeView/describeTreeView.types.ts
+++ b/test/utils/tree-view/describeTreeView/describeTreeView.types.ts
@@ -11,23 +11,7 @@ export type DescribeTreeViewTestRunner<TPlugins extends TreeViewAnyPluginSignatu
   params: DescribeTreeViewTestRunnerParams<TPlugins>,
 ) => void;
 
-export interface DescribeTreeViewRendererReturnValue<
-  TPlugins extends TreeViewAnyPluginSignature[],
-> {
-  /**
-   * Passes new props to the Tree View.
-   * @param {Partial<TreeViewUsedParams<TPlugin>>} props A subset of the props accepted by the Tree View.
-   */
-  setProps: (props: Partial<MergePluginsProperty<TPlugins, 'params'>>) => void;
-  /**
-   * Passes new items to the Tree View.
-   * @param {readyonly DescribeTreeViewItem[]} items The new items.
-   */
-  setItems: (items: readonly DescribeTreeViewItem[]) => void;
-  /**
-   * The ref object that allows Tree View manipulation.
-   */
-  apiRef: { current: TreeViewPublicAPI<TPlugins> };
+export interface DescribeTreeViewRendererUtils {
   /**
    * Returns the `root` slot of the Tree View.
    * @returns {HTMLElement} `root` slot of the Tree View.
@@ -101,6 +85,24 @@ export interface DescribeTreeViewRendererReturnValue<
   getSelectedTreeItems: () => string[];
 }
 
+export interface DescribeTreeViewRendererReturnValue<TPlugins extends TreeViewAnyPluginSignature[]>
+  extends DescribeTreeViewRendererUtils {
+  /**
+   * The ref object that allows Tree View manipulation.
+   */
+  apiRef: { current: TreeViewPublicAPI<TPlugins> };
+  /**
+   * Passes new props to the Tree View.
+   * @param {Partial<TreeViewUsedParams<TPlugin>>} props A subset of the props accepted by the Tree View.
+   */
+  setProps: (props: Partial<MergePluginsProperty<TPlugins, 'params'>>) => void;
+  /**
+   * Passes new items to the Tree View.
+   * @param {readyonly DescribeTreeViewItem[]} items The new items.
+   */
+  setItems: (items: readonly DescribeTreeViewItem[]) => void;
+}
+
 export type DescribeTreeViewRenderer<TPlugins extends TreeViewAnyPluginSignature[]> = <
   R extends DescribeTreeViewItem,
 >(
@@ -120,14 +122,51 @@ export type DescribeTreeViewRenderer<TPlugins extends TreeViewAnyPluginSignature
     },
 ) => DescribeTreeViewRendererReturnValue<TPlugins>;
 
-type TreeViewComponent = 'RichTreeView' | 'RichTreeViewPro' | 'SimpleTreeView';
-type TreeItemComponent = 'TreeItem' | 'TreeItem2';
+export type DescribeTreeViewJSXRenderer = (
+  element: React.ReactElement,
+) => DescribeTreeViewRendererUtils;
+
+type TreeViewComponentName = 'RichTreeView' | 'RichTreeViewPro' | 'SimpleTreeView';
+type TreeItemComponentName = 'TreeItem' | 'TreeItem2';
 
 interface DescribeTreeViewTestRunnerParams<TPlugins extends TreeViewAnyPluginSignature[]> {
+  /**
+   * Render the Tree View with its props and items defined as parameters of the "render" function as follows:
+   *
+   * ```ts
+   * const response = render({
+   *   items: [{ id: '1', children: [] }],
+   *   defaultExpandedItems: ['1'],
+   * });
+   * ```
+   */
   render: DescribeTreeViewRenderer<TPlugins>;
-  setup: `${TreeViewComponent} + ${TreeItemComponent}`;
-  treeViewComponent: TreeViewComponent;
-  treeItemComponent: TreeItemComponent;
+  /**
+   * Render the Tree View by passing the JSX element to the renderFromJSX function as follows:
+   *
+   * ```tsx
+   * const response = renderFromJSX(
+   *   <TreeViewComponent defaultExpandedItems={['1']}>
+   *     <TreeItemComponent itemId={'1'} label={'1'} data-testid={'1'}>
+   *   </TreeViewComponent>
+   * );
+   * ```
+   *
+   * `TreeViewComponent` and `TreeItemComponent` are passed as parameters to the `describeTreeView` function.
+   * The JSX should be adapted depending on the component being rendered.
+   *
+   * Warning: This method should only be used if `render` is not compatible with the test being written
+   * (most likely to advanced testing of the children rendering aspect on the SimpleTreeView)
+   *
+   * Warning: If you want to use the utils returned by the `renderFromJSX` function,
+   * each item should receive a `label` and a `data-testid` equals to its `id`.
+   */
+  renderFromJSX: DescribeTreeViewJSXRenderer;
+  setup: `${TreeViewComponentName} + ${TreeItemComponentName}`;
+  treeViewComponentName: TreeViewComponentName;
+  treeItemComponentName: TreeItemComponentName;
+  TreeViewComponent: React.ElementType<any>;
+  TreeItemComponent: React.ElementType<any>;
 }
 
 export interface DescribeTreeViewItem {


### PR DESCRIPTION
Part of #12433

I had to improve `describeTreeView` to handle these less traditional tests