### PR TITLE
[docs] Improve error message when moving between plans

### DIFF
--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGrid.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGrid.tsx
@@ -8,9 +8,10 @@ export function DataGrid() {
 
   throw new Error(
     [
-      "You try to import `DataGrid` from @mui/x-data-grid-premium but this module doesn't exist.",
+      "You try to import `DataGrid` from @mui/x-data-grid-premium but this module isn't exported from this npm package.",
       '',
       "Instead, you can do `import { DataGridPremium } from '@mui/x-data-grid-premium'`.",
+      '',
     ].join('\n'),
   );
 }
@@ -25,9 +26,10 @@ export function DataGridPro() {
 
   throw new Error(
     [
-      "You try to import `DataGridPro` from @mui/x-data-grid-premium but this module doesn't exist.",
+      "You try to import `DataGridPro` from @mui/x-data-grid-premium but this module isn't exported from this npm package.",
       '',
       "Instead, you can do `import { DataGridPremium } from '@mui/x-data-grid-premium'`.",
+      '',
     ].join('\n'),
   );
 }

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGrid.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGrid.tsx
@@ -8,9 +8,10 @@ export function DataGrid() {
 
   throw new Error(
     [
-      "You try to import `DataGrid` from @mui/x-data-grid-pro but this module doesn't exist.",
+      "You try to import `DataGrid` from @mui/x-data-grid-pro but this module isn't exported from this npm package.",
       '',
       "Instead, you can do `import { DataGridPro } from '@mui/x-data-grid-pro'`.",
+      '',
     ].join('\n'),
   );
 }
@@ -25,9 +26,13 @@ export function DataGridPremium() {
 
   throw new Error(
     [
-      "You try to import `DataGridPremium` from @mui/x-data-grid-pro but this module doesn't exist.",
+      "You try to import `DataGridPremium` from @mui/x-data-grid-pro but this module isn't exported from this npm package.",
       '',
-      "Instead, you can do `import { DataGridPro } from '@mui/x-data-grid-pro'`.",
+      'Instead, if you have a Premium plan license or want to try Premium, you can do this:',
+      `import { DataGridPremium } from '@mui/x-data-grid-premium'`,
+      '',
+      "Otherwise, you can stay on the Pro plan: `import { DataGridPro } from '@mui/x-data-grid-pro'`.",
+      '',
     ].join('\n'),
   );
 }


### PR DESCRIPTION
From https://discord.com/channels/1131323012554174485/1131329358062178324/1259822217475260447, it feels like the current error messages are confusing.

```jsx
import { DataGridPremium } from "@mui/x-data-grid-pro";
```

Before
<img width="793" alt="SCR-20240717-uoet" src="https://github.com/user-attachments/assets/aeaaf908-5944-4def-b138-1f8137334a92">

After
<img width="798" alt="SCR-20240717-uppp" src="https://github.com/user-attachments/assets/55a56928-c3a3-4c67-b274-f8635c587037">

