### PR TITLE
[DataGrid] Fix pagination when `pagination={undefined}`

### DIFF
--- a/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -104,15 +104,26 @@ export const useDataGridProps = <R extends GridValidRowModel>(inProps: DataGridP
     [themedProps.slots],
   );
 
+  const injectDefaultProps = React.useMemo(() => {
+    return (
+      Object.keys(DATA_GRID_PROPS_DEFAULT_VALUES) as Array<
+        keyof DataGridPropsWithDefaultValues<any>
+      >
+    ).reduce((acc, key) => {
+      // @ts-ignore
+      acc[key] = themedProps[key] ?? DATA_GRID_PROPS_DEFAULT_VALUES[key];
+      return acc;
+    }, {} as DataGridPropsWithDefaultValues<any>);
+  }, [themedProps]);
+
   return React.useMemo<DataGridProcessedProps<R>>(
     () => ({
-      ...DATA_GRID_PROPS_DEFAULT_VALUES,
       ...themedProps,
-      paginationMode: themedProps.paginationMode ?? DATA_GRID_PROPS_DEFAULT_VALUES.paginationMode,
+      ...injectDefaultProps,
       localeText,
       slots,
       ...DATA_GRID_FORCED_PROPS,
     }),
-    [themedProps, localeText, slots],
+    [themedProps, localeText, slots, injectDefaultProps],
   );
 };

--- a/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -108,6 +108,7 @@ export const useDataGridProps = <R extends GridValidRowModel>(inProps: DataGridP
     () => ({
       ...DATA_GRID_PROPS_DEFAULT_VALUES,
       ...themedProps,
+      paginationMode: themedProps.paginationMode ?? DATA_GRID_PROPS_DEFAULT_VALUES.paginationMode,
       localeText,
       slots,
       ...DATA_GRID_FORCED_PROPS,

--- a/packages/x-data-grid/src/tests/DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/DataGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
-import { DataGrid } from '@mui/x-data-grid';
+import { DataGrid, DATA_GRID_PROPS_DEFAULT_VALUES } from '@mui/x-data-grid';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -61,5 +61,31 @@ describe('<DataGrid />', () => {
         <DataGrid rows={rows} columns={columns} />
       </div>,
     );
+  });
+
+  it('should not cause unexpected behavior when props are explictly set to undefined', () => {
+    const rows = [
+      { id: 'a', col1: 'Hello', col2: 'World' },
+      { id: 'constructor', col1: 'DataGridPro', col2: 'is Awesome' },
+      { id: 'hasOwnProperty', col1: 'MUI', col2: 'is Amazing' },
+    ];
+
+    const columns = [
+      { field: 'col1', headerName: 'Column 1', width: 150 },
+      { field: 'col2', headerName: 'Column 2', width: 150 },
+    ];
+    expect(
+      render(
+        <DataGrid
+          rows={rows}
+          columns={columns}
+          {...Object.keys(DATA_GRID_PROPS_DEFAULT_VALUES).reduce((acc, key) => {
+            // @ts-ignore
+            acc[key] = undefined;
+            return acc;
+          }, {})}
+        />,
+      ),
+    ).not.toErrorDev();
   });
 });

--- a/packages/x-data-grid/src/tests/DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/DataGrid.test.tsx
@@ -74,18 +74,22 @@ describe('<DataGrid />', () => {
       { field: 'col1', headerName: 'Column 1', width: 150 },
       { field: 'col2', headerName: 'Column 2', width: 150 },
     ];
-    expect(
+    expect(() => {
       render(
         <DataGrid
-          rows={rows}
-          columns={columns}
-          {...Object.keys(DATA_GRID_PROPS_DEFAULT_VALUES).reduce((acc, key) => {
+          {...(
+            Object.keys(DATA_GRID_PROPS_DEFAULT_VALUES) as Array<
+              keyof typeof DATA_GRID_PROPS_DEFAULT_VALUES
+            >
+          ).reduce((acc, key) => {
             // @ts-ignore
             acc[key] = undefined;
             return acc;
           }, {})}
+          rows={rows}
+          columns={columns}
         />,
-      ),
-    ).not.toErrorDev();
+      );
+    }).not.toErrorDev();
   });
 });

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -751,10 +751,4 @@ describe('<DataGrid /> - Pagination', () => {
       ].join('\n'),
     );
   });
-
-  it('should not log an error if paginationMode is set to undefined', () => {
-    expect(() => {
-      render(<BaselineTestCase paginationMode={undefined} />);
-    }).not.toErrorDev();
-  });
 });

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -751,4 +751,10 @@ describe('<DataGrid /> - Pagination', () => {
       ].join('\n'),
     );
   });
+
+  it('should not log an error if paginationMode is set to undefined', () => {
+    expect(() => {
+      render(<BaselineTestCase paginationMode={undefined} />);
+    }).not.toErrorDev();
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/mui-x/issues/13330

preview: https://deploy-preview-13349--material-ui-x.netlify.app/x/react-data-grid/pagination/

check this https://github.com/mui/mui-x/pull/13349#discussion_r1623490501 dicussion  for more context on implementaion of logic

after applying fix:
<img width="487" alt="image" src="https://github.com/mui/mui-x/assets/60743144/444e39b2-da36-484a-a35b-4b66f9578bf5">

 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
