### PR TITLE
[charts] Fix area with log scale

### DIFF
--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -91,7 +91,13 @@ const useAggregatedData = () => {
         }>()
           .x((d) => xScale(d.x))
           .defined((_, i) => connectNulls || data[i] != null)
-          .y0((d) => d.y && yScale(d.y[0])!)
+          .y0((d) => {
+            const value = d.y && yScale(d.y[0])!;
+            if (Number.isNaN(value)) {
+              return yScale.range()[0];
+            }
+            return value;
+          })
           .y1((d) => d.y && yScale(d.y[1])!);
 
         const curve = getCurveFactory(series[seriesId].curve);

--- a/packages/x-charts/src/LineChart/extremums.ts
+++ b/packages/x-charts/src/LineChart/extremums.ts
@@ -41,7 +41,8 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
         const { area, stackedData } = series[seriesId];
         const isArea = area !== undefined;
 
-        const getValues: GetValuesTypes = isArea ? (d) => d : (d) => [d[1], d[1]]; // Since this series is not used to display an area, we do not consider the base (the d[0]).
+        const getValues: GetValuesTypes =
+          isArea && axis.scaleType !== 'log' ? (d) => d : (d) => [d[1], d[1]]; // Since this series is not used to display an area, we do not consider the base (the d[0]).
 
         const seriesExtremums = getSeriesExtremums(getValues, stackedData);
 


### PR DESCRIPTION
Fix #13759

The issue codesandbox with the fix https://codesandbox.io/s/quirky-meadow-glcdvy?file=/src/Demo.tsx

@JCQuintas The idea is to use the axis scale to replace the base value if out of range (the scale returns a NaN) I assume it will be impacted by zoom in a sens that we will need to refine the replacement value to be compatible