### PR TITLE
[TimePicker] Add `Mui-selected` class to `TimeClock` meridiem buttons

### DIFF
--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
-import { styled, useThemeProps } from '@mui/material/styles';
+import { styled, useThemeProps, Theme } from '@mui/material/styles';
 import {
   unstable_useEnhancedEffect as useEnhancedEffect,
   unstable_composeClasses as composeClasses,
@@ -14,7 +14,7 @@ import type { PickerSelectionState } from '../internals/hooks/usePicker';
 import { useMeridiemMode } from '../internals/hooks/date-helpers-hooks';
 import { CLOCK_HOUR_WIDTH, getHours, getMinutes } from './shared';
 import { PickerValidDate, TimeView } from '../models';
-import { ClockClasses, getClockUtilityClass } from './clockClasses';
+import { clockClasses, ClockClasses, getClockUtilityClass } from './clockClasses';
 import { formatMeridiem } from '../internals/utils/date-utils';
 
 export interface ClockProps<TDate extends PickerValidDate>
@@ -145,15 +145,9 @@ const ClockPin = styled('div', {
   transform: 'translate(-50%, -50%)',
 }));
 
-const ClockAmButton = styled(IconButton, {
-  name: 'MuiClock',
-  slot: 'AmButton',
-  overridesResolver: (_, styles) => styles.amButton,
-})<{ ownerState: ClockProps<any> }>(({ theme }) => ({
+const meridiemButtonCommonStyles = (theme: Theme) => ({
   zIndex: 1,
-  position: 'absolute',
   bottom: 8,
-  left: 8,
   paddingLeft: 4,
   paddingRight: 4,
   width: CLOCK_HOUR_WIDTH,
@@ -164,6 +158,17 @@ const ClockAmButton = styled(IconButton, {
       backgroundColor: (theme.vars || theme).palette.primary.light,
     },
   },
+});
+
+const ClockAmButton = styled(IconButton, {
+  name: 'MuiClock',
+  slot: 'AmButton',
+  overridesResolver: (_, styles) => styles.amButton,
+})<{ ownerState: ClockProps<any> }>(({ theme }) => ({
+  ...meridiemButtonCommonStyles(theme),
+  // keeping it here to make TS happy
+  position: 'absolute',
+  left: 8,
 }));
 
 const ClockPmButton = styled(IconButton, {
@@ -171,20 +176,10 @@ const ClockPmButton = styled(IconButton, {
   slot: 'PmButton',
   overridesResolver: (_, styles) => styles.pmButton,
 })<{ ownerState: ClockProps<any> }>(({ theme }) => ({
-  zIndex: 1,
+  ...meridiemButtonCommonStyles(theme),
+  // keeping it here to make TS happy
   position: 'absolute',
-  bottom: 8,
   right: 8,
-  paddingLeft: 4,
-  paddingRight: 4,
-  width: CLOCK_HOUR_WIDTH,
-  [`&.${clockClasses.selected}`]: {
-    backgroundColor: (theme.vars || theme).palette.primary.main,
-    color: (theme.vars || theme).palette.primary.contrastText,
-    '&:hover': {
-      backgroundColor: (theme.vars || theme).palette.primary.light,
-    },
-  },
 }));
 
 const ClockMeridiemText = styled(Typography, {

--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -14,8 +14,9 @@ import type { PickerSelectionState } from '../internals/hooks/usePicker';
 import { useMeridiemMode } from '../internals/hooks/date-helpers-hooks';
 import { CLOCK_HOUR_WIDTH, getHours, getMinutes } from './shared';
 import { PickerValidDate, TimeView } from '../models';
-import { clockClasses, ClockClasses, getClockUtilityClass } from './clockClasses';
+import { ClockClasses, getClockUtilityClass } from './clockClasses';
 import { formatMeridiem } from '../internals/utils/date-utils';
+import { Meridiem } from '../internals/utils/time-utils';
 
 export interface ClockProps<TDate extends PickerValidDate>
   extends ReturnType<typeof useMeridiemMode> {
@@ -145,19 +146,24 @@ const ClockPin = styled('div', {
   transform: 'translate(-50%, -50%)',
 }));
 
-const meridiemButtonCommonStyles = (theme: Theme) => ({
+const meridiemButtonCommonStyles = (theme: Theme, meridiemMode: Meridiem) => ({
   zIndex: 1,
   bottom: 8,
   paddingLeft: 4,
   paddingRight: 4,
   width: CLOCK_HOUR_WIDTH,
-  [`&.${clockClasses.selected}`]: {
-    backgroundColor: (theme.vars || theme).palette.primary.main,
-    color: (theme.vars || theme).palette.primary.contrastText,
-    '&:hover': {
-      backgroundColor: (theme.vars || theme).palette.primary.light,
+  variants: [
+    {
+      props: { meridiemMode },
+      style: {
+        backgroundColor: (theme.vars || theme).palette.primary.main,
+        color: (theme.vars || theme).palette.primary.contrastText,
+        '&:hover': {
+          backgroundColor: (theme.vars || theme).palette.primary.light,
+        },
+      },
     },
-  },
+  ],
 });
 
 const ClockAmButton = styled(IconButton, {
@@ -165,7 +171,7 @@ const ClockAmButton = styled(IconButton, {
   slot: 'AmButton',
   overridesResolver: (_, styles) => styles.amButton,
 })<{ ownerState: ClockProps<any> }>(({ theme }) => ({
-  ...meridiemButtonCommonStyles(theme),
+  ...meridiemButtonCommonStyles(theme, 'am'),
   // keeping it here to make TS happy
   position: 'absolute',
   left: 8,
@@ -176,7 +182,7 @@ const ClockPmButton = styled(IconButton, {
   slot: 'PmButton',
   overridesResolver: (_, styles) => styles.pmButton,
 })<{ ownerState: ClockProps<any> }>(({ theme }) => ({
-  ...meridiemButtonCommonStyles(theme),
+  ...meridiemButtonCommonStyles(theme, 'pm'),
   // keeping it here to make TS happy
   position: 'absolute',
   right: 8,

--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -47,15 +47,15 @@ export interface ClockProps<TDate extends PickerValidDate>
 }
 
 const useUtilityClasses = (ownerState: ClockProps<any>) => {
-  const { classes } = ownerState;
+  const { classes, meridiemMode } = ownerState;
   const slots = {
     root: ['root'],
     clock: ['clock'],
     wrapper: ['wrapper'],
     squareMask: ['squareMask'],
     pin: ['pin'],
-    amButton: ['amButton'],
-    pmButton: ['pmButton'],
+    amButton: ['amButton', meridiemMode === 'am' && 'selected'],
+    pmButton: ['pmButton', meridiemMode === 'pm' && 'selected'],
     meridiemText: ['meridiemText'],
   };
 

--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -157,18 +157,13 @@ const ClockAmButton = styled(IconButton, {
   paddingLeft: 4,
   paddingRight: 4,
   width: CLOCK_HOUR_WIDTH,
-  variants: [
-    {
-      props: { meridiemMode: 'am' },
-      style: {
-        backgroundColor: (theme.vars || theme).palette.primary.main,
-        color: (theme.vars || theme).palette.primary.contrastText,
-        '&:hover': {
-          backgroundColor: (theme.vars || theme).palette.primary.light,
-        },
-      },
+  [`&.${clockClasses.selected}`]: {
+    backgroundColor: (theme.vars || theme).palette.primary.main,
+    color: (theme.vars || theme).palette.primary.contrastText,
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.primary.light,
     },
-  ],
+  },
 }));
 
 const ClockPmButton = styled(IconButton, {
@@ -183,18 +178,13 @@ const ClockPmButton = styled(IconButton, {
   paddingLeft: 4,
   paddingRight: 4,
   width: CLOCK_HOUR_WIDTH,
-  variants: [
-    {
-      props: { meridiemMode: 'pm' },
-      style: {
-        backgroundColor: (theme.vars || theme).palette.primary.main,
-        color: (theme.vars || theme).palette.primary.contrastText,
-        '&:hover': {
-          backgroundColor: (theme.vars || theme).palette.primary.light,
-        },
-      },
+  [`&.${clockClasses.selected}`]: {
+    backgroundColor: (theme.vars || theme).palette.primary.main,
+    color: (theme.vars || theme).palette.primary.contrastText,
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.primary.light,
     },
-  ],
+  },
 }));
 
 const ClockMeridiemText = styled(Typography, {

--- a/packages/x-date-pickers/src/TimeClock/clockClasses.ts
+++ b/packages/x-date-pickers/src/TimeClock/clockClasses.ts
@@ -20,6 +20,8 @@ export interface ClockClasses {
   pmButton: string;
   /** Styles applied to the meridiem typography element. */
   meridiemText: string;
+  /** Styles applied to the selected meridiem button element */
+  selected: string;
 }
 
 export type ClockClassKey = keyof ClockClasses;
@@ -37,4 +39,5 @@ export const clockClasses: ClockClasses = generateUtilityClasses('MuiClock', [
   'amButton',
   'pmButton',
   'meridiemText',
+  'selected',
 ]);


### PR DESCRIPTION
Fixes #12493.

Additional changes:
- ~Refactor active/selected styles to depend on the `Mui-selected` class rather than using a `variant`~. Can't do it now, because it's a possible BC: https://github.com/mui/mui-x/pull/13848#discussion_r1678801329
- Extract common meridiem button styles into a reusable function

P.S. I picked this up after I saw an old stash with partially complete work. 🙈 