### PR TITLE
[core] Remove unused `@types/prettier` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@types/lodash": "^4.17.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.19.33",
-    "@types/prettier": "^3.0.0",
     "@types/react": "^18.2.60",
     "@types/react-dom": "^18.2.25",
     "@types/react-test-renderer": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "remark": "^13.0.0",
+    "rimraf": "^5.0.7",
     "serve": "^14.2.3",
     "sinon": "^16.1.3",
     "stream-browserify": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,9 @@ importers:
       remark:
         specifier: ^13.0.0
         version: 13.0.0
+      rimraf:
+        specifier: ^5.0.7
+        version: 5.0.7
       serve:
         specifier: ^14.2.3
         version: 14.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       '@types/node':
         specifier: ^18.19.33
         version: 18.19.33
-      '@types/prettier':
-        specifier: ^3.0.0
-        version: 3.0.0
       '@types/react':
         specifier: ^18.2.60
         version: 18.2.60
@@ -3585,10 +3582,6 @@ packages:
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
-  '@types/prettier@3.0.0':
-    resolution: {integrity: sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==}
-    deprecated: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
 
   '@types/promise.allsettled@1.0.6':
     resolution: {integrity: sha512-wA0UT0HeT2fGHzIFV9kWpYz5mdoyLxKrTgMdZQM++5h6pYAFH73HXcQhefg24nD1yivUFEn5KU+EF4b+CXJ4Wg==}
@@ -12355,10 +12348,6 @@ snapshots:
   '@types/p-queue@2.3.2': {}
 
   '@types/parse-json@4.0.2': {}
-
-  '@types/prettier@3.0.0':
-    dependencies:
-      prettier: 3.3.0
 
   '@types/promise.allsettled@1.0.6': {}
 


### PR DESCRIPTION
Fixes:
![Screenshot 2024-06-05 at 21 28 21](https://github.com/mui/mui-x/assets/4941090/f96f707f-0f98-42e5-9293-5a3fcc4f5fcd)

Add missing root `rimraf` dep to make `clean:node_modules` work.