### PR TITLE
[docs] Removes unused lines in TreeItem2 styling

### DIFF
--- a/docs/data/tree-view/rich-tree-view/customization/FileExplorer.js
+++ b/docs/data/tree-view/rich-tree-view/customization/FileExplorer.js
@@ -97,9 +97,6 @@ const CustomTreeItemContent = styled(TreeItem2Content)(({ theme }) => ({
   padding: theme.spacing(0.5),
   paddingRight: theme.spacing(1),
   fontWeight: 500,
-  [`& .${treeItemClasses.iconContainer}`]: {
-    marginRight: theme.spacing(2),
-  },
   [`&.Mui-expanded `]: {
     '&:not(.Mui-focused, .Mui-selected, .Mui-selected.Mui-focused) .labelIcon': {
       color:

--- a/docs/data/tree-view/rich-tree-view/customization/FileExplorer.tsx
+++ b/docs/data/tree-view/rich-tree-view/customization/FileExplorer.tsx
@@ -115,9 +115,6 @@ const CustomTreeItemContent = styled(TreeItem2Content)(({ theme }) => ({
   padding: theme.spacing(0.5),
   paddingRight: theme.spacing(1),
   fontWeight: 500,
-  [`& .${treeItemClasses.iconContainer}`]: {
-    marginRight: theme.spacing(2),
-  },
   [`&.Mui-expanded `]: {
     '&:not(.Mui-focused, .Mui-selected, .Mui-selected.Mui-focused) .labelIcon': {
       color:


### PR DESCRIPTION
Removes a line that has no effect for `TreeItem2`
Reported on #13259  