### PR TITLE
[core] Add MUI Internal `renovate` group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,7 +94,7 @@
     },
     {
       "groupName": "MUI Internal",
-      "matchPackagePatterns": "@mui/internal-*"
+      "matchPackagePatterns": ["@mui/internal-*", "@mui/docs"]
     },
     {
       "groupName": "Playwright",

--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,10 @@
       ]
     },
     {
+      "groupName": "MUI Internal",
+      "matchPackagePatterns": "@mui/internal-*"
+    },
+    {
       "groupName": "Playwright",
       "matchPackagePatterns": ["playwright", "@playwright/test"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,7 @@
       "matchPackageNames": [
         "@mui/base",
         "@mui/icons-material",
+        "@mui/joy",
         "@mui/lab",
         "@mui/material",
         "@mui/styles",

--- a/renovate.json
+++ b/renovate.json
@@ -88,6 +88,7 @@
         "@mui/material",
         "@mui/styles",
         "@mui/system",
+        "@mui/types",
         "@mui/utils"
       ]
     },


### PR DESCRIPTION
- Add `@mui/joy` back to the `MUI Core` group
  - Removed in https://github.com/mui/mui-x/pull/13000
  I forgot to add it back with https://github.com/mui/mui-x/pull/13741
- Add `@mui/types` to the `MUI Core` group as per: https://github.com/mui/mui-x/pull/13846#discussion_r1677770842

I've noticed that the internal packages are being released frequently and they trigger a lot of CI runtime even for these packages.
<img width="600" alt="Screenshot 2024-07-15 at 15 18 19" src="https://github.com/user-attachments/assets/03ec0086-34a1-4878-8171-7a717e8b9adb">

Grouping them together should reduce the CI effort.
Seeing the below case was the final "ding-ding" moment:
<img width="1586" alt="Screenshot 2024-07-15 at 15 17 02" src="https://github.com/user-attachments/assets/3a30e405-da4c-47af-8507-5370699b9f83">
When we have separate bump PR: https://github.com/mui/mui-x/pull/13830.

WDYT @mui/code-infra, should we add `@mui/docs` to this group or `MUI Core`?
https://github.com/mui/mui-x/blob/29aeeb83613ea76b4b366ad3bbf18641da084412/renovate.json#L82-L91