### PR TITLE
[charts] Zoom Props

### DIFF
--- a/packages/x-charts-pro/src/context/ZoomProvider/ZoomProps.ts
+++ b/packages/x-charts-pro/src/context/ZoomProvider/ZoomProps.ts
@@ -1,0 +1,23 @@
+export type ZoomOptions = {
+  axisId?: string;
+  axis: 'x' | 'y';
+  min?: number;
+  max?: number;
+  step?: number;
+  minSpan?: number;
+  maxSpan?: number;
+};
+
+export type ZoomData = {
+  range: [number, number];
+  axisId: string;
+};
+
+export type ZoomState = {
+  zoomState: ZoomData[];
+  onZoomChange: (params: ZoomData) => void;
+};
+
+export type ZoomProps = {
+  zoom?: ZoomOptions[] | 'x' | 'y' | 'xy';
+};

--- a/packages/x-charts-pro/src/context/ZoomProvider/ZoomProps.ts
+++ b/packages/x-charts-pro/src/context/ZoomProvider/ZoomProps.ts
@@ -6,6 +6,7 @@ export type ZoomOptions = {
   step?: number;
   minSpan?: number;
   maxSpan?: number;
+  panning?: boolean;
 };
 
 export type ZoomData = {

--- a/packages/x-charts-pro/src/context/ZoomProvider/defaultizeZoom.ts
+++ b/packages/x-charts-pro/src/context/ZoomProvider/defaultizeZoom.ts
@@ -1,0 +1,27 @@
+import { ZoomOptions, ZoomProps } from './ZoomProps';
+
+const defaultZoomOptions = {
+  min: 0,
+  max: 100,
+  step: 5,
+  minSpan: 10,
+  maxSpan: 100,
+};
+
+export const defaultizeZoomOptions = (
+  zoom: ZoomProps['zoom'],
+): (Required<Omit<ZoomOptions, 'axisId'>> & Pick<ZoomOptions, 'axisId'>)[] | undefined => {
+  if (zoom === 'x') {
+    return [{ axis: 'x', ...defaultZoomOptions }];
+  }
+  if (zoom === 'y') {
+    return [{ axis: 'y', ...defaultZoomOptions }];
+  }
+  if (zoom === 'xy') {
+    return [
+      { axis: 'x', ...defaultZoomOptions },
+      { axis: 'y', ...defaultZoomOptions },
+    ];
+  }
+  return zoom?.map((v) => ({ ...defaultZoomOptions, ...v }));
+};


### PR DESCRIPTION
I see at least two options for the zooming props, let me know what you think

1. zoomOptions: ZoomOptions is a separate prop from the rest of the props.
   - We then have zoom: ZoomState
2. ZoomOptions is inside axis, eg: xAxis={{ zoom: ZoomOptions }}
   - We then have zoom: ZoomState

I prefer 1 because it is standalone and offers a sufficient level of abstraction. But I feel the dx of 2 is better for the end user.