### PR TITLE
[DataGrid] Fix `columnResizeStop` event not emitted when column is not resized

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -400,6 +400,7 @@ export const useGridColumnResize = (
         nativeEvent.clientY === prevClientY
       ) {
         refs.previousMouseClickEvent = undefined;
+        apiRef.current.publishEvent('columnResizeStop', null, nativeEvent);
         return;
       }
     }


### PR DESCRIPTION
### What I did

- Ensured the `columnResizeStop` event is emitted when the column resizer is clicked but not moved.

Closes: https://github.com/mui/mui-x/issues/13178