### PR TITLE
[core] Remove explicit `marked` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -69,7 +69,6 @@
     "luxon": "^3.4.4",
     "lz-string": "^1.5.0",
     "markdown-to-jsx": "^7.4.7",
-    "marked": "^5.1.2",
     "moment": "^2.30.1",
     "moment-hijri": "^2.1.2",
     "moment-jalaali": "^0.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,9 +548,6 @@ importers:
       markdown-to-jsx:
         specifier: ^7.4.7
         version: 7.4.7(react@18.2.0)
-      marked:
-        specifier: ^5.1.2
-        version: 5.1.2
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -12455,6 +12452,7 @@ packages:
     resolution: {integrity: sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==}
     engines: {node: '>= 16'}
     hasBin: true
+    dev: true
 
   /mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}


### PR DESCRIPTION
With the introduction of a direct dependency:
https://github.com/mui/mui-x/blob/671e68394d7ccde8badbbc1dbd923b971d004c32/package.json#L90
We are getting the `marked` dependency installed without us needing to specify it explicitly:
https://github.com/mui/mui-x/blob/671e68394d7ccde8badbbc1dbd923b971d004c32/pnpm-lock.yaml#L3718-L3725

Removing the explicit dependency to have easier control over it's versioning.