### PR TITLE
[charts] Improve zoomed highlight behaviour

### DIFF
--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -51,10 +51,10 @@ const BarChartPro = React.forwardRef(function BarChartPro(props: BarChartProProp
       <g {...clipPathGroupProps}>
         <BarChartPlotZoom {...barPlotProps} />
         <ChartsOverlay {...overlayProps} />
+        <ChartsAxisHighlight {...axisHighlightProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
       <ChartsLegend {...legendProps} />
-      <ChartsAxisHighlight {...axisHighlightProps} />
       {!props.loading && <ChartsTooltip {...tooltipProps} />}
       <ChartsClipPath {...clipPathProps} />
       <ZoomSetup />

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -62,9 +62,9 @@ const LineChartPro = React.forwardRef(function LineChartPro(props: LineChartProP
         <AreaPlotZoom {...areaPlotProps} />
         <LinePlotZoom {...linePlotProps} />
         <ChartsOverlay {...overlayProps} />
+        <ChartsAxisHighlight {...axisHighlightProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
-      <ChartsAxisHighlight {...axisHighlightProps} />
       <MarkPlotZoom {...markPlotProps} />
       <LineHighlightPlot {...lineHighlightPlotProps} />
       <ChartsLegend {...legendProps} />

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -62,11 +62,11 @@ const LineChartPro = React.forwardRef(function LineChartPro(props: LineChartProP
         <AreaPlotZoom {...areaPlotProps} />
         <LinePlotZoom {...linePlotProps} />
         <ChartsOverlay {...overlayProps} />
+        <ChartsAxisHighlight {...axisHighlightProps} />
+        <LineHighlightPlot {...lineHighlightPlotProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
-      <ChartsAxisHighlight {...axisHighlightProps} />
       <MarkPlotZoom {...markPlotProps} />
-      <LineHighlightPlot {...lineHighlightPlotProps} />
       <ChartsLegend {...legendProps} />
       {!props.loading && <ChartsTooltip {...tooltipProps} />}
       <ChartsClipPath {...clipPathProps} />

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -62,11 +62,11 @@ const LineChartPro = React.forwardRef(function LineChartPro(props: LineChartProP
         <AreaPlotZoom {...areaPlotProps} />
         <LinePlotZoom {...linePlotProps} />
         <ChartsOverlay {...overlayProps} />
-        <ChartsAxisHighlight {...axisHighlightProps} />
-        <LineHighlightPlot {...lineHighlightPlotProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
+      <ChartsAxisHighlight {...axisHighlightProps} />
       <MarkPlotZoom {...markPlotProps} />
+      <LineHighlightPlot {...lineHighlightPlotProps} />
       <ChartsLegend {...legendProps} />
       {!props.loading && <ChartsTooltip {...tooltipProps} />}
       <ChartsClipPath {...clipPathProps} />

--- a/packages/x-charts-pro/src/context/ZoomProvider/useSetupPan.ts
+++ b/packages/x-charts-pro/src/context/ZoomProvider/useSetupPan.ts
@@ -4,18 +4,9 @@ import { getSVGPoint } from '@mui/x-charts/internals';
 import { useZoom } from './useZoom';
 import { ZoomData } from './Zoom.types';
 
-const isPointOutside = (
-  point: { x: number; y: number },
-  area: { left: number; top: number; width: number; height: number },
-) => {
-  const outsideX = point.x < area.left || point.x > area.left + area.width;
-  const outsideY = point.y < area.top || point.y > area.top + area.height;
-  return outsideX || outsideY;
-};
-
 export const useSetupPan = () => {
   const { zoomData, setZoomData, setIsInteracting, isPanEnabled, options } = useZoom();
-  const area = useDrawingArea();
+  const drawingArea = useDrawingArea();
 
   const svgRef = useSvgRef();
 
@@ -55,7 +46,7 @@ export const useSetupPan = () => {
         const MAX_PERCENT = option.maxEnd;
 
         const movement = option.axisDirection === 'x' ? movementX : movementY;
-        const dimension = option.axisDirection === 'x' ? area.width : area.height;
+        const dimension = option.axisDirection === 'x' ? drawingArea.width : drawingArea.height;
 
         let newMinPercent = min - (movement / dimension) * span;
         let newMaxPercent = max - (movement / dimension) * span;
@@ -93,7 +84,7 @@ export const useSetupPan = () => {
       eventCacheRef.current.push(event);
       const point = getSVGPoint(element, event);
 
-      if (isPointOutside(point, area)) {
+      if (!drawingArea.isPointInside(point)) {
         return;
       }
 
@@ -135,5 +126,14 @@ export const useSetupPan = () => {
       document.removeEventListener('pointercancel', handleUp);
       document.removeEventListener('pointerleave', handleUp);
     };
-  }, [area, svgRef, isDraggingRef, setIsInteracting, zoomData, setZoomData, isPanEnabled, options]);
+  }, [
+    drawingArea,
+    svgRef,
+    isDraggingRef,
+    setIsInteracting,
+    zoomData,
+    setZoomData,
+    isPanEnabled,
+    options,
+  ]);
 };

--- a/packages/x-charts-pro/src/context/ZoomProvider/useSetupZoom.ts
+++ b/packages/x-charts-pro/src/context/ZoomProvider/useSetupZoom.ts
@@ -54,18 +54,9 @@ const zoomAtPoint = (
   return [newMinRange, newMaxRange];
 };
 
-const isPointOutside = (
-  point: { x: number; y: number },
-  area: { left: number; top: number; width: number; height: number },
-) => {
-  const outsideX = point.x < area.left || point.x > area.left + area.width;
-  const outsideY = point.y < area.top || point.y > area.top + area.height;
-  return outsideX || outsideY;
-};
-
 export const useSetupZoom = () => {
   const { zoomData, setZoomData, isZoomEnabled, options, setIsInteracting } = useZoom();
-  const area = useDrawingArea();
+  const drawingArea = useDrawingArea();
 
   const svgRef = useSvgRef();
   const eventCacheRef = React.useRef<PointerEvent[]>([]);
@@ -85,7 +76,7 @@ export const useSetupZoom = () => {
 
       const point = getSVGPoint(element, event);
 
-      if (isPointOutside(point, area)) {
+      if (!drawingArea.isPointInside(point)) {
         return;
       }
 
@@ -104,8 +95,8 @@ export const useSetupZoom = () => {
         const option = options[zoom.axisId];
         const centerRatio =
           option.axisDirection === 'x'
-            ? getHorizontalCenterRatio(point, area)
-            : getVerticalCenterRatio(point, area);
+            ? getHorizontalCenterRatio(point, drawingArea)
+            : getVerticalCenterRatio(point, drawingArea);
 
         const { scaleRatio, isZoomIn } = getWheelScaleRatio(event, option.step);
         const [newMinRange, newMaxRange] = zoomAtPoint(centerRatio, scaleRatio, zoom, option);
@@ -162,8 +153,8 @@ export const useSetupZoom = () => {
 
         const centerRatio =
           option.axisDirection === 'x'
-            ? getHorizontalCenterRatio(point, area)
-            : getVerticalCenterRatio(point, area);
+            ? getHorizontalCenterRatio(point, drawingArea)
+            : getVerticalCenterRatio(point, drawingArea);
 
         const [newMinRange, newMaxRange] = zoomAtPoint(centerRatio, scaleRatio, zoom, option);
 
@@ -219,7 +210,7 @@ export const useSetupZoom = () => {
         clearTimeout(interactionTimeoutRef.current);
       }
     };
-  }, [svgRef, setZoomData, zoomData, area, isZoomEnabled, options, setIsInteracting]);
+  }, [svgRef, setZoomData, zoomData, drawingArea, isZoomEnabled, options, setIsInteracting]);
 };
 
 /**

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -132,10 +132,10 @@ const BarChart = React.forwardRef(function BarChart(props: BarChartProps, ref) {
       <g {...clipPathGroupProps}>
         <BarPlot {...barPlotProps} />
         <ChartsOverlay {...overlayProps} />
+        <ChartsAxisHighlight {...axisHighlightProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
       <ChartsLegend {...legendProps} />
-      <ChartsAxisHighlight {...axisHighlightProps} />
       {!props.loading && <ChartsTooltip {...tooltipProps} />}
       <ChartsClipPath {...clipPathProps} />
       {children}

--- a/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/DefaultChartsLegend.tsx
@@ -10,7 +10,7 @@ export interface LegendRendererProps extends Omit<LegendPerItemProps, 'itemsToDi
   /**
    * @deprecated Use the `useDrawingArea` hook instead.
    */
-  drawingArea: DrawingArea;
+  drawingArea: Omit<DrawingArea, 'isPointInside'>;
 }
 
 function DefaultChartsLegend(props: LegendRendererProps) {

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -31,7 +31,7 @@ type VoronoiSeries = { seriesId: SeriesId; startIndex: number; endIndex: number 
 function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
   const { voronoiMaxRadius, onItemClick } = props;
   const svgRef = useSvgRef();
-  const { left, top, width, height } = useDrawingArea();
+  const drawingArea = useDrawingArea();
   const { xAxis, yAxis, xAxisIds, yAxisIds } = useCartesianContext();
   const { dispatch } = React.useContext(InteractionContext);
 
@@ -75,8 +75,8 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
         const pointX = getXPosition(x);
         const pointY = getYPosition(y);
 
-        if (pointX < left || pointX > left + width || pointY < top || pointY > top + height) {
-          return [0, 0];
+        if (!drawingArea.isPointInside({ x: pointX, y: pointY })) {
+          return [-drawingArea.width, -drawingArea.height];
         }
 
         return [pointX, pointY];
@@ -91,7 +91,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
     });
 
     delauneyRef.current = new Delaunay(points);
-  }, [defaultXAxisId, defaultYAxisId, series, seriesOrder, xAxis, yAxis, left, top, width, height]);
+  }, [defaultXAxisId, defaultYAxisId, series, seriesOrder, xAxis, yAxis, drawingArea]);
 
   React.useEffect(() => {
     const element = svgRef.current;
@@ -109,9 +109,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       // Get mouse coordinate in global SVG space
       const svgPoint = getSVGPoint(element, event);
 
-      const outsideX = svgPoint.x < left || svgPoint.x > left + width;
-      const outsideY = svgPoint.y < top || svgPoint.y > top + height;
-      if (outsideX || outsideY) {
+      if (!drawingArea.isPointInside(svgPoint)) {
         lastFind.current = undefined;
         return 'outside-chart';
       }
@@ -203,16 +201,13 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
   }, [
     svgRef,
     dispatch,
-    left,
-    width,
-    top,
-    height,
     yAxis,
     xAxis,
     voronoiMaxRadius,
     onItemClick,
     setHighlighted,
     clearHighlighted,
+    drawingArea,
   ]);
 
   // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -38,6 +38,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
   const { series, seriesOrder } = useScatterSeries() ?? {};
   const voronoiRef = React.useRef<Record<string, VoronoiSeries>>({});
   const delauneyRef = React.useRef<Delaunay<any> | undefined>(undefined);
+  const lastFind = React.useRef<number | undefined>(undefined);
 
   const { setHighlighted, clearHighlighted } = useHighlighted();
 
@@ -88,7 +89,6 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       return undefined;
     }
 
-    // TODO: A perf optimisation of voronoi could be to use the last point as the initial point for the next search.
     function getClosestPoint(
       event: MouseEvent,
     ):
@@ -103,6 +103,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       const outsideX = svgPoint.x < left || svgPoint.x > left + width;
       const outsideY = svgPoint.y < top || svgPoint.y > top + height;
       if (outsideX || outsideY) {
+        lastFind.current = undefined;
         return 'outside-chart';
       }
 
@@ -110,11 +111,12 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
         return 'no-point-found';
       }
 
-      const closestPointIndex = delauneyRef.current.find(svgPoint.x, svgPoint.y);
+      const closestPointIndex = delauneyRef.current.find(svgPoint.x, svgPoint.y, lastFind.current);
       if (closestPointIndex === undefined) {
         return 'no-point-found';
       }
 
+      lastFind.current = closestPointIndex;
       const closestSeries = Object.values(voronoiRef.current).find((value) => {
         return 2 * closestPointIndex >= value.startIndex && 2 * closestPointIndex < value.endIndex;
       });

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -76,6 +76,9 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
         const pointY = getYPosition(y);
 
         if (!drawingArea.isPointInside({ x: pointX, y: pointY })) {
+          // If the point is not displayed we move them to a trash coordinate.
+          // This avoids managing index mapping before/after filtering.
+          // The trash point is far enough such that any point in the drawing area will be closer to the mouse than the trash coordinate.
           return [-drawingArea.width, -drawingArea.height];
         }
 

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -91,6 +91,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
     });
 
     delauneyRef.current = new Delaunay(points);
+    lastFind.current = undefined;
   }, [defaultXAxisId, defaultYAxisId, series, seriesOrder, xAxis, yAxis, drawingArea]);
 
   React.useEffect(() => {

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -71,7 +71,17 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       const getXPosition = getValueToPositionMapper(xScale);
       const getYPosition = getValueToPositionMapper(yScale);
 
-      const seriesPoints = data.flatMap(({ x, y }) => [getXPosition(x), getYPosition(y)]);
+      const seriesPoints = data.flatMap(({ x, y }) => {
+        const pointX = getXPosition(x);
+        const pointY = getYPosition(y);
+
+        if (pointX < left || pointX > left + width || pointY < top || pointY > top + height) {
+          return [0, 0];
+        }
+
+        return [pointX, pointY];
+      });
+
       voronoiRef.current[seriesId] = {
         seriesId,
         startIndex: points.length,
@@ -81,7 +91,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
     });
 
     delauneyRef.current = new Delaunay(points);
-  }, [defaultXAxisId, defaultYAxisId, series, seriesOrder, xAxis, yAxis]);
+  }, [defaultXAxisId, defaultYAxisId, series, seriesOrder, xAxis, yAxis, left, top, width, height]);
 
   React.useEffect(() => {
     const element = svgRef.current;
@@ -95,8 +105,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       | { seriesId: SeriesId; dataIndex: number }
       | 'outside-chart'
       | 'outside-voronoi-max-radius'
-      | 'no-point-found'
-      | 'outside-render-area' {
+      | 'no-point-found' {
       // Get mouse coordinate in global SVG space
       const svgPoint = getSVGPoint(element, event);
 
@@ -128,15 +137,14 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
       const dataIndex =
         (2 * closestPointIndex - voronoiRef.current[closestSeries.seriesId].startIndex) / 2;
 
-      const pointX = delauneyRef.current.points[2 * closestPointIndex];
-      const pointY = delauneyRef.current.points[2 * closestPointIndex + 1];
-      const dist2 = (pointX - svgPoint.x) ** 2 + (pointY - svgPoint.y) ** 2;
-      if (pointX < left || pointX > left + width || pointY < top || pointY > top + height) {
-        return 'outside-render-area';
-      }
-      if (dist2 > (voronoiMaxRadius ?? Infinity) ** 2) {
-        // The closest point is too far to be considered.
-        return 'outside-voronoi-max-radius';
+      if (voronoiMaxRadius !== undefined) {
+        const pointX = delauneyRef.current.points[2 * closestPointIndex];
+        const pointY = delauneyRef.current.points[2 * closestPointIndex + 1];
+        const dist2 = (pointX - svgPoint.x) ** 2 + (pointY - svgPoint.y) ** 2;
+        if (dist2 > voronoiMaxRadius ** 2) {
+          // The closest point is too far to be considered.
+          return 'outside-voronoi-max-radius';
+        }
       }
       return { seriesId: closestSeries.seriesId, dataIndex };
     }
@@ -155,11 +163,7 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
         return;
       }
 
-      if (
-        closestPoint === 'outside-voronoi-max-radius' ||
-        closestPoint === 'no-point-found' ||
-        closestPoint === 'outside-render-area'
-      ) {
+      if (closestPoint === 'outside-voronoi-max-radius' || closestPoint === 'no-point-found') {
         dispatch({ type: 'leaveItem', data: { type: 'scatter' } });
         clearHighlighted();
         return;

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -162,9 +162,9 @@ const LineChart = React.forwardRef(function LineChart(props: LineChartProps, ref
         <AreaPlot {...areaPlotProps} />
         <LinePlot {...linePlotProps} />
         <ChartsOverlay {...overlayProps} />
+        <ChartsAxisHighlight {...axisHighlightProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
-      <ChartsAxisHighlight {...axisHighlightProps} />
       <MarkPlot {...markPlotProps} />
       <LineHighlightPlot {...lineHighlightPlotProps} />
       <ChartsLegend {...legendProps} />

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -162,11 +162,11 @@ const LineChart = React.forwardRef(function LineChart(props: LineChartProps, ref
         <AreaPlot {...areaPlotProps} />
         <LinePlot {...linePlotProps} />
         <ChartsOverlay {...overlayProps} />
+        <ChartsAxisHighlight {...axisHighlightProps} />
+        <LineHighlightPlot {...lineHighlightPlotProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
-      <ChartsAxisHighlight {...axisHighlightProps} />
       <MarkPlot {...markPlotProps} />
-      <LineHighlightPlot {...lineHighlightPlotProps} />
       <ChartsLegend {...legendProps} />
       {!props.loading && <ChartsTooltip {...tooltipProps} />}
       <ChartsClipPath {...clipPathProps} />

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -162,11 +162,11 @@ const LineChart = React.forwardRef(function LineChart(props: LineChartProps, ref
         <AreaPlot {...areaPlotProps} />
         <LinePlot {...linePlotProps} />
         <ChartsOverlay {...overlayProps} />
-        <ChartsAxisHighlight {...axisHighlightProps} />
-        <LineHighlightPlot {...lineHighlightPlotProps} />
       </g>
       <ChartsAxis {...chartsAxisProps} />
+      <ChartsAxisHighlight {...axisHighlightProps} />
       <MarkPlot {...markPlotProps} />
+      <LineHighlightPlot {...lineHighlightPlotProps} />
       <ChartsLegend {...legendProps} />
       {!props.loading && <ChartsTooltip {...tooltipProps} />}
       <ChartsClipPath {...clipPathProps} />

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -7,6 +7,7 @@ import { InteractionContext } from '../context/InteractionProvider';
 import { DEFAULT_X_AXIS_KEY } from '../constants';
 import getColor from './getColor';
 import { useLineSeries } from '../hooks/useSeries';
+import { useDrawingArea } from '../hooks/useDrawingArea';
 
 export interface LineHighlightPlotSlots {
   lineHighlight?: React.JSXElementConstructor<LineHighlightElementProps>;
@@ -44,6 +45,7 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
 
   const seriesData = useLineSeries();
   const axisData = useCartesianContext();
+  const drawingArea = useDrawingArea();
   const { axis } = React.useContext(InteractionContext);
 
   const highlightedIndex = axis.x?.index;
@@ -92,6 +94,10 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
 
           const x = xScale(xData[highlightedIndex]);
           const y = yScale(stackedData[highlightedIndex][1])!; // This should not be undefined since y should not be a band scale
+
+          if (!drawingArea.isPointInside({ x, y })) {
+            return null;
+          }
 
           const colorGetter = getColor(series[seriesId], xAxis[xAxisKey], yAxis[yAxisKey]);
           return (

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -59,7 +59,7 @@ function MarkPlot(props: MarkPlotProps) {
   const seriesData = useLineSeries();
   const axisData = useCartesianContext();
   const chartId = useChartId();
-  const { left, width, top, height } = useDrawingArea();
+  const drawingArea = useDrawingArea();
 
   const Mark = slots?.mark ?? MarkElement;
 
@@ -90,16 +90,6 @@ function MarkPlot(props: MarkPlotProps) {
           const xScale = getValueToPositionMapper(xAxis[xAxisKey].scale);
           const yScale = yAxis[yAxisKey].scale;
           const xData = xAxis[xAxisKey].data;
-
-          const isInRange = ({ x, y }: { x: number; y: number }) => {
-            if (x < left || x > left + width) {
-              return false;
-            }
-            if (y < top || y > top + height) {
-              return false;
-            }
-            return true;
-          };
 
           if (xData === undefined) {
             throw new Error(
@@ -133,7 +123,7 @@ function MarkPlot(props: MarkPlotProps) {
                     // Remove missing data point
                     return false;
                   }
-                  if (!isInRange({ x, y })) {
+                  if (!drawingArea.isPointInside({ x, y })) {
                     // Remove out of range
                     return false;
                   }

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -43,7 +43,7 @@ export interface ScatterProps {
 function Scatter(props: ScatterProps) {
   const { series, xScale, yScale, color, colorGetter, markerSize, onItemClick } = props;
 
-  const { left, width, top, height } = useDrawingArea();
+  const drawingArea = useDrawingArea();
 
   const { useVoronoiInteraction } = React.useContext(InteractionContext);
 
@@ -69,7 +69,7 @@ function Scatter(props: ScatterProps) {
       const x = getXPosition(scatterPoint.x);
       const y = getYPosition(scatterPoint.y);
 
-      const isInRange = x >= left && x <= left + width && y >= top && y <= top + height;
+      const isInRange = drawingArea.isPointInside({ x, y });
 
       const pointCtx = { type: 'scatter' as const, seriesId: series.id, dataIndex: i };
 
@@ -96,10 +96,7 @@ function Scatter(props: ScatterProps) {
   }, [
     xScale,
     yScale,
-    left,
-    width,
-    top,
-    height,
+    drawingArea,
     series.data,
     series.id,
     isHighlighted,

--- a/packages/x-charts/src/context/DrawingProvider.tsx
+++ b/packages/x-charts/src/context/DrawingProvider.tsx
@@ -37,6 +37,13 @@ export type DrawingArea = {
    * The height of the drawing area.
    */
   height: number;
+  /**
+   * Checks if a point is inside the drawing area.
+   * @param x The x coordinate of the point.
+   * @param y The y coordinate of the point.
+   * @returns `true` if the point is inside the drawing area, `false` otherwise.
+   */
+  isPointInside: (point: { x: number; y: number }) => boolean;
 };
 
 export const DrawingContext = React.createContext<
@@ -54,6 +61,7 @@ export const DrawingContext = React.createContext<
   height: 300,
   width: 400,
   chartId: '',
+  isPointInside: () => false,
 });
 
 if (process.env.NODE_ENV !== 'production') {
@@ -76,8 +84,17 @@ export function DrawingProvider(props: DrawingProviderProps) {
   const drawingArea = useChartDimensions(width, height, margin);
   const chartId = useId();
 
+  const isPointInside = React.useCallback<DrawingArea['isPointInside']>(
+    ({ x, y }) =>
+      x >= drawingArea.left &&
+      x <= drawingArea.left + drawingArea.width &&
+      y >= drawingArea.top &&
+      y <= drawingArea.top + drawingArea.height,
+    [drawingArea],
+  );
+
   const value = React.useMemo(
-    () => ({ chartId: chartId ?? '', ...drawingArea }),
+    () => ({ chartId: chartId ?? '', ...drawingArea, isPointInside }),
     [chartId, drawingArea],
   );
 

--- a/packages/x-charts/src/context/DrawingProvider.tsx
+++ b/packages/x-charts/src/context/DrawingProvider.tsx
@@ -39,9 +39,10 @@ export type DrawingArea = {
   height: number;
   /**
    * Checks if a point is inside the drawing area.
-   * @param x The x coordinate of the point.
-   * @param y The y coordinate of the point.
-   * @returns `true` if the point is inside the drawing area, `false` otherwise.
+   * @param {Object} point The point to check.
+   * @param {number} point.x The x coordinate of the point.
+   * @param {number} point.y The y coordinate of the point.
+   * @returns {boolean} `true` if the point is inside the drawing area, `false` otherwise.
    */
   isPointInside: (point: { x: number; y: number }) => boolean;
 };
@@ -95,7 +96,7 @@ export function DrawingProvider(props: DrawingProviderProps) {
 
   const value = React.useMemo(
     () => ({ chartId: chartId ?? '', ...drawingArea, isPointInside }),
-    [chartId, drawingArea],
+    [chartId, drawingArea, isPointInside],
   );
 
   const refValue = React.useMemo(() => ({ isInitialized: true, data: svgRef }), [svgRef]);

--- a/packages/x-charts/src/hooks/useAxisEvents.ts
+++ b/packages/x-charts/src/hooks/useAxisEvents.ts
@@ -12,7 +12,7 @@ function getAsANumber(value: number | Date) {
 }
 export const useAxisEvents = (disableAxisListener: boolean) => {
   const svgRef = useSvgRef();
-  const { left, top, width, height } = useDrawingArea();
+  const drawingArea = useDrawingArea();
   const { xAxis, yAxis, xAxisIds, yAxisIds } = useCartesianContext();
   const { dispatch } = React.useContext(InteractionContext);
 
@@ -109,9 +109,7 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
         y: svgPoint.y,
       };
 
-      const outsideX = svgPoint.x < left || svgPoint.x > left + width;
-      const outsideY = svgPoint.y < top || svgPoint.y > top + height;
-      if (outsideX || outsideY) {
+      if (!drawingArea.isPointInside(svgPoint)) {
         dispatch({ type: 'exitChart' });
         return;
       }
@@ -144,17 +142,5 @@ export const useAxisEvents = (disableAxisListener: boolean) => {
       element.removeEventListener('pointercancel', handleOut);
       element.removeEventListener('pointerleave', handleOut);
     };
-  }, [
-    svgRef,
-    dispatch,
-    left,
-    width,
-    top,
-    height,
-    usedYAxis,
-    yAxis,
-    usedXAxis,
-    xAxis,
-    disableAxisListener,
-  ]);
+  }, [svgRef, dispatch, usedYAxis, yAxis, usedXAxis, xAxis, disableAxisListener, drawingArea]);
 };

--- a/packages/x-charts/src/hooks/useDrawingArea.ts
+++ b/packages/x-charts/src/hooks/useDrawingArea.ts
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { DrawingArea, DrawingContext } from '../context/DrawingProvider';
 
 export function useDrawingArea(): DrawingArea {
-  const { left, top, width, height, bottom, right } = React.useContext(DrawingContext);
+  const { left, top, width, height, bottom, right, isPointInside } =
+    React.useContext(DrawingContext);
   return React.useMemo(
-    () => ({ left, top, width, height, bottom, right }),
-    [height, left, top, width, bottom, right],
+    () => ({ left, top, width, height, bottom, right, isPointInside }),
+    [height, left, top, width, bottom, right, isPointInside],
   );
 }


### PR DESCRIPTION
- `BarChart`
  - **highlight**: Move the highlight component inside the clip group
  - **tooltip**: No change needed, as when the bars are fully outside the tooltip doesn't trigger.

- `LineChart` 
  - **highlight**: Move the highlight component inside the clip group
  - **tooltip**: Left as is. When you are zoomed in you might still want to see the value of what is outside

- `ScatterChart`
  - **highlight**: none
  - **tooltip**: Changed the voronoi/delauney to only consider the points inside render area
