### PR TITLE
[TreeView] Support `itemId` with escaping characters when using `SimpleTreeView`

### DIFF
--- a/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.test.tsx
@@ -47,6 +47,18 @@ describeTreeView<[]>('TreeItem component', ({ render, treeItemComponentName }) =
 
       expect(response.getItemContent('1').textContent).to.equal('ABCDEF');
     });
+
+    it('should render TreeItem when itemId prop is escaping characters without throwing an error', function test() {
+      if (treeItemComponentName === 'TreeItem2') {
+        this.skip();
+      }
+
+      const response = render({
+        items: [{ id: 'C:\\\\', label: 'ABCDEF' }],
+      });
+
+      expect(response.getItemContent('C:\\\\').textContent).to.equal('ABCDEF');
+    });
   });
 });
 

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewChildrenItemProvider.tsx
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewChildrenItemProvider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useTreeViewContext } from './useTreeViewContext';
-import { escapeOperandAttributeSelector } from '../../../../x-data-grid/src/utils/domUtils';
+import { escapeOperandAttributeSelector } from '../utils/utils';
 import type { UseTreeViewJSXItemsSignature } from '../plugins/useTreeViewJSXItems';
 import type { UseTreeViewItemsSignature } from '../plugins/useTreeViewItems';
 import type { UseTreeViewIdSignature } from '../plugins/useTreeViewId';

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewChildrenItemProvider.tsx
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewChildrenItemProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useTreeViewContext } from './useTreeViewContext';
+import { escapeOperandAttributeSelector } from '../../../../x-data-grid/src/utils/domUtils';
 import type { UseTreeViewJSXItemsSignature } from '../plugins/useTreeViewJSXItems';
 import type { UseTreeViewItemsSignature } from '../plugins/useTreeViewItems';
 import type { UseTreeViewIdSignature } from '../plugins/useTreeViewId';
@@ -47,8 +48,9 @@ export function TreeViewChildrenItemProvider(props: TreeViewChildrenItemProvider
     }
 
     const previousChildrenIds = instance.getItemOrderedChildrenIds(itemId ?? null) ?? [];
+    const escapedIdAttr = escapeOperandAttributeSelector(idAttr);
     const childrenElements = rootRef.current.querySelectorAll(
-      `${itemId == null ? '' : `*[id="${idAttr}"] `}[role="treeitem"]:not(*[id="${idAttr}"] [role="treeitem"] [role="treeitem"])`,
+      `${itemId == null ? '' : `*[id="${escapedIdAttr}"] `}[role="treeitem"]:not(*[id="${escapedIdAttr}"] [role="treeitem"] [role="treeitem"])`,
     );
     const childrenIds = Array.from(childrenElements).map(
       (child) => childrenIdAttrToIdRef.current.get(child.id)!,

--- a/packages/x-tree-view/src/internals/utils/utils.ts
+++ b/packages/x-tree-view/src/internals/utils/utils.ts
@@ -12,3 +12,9 @@ export const getActiveElement = (root: Document | ShadowRoot = document): Elemen
 
   return activeEl;
 };
+
+// TODO, eventually replaces this function with CSS.escape, once available in jsdom, either added manually or built in
+// https://github.com/jsdom/jsdom/issues/1550#issuecomment-236734471
+export function escapeOperandAttributeSelector(operand: string): string {
+  return operand.replace(/["\\]/g, '\\$&');
+}


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/13414
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
