### PR TITLE
[TreeView] Remove unused state from `useTreeViewId`

### DIFF
--- a/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.types.ts
+++ b/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.types.ts
@@ -23,13 +23,8 @@ export interface UseTreeViewIdParameters {
 
 export type UseTreeViewIdDefaultizedParameters = UseTreeViewIdParameters;
 
-export interface UseTreeViewIdState {
-  focusedItemId: string | null;
-}
-
 export type UseTreeViewIdSignature = TreeViewPluginSignature<{
   params: UseTreeViewIdParameters;
   defaultizedParams: UseTreeViewIdDefaultizedParameters;
   instance: UseTreeViewIdInstance;
-  state: UseTreeViewIdState;
 }>;


### PR DESCRIPTION
No idea why it was here :laughing: 
It's also defined in `useTreeViewFocus` (and should only be defined there)