### PR TITLE
[docs] Update a11y pages description

### DIFF
--- a/docs/data/data-grid/accessibility/accessibility.md
+++ b/docs/data/data-grid/accessibility/accessibility.md
@@ -1,6 +1,6 @@
 # Data Grid - Accessibility
 
-<p class="description">The Data Grid has complete accessibility support, including built-in keyboard navigation that follows international standards.</p>
+<p class="description">Learn how the Data Grid implements accessibility features and guidelines, including keyboard navigation that follows international standards.</p>
 
 ## Guidelines
 

--- a/docs/data/date-pickers/accessibility/accessibility.md
+++ b/docs/data/date-pickers/accessibility/accessibility.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 
 # Accessibility
 
-<p class="description">The Date and Time Pickers have complete accessibility support, including built-in keyboard navigation that follows international standards.</p>
+<p class="description">Learn how the Date and Time Pickers implements accessibility features and guidelines, including keyboard navigation that follows international standards.</p>
 
 ## Guidelines
 

--- a/docs/data/date-pickers/accessibility/accessibility.md
+++ b/docs/data/date-pickers/accessibility/accessibility.md
@@ -7,7 +7,7 @@ packageName: '@mui/x-date-pickers'
 
 # Accessibility
 
-<p class="description">Learn how the Date and Time Pickers implements accessibility features and guidelines, including keyboard navigation that follows international standards.</p>
+<p class="description">Learn how the Date and Time Pickers implement accessibility features and guidelines, including keyboard navigation that follows international standards.</p>
 
 ## Guidelines
 

--- a/docs/data/tree-view/accessibility/accessibility.md
+++ b/docs/data/tree-view/accessibility/accessibility.md
@@ -8,7 +8,7 @@ packageName: '@mui/x-tree-view'
 
 # Accessibility
 
-<p class="description">The Tree View has complete accessibility support, including built-in keyboard interactions that follow international standards.</p>
+<p class="description">Learn how the Tree View implements accessibility features and guidelines, including keyboard navigation that follows international standards.</p>
 
 ## Guidelines
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

We were talking about documenting accessibility testing guidelines in one of the Core meetings and eventually touched on how the Tree View component implemented keyboard navigation. Then, on each accessibility page, we realized we were saying "complete accessibility support" which is arguably one thing we can't ever say—we don't know if we're supporting every single accessibility-related feature or if we're being fully accessible, particularly given there's very little focus on, in any of these pages, screen readers; they're mostly focused on keyboard navigation.

So, this PR changes the descriptions of the accessibility-focused pages a bit to reflect that train of thought.
