### PR TITLE
[DateRangePicker] Fix `calendarHeader` slot props propagation

### DIFF
--- a/packages/x-date-pickers-pro/src/PickersRangeCalendarHeader/PickersRangeCalendarHeader.tsx
+++ b/packages/x-date-pickers-pro/src/PickersRangeCalendarHeader/PickersRangeCalendarHeader.tsx
@@ -41,6 +41,7 @@ const PickersRangeCalendarHeader = React.forwardRef(function PickersRangeCalenda
     minDate,
     maxDate,
     timezone,
+    // omit props that are not used in the PickersArrowSwitcher
     reduceAnimations,
     views,
     view,

--- a/packages/x-date-pickers-pro/src/PickersRangeCalendarHeader/PickersRangeCalendarHeader.tsx
+++ b/packages/x-date-pickers-pro/src/PickersRangeCalendarHeader/PickersRangeCalendarHeader.tsx
@@ -41,7 +41,11 @@ const PickersRangeCalendarHeader = React.forwardRef(function PickersRangeCalenda
     minDate,
     maxDate,
     timezone,
-  } = props;
+    reduceAnimations,
+    views,
+    view,
+    ...otherRangeProps
+  } = other;
 
   const isNextMonthDisabled = useNextMonthDisabled(currentMonth, {
     disableFuture,
@@ -65,6 +69,7 @@ const PickersRangeCalendarHeader = React.forwardRef(function PickersRangeCalenda
 
   return (
     <PickersRangeCalendarHeaderContentMultipleCalendars
+      {...otherRangeProps}
       ref={ref}
       onGoToPrevious={selectPreviousMonth}
       onGoToNext={selectNextMonth}


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/13774.