### PR TITLE
[core] Add comment on why logic to sync column header

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -430,6 +430,9 @@ export const useGridColumnResize = (
       apiRef.current.setColumnWidth(refs.colDef.field, refs.colDef.width!);
       logger.debug(`Updating col ${refs.colDef.field} with new width: ${refs.colDef.width}`);
 
+      // Since during resizing we update the columns width outside of React, React is unable to
+      // reapply the right style properties. We need to sync the state manually.
+      // So we reapply the same logic as in https://github.com/mui/mui-x/blob/0511bf65543ca05d2602a5a3e0a6156f2fc8e759/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx#L405
       const columnsState = gridColumnsStateSelector(apiRef.current.state);
       refs.groupHeaderElements!.forEach((element) => {
         const fields = getFieldsFromGroupHeaderElem(element);

--- a/packages/x-data-grid/src/utils/domUtils.ts
+++ b/packages/x-data-grid/src/utils/domUtils.ts
@@ -72,8 +72,7 @@ export function findHeaderElementFromField(elem: Element, field: string): HTMLDi
 }
 
 export function getFieldsFromGroupHeaderElem(colCellEl: Element): string[] {
-  const fieldsString = colCellEl.getAttribute('data-fields');
-  return fieldsString?.startsWith('|-') ? fieldsString!.slice(2, -2).split('-|-') : [];
+  return colCellEl.getAttribute('data-fields')!.slice(2, -2).split('-|-');
 }
 
 export function findGroupHeaderElementsFromField(elem: Element, field: string): Element[] {


### PR DESCRIPTION
As part of my due diligence on https://app.ashbyhq.com/jobs/c86e52ce-0f3b-41cd-871b-5a7fd4044238/candidate-pipeline/active/right-side/candidates/9f3a6ab2-c71b-4b25-a92b-3996f1d04647/applications/ed537f84-6d1b-4efc-b788-a29fa6c7a081/emails. I looked at #12863. I wanted to better understand how the changes connect to the rest of the codebase.

I have added comments to explain why this much complexity.

It would be possible to cheat this, meaning working around https://codesandbox.io/p/sandbox/style-sync-np6fdh?file=%2Fsrc%2FApp.js%3A5%2C30, but it would mean adding some randomness to the width, hacky 😄