### PR TITLE
[code-infra] Cleanup monorepo and `@mui/docs` usage

### DIFF
--- a/docs/data/charts/gauge/gauge.md
+++ b/docs/data/charts/gauge/gauge.md
@@ -11,7 +11,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/meter/
 
 <p class="description">Gauge charts let the user evaluate metrics.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
 ## Basics
 

--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -9,7 +9,7 @@ packageName: '@mui/x-charts'
 
 <p class="description">A fast and extendable library of react chart components for data visualization.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "@mui/docs/ComponentLinkHeader", "design": false}}
 
 ## Overview
 

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -12,7 +12,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 The Data Grid component is built with React and TypeScript to provide a smooth UX for manipulating an unlimited set of data.
 It features an intuitive API for real-time updates as well as theming and custom templates—all with blazing-fast performance.
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
+{{"component": "@mui/docs/ComponentLinkHeader"}}
 
 ## Overview
 

--- a/docs/data/date-pickers/date-picker/CustomizationExamplesNoSnap.js
+++ b/docs/data/date-pickers/date-picker/CustomizationExamplesNoSnap.js
@@ -4,7 +4,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Stack from '@mui/material/Stack';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import BrandingProvider from 'docs/src/BrandingProvider';
+import { BrandingProvider } from '@mui/docs/branding';
 import CustomizationPlayground from 'docsx/src/modules/components/CustomizationPlayground';
 import CircularProgress from '@mui/material/CircularProgress';
 import { pickerExamples } from './examplesConfig.styling';

--- a/docs/data/date-pickers/overview/overview.md
+++ b/docs/data/date-pickers/overview/overview.md
@@ -11,7 +11,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepick
 
 <p class="description">These react date picker and time picker components let users select date or time values.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
+{{"component": "@mui/docs/ComponentLinkHeader"}}
 
 ## Overview
 

--- a/docs/data/tree-view/overview/overview.md
+++ b/docs/data/tree-view/overview/overview.md
@@ -10,7 +10,7 @@ packageName: '@mui/x-tree-view'
 
 <p class="description">The Tree View component lets users navigate hierarchical lists of data with nested levels that can be expanded and collapsed.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
