### PR TITLE
[core] Add `eslint-plugin-react-compiler` experimental version and rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,17 +23,11 @@ const isAnyReactCompilerPluginEnabled =
 
 // TODO move this helper to @mui/monorepo/.eslintrc
 // It needs to know about the parent "no-restricted-imports" to not override them.
-const buildPackageRestrictedImports = (
-  packageName,
-  root,
-  allowRootImports = true,
-  enableReactCompilerRules = false,
-) => [
+const buildPackageRestrictedImports = (packageName, root, allowRootImports = true) => [
   {
     files: [`packages/${root}/src/**/*{.ts,.tsx,.js}`],
     excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx', '**.test.tx', '**.test.tsx'],
     rules: {
-      ...(enableReactCompilerRules ? { 'react-compiler/react-compiler': 'error' } : {}),
       'no-restricted-imports': [
         'error',
         {
@@ -241,62 +235,17 @@ module.exports = {
         ],
       },
     },
-    ...buildPackageRestrictedImports(
-      '@mui/x-charts',
-      'x-charts',
-      false,
-      ENABLE_REACT_COMPILER_PLUGIN_CHARTS,
-    ),
-    ...buildPackageRestrictedImports(
-      '@mui/x-charts-pro',
-      'x-charts-pro',
-      false,
-      ENABLE_REACT_COMPILER_PLUGIN_CHARTS,
-    ),
+    ...buildPackageRestrictedImports('@mui/x-charts', 'x-charts', false),
+    ...buildPackageRestrictedImports('@mui/x-charts-pro', 'x-charts-pro', false),
     ...buildPackageRestrictedImports('@mui/x-codemod', 'x-codemod', false),
-    ...buildPackageRestrictedImports(
-      '@mui/x-data-grid',
-      'x-data-grid',
-      true,
-      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
-    ),
-    ...buildPackageRestrictedImports(
-      '@mui/x-data-grid-pro',
-      'x-data-grid-pro',
-      true,
-      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
-    ),
-    ...buildPackageRestrictedImports(
-      '@mui/x-data-grid-premium',
-      'x-data-grid-premium',
-      true,
-      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
-    ),
+    ...buildPackageRestrictedImports('@mui/x-data-grid', 'x-data-grid'),
+    ...buildPackageRestrictedImports('@mui/x-data-grid-pro', 'x-data-grid-pro'),
+    ...buildPackageRestrictedImports('@mui/x-data-grid-premium', 'x-data-grid-premium'),
     ...buildPackageRestrictedImports('@mui/x-data-grid-generator', 'x-data-grid-generator'),
-    ...buildPackageRestrictedImports(
-      '@mui/x-date-pickers',
-      'x-date-pickers',
-      false,
-      ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS,
-    ),
-    ...buildPackageRestrictedImports(
-      '@mui/x-date-pickers-pro',
-      'x-date-pickers-pro',
-      false,
-      ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS,
-    ),
-    ...buildPackageRestrictedImports(
-      '@mui/x-tree-view',
-      'x-tree-view',
-      false,
-      ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW,
-    ),
-    ...buildPackageRestrictedImports(
-      '@mui/x-tree-view-pro',
-      'x-tree-view-pro',
-      false,
-      ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW,
-    ),
-    ...buildPackageRestrictedImports('@mui/x-license', 'x-license', true),
+    ...buildPackageRestrictedImports('@mui/x-date-pickers', 'x-date-pickers', false),
+    ...buildPackageRestrictedImports('@mui/x-date-pickers-pro', 'x-date-pickers-pro', false),
+    ...buildPackageRestrictedImports('@mui/x-tree-view', 'x-tree-view', false),
+    ...buildPackageRestrictedImports('@mui/x-tree-view-pro', 'x-tree-view-pro', false),
+    ...buildPackageRestrictedImports('@mui/x-license', 'x-license'),
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,16 @@ const isAnyReactCompilerPluginEnabled =
   ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS ||
   ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW;
 
+const addReactCompilerRule = (packagesNames, isEnabled) =>
+  !isEnabled
+    ? []
+    : packagesNames.map((packageName) => ({
+        files: [`packages/${packageName}/src/**/*{.ts,.tsx,.js}`],
+        rules: {
+          'react-compiler/react-compiler': 'error',
+        },
+      }));
+
 // TODO move this helper to @mui/monorepo/.eslintrc
 // It needs to know about the parent "no-restricted-imports" to not override them.
 const buildPackageRestrictedImports = (packageName, root, allowRootImports = true) => [
@@ -247,5 +257,19 @@ module.exports = {
     ...buildPackageRestrictedImports('@mui/x-tree-view', 'x-tree-view', false),
     ...buildPackageRestrictedImports('@mui/x-tree-view-pro', 'x-tree-view-pro', false),
     ...buildPackageRestrictedImports('@mui/x-license', 'x-license'),
+
+    ...addReactCompilerRule(['x-charts', 'x-charts-pro'], ENABLE_REACT_COMPILER_PLUGIN_CHARTS),
+    ...addReactCompilerRule(
+      ['x-data-grid', 'x-data-grid-pro', 'x-data-grid-premium', 'x-data-grid-generator'],
+      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
+    ),
+    ...addReactCompilerRule(
+      ['x-date-pickers', 'x-date-pickers-pro'],
+      ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS,
+    ),
+    ...addReactCompilerRule(
+      ['x-tree-view', 'x-tree-view-pro'],
+      ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW,
+    ),
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,39 @@
 const baseline = require('@mui/monorepo/.eslintrc');
 const path = require('path');
 
+// Enable React Compiler Plugin rules globally
+const ENABLE_REACT_COMPILER_PLUGIN = process.env.ENABLE_REACT_COMPILER_PLUGIN ?? false;
+
+// Enable React Compiler Plugin rules per package
+const ENABLE_REACT_COMPILER_PLUGIN_CHARTS =
+  process.env.ENABLE_REACT_COMPILER_PLUGIN_CHARTS ?? false;
+const ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID =
+  process.env.ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID ?? false;
+const ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS =
+  process.env.ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS ?? false;
+const ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW =
+  process.env.ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW ?? false;
+
+const isAnyReactCompilerPluginEnabled =
+  ENABLE_REACT_COMPILER_PLUGIN ||
+  ENABLE_REACT_COMPILER_PLUGIN_CHARTS ||
+  ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID ||
+  ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS ||
+  ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW;
+
 // TODO move this helper to @mui/monorepo/.eslintrc
 // It needs to know about the parent "no-restricted-imports" to not override them.
-const buildPackageRestrictedImports = (packageName, root, allowRootImports = true) => [
+const buildPackageRestrictedImports = (
+  packageName,
+  root,
+  allowRootImports = true,
+  enableReactCompilerRules = false,
+) => [
   {
     files: [`packages/${root}/src/**/*{.ts,.tsx,.js}`],
     excludedFiles: ['*.d.ts', '*.spec.ts', '*.spec.tsx', '**.test.tx', '**.test.tsx'],
     rules: {
+      ...(enableReactCompilerRules ? { 'react-compiler/react-compiler': 'error' } : {}),
       'no-restricted-imports': [
         'error',
         {
@@ -89,7 +115,11 @@ const buildPackageRestrictedImports = (packageName, root, allowRootImports = tru
 
 module.exports = {
   ...baseline,
-  plugins: [...baseline.plugins, 'eslint-plugin-jsdoc'],
+  plugins: [
+    ...baseline.plugins,
+    'eslint-plugin-jsdoc',
+    ...(isAnyReactCompilerPluginEnabled ? ['eslint-plugin-react-compiler'] : []),
+  ],
   settings: {
     'import/resolver': {
       webpack: {
@@ -103,6 +133,7 @@ module.exports = {
    */
   rules: {
     ...baseline.rules,
+    ...(ENABLE_REACT_COMPILER_PLUGIN ? { 'react-compiler/react-compiler': 'error' } : {}),
     // TODO move to @mui/monorepo/.eslintrc, codebase is moving away from default exports
     'import/prefer-default-export': 'off',
     // TODO move rule into the main repo once it has upgraded
@@ -210,17 +241,62 @@ module.exports = {
         ],
       },
     },
-    ...buildPackageRestrictedImports('@mui/x-charts', 'x-charts', false),
-    ...buildPackageRestrictedImports('@mui/x-charts-pro', 'x-charts-pro', false),
+    ...buildPackageRestrictedImports(
+      '@mui/x-charts',
+      'x-charts',
+      false,
+      ENABLE_REACT_COMPILER_PLUGIN_CHARTS,
+    ),
+    ...buildPackageRestrictedImports(
+      '@mui/x-charts-pro',
+      'x-charts-pro',
+      false,
+      ENABLE_REACT_COMPILER_PLUGIN_CHARTS,
+    ),
     ...buildPackageRestrictedImports('@mui/x-codemod', 'x-codemod', false),
-    ...buildPackageRestrictedImports('@mui/x-data-grid', 'x-data-grid'),
-    ...buildPackageRestrictedImports('@mui/x-data-grid-pro', 'x-data-grid-pro'),
-    ...buildPackageRestrictedImports('@mui/x-data-grid-premium', 'x-data-grid-premium'),
+    ...buildPackageRestrictedImports(
+      '@mui/x-data-grid',
+      'x-data-grid',
+      true,
+      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
+    ),
+    ...buildPackageRestrictedImports(
+      '@mui/x-data-grid-pro',
+      'x-data-grid-pro',
+      true,
+      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
+    ),
+    ...buildPackageRestrictedImports(
+      '@mui/x-data-grid-premium',
+      'x-data-grid-premium',
+      true,
+      ENABLE_REACT_COMPILER_PLUGIN_DATA_GRID,
+    ),
     ...buildPackageRestrictedImports('@mui/x-data-grid-generator', 'x-data-grid-generator'),
-    ...buildPackageRestrictedImports('@mui/x-date-pickers', 'x-date-pickers', false),
-    ...buildPackageRestrictedImports('@mui/x-date-pickers-pro', 'x-date-pickers-pro', false),
-    ...buildPackageRestrictedImports('@mui/x-tree-view', 'x-tree-view', false),
-    ...buildPackageRestrictedImports('@mui/x-tree-view-pro', 'x-tree-view-pro', false),
-    ...buildPackageRestrictedImports('@mui/x-license', 'x-license'),
+    ...buildPackageRestrictedImports(
+      '@mui/x-date-pickers',
+      'x-date-pickers',
+      false,
+      ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS,
+    ),
+    ...buildPackageRestrictedImports(
+      '@mui/x-date-pickers-pro',
+      'x-date-pickers-pro',
+      false,
+      ENABLE_REACT_COMPILER_PLUGIN_DATE_PICKERS,
+    ),
+    ...buildPackageRestrictedImports(
+      '@mui/x-tree-view',
+      'x-tree-view',
+      false,
+      ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW,
+    ),
+    ...buildPackageRestrictedImports(
+      '@mui/x-tree-view-pro',
+      'x-tree-view-pro',
+      false,
+      ENABLE_REACT_COMPILER_PLUGIN_TREE_VIEW,
+    ),
+    ...buildPackageRestrictedImports('@mui/x-license', 'x-license', true),
   ],
 };

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.2",
+    "eslint-plugin-react-compiler": "0.0.0-experimental-51a85ea-20240601",
     "eslint-plugin-react-hooks": "^4.6.2",
     "fast-glob": "^3.3.2",
     "format-util": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.34.2
         version: 7.34.2(eslint@8.57.0)
+      eslint-plugin-react-compiler:
+        specifier: 0.0.0-experimental-51a85ea-20240601
+        version: 0.0.0-experimental-51a85ea-20240601(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
         version: 4.6.2(eslint@8.57.0)
@@ -1750,6 +1753,13 @@ packages:
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -5429,6 +5439,12 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-react-compiler@0.0.0-experimental-51a85ea-20240601:
+    resolution: {integrity: sha512-ROiKTVu9pZsNHyJepZj/JULWnkw8+I8+9gOF/MkJ8Q22/9f9MkPQkD2f6FXzVH+iyWbp7DQ3RXKhB3hWhf8AIg==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
+
   eslint-plugin-react-hooks@4.6.2:
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
     engines: {node: '>=10'}
@@ -6077,6 +6093,12 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hermes-estree@0.20.1:
+    resolution: {integrity: sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==}
+
+  hermes-parser@0.20.1:
+    resolution: {integrity: sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -9783,6 +9805,15 @@ packages:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
 
+  zod-validation-error@3.3.0:
+    resolution: {integrity: sha512-Syib9oumw1NTqEv4LT0e6U83Td9aVRk9iTXPUQr1otyV1PuXQKOvOwhMNqZIq5hluzHP2pMgnOmHEo7kPdI2mw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.18.0
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
 
@@ -10134,6 +10165,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.6
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.6)
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.24.6)':
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/helper-create-class-features-plugin': 7.24.6(@babel/core@7.24.6)
+      '@babel/helper-plugin-utils': 7.24.6
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.6)':
     dependencies:
@@ -14620,6 +14657,18 @@ snapshots:
       '@types/eslint': 8.56.10
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
+  eslint-plugin-react-compiler@0.0.0-experimental-51a85ea-20240601(eslint@8.57.0):
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/parser': 7.24.6
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.6)
+      eslint: 8.57.0
+      hermes-parser: 0.20.1
+      zod: 3.23.8
+      zod-validation-error: 3.3.0(zod@3.23.8)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-hooks@4.6.2(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
@@ -15462,6 +15511,12 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  hermes-estree@0.20.1: {}
+
+  hermes-parser@0.20.1:
+    dependencies:
+      hermes-estree: 0.20.1
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -19824,5 +19879,11 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zod-validation-error@3.3.0(zod@3.23.8):
+    dependencies:
+      zod: 3.23.8
+
+  zod@3.23.8: {}
 
   zwitch@1.0.5: {}


### PR DESCRIPTION
Added multiple ways to enable the eslint rule, globaly or by "package"

```
ENABLE_REACT_COMPILER_PLUGIN=true pnpm eslint

// Or use one of the package specific ones
```

Part of https://github.com/mui/material-ui/issues/42548