### PR TITLE
[DataGrid] Fix: enable flip on preferences panel

### DIFF
--- a/packages/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.tsx
@@ -81,8 +81,8 @@ const GridPanel = React.forwardRef<HTMLDivElement, GridPanelProps>((props, ref) 
         name: 'flip',
         enabled: true,
         options: {
-          rootBoundary: 'document'
-        }
+          rootBoundary: 'document',
+        },
       },
       {
         name: 'isPlaced',

--- a/packages/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.tsx
@@ -79,7 +79,10 @@ const GridPanel = React.forwardRef<HTMLDivElement, GridPanelProps>((props, ref) 
     () => [
       {
         name: 'flip',
-        enabled: false,
+        enabled: true,
+        options: {
+          rootBoundary: 'document'
+        }
       },
       {
         name: 'isPlaced',


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/13473

Enable flip on the grid panel, as described in https://github.com/mui/mui-x/issues/13473#issuecomment-2168022198.

Before: https://codesandbox.io/p/sandbox/kind-roman-jqt8hy
After: https://codesandbox.io/p/sandbox/serene-cookies-p8ffrf