### PR TITLE
[DataGrid] Fix CSV export escaping for non-string values

### DIFF
--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -6,7 +6,7 @@ import type { GridApiCommunity } from '../../../../models/api/gridApiCommunity';
 import { buildWarning } from '../../../../utils/warning';
 
 function sanitizeCellValue(value: unknown, csvOptions: CSVOptions): string {
-  const valueStr = typeof value === 'string' ? value : '' + value;
+  const valueStr = typeof value === 'string' ? value : `${value}`;
 
   if (csvOptions.shouldAppendQuotes || csvOptions.escapeFormulas) {
     const escapedValue = valueStr.replace(/"/g, '""');

--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -5,27 +5,25 @@ import type { GridStateColDef } from '../../../../models/colDef/gridColDef';
 import type { GridApiCommunity } from '../../../../models/api/gridApiCommunity';
 import { buildWarning } from '../../../../utils/warning';
 
-function sanitizeCellValue(value: any, csvOptions: CSVOptions) {
-  if (typeof value === 'string') {
-    if (csvOptions.shouldAppendQuotes || csvOptions.escapeFormulas) {
-      const escapedValue = value.replace(/"/g, '""');
-      // Make sure value containing delimiter or line break won't be split into multiple cells
-      if ([csvOptions.delimiter, '\n', '\r', '"'].some((delimiter) => value.includes(delimiter))) {
-        return `"${escapedValue}"`;
-      }
-      if (csvOptions.escapeFormulas) {
-        // See https://owasp.org/www-community/attacks/CSV_Injection
-        if (['=', '+', '-', '@', '\t', '\r'].includes(escapedValue[0])) {
-          return `'${escapedValue}`;
-        }
-      }
-      return escapedValue;
-    }
+function sanitizeCellValue(value: unknown, csvOptions: CSVOptions): string {
+  const valueStr = typeof value === 'string' ? value : '' + value;
 
-    return value;
+  if (csvOptions.shouldAppendQuotes || csvOptions.escapeFormulas) {
+    const escapedValue = valueStr.replace(/"/g, '""');
+    // Make sure value containing delimiter or line break won't be split into multiple cells
+    if ([csvOptions.delimiter, '\n', '\r', '"'].some((delimiter) => valueStr.includes(delimiter))) {
+      return `"${escapedValue}"`;
+    }
+    if (csvOptions.escapeFormulas) {
+      // See https://owasp.org/www-community/attacks/CSV_Injection
+      if (['=', '+', '-', '@', '\t', '\r'].includes(escapedValue[0])) {
+        return `'${escapedValue}`;
+      }
+    }
+    return escapedValue;
   }
 
-  return value;
+  return valueStr;
 }
 
 export const serializeCellValue = (


### PR DESCRIPTION
Fixes mui/mui-x#12945

The actual fix is to apply escaping to values other than just strings, by first converting the value to a string.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Before: https://codesandbox.io/p/sandbox/boring-wildflower-rwjz6x?file=%2Fsrc%2FDemo.tsx%3A4%2C53
After: https://codesandbox.io/p/sandbox/optimistic-rain-d8zhk8