### PR TITLE
[core] Update release readme with `pnpm` notice

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,9 @@
 
 > Tip: You can copy raw markdown checklist below to the release Pull Request and follow it step by step marking completed items.
 
+> Tip: Ensure you have `pnpm` installed as `release:build` uses it.
+> If you are not using `corepack`, run `npm install -g pnpm` to install it globally.
+
 A typical release goes like this:
 
 ### Prepare the release of the packages


### PR DESCRIPTION
Releasing `v6.x` locally requires `pnpm`.
Depending on the setup that might not be available (if `pnpm` is used only with `corepack`).