### PR TITLE
[docs] Update Pickers demo configurations

### DIFF
--- a/docs/data/date-pickers/custom-components/CalendarHeaderComponent.js
+++ b/docs/data/date-pickers/custom-components/CalendarHeaderComponent.js
@@ -56,7 +56,7 @@ function CustomCalendarHeader(props) {
 export default function CalendarHeaderComponent() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateCalendar']}>
         <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/custom-components/CalendarHeaderComponent.tsx
+++ b/docs/data/date-pickers/custom-components/CalendarHeaderComponent.tsx
@@ -57,7 +57,7 @@ function CustomCalendarHeader(props: PickersCalendarHeaderProps<Dayjs>) {
 export default function CalendarHeaderComponent() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateCalendar']}>
         <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/custom-components/CalendarHeaderComponentProps.js
+++ b/docs/data/date-pickers/custom-components/CalendarHeaderComponentProps.js
@@ -7,7 +7,7 @@ import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 export default function CalendarHeaderComponentProps() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateCalendar']}>
         <DateCalendar
           slotProps={{ calendarHeader: { sx: { border: '1px red solid' } } }}
         />

--- a/docs/data/date-pickers/custom-components/CalendarHeaderComponentProps.tsx
+++ b/docs/data/date-pickers/custom-components/CalendarHeaderComponentProps.tsx
@@ -7,7 +7,7 @@ import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 export default function CalendarHeaderComponentProps() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateCalendar']}>
         <DateCalendar
           slotProps={{ calendarHeader: { sx: { border: '1px red solid' } } }}
         />

--- a/docs/data/date-pickers/custom-components/CalendarHeaderComponentRange.js
+++ b/docs/data/date-pickers/custom-components/CalendarHeaderComponentRange.js
@@ -49,7 +49,7 @@ function CustomCalendarHeader(props) {
 export default function CalendarHeaderComponentRange() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateRangeCalendar']}>
         <DateRangeCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/custom-components/CalendarHeaderComponentRange.tsx
+++ b/docs/data/date-pickers/custom-components/CalendarHeaderComponentRange.tsx
@@ -50,7 +50,7 @@ function CustomCalendarHeader(props: PickersRangeCalendarHeaderProps<Dayjs>) {
 export default function CalendarHeaderComponentRange() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateRangeCalendar']}>
         <DateRangeCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/custom-field/MaterialV7Field.js
+++ b/docs/data/date-pickers/custom-field/MaterialV7Field.js
@@ -8,7 +8,7 @@ import { DateField } from '@mui/x-date-pickers/DateField';
 export default function MaterialV7Field() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DateField', 'DatePicker']}>
+      <DemoContainer components={['DatePicker', 'DateField']}>
         <DateField enableAccessibleFieldDOMStructure />
         <DatePicker enableAccessibleFieldDOMStructure />
       </DemoContainer>

--- a/docs/data/date-pickers/custom-field/MaterialV7Field.tsx
+++ b/docs/data/date-pickers/custom-field/MaterialV7Field.tsx
@@ -8,7 +8,7 @@ import { DateField } from '@mui/x-date-pickers/DateField';
 export default function MaterialV7Field() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DateField', 'DatePicker']}>
+      <DemoContainer components={['DatePicker', 'DateField']}>
         <DateField enableAccessibleFieldDOMStructure />
         <DatePicker enableAccessibleFieldDOMStructure />
       </DemoContainer>

--- a/docs/data/date-pickers/custom-opening-button/AddWarningIconWhenInvalidRange.js
+++ b/docs/data/date-pickers/custom-opening-button/AddWarningIconWhenInvalidRange.js
@@ -22,7 +22,7 @@ export default function AddWarningIconWhenInvalidRange() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateRangePicker']}>
         <DateRangePicker
           label="Picker with error icon"
           maxDate={dayjs('2022-04-19')}

--- a/docs/data/date-pickers/custom-opening-button/AddWarningIconWhenInvalidRange.tsx
+++ b/docs/data/date-pickers/custom-opening-button/AddWarningIconWhenInvalidRange.tsx
@@ -23,7 +23,7 @@ export default function AddWarningIconWhenInvalidRange() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['DatePicker']}>
+      <DemoContainer components={['DateRangePicker']}>
         <DateRangePicker
           label="Picker with error icon"
           maxDate={dayjs('2022-04-19')}

--- a/docs/data/date-pickers/date-time-picker/DateTimePickerOpenTo.js
+++ b/docs/data/date-pickers/date-time-picker/DateTimePickerOpenTo.js
@@ -8,7 +8,7 @@ import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 export default function DateTimePickerOpenTo() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['MobileDateTimePicker', 'MobileDateTimePicker']}>
+      <DemoContainer components={['DateTimePicker', 'MobileTimePicker']}>
         <DateTimePicker label={'"year"'} openTo="year" />
         <MobileTimePicker label={'"hours"'} openTo="hours" />
       </DemoContainer>

--- a/docs/data/date-pickers/date-time-picker/DateTimePickerOpenTo.tsx
+++ b/docs/data/date-pickers/date-time-picker/DateTimePickerOpenTo.tsx
@@ -8,7 +8,7 @@ import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 export default function DateTimePickerOpenTo() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer components={['MobileDateTimePicker', 'MobileDateTimePicker']}>
+      <DemoContainer components={['DateTimePicker', 'MobileTimePicker']}>
         <DateTimePicker label={'"year"'} openTo="year" />
         <MobileTimePicker label={'"hours"'} openTo="hours" />
       </DemoContainer>

--- a/docs/data/date-pickers/date-time-range-picker/ResponsiveDateTimeRangePickers.js
+++ b/docs/data/date-pickers/date-time-range-picker/ResponsiveDateTimeRangePickers.js
@@ -13,16 +13,16 @@ export default function ResponsiveDateTimeRangePickers() {
       <DemoContainer
         components={[
           'DateTimeRangePicker',
-          'DateTimeRangePicker',
-          'DateTimeRangePicker',
+          'MobileDateTimeRangePicker',
+          'DesktopDateTimeRangePicker',
         ]}
       >
-        <DemoItem label="Desktop variant" component="DateTimeRangePicker">
+        <DemoItem label="Desktop variant" component="DesktopDateTimeRangePicker">
           <DesktopDateTimeRangePicker
             defaultValue={[dayjs('2022-04-17T15:30'), dayjs('2022-04-21T18:30')]}
           />
         </DemoItem>
-        <DemoItem label="Mobile variant" component="DateTimeRangePicker">
+        <DemoItem label="Mobile variant" component="MobileDateTimeRangePicker">
           <MobileDateTimeRangePicker
             defaultValue={[dayjs('2022-04-17T15:30'), dayjs('2022-04-21T18:30')]}
           />

--- a/docs/data/date-pickers/date-time-range-picker/ResponsiveDateTimeRangePickers.tsx
+++ b/docs/data/date-pickers/date-time-range-picker/ResponsiveDateTimeRangePickers.tsx
@@ -13,16 +13,16 @@ export default function ResponsiveDateTimeRangePickers() {
       <DemoContainer
         components={[
           'DateTimeRangePicker',
-          'DateTimeRangePicker',
-          'DateTimeRangePicker',
+          'MobileDateTimeRangePicker',
+          'DesktopDateTimeRangePicker',
         ]}
       >
-        <DemoItem label="Desktop variant" component="DateTimeRangePicker">
+        <DemoItem label="Desktop variant" component="DesktopDateTimeRangePicker">
           <DesktopDateTimeRangePicker
             defaultValue={[dayjs('2022-04-17T15:30'), dayjs('2022-04-21T18:30')]}
           />
         </DemoItem>
-        <DemoItem label="Mobile variant" component="DateTimeRangePicker">
+        <DemoItem label="Mobile variant" component="MobileDateTimeRangePicker">
           <MobileDateTimeRangePicker
             defaultValue={[dayjs('2022-04-17T15:30'), dayjs('2022-04-21T18:30')]}
           />

--- a/docs/data/date-pickers/date-time-range-picker/ResponsiveDateTimeRangePickers.tsx.preview
+++ b/docs/data/date-pickers/date-time-range-picker/ResponsiveDateTimeRangePickers.tsx.preview
@@ -1,9 +1,9 @@
-<DemoItem label="Desktop variant" component="DateTimeRangePicker">
+<DemoItem label="Desktop variant" component="DesktopDateTimeRangePicker">
   <DesktopDateTimeRangePicker
     defaultValue={[dayjs('2022-04-17T15:30'), dayjs('2022-04-21T18:30')]}
   />
 </DemoItem>
-<DemoItem label="Mobile variant" component="DateTimeRangePicker">
+<DemoItem label="Mobile variant" component="MobileDateTimeRangePicker">
   <MobileDateTimeRangePicker
     defaultValue={[dayjs('2022-04-17T15:30'), dayjs('2022-04-21T18:30')]}
   />

--- a/docs/data/date-pickers/digital-clock/DigitalClockAmPm.js
+++ b/docs/data/date-pickers/digital-clock/DigitalClockAmPm.js
@@ -13,10 +13,10 @@ export default function DigitalClockAmPm() {
       <DemoContainer
         components={[
           'DigitalClock',
-          'MultiSectionDigitalClock',
+          'DigitalClock',
           'DigitalClock',
           'MultiSectionDigitalClock',
-          'DigitalClock',
+          'MultiSectionDigitalClock',
           'MultiSectionDigitalClock',
         ]}
       >

--- a/docs/data/date-pickers/digital-clock/DigitalClockAmPm.tsx
+++ b/docs/data/date-pickers/digital-clock/DigitalClockAmPm.tsx
@@ -13,10 +13,10 @@ export default function DigitalClockAmPm() {
       <DemoContainer
         components={[
           'DigitalClock',
-          'MultiSectionDigitalClock',
+          'DigitalClock',
           'DigitalClock',
           'MultiSectionDigitalClock',
-          'DigitalClock',
+          'MultiSectionDigitalClock',
           'MultiSectionDigitalClock',
         ]}
       >

--- a/docs/data/date-pickers/time-picker/TimePickerViews.js
+++ b/docs/data/date-pickers/time-picker/TimePickerViews.js
@@ -7,9 +7,7 @@ import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 export default function TimePickerViews() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer
-        components={['MobileTimePicker', 'MobileTimePicker', 'MobileTimePicker']}
-      >
+      <DemoContainer components={['TimePicker', 'TimePicker', 'TimePicker']}>
         <DemoItem label={'"hours", "minutes" and "seconds"'}>
           <TimePicker views={['hours', 'minutes', 'seconds']} />
         </DemoItem>

--- a/docs/data/date-pickers/time-picker/TimePickerViews.tsx
+++ b/docs/data/date-pickers/time-picker/TimePickerViews.tsx
@@ -7,9 +7,7 @@ import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 export default function TimePickerViews() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DemoContainer
-        components={['MobileTimePicker', 'MobileTimePicker', 'MobileTimePicker']}
-      >
+      <DemoContainer components={['TimePicker', 'TimePicker', 'TimePicker']}>
         <DemoItem label={'"hours", "minutes" and "seconds"'}>
           <TimePicker views={['hours', 'minutes', 'seconds']} />
         </DemoItem>

--- a/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.js
+++ b/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.js
@@ -16,7 +16,7 @@ export default function DateTimeValidationMaxDateTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={todayAtNoon} maxDateTime={todayAt9AM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker
             defaultValue={[todayAt9AM, todayAtNoon]}
             maxDateTime={todayAt9AM}

--- a/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx
+++ b/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx
@@ -16,7 +16,7 @@ export default function DateTimeValidationMaxDateTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={todayAtNoon} maxDateTime={todayAt9AM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker
             defaultValue={[todayAt9AM, todayAtNoon]}
             maxDateTime={todayAt9AM}

--- a/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx.preview
+++ b/docs/data/date-pickers/validation/DateTimeValidationMaxDateTime.tsx.preview
@@ -1,7 +1,7 @@
 <DemoItem label="DateTimePicker">
   <DateTimePicker defaultValue={todayAtNoon} maxDateTime={todayAt9AM} />
 </DemoItem>
-<DemoItem label="DateTimeRangePicker">
+<DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
   <DateTimeRangePicker
     defaultValue={[todayAt9AM, todayAtNoon]}
     maxDateTime={todayAt9AM}

--- a/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.js
+++ b/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.js
@@ -16,7 +16,7 @@ export default function DateTimeValidationMinDateTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={todayAtNoon} minDateTime={todayAt3PM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker
             defaultValue={[todayAtNoon, todayAt3PM]}
             minDateTime={todayAt3PM}

--- a/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx
+++ b/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx
@@ -16,7 +16,7 @@ export default function DateTimeValidationMinDateTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={todayAtNoon} minDateTime={todayAt3PM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker
             defaultValue={[todayAtNoon, todayAt3PM]}
             minDateTime={todayAt3PM}

--- a/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx.preview
+++ b/docs/data/date-pickers/validation/DateTimeValidationMinDateTime.tsx.preview
@@ -1,7 +1,7 @@
 <DemoItem label="DateTimePicker">
   <DateTimePicker defaultValue={todayAtNoon} minDateTime={todayAt3PM} />
 </DemoItem>
-<DemoItem label="DateTimeRangePicker">
+<DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
   <DateTimeRangePicker
     defaultValue={[todayAtNoon, todayAt3PM]}
     minDateTime={todayAt3PM}

--- a/docs/data/date-pickers/validation/TimeValidationMaxTime.js
+++ b/docs/data/date-pickers/validation/TimeValidationMaxTime.js
@@ -22,7 +22,7 @@ export default function TimeValidationMaxTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={nineAM} maxTime={fiveAM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker defaultValue={[fiveAM, nineAM]} maxTime={fiveAM} />
         </DemoItem>
       </DemoContainer>

--- a/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx
+++ b/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx
@@ -22,7 +22,7 @@ export default function TimeValidationMaxTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={nineAM} maxTime={fiveAM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker defaultValue={[fiveAM, nineAM]} maxTime={fiveAM} />
         </DemoItem>
       </DemoContainer>

--- a/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx.preview
+++ b/docs/data/date-pickers/validation/TimeValidationMaxTime.tsx.preview
@@ -4,6 +4,6 @@
 <DemoItem label="DateTimePicker">
   <DateTimePicker defaultValue={nineAM} maxTime={fiveAM} />
 </DemoItem>
-<DemoItem label="DateTimeRangePicker">
+<DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
   <DateTimeRangePicker defaultValue={[fiveAM, nineAM]} maxTime={fiveAM} />
 </DemoItem>

--- a/docs/data/date-pickers/validation/TimeValidationMinTime.js
+++ b/docs/data/date-pickers/validation/TimeValidationMinTime.js
@@ -22,7 +22,7 @@ export default function TimeValidationMinTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={fiveAM} minTime={nineAM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker defaultValue={[fiveAM, nineAM]} minTime={nineAM} />
         </DemoItem>
       </DemoContainer>

--- a/docs/data/date-pickers/validation/TimeValidationMinTime.tsx
+++ b/docs/data/date-pickers/validation/TimeValidationMinTime.tsx
@@ -22,7 +22,7 @@ export default function TimeValidationMinTime() {
         <DemoItem label="DateTimePicker">
           <DateTimePicker defaultValue={fiveAM} minTime={nineAM} />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker defaultValue={[fiveAM, nineAM]} minTime={nineAM} />
         </DemoItem>
       </DemoContainer>

--- a/docs/data/date-pickers/validation/TimeValidationMinTime.tsx.preview
+++ b/docs/data/date-pickers/validation/TimeValidationMinTime.tsx.preview
@@ -4,6 +4,6 @@
 <DemoItem label="DateTimePicker">
   <DateTimePicker defaultValue={fiveAM} minTime={nineAM} />
 </DemoItem>
-<DemoItem label="DateTimeRangePicker">
+<DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
   <DateTimeRangePicker defaultValue={[fiveAM, nineAM]} minTime={nineAM} />
 </DemoItem>

--- a/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.js
+++ b/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.js
@@ -30,7 +30,7 @@ export default function TimeValidationShouldDisableTime() {
             shouldDisableTime={shouldDisableTime}
           />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker
             defaultValue={[defaultValue, defaultValue.add(30, 'minutes')]}
             shouldDisableTime={shouldDisableTime}

--- a/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.tsx
+++ b/docs/data/date-pickers/validation/TimeValidationShouldDisableTime.tsx
@@ -32,7 +32,7 @@ export default function TimeValidationShouldDisableTime() {
             shouldDisableTime={shouldDisableTime}
           />
         </DemoItem>
-        <DemoItem label="DateTimeRangePicker">
+        <DemoItem label="DateTimeRangePicker" component="DateTimeRangePicker">
           <DateTimeRangePicker
             defaultValue={[defaultValue, defaultValue.add(30, 'minutes')]}
             shouldDisableTime={shouldDisableTime}


### PR DESCRIPTION
I remembered this script while trying to run various scripts after the babel update.

- Ran the script
- Removed unwanted changes (mostly tries of replacing `SingleInputDateRangeField` with `DateRangePicker`, which would introduce a regression)
- run demo transpilation script to update js and previews