### PR TITLE
[pickers] Handle `luxon` `throwOnInvalid` setting (exception)

### DIFF
--- a/packages/x-date-pickers/src/models/adapters.ts
+++ b/packages/x-date-pickers/src/models/adapters.ts
@@ -196,7 +196,7 @@ export interface MuiPickersAdapter<TDate extends PickerValidDate, TLocale = any>
    * Creates an invalid date in the date library format.
    * @returns {TDate} The invalid date.
    */
-  getInvalidDate(): TDate;
+  getInvalidDate(): TDate | null;
   /**
    * Extracts the timezone from a date.
    * @template TDate


### PR DESCRIPTION
Fixes #11853.

When `Settings.throwOnInvalid = true` luxon:
- throws an error if an invalid entry is being parsed (i.e. manually entering/selecting section the field)
- disallows invalid date (i.e. removing value from a section)