### PR TITLE
[charts] POC Support BarChart with scaletype `time`

### DIFF
--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -45,12 +45,14 @@
     "@mui/utils": "^5.15.14",
     "@react-spring/rafz": "^9.7.3",
     "@react-spring/web": "^9.7.3",
+    "@types/d3-time": "^3.0.3",
     "clsx": "^2.1.1",
     "d3-color": "^3.1.0",
     "d3-delaunay": "^6.0.4",
     "d3-interpolate": "^3.0.1",
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
+    "d3-time": "^3.1.0",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -720,6 +720,9 @@ importers:
       '@react-spring/web':
         specifier: ^9.7.3
         version: 9.7.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@types/d3-time':
+        specifier: ^3.0.3
+        version: 3.0.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -738,6 +741,9 @@ importers:
       d3-shape:
         specifier: ^3.2.0
         version: 3.2.0
+      d3-time:
+        specifier: ^3.1.0
+        version: 3.1.0
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1


### PR DESCRIPTION
## Concept

We could technically create conditional behaviour to handle time series in the bar chart. 

## Issues

There some issues with the current changes:
- Bar offset is kinda wrong
- The padding is currently fixed to 1px, but it should be adjustable, which is different from band type where it uses a "ratio"

Example: https://codesandbox.io/p/sandbox/barchart-scale-time-xkw9ln?file=%2Fsrc%2Fdemo.tsx%3A5%2C4

resolves #12537