### PR TITLE
[core] Fix `renovate` config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -104,6 +104,7 @@
     },
     {
       "groupName": "@mui/docs",
+      "matchPackageNames": ["@mui/docs"],
       "followTag": "next"
     }
   ],


### PR DESCRIPTION
Fix a regression introduced by https://github.com/mui/mui-x/pull/13813.
It is missing the package matching:
<img width="1187" alt="Screenshot 2024-07-15 at 11 00 03" src="https://github.com/user-attachments/assets/882996bb-d69b-4245-9dd2-f3dc509833c5">
