### PR TITLE
[docs] Add information about key combinations on a11y sections

### DIFF
--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -107,7 +107,7 @@ renderCell: (params) => (
 ### Navigation
 
 :::info
-The key assignments on the table below apply to Windows and Linux users.
+The key assignments in the table below apply to Windows and Linux users.
 
 On macOS replace:
 
@@ -116,10 +116,10 @@ On macOS replace:
 
 Some devices may lack certain keys, requiring the use of key combinations. In this case, replace:
 
-- <kbd class="key">Page Up</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Up</kbd>
-- <kbd class="key">Page Down</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Down</kbd>
-- <kbd class="key">Home</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Left</kbd>
-- <kbd class="key">End</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Right</kbd>
+- <kbd class="key">Page Up</kbd> with <kbd class="key">Fn</kbd>+<kbd class="key">Arrow Up</kbd>
+- <kbd class="key">Page Down</kbd> with <kbd class="key">Fn</kbd>+<kbd class="key">Arrow Down</kbd>
+- <kbd class="key">Home</kbd> with <kbd class="key">Fn</kbd>+<kbd class="key">Arrow Left</kbd>
+- <kbd class="key">End</kbd> with <kbd class="key">Fn</kbd>+<kbd class="key">Arrow Right</kbd>
 
 :::
 

--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -107,12 +107,19 @@ renderCell: (params) => (
 ### Navigation
 
 :::info
-The following key assignments apply to Windows and Linux users.
+The key assignments on the table below apply to Windows and Linux users.
 
 On macOS replace:
 
 - <kbd class="key">Ctrl</kbd> with <kbd class="key">⌘ Command</kbd>
 - <kbd class="key">Alt</kbd> with <kbd class="key">⌥ Option</kbd>
+
+Some devices may lack certain keys, requiring the use of key combinations. In this case, replace:
+
+- <kbd class="key">Page Up</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Up</kbd>
+- <kbd class="key">Page Down</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Down</kbd>
+- <kbd class="key">Home</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Left</kbd>
+- <kbd class="key">End</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Right</kbd>
 
 :::
 

--- a/docs/data/tree-view/accessibility/accessibility.md
+++ b/docs/data/tree-view/accessibility/accessibility.md
@@ -29,9 +29,14 @@ The [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/tree
 ## Keyboard interactions
 
 :::info
-The following key assignments apply to Windows and Linux users.
+The key assignments on the table below apply to Windows and Linux users.
 
 On macOS replace <kbd class="key">Ctrl</kbd> with <kbd class="key">⌘ Command</kbd>.
+
+Some devices may lack certain keys, requiring the use of key combinations. In this case, replace:
+
+- <kbd class="key">Home</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Left</kbd>
+- <kbd class="key">End</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Right</kbd>
 
 :::
 

--- a/docs/data/tree-view/accessibility/accessibility.md
+++ b/docs/data/tree-view/accessibility/accessibility.md
@@ -29,14 +29,14 @@ The [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/tree
 ## Keyboard interactions
 
 :::info
-The key assignments on the table below apply to Windows and Linux users.
+The key assignments in the table below apply to Windows and Linux users.
 
 On macOS replace <kbd class="key">Ctrl</kbd> with <kbd class="key">⌘ Command</kbd>.
 
 Some devices may lack certain keys, requiring the use of key combinations. In this case, replace:
 
-- <kbd class="key">Home</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Left</kbd>
-- <kbd class="key">End</kbd> with <kbd class="key">fn</kbd>+<kbd class="key">Arrow Right</kbd>
+- <kbd class="key">Home</kbd> with <kbd class="key">Fn</kbd>+<kbd class="key">Arrow Left</kbd>
+- <kbd class="key">End</kbd> with <kbd class="key">Fn</kbd>+<kbd class="key">Arrow Right</kbd>
 
 :::
 


### PR DESCRIPTION
Adds information about key combinations that might be necessary on some devices.

The design and content are open to discussion