### PR TITLE
Prevent "Add reviewers" workflow from triggering since it doesn't work

### DIFF
--- a/.github/workflows/add-release-reviewers.yml
+++ b/.github/workflows/add-release-reviewers.yml
@@ -1,9 +1,10 @@
 name: Add reviewers to release PRs
 
 on:
-  pull_request_target:
-    branches: ['master', 'next']
-    types: ['labeled']
+  # pull_request_target:
+  #   branches: ['master', 'next']
+  #   types: ['labeled']
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
