### PR TITLE
[TreeView] Support experimental features from plugin's dependencies

### DIFF
--- a/packages/x-tree-view/src/internals/models/plugin.ts
+++ b/packages/x-tree-view/src/internals/models/plugin.ts
@@ -67,7 +67,9 @@ export type TreeViewPluginSignature<
         >;
       }
     : {};
-  experimentalFeatures: T['experimentalFeatures'];
+  experimentalFeatures: T extends { experimentalFeatures: string }
+    ? { [key in T['experimentalFeatures']]?: boolean }
+    : {};
   dependencies: T extends { dependencies: Array<any> } ? T['dependencies'] : [];
   optionalDependencies: T extends { optionalDependencies: Array<any> }
     ? T['optionalDependencies']

--- a/packages/x-tree-view/src/internals/models/treeView.ts
+++ b/packages/x-tree-view/src/internals/models/treeView.ts
@@ -38,4 +38,5 @@ export type TreeViewPublicAPI<
 
 export type TreeViewExperimentalFeatures<
   TSignatures extends readonly TreeViewAnyPluginSignature[],
-> = { [key in MergeSignaturesProperty<TSignatures, 'experimentalFeatures'>]?: boolean };
+  TOptionalSignatures extends readonly TreeViewAnyPluginSignature[] = [],
+> = MergeSignaturesProperty<[...TSignatures, ...TOptionalSignatures], 'experimentalFeatures'>;

--- a/packages/x-tree-view/src/internals/useTreeView/extractPluginParamsFromProps.ts
+++ b/packages/x-tree-view/src/internals/useTreeView/extractPluginParamsFromProps.ts
@@ -71,6 +71,6 @@ export const extractPluginParamsFromProps = <
     pluginParams: defaultizedPluginParams,
     slots: slots ?? ({} as any),
     slotProps: slotProps ?? ({} as any),
-    experimentalFeatures: experimentalFeatures ?? {},
+    experimentalFeatures: experimentalFeatures ?? ({} as any),
   };
 };


### PR DESCRIPTION
While working on #13520, I noticed that if a plugin had an experimental feature and one of its dependencies also had an experimental feature, then the typing broke.

The reason is that calling `MergeSignaturesProperty` on a union did not work (we ended up with `'virtualization' & 'indentationPerLevel'` instead of `'virtualization' | 'indentationPerLevel'`.
I changed the logic to instead transform the experimental features into an object inside `TreeViewPluginSignature` to keep all the merging strategies consistent.