### PR TITLE
[charts] Allow controlling the demo form from the example

### DIFF
--- a/docs/src/modules/components/ChartsUsageDemo.js
+++ b/docs/src/modules/components/ChartsUsageDemo.js
@@ -55,7 +55,7 @@ export default function ChartsUsageDemo({
             width: '100%',
           }}
         >
-          {renderDemo(demoProps)}
+          {renderDemo(demoProps, setProps)}
         </Box>
         <BrandingProvider mode="dark">
           <HighlightedCode
@@ -69,7 +69,12 @@ export default function ChartsUsageDemo({
           />
         </BrandingProvider>
       </Box>
-      <DemoPropsForm data={data} componentName={componentName} onPropsChange={setProps} />
+      <DemoPropsForm
+        data={data}
+        props={props}
+        componentName={componentName}
+        onPropsChange={setProps}
+      />
     </Box>
   );
 }

--- a/docs/src/modules/components/ChartsUsageDemo.js
+++ b/docs/src/modules/components/ChartsUsageDemo.js
@@ -12,26 +12,22 @@ export default function ChartsUsageDemo({
   renderDemo,
   getCode,
 }) {
-  const initialProps = {};
-  let demoProps = {};
-  let codeBlockProps = {};
-  data.forEach((p) => {
-    demoProps[p.propName] = p.defaultValue;
-    if (p.codeBlockDisplay) {
-      initialProps[p.propName] = p.defaultValue;
-    }
-    if (!p.knob) {
-      codeBlockProps[p.propName] = p.defaultValue;
-    }
-  });
-  const [props, setProps] = React.useState(initialProps);
-  demoProps = { ...demoProps, ...props };
-  codeBlockProps = { ...props, ...codeBlockProps };
-  data.forEach((p) => {
-    if (p.codeBlockDisplay === false) {
-      delete codeBlockProps[p.propName];
-    }
-  });
+  const [props, setProps] = React.useState(
+    data.reduce((acc, { propName, defaultValue }) => {
+      acc[propName] = defaultValue;
+      return acc;
+    }, {}),
+  );
+
+  React.useEffect(() => {
+    setProps(
+      data.reduce((acc, { propName, defaultValue }) => {
+        acc[propName] = defaultValue;
+        return acc;
+      }, {}),
+    );
+  }, [data]);
+
   return (
     <Box
       sx={{
@@ -55,13 +51,18 @@ export default function ChartsUsageDemo({
             width: '100%',
           }}
         >
-          {renderDemo(demoProps, setProps)}
+          {renderDemo(props, setProps)}
         </Box>
         <BrandingProvider mode="dark">
           <HighlightedCode
             code={getCode({
               name: componentName,
-              props: codeBlockProps,
+              props: Object.entries(props).reduce((acc, [key, value]) => {
+                if (data.find((d) => d.propName === key)?.codeBlockDisplay !== false) {
+                  acc[key] = value;
+                }
+                return acc;
+              }, {}),
               childrenAccepted,
             })}
             language="jsx"

--- a/docs/src/modules/components/DemoPropsForm.tsx
+++ b/docs/src/modules/components/DemoPropsForm.tsx
@@ -11,6 +11,7 @@ import FormLabel, { formLabelClasses } from '@mui/material/FormLabel';
 import IconButton from '@mui/material/IconButton';
 import Input, { inputClasses } from '@mui/material/Input';
 import MenuItem from '@mui/material/MenuItem';
+import Slider from '@mui/material/Slider';
 
 import FormControlLabel, { formControlLabelClasses } from '@mui/material/FormControlLabel';
 import Radio from '@mui/material/Radio';
@@ -30,11 +31,11 @@ const shallowEqual = (item1: { [k: string]: any }, item2: { [k: string]: any }) 
   return equal;
 };
 
-type DataType<ComponentProps> = {
+type DataType<PropName> = {
   /**
    * Name of the prop, for example 'children'
    */
-  propName: Extract<keyof ComponentProps, string>;
+  propName: PropName;
   /**
    * The controller to be used:
    * - `switch`: render the switch component for boolean
@@ -42,8 +43,18 @@ type DataType<ComponentProps> = {
    * - `select`: render <select> with the specified options
    * - `input`: render <input />
    * - `radio`: render group of radios
+   * - `slider`: render the slider component
    */
-  knob?: 'switch' | 'color' | 'select' | 'input' | 'radio' | 'controlled' | 'number' | 'placement';
+  knob?:
+    | 'switch'
+    | 'color'
+    | 'select'
+    | 'input'
+    | 'radio'
+    | 'controlled'
+    | 'number'
+    | 'placement'
+    | 'slider';
   /**
    * The options for these knobs: `select` and `radio`
    */
@@ -78,9 +89,9 @@ type DataType<ComponentProps> = {
    * Option for knobs: `number`
    */
   max?: number;
-}[];
+};
 
-interface ChartDemoPropsFormProps<ComponentProps> {
+interface ChartDemoPropsFormProps<PropName extends string> {
   /**
    * Name of the component to show in the code block.
    */
@@ -88,8 +99,12 @@ interface ChartDemoPropsFormProps<ComponentProps> {
   /**
    * Configuration
    */
-  data: DataType<ComponentProps>;
-  onPropsChange: (data: any) => void;
+  data: DataType<PropName>[];
+  /**
+   * Props to be displayed in the form
+   */
+  props: Record<PropName, any>;
+  onPropsChange: (data: Record<PropName, any> | ((data: Record<PropName, any>) => void)) => void;
 }
 
 function ControlledColorRadio(props: any) {
@@ -131,26 +146,32 @@ function ControlledColorRadio(props: any) {
   );
 }
 
-export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>({
+const a = [
+  {
+    propName: 'yolo',
+  },
+  {
+    propName: 'children',
+  },
+];
+
+export default function ChartDemoPropsForm<T extends string>({
   componentName,
   data,
+  props,
   onPropsChange,
 }: ChartDemoPropsFormProps<T>) {
-  const initialProps = {} as { [k in keyof T]: any };
-  let demoProps = {} as { [k in keyof T]: any };
-
-  data.forEach((p) => {
-    demoProps[p.propName] = p.defaultValue;
-
-    initialProps[p.propName] = p.defaultValue;
-  });
-  const [props, setProps] = React.useState<T>(initialProps as T);
+  const initialProps = React.useRef<Record<T, any>>({} as Record<T, any>);
 
   React.useEffect(() => {
-    onPropsChange(props);
-  }, [props, onPropsChange]);
-
-  demoProps = { ...demoProps, ...props };
+    data.reduce(
+      (acc, { propName, defaultValue }) => {
+        acc[propName] = defaultValue;
+        return acc;
+      },
+      {} as Record<T, any>,
+    );
+  }, [data]);
 
   return (
     <Box
@@ -187,7 +208,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
         <IconButton
           aria-label="Reset all"
           size="small"
-          onClick={() => setProps(initialProps as T)}
+          onClick={() => onPropsChange(initialProps.current)}
           sx={{
             visibility: !shallowEqual(props, initialProps) ? 'visible' : 'hidden',
             '--IconButton-size': '30px',
@@ -224,11 +245,30 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                 <Switch
                   checked={Boolean(resolvedValue)}
                   onChange={(event) =>
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: event.target.checked,
                     }))
                   }
+                />
+              </FormControl>
+            );
+          }
+          if (knob === 'slider') {
+            return (
+              <FormControl key={propName}>
+                <FormLabel>{propName}</FormLabel>
+                <Slider
+                  value={Number.parseFloat(`${resolvedValue}`)}
+                  onChange={(_, value) =>
+                    onPropsChange((latestProps) => ({
+                      ...latestProps,
+                      [propName]: Number.parseFloat(`${value}`),
+                    }))
+                  }
+                  step={step}
+                  min={min}
+                  max={max}
                 />
               </FormControl>
             );
@@ -251,7 +291,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                     } else if (value === 'undefined') {
                       value = undefined;
                     }
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: value,
                     }));
@@ -282,7 +322,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                   name={`${componentName}-color`}
                   value={resolvedValue || ''}
                   onChange={(event) =>
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: event.target.value,
                     }))
