### PR TITLE
[core] Remove outdated prop-types

### DIFF
--- a/packages/x-charts/src/LineChart/MarkElement.tsx
+++ b/packages/x-charts/src/LineChart/MarkElement.tsx
@@ -64,26 +64,6 @@ const MarkElementPath = styled(animated.path, {
   strokeWidth: 2,
 }));
 
-MarkElementPath.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  as: PropTypes.elementType,
-  ownerState: PropTypes.shape({
-    classes: PropTypes.object,
-    color: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
-    isFaded: PropTypes.bool.isRequired,
-    isHighlighted: PropTypes.bool.isRequired,
-  }).isRequired,
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-} as any;
-
 export type MarkElementProps = Omit<MarkElementOwnerState, 'isFaded' | 'isHighlighted'> &
   Omit<React.SVGProps<SVGPathElement>, 'ref' | 'id'> & {
     /**

--- a/packages/x-data-grid-premium/src/components/GridColumnMenuRowGroupItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridColumnMenuRowGroupItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -17,7 +16,7 @@ import {
 } from '../hooks/features/rowGrouping/gridRowGroupingUtils';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 
-function GridColumnMenuRowGroupItem(props: GridColumnMenuItemProps) {
+export function GridColumnMenuRowGroupItem(props: GridColumnMenuItemProps) {
   const { colDef, onClick } = props;
   const apiRef = useGridApiContext();
   const rowGroupingModel = useGridSelector(apiRef, gridRowGroupingSanitizedModelSelector);
@@ -52,14 +51,3 @@ function GridColumnMenuRowGroupItem(props: GridColumnMenuItemProps) {
 
   return renderUnGroupingMenuItem(getRowGroupingCriteriaFromGroupingField(colDef.field)!);
 }
-
-GridColumnMenuRowGroupItem.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  colDef: PropTypes.object.isRequired,
-  onClick: PropTypes.func.isRequired,
-} as any;
-
-export { GridColumnMenuRowGroupItem };

--- a/packages/x-data-grid-premium/src/components/GridColumnMenuRowUngroupItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridColumnMenuRowUngroupItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -12,7 +11,7 @@ import { useGridApiContext } from '../hooks/utils/useGridApiContext';
 import { gridRowGroupingSanitizedModelSelector } from '../hooks/features/rowGrouping/gridRowGroupingSelector';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 
-function GridColumnMenuRowUngroupItem(props: GridColumnMenuItemProps) {
+export function GridColumnMenuRowUngroupItem(props: GridColumnMenuItemProps) {
   const { colDef, onClick } = props;
   const apiRef = useGridApiContext();
   const rowGroupingModel = useGridSelector(apiRef, gridRowGroupingSanitizedModelSelector);
@@ -55,14 +54,3 @@ function GridColumnMenuRowUngroupItem(props: GridColumnMenuItemProps) {
     </MenuItem>
   );
 }
-
-GridColumnMenuRowUngroupItem.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  colDef: PropTypes.object.isRequired,
-  onClick: PropTypes.func.isRequired,
-} as any;
-
-export { GridColumnMenuRowUngroupItem };

--- a/packages/x-data-grid-premium/src/components/GridPremiumColumnMenu.tsx
+++ b/packages/x-data-grid-premium/src/components/GridPremiumColumnMenu.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import {
   GridGenericColumnMenu,
   GridColumnMenuProps,
@@ -33,7 +32,7 @@ export const GRID_COLUMN_MENU_SLOT_PROPS_PREMIUM = {
   columnMenuGroupingItem: { displayOrder: 27 },
 };
 
-const GridPremiumColumnMenu = React.forwardRef<HTMLUListElement, GridColumnMenuProps>(
+export const GridPremiumColumnMenu = React.forwardRef<HTMLUListElement, GridColumnMenuProps>(
   function GridPremiumColumnMenuSimple(props, ref) {
     return (
       <GridGenericColumnMenu
@@ -45,15 +44,3 @@ const GridPremiumColumnMenu = React.forwardRef<HTMLUListElement, GridColumnMenuP
     );
   },
 );
-
-GridPremiumColumnMenu.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  colDef: PropTypes.object.isRequired,
-  hideMenu: PropTypes.func.isRequired,
-  open: PropTypes.bool.isRequired,
-} as any;
-
-export { GridPremiumColumnMenu };

--- a/packages/x-data-grid-pro/src/components/GridProColumnMenu.tsx
+++ b/packages/x-data-grid-pro/src/components/GridProColumnMenu.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import {
   GridGenericColumnMenu,
   GridColumnMenuProps,
@@ -20,7 +19,7 @@ export const GRID_COLUMN_MENU_SLOT_PROPS_PRO = {
   },
 };
 
-const GridProColumnMenu = React.forwardRef<HTMLUListElement, GridColumnMenuProps>(
+export const GridProColumnMenu = React.forwardRef<HTMLUListElement, GridColumnMenuProps>(
   function GridProColumnMenu(props, ref) {
     return (
       <GridGenericColumnMenu
@@ -32,15 +31,3 @@ const GridProColumnMenu = React.forwardRef<HTMLUListElement, GridColumnMenuProps
     );
   },
 );
-
-GridProColumnMenu.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  colDef: PropTypes.object.isRequired,
-  hideMenu: PropTypes.func.isRequired,
-  open: PropTypes.bool.isRequired,
-} as any;
-
-export { GridProColumnMenu };

--- a/packages/x-data-grid/src/components/GridScrollArea.tsx
+++ b/packages/x-data-grid/src/components/GridScrollArea.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import {
   unstable_composeClasses as composeClasses,
@@ -170,14 +169,4 @@ function GridScrollAreaRaw(props: ScrollAreaProps) {
   );
 }
 
-GridScrollAreaRaw.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  scrollDirection: PropTypes.oneOf(['left', 'right']).isRequired,
-} as any;
-
-const GridScrollArea = fastMemo(GridScrollAreaRaw);
-
-export { GridScrollArea };
+export const GridScrollArea = fastMemo(GridScrollAreaRaw);

--- a/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePickerDay/DateRangePickerDay.tsx
@@ -211,14 +211,6 @@ const DateRangePickerDayRoot = styled('div', {
   ],
 }));
 
-DateRangePickerDayRoot.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  ownerState: PropTypes.object.isRequired,
-} as any;
-
 const DateRangePickerDayRangeIntervalPreview = styled('div', {
   name: 'MuiDateRangePickerDay',
   slot: 'RangeIntervalPreview',
@@ -271,14 +263,6 @@ const DateRangePickerDayRangeIntervalPreview = styled('div', {
     },
   ],
 }));
-
-DateRangePickerDayRangeIntervalPreview.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  ownerState: PropTypes.object.isRequired,
-} as any;
 
 const DateRangePickerDayDay = styled(PickersDay, {
   name: 'MuiDateRangePickerDay',

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -92,28 +92,6 @@ const DateTimePickerToolbarRoot = styled(PickersToolbar, {
   ],
 }));
 
-DateTimePickerToolbarRoot.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  as: PropTypes.elementType,
-  classes: PropTypes.object,
-  className: PropTypes.string,
-  isLandscape: PropTypes.bool.isRequired,
-  isMobileKeyboardViewOpen: PropTypes.bool,
-  landscapeDirection: PropTypes.oneOf(['column', 'row']),
-  ownerState: PropTypes.object.isRequired,
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-  toggleMobileKeyboardView: PropTypes.func,
-  toolbarTitle: PropTypes.node,
-  viewType: PropTypes.oneOf(['date', 'time']),
-} as any;
-
 const DateTimePickerToolbarDateContainer = styled('div', {
   name: 'MuiDateTimePickerToolbar',
   slot: 'DateContainer',
@@ -174,20 +152,6 @@ const DateTimePickerToolbarTimeDigitsContainer = styled('div', {
     },
   ],
 }));
-
-DateTimePickerToolbarTimeContainer.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  as: PropTypes.elementType,
-  ownerState: PropTypes.object.isRequired,
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-} as any;
 
 const DateTimePickerToolbarSeparator = styled(PickersToolbarText, {
   name: 'MuiDateTimePickerToolbar',

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
@@ -68,16 +68,6 @@ const DayCalendarSkeletonDay = styled(Skeleton, {
   ],
 });
 
-DayCalendarSkeletonDay.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  ownerState: PropTypes.shape({
-    day: PropTypes.number.isRequired,
-  }).isRequired,
-} as any;
-
 const monthMap = [
   [0, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1],

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -19,7 +19,7 @@ const useUtilityClasses = (ownerState: PickersLayoutProps<any, any, any>) => {
   return composeClasses(slots, getPickersLayoutUtilityClass, classes);
 };
 
-const PickersLayoutRoot = styled('div', {
+export const PickersLayoutRoot = styled('div', {
   name: 'MuiPickersLayout',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
@@ -51,24 +51,6 @@ const PickersLayoutRoot = styled('div', {
     },
   ],
 }));
-
-PickersLayoutRoot.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  as: PropTypes.elementType,
-  ownerState: PropTypes.shape({
-    isLandscape: PropTypes.bool.isRequired,
-  }).isRequired,
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-} as any;
-
-export { PickersLayoutRoot };
 
 export const PickersLayoutContentWrapper = styled('div', {
   name: 'MuiPickersLayout',

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -98,20 +98,6 @@ const TimePickerToolbarHourMinuteLabel = styled('div', {
   ],
 }));
 
-TimePickerToolbarHourMinuteLabel.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  as: PropTypes.elementType,
-  ownerState: PropTypes.object.isRequired,
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-} as any;
-
 const TimePickerToolbarAmPmSelection = styled('div', {
   name: 'MuiTimePickerToolbar',
   slot: 'AmPmSelection',
@@ -142,20 +128,6 @@ const TimePickerToolbarAmPmSelection = styled('div', {
     },
   ],
 });
-
-TimePickerToolbarAmPmSelection.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "yarn proptypes"  |
-  // ----------------------------------------------------------------------
-  as: PropTypes.elementType,
-  ownerState: PropTypes.object.isRequired,
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-} as any;
 
 /**
  * Demos:


### PR DESCRIPTION
Follow up on #13167

To be honest I did not dive deep to understand why those were outdated.
But the CI shows that generating the prop-types do not add those back, and I don't think we should keep prop-types that are not synchronized with the typing.