### PR TITLE
[infra] Remove explicit `@testing-library/react` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@octokit/plugin-retry": "^6.0.1",
     "@octokit/rest": "^20.1.1",
     "@playwright/test": "^1.44.1",
-    "@testing-library/react": "^15.0.7",
     "@types/babel__traverse": "^7.20.6",
     "@types/babel__core": "^7.20.5",
     "@types/chai": "^4.3.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       '@playwright/test':
         specifier: ^1.44.1
         version: 1.44.1
-      '@testing-library/react':
-        specifier: ^15.0.7
-        version: 15.0.7(@types/react@18.2.60)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5


### PR DESCRIPTION
Based on https://github.com/mui/mui-x/pull/13463#issuecomment-2162775711

We are not using this dependency directly and it is even disallowed: https://github.com/mui/mui-x/blob/40b6038015646d41146614947fb53c52e7277687/.eslintrc.js#L187
This dependency is now coming from: https://github.com/mui/material-ui/blob/58831f0a1861337a7dddffe522cf3edbbeaf00d9/packages-internal/test-utils/package.json#L42

This will remove the need to separately control the dependency version and possibly introduce a discrepancy between expected package versions: https://github.com/mui/mui-x/pull/13429