### PR TITLE
[pickers] Fix `DateBuilderReturnType` when the date is `undefined`

### DIFF
--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -155,7 +155,7 @@ export type AdapterOptions<TLocale, TInstance> = {
   locale?: TLocale;
 } & PropertyIfNotNever<'instance', TInstance>;
 
-export type DateBuilderReturnType<T extends string | null | undefined, TDate> = T extends null
+export type DateBuilderReturnType<T extends string | null | undefined, TDate> = [T] extends [null]
   ? null
   : TDate;
 

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -120,10 +120,10 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
     });
 
     it('should work without args', () => {
-      const date = adapter.date().valueOf()
+      const date = adapter.date().valueOf();
 
-      expect(Math.abs(date - Date.now())).to.be.lessThan(5)
-    })
+      expect(Math.abs(date - Date.now())).to.be.lessThan(5);
+    });
   });
 
   it('Method: getTimezone', () => {

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -118,6 +118,12 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
         ).to.be.lessThan(5);
       }
     });
+
+    it('should work without args', () => {
+      const date = adapter.date().valueOf()
+
+      expect(Math.abs(date - Date.now())).to.be.lessThan(5)
+    })
   });
 
   it('Method: getTimezone', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #13239
