### PR TITLE
[data grid] Remove dead logic to support Safari < 13

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -57,28 +57,6 @@ type AutosizeOptionsRequired = Required<GridAutosizeOptions>;
 
 type ResizeDirection = keyof typeof GridColumnHeaderSeparatorSides;
 
-// TODO: remove support for Safari < 13.
-// https://caniuse.com/#search=touch-action
-//
-// Safari, on iOS, supports touch action since v13.
-// Over 80% of the iOS phones are compatible
-// in August 2020.
-// Utilizing the CSS.supports method to check if touch-action is supported.
-// Since CSS.supports is supported on all but Edge@12 and IE and touch-action
-// is supported on both Edge@12 and IE if CSS.supports is not available that means that
-// touch-action will be supported
-let cachedSupportsTouchActionNone = false;
-function doesSupportTouchActionNone(): boolean {
-  if (cachedSupportsTouchActionNone === undefined) {
-    if (typeof CSS !== 'undefined' && typeof CSS.supports === 'function') {
-      cachedSupportsTouchActionNone = CSS.supports('touch-action', 'none');
-    } else {
-      cachedSupportsTouchActionNone = true;
-    }
-  }
-  return cachedSupportsTouchActionNone;
-}
-
 function trackFinger(event: any, currentTouchId: number | undefined): CursorCoordinates | boolean {
   if (currentTouchId !== undefined && event.changedTouches) {
     for (let i = 0; i < event.changedTouches.length; i += 1) {
@@ -593,10 +571,6 @@ export const useGridColumnResize = (
     if (!cellSeparator) {
       return;
     }
-    // If touch-action: none; is not supported we need to prevent the scroll manually.
-    if (!doesSupportTouchActionNone()) {
-      event.preventDefault();
-    }
 
     const touch = event.changedTouches[0];
     if (touch != null) {
@@ -812,7 +786,7 @@ export const useGridColumnResize = (
     () => apiRef.current.columnHeadersContainerRef?.current,
     'touchstart',
     handleTouchStart,
-    { passive: doesSupportTouchActionNone() },
+    { passive: true },
   );
 
   useGridApiMethod(


### PR DESCRIPTION
Since MUI X v7 is supposed to have the same browser support as Material UI v6 https://github.com/mui/material-ui/issues/40958. So support Safari >=15.4. I'm removing code that is well supposed in that range: https://caniuse.com/css-touch-action.

Less code, faster parse time, faster rendering.

I saw this from working on #13248.