### PR TITLE
[code-infra] Follow `next` tag for `@mui/docs` package bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -101,6 +101,10 @@
     {
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "@mui/docs",
+      "followTag": "next"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
Implement https://github.com/mui/mui-x/pull/13760#discussion_r1668577151 suggestion as renovate still wants to bump to the incorrect version: https://github.com/mui/mui-x/pull/13746. 🙈 