@@ -317,7 +357,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                   placeholder="Select a variant..."
                   value={(resolvedValue || 'none') as string}
                   onChange={(event) =>
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: event.target.value,
                     }))
@@ -340,7 +380,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                   size="small"
                   value={props[propName] ?? ''}
                   onChange={(event) =>
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: event.target.value,
                     }))
@@ -371,7 +411,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                     if (Number.isNaN(Number.parseFloat(event.target.value))) {
                       return;
                     }
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: Number.parseFloat(event.target.value),
                     }));
@@ -401,7 +441,7 @@ export default function ChartDemoPropsForm<T extends { [k: string]: any } = {}>(
                   name="placement"
                   value={resolvedValue}
                   onChange={(event) =>
-                    setProps((latestProps) => ({
+                    onPropsChange((latestProps) => ({
                       ...latestProps,
                       [propName]: event.target.value,
                     }))

--- a/docs/src/modules/components/DemoPropsForm.tsx
+++ b/docs/src/modules/components/DemoPropsForm.tsx
@@ -152,25 +152,17 @@ export default function ChartDemoPropsForm<T extends string>({
   props,
   onPropsChange,
 }: ChartDemoPropsFormProps<T>) {
-  const initialProps = React.useRef<Record<T, any>>(
-    data.reduce(
-      (acc, { propName, defaultValue }) => {
-        acc[propName] = defaultValue;
-        return acc;
-      },
-      {} as Record<T, any>,
-    ),
+  const initialProps = React.useMemo<Record<T, any>>(
+    () =>
+      data.reduce(
+        (acc, { propName, defaultValue }) => {
+          acc[propName] = defaultValue;
+          return acc;
+        },
+        {} as Record<T, any>,
+      ),
+    [data],
   );
-
-  React.useEffect(() => {
-    data.reduce(
-      (acc, { propName, defaultValue }) => {
-        acc[propName] = defaultValue;
-        return acc;
-      },
-      {} as Record<T, any>,
-    );
-  }, [data]);
 
   return (
     <Box
@@ -207,9 +199,9 @@ export default function ChartDemoPropsForm<T extends string>({
         <IconButton
           aria-label="Reset all"
           size="small"
-          onClick={() => onPropsChange(initialProps.current)}
+          onClick={() => onPropsChange(initialProps)}
           sx={{
-            visibility: !shallowEqual(props, initialProps.current) ? 'visible' : 'hidden',
+            visibility: !shallowEqual(props, initialProps) ? 'visible' : 'hidden',
             '--IconButton-size': '30px',
           }}
         >

--- a/docs/src/modules/components/DemoPropsForm.tsx
+++ b/docs/src/modules/components/DemoPropsForm.tsx
@@ -146,15 +146,6 @@ function ControlledColorRadio(props: any) {
   );
 }
 
-const a = [
-  {
-    propName: 'yolo',
-  },
-  {
-    propName: 'children',
-  },
-];
-
 export default function ChartDemoPropsForm<T extends string>({
   componentName,
   data,

--- a/docs/src/modules/components/DemoPropsForm.tsx
+++ b/docs/src/modules/components/DemoPropsForm.tsx
@@ -45,7 +45,7 @@ type DataType<PropName> = {
    * - `radio`: render group of radios
    * - `slider`: render the slider component
    */
-  knob?:
+  knob:
     | 'switch'
     | 'color'
     | 'select'
@@ -161,7 +161,15 @@ export default function ChartDemoPropsForm<T extends string>({
   props,
   onPropsChange,
 }: ChartDemoPropsFormProps<T>) {
-  const initialProps = React.useRef<Record<T, any>>({} as Record<T, any>);
+  const initialProps = React.useRef<Record<T, any>>(
+    data.reduce(
+      (acc, { propName, defaultValue }) => {
+        acc[propName] = defaultValue;
+        return acc;
+      },
+      {} as Record<T, any>,
+    ),
+  );
 
   React.useEffect(() => {
     data.reduce(
@@ -210,7 +218,7 @@ export default function ChartDemoPropsForm<T extends string>({
           size="small"
           onClick={() => onPropsChange(initialProps.current)}
           sx={{
-            visibility: !shallowEqual(props, initialProps) ? 'visible' : 'hidden',
+            visibility: !shallowEqual(props, initialProps.current) ? 'visible' : 'hidden',
             '--IconButton-size': '30px',
           }}
         >


### PR DESCRIPTION
- Make `ChartDemoPropsForm` only work in controlled mode. Controller is now `ChartsUsageDemo`
- This allows us to pass the `onChange` handler to the render function, which allows children(examples) to change the knobs from their own logic 
  - Useful on zoom to prevent throwing errors, we can check if prop.start > prop.end and update the knobs accordingly. 
- Cleaned up typing a and logic (removed undefined knob logic)
- Added `slider` component

For testing the slider locally.

```tsx
import * as React from 'react';
import Box from '@mui/material/Box';
import ChartsUsageDemo from 'docsx/src/modules/components/ChartsUsageDemo';
import { ScatterChart } from '@mui/x-charts/ScatterChart';
import { Chance } from 'chance';

const chance = new Chance(42);

const data = Array.from({ length: 200 }, () => ({
  x: chance.floating({ min: -25, max: 25 }),
  y: chance.floating({ min: -25, max: 25 }),
})).map((d, index) => ({ ...d, id: index }));

const knobs = [{ propName: 'tickSize', knob: 'slider', defaultValue: 6 }];
export default function AxisCustomizationNoSnap() {
  return (
    <ChartsUsageDemo
      componentName="Alert"
      data={knobs}
      renderDemo={(props, onChange) => (
        <Box sx={{ width: '100%', maxWidth: 400 }}>
          <button onClick={() => onChange({ ...props, tickSize: 50 })}>
            Change
          </button>
          <ScatterChart
            series={[
              {
                type: 'scatter',
                id: 'linear',
                data,
              },
            ]}
            leftAxis={null}
            bottomAxis={{
              ...props,
            }}
            height={300}
            margin={{ top: 10, left: 20, right: 20 }}
          />
        </Box>
      )}
      getCode={({ props }) =>
        [
          ...Object.keys(props).map(
            (prop) =>
              `    ${prop}: ${
                typeof props[prop] === 'string' ? `"${props[prop]}"` : props[prop]
              },`,
          ),
        ].join('\n')
      }
    />
  );
}

```