### PR TITLE
[core] add docs .env.local to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __diff_output__
 /docs/.next
 /docs/pages/playground/*
 !/docs/pages/playground/tsconfig.json
+/docs/.env.local
 /docs/export
 /test/regressions/screenshots
 build


### PR DESCRIPTION
Adds `.env.local` to gitignore. @cherniavskii realised it was missing when testing a license key locally.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
