### PR TITLE
[docs] Fix the description of `tickInterval`

### DIFF
--- a/docs/translations/api-docs/charts/axis-config.json
+++ b/docs/translations/api-docs/charts/axis-config.json
@@ -34,7 +34,7 @@
     "stroke": { "description": "The stroke color of the axis line." },
     "tickFontSize": { "description": "The font size of the axis ticks text." },
     "tickInterval": {
-      "description": "Defines which ticks are displayed. Its value can be:<br />- &#39;auto&#39; In such case the ticks are computed based on axis scale and other parameters.<br />- a filtering function of the form <code>(value, index) =&amp;gt; boolean</code> which is available only if the axis has a data property.<br />- an array containing the values where ticks should be displayed."
+      "description": "Defines which ticks are displayed.<br />Its value can be:<br />- &#39;auto&#39; In such case the ticks are computed based on axis scale and other parameters.<br />- a filtering function of the form <code>(value, index) =&amp;gt; boolean</code> which is available only if the axis has &quot;point&quot; scale.<br />- an array containing the values where ticks should be displayed."
     },
     "tickLabelInterval": {
       "description": "Defines which ticks get its label displayed. Its value can be:<br />- &#39;auto&#39; In such case, labels are displayed if they do not overlap with the previous one.<br />- a filtering function of the form (value, index) =&gt; boolean. Warning: the index is tick index, not data ones."

--- a/docs/translations/api-docs/charts/charts-x-axis/charts-x-axis.json
+++ b/docs/translations/api-docs/charts/charts-x-axis/charts-x-axis.json
@@ -17,7 +17,7 @@
     "stroke": { "description": "The stroke color of the axis line." },
     "tickFontSize": { "description": "The font size of the axis ticks text." },
     "tickInterval": {
-      "description": "Defines which ticks are displayed. Its value can be: - &#39;auto&#39; In such case the ticks are computed based on axis scale and other parameters. - a filtering function of the form <code>(value, index) =&gt; boolean</code> which is available only if the axis has a data property. - an array containing the values where ticks should be displayed."
+      "description": "Defines which ticks are displayed. Its value can be: - &#39;auto&#39; In such case the ticks are computed based on axis scale and other parameters. - a filtering function of the form <code>(value, index) =&gt; boolean</code> which is available only if the axis has &quot;point&quot; scale. - an array containing the values where ticks should be displayed."
     },
     "tickLabelInterval": {
       "description": "Defines which ticks get its label displayed. Its value can be: - &#39;auto&#39; In such case, labels are displayed if they do not overlap with the previous one. - a filtering function of the form (value, index) =&gt; boolean. Warning: the index is tick index, not data ones."

--- a/docs/translations/api-docs/charts/charts-y-axis/charts-y-axis.json
+++ b/docs/translations/api-docs/charts/charts-y-axis/charts-y-axis.json
@@ -17,7 +17,7 @@
     "stroke": { "description": "The stroke color of the axis line." },
     "tickFontSize": { "description": "The font size of the axis ticks text." },
     "tickInterval": {
-      "description": "Defines which ticks are displayed. Its value can be: - &#39;auto&#39; In such case the ticks are computed based on axis scale and other parameters. - a filtering function of the form <code>(value, index) =&gt; boolean</code> which is available only if the axis has a data property. - an array containing the values where ticks should be displayed."
+      "description": "Defines which ticks are displayed. Its value can be: - &#39;auto&#39; In such case the ticks are computed based on axis scale and other parameters. - a filtering function of the form <code>(value, index) =&gt; boolean</code> which is available only if the axis has &quot;point&quot; scale. - an array containing the values where ticks should be displayed."
     },
     "tickLabelInterval": {
       "description": "Defines which ticks get its label displayed. Its value can be: - &#39;auto&#39; In such case, labels are displayed if they do not overlap with the previous one. - a filtering function of the form (value, index) =&gt; boolean. Warning: the index is tick index, not data ones."

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -315,10 +315,12 @@ ChartsXAxis.propTypes = {
    */
   tickFontSize: PropTypes.number,
   /**
-   * Defines which ticks are displayed. Its value can be:
+   * Defines which ticks are displayed.
+   * Its value can be:
    * - 'auto' In such case the ticks are computed based on axis scale and other parameters.
-   * - a filtering function of the form `(value, index) => boolean` which is available only if the axis has a data property.
+   * - a filtering function of the form `(value, index) => boolean` which is available only if the axis has "point" scale.
    * - an array containing the values where ticks should be displayed.
+   * @see See {@link https://mui.com/x/react-charts/axis/#fixed-tick-positions}
    * @default 'auto'
    */
   tickInterval: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.array, PropTypes.func]),

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -255,10 +255,12 @@ ChartsYAxis.propTypes = {
    */
   tickFontSize: PropTypes.number,
   /**
-   * Defines which ticks are displayed. Its value can be:
+   * Defines which ticks are displayed.
+   * Its value can be:
    * - 'auto' In such case the ticks are computed based on axis scale and other parameters.
-   * - a filtering function of the form `(value, index) => boolean` which is available only if the axis has a data property.
+   * - a filtering function of the form `(value, index) => boolean` which is available only if the axis has "point" scale.
    * - an array containing the values where ticks should be displayed.
+   * @see See {@link https://mui.com/x/react-charts/axis/#fixed-tick-positions}
    * @default 'auto'
    */
   tickInterval: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.array, PropTypes.func]),

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -21,10 +21,12 @@ export interface TickParams {
    */
   tickNumber?: number;
   /**
-   * Defines which ticks are displayed. Its value can be:
+   * Defines which ticks are displayed.
+   * Its value can be:
    * - 'auto' In such case the ticks are computed based on axis scale and other parameters.
-   * - a filtering function of the form `(value, index) => boolean` which is available only if the axis has a data property.
+   * - a filtering function of the form `(value, index) => boolean` which is available only if the axis has "point" scale.
    * - an array containing the values where ticks should be displayed.
+   * @see See {@link https://mui.com/x/react-charts/axis/#fixed-tick-positions}
    * @default 'auto'
    */
   tickInterval?: 'auto' | ((value: any, index: number) => boolean) | any[];


### PR DESCRIPTION
From docs feedback

> It is not clear when tickInterval is used and when is not. I placed breakpoint in useTicks.js to see how ticks are calculated for my BarChart, and useTicks returned result without using tickInterval value at all, doesn't matter if it is array or filtering function (code bellow comment //scale type = 'band').


BtW this feature is not applied on bar chart. The reason why is very opinionated. bar chart should be used on categorical plotting. So each tick should be present. But it's something open to dicussion