### PR TITLE
[DataGridPro] Fix multi-sorting indicator being cut off

### DIFF
--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderSortIcon.tsx
@@ -80,7 +80,7 @@ function GridColumnHeaderSortIconRaw(props: GridColumnHeaderSortIconProps) {
   return (
     <GridIconButtonContainer>
       {index != null && (
-        <Badge badgeContent={index} color="default">
+        <Badge badgeContent={index} color="default" overlap="circular">
           {iconButton}
         </Badge>
       )}


### PR DESCRIPTION
Sets the multi-sort badge `overlap` prop to `circular` - this brings the number closer to the icon, and hopefully in most cases will prevent it getting cut off as seen in the issue below.

Tested on macOS Chrome, Safari and Firefox. 

https://deploy-preview-13625--material-ui-x.netlify.app/x/react-data-grid/sorting/#multi-sorting

Fixes #13406

## Before

![before](https://github.com/mui/mui-x/assets/9557798/f7766f2f-122c-448b-95cb-96597f9b2993)

## After

![after](https://github.com/mui/mui-x/assets/9557798/9b737121-12b9-4cc8-ae6e-4f51d47fdc46)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
