### PR TITLE
[core] Fix `l10n` script execution with arguments

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,8 @@
     "create-playground": "cpy --cwd=scripts playground.template.tsx ../../pages/playground --rename=index.tsx",
     "typescript": "tsc -p tsconfig.json",
     "typescript:transpile": "cross-env BABEL_ENV=development node scripts/formattedTSDemos",
-    "typescript:transpile:dev": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" scripts/formattedTSDemos --watch",
-    "populate:demos": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" scripts/populatePickersDemos"
+    "typescript:transpile:dev": "cross-env BABEL_ENV=development node scripts/formattedTSDemos --watch",
+    "populate:demos": "tsx scripts/populatePickersDemos"
   },
   "dependencies": {
     "@babel/core": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "docs:deploy": "pnpm --filter docs deploy",
     "deduplicate": "pnpm dedupe",
     "dataset:file-tree": "babel-node -x .ts ./scripts/treeDataFromFileTree.ts",
-    "l10n": "babel-node -x .ts ./scripts/l10n.ts",
+    "l10n": "tsx ./scripts/l10n.ts",
     "jsonlint": "node ./scripts/jsonlint.mjs",
     "eslint": "eslint . --cache --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",
     "eslint:fix": "pnpm eslint --fix",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "docs:size-why": "cross-env DOCS_STATS_ENABLED=true pnpm docs:build",
     "docs:deploy": "pnpm --filter docs deploy",
     "deduplicate": "pnpm dedupe",
-    "dataset:file-tree": "babel-node -x .ts ./scripts/treeDataFromFileTree.ts",
+    "dataset:file-tree": "tsx ./scripts/treeDataFromFileTree.ts",
     "l10n": "tsx ./scripts/l10n.ts",
     "jsonlint": "node ./scripts/jsonlint.mjs",
     "eslint": "eslint . --cache --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",


### PR DESCRIPTION
Fix https://github.com/mui/mui-x/actions/runs/9287240393

Follow up on https://github.com/mui/mui-x/pull/13251#discussion_r1618835800

Replace a few other easy instances of `babel-node` usages with `node` or `tsx`.