### PR TITLE
[charts] Improve charts interaction for mobile users

### DIFF
--- a/packages/x-charts/src/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface.tsx
@@ -35,7 +35,10 @@ export interface ChartsSurfaceProps {
 const ChartChartsSurfaceStyles = styled('svg', {
   name: 'MuiChartsSurface',
   slot: 'Root',
-})(() => ({}));
+})(() => ({
+  // This prevents default touch actions when using the svg on mobile devices.
+  touchAction: 'none',
+}));
 
 const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(function ChartsSurface(
   props: ChartsSurfaceProps,

--- a/packages/x-charts/src/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface.tsx
@@ -37,6 +37,7 @@ const ChartChartsSurfaceStyles = styled('svg', {
   slot: 'Root',
 })(() => ({
   // This prevents default touch actions when using the svg on mobile devices.
+  // For example, prevent page scroll & zoom.
   touchAction: 'none',
 }));
 

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -149,6 +149,14 @@ function ChartsTooltip(props: ChartsTooltipProps) {
       placement:
         mousePosition?.pointerType === 'mouse' ? ('right-start' as const) : ('top' as const),
       anchorEl: generateVirtualElement(mousePosition),
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, mousePosition?.pointerType === 'touch' ? 40 - mousePosition.height : 0],
+          },
+        },
+      ],
     },
     ownerState: {},
   });

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -146,7 +146,7 @@ function ChartsTooltip(props: ChartsTooltipProps) {
     externalSlotProps: slotProps?.popper,
     additionalProps: {
       open: popperOpen,
-      placement: 'right-start' as const,
+      placement: mousePosition?.isMouse ? ('right-start' as const) : ('top' as const),
       anchorEl: generateVirtualElement(mousePosition),
     },
     ownerState: {},

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -146,7 +146,8 @@ function ChartsTooltip(props: ChartsTooltipProps) {
     externalSlotProps: slotProps?.popper,
     additionalProps: {
       open: popperOpen,
-      placement: mousePosition?.isMouse ? ('right-start' as const) : ('top' as const),
+      placement:
+        mousePosition?.pointerType === 'mouse' ? ('right-start' as const) : ('top' as const),
       anchorEl: generateVirtualElement(mousePosition),
     },
     ownerState: {},

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -64,8 +64,6 @@ export function useMouseTracker() {
     };
 
     const handleMove = (event: PointerEvent) => {
-      document.getElementById('console')!.innerText =
-        `${event.height} ${event.width} ${event.pointerType}`;
       setMousePosition({
         x: event.clientX,
         y: event.clientY,

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -23,7 +23,7 @@ export function generateVirtualElement(
   }
   const { x, y, isMouse } = mousePosition;
   const xPosition = x;
-  const yPosition = y + (isMouse ? 0 : -30);
+  const yPosition = y + (isMouse ? 0 : -40);
   const boundingBox = {
     width: 0,
     height: 0,

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -3,9 +3,14 @@ import { AxisInteractionData, ItemInteractionData } from '../context/Interaction
 import { ChartSeriesType } from '../models/seriesType/config';
 import { useSvgRef } from '../hooks';
 
-export function generateVirtualElement(
-  mousePosition: { x: number; y: number; isMouse: boolean } | null,
-) {
+type MousePosition = {
+  x: number;
+  y: number;
+  pointerType: 'mouse' | 'touch' | 'pen';
+  height: number;
+};
+
+export function generateVirtualElement(mousePosition: MousePosition | null) {
   if (mousePosition === null) {
     return {
       getBoundingClientRect: () => ({
@@ -21,9 +26,9 @@ export function generateVirtualElement(
       }),
     };
   }
-  const { x, y, isMouse } = mousePosition;
+  const { x, y, pointerType, height } = mousePosition;
   const xPosition = x;
-  const yPosition = y + (isMouse ? 0 : -40);
+  const yPosition = y - (pointerType === 'touch' ? 40 - height : 0);
   const boundingBox = {
     width: 0,
     height: 0,
@@ -46,11 +51,7 @@ export function useMouseTracker() {
   const svgRef = useSvgRef();
 
   // Use a ref to avoid rerendering on every mousemove event.
-  const [mousePosition, setMousePosition] = React.useState<null | {
-    x: number;
-    y: number;
-    isMouse: boolean;
-  }>(null);
+  const [mousePosition, setMousePosition] = React.useState<MousePosition | null>(null);
 
   React.useEffect(() => {
     const element = svgRef.current;
@@ -63,10 +64,13 @@ export function useMouseTracker() {
     };
 
     const handleMove = (event: PointerEvent) => {
+      document.getElementById('console')!.innerText =
+        `${event.height} ${event.width} ${event.pointerType}`;
       setMousePosition({
         x: event.clientX,
         y: event.clientY,
-        isMouse: event.pointerType === 'mouse',
+        height: event.height,
+        pointerType: event.pointerType as MousePosition['pointerType'],
       });
     };
 

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -26,18 +26,16 @@ export function generateVirtualElement(mousePosition: MousePosition | null) {
       }),
     };
   }
-  const { x, y, pointerType, height } = mousePosition;
-  const xPosition = x;
-  const yPosition = y - (pointerType === 'touch' ? 40 - height : 0);
+  const { x, y } = mousePosition;
   const boundingBox = {
     width: 0,
     height: 0,
-    x: xPosition,
-    y: yPosition,
-    top: yPosition,
-    right: xPosition,
-    bottom: yPosition,
-    left: xPosition,
+    x: x,
+    y: y,
+    top: y,
+    right: x,
+    bottom: y,
+    left: x,
   };
   return {
     getBoundingClientRect: () => ({

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -52,23 +52,19 @@ export function useMouseTracker() {
       setMousePosition(null);
     };
 
-    const handleMove = (event: MouseEvent | TouchEvent) => {
-      const target = 'targetTouches' in event ? event.targetTouches[0] : event;
+    const handleMove = (event: PointerEvent) => {
       setMousePosition({
-        x: target.clientX,
-        y: target.clientY,
+        x: event.clientX,
+        y: event.clientY,
       });
     };
 
-    element.addEventListener('mouseout', handleOut);
-    element.addEventListener('mousemove', handleMove);
-    element.addEventListener('touchend', handleOut);
-    element.addEventListener('touchmove', handleMove);
+    element.addEventListener('pointermove', handleMove);
+    element.addEventListener('pointerup', handleOut);
+
     return () => {
-      element.removeEventListener('mouseout', handleOut);
-      element.removeEventListener('mousemove', handleMove);
-      element.addEventListener('touchend', handleOut);
-      element.addEventListener('touchmove', handleMove);
+      element.removeEventListener('pointermove', handleMove);
+      element.removeEventListener('pointerup', handleOut);
     };
   }, [svgRef]);
 

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -30,8 +30,8 @@ export function generateVirtualElement(mousePosition: MousePosition | null) {
   const boundingBox = {
     width: 0,
     height: 0,
-    x: x,
-    y: y,
+    x,
+    y,
     top: y,
     right: x,
     bottom: y,

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -97,7 +97,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       | 'outside-voronoi-max-radius'
       | 'no-point-found' {
       // Get mouse coordinate in global SVG space
-      const svgPoint = getSVGPoint(svgRef.current!, event);
+      const svgPoint = getSVGPoint(element, event);
 
       const outsideX = svgPoint.x < left || svgPoint.x > left + width;
       const outsideY = svgPoint.y < top || svgPoint.y > top + height;
@@ -180,12 +180,12 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       onItemClick(event, { type: 'scatter', seriesId, dataIndex });
     };
 
-    element.addEventListener('mouseout', handleMouseOut);
-    element.addEventListener('mousemove', handleMouseMove);
+    element.addEventListener('pointerout', handleMouseOut);
+    element.addEventListener('pointermove', handleMouseMove);
     element.addEventListener('click', handleMouseClick);
     return () => {
-      element.removeEventListener('mouseout', handleMouseOut);
-      element.removeEventListener('mousemove', handleMouseMove);
+      element.removeEventListener('pointerout', handleMouseOut);
+      element.removeEventListener('pointermove', handleMouseMove);
       element.removeEventListener('click', handleMouseClick);
     };
   }, [

--- a/packages/x-charts/src/hooks/useAxisEvents.ts
+++ b/packages/x-charts/src/hooks/useAxisEvents.ts
@@ -102,7 +102,7 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
 
     const handleMove = (event: MouseEvent | TouchEvent) => {
       const target = 'targetTouches' in event ? event.targetTouches[0] : event;
-      const svgPoint = getSVGPoint(svgRef.current!, target);
+      const svgPoint = getSVGPoint(element, target);
 
       mousePosition.current = {
         x: svgPoint.x,
@@ -121,15 +121,26 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
       dispatch({ type: 'updateAxis', data: { x: newStateX, y: newStateY } });
     };
 
-    element.addEventListener('mouseout', handleOut);
-    element.addEventListener('mousemove', handleMove);
-    element.addEventListener('touchend', handleOut);
-    element.addEventListener('touchmove', handleMove);
+    const handleDown = (event: PointerEvent) => {
+      const target = event.currentTarget;
+      if (!target) return;
+
+      if ((target as HTMLElement).hasPointerCapture(event.pointerId)) {
+        (target as HTMLElement).releasePointerCapture(event.pointerId);
+      }
+    };
+
+    element.addEventListener('pointerdown', handleDown);
+    element.addEventListener('pointermove', handleMove);
+    element.addEventListener('pointerout', handleOut);
+    element.addEventListener('pointercancel', handleOut);
+    element.addEventListener('pointerleave', handleOut);
     return () => {
-      element.removeEventListener('mouseout', handleOut);
-      element.removeEventListener('mousemove', handleMove);
-      element.removeEventListener('touchend', handleOut);
-      element.removeEventListener('touchmove', handleMove);
+      element.removeEventListener('pointerdown', handleDown);
+      element.removeEventListener('pointermove', handleMove);
+      element.removeEventListener('pointerout', handleOut);
+      element.removeEventListener('pointercancel', handleOut);
+      element.removeEventListener('pointerleave', handleOut);
     };
   }, [
     svgRef,

--- a/packages/x-charts/src/hooks/useAxisEvents.ts
+++ b/packages/x-charts/src/hooks/useAxisEvents.ts
@@ -123,7 +123,9 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
 
     const handleDown = (event: PointerEvent) => {
       const target = event.currentTarget;
-      if (!target) return;
+      if (!target) {
+        return;
+      }
 
       if ((target as HTMLElement).hasPointerCapture(event.pointerId)) {
         (target as HTMLElement).releasePointerCapture(event.pointerId);

--- a/packages/x-charts/src/hooks/useInteractionItemProps.ts
+++ b/packages/x-charts/src/hooks/useInteractionItemProps.ts
@@ -11,7 +11,12 @@ export const useInteractionItemProps = (skip?: boolean) => {
     return () => ({});
   }
   const getInteractionItemProps = (data: SeriesItemIdentifier) => {
-    const onMouseEnter = () => {
+    const onPointerDown = (event: React.PointerEvent) => {
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+    };
+    const onPointerEnter = (event: React.PointerEvent) => {
       dispatchInteraction({
         type: 'enterItem',
         data,
@@ -21,13 +26,15 @@ export const useInteractionItemProps = (skip?: boolean) => {
         dataIndex: data.dataIndex,
       });
     };
-    const onMouseLeave = () => {
+    const onPointerLeave = (event: React.PointerEvent) => {
+      event.currentTarget.releasePointerCapture(event.pointerId);
       dispatchInteraction({ type: 'leaveItem', data });
       clearHighlighted();
     };
     return {
-      onMouseEnter,
-      onMouseLeave,
+      onPointerEnter,
+      onPointerLeave,
+      onPointerDown,
     };
   };
   return getInteractionItemProps;

--- a/packages/x-charts/src/hooks/useInteractionItemProps.ts
+++ b/packages/x-charts/src/hooks/useInteractionItemProps.ts
@@ -16,7 +16,7 @@ export const useInteractionItemProps = (skip?: boolean) => {
         event.currentTarget.releasePointerCapture(event.pointerId);
       }
     };
-    const onPointerEnter = (event: React.PointerEvent) => {
+    const onPointerEnter = () => {
       dispatchInteraction({
         type: 'enterItem',
         data,


### PR DESCRIPTION
- Disable `touchActions` on mobile inside the SVG
- Move events to use `pointer` events instead of high-level `touch/mouse` for better pointer capture control.
  - This allows users to move the thumb around on mobile and the tooltip updates accordingly
- Move tooltip to the `top` when we detect user is not using a mouse
- Add some extra padding between pointer and tooltip
  - `const yPosition = y - (pointerType === 'touch' ? 40 - height : 0);`
  - `height` is the height of the pointer itself, eg: a mouse is usually `1px`, a thumb is around `2-5px`, a touch indicator on mobile emulation is a big circle, `~30px`, this formula allows us to display somewhat decently in most common situations.

Recoding on actual mobile

https://github.com/mui/mui-x/assets/9891233/8ef47858-35c7-4c20-b95d-de8aca67d119


fixes #13109


