### PR TITLE
[DataGrid] Use `readonly` on more array props

### DIFF
--- a/docs/pages/x/api/data-grid/grid-actions-col-def.json
+++ b/docs/pages/x/api/data-grid/grid-actions-col-def.json
@@ -10,7 +10,7 @@
     "field": { "type": { "description": "string" }, "required": true },
     "getActions": {
       "type": {
-        "description": "(params: GridRowParams&lt;R&gt;) =&gt; React.ReactElement&lt;GridActionsCellItemProps&gt;[]"
+        "description": "(params: GridRowParams&lt;R&gt;) =&gt; readonly React.ReactElement&lt;GridActionsCellItemProps&gt;[]"
       },
       "required": true
     },
@@ -37,7 +37,9 @@
     "display": { "type": { "description": "'text' | 'flex'" } },
     "editable": { "type": { "description": "boolean" }, "default": "false" },
     "filterable": { "type": { "description": "boolean" }, "default": "true" },
-    "filterOperators": { "type": { "description": "GridFilterOperator&lt;R, V, F&gt;[]" } },
+    "filterOperators": {
+      "type": { "description": "readonly GridFilterOperator&lt;R, V, F&gt;[]" }
+    },
     "flex": { "type": { "description": "number" } },
     "getApplyQuickFilterFn": { "type": { "description": "GetApplyQuickFilterFn&lt;R, V&gt;" } },
     "getSortComparator": {
@@ -89,7 +91,7 @@
     "resizable": { "type": { "description": "boolean" }, "default": "true" },
     "sortable": { "type": { "description": "boolean" }, "default": "true" },
     "sortComparator": { "type": { "description": "GridComparatorFn&lt;V&gt;" } },
-    "sortingOrder": { "type": { "description": "GridSortDirection[]" } },
+    "sortingOrder": { "type": { "description": "readonly GridSortDirection[]" } },
     "valueFormatter": { "type": { "description": "GridValueFormatter&lt;R, V, F&gt;" } },
     "valueGetter": { "type": { "description": "GridValueGetter&lt;R, V, F&gt;" } },
     "valueParser": { "type": { "description": "GridValueParser&lt;R, V, F&gt;" } },

--- a/docs/pages/x/api/data-grid/grid-api.json
+++ b/docs/pages/x/api/data-grid/grid-api.json
@@ -388,7 +388,7 @@
     },
     "setRows": { "type": { "description": "(rows: GridRowModel[]) =&gt; void" }, "required": true },
     "setRowSelectionModel": {
-      "type": { "description": "(rowIds: GridRowId[]) =&gt; void" },
+      "type": { "description": "(rowIds: readonly GridRowId[]) =&gt; void" },
       "required": true
     },
     "setSortModel": {

--- a/docs/pages/x/api/data-grid/grid-col-def.json
+++ b/docs/pages/x/api/data-grid/grid-col-def.json
@@ -30,7 +30,9 @@
     "display": { "type": { "description": "'text' | 'flex'" } },
     "editable": { "type": { "description": "boolean" }, "default": "false" },
     "filterable": { "type": { "description": "boolean" }, "default": "true" },
-    "filterOperators": { "type": { "description": "GridFilterOperator&lt;R, V, F&gt;[]" } },
+    "filterOperators": {
+      "type": { "description": "readonly GridFilterOperator&lt;R, V, F&gt;[]" }
+    },
     "flex": { "type": { "description": "number" } },
     "getApplyQuickFilterFn": { "type": { "description": "GetApplyQuickFilterFn&lt;R, V&gt;" } },
     "getSortComparator": {
@@ -82,7 +84,7 @@
     "resizable": { "type": { "description": "boolean" }, "default": "true" },
     "sortable": { "type": { "description": "boolean" }, "default": "true" },
     "sortComparator": { "type": { "description": "GridComparatorFn&lt;V&gt;" } },
-    "sortingOrder": { "type": { "description": "GridSortDirection[]" } },
+    "sortingOrder": { "type": { "description": "readonly GridSortDirection[]" } },
     "type": { "type": { "description": "GridColType" }, "default": "'singleSelect'" },
     "valueFormatter": { "type": { "description": "GridValueFormatter&lt;R, V, F&gt;" } },
     "valueGetter": { "type": { "description": "GridValueGetter&lt;R, V, F&gt;" } },

--- a/docs/pages/x/api/data-grid/grid-row-selection-api.json
+++ b/docs/pages/x/api/data-grid/grid-row-selection-api.json
@@ -25,7 +25,7 @@
     {
       "name": "setRowSelectionModel",
       "description": "Updates the selected rows to be those passed to the <code>rowIds</code> argument. Any row already selected will be unselected.",
-      "type": "(rowIds: GridRowId[]) => void"
+      "type": "(rowIds: readonly GridRowId[]) => void"
     }
   ]
 }

