### PR TITLE
Bugfix: AdapterDayjs.ts crashing in UTC mode with DateTimePicker

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -323,8 +323,12 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
         return zone;
       }
     }
-
-    if (this.hasUTCPlugin() && value.isUTC()) {
+    
+    if (typeof value === 'string' && value.endsWith('Z')) {
+      // `value` can end up being a formatted ISO string
+      return 'UTC'
+    }
+    if (this.hasUTCPlugin() && typeof value.isUTC === 'function' && value.isUTC()) {
       return 'UTC';
     }
 


### PR DESCRIPTION
Bugfix for working in UTC mode, AdapterDayJS throws an exception when accessing `value.isUTC()` when `value` is unexpectedly an ISO formatted datetime string.

This occurs for me when using both `timezone` and `utc` plugins, with the DateTimePicker.

- [✅] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
