### PR TITLE
[charts] Fix charts not passing className to root element

### DIFF
--- a/packages/x-charts/src/BarChart/BarChart.test.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.test.tsx
@@ -2,15 +2,23 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { test } from 'mocha';
-import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+import { BarChart } from './BarChart';
 
-describe('<ResponsiveChartContainer />', () => {
+describe('<BarChart />', () => {
   const { render } = createRenderer();
-  const testClass = 'test-class-responsive-container';
+  const testClass = 'test-class';
 
   test('should pass className prop to root component', () => {
     const { container } = render(
-      <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+      <BarChart
+        height={100}
+        series={[
+          {
+            data: [100, 200],
+          },
+        ]}
+        className={testClass}
+      />,
     );
     expect(container.firstElementChild?.classList.contains(testClass)).to.equal(true);
   });

--- a/packages/x-charts/src/BarChart/useBarChartProps.ts
+++ b/packages/x-charts/src/BarChart/useBarChartProps.ts
@@ -50,6 +50,7 @@ export const useBarChartProps = (props: BarChartProps) => {
     onHighlightChange,
     borderRadius,
     barLabel,
+    className,
   } = props;
 
   const id = useId();
@@ -92,6 +93,7 @@ export const useBarChartProps = (props: BarChartProps) => {
       axisHighlight?.x === 'none' &&
       axisHighlight?.y === 'none' &&
       !onAxisClick,
+    className,
   };
 
   const barPlotProps: BarPlotProps = {

--- a/packages/x-charts/src/ChartContainer/ChartContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ChartContainer.tsx
@@ -59,6 +59,7 @@ const ChartContainer = React.forwardRef(function ChartContainer(props: ChartCont
     onHighlightChange,
     plugins,
     children,
+    className,
   } = props;
   const {
     svgRef,
@@ -99,6 +100,7 @@ const ChartContainer = React.forwardRef(function ChartContainer(props: ChartCont
                     title={title}
                     desc={desc}
                     disableAxisListener={disableAxisListener}
+                    className={className}
                   >
                     <ChartsAxesGradients />
                     {children}

--- a/packages/x-charts/src/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface.tsx
@@ -62,6 +62,7 @@ const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(functi
       height={height}
       viewBox={`${svgView.x} ${svgView.y} ${svgView.width} ${svgView.height}`}
       ref={ref}
+      className={className}
       {...other}
     >
       <title>{title}</title>

--- a/packages/x-charts/src/Gauge/Gauge.tsx
+++ b/packages/x-charts/src/Gauge/Gauge.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
+import clsx from 'clsx';
 import { GaugeContainer, GaugeContainerProps } from './GaugeContainer';
 import { GaugeValueArc } from './GaugeValueArc';
 import { GaugeReferenceArc } from './GaugeReferenceArc';
@@ -26,10 +27,10 @@ const useUtilityClasses = (props: GaugeProps) => {
 };
 
 function Gauge(props: GaugeProps) {
-  const { text, children, classes: propsClasses, ...other } = props;
+  const { text, children, classes: propsClasses, className, ...other } = props;
   const classes = useUtilityClasses(props);
   return (
-    <GaugeContainer {...other} className={classes.root}>
+    <GaugeContainer {...other} className={clsx(classes.root, className)}>
       <GaugeReferenceArc className={classes.referenceArc} />
       <GaugeValueArc className={classes.valueArc} />
       <GaugeValueText className={classes.valueText} text={text} />

--- a/packages/x-charts/src/Gauge/Gaugle.test.tsx
+++ b/packages/x-charts/src/Gauge/Gaugle.test.tsx
@@ -2,15 +2,26 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { test } from 'mocha';
-import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+import { Gauge } from './Gauge';
 
-describe('<ResponsiveChartContainer />', () => {
+describe('<Gauge />', () => {
   const { render } = createRenderer();
-  const testClass = 'test-class-responsive-container';
+  const testClass = 'test-class';
 
   test('should pass className prop to root component', () => {
     const { container } = render(
-      <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+      <Gauge
+        height={100}
+        series={[
+          {
+            data: [
+              { id: 'A', value: 100 },
+              { id: 'B', value: 200 },
+            ],
+          },
+        ]}
+        className={testClass}
+      />,
     );
     expect(container.firstElementChild?.classList.contains(testClass)).to.equal(true);
   });

--- a/packages/x-charts/src/LineChart/LineChart.test.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.test.tsx
@@ -2,15 +2,23 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { test } from 'mocha';
-import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+import { LineChart } from './LineChart';
 
-describe('<ResponsiveChartContainer />', () => {
+describe('<LineChart />', () => {
   const { render } = createRenderer();
-  const testClass = 'test-class-responsive-container';
+  const testClass = 'test-class';
 
   test('should pass className prop to root component', () => {
     const { container } = render(
-      <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+      <LineChart
+        height={100}
+        series={[
+          {
+            data: [100, 200],
+          },
+        ]}
+        className={testClass}
+      />,
     );
     expect(container.firstElementChild?.classList.contains(testClass)).to.equal(true);
   });

--- a/packages/x-charts/src/LineChart/useLineChartProps.ts
+++ b/packages/x-charts/src/LineChart/useLineChartProps.ts
@@ -53,6 +53,7 @@ export const useLineChartProps = (props: LineChartProps) => {
     loading,
     highlightedItem,
     onHighlightChange,
+    className,
   } = props;
 
   const id = useId();
@@ -88,6 +89,7 @@ export const useLineChartProps = (props: LineChartProps) => {
       axisHighlight?.x === 'none' &&
       axisHighlight?.y === 'none' &&
       !onAxisClick,
+    className,
   };
 
   const axisClickHandlerProps: ChartsOnAxisClickHandlerProps = {

--- a/packages/x-charts/src/PieChart/PieChart.test.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.test.tsx
@@ -2,15 +2,26 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { test } from 'mocha';
-import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+import { PieChart } from './PieChart';
 
-describe('<ResponsiveChartContainer />', () => {
+describe('<PieChart />', () => {
   const { render } = createRenderer();
-  const testClass = 'test-class-responsive-container';
+  const testClass = 'test-class';
 
   test('should pass className prop to root component', () => {
     const { container } = render(
-      <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+      <PieChart
+        height={100}
+        series={[
+          {
+            data: [
+              { id: 'A', value: 100 },
+              { id: 'B', value: 200 },
+            ],
+          },
+        ]}
+        className={testClass}
+      />,
     );
     expect(container.firstElementChild?.classList.contains(testClass)).to.equal(true);
   });

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -148,6 +148,7 @@ function PieChart(props: PieChartProps) {
     loading,
     highlightedItem,
     onHighlightChange,
+    className,
   } = props;
   const isRTL = useIsRTL();
 
@@ -183,6 +184,7 @@ function PieChart(props: PieChartProps) {
       }
       highlightedItem={highlightedItem}
       onHighlightChange={onHighlightChange}
+      className={className}
     >
       <ChartsAxis
         topAxis={topAxis}

--- a/packages/x-charts/src/ResponsiveChartContainer/ResponsiveChartContainer.test.tsx
+++ b/packages/x-charts/src/ResponsiveChartContainer/ResponsiveChartContainer.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { createRenderer } from '@mui/internal-test-utils';
+import { describeConformance } from 'test/utils/describeConformance';
+import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+
+describe('<ResponsiveChartContainer />', () => {
+  const { render } = createRenderer();
+  const testClass = 'test-class-responsive-container';
+  describeConformance(
+    <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+    () => ({
+      classes: { root: testClass },
+      inheritComponent: 'div',
+      muiName: 'MuiChartsResponsiveChartContainer',
+      render,
+      refInstanceof: window.HTMLDivElement,
+      // only: ['mergeClassName', 'propsSpread', 'refForwarding', 'rootClass'],
+    }),
+  );
+});

--- a/packages/x-charts/src/ResponsiveChartContainer/ResponsiveChartContainer.tsx
+++ b/packages/x-charts/src/ResponsiveChartContainer/ResponsiveChartContainer.tsx
@@ -24,9 +24,19 @@ const ResponsiveChartContainer = React.forwardRef(function ResponsiveChartContai
   const [containerRef, width, height] = useChartContainerDimensions(inWidth, inHeight);
 
   return (
-    <ResizableContainer ref={containerRef} ownerState={{ width: inWidth, height: inHeight }}>
+    <ResizableContainer
+      ref={containerRef}
+      ownerState={{ width: inWidth, height: inHeight }}
+      className={props.className}
+    >
       {width && height ? (
-        <ChartContainer {...other} width={width} height={height} ref={ref} />
+        <ChartContainer
+          {...other}
+          width={width}
+          height={height}
+          ref={ref}
+          className={props.className}
+        />
       ) : null}
     </ResizableContainer>
   );

--- a/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
@@ -2,15 +2,26 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { test } from 'mocha';
-import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+import { ScatterChart } from './ScatterChart';
 
-describe('<ResponsiveChartContainer />', () => {
+describe('<ScatterChart />', () => {
   const { render } = createRenderer();
-  const testClass = 'test-class-responsive-container';
+  const testClass = 'test-class';
 
   test('should pass className prop to root component', () => {
     const { container } = render(
-      <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+      <ScatterChart
+        height={100}
+        series={[
+          {
+            data: [
+              { id: 'A', x: 100, y: 10 },
+              { id: 'B', x: 200, y: 20 },
+            ],
+          },
+        ]}
+        className={testClass}
+      />,
     );
     expect(container.firstElementChild?.classList.contains(testClass)).to.equal(true);
   });

--- a/packages/x-charts/src/ScatterChart/useScatterChartProps.ts
+++ b/packages/x-charts/src/ScatterChart/useScatterChartProps.ts
@@ -45,6 +45,7 @@ export const useScatterChartProps = (props: ScatterChartProps) => {
     loading,
     highlightedItem,
     onHighlightChange,
+    className,
   } = props;
 
   const chartContainerProps: ResponsiveChartContainerProps = {
@@ -58,6 +59,7 @@ export const useScatterChartProps = (props: ScatterChartProps) => {
     sx,
     highlightedItem,
     onHighlightChange,
+    className,
   };
   const zAxisProps: Omit<ZAxisContextProviderProps, 'children'> = {
     zAxis,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.test.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.test.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { test } from 'mocha';
-import { ResponsiveChartContainer } from './ResponsiveChartContainer';
+import { SparkLineChart } from './SparkLineChart';
 
-describe('<ResponsiveChartContainer />', () => {
+describe('<SparkLineChart />', () => {
   const { render } = createRenderer();
-  const testClass = 'test-class-responsive-container';
+  const testClass = 'test-class';
 
   test('should pass className prop to root component', () => {
     const { container } = render(
-      <ResponsiveChartContainer height={100} series={[]} className={testClass} />,
+      <SparkLineChart height={100} data={[100, 200]} className={testClass} />,
     );
     expect(container.firstElementChild?.classList.contains(testClass)).to.equal(true);
   });

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -155,6 +155,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
     valueFormatter = (value: number | null) => (value === null ? '' : value.toString()),
     area,
     curve = 'linear',
+    className,
   } = props;
 
   const defaultXHighlight: { x: 'band' | 'none' } =
@@ -178,6 +179,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(props: SparkLine
       width={width}
       height={height}
       margin={margin}
+      className={className}
       xAxis={[
         {
           id: DEFAULT_X_AXIS_KEY,


### PR DESCRIPTION
Simply forward `className` to the root elements of all charts top level components.

I've tried using `describeConformance` but I couldn't fully understand it, so I've just tried using regular `classList.contains(class)` instead. Open to suggestions and explanations on how to improve that 😅 


fixes #13292