--- a/docs/pages/x/api/data-grid/grid-single-select-col-def.json
+++ b/docs/pages/x/api/data-grid/grid-single-select-col-def.json
@@ -35,7 +35,9 @@
     "display": { "type": { "description": "'text' | 'flex'" } },
     "editable": { "type": { "description": "boolean" }, "default": "false" },
     "filterable": { "type": { "description": "boolean" }, "default": "true" },
-    "filterOperators": { "type": { "description": "GridFilterOperator&lt;R, V, F&gt;[]" } },
+    "filterOperators": {
+      "type": { "description": "readonly GridFilterOperator&lt;R, V, F&gt;[]" }
+    },
     "flex": { "type": { "description": "number" } },
     "getApplyQuickFilterFn": { "type": { "description": "GetApplyQuickFilterFn&lt;R, V&gt;" } },
     "getOptionLabel": { "type": { "description": "(value: ValueOptions) =&gt; string" } },
@@ -89,7 +91,7 @@
     "resizable": { "type": { "description": "boolean" }, "default": "true" },
     "sortable": { "type": { "description": "boolean" }, "default": "true" },
     "sortComparator": { "type": { "description": "GridComparatorFn&lt;V&gt;" } },
-    "sortingOrder": { "type": { "description": "GridSortDirection[]" } },
+    "sortingOrder": { "type": { "description": "readonly GridSortDirection[]" } },
     "valueFormatter": { "type": { "description": "GridValueFormatter&lt;R, V, F&gt;" } },
     "valueGetter": { "type": { "description": "GridValueGetter&lt;R, V, F&gt;" } },
     "valueOptions": {

--- a/packages/x-data-grid/src/models/api/gridRowSelectionApi.ts
+++ b/packages/x-data-grid/src/models/api/gridRowSelectionApi.ts
@@ -31,9 +31,9 @@ export interface GridRowSelectionApi {
   /**
    * Updates the selected rows to be those passed to the `rowIds` argument.
    * Any row already selected will be unselected.
-   * @param {GridRowId[]} rowIds The row ids to select.
+   * @param {readonly GridRowId[]} rowIds The row ids to select.
    */
-  setRowSelectionModel: (rowIds: GridRowId[]) => void;
+  setRowSelectionModel: (rowIds: readonly GridRowId[]) => void;
 }
 
 export interface GridRowMultiSelectionApi {

--- a/packages/x-data-grid/src/models/colDef/gridColDef.ts
+++ b/packages/x-data-grid/src/models/colDef/gridColDef.ts
@@ -134,7 +134,7 @@ export interface GridBaseColDef<R extends GridValidRowModel = GridValidRowModel,
   /**
    * The order of the sorting sequence.
    */
-  sortingOrder?: GridSortDirection[];
+  sortingOrder?: readonly GridSortDirection[];
   /**
    * If `true`, the column is resizable.
    * @default true
@@ -264,7 +264,7 @@ export interface GridBaseColDef<R extends GridValidRowModel = GridValidRowModel,
   /**
    * Allows setting the filter operators for this column.
    */
-  filterOperators?: GridFilterOperator<R, V, F>[];
+  filterOperators?: readonly GridFilterOperator<R, V, F>[];
   /**
    * The callback that generates a filtering function for a given quick filter value.
    * This function can return `null` to skip filtering for this value and column.
@@ -306,9 +306,9 @@ export interface GridActionsColDef<R extends GridValidRowModel = any, V = any, F
   /**
    * Function that returns the actions to be shown.
    * @param {GridRowParams} params The params for each row.
-   * @returns {React.ReactElement<GridActionsCellItemProps>[]} An array of [[GridActionsCell]] elements.
+   * @returns {readonly React.ReactElement<GridActionsCellItemProps>[]} An array of [[GridActionsCell]] elements.
    */
-  getActions: (params: GridRowParams<R>) => React.ReactElement<GridActionsCellItemProps>[];
+  getActions: (params: GridRowParams<R>) => readonly React.ReactElement<GridActionsCellItemProps>[];
 }
 
 /**

--- a/packages/x-data-grid/src/models/gridRowSelectionModel.ts
+++ b/packages/x-data-grid/src/models/gridRowSelectionModel.ts
@@ -1,5 +1,5 @@
 import { GridRowId } from './gridRows';
 
-export type GridInputRowSelectionModel = GridRowId[] | GridRowId;
+export type GridInputRowSelectionModel = readonly GridRowId[] | GridRowId;
 
-export type GridRowSelectionModel = GridRowId[];
+export type GridRowSelectionModel = readonly GridRowId[];


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
