### PR TITLE
[TreeView] Add `getItemTree` and `getItemOrderedChildrenIds` methods to the public API

### DIFF
--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemOrderedChildrenIds.js
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemOrderedChildrenIds.js
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
+
+import { useTreeViewApiRef } from '@mui/x-tree-view/hooks';
+
+const MUI_X_PRODUCTS = [
+  {
+    id: 'grid',
+    label: 'Data Grid',
+    children: [
+      { id: 'grid-community', label: '@mui/x-data-grid' },
+      { id: 'grid-pro', label: '@mui/x-data-grid-pro' },
+      { id: 'grid-premium', label: '@mui/x-data-grid-premium' },
+    ],
+  },
+  {
+    id: 'pickers',
+    label: 'Date and Time Pickers',
+    children: [
+      { id: 'pickers-community', label: '@mui/x-date-pickers' },
+      { id: 'pickers-pro', label: '@mui/x-date-pickers-pro' },
+    ],
+  },
+  {
+    id: 'charts',
+    label: 'Charts',
+    children: [{ id: 'charts-community', label: '@mui/x-charts' }],
+  },
+  {
+    id: 'tree-view',
+    label: 'Tree View',
+    children: [{ id: 'tree-view-community', label: '@mui/x-tree-view' }],
+  },
+];
+
+export default function ApiMethodGetItemOrderedChildrenIds() {
+  const apiRef = useTreeViewApiRef();
+  const [isSelectedItemLeaf, setIsSelectedItemLeaf] = React.useState(null);
+
+  const handleSelectedItemsChange = (event, itemId) => {
+    if (itemId == null) {
+      setIsSelectedItemLeaf(null);
+    } else {
+      const children = apiRef.current.getItemOrderedChildrenIds(itemId);
+      setIsSelectedItemLeaf(children.length === 0);
+    }
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Typography>
+        {isSelectedItemLeaf == null && 'No item selected'}
+        {isSelectedItemLeaf === true && 'The selected item is a leaf'}
+        {isSelectedItemLeaf === false && 'The selected item is a node with children'}
+      </Typography>
+      <Box sx={{ minHeight: 352, minWidth: 300 }}>
+        <RichTreeView
+          items={MUI_X_PRODUCTS}
+          apiRef={apiRef}
+          onSelectedItemsChange={handleSelectedItemsChange}
+        />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemOrderedChildrenIds.tsx
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemOrderedChildrenIds.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
+import { TreeViewBaseItem } from '@mui/x-tree-view/models';
+import { useTreeViewApiRef } from '@mui/x-tree-view/hooks';
+
+const MUI_X_PRODUCTS: TreeViewBaseItem[] = [
+  {
+    id: 'grid',
+    label: 'Data Grid',
+    children: [
+      { id: 'grid-community', label: '@mui/x-data-grid' },
+      { id: 'grid-pro', label: '@mui/x-data-grid-pro' },
+      { id: 'grid-premium', label: '@mui/x-data-grid-premium' },
+    ],
+  },
+  {
+    id: 'pickers',
+    label: 'Date and Time Pickers',
+    children: [
+      { id: 'pickers-community', label: '@mui/x-date-pickers' },
+      { id: 'pickers-pro', label: '@mui/x-date-pickers-pro' },
+    ],
+  },
+  {
+    id: 'charts',
+    label: 'Charts',
+    children: [{ id: 'charts-community', label: '@mui/x-charts' }],
+  },
+  {
+    id: 'tree-view',
+    label: 'Tree View',
+    children: [{ id: 'tree-view-community', label: '@mui/x-tree-view' }],
+  },
+];
+
+export default function ApiMethodGetItemOrderedChildrenIds() {
+  const apiRef = useTreeViewApiRef();
+  const [isSelectedItemLeaf, setIsSelectedItemLeaf] = React.useState<boolean | null>(
+    null,
+  );
+
+  const handleSelectedItemsChange = (
+    event: React.SyntheticEvent,
+    itemId: string | null,
+  ) => {
+    if (itemId == null) {
+      setIsSelectedItemLeaf(null);
+    } else {
+      const children = apiRef.current!.getItemOrderedChildrenIds(itemId);
+      setIsSelectedItemLeaf(children.length === 0);
+    }
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Typography>
+        {isSelectedItemLeaf == null && 'No item selected'}
+        {isSelectedItemLeaf === true && 'The selected item is a leaf'}
+        {isSelectedItemLeaf === false && 'The selected item is a node with children'}
+      </Typography>
+      <Box sx={{ minHeight: 352, minWidth: 300 }}>
+        <RichTreeView
+          items={MUI_X_PRODUCTS}
+          apiRef={apiRef}
+          onSelectedItemsChange={handleSelectedItemsChange}
+        />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemOrderedChildrenIds.tsx.preview
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemOrderedChildrenIds.tsx.preview
@@ -1,0 +1,12 @@
+<Typography>
+  {isSelectedItemLeaf == null && 'No item selected'}
+  {isSelectedItemLeaf === true && 'The selected item is a leaf'}
+  {isSelectedItemLeaf === false && 'The selected item is a node with children'}
+</Typography>
+<Box sx={{ minHeight: 352, minWidth: 300 }}>
+  <RichTreeView
+    items={MUI_X_PRODUCTS}
+    apiRef={apiRef}
+    onSelectedItemsChange={handleSelectedItemsChange}
+  />
+</Box>

--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemTree.js
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemTree.js
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
+
+import { useTreeViewApiRef } from '@mui/x-tree-view/hooks';
+
+const MUI_X_PRODUCTS = [
+  {
+    id: 'grid',
+    label: 'Data Grid',
+    children: [
+      { id: 'grid-community', label: '@mui/x-data-grid' },
+      { id: 'grid-pro', label: '@mui/x-data-grid-pro' },
+      { id: 'grid-premium', label: '@mui/x-data-grid-premium' },
+    ],
+  },
+  {
+    id: 'pickers',
+    label: 'Date and Time Pickers',
+    children: [
+      { id: 'pickers-community', label: '@mui/x-date-pickers' },
+      { id: 'pickers-pro', label: '@mui/x-date-pickers-pro' },
+    ],
+  },
+  {
+    id: 'charts',
+    label: 'Charts',
+    children: [{ id: 'charts-community', label: '@mui/x-charts' }],
+  },
+  {
+    id: 'tree-view',
+    label: 'Tree View',
+    children: [{ id: 'tree-view-community', label: '@mui/x-tree-view' }],
+  },
+];
+
+export default function ApiMethodGetItemTree() {
+  const apiRef = useTreeViewApiRef();
+
+  const [items, setItems] = React.useState(MUI_X_PRODUCTS);
+  const [itemOnTop, setItemOnTop] = React.useState(items[0].label);
+
+  const handleInvertItems = () => {
+    setItems((prevItems) => [...prevItems].reverse());
+  };
+
+  const handleUpdateItemOnTop = () => {
+    setItemOnTop(apiRef.current.getItemTree()[0].label);
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <Button onClick={handleInvertItems}>Invert first tree</Button>
+        <Button onClick={handleUpdateItemOnTop}>Update item on top</Button>
+      </Stack>
+      <Typography>Item on top: {itemOnTop}</Typography>
+      <Box sx={{ minHeight: 352, minWidth: 300 }}>
+        <RichTreeView apiRef={apiRef} items={items} />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemTree.tsx
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemTree.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
+import { TreeViewBaseItem } from '@mui/x-tree-view/models';
+import { useTreeViewApiRef } from '@mui/x-tree-view/hooks';
+
+const MUI_X_PRODUCTS: TreeViewBaseItem[] = [
+  {
+    id: 'grid',
+    label: 'Data Grid',
+    children: [
+      { id: 'grid-community', label: '@mui/x-data-grid' },
+      { id: 'grid-pro', label: '@mui/x-data-grid-pro' },
+      { id: 'grid-premium', label: '@mui/x-data-grid-premium' },
+    ],
+  },
+  {
+    id: 'pickers',
+    label: 'Date and Time Pickers',
+    children: [
+      { id: 'pickers-community', label: '@mui/x-date-pickers' },
+      { id: 'pickers-pro', label: '@mui/x-date-pickers-pro' },
+    ],
+  },
+  {
+    id: 'charts',
+    label: 'Charts',
+    children: [{ id: 'charts-community', label: '@mui/x-charts' }],
+  },
+  {
+    id: 'tree-view',
+    label: 'Tree View',
+    children: [{ id: 'tree-view-community', label: '@mui/x-tree-view' }],
+  },
+];
+
+export default function ApiMethodGetItemTree() {
+  const apiRef = useTreeViewApiRef();
+
+  const [items, setItems] = React.useState(MUI_X_PRODUCTS);
+  const [itemOnTop, setItemOnTop] = React.useState(items[0].label);
+
+  const handleInvertItems = () => {
+    setItems((prevItems) => [...prevItems].reverse());
+  };
+
+  const handleUpdateItemOnTop = () => {
+    setItemOnTop(apiRef.current!.getItemTree()[0].label);
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={2}>
+        <Button onClick={handleInvertItems}>Invert first tree</Button>
+        <Button onClick={handleUpdateItemOnTop}>Update item on top</Button>
+      </Stack>
+      <Typography>Item on top: {itemOnTop}</Typography>
+      <Box sx={{ minHeight: 352, minWidth: 300 }}>
+        <RichTreeView apiRef={apiRef} items={items} />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemTree.tsx.preview
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemTree.tsx.preview
@@ -1,0 +1,8 @@
+<Stack direction="row" spacing={2}>
+  <Button onClick={handleInvertItems}>Invert first tree</Button>
+  <Button onClick={handleUpdateItemOnTop}>Update item on top</Button>
+</Stack>
+<Typography>Item on top: {itemOnTop}</Typography>
+<Box sx={{ minHeight: 352, minWidth: 300 }}>
+  <RichTreeView apiRef={apiRef} items={items} />
+</Box>

--- a/docs/data/tree-view/rich-tree-view/items/items.md
+++ b/docs/data/tree-view/rich-tree-view/items/items.md
@@ -170,3 +170,31 @@ const itemElement = apiRef.current.getItemDOMElement(
 ```
 
 {{"demo": "ApiMethodGetItemDOMElement.js", "defaultCodeOpen": false}}
+
+### Get the current item tree
+
+Use the `getItemTree` API method to get the current item tree.
+
+```ts
+const itemTree = apiRef.current.getItemTree();
+```
+
+{{"demo": "ApiMethodGetItemTree.js", "defaultCodeOpen": false}}
+
+:::info
+This method is mostly useful when the Tree View has some internal updates on the items.
+For now, the only features causing updates on the items is the [re-ordering](/x/react-tree-view/rich-tree-view/ordering/).
+:::
+
+### Get an item's children by ID
+
+Use the `getItemOrderedChildrenIds` API method to get an item's children by its ID.
+
+```ts
+const childrenIds = apiRef.current.getItemOrderedChildrenIds(
+  // The id of the item to retrieve the children from
+  itemId,
+);
+```
+
+{{"demo": "ApiMethodGetItemOrderedChildrenIds.js", "defaultCodeOpen": false}}

--- a/docs/data/tree-view/rich-tree-view/items/items.md
+++ b/docs/data/tree-view/rich-tree-view/items/items.md
@@ -181,11 +181,6 @@ const itemTree = apiRef.current.getItemTree();
 
 {{"demo": "ApiMethodGetItemTree.js", "defaultCodeOpen": false}}
 
-:::info
-This method is mostly useful when the Tree View has some internal updates on the items.
-For now, the only features causing updates on the items is the [re-ordering](/x/react-tree-view/rich-tree-view/ordering/).
-:::
-
 ### Get an item's children by ID
 
 Use the `getItemOrderedChildrenIds` API method to get an item's children by its ID.

--- a/docs/pages/x/api/tree-view/rich-tree-view.json
+++ b/docs/pages/x/api/tree-view/rich-tree-view.json
@@ -3,7 +3,7 @@
     "apiRef": {
       "type": {
         "name": "shape",
-        "description": "{ current?: { focusItem: func, getItem: func, getItemDOMElement: func, selectItem: func, setItemExpansion: func } }"
+        "description": "{ current?: { focusItem: func, getItem: func, getItemDOMElement: func, getItemOrderedChildrenIds: func, getItemTree: func, selectItem: func, setItemExpansion: func } }"
       }
     },
     "checkboxSelection": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/tree-view/simple-tree-view.json
+++ b/docs/pages/x/api/tree-view/simple-tree-view.json
@@ -3,7 +3,7 @@
     "apiRef": {
       "type": {
         "name": "shape",
-        "description": "{ current?: { focusItem: func, getItem: func, getItemDOMElement: func, selectItem: func, setItemExpansion: func } }"
+        "description": "{ current?: { focusItem: func, getItem: func, getItemDOMElement: func, getItemOrderedChildrenIds: func, getItemTree: func, selectItem: func, setItemExpansion: func } }"
       }
     },
     "checkboxSelection": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/tree-view/tree-view.json
+++ b/docs/pages/x/api/tree-view/tree-view.json
@@ -3,7 +3,7 @@
     "apiRef": {
       "type": {
         "name": "shape",
-        "description": "{ current?: { focusItem: func, getItem: func, getItemDOMElement: func, selectItem: func, setItemExpansion: func } }"
+        "description": "{ current?: { focusItem: func, getItem: func, getItemDOMElement: func, getItemOrderedChildrenIds: func, getItemTree: func, selectItem: func, setItemExpansion: func } }"
       }
     },
     "checkboxSelection": { "type": { "name": "bool" }, "default": "false" },

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
@@ -152,6 +152,8 @@ RichTreeView.propTypes = {
       focusItem: PropTypes.func.isRequired,
       getItem: PropTypes.func.isRequired,
       getItemDOMElement: PropTypes.func.isRequired,
+      getItemOrderedChildrenIds: PropTypes.func.isRequired,
+      getItemTree: PropTypes.func.isRequired,
       selectItem: PropTypes.func.isRequired,
       setItemExpansion: PropTypes.func.isRequired,
     }),

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -111,6 +111,8 @@ SimpleTreeView.propTypes = {
       focusItem: PropTypes.func.isRequired,
       getItem: PropTypes.func.isRequired,
       getItemDOMElement: PropTypes.func.isRequired,
+      getItemOrderedChildrenIds: PropTypes.func.isRequired,
+      getItemTree: PropTypes.func.isRequired,
       selectItem: PropTypes.func.isRequired,
       setItemExpansion: PropTypes.func.isRequired,
     }),

--- a/packages/x-tree-view/src/TreeView/TreeView.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.tsx
@@ -96,6 +96,8 @@ TreeView.propTypes = {
       focusItem: PropTypes.func.isRequired,
       getItem: PropTypes.func.isRequired,
       getItemDOMElement: PropTypes.func.isRequired,
+      getItemOrderedChildrenIds: PropTypes.func.isRequired,
+      getItemTree: PropTypes.func.isRequired,
       selectItem: PropTypes.func.isRequired,
       setItemExpansion: PropTypes.func.isRequired,
     }),

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
@@ -183,21 +183,141 @@ describeTreeView<
       });
     });
 
-    describe('getItemDOMElement api method', () => {
-      it('should return the DOM element of the item', () => {
-        const response = render({
-          items: [{ id: '1' }],
+    describe('API methods', () => {
+      describe('getItem', () => {
+        // This method is only usable with Rich Tree View components
+        if (treeViewComponentName === 'SimpleTreeView') {
+          return;
+        }
+
+        it('should return the tree', () => {
+          const response = render({
+            items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
+          });
+
+          expect(response.apiRef.current.getItem('1')).to.deep.equal({
+            id: '1',
+            children: [{ id: '1.1' }],
+          });
         });
 
-        expect(response.apiRef.current.getItemDOMElement('1')).to.equal(response.getItemRoot('1'));
+        it('should have up to date tree when props.items changes', () => {
+          const response = render({
+            items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
+          });
+
+          response.setItems([{ id: '1' }, { id: '2' }]);
+
+          expect(response.apiRef.current.getItem('1')).to.deep.equal({ id: '1' });
+        });
+
+        it('should contain custom item properties', () => {
+          const response = render({
+            items: [{ id: '1', customProp: 'foo' }],
+          });
+
+          expect(response.apiRef.current.getItem('1')).to.deep.equal({
+            id: '1',
+            customProp: 'foo',
+          });
+        });
       });
 
-      it("should return the null when the item doesn't exist", () => {
-        const response = render({
-          items: [{ id: '1' }],
+      describe('getItemDOMElement', () => {
+        it('should return the DOM element of the item', () => {
+          const response = render({
+            items: [{ id: '1' }],
+          });
+
+          expect(response.apiRef.current.getItemDOMElement('1')).to.equal(
+            response.getItemRoot('1'),
+          );
         });
 
-        expect(response.apiRef.current.getItemDOMElement('2')).to.equal(null);
+        it("should return the null when the item doesn't exist", () => {
+          const response = render({
+            items: [{ id: '1' }],
+          });
+
+          expect(response.apiRef.current.getItemDOMElement('2')).to.equal(null);
+        });
+      });
+
+      describe('getItemTree', () => {
+        // This method is only usable with Rich Tree View components
+        if (treeViewComponentName === 'SimpleTreeView') {
+          return;
+        }
+
+        it('should return the tree', () => {
+          const response = render({
+            items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
+          });
+
+          expect(response.apiRef.current.getItemTree()).to.deep.equal([
+            { id: '1', children: [{ id: '1.1' }] },
+            { id: '2' },
+          ]);
+        });
+
+        it('should have up to date tree when props.items changes', () => {
+          const response = render({
+            items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
+          });
+
+          response.setItems([{ id: '1' }, { id: '2' }]);
+
+          expect(response.apiRef.current.getItemTree()).to.deep.equal([{ id: '1' }, { id: '2' }]);
+        });
+
+        it('should contain custom item properties', () => {
+          const response = render({
+            items: [{ id: '1', customProp: 'foo' }],
+          });
+
+          expect(response.apiRef.current.getItemTree()).to.deep.equal([
+            { id: '1', customProp: 'foo' },
+          ]);
+        });
+      });
+
+      describe('getItemOrderedChildrenIds', () => {
+        // This method is only usable with Rich Tree View components
+        if (treeViewComponentName === 'SimpleTreeView') {
+          return;
+        }
+
+        it('should return the children of an item in their rendering order', () => {
+          const response = render({
+            items: [{ id: '1', children: [{ id: '1.1' }, { id: '1.2' }] }],
+          });
+
+          expect(response.apiRef.current.getItemOrderedChildrenIds('1')).to.deep.equal([
+            '1.1',
+            '1.2',
+          ]);
+        });
+
+        it('should work for the root items', () => {
+          const response = render({
+            items: [{ id: '1' }, { id: '2' }],
+          });
+
+          expect(response.apiRef.current.getItemOrderedChildrenIds(null)).to.deep.equal(['1', '2']);
+        });
+
+        it('should have up to date children when props.items changes', () => {
+          const response = render({
+            items: [{ id: '1', children: [{ id: '1.1' }] }, { id: '2' }],
+          });
+
+          response.setItems([{ id: '1', children: [{ id: '1.1' }, { id: '1.2' }] }]);
+
+          expect(response.apiRef.current.getItemOrderedChildrenIds('1')).to.deep.equal([
+            '1.1',
+            '1.2',
+          ]);
+        });
       });
     });
   },

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
@@ -22,7 +22,7 @@ const updateItemsState = ({
   isItemDisabled,
   getItemLabel,
   getItemId,
-}: UpdateNodesStateParameters): UseTreeViewItemsState<any>['items'] => {
+}: UpdateNodesStateParameters): State => {
   const itemMetaMap: State['itemMetaMap'] = {};
   const itemMap: State['itemMap'] = {};
   const itemOrderedChildrenIds: State['itemOrderedChildrenIds'] = {
@@ -76,7 +76,6 @@ const updateItemsState = ({
     };
 
     itemMap[id] = item;
-    itemOrderedChildrenIds[id] = [];
     const parentIdWithDefault = parentId ?? TREE_VIEW_ROOT_PARENT_ID;
     if (!itemOrderedChildrenIds[parentIdWithDefault]) {
       itemOrderedChildrenIds[parentIdWithDefault] = [];
@@ -237,7 +236,7 @@ export const useTreeViewItems: TreeViewPlugin<UseTreeViewItemsSignature> = ({
         label: item.label!,
         itemId: item.id,
         id: item.idAttribute,
-        children: state.items.itemOrderedChildrenIds[id].map(getPropsFromItemId),
+        children: state.items.itemOrderedChildrenIds[id]?.map(getPropsFromItemId),
       };
     };
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
@@ -118,6 +118,20 @@ export const useTreeViewItems: TreeViewPlugin<UseTreeViewItemsSignature> = ({
     [state.items.itemMap],
   );
 
+  const getItemTree = React.useCallback(() => {
+    const getItemFromItemId = (id: TreeViewItemId): TreeViewBaseItem => {
+      const { children: oldChildren, ...item } = state.items.itemMap[id];
+      const newChildren = state.items.itemOrderedChildrenIds[id];
+      if (newChildren) {
+        item.children = newChildren.map(getItemFromItemId);
+      }
+
+      return item;
+    };
+
+    return state.items.itemOrderedChildrenIds[TREE_VIEW_ROOT_PARENT_ID].map(getItemFromItemId);
+  }, [state.items.itemMap, state.items.itemOrderedChildrenIds]);
+
   const isItemDisabled = React.useCallback(
     (itemId: string | null): itemId is string => {
       if (itemId == null) {
@@ -242,10 +256,13 @@ export const useTreeViewItems: TreeViewPlugin<UseTreeViewItemsSignature> = ({
     publicAPI: {
       getItem,
       getItemDOMElement,
+      getItemTree,
+      getItemOrderedChildrenIds,
     },
     instance: {
       getItemMeta,
       getItem,
+      getItemTree,
       getItemsToRender,
       getItemIndex,
       getItemDOMElement,

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
@@ -30,7 +30,7 @@ export interface UseTreeViewItemsPublicAPI<R extends {}> {
    */
   getItemOrderedChildrenIds: (itemId: TreeViewItemId | null) => TreeViewItemId[];
   /**
-   * Get all the items in the same provided as provided by `props.items`.
+   * Get all the items in the same format as provided by `props.items`.
    * @returns {TreeViewItemProps[]} The items in the tree.
    */
   getItemTree: () => TreeViewBaseItem[];

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
@@ -1,5 +1,5 @@
 import { TreeViewItemMeta, DefaultizedProps, TreeViewPluginSignature } from '../../models';
-import { TreeViewItemId } from '../../../models';
+import { TreeViewBaseItem, TreeViewItemId } from '../../../models';
 
 interface TreeViewItemProps {
   label: string;
@@ -22,6 +22,18 @@ export interface UseTreeViewItemsPublicAPI<R extends {}> {
    * @returns {HTMLElement | null} The DOM element of the item with the given id.
    */
   getItemDOMElement: (itemId: TreeViewItemId) => HTMLElement | null;
+  /**
+   * Get the ids of a given item's children.
+   * Those ids are returned in the order they should be rendered.
+   * @param {TreeViewItemId | null} itemId The id of the item to get the children of.
+   * @returns {TreeViewItemId[]} The ids of the item's children.
+   */
+  getItemOrderedChildrenIds: (itemId: TreeViewItemId | null) => TreeViewItemId[];
+  /**
+   * Get all the items in the same provided as provided by `props.items`.
+   * @returns {TreeViewItemProps[]} The items in the tree.
+   */
+  getItemTree: () => TreeViewBaseItem[];
 }
 
 export interface UseTreeViewItemsInstance<R extends {}> extends UseTreeViewItemsPublicAPI<R> {
@@ -39,13 +51,6 @@ export interface UseTreeViewItemsInstance<R extends {}> extends UseTreeViewItems
    * @returns {TreeViewItemProps[]} The items to render.
    */
   getItemsToRender: () => TreeViewItemProps[];
-  /**
-   * Get the ids of a given item's children.
-   * Those ids are returned in the order they should be rendered.
-   * @param {TreeViewItemId | null} itemId The id of the item to get the children of.
-   * @returns {TreeViewItemId[]} The ids of the item's children.
-   */
-  getItemOrderedChildrenIds: (itemId: TreeViewItemId | null) => TreeViewItemId[];
   /**
    * Check if a given item is disabled.
    * An item is disabled if it was marked as disabled or if one of its ancestors is disabled.

--- a/test/utils/tree-view/fakeContextValue.ts
+++ b/test/utils/tree-view/fakeContextValue.ts
@@ -17,9 +17,11 @@ export const getFakeContextValue = (
   publicAPI: {
     focusItem: () => {},
     getItem: () => ({}),
+    getItemOrderedChildrenIds: () => [],
     setItemExpansion: () => {},
     getItemDOMElement: () => null,
     selectItem: () => {},
+    getItemTree: () => [],
   },
   runItemPlugins: () => ({
     rootRef: null,


### PR DESCRIPTION
Extracted from #12213
Used in #13388