### PR TITLE
[pickers] Fix `DateBuilderReturnType` when the date is `undefined` (@alexey-kozlenkov)

### DIFF
--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -196,7 +196,7 @@ export type AdapterOptions<TLocale, TInstance> = {
   locale?: TLocale;
 } & PropertyIfNotNever<'instance', TInstance>;
 
-export type DateBuilderReturnType<T extends string | null | undefined, TDate> = T extends null
+export type DateBuilderReturnType<T extends string | null | undefined, TDate> = [T] extends [null]
   ? null
   : TDate;
 

--- a/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeGregorianAdapter/testCalculations.ts
@@ -146,6 +146,12 @@ export const testCalculations: DescribeGregorianAdapterTestSuite = ({
         ).to.be.lessThan(5);
       }
     });
+
+    it('should work without args', () => {
+      const date = adapter.date().valueOf();
+
+      expect(Math.abs(date - Date.now())).to.be.lessThan(5);
+    });
   });
 
   it('Method: getTimezone', () => {


### PR DESCRIPTION
Cherry-pick https://github.com/mui/mui-x/pull/13244.