### PR TITLE
[TreeView] Add `expansionTrigger` prop

### DIFF
--- a/docs/data/tree-view/rich-tree-view/customization/IconExpansionTreeView.js
+++ b/docs/data/tree-view/rich-tree-view/customization/IconExpansionTreeView.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
-import { useTreeItem2Utils } from '@mui/x-tree-view/hooks';
-
 import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
 
 const MUI_X_PRODUCTS = [
@@ -35,37 +33,14 @@ const MUI_X_PRODUCTS = [
   },
 ];
 
-const CustomTreeItem = React.forwardRef(function MyTreeItem(props, ref) {
-  const { interactions } = useTreeItem2Utils({
-    itemId: props.itemId,
-    children: props.children,
-  });
-
-  const handleContentClick = (event) => {
-    event.defaultMuiPrevented = true;
-    interactions.handleSelection(event);
-  };
-
-  const handleIconContainerClick = (event) => {
-    interactions.handleExpansion(event);
-  };
-
-  return (
-    <TreeItem2
-      {...props}
-      ref={ref}
-      slotProps={{
-        content: { onClick: handleContentClick },
-        iconContainer: { onClick: handleIconContainerClick },
-      }}
-    />
-  );
-});
-
 export default function IconExpansionTreeView() {
   return (
     <Box sx={{ minHeight: 352, minWidth: 250 }}>
-      <RichTreeView items={MUI_X_PRODUCTS} slots={{ item: CustomTreeItem }} />
+      <RichTreeView
+        items={MUI_X_PRODUCTS}
+        slots={{ item: TreeItem2 }}
+        expansionTrigger="iconContainer"
+      />
     </Box>
   );
 }

--- a/docs/data/tree-view/rich-tree-view/customization/IconExpansionTreeView.tsx
+++ b/docs/data/tree-view/rich-tree-view/customization/IconExpansionTreeView.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
-import { useTreeItem2Utils } from '@mui/x-tree-view/hooks';
-import { UseTreeItem2ContentSlotOwnProps } from '@mui/x-tree-view/useTreeItem2';
-import { TreeItem2, TreeItem2Props } from '@mui/x-tree-view/TreeItem2';
+import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
 import { TreeViewBaseItem } from '@mui/x-tree-view/models';
 
 const MUI_X_PRODUCTS: TreeViewBaseItem[] = [
@@ -36,40 +34,14 @@ const MUI_X_PRODUCTS: TreeViewBaseItem[] = [
   },
 ];
 
-const CustomTreeItem = React.forwardRef(function MyTreeItem(
-  props: TreeItem2Props,
-  ref: React.Ref<HTMLLIElement>,
-) {
-  const { interactions } = useTreeItem2Utils({
-    itemId: props.itemId,
-    children: props.children,
-  });
-
-  const handleContentClick: UseTreeItem2ContentSlotOwnProps['onClick'] = (event) => {
-    event.defaultMuiPrevented = true;
-    interactions.handleSelection(event);
-  };
-
-  const handleIconContainerClick = (event: React.MouseEvent) => {
-    interactions.handleExpansion(event);
-  };
-
-  return (
-    <TreeItem2
-      {...props}
-      ref={ref}
-      slotProps={{
-        content: { onClick: handleContentClick },
-        iconContainer: { onClick: handleIconContainerClick },
-      }}
-    />
-  );
-});
-
 export default function IconExpansionTreeView() {
   return (
     <Box sx={{ minHeight: 352, minWidth: 250 }}>
-      <RichTreeView items={MUI_X_PRODUCTS} slots={{ item: CustomTreeItem }} />
+      <RichTreeView
+        items={MUI_X_PRODUCTS}
+        slots={{ item: TreeItem2 }}
+        expansionTrigger="iconContainer"
+      />
     </Box>
   );
 }

