### PR TITLE
[TreeView] Improve typing to support optional dependencies in plugins and in the item

### DIFF
--- a/docs/data/tree-view/rich-tree-view/headless/LogExpandedItems.tsx
+++ b/docs/data/tree-view/rich-tree-view/headless/LogExpandedItems.tsx
@@ -37,7 +37,7 @@ type TreeViewLogExpandedSignature = TreeViewPluginSignature<{
   // The parameters of this plugin as they are passed to the plugin after calling `plugin.getDefaultizedParams`
   defaultizedParams: TreeViewLogExpandedDefaultizedParameters;
   // Dependencies of this plugin (we need the expansion plugin to access its model)
-  dependantPlugins: [UseTreeViewExpansionSignature];
+  dependencies: [UseTreeViewExpansionSignature];
 }>;
 
 const useTreeViewLogExpanded: TreeViewPlugin<TreeViewLogExpandedSignature> = ({

--- a/docs/data/tree-view/rich-tree-view/headless/headless.md
+++ b/docs/data/tree-view/rich-tree-view/headless/headless.md
@@ -283,7 +283,7 @@ type UseCustomPluginSignature = TreeViewPluginSignature<{
   // The name of the models defined by your plugin
   modelNames: UseCustomPluginModelNames;
   // The plugins this plugin needs to work correctly
-  dependantPlugins: UseCustomPluginDependantPlugins;
+  dependencies: UseCustomPluginDependantPlugins;
 }>;
 ```
 
@@ -317,7 +317,7 @@ type UseCustomPluginSignature = TreeViewPluginSignature<{
   contextValue: { customPlugin: { enabled: boolean } };
   modelNames: 'customModel';
   // We want to have access to the expansion models and methods of the expansion plugin.
-  dependantPlugins: [UseTreeViewExpansionSignature];
+  dependencies: [UseTreeViewExpansionSignature];
 }>;
 ```
 

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -13,7 +13,12 @@ import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { styled, createUseThemeProps } from '../internals/zero-styled';
 import { TreeItemContent } from './TreeItemContent';
 import { treeItemClasses, getTreeItemUtilityClass } from './treeItemClasses';
-import { TreeItemMinimalPlugins, TreeItemOwnerState, TreeItemProps } from './TreeItem.types';
+import {
+  TreeItemMinimalPlugins,
+  TreeItemOptionalPlugins,
+  TreeItemOwnerState,
+  TreeItemProps,
+} from './TreeItem.types';
 import { useTreeViewContext } from '../internals/TreeViewProvider/useTreeViewContext';
 import { TreeViewCollapseIcon, TreeViewExpandIcon } from '../icons';
 import { TreeItem2Provider } from '../TreeItem2Provider';
@@ -185,7 +190,7 @@ export const TreeItem = React.forwardRef(function TreeItem(
     disabledItemsFocusable,
     indentationAtItemLevel,
     instance,
-  } = useTreeViewContext<TreeItemMinimalPlugins>();
+  } = useTreeViewContext<TreeItemMinimalPlugins, TreeItemOptionalPlugins>();
   const depthContext = React.useContext(TreeViewItemDepthContext);
 
   const props = useThemeProps({ props: inProps, name: 'MuiTreeItem' });

--- a/packages/x-tree-view/src/TreeItem/TreeItem.types.ts
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.types.ts
@@ -113,6 +113,9 @@ export interface TreeItemOwnerState extends TreeItemProps {
   indentationAtItemLevel: boolean;
 }
 
+/**
+ * Plugins that need to be present in the Tree View in order for `TreeItem` to work correctly.
+ */
 export type TreeItemMinimalPlugins = readonly [
   UseTreeViewIconsSignature,
   UseTreeViewSelectionSignature,
@@ -122,3 +125,8 @@ export type TreeItemMinimalPlugins = readonly [
   UseTreeViewKeyboardNavigationSignature,
   UseTreeViewIdSignature,
 ];
+
+/**
+ * Plugins that `TreeItem` can use if they are present, but are not required.
+ */
+export type TreeItemOptionalPlugins = readonly [];

--- a/packages/x-tree-view/src/TreeItem/useTreeItemState.ts
+++ b/packages/x-tree-view/src/TreeItem/useTreeItemState.ts
@@ -12,11 +12,13 @@ type UseTreeItemStateMinimalPlugins = readonly [
   UseTreeViewItemsSignature,
 ];
 
+type UseTreeItemStateOptionalPlugins = readonly [];
+
 export function useTreeItemState(itemId: string) {
   const {
     instance,
     selection: { multiSelect, checkboxSelection, disableSelection },
-  } = useTreeViewContext<UseTreeItemStateMinimalPlugins>();
+  } = useTreeViewContext<UseTreeItemStateMinimalPlugins, UseTreeItemStateOptionalPlugins>();
 
   const expandable = instance.isItemExpandable(itemId);
   const expanded = instance.isItemExpanded(itemId);

--- a/packages/x-tree-view/src/hooks/useTreeItem2Utils/useTreeItem2Utils.tsx
+++ b/packages/x-tree-view/src/hooks/useTreeItem2Utils/useTreeItem2Utils.tsx
@@ -24,12 +24,20 @@ const isItemExpandable = (reactChildren: React.ReactNode) => {
   return Boolean(reactChildren);
 };
 
+/**
+ * Plugins that need to be present in the Tree View in order for `useTreeItem2Utils` to work correctly.
+ */
 type UseTreeItem2UtilsMinimalPlugins = readonly [
   UseTreeViewSelectionSignature,
   UseTreeViewExpansionSignature,
   UseTreeViewItemsSignature,
   UseTreeViewFocusSignature,
 ];
+
+/**
+ * Plugins that `useTreeItem2Utils` can use if they are present, but are not required.
+ */
+export type UseTreeItem2UtilsOptionalPlugins = readonly [];
 
 export const useTreeItem2Utils = ({
   itemId,
@@ -41,7 +49,7 @@ export const useTreeItem2Utils = ({
   const {
     instance,
     selection: { multiSelect },
-  } = useTreeViewContext<UseTreeItem2UtilsMinimalPlugins>();
+  } = useTreeViewContext<UseTreeItem2UtilsMinimalPlugins, UseTreeItem2UtilsOptionalPlugins>();
 
   const status: UseTreeItem2Status = {
     expandable: isItemExpandable(children),

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewProvider.types.ts
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewProvider.types.ts
@@ -13,10 +13,13 @@ export type TreeViewItemPluginsRunner = <TProps extends {}>(
   props: TProps,
 ) => Required<TreeViewItemPluginResponse>;
 
-export type TreeViewContextValue<TSignatures extends readonly TreeViewAnyPluginSignature[]> =
-  MergeSignaturesProperty<TSignatures, 'contextValue'> & {
-    instance: TreeViewInstance<TSignatures>;
-    publicAPI: TreeViewPublicAPI<TSignatures>;
+export type TreeViewContextValue<
+  TSignatures extends readonly TreeViewAnyPluginSignature[],
+  TOptionalSignatures extends readonly TreeViewAnyPluginSignature[] = [],
+> = MergeSignaturesProperty<TSignatures, 'contextValue'> &
+  Partial<MergeSignaturesProperty<TOptionalSignatures, 'contextValue'>> & {
+    instance: TreeViewInstance<TSignatures, TOptionalSignatures>;
+    publicAPI: TreeViewPublicAPI<TSignatures, TOptionalSignatures>;
     rootRef: React.RefObject<HTMLUListElement>;
     wrapItem: TreeItemWrapper<TSignatures>;
     wrapRoot: TreeRootWrapper<TSignatures>;

--- a/packages/x-tree-view/src/internals/TreeViewProvider/useTreeViewContext.ts
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/useTreeViewContext.ts
@@ -3,8 +3,14 @@ import { TreeViewAnyPluginSignature } from '../models';
 import { TreeViewContext } from './TreeViewContext';
 import { TreeViewContextValue } from './TreeViewProvider.types';
 
-export const useTreeViewContext = <TSignatures extends readonly TreeViewAnyPluginSignature[]>() => {
-  const context = React.useContext(TreeViewContext) as TreeViewContextValue<TSignatures>;
+export const useTreeViewContext = <
+  TSignatures extends readonly TreeViewAnyPluginSignature[],
+  TOptionalSignatures extends readonly TreeViewAnyPluginSignature[] = [],
+>() => {
+  const context = React.useContext(TreeViewContext) as TreeViewContextValue<
+    TSignatures,
+    TOptionalSignatures
+  >;
   if (context == null) {
     throw new Error(
       [

--- a/packages/x-tree-view/src/internals/models/treeView.ts
+++ b/packages/x-tree-view/src/internals/models/treeView.ts
@@ -24,11 +24,17 @@ export interface TreeViewModel<TValue> {
   setControlledValue: (value: TValue | ((prevValue: TValue) => TValue)) => void;
 }
 
-export type TreeViewInstance<TSignatures extends readonly TreeViewAnyPluginSignature[]> =
-  MergeSignaturesProperty<[...TreeViewCorePluginSignatures, ...TSignatures], 'instance'>;
+export type TreeViewInstance<
+  TSignatures extends readonly TreeViewAnyPluginSignature[],
+  TOptionalSignatures extends readonly TreeViewAnyPluginSignature[] = [],
+> = MergeSignaturesProperty<[...TreeViewCorePluginSignatures, ...TSignatures], 'instance'> &
+  Partial<MergeSignaturesProperty<TOptionalSignatures, 'instance'>>;
 
-export type TreeViewPublicAPI<TSignatures extends readonly TreeViewAnyPluginSignature[]> =
-  MergeSignaturesProperty<[...TreeViewCorePluginSignatures, ...TSignatures], 'publicAPI'>;
+export type TreeViewPublicAPI<
+  TSignatures extends readonly TreeViewAnyPluginSignature[],
+  TOptionalSignatures extends readonly TreeViewAnyPluginSignature[] = [],
+> = MergeSignaturesProperty<[...TreeViewCorePluginSignatures, ...TSignatures], 'publicAPI'> &
+  Partial<MergeSignaturesProperty<TOptionalSignatures, 'instance'>>;
 
 export type TreeViewExperimentalFeatures<
   TSignatures extends readonly TreeViewAnyPluginSignature[],

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
@@ -85,5 +85,5 @@ export type UseTreeViewExpansionSignature = TreeViewPluginSignature<{
   instance: UseTreeViewExpansionInstance;
   publicAPI: UseTreeViewExpansionPublicAPI;
   modelNames: 'expandedItems';
-  dependantPlugins: [UseTreeViewItemsSignature];
+  dependencies: [UseTreeViewItemsSignature];
 }>;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.types.ts
@@ -61,7 +61,7 @@ export type UseTreeViewFocusSignature = TreeViewPluginSignature<{
   instance: UseTreeViewFocusInstance;
   publicAPI: UseTreeViewFocusPublicAPI;
   state: UseTreeViewFocusState;
-  dependantPlugins: [
+  dependencies: [
     UseTreeViewIdSignature,
     UseTreeViewItemsSignature,
     UseTreeViewSelectionSignature,

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewIcons/useTreeViewIcons.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewIcons/useTreeViewIcons.types.ts
@@ -43,5 +43,5 @@ export type UseTreeViewIconsSignature = TreeViewPluginSignature<{
   contextValue: UseTreeViewIconsContextValue;
   slots: UseTreeViewIconsSlots;
   slotProps: UseTreeViewIconsSlotProps;
-  dependantPlugins: [UseTreeViewItemsSignature, UseTreeViewSelectionSignature];
+  dependencies: [UseTreeViewItemsSignature, UseTreeViewSelectionSignature];
 }>;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewJSXItems/useTreeViewJSXItems.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewJSXItems/useTreeViewJSXItems.types.ts
@@ -38,5 +38,5 @@ export type UseTreeViewJSXItemsSignature = TreeViewPluginSignature<{
   params: UseTreeViewJSXItemsParameters;
   defaultizedParams: UseTreeViewItemsDefaultizedParameters;
   instance: UseTreeViewItemsInstance;
-  dependantPlugins: [UseTreeViewItemsSignature, UseTreeViewKeyboardNavigationSignature];
+  dependencies: [UseTreeViewItemsSignature, UseTreeViewKeyboardNavigationSignature];
 }>;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.types.ts
@@ -29,7 +29,7 @@ export interface UseTreeViewKeyboardNavigationInstance {
 
 export type UseTreeViewKeyboardNavigationSignature = TreeViewPluginSignature<{
   instance: UseTreeViewKeyboardNavigationInstance;
-  dependantPlugins: [
+  dependencies: [
     UseTreeViewItemsSignature,
     UseTreeViewSelectionSignature,
     UseTreeViewFocusSignature,

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.types.ts
@@ -131,7 +131,7 @@ export type UseTreeViewSelectionSignature = TreeViewPluginSignature<{
   instance: UseTreeViewSelectionInstance;
   contextValue: UseTreeViewSelectionContextValue;
   modelNames: 'selectedItems';
-  dependantPlugins: [
+  dependencies: [
     UseTreeViewItemsSignature,
     UseTreeViewExpansionSignature,
     UseTreeViewItemsSignature,

--- a/packages/x-tree-view/src/useTreeItem2/useTreeItem2.ts
+++ b/packages/x-tree-view/src/useTreeItem2/useTreeItem2.ts
@@ -11,6 +11,7 @@ import {
   UseTreeItemIconContainerSlotProps,
   UseTreeItem2CheckboxSlotProps,
   UseTreeItem2MinimalPlugins,
+  UseTreeItem2OptionalPlugins,
 } from './useTreeItem2.types';
 import { useTreeViewContext } from '../internals/TreeViewProvider/useTreeViewContext';
 import { MuiCancellableEvent } from '../internals/models/MuiCancellableEvent';
@@ -19,9 +20,10 @@ import { TreeViewItemDepthContext } from '../internals/TreeViewItemDepthContext'
 
 export const useTreeItem2 = <
   TSignatures extends UseTreeItem2MinimalPlugins = UseTreeItem2MinimalPlugins,
+  TOptionalSignatures extends UseTreeItem2OptionalPlugins = UseTreeItem2OptionalPlugins,
 >(
   parameters: UseTreeItem2Parameters,
-): UseTreeItem2ReturnValue<TSignatures> => {
+): UseTreeItem2ReturnValue<TSignatures, TOptionalSignatures> => {
   const {
     runItemPlugins,
     selection: { multiSelect, disableSelection, checkboxSelection },
@@ -29,7 +31,7 @@ export const useTreeItem2 = <
     indentationAtItemLevel,
     instance,
     publicAPI,
-  } = useTreeViewContext<TSignatures>();
+  } = useTreeViewContext<TSignatures, TOptionalSignatures>();
   const depthContext = React.useContext(TreeViewItemDepthContext);
 
   const { id, itemId, label, children, rootRef } = parameters;

--- a/packages/x-tree-view/src/useTreeItem2/useTreeItem2.types.ts
+++ b/packages/x-tree-view/src/useTreeItem2/useTreeItem2.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TreeViewItemId } from '../models';
 import { MuiCancellableEventHandler } from '../internals/models/MuiCancellableEvent';
-import { TreeViewAnyPluginSignature, TreeViewPublicAPI } from '../internals/models';
+import { TreeViewPublicAPI } from '../internals/models';
 import { UseTreeViewSelectionSignature } from '../internals/plugins/useTreeViewSelection';
 import { UseTreeViewItemsSignature } from '../internals/plugins/useTreeViewItems';
 import { UseTreeViewIdSignature } from '../internals/plugins/useTreeViewId';
@@ -116,7 +116,8 @@ export interface UseTreeItem2Status {
 }
 
 export interface UseTreeItem2ReturnValue<
-  TSignatures extends readonly TreeViewAnyPluginSignature[],
+  TSignatures extends UseTreeItem2MinimalPlugins,
+  TOptionalSignatures extends UseTreeItem2OptionalPlugins,
 > {
   /**
    * Resolver for the root slot's props.
@@ -177,9 +178,12 @@ export interface UseTreeItem2ReturnValue<
   /**
    * The object the allows Tree View manipulation.
    */
-  publicAPI: TreeViewPublicAPI<TSignatures>;
+  publicAPI: TreeViewPublicAPI<TSignatures, TOptionalSignatures>;
 }
 
+/**
+ * Plugins that need to be present in the Tree View in order for `useTreeItem2` to work correctly.
+ */
 export type UseTreeItem2MinimalPlugins = readonly [
   UseTreeViewSelectionSignature,
   UseTreeViewItemsSignature,
@@ -187,3 +191,8 @@ export type UseTreeItem2MinimalPlugins = readonly [
   UseTreeViewFocusSignature,
   UseTreeViewKeyboardNavigationSignature,
 ];
+
+/**
+ * Plugins that `useTreeItem2` can use if they are present, but are not required.
+ */
+export type UseTreeItem2OptionalPlugins = readonly [];


### PR DESCRIPTION
Internal improvements for #13388

If a function needs to execute some logic from a plugin, it can usually be done in two ways:

1. The function calls some method exposed by the plugin (this is the role of the `apiRef` in both the Tree View and the Data Grid)
2. The function calls a generic method that do not depend on the plugin and on which the plugin might be hooked (this is the role of the pre-processors on the Data Grid and of the item wrapper and enhancers on the Tree View. For now the Tree View have no concept of pre-processors because it does not require it yet).

Solution 1. is usually simpler to implement and to read, but it does not respect the separation of concern, if our function is inside a plugin A and wants to call a method of the plugin B, then we have a dependency, A require B in order to work.
For pro features, we tend to favor solution 2 to avoid leaking pro code inside the community package (which is why the item enhancers have been introduced for the Drag and Drop feature on the Tree View). 
But on the Tree View, we also have to support 2 versions of the components in the same plan (`SimpleTreeView` and `RichTreeView`). @noraleonte is currently working on an editing feature that will only be available in the `RichTreeView`, this feature has a lot of dependencies (the keyboard navigation needs to be aware of it for example). We could rely on Solution 2 but it would make the codebase a lot harder to read. Instead, I am proposing to boost Solution 1. by introducing a notion of optional dependencies. The Plugin A is aware of the plugin B, it calls the method of the plugin B, but it is not sure if the plugin B is present or not.