### PR TITLE
[infra] Adjust CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,6 @@ commands:
                 name: Install pnpm package manager
                 command: |
                   corepack enable
-                  corepack prepare pnpm@9.2.0 --activate
             - run:
                 name: Prepare playwright hash
                 command: pnpm list --json --filter playwright > /tmp/playwright_info.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,15 +276,9 @@ jobs:
           command: pnpm test:argos
   run_danger:
     <<: *default-job
-    docker:
-      - image: mcr.microsoft.com/playwright:v1.44.1-focal
-        environment:
-          NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - install_js:
-          # TODO remove, no needed
-          browsers: true
+      - install_js
       - run:
           name: Run danger on PRs
           command: pnpm danger ci --fail-on-errors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
                 name: Install pnpm package manager
                 command: |
                   corepack enable
-                  corepack prepare pnpm@latest-8 --activate
+                  corepack prepare pnpm@9.2.0 --activate
             - run:
                 name: Prepare playwright hash
                 command: pnpm list --json --filter playwright > /tmp/playwright_info.json


### PR DESCRIPTION
- Use a regular docker container for the `danger` step as the playwright does not seem to need it... 🤷 🙈 
- Use the same `pnpm` version as in `package.json`
  - using `latest-8` is no longer correct as we already use v9
  - using `latest-9` is potentially incorrect depending on which version is specified in `package.json`.
  ~~Do you know if omitting the `@` portion would end up using the `package.json` specifier? @Janpot @michaldudak I see that both [base-ui](https://github.com/mui/base-ui/blob/master/.circleci/config.yml) and [toolpad](https://github.com/mui/mui-toolpad/blob/master/.circleci/config.yml) do not call `corepack prepare`. Have you seen any problems with it? Or maybe we could also remove it? 🤔~~
  Removed the `corepack prepare` as agreed here: https://github.com/mui/mui-x/pull/13448#pullrequestreview-2110787594