### PR TITLE
[l10n] Improve Korean (ko-KR) locale

### DIFF
--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -6,7 +6,7 @@ const views: Record<TimeViewWithMeridiem, string> = {
   hours: '시간을',
   minutes: '분을',
   seconds: '초를',
-  meridiem: '메리디엠',
+  meridiem: '오전/오후를',
 };
 
 const koKRPickers: Partial<PickersLocaleText<any>> = {

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -45,7 +45,7 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
   // Clock labels
   clockLabelText: (view, time, adapter) =>
     `${views[view]} 선택하세요. ${time === null ? '시간을 선택하지 않았습니다.' : `현재 선택된 시간은 ${adapter.format(time, 'fullTime')}입니다.`}`,
-  hoursClockNumberText: (hours) => `${hours}시간`,
+  hoursClockNumberText: (hours) => `${hours}시`,
   minutesClockNumberText: (minutes) => `${minutes}분`,
   secondsClockNumberText: (seconds) => `${seconds}초`,
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

- Changing the translation of "meridiem" to "오전/오후를"
- Updating the hoursClockNumberText from "hh시간" to "hh시"

The current translation for hoursClockNumberText is 'hh시간', which is incorrect and misleading in the context of time selection. This commit changes it to 'hh시', which is the correct and appropriate translation for selecting hours.

