### PR TITLE
[DataGrid] Support `date` and `datetime-local` input types in `GridFilterInputMultipleValue` type

### DIFF
--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -6,7 +6,7 @@ import { useGridRootProps } from '../../../hooks/utils/useGridRootProps';
 import { GridFilterInputValueProps } from './GridFilterInputValueProps';
 
 export type GridFilterInputMultipleValueProps = {
-  type?: 'text' | 'number';
+  type?: 'text' | 'number' | 'date' | 'datetime-local';
 } & GridFilterInputValueProps &
   Omit<AutocompleteProps<string, true, false, true>, 'options' | 'renderInput'>;
 
@@ -113,7 +113,7 @@ GridFilterInputMultipleValue.propTypes = {
     operator: PropTypes.string.isRequired,
     value: PropTypes.any,
   }).isRequired,
-  type: PropTypes.oneOf(['number', 'text']),
+  type: PropTypes.oneOf(['number', 'text', 'date', 'datetime-local']),
 } as any;
 
 export { GridFilterInputMultipleValue };

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -113,7 +113,6 @@ GridFilterInputMultipleValue.propTypes = {
     operator: PropTypes.string.isRequired,
     value: PropTypes.any,
   }).isRequired,
-  type: PropTypes.oneOf(['number', 'text', 'date', 'datetime-local']),
 } as any;
 
 export { GridFilterInputMultipleValue };

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -113,6 +113,7 @@ GridFilterInputMultipleValue.propTypes = {
     operator: PropTypes.string.isRequired,
     value: PropTypes.any,
   }).isRequired,
+  type: PropTypes.oneOf(['date', 'datetime-local', 'number', 'text']),
 } as any;
 
 export { GridFilterInputMultipleValue };


### PR DESCRIPTION
### Description

When using `type = date` or `type = datetime-local` the prop types on `GridFilterInputMultipleValue` produce an error despite actually working perfectly fine given that this component (by default) just uses a native input.

This change is also consistent with how [GridFilterInputValue](https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx#L12) handles this property's typing (except there's no enum enforcement in the prop types over there, for some reason).

Please do let me know if I missed something, the change in the prop-types/types seemed trivial enough to do by hand, but if I must clone this and and run `pnpm prototype` to have the codegen do it for me I can, I had just chosen to take the easy way and directly edited this in GitHub.

Fixes #13409

### From the template

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
  - There was something about signing a CLA- though I wasn't prompted to do so when opening the PR