### PR TITLE
Disallow unknown properties in GridToolbarExportProps.

### DIFF
--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
@@ -32,7 +32,6 @@ export interface GridToolbarExportProps {
    * @default {}
    */
   slotProps?: { button?: Partial<ButtonProps>; tooltip?: Partial<TooltipProps> };
-  [key: string]: any;
 }
 
 export function GridCsvExportMenuItem(props: GridCsvExportMenuItemProps) {

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
@@ -70,7 +70,7 @@ export function GridPrintExportMenuItem(props: GridPrintExportMenuItemProps) {
 
 const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportProps>(
   function GridToolbarExport(props, ref) {
-    const { csvOptions = {}, printOptions = {}, excelOptions, ...other } = props;
+    const { csvOptions = {}, printOptions = {}, excelOptions, ...other } = props as GridToolbarExportProps & { excelOptions?: any };
 
     const apiRef = useGridApiContext();
 


### PR DESCRIPTION
This interface is exposed in `toolbar` property of `slotProps` and allowing arbitrary unknown properties prevents the type checker from catching unexpected properties (I nearly pushed a serious bug to production because I misspelled a toolbar property name).

The removed line was added in #3981 but appears to be unnecessary for supporting Excel export as the `excelOptions` property is added explicitly elsewhere. If the goal is to support users adding their own custom export types, this might be better accomplished by adding a `GridToolbarExportOverrides` interface to allow module augmentation.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
