### PR TITLE
[core] Minor setup cleanup

### DIFF
--- a/docs/scripts/api/buildApi.ts
+++ b/docs/scripts/api/buildApi.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
-import * as yargs from 'yargs';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import path from 'path';
 import fs from 'fs';
 import * as prettier from 'prettier';
@@ -144,7 +145,7 @@ async function run() {
   });
 }
 
-yargs
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     describe: 'generates API docs',

--- a/docs/scripts/api/buildGridEventsDocumentation.ts
+++ b/docs/scripts/api/buildGridEventsDocumentation.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import path from 'path';
-import { renderMarkdown } from '@mui/monorepo/packages/markdown';
+import { renderMarkdown } from '@mui/internal-markdown';
 import {
   DocumentedInterfaces,
   getSymbolDescription,

--- a/docs/scripts/api/buildInterfacesDocumentation.ts
+++ b/docs/scripts/api/buildInterfacesDocumentation.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import { EOL } from 'os';
 import kebabCase from 'lodash/kebabCase';
 import path from 'path';
-import { renderMarkdown } from '@mui/monorepo/packages/markdown';
+import { renderMarkdown } from '@mui/internal-markdown';
 import {
   getSymbolDescription,
   getSymbolJSDocTags,

--- a/docs/scripts/generateProptypes.ts
+++ b/docs/scripts/generateProptypes.ts
@@ -1,4 +1,5 @@
-import * as yargs from 'yargs';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import * as path from 'path';
 import * as fse from 'fs-extra';
 import * as prettier from 'prettier';
@@ -199,7 +200,7 @@ async function run() {
   }
 }
 
-yargs
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     describe: 'Generates Component.propTypes from TypeScript declarations',

--- a/docs/scripts/tsconfig.json
+++ b/docs/scripts/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": [
-    "../../node_modules/@mui/monorepo/packages/api-docs-builder/react-docgen.d.ts",
-    "api/buildApi.ts",
-    "i18n.js"
-  ],
+  "include": ["api/buildApi.ts", "i18n.js"],
   "compilerOptions": {
     "allowJs": true,
     "isolatedModules": true,

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@octokit/rest": "^20.1.1",
     "@playwright/test": "^1.44.1",
     "@testing-library/react": "^15.0.7",
+    "@types/babel__traverse": "^7.20.6",
     "@types/babel__core": "^7.20.5",
     "@types/chai": "^4.3.16",
     "@types/chai-dom": "^1.11.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      '@types/babel__traverse':
+        specifier: ^7.20.6
+        version: 7.20.6
       '@types/chai':
         specifier: ^4.3.16
         version: 4.3.16
@@ -3560,8 +3563,8 @@ packages:
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
-  '@types/babel__traverse@7.20.5':
-    resolution: {integrity: sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==}
+  '@types/babel__traverse@7.20.6':
+    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -12424,7 +12427,7 @@ snapshots:
       '@babel/types': 7.24.7
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.5
+      '@types/babel__traverse': 7.20.6
 
   '@types/babel__generator@7.6.8':
     dependencies:
@@ -12435,7 +12438,7 @@ snapshots:
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
 
-  '@types/babel__traverse@7.20.5':
+  '@types/babel__traverse@7.20.6':
     dependencies:
       '@babel/types': 7.24.7
 

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,14 +1,1 @@
-const baseline = require('@mui/monorepo/prettier.config');
-
-module.exports = {
-  ...baseline,
-  overrides: [
-    ...baseline.overrides,
-    {
-      files: ['**/*.json'],
-      options: {
-        trailingComma: 'none',
-      },
-    },
-  ],
-};
+module.exports = require('@mui/monorepo/prettier.config');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -4,6 +4,7 @@ import glob from 'fast-glob';
 import path from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { getWorkspaceRoot } from './utils.mjs';
 
 const exec = promisify(childProcess.exec);
@@ -102,7 +103,7 @@ async function run(argv) {
   }
 }
 
