### PR TITLE
[docs] Update Import section in data grid api documentation

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -459,8 +459,8 @@
   "imports": [
     "import { DataGrid } from '@mui/x-data-grid/DataGrid';",
     "import { DataGrid } from '@mui/x-data-grid';",
-    "import { DataGrid } from '@mui/x-data-grid-pro';",
-    "import { DataGrid } from '@mui/x-data-grid-premium';"
+    "import { DataGridPro } from '@mui/x-data-grid-pro';",
+    "import { DataGridPremium } from '@mui/x-data-grid-premium';"
   ],
   "slots": [
     {


### PR DESCRIPTION
I noticed the [named imports in the API documentation](https://mui.com/x/api/data-grid/data-grid/#import) are deprecated.

![image](https://github.com/user-attachments/assets/e08870db-5b51-4e3c-b32e-92db452a7032)

PR updates the imports to match the imports in the DataGrid demo page:
https://mui.com/x/react-data-grid/#premium-plan
https://mui.com/x/react-data-grid/#pro-plan

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
