### PR TITLE
[fields] Fix section clearing behavior on Android

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -2030,13 +2030,13 @@ describe('<DateField /> - Editing', () => {
           fireEvent.change(input, { target: { value: initialValueStr.replace('23', '1') } });
         });
 
-        expectFieldValueV6(input, '11/21/2022');
+        expectFieldValueV6(input, '11/01/2022');
       });
 
       it('should support letter editing', () => {
         // Test with v6 input
         const v6Response = renderWithProps({
-          defaultValue: adapter.date('2022-05-16'),
+          defaultValue: adapter.date('2022-01-16'),
           format: `${adapter.formats.month} ${adapter.formats.year}`,
           enableAccessibleFieldDOMStructure: false,
         });
@@ -2057,10 +2057,10 @@ describe('<DateField /> - Editing', () => {
           fireEvent.change(input, { target: { value: ' 2022' } });
 
           // Set the key pressed in the selected section
-          fireEvent.change(input, { target: { value: 'u 2022' } });
+          fireEvent.change(input, { target: { value: 'a 2022' } });
         });
 
-        expectFieldValueV6(input, 'June 2022');
+        expectFieldValueV6(input, 'April 2022');
       });
     },
   );

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -377,10 +377,9 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
     if (keyPressed.length === 0) {
       if (isAndroid()) {
         setTempAndroidValueStr(valueStr);
-      } else {
-        resetCharacterQuery();
-        clearActiveSection();
       }
+      resetCharacterQuery();
+      clearActiveSection();
 
       return;
     }

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -162,6 +162,18 @@ export const useFieldV6TextField: UseFieldTextField<false> = (params) => {
               inputRef.current.setSelectionRange(selectionStart, selectionEnd);
             }
           }
+          setTimeout(() => {
+            // handle case when the selection is not updated correctly
+            // could happen on Android
+            if (
+              inputRef.current &&
+              inputRef.current === getActiveElement(document) &&
+              (inputRef.current.selectionStart !== selectionStart ||
+                inputRef.current.selectionEnd !== selectionEnd)
+            ) {
+              interactions.syncSelectionToDOM();
+            }
+          });
         }
 
         // Even reading this variable seems to do the trick, but also setting it just to make use of it


### PR DESCRIPTION
Fixes #13620 

Related to #10399.

The present behavior and test for section clearing on Android seemed incorrect.
It doesn't work like that on Desktop.
The change aligns the section clearing behavior between Desktop and Android.

~There is still an issue on Chrome on Android with syncing the focus on a section, which has a different length placeholder than the value (i.e. full length month).~

https://github.com/mui/mui-x/assets/4941090/72bcfc89-83d7-4c64-936d-f226e1ad65fd


~Maybe because it requires an extra repaint/resize cycle. 🤷 
If you have ideas on how to solve it—I'm all ears.
P.S. Wrapping the `syncSelectionToDOM` call in a `setTimeout` fixes the issue, but introduces a delay and causes the caret to be momentarily visible.
P.P.S. The situation with the MS Swiftkey keyboard is even worse... All the section selections are no syncked after section removal. 🙈~
This fix seems to avoid the problem and works stable: https://github.com/mui/mui-x/pull/13652/commits/73ed8e9e9e3455eab8e5cd7d8ccae8fd5739393c (albeit with a slight chance of endless recursion in an unforeseen case).

In any case, I'd be happy to ship this fix as is, because the current state of Chrome on Android with Gboard is pretty bad-unusable when deleting. 🙈 