-yargs(process.argv.slice(2))
+yargs(hideBin(process.argv))
   .command({
     command: '$0 <bundle>',
     description: 'build package',

--- a/scripts/buildApiDocs/index.ts
+++ b/scripts/buildApiDocs/index.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { ProjectSettings, buildApi } from '@mui-internal/api-docs-builder';
 import { projectPickersSettings } from './pickersSettings';
 import { projectChartsSettings } from './chartsSettings';
@@ -19,7 +20,7 @@ async function run(argv: yargs.ArgumentsCamelCase<CommandOptions>) {
   return buildApi(projectSettings, grep);
 }
 
-yargs(process.argv.slice(2))
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     describe: 'Generates API documentation for the MUI packages.',

--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -5,7 +5,8 @@ import traverse from '@babel/traverse';
 import * as prettier from 'prettier';
 import * as babel from '@babel/core';
 import * as babelTypes from '@babel/types';
-import * as yargs from 'yargs';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { Octokit } from '@octokit/rest';
 import { retry } from '@octokit/plugin-retry';
 import localeNames from './localeNames';
@@ -491,7 +492,7 @@ async function run(argv: yargs.ArgumentsCamelCase<HandlerArgv>) {
   process.exit(0);
 }
 
-yargs
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     describe: 'Syncs translation files.',

--- a/scripts/prettier.mjs
+++ b/scripts/prettier.mjs
@@ -1,1 +1,0 @@
-import '@mui/monorepo/scripts/prettier.mjs';

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 import { Octokit } from '@octokit/rest';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 const GIT_ORGANIZATION = 'mui';
 const GIT_REPO = 'mui-x';
@@ -43,7 +44,7 @@ async function findLatestTaggedVersion(octokit) {
 }
 
 function resolvePackagesByLabels(labels) {
-  let resolvedPackages = [];
+  const resolvedPackages = [];
   labels.forEach((label) => {
     switch (label.name) {
       case 'component: data grid':
@@ -323,7 +324,7 @@ ${logChangelogSection(otherCommits, '')}
   console.log(changelog);
 }
 
-yargs(process.argv.slice(2))
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     description: 'Creates a changelog',

--- a/scripts/releaseTag.mjs
+++ b/scripts/releaseTag.mjs
@@ -3,6 +3,7 @@ import fse from 'fs-extra';
 import path from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { getWorkspaceRoot } from './utils.mjs';
 
 /**
@@ -75,7 +76,7 @@ async function main(argv) {
   );
 }
 
-yargs(process.argv.slice(2))
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     description: 'Tags the current release and pushes these changes to mui/mui-x.',

--- a/scripts/treeDataFromFileTree.ts
+++ b/scripts/treeDataFromFileTree.ts
@@ -1,6 +1,6 @@
 import { promises as fs, Stats } from 'fs';
 import path from 'path';
-import yargs from 'yargs';
+import yargs, { ArgumentsCamelCase } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 interface Node {
@@ -50,7 +50,7 @@ const getSubTree = async (nodePath: string, parentHierarchy: string[] = []) => {
   return nodes;
 };
 
-const run = async (argv: yargs.ArgumentsCamelCase<{ path: string }>) => {
+const run = async (argv: ArgumentsCamelCase<{ path: string }>) => {
   const children = await fs.readdir(argv.path);
 
   const nodes: Node[] = [];

--- a/scripts/treeDataFromFileTree.ts
+++ b/scripts/treeDataFromFileTree.ts
@@ -1,6 +1,7 @@
 import { promises as fs, Stats } from 'fs';
 import path from 'path';
-import * as yargs from 'yargs';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 interface Node {
   hierarchy: string[];
@@ -68,7 +69,7 @@ const run = async (argv: yargs.ArgumentsCamelCase<{ path: string }>) => {
   );
 };
 
-yargs
+yargs(hideBin(process.argv))
   .command({
     command: '$0',
     describe: 'Generate tree data rows from a folder.',


### PR DESCRIPTION
- Fix TS issues and align approach of `yargs` usages
- Add missing `@babel/traverse` type
- Fix `l10n` TS issues
- Remove unused `scripts/prettier.mjs` file importing non-existent file
- Remove explicit prettier override as it is included in the monorepo already: https://github.com/mui/material-ui/pull/40668/files#diff-e42472dd65561fe56344281078077fb924cddca92821eadfbc2318cca3f89c9a
- Use `@mui/internal-markdown` import instead of `@mui/monorepo/packages/markdown`