--- a/docs/data/tree-view/rich-tree-view/customization/IconExpansionTreeView.tsx.preview
+++ b/docs/data/tree-view/rich-tree-view/customization/IconExpansionTreeView.tsx.preview
@@ -1,1 +1,5 @@
-<RichTreeView items={MUI_X_PRODUCTS} slots={{ item: CustomTreeItem }} />
+<RichTreeView
+  items={MUI_X_PRODUCTS}
+  slots={{ item: TreeItem2 }}
+  expansionTrigger="iconContainer"
+/>

--- a/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.js
+++ b/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.js
@@ -1,56 +1,27 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
-import { useTreeItem2Utils } from '@mui/x-tree-view/hooks';
-
 import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
-
-const CustomTreeItem = React.forwardRef(function MyTreeItem(props, ref) {
-  const { interactions } = useTreeItem2Utils({
-    itemId: props.itemId,
-    children: props.children,
-  });
-
-  const handleContentClick = (event) => {
-    event.defaultMuiPrevented = true;
-    interactions.handleSelection(event);
-  };
-
-  const handleIconContainerClick = (event) => {
-    interactions.handleExpansion(event);
-  };
-
-  return (
-    <TreeItem2
-      {...props}
-      ref={ref}
-      slotProps={{
-        content: { onClick: handleContentClick },
-        iconContainer: { onClick: handleIconContainerClick },
-      }}
-    />
-  );
-});
 
 export default function IconExpansionTreeView() {
   return (
     <Box sx={{ minHeight: 352, minWidth: 250 }}>
-      <SimpleTreeView aria-label="icon expansion">
-        <CustomTreeItem itemId="grid" label="Data Grid">
-          <CustomTreeItem itemId="grid-community" label="@mui/x-data-grid" />
-          <CustomTreeItem itemId="grid-pro" label="@mui/x-data-grid-pro" />
-          <CustomTreeItem itemId="grid-premium" label="@mui/x-data-grid-premium" />
-        </CustomTreeItem>
-        <CustomTreeItem itemId="pickers" label="Date and Time Pickers">
-          <CustomTreeItem itemId="pickers-community" label="@mui/x-date-pickers" />
-          <CustomTreeItem itemId="pickers-pro" label="@mui/x-date-pickers-pro" />
-        </CustomTreeItem>
-        <CustomTreeItem itemId="charts" label="Charts">
-          <CustomTreeItem itemId="charts-community" label="@mui/x-charts" />
-        </CustomTreeItem>
-        <CustomTreeItem itemId="tree-view" label="Tree View">
-          <CustomTreeItem itemId="tree-view-community" label="@mui/x-tree-view" />
-        </CustomTreeItem>
+      <SimpleTreeView aria-label="icon expansion" expansionTrigger="iconContainer">
+        <TreeItem2 itemId="grid" label="Data Grid">
+          <TreeItem2 itemId="grid-community" label="@mui/x-data-grid" />
+          <TreeItem2 itemId="grid-pro" label="@mui/x-data-grid-pro" />
+          <TreeItem2 itemId="grid-premium" label="@mui/x-data-grid-premium" />
+        </TreeItem2>
+        <TreeItem2 itemId="pickers" label="Date and Time Pickers">
+          <TreeItem2 itemId="pickers-community" label="@mui/x-date-pickers" />
+          <TreeItem2 itemId="pickers-pro" label="@mui/x-date-pickers-pro" />
+        </TreeItem2>
+        <TreeItem2 itemId="charts" label="Charts">
+          <TreeItem2 itemId="charts-community" label="@mui/x-charts" />
+        </TreeItem2>
+        <TreeItem2 itemId="tree-view" label="Tree View">
+          <TreeItem2 itemId="tree-view-community" label="@mui/x-tree-view" />
+        </TreeItem2>
       </SimpleTreeView>
     </Box>
   );

--- a/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.tsx
+++ b/docs/data/tree-view/simple-tree-view/customization/IconExpansionTreeView.tsx
@@ -1,59 +1,27 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
-import { useTreeItem2Utils } from '@mui/x-tree-view/hooks';
-import { UseTreeItem2ContentSlotOwnProps } from '@mui/x-tree-view/useTreeItem2';
-import { TreeItem2, TreeItem2Props } from '@mui/x-tree-view/TreeItem2';
-
-const CustomTreeItem = React.forwardRef(function MyTreeItem(
-  props: TreeItem2Props,
-  ref: React.Ref<HTMLLIElement>,
-) {
-  const { interactions } = useTreeItem2Utils({
-    itemId: props.itemId,
-    children: props.children,
-  });
-
-  const handleContentClick: UseTreeItem2ContentSlotOwnProps['onClick'] = (event) => {
-    event.defaultMuiPrevented = true;
-    interactions.handleSelection(event);
-  };
-
-  const handleIconContainerClick = (event: React.MouseEvent) => {
-    interactions.handleExpansion(event);
-  };
-
-  return (
-    <TreeItem2
-      {...props}
-      ref={ref}
-      slotProps={{
-        content: { onClick: handleContentClick },
-        iconContainer: { onClick: handleIconContainerClick },
-      }}
-    />
-  );
-});
+import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
 
 export default function IconExpansionTreeView() {
   return (
     <Box sx={{ minHeight: 352, minWidth: 250 }}>
-      <SimpleTreeView aria-label="icon expansion">
-        <CustomTreeItem itemId="grid" label="Data Grid">
-          <CustomTreeItem itemId="grid-community" label="@mui/x-data-grid" />
-          <CustomTreeItem itemId="grid-pro" label="@mui/x-data-grid-pro" />
-          <CustomTreeItem itemId="grid-premium" label="@mui/x-data-grid-premium" />
-        </CustomTreeItem>
-        <CustomTreeItem itemId="pickers" label="Date and Time Pickers">
-          <CustomTreeItem itemId="pickers-community" label="@mui/x-date-pickers" />
-          <CustomTreeItem itemId="pickers-pro" label="@mui/x-date-pickers-pro" />
-        </CustomTreeItem>
-        <CustomTreeItem itemId="charts" label="Charts">
-          <CustomTreeItem itemId="charts-community" label="@mui/x-charts" />
-        </CustomTreeItem>
-        <CustomTreeItem itemId="tree-view" label="Tree View">
-          <CustomTreeItem itemId="tree-view-community" label="@mui/x-tree-view" />
-        </CustomTreeItem>
+      <SimpleTreeView aria-label="icon expansion" expansionTrigger="iconContainer">
+        <TreeItem2 itemId="grid" label="Data Grid">
+          <TreeItem2 itemId="grid-community" label="@mui/x-data-grid" />
+          <TreeItem2 itemId="grid-pro" label="@mui/x-data-grid-pro" />
+          <TreeItem2 itemId="grid-premium" label="@mui/x-data-grid-premium" />
+        </TreeItem2>
+        <TreeItem2 itemId="pickers" label="Date and Time Pickers">
+          <TreeItem2 itemId="pickers-community" label="@mui/x-date-pickers" />
+          <TreeItem2 itemId="pickers-pro" label="@mui/x-date-pickers-pro" />
+        </TreeItem2>
+        <TreeItem2 itemId="charts" label="Charts">
+          <TreeItem2 itemId="charts-community" label="@mui/x-charts" />
+        </TreeItem2>
+        <TreeItem2 itemId="tree-view" label="Tree View">
+          <TreeItem2 itemId="tree-view-community" label="@mui/x-tree-view" />
+        </TreeItem2>
       </SimpleTreeView>
     </Box>
   );

--- a/docs/pages/x/api/tree-view/rich-tree-view.json
+++ b/docs/pages/x/api/tree-view/rich-tree-view.json
@@ -16,6 +16,10 @@
     "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
     "disableSelection": { "type": { "name": "bool" }, "default": "false" },
     "expandedItems": { "type": { "name": "arrayOf", "description": "Array&lt;string&gt;" } },
+    "expansionTrigger": {
+      "type": { "name": "enum", "description": "'content'<br>&#124;&nbsp;'iconContainer'" },
+      "default": "'content'"
+    },
     "experimentalFeatures": {
       "type": { "name": "shape", "description": "{ indentationAtItemLevel?: bool }" }
     },

--- a/docs/pages/x/api/tree-view/simple-tree-view.json
+++ b/docs/pages/x/api/tree-view/simple-tree-view.json
@@ -17,6 +17,10 @@
     "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
     "disableSelection": { "type": { "name": "bool" }, "default": "false" },
     "expandedItems": { "type": { "name": "arrayOf", "description": "Array&lt;string&gt;" } },
+    "expansionTrigger": {
+      "type": { "name": "enum", "description": "'content'<br>&#124;&nbsp;'iconContainer'" },
+      "default": "'content'"
+    },
     "experimentalFeatures": {
       "type": { "name": "shape", "description": "{ indentationAtItemLevel?: bool }" }
     },

--- a/docs/pages/x/api/tree-view/tree-view.json
+++ b/docs/pages/x/api/tree-view/tree-view.json
@@ -17,6 +17,10 @@
     "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
     "disableSelection": { "type": { "name": "bool" }, "default": "false" },
     "expandedItems": { "type": { "name": "arrayOf", "description": "Array&lt;string&gt;" } },
+    "expansionTrigger": {
+      "type": { "name": "enum", "description": "'content'<br>&#124;&nbsp;'iconContainer'" },
+      "default": "'content'"
+    },
     "experimentalFeatures": {
       "type": { "name": "shape", "description": "{ indentationAtItemLevel?: bool }" }
     },

--- a/docs/translations/api-docs/tree-view/rich-tree-view/rich-tree-view.json
+++ b/docs/translations/api-docs/tree-view/rich-tree-view/rich-tree-view.json
@@ -21,6 +21,9 @@
     "expandedItems": {
       "description": "Expanded item ids. Used when the item&#39;s expansion is controlled."
     },
+    "expansionTrigger": {
+      "description": "The slot that triggers the item&#39;s expansion when clicked."
+    },
     "experimentalFeatures": {
       "description": "Unstable features, breaking changes might be introduced. For each feature, if the flag is not explicitly set to <code>true</code>, the feature will be fully disabled and any property / method call will not have any effect."
     },

--- a/docs/translations/api-docs/tree-view/simple-tree-view/simple-tree-view.json
+++ b/docs/translations/api-docs/tree-view/simple-tree-view/simple-tree-view.json
@@ -22,6 +22,9 @@
     "expandedItems": {
       "description": "Expanded item ids. Used when the item&#39;s expansion is controlled."
     },
+    "expansionTrigger": {
+      "description": "The slot that triggers the item&#39;s expansion when clicked."
+    },
     "experimentalFeatures": {
       "description": "Unstable features, breaking changes might be introduced. For each feature, if the flag is not explicitly set to <code>true</code>, the feature will be fully disabled and any property / method call will not have any effect."
     },

--- a/docs/translations/api-docs/tree-view/tree-view/tree-view.json
+++ b/docs/translations/api-docs/tree-view/tree-view/tree-view.json
@@ -22,6 +22,9 @@
     "expandedItems": {
       "description": "Expanded item ids. Used when the item&#39;s expansion is controlled."
     },
+    "expansionTrigger": {
+      "description": "The slot that triggers the item&#39;s expansion when clicked."
+    },
     "experimentalFeatures": {
       "description": "Unstable features, breaking changes might be introduced. For each feature, if the flag is not explicitly set to <code>true</code>, the feature will be fully disabled and any property / method call will not have any effect."
     },

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
@@ -192,6 +192,11 @@ RichTreeView.propTypes = {
    */
   expandedItems: PropTypes.arrayOf(PropTypes.string),
   /**
+   * The slot that triggers the item's expansion when clicked.
+   * @default 'content'
+   */
+  expansionTrigger: PropTypes.oneOf(['content', 'iconContainer']),
+  /**
    * Unstable features, breaking changes might be introduced.
    * For each feature, if the flag is not explicitly set to `true`,
    * the feature will be fully disabled and any property / method call will not have any effect.

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -155,6 +155,11 @@ SimpleTreeView.propTypes = {
    */
   expandedItems: PropTypes.arrayOf(PropTypes.string),
   /**
+   * The slot that triggers the item's expansion when clicked.
+   * @default 'content'
+   */
+  expansionTrigger: PropTypes.oneOf(['content', 'iconContainer']),
+  /**
    * Unstable features, breaking changes might be introduced.
    * For each feature, if the flag is not explicitly set to `true`,
    * the feature will be fully disabled and any property / method call will not have any effect.

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -18,6 +18,7 @@ import { useTreeViewContext } from '../internals/TreeViewProvider/useTreeViewCon
 import { TreeViewCollapseIcon, TreeViewExpandIcon } from '../icons';
 import { TreeItem2Provider } from '../TreeItem2Provider';
 import { TreeViewItemDepthContext } from '../internals/TreeViewItemDepthContext';
+import { useTreeItemState } from './useTreeItemState';
 
 const useThemeProps = createUseThemeProps('MuiTreeItem');
 
@@ -182,6 +183,7 @@ export const TreeItem = React.forwardRef(function TreeItem(
     icons: contextIcons,
     runItemPlugins,
     selection: { multiSelect },
+    expansion: { expansionTrigger },
     disabledItemsFocusable,
     indentationAtItemLevel,
     instance,
@@ -207,6 +209,8 @@ export const TreeItem = React.forwardRef(function TreeItem(
     onKeyDown,
     ...other
   } = props;
+
+  const { handleExpansion } = useTreeItemState(itemId);
 
   const { contentRef, rootRef } = runItemPlugins<TreeItemProps>(props);
   const handleRootRef = useForkRef(inRef, rootRef);
@@ -258,6 +262,11 @@ export const TreeItem = React.forwardRef(function TreeItem(
     className: classes.groupTransition,
   });
 
+  const handleIconContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (expansionTrigger === 'iconContainer') {
+      handleExpansion(event);
+    }
+  };
   const ExpansionIcon = expanded ? slots.collapseIcon : slots.expandIcon;
   const { ownerState: expansionIconOwnerState, ...expansionIconProps } = useSlotProps({
     elementType: ExpansionIcon,
@@ -274,6 +283,9 @@ export const TreeItem = React.forwardRef(function TreeItem(
         ...resolveComponentProps(contextIcons.slotProps.expandIcon, tempOwnerState),
         ...resolveComponentProps(inSlotProps?.expandIcon, tempOwnerState),
       };
+    },
+    additionalProps: {
+      onClick: handleIconContainerClick,
     },
   });
   const expansionIcon =

--- a/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItemContent.tsx
@@ -82,6 +82,7 @@ const TreeItemContent = React.forwardRef(function TreeItemContent(
     handleSelection,
     handleCheckboxSelection,
     preventSelection,
+    expansionTrigger,
   } = useTreeItemState(itemId);
 
   const icon = iconProp || expansionIcon || displayIcon;
@@ -100,7 +101,9 @@ const TreeItemContent = React.forwardRef(function TreeItemContent(
       return;
     }
 
-    handleExpansion(event);
+    if (expansionTrigger === 'content') {
+      handleExpansion(event);
+    }
 
     if (!checkboxSelection) {
       handleSelection(event);

--- a/packages/x-tree-view/src/TreeItem/useTreeItemState.ts
+++ b/packages/x-tree-view/src/TreeItem/useTreeItemState.ts
@@ -16,6 +16,7 @@ export function useTreeItemState(itemId: string) {
   const {
     instance,
     selection: { multiSelect, checkboxSelection, disableSelection },
+    expansion: { expansionTrigger },
   } = useTreeViewContext<UseTreeItemStateMinimalPlugins>();
 
   const expandable = instance.isItemExpandable(itemId);
@@ -90,5 +91,6 @@ export function useTreeItemState(itemId: string) {
     handleSelection,
     handleCheckboxSelection,
     preventSelection,
+    expansionTrigger,
   };
 }

--- a/packages/x-tree-view/src/TreeView/TreeView.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.tsx
@@ -140,6 +140,11 @@ TreeView.propTypes = {
    */
   expandedItems: PropTypes.arrayOf(PropTypes.string),
   /**
+   * The slot that triggers the item's expansion when clicked.
+   * @default 'content'
+   */
+  expansionTrigger: PropTypes.oneOf(['content', 'iconContainer']),
+  /**
    * Unstable features, breaking changes might be introduced.
    * For each feature, if the flag is not explicitly set to `true`,
    * the feature will be fully disabled and any property / method call will not have any effect.

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.ts
@@ -83,6 +83,14 @@ export const useTreeViewExpansion: TreeViewPlugin<UseTreeViewExpansionSignature>
     }
   };
 
+  const expansionTrigger = React.useMemo(() => {
+    if (params.expansionTrigger) {
+      return params.expansionTrigger;
+    }
+
+    return 'content';
+  }, [params.expansionTrigger]);
+
   return {
     publicAPI: {
       setItemExpansion,
@@ -93,6 +101,11 @@ export const useTreeViewExpansion: TreeViewPlugin<UseTreeViewExpansionSignature>
       setItemExpansion,
       toggleItemExpansion,
       expandAllSiblings,
+    },
+    contextValue: {
+      expansion: {
+        expansionTrigger,
+      },
     },
   };
 };
@@ -108,6 +121,7 @@ const DEFAULT_EXPANDED_ITEMS: string[] = [];
 useTreeViewExpansion.getDefaultizedParams = (params) => ({
   ...params,
   defaultExpandedItems: params.defaultExpandedItems ?? DEFAULT_EXPANDED_ITEMS,
+  expansionTrigger: params.expansionTrigger ?? 'content',
 });
 
 useTreeViewExpansion.params = {
@@ -115,4 +129,5 @@ useTreeViewExpansion.params = {
   defaultExpandedItems: true,
   onExpandedItemsChange: true,
   onItemExpansionToggle: true,
+  expansionTrigger: true,
 };

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
@@ -72,12 +72,21 @@ export interface UseTreeViewExpansionParameters {
     itemId: string,
     isExpanded: boolean,
   ) => void;
+  /**
+   * The slot that triggers the item's expansion when clicked.
+   * @default 'content'
+   */
+  expansionTrigger?: 'content' | 'iconContainer';
 }
 
 export type UseTreeViewExpansionDefaultizedParameters = DefaultizedProps<
   UseTreeViewExpansionParameters,
-  'defaultExpandedItems'
+  'defaultExpandedItems' | 'expansionTrigger'
 >;
+
+interface UseTreeViewExpansionContextValue {
+  expansion: Pick<UseTreeViewExpansionDefaultizedParameters, 'expansionTrigger'>;
+}
 
 export type UseTreeViewExpansionSignature = TreeViewPluginSignature<{
   params: UseTreeViewExpansionParameters;
@@ -86,4 +95,5 @@ export type UseTreeViewExpansionSignature = TreeViewPluginSignature<{
   publicAPI: UseTreeViewExpansionPublicAPI;
   modelNames: 'expandedItems';
   dependantPlugins: [UseTreeViewItemsSignature];
+  contextValue: UseTreeViewExpansionContextValue;
 }>;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
@@ -94,6 +94,6 @@ export type UseTreeViewExpansionSignature = TreeViewPluginSignature<{
   instance: UseTreeViewExpansionInstance;
   publicAPI: UseTreeViewExpansionPublicAPI;
   modelNames: 'expandedItems';
-  dependantPlugins: [UseTreeViewItemsSignature];
   contextValue: UseTreeViewExpansionContextValue;
+  dependantPlugins: [UseTreeViewItemsSignature];
 }>;

--- a/packages/x-tree-view/src/useTreeItem2/useTreeItem2.ts
+++ b/packages/x-tree-view/src/useTreeItem2/useTreeItem2.ts
@@ -25,6 +25,7 @@ export const useTreeItem2 = <
   const {
     runItemPlugins,
     selection: { multiSelect, disableSelection, checkboxSelection },
+    expansion: { expansionTrigger },
     disabledItemsFocusable,
     indentationAtItemLevel,
     instance,
@@ -83,7 +84,9 @@ export const useTreeItem2 = <
         return;
       }
 
-      interactions.handleExpansion(event);
+      if (expansionTrigger === 'content') {
+        interactions.handleExpansion(event);
+      }
 
       if (!checkboxSelection) {
         interactions.handleSelection(event);
@@ -116,6 +119,17 @@ export const useTreeItem2 = <
       }
 
       interactions.handleCheckboxSelection(event);
+    };
+
+  const createIconContainerHandleClick =
+    (otherHandlers: EventHandlers) => (event: React.MouseEvent & MuiCancellableEvent) => {
+      otherHandlers.onClick?.(event);
+      if (event.defaultMuiPrevented) {
+        return;
+      }
+      if (expansionTrigger === 'iconContainer') {
+        interactions.handleExpansion(event);
+      }
     };
 
   const getRootProps = <ExternalProps extends Record<string, any> = {}>(
@@ -225,6 +239,7 @@ export const useTreeItem2 = <
     return {
       ...externalEventHandlers,
       ...externalProps,
+      onClick: createIconContainerHandleClick(externalEventHandlers),
     };
   };
 

--- a/packages/x-tree-view/src/useTreeItem2/useTreeItem2.types.ts
+++ b/packages/x-tree-view/src/useTreeItem2/useTreeItem2.types.ts
@@ -7,6 +7,7 @@ import { UseTreeViewItemsSignature } from '../internals/plugins/useTreeViewItems
 import { UseTreeViewIdSignature } from '../internals/plugins/useTreeViewId';
 import { UseTreeViewFocusSignature } from '../internals/plugins/useTreeViewFocus';
 import { UseTreeViewKeyboardNavigationSignature } from '../internals/plugins/useTreeViewKeyboardNavigation';
+import { UseTreeViewExpansionSignature } from '../internals';
 
 export interface UseTreeItem2Parameters {
   /**
@@ -68,7 +69,9 @@ export interface UseTreeItem2ContentSlotOwnProps {
 export type UseTreeItem2ContentSlotProps<ExternalProps = {}> = ExternalProps &
   UseTreeItem2ContentSlotOwnProps;
 
-export interface UseTreeItem2IconContainerSlotOwnProps {}
+export interface UseTreeItem2IconContainerSlotOwnProps {
+  onClick: MuiCancellableEventHandler<React.MouseEvent>;
+}
 
 export type UseTreeItemIconContainerSlotProps<ExternalProps = {}> = ExternalProps &
   UseTreeItem2IconContainerSlotOwnProps;
@@ -182,6 +185,7 @@ export interface UseTreeItem2ReturnValue<
 
 export type UseTreeItem2MinimalPlugins = readonly [
   UseTreeViewSelectionSignature,
+  UseTreeViewExpansionSignature,
   UseTreeViewItemsSignature,
   UseTreeViewIdSignature,
   UseTreeViewFocusSignature,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

extracted from https://github.com/mui/mui-x/pull/13388

By default, the expansion of a tree item is triggered if the `content` is clicked. This PR introduces a prop to allow users to override this behavior, and limit the expansion to `iconContainer`