### PR TITLE
[DataGrid] Do not show resize separators for column groups

### DIFF
--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
@@ -205,7 +205,7 @@ function GridColumnGroupHeader(props: GridColumnGroupHeaderProps) {
       width={width}
       columnMenuIconButton={null}
       columnTitleIconButtons={null}
-      resizable
+      resizable={false}
       label={label}
       aria-colspan={fields.length}
       // The fields are wrapped between |-...-| to avoid confusion between fields "id" and "id2" when using selector data-fields~=


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/13247