### PR TITLE
[docs-infra] Fix `@mui/material` version used in sandboxes

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -41,7 +41,10 @@ ponyfillGlobal.muiDocConfig = {
   csbIncludePeerDependencies: (deps, { versions }) => {
     const newDeps = { ...deps };
 
-    newDeps['@mui/material'] = versions['@mui/material'];
+    // #default-branch-switch
+    // Check which version of `@mui/material` should be resolved when opening docs examples in StackBlitz or CodeSandbox
+    newDeps['@mui/material'] =
+      versions['@mui/material'] !== 'next' ? versions['@mui/material'] : 'latest';
 
     if (newDeps['@mui/x-data-grid-generator']) {
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];


### PR DESCRIPTION
From @mui/monorepo we get `next` as the resolved version to be used in sandboxes, which is perfectly valid for them.
But `@mui/x` packages support only v5 releases of `@mui/material`.
This ensures consistency between docs demos and the opened sandbox examples (StackBlitz or CodeSandbox).

### Before
![Screenshot 2024-05-27 at 10 41 27](https://github.com/mui/mui-x/assets/4941090/236c7e23-e694-4fad-9cd6-ac493f0f9e1c)

### After
![Screenshot 2024-05-27 at 10 41 40](https://github.com/mui/mui-x/assets/4941090/a0147cca-c8e7-4cee-982c-517533a040b8)