+{{"component": "@mui/docs/ComponentLinkHeader"}}
 
 ## Available components
 

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -65,7 +65,6 @@ export default withDocsInfra({
   transpilePackages: [
     // TODO, those shouldn't be needed in the first place
     '@mui/monorepo', // Migrate everything to @mui/docs until the @mui/monorepo dependency becomes obsolete
-    '@mui/docs',
   ],
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -65,6 +65,7 @@ export default withDocsInfra({
   transpilePackages: [
     // TODO, those shouldn't be needed in the first place
     '@mui/monorepo', // Migrate everything to @mui/docs until the @mui/monorepo dependency becomes obsolete
+    '@mui/docs', // needed to fix slashes in the generated links (https://github.com/mui/mui-x/pull/13713#issuecomment-2205591461, )
   ],
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: process.env.DEPLOY_ENV === 'development' ? undefined : '/x',

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -21,9 +21,6 @@ const require = createRequire(import.meta.url);
 
 const WORKSPACE_ROOT = path.resolve(currentDirectory, '../');
 const MONOREPO_PATH = path.resolve(WORKSPACE_ROOT, './node_modules/@mui/monorepo');
-const MONOREPO_ALIASES = {
-  '@mui/docs': path.resolve(MONOREPO_PATH, './packages/mui-docs/src'),
-};
 
 const WORKSPACE_ALIASES = {
   '@mui/x-data-grid': path.resolve(WORKSPACE_ROOT, './packages/x-data-grid/src'),
@@ -108,7 +105,6 @@ export default withDocsInfra({
         ...config.resolve,
         alias: {
           ...config.resolve.alias,
-          ...MONOREPO_ALIASES,
           ...WORKSPACE_ALIASES,
           // TODO: get rid of this, replace with @mui/docs
           docs: path.resolve(MONOREPO_PATH, './docs'),

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -21,6 +21,9 @@ const require = createRequire(import.meta.url);
 
 const WORKSPACE_ROOT = path.resolve(currentDirectory, '../');
 const MONOREPO_PATH = path.resolve(WORKSPACE_ROOT, './node_modules/@mui/monorepo');
+const MONOREPO_ALIASES = {
+  '@mui/docs': path.resolve(MONOREPO_PATH, './packages/mui-docs/src'),
+};
 
 const WORKSPACE_ALIASES = {
   '@mui/x-data-grid': path.resolve(WORKSPACE_ROOT, './packages/x-data-grid/src'),
@@ -105,6 +108,7 @@ export default withDocsInfra({
         ...config.resolve,
         alias: {
           ...config.resolve.alias,
+          ...MONOREPO_ALIASES,
           ...WORKSPACE_ALIASES,
           // TODO: get rid of this, replace with @mui/docs
           docs: path.resolve(MONOREPO_PATH, './docs'),

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.5",
     "@mui/base": "^5.0.0-beta.40",
+    "@mui/docs": "^6.0.0-alpha.13",
     "@mui/icons-material": "^5.15.21",
     "@mui/joy": "5.0.0-beta.32",
     "@mui/lab": "^5.0.0-alpha.170",

--- a/docs/src/modules/components/ChartFeaturesGrid.js
+++ b/docs/src/modules/components/ChartFeaturesGrid.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Grid from '@mui/material/Unstable_Grid2';
-import InfoCard from 'docs/src/components/action/InfoCard';
+import { InfoCard } from '@mui/docs/InfoCard';
 import LineAxisRoundedIcon from '@mui/icons-material/LineAxisRounded';
 import DashboardCustomizeRoundedIcon from '@mui/icons-material/DashboardCustomizeRounded';
 import LegendToggleRoundedIcon from '@mui/icons-material/LegendToggleRounded';

--- a/docs/src/modules/components/ChartsUsageDemo.js
+++ b/docs/src/modules/components/ChartsUsageDemo.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Box from '@mui/joy/Box';
-import BrandingProvider from 'docs/src/BrandingProvider';
+import { BrandingProvider } from '@mui/docs/branding';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
 import DemoPropsForm from './DemoPropsForm';
 

--- a/docs/src/modules/components/ComponentLinkHeader.js
+++ b/docs/src/modules/components/ComponentLinkHeader.js
@@ -1,1 +1,0 @@
-export { default } from 'docs/src/modules/components/ComponentLinkHeader';

--- a/docs/src/modules/components/CustomizationPlayground.tsx
+++ b/docs/src/modules/components/CustomizationPlayground.tsx
@@ -351,7 +351,7 @@ const CustomizationPlayground = function CustomizationPlayground({
           {moreInformation}
         </PlaygroundDemoArea>
         {shouldBeInteractive && (
-          // @ts-ignore - `undefined` `mode` is handled
+          // @ts-expect-error - should no longer be a problem when `BrandingProvider` supports `undefined`: https://github.com/mui/material-ui/pull/42833
           <BrandingProvider>
             <PlaygroundConfigArea>
               <ConfigSectionWrapper>
@@ -405,7 +405,7 @@ const CustomizationPlayground = function CustomizationPlayground({
         )}
       </PlaygroundWrapper>
       {selectedDemo && customizationOptions && selectedCustomizationOption && (
-        // @ts-ignore - `undefined` `mode` is handled
+        // @ts-expect-error - should no longer be a problem when `BrandingProvider` supports `undefined`: https://github.com/mui/material-ui/pull/42833
         <BrandingProvider>
           <TabsWrapper>
             <StylingApproachTabs

--- a/docs/src/modules/components/CustomizationPlayground.tsx
+++ b/docs/src/modules/components/CustomizationPlayground.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-// @ts-ignore
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
-// @ts-ignore
-import BrandingProvider from 'docs/src/BrandingProvider';
+import { BrandingProvider } from '@mui/docs/branding';
 import { styled, Theme, alpha, useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Tabs from '@mui/material/Tabs';
@@ -353,6 +351,7 @@ const CustomizationPlayground = function CustomizationPlayground({
           {moreInformation}
         </PlaygroundDemoArea>
         {shouldBeInteractive && (
+          // @ts-ignore - `undefined` `mode` is handled
           <BrandingProvider>
             <PlaygroundConfigArea>
               <ConfigSectionWrapper>
@@ -406,6 +405,7 @@ const CustomizationPlayground = function CustomizationPlayground({
         )}
       </PlaygroundWrapper>
       {selectedDemo && customizationOptions && selectedCustomizationOption && (
+        // @ts-ignore - `undefined` `mode` is handled
         <BrandingProvider>
           <TabsWrapper>
             <StylingApproachTabs

--- a/docs/src/modules/components/InstallationGrid.js
+++ b/docs/src/modules/components/InstallationGrid.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Grid from '@mui/material/Unstable_Grid2';
-import InfoCard from 'docs/src/components/action/InfoCard';
+import { InfoCard } from '@mui/docs/InfoCard';
 import AccountTreeRounded from '@mui/icons-material/AccountTreeRounded';
 import PivotTableChartRoundedIcon from '@mui/icons-material/PivotTableChartRounded';
 import CalendarMonthRoundedIcon from '@mui/icons-material/CalendarMonthRounded';

--- a/docs/src/modules/components/InterfaceApiPage.js
+++ b/docs/src/modules/components/InterfaceApiPage.js
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import VerifiedRoundedIcon from '@mui/icons-material/VerifiedRounded';
 import { alpha } from '@mui/material/styles';
-import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
+import { useTranslate, useUserLanguage } from '@mui/docs/i18n';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
 import { MarkdownElement } from '@mui/docs/MarkdownElement';
 import { SectionTitle } from '@mui/docs/SectionTitle';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       '@mui/base':
         specifier: ^5.0.0-beta.40
         version: 5.0.0-beta.40(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/docs':
+        specifier: ^6.0.0-alpha.13
+        version: 6.0.0-alpha.13(iw4ny2enbrlfobn5tze2av46uq)
       '@mui/icons-material':
         specifier: ^5.15.21
         version: 5.15.21(@mui/material@5.15.21(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
@@ -2762,6 +2765,21 @@ packages:
 
   '@mui/core-downloads-tracker@5.15.21':
     resolution: {integrity: sha512-dp9lXBaJZzJYeJfQY3Ow4Rb49QaCEdkl2KKYscdQHQm6bMJ+l4XPY3Cd9PCeeJTsHPIDJ60lzXbeRgs6sx/rpw==}
+
+  '@mui/docs@6.0.0-alpha.13':
+    resolution: {integrity: sha512-ijFZ2O65jGateb1/BK+1+Eir/jZ7hT1ZRgH7s3KJ5YEIcGN+PnAHOYBHEr3oOPqStaGJsZpXp887BYS0ztAGGQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@mui/base': '*'
+      '@mui/icons-material': ^5.0.0
+      '@mui/material': ^5.0.0
+      '@mui/system': ^5.0.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      next: ^13.5.1 || ^14
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@mui/icons-material@5.15.21':
     resolution: {integrity: sha512-yqkq1MbdkmX5ZHyvZTBuAaA6RkvoqkoAgwBSx9Oh0L0jAfj9T/Ih/NhMNjkl8PWVSonjfDUkKroBnjRyo/1M9Q==}
@@ -11059,6 +11077,23 @@ snapshots:
       '@types/react': 18.3.3
 
   '@mui/core-downloads-tracker@5.15.21': {}
+
+  '@mui/docs@6.0.0-alpha.13(iw4ny2enbrlfobn5tze2av46uq)':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@mui/base': 5.0.0-beta.40(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/icons-material': 5.15.21(@mui/material@5.15.21(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
+      '@mui/internal-markdown': 1.0.6
+      '@mui/material': 5.15.21(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 5.15.20(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
+      clipboard-copy: 4.0.1
+      clsx: 2.1.1
+      next: 14.2.4(@babel/core@7.24.7)(@opentelemetry/api@1.8.0)(@playwright/test@1.44.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      nprogress: 0.2.0
+      prop-types: 15.8.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   '@mui/icons-material@5.15.21(@mui/material@5.15.21(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)':
     dependencies:

--- a/scripts/buildApiDocs/tsconfig.json
+++ b/scripts/buildApiDocs/tsconfig.json
@@ -14,9 +14,6 @@
     "strict": true,
     "baseUrl": "./",
     "paths": {
-      "@mui/material-nextjs/*": [
-        "../../node_modules/@mui/monorepo/packages/mui-material-nextjs/src/*"
-      ],
       "docs/config": ["../../node_modules/@mui/monorepo/docs/config.d.ts"],
       "@mui-internal/api-docs-builder": [
         "../../node_modules/@mui/monorepo/packages/api-docs-builder/index.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,6 @@
       "@mui/x-license/*": ["./packages/x-license/src/*"],
       "@mui/x-internals": ["./packages/x-internals/src"],
       "@mui/x-internals/*": ["./packages/x-internals/src/*"],
-      "@mui/docs": ["./node_modules/@mui/monorepo/packages/mui-docs/src"],
-      "@mui/docs/*": ["./node_modules/@mui/monorepo/packages/mui-docs/src/*"],
       "@mui-internal/api-docs-builder": ["./node_modules/@mui/monorepo/packages/api-docs-builder"],
       "@mui-internal/api-docs-builder/*": [
         "./node_modules/@mui/monorepo/packages/api-docs-builder/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,8 @@
       "@mui/x-license/*": ["./packages/x-license/src/*"],
       "@mui/x-internals": ["./packages/x-internals/src"],
       "@mui/x-internals/*": ["./packages/x-internals/src/*"],
+      "@mui/docs": ["./node_modules/@mui/monorepo/packages/mui-docs/src"],
+      "@mui/docs/*": ["./node_modules/@mui/monorepo/packages/mui-docs/src/*"],
       "@mui-internal/api-docs-builder": ["./node_modules/@mui/monorepo/packages/api-docs-builder"],
       "@mui-internal/api-docs-builder/*": [
         "./node_modules/@mui/monorepo/packages/api-docs-builder/*"


### PR DESCRIPTION
- Cleanup remaining usages of imports that can be replaced with `@mui/docs`
- Use `@mui/docs` from npm (as a dep) instead of aliasing `monorepo`