### PR TITLE
[DataGridPro] Server side data source lazy loading

### DIFF
--- a/docs/data/data-grid/events/events.json
+++ b/docs/data/data-grid/events/events.json
@@ -227,7 +227,7 @@
   {
     "projects": ["x-data-grid-pro", "x-data-grid-premium"],
     "name": "fetchRows",
-    "description": "Fired when a new batch of rows is requested to be loaded. Called with a GridFetchRowsParams object.",
+    "description": "Fired when a new batch of rows is requested to be loaded. Called with a GridFetchRowsParams object. Used to trigger <code>onFetchRows</code>.",
     "params": "GridFetchRowsParams",
     "event": "MuiEvent<{}>",
     "componentProp": "onFetchRows"

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -237,9 +237,7 @@ const labelDisplayedRows = ({ from, to, count, estimated }) => {
   if (!estimated) {
     return `${from}–${to} od ${count !== -1 ? count : `više nego ${to}`}`;
   }
-  const estimateLabel =
-    estimated && estimated > to ? `oko ${estimated}` : `više nego ${to}`;
-  return `${from}–${to} od ${count !== -1 ? count : estimateLabel}`;
+  return `${from}–${to} od ${count !== -1 ? count : `više nego ${estimated > to ? estimated : to}`}`;
 };
 
 <DataGrid

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -237,7 +237,9 @@ const labelDisplayedRows = ({ from, to, count, estimated }) => {
   if (!estimated) {
     return `${from}–${to} od ${count !== -1 ? count : `više nego ${to}`}`;
   }
-  return `${from}–${to} od ${count !== -1 ? count : `više nego ${estimated > to ? estimated : to}`}`;
+  const estimateLabel =
+    estimated && estimated > to ? `oko ${estimated}` : `više nego ${to}`;
+  return `${from}–${to} od ${count !== -1 ? count : estimateLabel}`;
 };
 
 <DataGrid

--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -39,6 +39,14 @@ Multiple row updates at a time are supported in [Pro](/x/introduction/licensing/
 
 ## Infinite loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
+:::warning
+This feature is deprecated and will be removed in `v9.x`.
+
+Use [Server-side data infinite loading](/x/react-data-grid/server-side-data/lazy-loading/#infinite-loading) instead.
+
+If you are unable to migrate for some reason, please open an issue to describe what is missing in the new API so that we can improve it before this feature is removed.
+:::
+
 The grid provides a `onRowsScrollEnd` prop that can be used to load additional rows when the scroll reaches the bottom of the viewport area.
 
 In addition, the area in which `onRowsScrollEnd` is called can be changed using `scrollEndThreshold`.
@@ -51,6 +59,14 @@ Otherwise, the sorting and filtering will only be applied to the subset of rows 
 :::
 
 ## Lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+
+:::warning
+This feature is deprecated and will be removed in `v9.x`.
+
+Use [Server-side data viewport loading](/x/react-data-grid/server-side-data/lazy-loading/#viewport-loading) instead.
+
+If you are unable to migrate for some reason, please open an issue to describe what is missing in the new API so that we can improve it before this feature is removed.
+:::
 
 Lazy Loading works like a pagination system, but instead of loading new rows based on pages, it loads them based on the viewport.
 It loads new rows in chunks, as the user scrolls through the Data Grid and reveals empty rows.

--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -39,14 +39,6 @@ Multiple row updates at a time are supported in [Pro](/x/introduction/licensing/
 
 ## Infinite loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
-:::warning
-This feature is deprecated and will be removed in `v9.x`.
-
-Use [Server-side data infinite loading](/x/react-data-grid/server-side-data/lazy-loading/#infinite-loading) instead.
-
-If you are unable to migrate for some reason, please open an issue to describe what is missing in the new API so that we can improve it before this feature is removed.
-:::
-
 The grid provides a `onRowsScrollEnd` prop that can be used to load additional rows when the scroll reaches the bottom of the viewport area.
 
 In addition, the area in which `onRowsScrollEnd` is called can be changed using `scrollEndThreshold`.
@@ -59,14 +51,6 @@ Otherwise, the sorting and filtering will only be applied to the subset of rows 
 :::
 
 ## Lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
-
-:::warning
-This feature is deprecated and will be removed in `v9.x`.
-
-Use [Server-side data viewport loading](/x/react-data-grid/server-side-data/lazy-loading/#viewport-loading) instead.
-
-If you are unable to migrate for some reason, please open an issue to describe what is missing in the new API so that we can improve it before this feature is removed.
-:::
 
 Lazy Loading works like a pagination system, but instead of loading new rows based on pages, it loads them based on the viewport.
 It loads new rows in chunks, as the user scrolls through the Data Grid and reveals empty rows.

--- a/docs/data/data-grid/server-side-data/ServerSideDataGridNoCache.js
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGridNoCache.js
@@ -38,6 +38,7 @@ export default function ServerSideDataGridNoCache() {
       ...initialState,
       pagination: {
         paginationModel: { pageSize: 10, page: 0 },
+        rowCount: 0,
       },
     }),
     [initialState],

--- a/docs/data/data-grid/server-side-data/ServerSideDataGridNoCache.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGridNoCache.tsx
@@ -38,6 +38,7 @@ export default function ServerSideDataGridNoCache() {
       ...initialState,
       pagination: {
         paginationModel: { pageSize: 10, page: 0 },
+        rowCount: 0,
       },
     }),
     [initialState],

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
@@ -55,6 +55,9 @@ function ServerSideLazyLoadingErrorHandling() {
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,
         );
+
+        // Reset the retryParams when new rows are fetched
+        setRetryParams(null);
         return {
           rows: getRowsResponse.rows,
           rowCount: getRowsResponse.rowCount,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
@@ -10,27 +10,25 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import { useMockServer } from '@mui/x-data-grid-generator';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
 
-function ErrorAlert({ onClick }) {
+function ErrorSnackbar(props) {
+  const { onRetry, ...rest } = props;
   return (
-    <Alert
-      sx={{
-        position: 'absolute',
-        bottom: '0',
-        paddingX: 2,
-        paddingY: 1,
-        width: '100%',
-        zIndex: 10,
-      }}
-      severity="error"
-      action={
-        <Button color="inherit" size="small" onClick={onClick}>
-          Retry
-        </Button>
-      }
-    >
-      Could not fetch the data
-    </Alert>
+    <Snackbar {...rest}>
+      <Alert
+        severity="error"
+        variant="filled"
+        sx={{ width: '100%' }}
+        action={
+          <Button color="inherit" size="small" onClick={onRetry}>
+            Retry
+          </Button>
+        }
+      >
+        Failed to fetch row data
+      </Alert>
+    </Snackbar>
   );
 }
 
@@ -79,8 +77,9 @@ function ServerSideLazyLoadingErrorHandling() {
       />
       <div style={{ height: 400, position: 'relative' }}>
         {retryParams && (
-          <ErrorAlert
-            onClick={() => {
+          <ErrorSnackbar
+            open={!!retryParams}
+            onRetry={() => {
               apiRef.current.unstable_dataSource.fetchRows(
                 GRID_ROOT_GROUP_ID,
                 retryParams,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
@@ -51,8 +51,8 @@ function ServerSideLazyLoadingErrorHandling() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
@@ -97,7 +97,7 @@ function ServerSideLazyLoadingErrorHandling() {
           unstable_dataSource={dataSource}
           unstable_onDataSourceError={(_, params) => setRetryParams(params)}
           unstable_dataSourceCache={null}
-          lazyLoading
+          unstable_lazyLoading
           paginationModel={{ page: 0, pageSize: 10 }}
           slots={{ toolbar: GridToolbar }}
         />

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
@@ -11,9 +11,10 @@ function ErrorAlert({ onClick }) {
     <Alert
       sx={{
         position: 'absolute',
-        bottom: '20%',
-        left: '20%',
-        width: '60%',
+        bottom: '0',
+        paddingX: 2,
+        paddingY: 1,
+        width: '100%',
         zIndex: 10,
       }}
       severity="error"

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.js
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { DataGridPro, useGridApiRef, GridToolbar } from '@mui/x-data-grid-pro';
+import {
+  DataGridPro,
+  useGridApiRef,
+  GridToolbar,
+  GRID_ROOT_GROUP_ID,
+} from '@mui/x-data-grid-pro';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { useMockServer } from '@mui/x-data-grid-generator';
@@ -76,7 +81,10 @@ function ServerSideLazyLoadingErrorHandling() {
         {retryParams && (
           <ErrorAlert
             onClick={() => {
-              apiRef.current.unstable_dataSource.fetchRows(retryParams);
+              apiRef.current.unstable_dataSource.fetchRows(
+                GRID_ROOT_GROUP_ID,
+                retryParams,
+              );
               setRetryParams(null);
             }}
           />
@@ -86,6 +94,7 @@ function ServerSideLazyLoadingErrorHandling() {
           apiRef={apiRef}
           unstable_dataSource={dataSource}
           unstable_onDataSourceError={(_, params) => setRetryParams(params)}
+          unstable_dataSourceCache={null}
           lazyLoading
           paginationModel={{ page: 0, pageSize: 10 }}
           slots={{ toolbar: GridToolbar }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -13,26 +13,23 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 
-function ErrorAlert({ onClick }: { onClick: () => void }) {
+function ErrorSnackbar(props: SnackbarProps & { onRetry: () => void }) {
+  const { onRetry, ...rest } = props;
   return (
-    <Alert
-      sx={{
-        position: 'absolute',
-        bottom: '0',
-        paddingX: 2,
-        paddingY: 1,
-        width: '100%',
-        zIndex: 10,
-      }}
-      severity="error"
-      action={
-        <Button color="inherit" size="small" onClick={onClick}>
-          Retry
-        </Button>
-      }
-    >
-      Could not fetch the data
-    </Alert>
+    <Snackbar {...rest}>
+      <Alert
+        severity="error"
+        variant="filled"
+        sx={{ width: '100%' }}
+        action={
+          <Button color="inherit" size="small" onClick={onRetry}>
+            Retry
+          </Button>
+        }
+      >
+        Failed to fetch row data
+      </Alert>
+    </Snackbar>
   );
 }
 
@@ -83,16 +80,16 @@ function ServerSideLazyLoadingErrorHandling() {
       />
       <div style={{ height: 400, position: 'relative' }}>
         {retryParams && (
-          <ErrorAlert
-            onClick={() => {
-              apiRef.current.unstable_dataSource.fetchRows(
-                GRID_ROOT_GROUP_ID,
-                retryParams,
-              );
-              setRetryParams(null);
-            }}
-          />
-        )}
+        <ErrorSnackbar
+          open={!!retryParams}
+          onRetry={() => {
+            apiRef.current.unstable_dataSource.fetchRows(
+              GRID_ROOT_GROUP_ID,
+              retryParams,
+            );
+            setRetryParams(null);
+          }}
+        />
         <DataGridPro
           {...props}
           apiRef={apiRef}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -17,9 +17,10 @@ function ErrorAlert({ onClick }: { onClick: () => void }) {
     <Alert
       sx={{
         position: 'absolute',
-        bottom: '20%',
-        left: '20%',
-        width: '60%',
+        bottom: '0',
+        paddingX: 2,
+        paddingY: 1,
+        width: '100%',
         zIndex: 10,
       }}
       severity="error"

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -101,7 +101,7 @@ function ServerSideLazyLoadingErrorHandling() {
           unstable_dataSource={dataSource}
           unstable_onDataSourceError={(_, params) => setRetryParams(params)}
           unstable_dataSourceCache={null}
-          lazyLoading
+          unstable_lazyLoading
           paginationModel={{ page: 0, pageSize: 10 }}
           slots={{ toolbar: GridToolbar }}
         />

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -12,6 +12,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import { useMockServer } from '@mui/x-data-grid-generator';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
+import Snackbar, { SnackbarProps } from '@mui/material/Snackbar';
 
 function ErrorSnackbar(props: SnackbarProps & { onRetry: () => void }) {
   const { onRetry, ...rest } = props;
@@ -80,16 +81,17 @@ function ServerSideLazyLoadingErrorHandling() {
       />
       <div style={{ height: 400, position: 'relative' }}>
         {retryParams && (
-        <ErrorSnackbar
-          open={!!retryParams}
-          onRetry={() => {
-            apiRef.current.unstable_dataSource.fetchRows(
-              GRID_ROOT_GROUP_ID,
-              retryParams,
-            );
-            setRetryParams(null);
-          }}
-        />
+          <ErrorSnackbar
+            open={!!retryParams}
+            onRetry={() => {
+              apiRef.current.unstable_dataSource.fetchRows(
+                GRID_ROOT_GROUP_ID,
+                retryParams,
+              );
+              setRetryParams(null);
+            }}
+          />
+        )}
         <DataGridPro
           {...props}
           apiRef={apiRef}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -59,6 +59,9 @@ function ServerSideLazyLoadingErrorHandling() {
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,
         );
+
+        // Reset the retryParams when new rows are fetched
+        setRetryParams(null);
         return {
           rows: getRowsResponse.rows,
           rowCount: getRowsResponse.rowCount,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -55,8 +55,8 @@ function ServerSideLazyLoadingErrorHandling() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingErrorHandling.tsx
@@ -5,6 +5,7 @@ import {
   GridToolbar,
   GridDataSource,
   GridGetRowsParams,
+  GRID_ROOT_GROUP_ID,
 } from '@mui/x-data-grid-pro';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -84,7 +85,10 @@ function ServerSideLazyLoadingErrorHandling() {
         {retryParams && (
           <ErrorAlert
             onClick={() => {
-              apiRef.current.unstable_dataSource.fetchRows(retryParams);
+              apiRef.current.unstable_dataSource.fetchRows(
+                GRID_ROOT_GROUP_ID,
+                retryParams,
+              );
               setRetryParams(null);
             }}
           />
@@ -94,6 +98,7 @@ function ServerSideLazyLoadingErrorHandling() {
           apiRef={apiRef}
           unstable_dataSource={dataSource}
           unstable_onDataSourceError={(_, params) => setRetryParams(params)}
+          unstable_dataSourceCache={null}
           lazyLoading
           paginationModel={{ page: 0, pageSize: 10 }}
           slots={{ toolbar: GridToolbar }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
@@ -34,7 +34,7 @@ function ServerSideLazyLoadingInfinite() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
-        lazyLoading
+        unstable_lazyLoading
         paginationModel={{ page: 0, pageSize: 15 }}
       />
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
@@ -14,8 +14,8 @@ function ServerSideLazyLoadingInfinite() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
@@ -5,7 +5,7 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 function ServerSideLazyLoadingInfinite() {
   const { columns, fetchRows } = useMockServer(
     { rowLength: 100 },
-    { useCursorPagination: false },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
   const dataSource = React.useMemo(

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.js
@@ -3,7 +3,7 @@ import { DataGridPro } from '@mui/x-data-grid-pro';
 import { useMockServer } from '@mui/x-data-grid-generator';
 
 function ServerSideLazyLoadingInfinite() {
-  const { columns, fetchRows } = useMockServer(
+  const { fetchRows, ...props } = useMockServer(
     { rowLength: 100 },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
@@ -32,7 +32,7 @@ function ServerSideLazyLoadingInfinite() {
   return (
     <div style={{ width: '100%', height: 400 }}>
       <DataGridPro
-        columns={columns}
+        {...props}
         unstable_dataSource={dataSource}
         lazyLoading
         paginationModel={{ page: 0, pageSize: 15 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
@@ -9,7 +9,7 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 function ServerSideLazyLoadingInfinite() {
   const { columns, fetchRows } = useMockServer(
     { rowLength: 100 },
-    { useCursorPagination: false },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
   const dataSource: GridDataSource = React.useMemo(

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
@@ -7,7 +7,7 @@ import {
 import { useMockServer } from '@mui/x-data-grid-generator';
 
 function ServerSideLazyLoadingInfinite() {
-  const { columns, fetchRows } = useMockServer(
+  const { fetchRows, ...props } = useMockServer(
     { rowLength: 100 },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
@@ -36,7 +36,7 @@ function ServerSideLazyLoadingInfinite() {
   return (
     <div style={{ width: '100%', height: 400 }}>
       <DataGridPro
-        columns={columns}
+        {...props}
         unstable_dataSource={dataSource}
         lazyLoading
         paginationModel={{ page: 0, pageSize: 15 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
@@ -18,8 +18,8 @@ function ServerSideLazyLoadingInfinite() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingInfinite.tsx
@@ -38,7 +38,7 @@ function ServerSideLazyLoadingInfinite() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
-        lazyLoading
+        unstable_lazyLoading
         paginationModel={{ page: 0, pageSize: 15 }}
       />
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
@@ -33,7 +33,7 @@ function GridCustomToolbar({ count, setCount }) {
 function ServerSideLazyLoadingModeUpdate() {
   const { columns, fetchRows } = useMockServer(
     { rowLength: 100 },
-    { useCursorPagination: false },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
   const [rowCount, setRowCount] = React.useState(-1);

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
@@ -44,8 +44,8 @@ function ServerSideLazyLoadingModeUpdate() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
@@ -64,7 +64,7 @@ function ServerSideLazyLoadingModeUpdate() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
-        lazyLoading
+        unstable_lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}
         rowCount={rowCount}
         slots={{ toolbar: GridCustomToolbar }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.js
@@ -31,7 +31,7 @@ function GridCustomToolbar({ count, setCount }) {
 }
 
 function ServerSideLazyLoadingModeUpdate() {
-  const { columns, fetchRows } = useMockServer(
+  const { fetchRows, ...props } = useMockServer(
     { rowLength: 100 },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
@@ -62,7 +62,7 @@ function ServerSideLazyLoadingModeUpdate() {
   return (
     <div style={{ width: '100%', height: 450 }}>
       <DataGridPro
-        columns={columns}
+        {...props}
         unstable_dataSource={dataSource}
         lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
@@ -54,8 +54,8 @@ function ServerSideLazyLoadingModeUpdate() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
@@ -3,7 +3,7 @@ import {
   DataGridPro,
   GridDataSource,
   GridGetRowsParams,
-  GridSlots,
+  GridSlotProps,
 } from '@mui/x-data-grid-pro';
 import { useMockServer } from '@mui/x-data-grid-generator';
 import FormControl from '@mui/material/FormControl';
@@ -12,12 +12,14 @@ import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Radio from '@mui/material/Radio';
 
-interface CustomToolbarProps {
-  count: number;
-  setCount: (count: number) => void;
+declare module '@mui/x-data-grid' {
+  interface ToolbarPropsOverrides {
+    count: number;
+    setCount: React.Dispatch<React.SetStateAction<number>>;
+  }
 }
 
-function GridCustomToolbar({ count, setCount }: CustomToolbarProps) {
+function GridCustomToolbar({ count, setCount }: GridSlotProps['toolbar']) {
   return (
     <FormControl
       style={{
@@ -77,7 +79,7 @@ function ServerSideLazyLoadingModeUpdate() {
         lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}
         rowCount={rowCount}
-        slots={{ toolbar: GridCustomToolbar as GridSlots['toolbar'] }}
+        slots={{ toolbar: GridCustomToolbar }}
         slotProps={{
           toolbar: {
             count: rowCount,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
@@ -76,7 +76,7 @@ function ServerSideLazyLoadingModeUpdate() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
-        lazyLoading
+        unstable_lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}
         rowCount={rowCount}
         slots={{ toolbar: GridCustomToolbar }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
@@ -41,7 +41,7 @@ function GridCustomToolbar({ count, setCount }: CustomToolbarProps) {
 }
 
 function ServerSideLazyLoadingModeUpdate() {
-  const { columns, fetchRows } = useMockServer(
+  const { fetchRows, ...props } = useMockServer(
     { rowLength: 100 },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
@@ -72,7 +72,7 @@ function ServerSideLazyLoadingModeUpdate() {
   return (
     <div style={{ width: '100%', height: 450 }}>
       <DataGridPro
-        columns={columns}
+        {...props}
         unstable_dataSource={dataSource}
         lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingModeUpdate.tsx
@@ -43,7 +43,7 @@ function GridCustomToolbar({ count, setCount }: CustomToolbarProps) {
 function ServerSideLazyLoadingModeUpdate() {
   const { columns, fetchRows } = useMockServer(
     { rowLength: 100 },
-    { useCursorPagination: false },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
   const [rowCount, setRowCount] = React.useState<number>(-1);

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
@@ -90,7 +90,7 @@ function ServerSideLazyLoadingRequestThrottle() {
         {...props}
         unstable_dataSource={dataSource}
         rowCount={rowCount}
-        lazyLoading
+        unstable_lazyLoading
         lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}
         slots={{

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
@@ -91,7 +91,7 @@ function ServerSideLazyLoadingRequestThrottle() {
         unstable_dataSource={dataSource}
         rowCount={rowCount}
         unstable_lazyLoading
-        lazyLoadingRequestThrottleMs={throttleMs}
+        unstable_lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}
         slots={{
           footerRowCount: GridCustomFooterRowCount,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { DataGridPro, GridRowCount } from '@mui/x-data-grid-pro';
+import { useMockServer } from '@mui/x-data-grid-generator';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import RadioGroup from '@mui/material/RadioGroup';
+import Radio from '@mui/material/Radio';
+
+function GridCustomFooterRowCount({ requestCount, ...props }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'start' }}>
+      <span>Request count: {requestCount}</span>
+      <GridRowCount {...props} />
+    </Box>
+  );
+}
+
+function GridCustomToolbar({ throttleMs, setThrottleMs }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'start' }}>
+      <FormControl
+        style={{
+          padding: 8,
+        }}
+      >
+        <FormLabel id="demo-request-throttle-buttons-group-label">
+          Throttle
+        </FormLabel>
+        <RadioGroup
+          row
+          aria-labelledby="demo-request-throttle-buttons-group-label"
+          name="request-throttle-buttons-group"
+          value={throttleMs}
+          onChange={(event) => setThrottleMs(Number(event.target.value))}
+        >
+          <FormControlLabel value="0" control={<Radio />} label="0 ms" />
+          <FormControlLabel
+            value="500"
+            control={<Radio />}
+            label="500 ms (default)"
+          />
+          <FormControlLabel value="1500" control={<Radio />} label="1500 ms" />
+        </RadioGroup>
+      </FormControl>
+    </Box>
+  );
+}
+
+function ServerSideLazyLoadingRequestThrottle() {
+  const { fetchRows, ...props } = useMockServer(
+    { rowLength: 1000 },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
+  );
+
+  const [requestCount, setRequestCount] = React.useState(0);
+  const [throttleMs, setThrottleMs] = React.useState(500);
+
+  const dataSource = React.useMemo(
+    () => ({
+      getRows: async (params) => {
+        const urlParams = new URLSearchParams({
+          filterModel: JSON.stringify(params.filterModel),
+          sortModel: JSON.stringify(params.sortModel),
+          start: `${params.start}`,
+          end: `${params.end}`,
+        });
+        const getRowsResponse = await fetchRows(
+          `https://mui.com/x/api/data-grid?${urlParams.toString()}`,
+        );
+
+        setRequestCount((prev) => prev + 1);
+        return {
+          rows: getRowsResponse.rows,
+          rowCount: getRowsResponse.rowCount,
+        };
+      },
+    }),
+    [fetchRows],
+  );
+
+  React.useEffect(() => {
+    setRequestCount(0);
+  }, [dataSource]);
+
+  return (
+    <div style={{ width: '100%', height: 500 }}>
+      <DataGridPro
+        {...props}
+        unstable_dataSource={dataSource}
+        lazyLoading
+        lazyLoadingRequestThrottleMs={throttleMs}
+        paginationModel={{ page: 0, pageSize: 10 }}
+        slots={{
+          footerRowCount: GridCustomFooterRowCount,
+          toolbar: GridCustomToolbar,
+        }}
+        slotProps={{
+          footerRowCount: {
+            requestCount,
+          },
+          toolbar: {
+            throttleMs,
+            setThrottleMs,
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+export default ServerSideLazyLoadingRequestThrottle;

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.js
@@ -49,8 +49,9 @@ function GridCustomToolbar({ throttleMs, setThrottleMs }) {
 }
 
 function ServerSideLazyLoadingRequestThrottle() {
+  const rowCount = 1000;
   const { fetchRows, ...props } = useMockServer(
-    { rowLength: 1000 },
+    { rowLength: rowCount },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
@@ -73,7 +74,6 @@ function ServerSideLazyLoadingRequestThrottle() {
         setRequestCount((prev) => prev + 1);
         return {
           rows: getRowsResponse.rows,
-          rowCount: getRowsResponse.rowCount,
         };
       },
     }),
@@ -89,6 +89,7 @@ function ServerSideLazyLoadingRequestThrottle() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
+        rowCount={rowCount}
         lazyLoading
         lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
@@ -4,8 +4,7 @@ import {
   GridDataSource,
   GridGetRowsParams,
   GridRowCount,
-  GridRowCountProps,
-  GridSlots,
+  GridSlotProps,
 } from '@mui/x-data-grid-pro';
 import { useMockServer } from '@mui/x-data-grid-generator';
 import Box from '@mui/material/Box';
@@ -15,25 +14,20 @@ import FormLabel from '@mui/material/FormLabel';
 import RadioGroup from '@mui/material/RadioGroup';
 import Radio from '@mui/material/Radio';
 
-declare module '@mui/x-data-grid-pro' {
-  interface FooterRowCountOverrides {
-    requestCount: number;
+declare module '@mui/x-data-grid' {
+  interface ToolbarPropsOverrides {
+    throttleMs: number;
+    setThrottleMs: React.Dispatch<React.SetStateAction<number>>;
   }
-}
-
-interface CustomFooterRowCounProps extends GridRowCountProps {
-  requestCount: number;
-}
-
-interface CustomToolbarProps {
-  throttleMs: number;
-  setThrottleMs: (value: number) => void;
+  interface FooterRowCountOverrides {
+    requestCount?: number;
+  }
 }
 
 function GridCustomFooterRowCount({
   requestCount,
   ...props
-}: CustomFooterRowCounProps) {
+}: GridSlotProps['footerRowCount']) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'start' }}>
       <span>Request count: {requestCount}</span>
@@ -42,7 +36,7 @@ function GridCustomFooterRowCount({
   );
 }
 
-function GridCustomToolbar({ throttleMs, setThrottleMs }: CustomToolbarProps) {
+function GridCustomToolbar({ throttleMs, setThrottleMs }: GridSlotProps['toolbar']) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'start' }}>
       <FormControl
@@ -79,7 +73,7 @@ function ServerSideLazyLoadingRequestThrottle() {
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
-  const [requestCount, setRequestCount] = React.useState(0);
+  const [requestCount, setRequestCount] = React.useState<number>(0);
   const [throttleMs, setThrottleMs] = React.useState<number>(500);
 
   const dataSource: GridDataSource = React.useMemo(
@@ -118,8 +112,8 @@ function ServerSideLazyLoadingRequestThrottle() {
         lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}
         slots={{
-          footerRowCount: GridCustomFooterRowCount as GridSlots['footerRowCount'],
-          toolbar: GridCustomToolbar as GridSlots['toolbar'],
+          footerRowCount: GridCustomFooterRowCount,
+          toolbar: GridCustomToolbar,
         }}
         slotProps={{
           footerRowCount: {

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
@@ -68,8 +68,9 @@ function GridCustomToolbar({ throttleMs, setThrottleMs }: GridSlotProps['toolbar
 }
 
 function ServerSideLazyLoadingRequestThrottle() {
+  const rowCount = 1000;
   const { fetchRows, ...props } = useMockServer(
-    { rowLength: 1000 },
+    { rowLength: rowCount },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
@@ -92,7 +93,6 @@ function ServerSideLazyLoadingRequestThrottle() {
         setRequestCount((prev) => prev + 1);
         return {
           rows: getRowsResponse.rows,
-          rowCount: getRowsResponse.rowCount,
         };
       },
     }),
@@ -108,6 +108,7 @@ function ServerSideLazyLoadingRequestThrottle() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
+        rowCount={rowCount}
         lazyLoading
         lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import {
+  DataGridPro,
+  GridDataSource,
+  GridGetRowsParams,
+  GridRowCount,
+  GridRowCountProps,
+  GridSlots,
+} from '@mui/x-data-grid-pro';
+import { useMockServer } from '@mui/x-data-grid-generator';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import RadioGroup from '@mui/material/RadioGroup';
+import Radio from '@mui/material/Radio';
+
+declare module '@mui/x-data-grid-pro' {
+  interface FooterRowCountOverrides {
+    requestCount: number;
+  }
+}
+
+interface CustomFooterRowCounProps extends GridRowCountProps {
+  requestCount: number;
+}
+
+interface CustomToolbarProps {
+  throttleMs: number;
+  setThrottleMs: (value: number) => void;
+}
+
+function GridCustomFooterRowCount({
+  requestCount,
+  ...props
+}: CustomFooterRowCounProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'start' }}>
+      <span>Request count: {requestCount}</span>
+      <GridRowCount {...props} />
+    </Box>
+  );
+}
+
+function GridCustomToolbar({ throttleMs, setThrottleMs }: CustomToolbarProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'start' }}>
+      <FormControl
+        style={{
+          padding: 8,
+        }}
+      >
+        <FormLabel id="demo-request-throttle-buttons-group-label">
+          Throttle
+        </FormLabel>
+        <RadioGroup
+          row
+          aria-labelledby="demo-request-throttle-buttons-group-label"
+          name="request-throttle-buttons-group"
+          value={throttleMs}
+          onChange={(event) => setThrottleMs(Number(event.target.value))}
+        >
+          <FormControlLabel value="0" control={<Radio />} label="0 ms" />
+          <FormControlLabel
+            value="500"
+            control={<Radio />}
+            label="500 ms (default)"
+          />
+          <FormControlLabel value="1500" control={<Radio />} label="1500 ms" />
+        </RadioGroup>
+      </FormControl>
+    </Box>
+  );
+}
+
+function ServerSideLazyLoadingRequestThrottle() {
+  const { fetchRows, ...props } = useMockServer(
+    { rowLength: 1000 },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
+  );
+
+  const [requestCount, setRequestCount] = React.useState(0);
+  const [throttleMs, setThrottleMs] = React.useState<number>(500);
+
+  const dataSource: GridDataSource = React.useMemo(
+    () => ({
+      getRows: async (params: GridGetRowsParams) => {
+        const urlParams = new URLSearchParams({
+          filterModel: JSON.stringify(params.filterModel),
+          sortModel: JSON.stringify(params.sortModel),
+          start: `${params.start}`,
+          end: `${params.end}`,
+        });
+        const getRowsResponse = await fetchRows(
+          `https://mui.com/x/api/data-grid?${urlParams.toString()}`,
+        );
+
+        setRequestCount((prev) => prev + 1);
+        return {
+          rows: getRowsResponse.rows,
+          rowCount: getRowsResponse.rowCount,
+        };
+      },
+    }),
+    [fetchRows],
+  );
+
+  React.useEffect(() => {
+    setRequestCount(0);
+  }, [dataSource]);
+
+  return (
+    <div style={{ width: '100%', height: 500 }}>
+      <DataGridPro
+        {...props}
+        unstable_dataSource={dataSource}
+        lazyLoading
+        lazyLoadingRequestThrottleMs={throttleMs}
+        paginationModel={{ page: 0, pageSize: 10 }}
+        slots={{
+          footerRowCount: GridCustomFooterRowCount as GridSlots['footerRowCount'],
+          toolbar: GridCustomToolbar as GridSlots['toolbar'],
+        }}
+        slotProps={{
+          footerRowCount: {
+            requestCount,
+          },
+          toolbar: {
+            throttleMs,
+            setThrottleMs,
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+export default ServerSideLazyLoadingRequestThrottle;

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
@@ -109,7 +109,7 @@ function ServerSideLazyLoadingRequestThrottle() {
         {...props}
         unstable_dataSource={dataSource}
         rowCount={rowCount}
-        lazyLoading
+        unstable_lazyLoading
         lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}
         slots={{

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingRequestThrottle.tsx
@@ -110,7 +110,7 @@ function ServerSideLazyLoadingRequestThrottle() {
         unstable_dataSource={dataSource}
         rowCount={rowCount}
         unstable_lazyLoading
-        lazyLoadingRequestThrottleMs={throttleMs}
+        unstable_lazyLoadingRequestThrottleMs={throttleMs}
         paginationModel={{ page: 0, pageSize: 10 }}
         slots={{
           footerRowCount: GridCustomFooterRowCount,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
@@ -14,8 +14,8 @@ function ServerSideLazyLoadingViewport() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
@@ -3,8 +3,8 @@ import { DataGridPro } from '@mui/x-data-grid-pro';
 import { useMockServer } from '@mui/x-data-grid-generator';
 
 function ServerSideLazyLoadingViewport() {
-  const { columns, fetchRows } = useMockServer(
-    { rowLength: 100 },
+  const { fetchRows, ...props } = useMockServer(
+    { rowLength: 100000 },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
@@ -33,7 +33,7 @@ function ServerSideLazyLoadingViewport() {
   return (
     <div style={{ width: '100%', height: 400 }}>
       <DataGridPro
-        columns={columns}
+        {...props}
         unstable_dataSource={dataSource}
         lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
@@ -5,7 +5,7 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 function ServerSideLazyLoadingViewport() {
   const { columns, fetchRows } = useMockServer(
     { rowLength: 100 },
-    { useCursorPagination: false },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
   const dataSource = React.useMemo(

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.js
@@ -35,7 +35,7 @@ function ServerSideLazyLoadingViewport() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
-        lazyLoading
+        unstable_lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}
       />
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
@@ -39,7 +39,7 @@ function ServerSideLazyLoadingViewport() {
       <DataGridPro
         {...props}
         unstable_dataSource={dataSource}
-        lazyLoading
+        unstable_lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}
       />
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
@@ -9,7 +9,7 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 function ServerSideLazyLoadingViewport() {
   const { columns, fetchRows } = useMockServer(
     { rowLength: 100 },
-    { useCursorPagination: false },
+    { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
   const dataSource: GridDataSource = React.useMemo(

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
@@ -18,8 +18,8 @@ function ServerSideLazyLoadingViewport() {
         const urlParams = new URLSearchParams({
           filterModel: JSON.stringify(params.filterModel),
           sortModel: JSON.stringify(params.sortModel),
-          firstRowToRender: `${params.start}`,
-          lastRowToRender: `${params.end}`,
+          start: `${params.start}`,
+          end: `${params.end}`,
         });
         const getRowsResponse = await fetchRows(
           `https://mui.com/x/api/data-grid?${urlParams.toString()}`,

--- a/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideLazyLoadingViewport.tsx
@@ -7,8 +7,8 @@ import {
 import { useMockServer } from '@mui/x-data-grid-generator';
 
 function ServerSideLazyLoadingViewport() {
-  const { columns, fetchRows } = useMockServer(
-    { rowLength: 100 },
+  const { fetchRows, ...props } = useMockServer(
+    { rowLength: 100000 },
     { useCursorPagination: false, minDelay: 200, maxDelay: 500 },
   );
 
@@ -37,7 +37,7 @@ function ServerSideLazyLoadingViewport() {
   return (
     <div style={{ width: '100%', height: 400 }}>
       <DataGridPro
-        columns={columns}
+        {...props}
         unstable_dataSource={dataSource}
         lazyLoading
         paginationModel={{ page: 0, pageSize: 10 }}

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -191,38 +191,38 @@ The `GridDataSourceCacheDefault` is used by default which is a simple in-memory 
 
 ### Improving the cache hit rate
 
-To increase the cache hit rate, Data Grid splits `getRows` results into chunks before storing them in cache. For the next request one or more chunks are combined to recreate the response.
+To increase the cache hit rate, Data Grid splits `getRows()` results into chunks before storing them in cache. 
+For the requests that follow, chunks are combined as needed to recreate the response.
 This means that a single request can make multiple calls to the `get` or `set` method of `GridDataSourceCache`.
 
-Chunk size is the lowest expected amount of records per request based on `pageSize` from `paginationModel` and `pageSizeOptions` prop.
+Chunk size is the lowest expected amount of records per request based on the `pageSize` value from the `paginationModel` and `pageSizeOptions` props.
 
 Because of this, values in the `pageSizeOptions` prop play a big role in the cache hit rate.
-It is recommended to have values that are multiples of the lowest value.
-Even better if every value is a multiple of the previous value.
+We recommend using values that are multiples of the lowest value; even better if each subsequent value is a multiple of the previous value.
 
-Here are some examples.
+Here are some examples:
 
 1. Best scenario - `pageSizeOptions={[5, 10, 50, 100]}`
 
-   In this case the chunk size is 5, which means that for `pageSize={100}` 20 cache records are stored.
+   In this case the chunk size is 5, which means that with `pageSize={100}` there are 20 cache records stored.
 
    Retrieving data for any other `pageSize` up to the first 100 records results in a cache hit, since the whole dataset can be made of the existing chunks.
 
 2. Parts of the data missing - `pageSizeOptions={[10, 20, 50]}`
 
-   Loading the first page with the `pageSize={50}` results in 5 cache records.
-   This works well with the `pageSize={10}`, but not all the time with `pageSize={20}`.
+   Loading the first page with `pageSize={50}` results in 5 cache records.
+   This works well with `pageSize={10}`, but not as well with `pageSize={20}`.
+   Loading the third page with `pageSize={20}` results in a new request being made, even though half of the data is already in the cache.
 
-   Loading the third page with `pageSize={20}` results in a new request being made, even though half of the data is in the cache.
+3. Incompatible page sizes - `pageSizeOptions={[7, 15, 40]}`
 
-3. Not compatible page sizes - `pageSizeOptions={[7, 15, 40]}`
-
-   In this situation, the chunk size is 7. Retrieving the first page with `pageSize={15}` creates chunks with `[7, 7, 1]` record(s).
-   Loading the second page creates another 3 chunks (again `[7, 7, 1]` record(s)), but now the third chunk from the first request has an overlap of 1 record with the first chunk of the second request.
-   These chunks with 1 record can only be used as a last piece of a request for `pageSize={15}` and are useless in any other case.
+   In this situation, the chunk size is 7. 
+   Retrieving the first page with `pageSize={15}` creates chunks split into `[7, 7, 1]` records.
+   Loading the second page creates 3 new chunks (again `[7, 7, 1]`), but now the third chunk from the first request has an overlap of 1 record with the first chunk of the second request.
+   These chunks with 1 record can only be used as the last piece of a request for `pageSize={15}` and are useless in all other cases.
 
 :::info
-Keep in mind that in the examples above `sortModel` and `filterModel` remained unchanged.
+In the examples above, `sortModel` and `filterModel` remained unchanged.
 Changing those would require a new response to be retrieved and stored in the chunks.
 :::
 

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -189,6 +189,43 @@ This means that if the user navigates to a page or expands a node that has alrea
 
 The `GridDataSourceCacheDefault` is used by default which is a simple in-memory cache that stores the data in a plain object. It can be seen in action in the [demo above](#with-data-source).
 
+### Improving the cache-hit ratio
+
+To increase the cache-hit ratio, Data Grid splits `getRows` results into chunks before storing them in cache. For the next request one or more chunks are combined to recreate the response.
+This means that a single request can make multiple calls to the `get` or `set` method of `GridDataSourceCache`.
+
+Chunk size is the lowest expected amount of records per request based on `pageSize` from `paginationModel` and `pageSizeOptions` prop.
+
+Because of this, values in the `pageSizeOptions` prop play a big role in the cache-hit ratio.
+It is recommended to have values that are multiples of the lowest value.
+Even better if every value is a multiple of the previous value.
+
+Here are some examples.
+
+1. Best scenario - `pageSizeOptions={[5, 10, 50, 100]}`
+
+   In this case the chunk size is 5, which means that for `pageSize={100}` 20 cache records are stored.
+
+   Retrieving data for any other `pageSize` up to the first 100 records results in a cache hit, since the whole dataset can be made of the existing chunks.
+
+2. Parts of the data missing - `pageSizeOptions={[10, 20, 50]}`
+
+   Loading the first page with the `pageSize={50}` results in 5 cache records.
+   This works well with the `pageSize={10}`, but not all the time with `pageSize={20}`.
+
+   Loading the third page with `pageSize={20}` results in a new request being made, even though half of the data is in the cache.
+
+3. Not compatible page sizes - `pageSizeOptions={[7, 15, 40]}`
+
+   In this situation, the chunk size is 7. Retrieving the first page with `pageSize={15}` creates chunks with `[7, 7, 1]` record(s).
+   Loading the second page creates another 3 chunks (again `[7, 7, 1]` record(s)), but now the third chunk from the first request has an overlap of 1 record with the first chunk of the second request.
+   These chunks with 1 record can only be used as a last piece of a request for `pageSize={15}` and are useless in any other case.
+
+:::info
+Keep in mind that in the examples above `sortModel` and `filterModel` remained unchanged.
+Changing those would require a new response to be retrieved and stored in the chunks.
+:::
+
 ### Customize the cache lifetime
 
 The `GridDataSourceCacheDefault` has a default Time To Live (`ttl`) of 5 minutes. To customize it, pass the `ttl` option in milliseconds to the `GridDataSourceCacheDefault` constructor, and then pass it as the `unstable_dataSourceCache` prop.

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -191,9 +191,9 @@ The `GridDataSourceCacheDefault` is used by default which is a simple in-memory 
 
 ### Improving the cache hit rate
 
-To increase the cache hit rate, Data Grid splits `getRows()` results into chunks before storing them in cache. 
+To increase the cache hit rate, Data Grid splits `getRows()` results into chunks before storing them in cache.
 For the requests that follow, chunks are combined as needed to recreate the response.
-This means that a single request can make multiple calls to the `get` or `set` method of `GridDataSourceCache`.
+This means that a single request can make multiple calls to the `get()` or `set()` method of `GridDataSourceCache`.
 
 Chunk size is the lowest expected amount of records per request based on the `pageSize` value from the `paginationModel` and `pageSizeOptions` props.
 
@@ -216,7 +216,7 @@ Here are some examples:
 
 3. Incompatible page sizes - `pageSizeOptions={[7, 15, 40]}`
 
-   In this situation, the chunk size is 7. 
+   In this situation, the chunk size is 7.
    Retrieving the first page with `pageSize={15}` creates chunks split into `[7, 7, 1]` records.
    Loading the second page creates 3 new chunks (again `[7, 7, 1]`), but now the third chunk from the first request has an overlap of 1 record with the first chunk of the second request.
    These chunks with 1 record can only be used as the last piece of a request for `pageSize={15}` and are useless in all other cases.

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -176,10 +176,10 @@ The following demo showcases this behavior.
 {{"demo": "ServerSideDataGrid.js", "bg": "inline"}}
 
 :::info
-The data source demos use a utility function `useMockServer` to simulate the server-side data fetching.
-In a real-world scenario, you should replace this with your own server-side data-fetching logic.
+The data source demos use a `useMockServer` utility function to simulate server-side data fetching.
+In a real-world scenario you would replace this with your own server-side data-fetching logic.
 
-Open info section of the browser console to see the requests being made and the data being fetched in response.
+Open the Info section of your browser console to see the requests being made and the data being fetched in response.
 :::
 
 ## Data caching

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -189,14 +189,14 @@ This means that if the user navigates to a page or expands a node that has alrea
 
 The `GridDataSourceCacheDefault` is used by default which is a simple in-memory cache that stores the data in a plain object. It can be seen in action in the [demo above](#with-data-source).
 
-### Improving the cache-hit ratio
+### Improving the cache hit rate
 
-To increase the cache-hit ratio, Data Grid splits `getRows` results into chunks before storing them in cache. For the next request one or more chunks are combined to recreate the response.
+To increase the cache hit rate, Data Grid splits `getRows` results into chunks before storing them in cache. For the next request one or more chunks are combined to recreate the response.
 This means that a single request can make multiple calls to the `get` or `set` method of `GridDataSourceCache`.
 
 Chunk size is the lowest expected amount of records per request based on `pageSize` from `paginationModel` and `pageSizeOptions` prop.
 
-Because of this, values in the `pageSizeOptions` prop play a big role in the cache-hit ratio.
+Because of this, values in the `pageSizeOptions` prop play a big role in the cache hit rate.
 It is recommended to have values that are multiples of the lowest value.
 Even better if every value is a multiple of the previous value.
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -18,17 +18,13 @@ This loading strategy is often referred to as [**viewport loading**](#viewport-l
 If the total row count is unknown, the Data Grid fetches more data when the user scrolls to the bottom. This loading strategy is often referred to as [**infinite loading**](#infinite-loading).
 
 :::info
-Row count can be provided either by returning the `rowCount` in the response of the `getRows` method in `unstable_dataSource`, via the `rowCount` prop or by calling [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API.
-:::
+Row count can be provided in either of the following ways.
 
-:::warning
-Order of precedence for the row count:
+- Pass as [`rowCount`](/x/api/data-grid/data-grid/#data-grid-prop-rowCount) prop
+- Return `rowCount` in the `getRows` method of the [data source](/x/react-data-grid/server-side-data/#data-source)
+- Set the `rowCount` using the [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API method.
 
-- `rowCount` prop
-- `rowCount` returned by the `getRows` method
-- row count set using the `setRowCount` API
-
-This means that, if the row count is set using the API, that value gets overridden once a new value is returned by the `getRows` method, even if it is `undefined`.
+The above list is given in the order of precedence, which means if the row count is set using the API, that value gets overridden once a new value is returned by the `getRows` method, even if it is `undefined`.
 :::
 
 ## Viewport loading

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -48,7 +48,7 @@ Open info section of the browser console to see the requests being made and the 
 
 While user is scrolling through the grid, rendering context changes and the Data Grid tries to fill in any missing rows by making a new data source request. This avoid making huge amount of request, Data Grid throttles new data fetches on the rendering context change. By default throttle is set to 500 ms, but the time can be controlled with `lazyLoadingRequestThrottleMs` prop.
 
-The demo below shows the difference in behavior for different values of the `lazyLoadingRequestThrottleMs` prop. In the footer of the Data Grid, you can see amount of requests made while scrolling.
+The demo below shows the difference in behavior for different values of the `lazyLoadingRequestThrottleMs` prop. In the footer of the Data Grid, you can see the amount of requests made while scrolling.
 
 {{"demo": "ServerSideLazyLoadingRequestThrottle.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -14,25 +14,25 @@ Initially, data for the first page is fetched and displayed in the grid.
 The value of the total row count determines when the next page's data is loaded:
 
 - If the total row count is known, the Data Grid is filled with skeleton rows and fetches more data if one of the skeleton rows falls into the rendering context.
-   This loading strategy is often referred to as [**viewport loading**](#viewport-loading).
+  This loading strategy is often referred to as [**viewport loading**](#viewport-loading).
 
-- If the total row count is unknown, the Data Grid fetches more data when the user scrolls to the bottom. 
-   This loading strategy is often referred to as [**infinite loading**](#infinite-loading).
+- If the total row count is unknown, the Data Grid fetches more data when the user scrolls to the bottom.
+  This loading strategy is often referred to as [**infinite loading**](#infinite-loading).
 
 :::info
 You can provide the row count through one of the following ways:
 
 - Pass it as the [`rowCount`](/x/api/data-grid/data-grid/#data-grid-prop-rowCount) prop
-- Return `rowCount` in the `getRows` method of the [data source](/x/react-data-grid/server-side-data/#data-source)
-- Set the `rowCount` using the [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API method
+- Return `rowCount` in the `getRows()` method of the [data source](/x/react-data-grid/server-side-data/#data-source)
+- Set the `rowCount` using the [`setRowCount()`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API method
 
-These options are presented in order of precedence, which means if the row count is set using the API, that value is overridden once a new value is returned by the `getRows` method unless it's `undefined`.
+These options are presented in order of precedence, which means if the row count is set using the API, that value is overridden once a new value is returned by the `getRows()` method unless it's `undefined`.
 :::
 
 ## Viewport loading
 
 Viewport loading mode is enabled when the row count is known (and is greater than or equal to zero).
-The Grid fetches the first page immediately and adds skeleton rows to match the total row count. 
+The Grid fetches the first page immediately and adds skeleton rows to match the total row count.
 Other pages are fetched once the user starts scrolling and moves a skeleton row inside the rendering context (with the index range defined by [virtualization](/x/react-data-grid/virtualization/)).
 
 If the user scrolls too fast, the Grid loads multiple pages with one request (by adjusting `start` and `end` parameters) to reduce the server load.
@@ -59,20 +59,20 @@ Use the `unstable_lazyLoadingRequestThrottleMs` prop to set a custom time, as sh
 
 ## Infinite loading
 
-Infinite loading mode is enabled when the row count is unknown (either `-1` or `undefined`). 
+Infinite loading mode is enabled when the row count is unknown (either `-1` or `undefined`).
 A new page is loaded when the scroll reaches the bottom of the viewport area.
 
 You can use the `scrollEndThreshold` prop to change the area that triggers new requests.
 
-The demo below shows how infinite loading mode works. 
-Page size is set to `15` and the mock server is configured to return a total of 100 rows. 
+The demo below shows how infinite loading mode works.
+Page size is set to `15` and the mock server is configured to return a total of 100 rows.
 When the response contains no new rows, the Grid stops requesting new data.
 
 {{"demo": "ServerSideLazyLoadingInfinite.js", "bg": "inline"}}
 
 ## Updating the loading mode
 
-The grid changes the loading mode dynamically if the total row count gets updated in any of the three ways described above.
+The Grid changes the loading mode dynamically if the total row count gets updated by changing the `rowCount` prop, returning different `rowCount` in `GridGetRowsResponse` or via `setRowCount()` API.
 
 Based on the previous and the new value for the total row count, the following scenarios are possible:
 
@@ -83,7 +83,7 @@ Based on the previous and the new value for the total row count, the following s
 - **Known `rowCount` greater than the actual row count**: This can happen either by reducing the value of the row count after more rows were already fetched, or if the row count was unknown and the Grid (while in the infinite loading mode) already fetched more rows. In this case, the Grid resets, fetches the first page, and then continues in one mode or the other depending on the new value of the `rowCount`.
 
 :::warning
-`rowCount` is expected to be static. 
+`rowCount` is expected to be static.
 Changing its value can cause the Grid to reset and the cache to be cleared which may lead to performance and UX degradation.
 :::
 
@@ -105,9 +105,9 @@ When completed, it will be possible to use the `unstable_lazyLoading` flag in co
 
 ## Error handling
 
-To handle errors, use the `unstable_onDataSourceError` prop as described in [Server-side data—Error handling](/x/react-data-grid/server-side-data/#error-handling).
+To handle errors, use the `unstable_onDataSourceError()` prop as described in [Server-side data—Error handling](/x/react-data-grid/server-side-data/#error-handling).
 
-You can pass the second parameter of type `GridGetRowsParams` to the `getRows` method of the [`unstable_dataSource`](/x/api/data-grid/grid-api/#grid-api-prop-unstable_dataSource) to retry the request.
+You can pass the second parameter of type `GridGetRowsParams` to the `getRows()` method of the [`unstable_dataSource`](/x/api/data-grid/grid-api/#grid-api-prop-unstable_dataSource) to retry the request.
 If successful, the Data Grid uses `rows` and `rowCount` data to determine if the rows should be appended at the end of the grid or if the skeleton rows should be replaced.
 
 The following demo gives an example how to use `GridGetRowsParams` to retry a failed request.

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -48,7 +48,7 @@ Open info section of the browser console to see the requests being made and the 
 
 While user is scrolling through the grid, rendering context changes and the Data Grid tries to fill in any missing rows by making a new server request.
 The Data Grid throttles new data fetches on the rendering context change to avoid doing unnecessary requests.
-The default throttle time is 500 milliseconds, use `lazyLoadingRequestThrottleMs` prop to customize it, as the following example demonstrates.
+The default throttle time is 500 milliseconds, use `unstable_lazyLoadingRequestThrottleMs` prop to customize it, as the following example demonstrates.
 
 {{"demo": "ServerSideLazyLoadingRequestThrottle.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -12,9 +12,10 @@ It is enabled by adding `lazyLoading` prop in combination with `unstable_dataSou
 
 Initially, the first page data is fetched and displayed in the grid. What triggers the loading of next page data depends on the value of the total row count.
 
-If the total row count is known, the grid gets filled with skeleton rows and fetches more data if one of the skeleton rows falls into the rendering context.
+If the total row count is known, the Data Grid gets filled with skeleton rows and fetches more data if one of the skeleton rows falls into the rendering context.
+This loading strategy is often referred to as [**viewport loading**](#viewport-loading).
 
-If the total row count is unknown, the grid fetches more data when the user scrolls to the bottom of the grid. This loading strategy is often referred to as **infinite loading**.
+If the total row count is unknown, the Data Grid fetches more data when the user scrolls to the bottom. This loading strategy is often referred to as [**infinite loading**](#infinite-loading).
 
 :::info
 Row count can be provided either by returning the `rowCount` in the response of the `getRows` method in `unstable_dataSource`, via the `rowCount` prop or by calling [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API.
@@ -65,9 +66,9 @@ The grid changes the loading mode dynamically if the total row count gets update
 
 Based on the previous and the new value for the total row count, the following scenarios are possible:
 
-- **Unknown `rowCount` to known `rowCount`**: If row count is not unknown anymore, the grid switches to the viewport loading mode. It checks the amount of allready fetched rows and adds skeleton rows to match the total row count.
+- **Unknown `rowCount` to known `rowCount`**: When the row count is set to a valid value from an unknown value, the Data Grid switches to the viewport loading mode. It checks the number of already fetched rows and adds skeleton rows to match the provided row count.
 
-- **Known `rowCount` to unknown `rowCount`**: If the row count is updated and set to `-1`, the grid resets, fetches the first page and sets itself in the infinite loading mode.
+- **Known `rowCount` to unknown `rowCount`**: If the row count is updated and set to `-1`, the Data Grid resets, fetches the first page, and sets itself in the infinite loading mode.
 
 - **Known `rowCount` greater than the actual row count**: This can happen either by reducing the value of the row count after more rows were already fetched or if the row count was unknown and the grid in the inifite loading mode already fetched more rows. In this case, the grid resets, fetches the first page and continues in one of the modes depending on the new value of the `rowCount`.
 
@@ -89,7 +90,7 @@ This feature isn't implemented yet. It's coming.
 Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this feature, or if you are facing a pain point with your current solution.
 :::
 
-When completed, it will be possible to use `lazyLoading` flag in combination with [Tree data](/x/react-data-grid/server-side-data/tree-data/) and [Row grouping](/x/react-data-grid/server-side-data/row-grouping/).
+When completed, it would be possible to use `lazyLoading` flag in combination with [Tree data](/x/react-data-grid/server-side-data/tree-data/) and [Row grouping](/x/react-data-grid/server-side-data/row-grouping/).
 
 ## Error handling
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -4,61 +4,69 @@ title: React Data Grid - Server-side lazy loading
 
 # Data Grid - Server-side lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
-<p class="description">Row lazy-loading with server-side data source.</p>
+<p class="description">Learn how to implement lazy-loading rows with a server-side data source.</p>
 
-Lazy Loading changes the way pagination works by removing page controls and loading data dynamically (in a single list) as the user scrolls through the grid.
+Lazy loading changes the way pagination works by removing page controls and loading data dynamically (in a single list) as the user scrolls through the grid.
 
-It is enabled by adding `unstable_lazyLoading` prop in combination with `unstable_dataSource` prop.
+You can enable it with the `unstable_lazyLoading` prop paired with the `unstable_dataSource` prop.
 
-Initially, the first page data is fetched and displayed in the grid. What triggers the loading of next page data depends on the value of the total row count.
+Initially, data for the first page is fetched and displayed in the grid.
+The value of the total row count determines when the next page's data is loaded:
 
-If the total row count is known, the Data Grid gets filled with skeleton rows and fetches more data if one of the skeleton rows falls into the rendering context.
-This loading strategy is often referred to as [**viewport loading**](#viewport-loading).
+- If the total row count is known, the Data Grid is filled with skeleton rows and fetches more data if one of the skeleton rows falls into the rendering context.
+   This loading strategy is often referred to as [**viewport loading**](#viewport-loading).
 
-If the total row count is unknown, the Data Grid fetches more data when the user scrolls to the bottom. This loading strategy is often referred to as [**infinite loading**](#infinite-loading).
+- If the total row count is unknown, the Data Grid fetches more data when the user scrolls to the bottom. 
+   This loading strategy is often referred to as [**infinite loading**](#infinite-loading).
 
 :::info
-Row count can be provided in either of the following ways.
+You can provide the row count through one of the following ways:
 
-- Pass as [`rowCount`](/x/api/data-grid/data-grid/#data-grid-prop-rowCount) prop
+- Pass it as the [`rowCount`](/x/api/data-grid/data-grid/#data-grid-prop-rowCount) prop
 - Return `rowCount` in the `getRows` method of the [data source](/x/react-data-grid/server-side-data/#data-source)
-- Set the `rowCount` using the [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API method.
+- Set the `rowCount` using the [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API method
 
-The above list is given in the order of precedence, which means if the row count is set using the API, that value gets overridden once a new value is returned by the `getRows` method, unless if it is `undefined`.
+These options are presented in order of precedence, which means if the row count is set using the API, that value is overridden once a new value is returned by the `getRows` method unless it's `undefined`.
 :::
 
 ## Viewport loading
 
-The viewport loading mode is enabled when the row count is known (`rowCount >= 0`). Grid fetches the first page immediately and adds skeleton rows to match the total row count. Other pages are fetched once the user starts scrolling and moves a skeleton row inside the rendering context (index range defined by [Virtualization](/x/react-data-grid/virtualization/)).
+Viewport loading mode is enabled when the row count is known (and is greater than or equal to zero).
+The Grid fetches the first page immediately and adds skeleton rows to match the total row count. 
+Other pages are fetched once the user starts scrolling and moves a skeleton row inside the rendering context (with the index range defined by [virtualization](/x/react-data-grid/virtualization/)).
 
-If the user scrolls too fast, the grid loads multiple pages with one request (by adjusting `start` and `end` param) in order to reduce the server load.
+If the user scrolls too fast, the Grid loads multiple pages with one request (by adjusting `start` and `end` parameters) to reduce the server load.
 
-The demo below shows the viewport loading mode.
+The demo below shows how viewport loading mode works:
 
 {{"demo": "ServerSideLazyLoadingViewport.js", "bg": "inline"}}
 
 :::info
-The data source demos use a utility function `useMockServer` to simulate the server-side data fetching.
-In a real-world scenario, you should replace this with your own server-side data-fetching logic.
+The data source demos use a `useMockServer` utility function to simulate server-side data fetching.
+In a real-world scenario you would replace this with your own server-side data-fetching logic.
 
-Open info section of the browser console to see the requests being made and the data being fetched in response.
+Open the Info section of your browser console to see the requests being made and the data being fetched in response.
 :::
 
 ### Request throttling
 
-While user is scrolling through the grid, rendering context changes and the Data Grid tries to fill in any missing rows by making a new server request.
-The Data Grid throttles new data fetches on the rendering context change to avoid doing unnecessary requests.
-The default throttle time is 500 milliseconds, use `unstable_lazyLoadingRequestThrottleMs` prop to customize it, as the following example demonstrates.
+As a user scrolls through the Grid, the rendering context changes and the Grid tries to fill in any missing rows by making a new server request.
+It also throttles new data fetches to avoid making unnecessary requests.
+The default throttle time is 500 milliseconds.
+Use the `unstable_lazyLoadingRequestThrottleMs` prop to set a custom time, as shown below:
 
 {{"demo": "ServerSideLazyLoadingRequestThrottle.js", "bg": "inline"}}
 
 ## Infinite loading
 
-The infinite loading mode is enabled when the row count is unknown (`-1` or `undefined`). New page is loaded when the scroll reaches the bottom of the viewport area.
+Infinite loading mode is enabled when the row count is unknown (either `-1` or `undefined`). 
+A new page is loaded when the scroll reaches the bottom of the viewport area.
 
-The area which triggers the new request can be changed using `scrollEndThreshold`.
+You can use the `scrollEndThreshold` prop to change the area that triggers new requests.
 
-The demo below shows the infinite loading mode. Page size is set to `15` and the mock server is configured to return a total of `100` rows. Once the response does not contain any new rows, the grid stops requesting new data.
+The demo below shows how infinite loading mode works. 
+Page size is set to `15` and the mock server is configured to return a total of 100 rows. 
+When the response contains no new rows, the Grid stops requesting new data.
 
 {{"demo": "ServerSideLazyLoadingInfinite.js", "bg": "inline"}}
 
@@ -68,17 +76,18 @@ The grid changes the loading mode dynamically if the total row count gets update
 
 Based on the previous and the new value for the total row count, the following scenarios are possible:
 
-- **Unknown `rowCount` to known `rowCount`**: When the row count is set to a valid value from an unknown value, the Data Grid switches to the viewport loading mode. It checks the number of already fetched rows and adds skeleton rows to match the provided row count.
+- **Unknown `rowCount` to known `rowCount`**: When the row count is set to a valid value from an unknown value, the Data Grid switches to viewport loading mode. It checks the number of already fetched rows and adds skeleton rows to match the provided row count.
 
-- **Known `rowCount` to unknown `rowCount`**: If the row count is updated and set to `-1`, the Data Grid resets, fetches the first page, and sets itself in the infinite loading mode.
+- **Known `rowCount` to unknown `rowCount`**: If the row count is updated and set to `-1`, the Data Grid resets, fetches the first page, then sets itself to infinite loading mode.
 
-- **Known `rowCount` greater than the actual row count**: This can happen either by reducing the value of the row count after more rows were already fetched or if the row count was unknown and the grid in the inifite loading mode already fetched more rows. In this case, the grid resets, fetches the first page and continues in one of the modes depending on the new value of the `rowCount`.
+- **Known `rowCount` greater than the actual row count**: This can happen either by reducing the value of the row count after more rows were already fetched, or if the row count was unknown and the Grid (while in the infinite loading mode) already fetched more rows. In this case, the Grid resets, fetches the first page, and then continues in one mode or the other depending on the new value of the `rowCount`.
 
 :::warning
-`rowCount` is expected to be static. Changing its value can cause the grid to reset and the cache to be cleared which may lead to performance and UX degradation.
+`rowCount` is expected to be static. 
+Changing its value can cause the Grid to reset and the cache to be cleared which may lead to performance and UX degradation.
 :::
 
-The demo below serves more as a showcase of the behavior described above and is not representing something you would implement in a real-world scenario.
+The demo below serves as a showcase of the behavior described above, and is not representative of something you would implement in a real-world scenario.
 
 {{"demo": "ServerSideLazyLoadingModeUpdate.js", "bg": "inline"}}
 
@@ -89,16 +98,16 @@ This feature isn't implemented yet. It's coming.
 
 👍 Upvote [issue #14527](https://github.com/mui/mui-x/issues/14527) if you want to see it land faster.
 
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this feature, or if you are facing a pain point with your current solution.
+Don't hesitate to leave a comment on the issue to help influence what gets built—especially if you already have a use case for this feature, or if you're facing a specific pain point with your current solution.
 :::
 
-When completed, it would be possible to use `unstable_lazyLoading` flag in combination with [Tree data](/x/react-data-grid/server-side-data/tree-data/) and [Row grouping](/x/react-data-grid/server-side-data/row-grouping/).
+When completed, it will be possible to use the `unstable_lazyLoading` flag in combination with [tree data](/x/react-data-grid/server-side-data/tree-data/) and [row grouping](/x/react-data-grid/server-side-data/row-grouping/).
 
 ## Error handling
 
-To handle errors, use `unstable_onDataSourceError` prop as described in the [Error handling](/x/react-data-grid/server-side-data/#error-handling) section of the data source overview page.
+To handle errors, use the `unstable_onDataSourceError` prop as described in [Server-side data—Error handling](/x/react-data-grid/server-side-data/#error-handling).
 
-Second parameter of type `GridGetRowsParams` can be passed to `getRows` method of the [`unstable_dataSource`](/x/api/data-grid/grid-api/#grid-api-prop-unstable_dataSource) to retry the request.
+You can pass the second parameter of type `GridGetRowsParams` to the `getRows` method of the [`unstable_dataSource`](/x/api/data-grid/grid-api/#grid-api-prop-unstable_dataSource) to retry the request.
 If successful, the Data Grid uses `rows` and `rowCount` data to determine if the rows should be appended at the end of the grid or if the skeleton rows should be replaced.
 
 The following demo gives an example how to use `GridGetRowsParams` to retry a failed request.

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -8,7 +8,7 @@ title: React Data Grid - Server-side lazy loading
 
 Lazy Loading changes the way pagination works by removing page controls and loading data dynamically (in a single list) as the user scrolls through the grid.
 
-It is enabled by adding `lazyLoading` prop in combination with `unstable_dataSource` prop.
+It is enabled by adding `unstable_lazyLoading` prop in combination with `unstable_dataSource` prop.
 
 Initially, the first page data is fetched and displayed in the grid. What triggers the loading of next page data depends on the value of the total row count.
 
@@ -92,7 +92,7 @@ This feature isn't implemented yet. It's coming.
 Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this feature, or if you are facing a pain point with your current solution.
 :::
 
-When completed, it would be possible to use `lazyLoading` flag in combination with [Tree data](/x/react-data-grid/server-side-data/tree-data/) and [Row grouping](/x/react-data-grid/server-side-data/row-grouping/).
+When completed, it would be possible to use `unstable_lazyLoading` flag in combination with [Tree data](/x/react-data-grid/server-side-data/tree-data/) and [Row grouping](/x/react-data-grid/server-side-data/row-grouping/).
 
 ## Error handling
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -2,7 +2,7 @@
 title: React Data Grid - Server-side lazy loading
 ---
 
-# Data Grid - Server-side lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+# Data Grid - Server-side lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🧪
 
 <p class="description">Learn how to implement lazy-loading rows with a server-side data source.</p>
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -24,7 +24,7 @@ Row count can be provided in either of the following ways.
 - Return `rowCount` in the `getRows` method of the [data source](/x/react-data-grid/server-side-data/#data-source)
 - Set the `rowCount` using the [`setRowCount`](/x/api/data-grid/grid-api/#grid-api-prop-setRowCount) API method.
 
-The above list is given in the order of precedence, which means if the row count is set using the API, that value gets overridden once a new value is returned by the `getRows` method, even if it is `undefined`.
+The above list is given in the order of precedence, which means if the row count is set using the API, that value gets overridden once a new value is returned by the `getRows` method, unless if it is `undefined`.
 :::
 
 ## Viewport loading

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -33,8 +33,6 @@ The viewport loading mode is enabled when the row count is known (`rowCount >= 0
 
 If the user scrolls too fast, the grid loads multiple pages with one request (by adjusting `start` and `end` param) in order to reduce the server load.
 
-In addition to this, the grid throttles new requests made to the data source after each rendering context change. This can be controlled with `lazyLoadingRequestThrottleMs` prop.
-
 The demo below shows the viewport loading mode.
 
 {{"demo": "ServerSideLazyLoadingViewport.js", "bg": "inline"}}
@@ -45,6 +43,14 @@ In a real-world scenario, you should replace this with your own server-side data
 
 Open info section of the browser console to see the requests being made and the data being fetched in response.
 :::
+
+### Request throttling
+
+While user is scrolling through the grid, rendering context changes and the Data Grid tries to fill in any missing rows by making a new data source request. This avoid making huge amount of request, Data Grid throttles new data fetches on the rendering context change. By default throttle is set to 500 ms, but the time can be controlled with `lazyLoadingRequestThrottleMs` prop.
+
+The demo below shows the difference in behavior for different values of the `lazyLoadingRequestThrottleMs` prop. In the footer of the Data Grid, you can see amount of requests made while scrolling.
+
+{{"demo": "ServerSideLazyLoadingRequestThrottle.js", "bg": "inline"}}
 
 ## Infinite loading
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -46,9 +46,9 @@ Open info section of the browser console to see the requests being made and the 
 
 ### Request throttling
 
-While user is scrolling through the grid, rendering context changes and the Data Grid tries to fill in any missing rows by making a new data source request. This avoid making huge amount of request, Data Grid throttles new data fetches on the rendering context change. By default throttle is set to 500 ms, but the time can be controlled with `lazyLoadingRequestThrottleMs` prop.
-
-The demo below shows the difference in behavior for different values of the `lazyLoadingRequestThrottleMs` prop. In the footer of the Data Grid, you can see the amount of requests made while scrolling.
+While user is scrolling through the grid, rendering context changes and the Data Grid tries to fill in any missing rows by making a new server request.
+The Data Grid throttles new data fetches on the rendering context change to avoid doing unnecessary requests.
+The default throttle time is 500 milliseconds, use `lazyLoadingRequestThrottleMs` prop to customize it, as the following example demonstrates.
 
 {{"demo": "ServerSideLazyLoadingRequestThrottle.js", "bg": "inline"}}
 
@@ -75,14 +75,14 @@ Based on the previous and the new value for the total row count, the following s
 - **Known `rowCount` greater than the actual row count**: This can happen either by reducing the value of the row count after more rows were already fetched or if the row count was unknown and the grid in the inifite loading mode already fetched more rows. In this case, the grid resets, fetches the first page and continues in one of the modes depending on the new value of the `rowCount`.
 
 :::warning
-`rowCount` is expected to be static. Changing its value can cause the grid to reset and the cache to be cleared which leads to poor performance and user experience.
+`rowCount` is expected to be static. Changing its value can cause the grid to reset and the cache to be cleared which may lead to performance and UX degradation.
 :::
 
 The demo below serves more as a showcase of the behavior described above and is not representing something you would implement in a real-world scenario.
 
 {{"demo": "ServerSideLazyLoadingModeUpdate.js", "bg": "inline"}}
 
-## Nested rows 🚧
+## Nested lazy loading 🚧
 
 :::warning
 This feature isn't implemented yet. It's coming.
@@ -98,7 +98,8 @@ When completed, it would be possible to use `lazyLoading` flag in combination wi
 
 To handle errors, use `unstable_onDataSourceError` prop as described in the [Error handling](/x/react-data-grid/server-side-data/#error-handling) section of the data source overview page.
 
-Second parameter of type `GridGetRowsParams` can be passed to `getRows` method of the [`unstable_dataSource`](/x/api/data-grid/grid-api/#grid-api-prop-unstable_dataSource) to retry the request. If successful, the grid uses `rows` and `rowCount` data to determine if the rows should be appended at the end of the grid or if the skeleton rows should be replaced.
+Second parameter of type `GridGetRowsParams` can be passed to `getRows` method of the [`unstable_dataSource`](/x/api/data-grid/grid-api/#grid-api-prop-unstable_dataSource) to retry the request.
+If successful, the Data Grid uses `rows` and `rowCount` data to determine if the rows should be appended at the end of the grid or if the skeleton rows should be replaced.
 
 The following demo gives an example how to use `GridGetRowsParams` to retry a failed request.
 

--- a/docs/data/data-grid/server-side-data/tree-data.md
+++ b/docs/data/data-grid/server-side-data/tree-data.md
@@ -59,10 +59,10 @@ It also caches the data by default.
 {{"demo": "ServerSideTreeData.js", "bg": "inline"}}
 
 :::info
-The data source demos use a utility function `useMockServer` to simulate the server-side data fetching.
-In a real-world scenario, you would replace this with your own server-side data fetching logic.
+The data source demos use a `useMockServer` utility function to simulate server-side data fetching.
+In a real-world scenario you would replace this with your own server-side data-fetching logic.
 
-Open the info section of the browser console to see the requests being made and the data being fetched in response.
+Open the Info section of your browser console to see the requests being made and the data being fetched in response.
 :::
 
 ## Error handling

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -129,7 +129,6 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-data-grid/export' },
           { pathname: '/x/react-data-grid/clipboard', title: 'Copy and paste' },
           { pathname: '/x/react-data-grid/scrolling' },
-
           {
             pathname: '/x/react-data-grid/list-view',
             title: 'List view',

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -124,11 +124,31 @@ const pages: MuiPage[] = [
           {
             pathname: '/x/react-data-grid/server-side-data/row-grouping',
             plan: 'premium',
+            children: [
+              { pathname: '/x/react-data-grid/row-grouping', title: 'Overview' },
+              {
+                pathname: '/x/react-data-grid/recipes-row-grouping',
+                title: 'Recipes',
+              },
+            ],
+          },
+          { pathname: '/x/react-data-grid/aggregation', plan: 'premium' },
+          { pathname: '/x/react-data-grid/pivoting', plan: 'premium', planned: true },
+          { pathname: '/x/react-data-grid/export' },
+          { pathname: '/x/react-data-grid/clipboard', title: 'Copy and paste', newFeature: true },
+          { pathname: '/x/react-data-grid/scrolling' },
+
+          {
+            pathname: '/x/react-data-grid/list-view',
+            title: 'List view',
+            plan: 'pro',
+            unstable: true,
           },
           {
             pathname: '/x/react-data-grid/server-side-data-group',
             title: 'Server-side data',
             plan: 'pro',
+            newFeature: true,
             children: [
               {
                 pathname: '/x/react-data-grid/server-side-data',
@@ -148,7 +168,6 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-data-grid/server-side-data/row-grouping',
                 plan: 'premium',
-                unstable: true,
               },
               {
                 pathname: '/x/react-data-grid/server-side-data/aggregation',

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -115,7 +115,6 @@ const pages: MuiPage[] = [
           {
             pathname: '/x/react-data-grid/server-side-data/lazy-loading',
             plan: 'pro',
-            newFeature: true,
           },
           { pathname: '/x/react-data-grid/aggregation', plan: 'premium' },
           { pathname: '/x/react-data-grid/pivoting', plan: 'premium', planned: true },

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -90,7 +90,6 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-data-grid/filtering/header-filters',
                 plan: 'pro',
-                newFeature: true,
               },
               { pathname: '/x/react-data-grid/filtering-recipes', title: 'Recipes' },
             ],
@@ -100,7 +99,7 @@ const pages: MuiPage[] = [
             pathname: '/x/react-data-grid/selection',
             children: [
               { pathname: '/x/react-data-grid/row-selection' },
-              { pathname: '/x/react-data-grid/cell-selection', plan: 'premium', newFeature: true },
+              { pathname: '/x/react-data-grid/cell-selection', plan: 'premium' },
             ],
           },
           { pathname: '/x/react-data-grid/virtualization' },
@@ -128,7 +127,7 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-data-grid/aggregation', plan: 'premium' },
           { pathname: '/x/react-data-grid/pivoting', plan: 'premium', planned: true },
           { pathname: '/x/react-data-grid/export' },
-          { pathname: '/x/react-data-grid/clipboard', title: 'Copy and paste', newFeature: true },
+          { pathname: '/x/react-data-grid/clipboard', title: 'Copy and paste' },
           { pathname: '/x/react-data-grid/scrolling' },
 
           {
@@ -345,7 +344,6 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-date-pickers/date-time-range-picker',
                 title: 'Date Time Range Picker',
-                newFeature: true,
               },
               {
                 pathname: '/x/react-date-pickers/date-time-range-field',
@@ -415,7 +413,6 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-charts-group',
     title: 'Charts',
-    newFeature: true,
     children: [
       { pathname: '/x/react-charts', title: 'Overview' },
       { pathname: '/x/react-charts/getting-started' },
@@ -465,7 +462,6 @@ const pages: MuiPage[] = [
             pathname: '/x/react-charts/heatmap',
             title: 'Heatmap',
             plan: 'pro',
-            unstable: true,
           },
           {
             pathname: '/x/react-charts/main-features',
@@ -484,7 +480,6 @@ const pages: MuiPage[] = [
                 pathname: '/x/react-charts/zoom-and-pan',
                 title: 'Zoom and pan',
                 plan: 'pro',
-                unstable: true,
               },
             ],
           },
@@ -530,7 +525,6 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-tree-view-group',
     title: 'Tree View',
-    newFeature: true,
     children: [
       { pathname: '/x/react-tree-view', title: 'Overview' },
       { pathname: '/x/react-tree-view/getting-started' },
@@ -554,8 +548,8 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-tree-view/rich-tree-view/expansion' },
           { pathname: '/x/react-tree-view/rich-tree-view/customization' },
           { pathname: '/x/react-tree-view/rich-tree-view/focus' },
-          { pathname: '/x/react-tree-view/rich-tree-view/editing' },
-          { pathname: '/x/react-tree-view/rich-tree-view/ordering', plan: 'pro' },
+          { pathname: '/x/react-tree-view/rich-tree-view/editing', newFeature: true },
+          { pathname: '/x/react-tree-view/rich-tree-view/ordering', plan: 'pro', newFeature: true },
         ],
       },
       {

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -148,7 +148,6 @@ const pages: MuiPage[] = [
             pathname: '/x/react-data-grid/server-side-data-group',
             title: 'Server-side data',
             plan: 'pro',
-            newFeature: true,
             children: [
               {
                 pathname: '/x/react-data-grid/server-side-data',
@@ -164,10 +163,12 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-data-grid/server-side-data/lazy-loading',
                 plan: 'pro',
+                unstable: true,
               },
               {
                 pathname: '/x/react-data-grid/server-side-data/row-grouping',
                 plan: 'premium',
+                unstable: true,
               },
               {
                 pathname: '/x/react-data-grid/server-side-data/aggregation',

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -90,6 +90,7 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-data-grid/filtering/header-filters',
                 plan: 'pro',
+                newFeature: true,
               },
               { pathname: '/x/react-data-grid/filtering-recipes', title: 'Recipes' },
             ],
@@ -99,7 +100,7 @@ const pages: MuiPage[] = [
             pathname: '/x/react-data-grid/selection',
             children: [
               { pathname: '/x/react-data-grid/row-selection' },
-              { pathname: '/x/react-data-grid/cell-selection', plan: 'premium' },
+              { pathname: '/x/react-data-grid/cell-selection', plan: 'premium', newFeature: true },
             ],
           },
           { pathname: '/x/react-data-grid/virtualization' },
@@ -113,16 +114,8 @@ const pages: MuiPage[] = [
         children: [
           { pathname: '/x/react-data-grid/tree-data', plan: 'pro' },
           {
-            pathname: '/x/react-data-grid/server-side-data/lazy-loading',
-            plan: 'pro',
-          },
-          { pathname: '/x/react-data-grid/aggregation', plan: 'premium' },
-          { pathname: '/x/react-data-grid/pivoting', plan: 'premium', planned: true },
-          { pathname: '/x/react-data-grid/export' },
-          { pathname: '/x/react-data-grid/clipboard', title: 'Copy and paste' },
-          { pathname: '/x/react-data-grid/scrolling' },
-          {
-            pathname: '/x/react-data-grid/server-side-data/row-grouping',
+            pathname: '/x/react-data-grid/row-grouping-group',
+            title: 'Row grouping',
             plan: 'premium',
             children: [
               { pathname: '/x/react-data-grid/row-grouping', title: 'Overview' },
@@ -352,6 +345,7 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-date-pickers/date-time-range-picker',
                 title: 'Date Time Range Picker',
+                newFeature: true,
               },
               {
                 pathname: '/x/react-date-pickers/date-time-range-field',
@@ -421,6 +415,7 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-charts-group',
     title: 'Charts',
+    newFeature: true,
     children: [
       { pathname: '/x/react-charts', title: 'Overview' },
       { pathname: '/x/react-charts/getting-started' },
@@ -470,6 +465,7 @@ const pages: MuiPage[] = [
             pathname: '/x/react-charts/heatmap',
             title: 'Heatmap',
             plan: 'pro',
+            unstable: true,
           },
           {
             pathname: '/x/react-charts/main-features',
@@ -488,6 +484,7 @@ const pages: MuiPage[] = [
                 pathname: '/x/react-charts/zoom-and-pan',
                 title: 'Zoom and pan',
                 plan: 'pro',
+                unstable: true,
               },
             ],
           },
@@ -533,6 +530,7 @@ const pages: MuiPage[] = [
   {
     pathname: '/x/react-tree-view-group',
     title: 'Tree View',
+    newFeature: true,
     children: [
       { pathname: '/x/react-tree-view', title: 'Overview' },
       { pathname: '/x/react-tree-view/getting-started' },
@@ -556,8 +554,8 @@ const pages: MuiPage[] = [
           { pathname: '/x/react-tree-view/rich-tree-view/expansion' },
           { pathname: '/x/react-tree-view/rich-tree-view/customization' },
           { pathname: '/x/react-tree-view/rich-tree-view/focus' },
-          { pathname: '/x/react-tree-view/rich-tree-view/editing', newFeature: true },
-          { pathname: '/x/react-tree-view/rich-tree-view/ordering', plan: 'pro', newFeature: true },
+          { pathname: '/x/react-tree-view/rich-tree-view/editing' },
+          { pathname: '/x/react-tree-view/rich-tree-view/ordering', plan: 'pro' },
         ],
       },
       {

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -396,8 +396,6 @@
     },
     "onFetchRows": {
       "type": { "name": "func" },
-      "deprecated": true,
-      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridFetchRowsParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -532,8 +530,6 @@
     },
     "onRowsScrollEnd": {
       "type": { "name": "func" },
-      "deprecated": true,
-      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridRowScrollEndParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -610,9 +606,7 @@
     },
     "rowsLoadingMode": {
       "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" },
-      "default": "\"client\"",
-      "deprecated": true,
-      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead."
+      "default": "\"client\""
     },
     "rowSpacingType": {
       "type": { "name": "enum", "description": "'border'<br>&#124;&nbsp;'margin'" },

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -396,6 +396,8 @@
     },
     "onFetchRows": {
       "type": { "name": "func" },
+      "deprecated": true,
+      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridFetchRowsParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -530,6 +532,8 @@
     },
     "onRowsScrollEnd": {
       "type": { "name": "func" },
+      "deprecated": true,
+      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridRowScrollEndParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -605,7 +609,10 @@
       "default": "{ parents: true, descendants: true }"
     },
     "rowsLoadingMode": {
-      "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" }
+      "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" },
+      "default": "\"client\"",
+      "deprecated": true,
+      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead."
     },
     "rowSpacingType": {
       "type": { "name": "enum", "description": "'border'<br>&#124;&nbsp;'margin'" },

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -211,7 +211,6 @@
     },
     "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" }, "default": "false" },
     "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
-    "lazyLoading": { "type": { "name": "bool" }, "default": "false" },
     "lazyLoadingRequestThrottleMs": { "type": { "name": "number" }, "default": "500" },
     "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
@@ -645,6 +644,7 @@
     },
     "throttleRowsMs": { "type": { "name": "number" }, "default": "0" },
     "treeData": { "type": { "name": "bool" }, "default": "false" },
+    "unstable_lazyLoading": { "type": { "name": "bool" }, "default": "false" },
     "unstable_listColumn": {
       "type": {
         "name": "shape",

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -211,7 +211,6 @@
     },
     "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" }, "default": "false" },
     "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
-    "lazyLoadingRequestThrottleMs": { "type": { "name": "number" }, "default": "500" },
     "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "logger": {
@@ -645,6 +644,7 @@
     "throttleRowsMs": { "type": { "name": "number" }, "default": "0" },
     "treeData": { "type": { "name": "bool" }, "default": "false" },
     "unstable_lazyLoading": { "type": { "name": "bool" }, "default": "false" },
+    "unstable_lazyLoadingRequestThrottleMs": { "type": { "name": "number" }, "default": "500" },
     "unstable_listColumn": {
       "type": {
         "name": "shape",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -188,7 +188,6 @@
     },
     "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" }, "default": "false" },
     "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
-    "lazyLoadingRequestThrottleMs": { "type": { "name": "number" }, "default": "500" },
     "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
     "logger": {
@@ -579,6 +578,7 @@
     "throttleRowsMs": { "type": { "name": "number" }, "default": "0" },
     "treeData": { "type": { "name": "bool" }, "default": "false" },
     "unstable_lazyLoading": { "type": { "name": "bool" }, "default": "false" },
+    "unstable_lazyLoadingRequestThrottleMs": { "type": { "name": "number" }, "default": "500" },
     "unstable_listColumn": {
       "type": {
         "name": "shape",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -188,7 +188,6 @@
     },
     "keepColumnPositionIfDraggedOutside": { "type": { "name": "bool" }, "default": "false" },
     "keepNonExistentRowsSelected": { "type": { "name": "bool" }, "default": "false" },
-    "lazyLoading": { "type": { "name": "bool" }, "default": "false" },
     "lazyLoadingRequestThrottleMs": { "type": { "name": "number" }, "default": "500" },
     "loading": { "type": { "name": "bool" }, "default": "false" },
     "localeText": { "type": { "name": "object" } },
@@ -579,6 +578,7 @@
     },
     "throttleRowsMs": { "type": { "name": "number" }, "default": "0" },
     "treeData": { "type": { "name": "bool" }, "default": "false" },
+    "unstable_lazyLoading": { "type": { "name": "bool" }, "default": "false" },
     "unstable_listColumn": {
       "type": {
         "name": "shape",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -346,6 +346,8 @@
     },
     "onFetchRows": {
       "type": { "name": "func" },
+      "deprecated": true,
+      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridFetchRowsParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -473,6 +475,8 @@
     },
     "onRowsScrollEnd": {
       "type": { "name": "func" },
+      "deprecated": true,
+      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridRowScrollEndParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -543,7 +547,10 @@
       "default": "{ parents: true, descendants: true }"
     },
     "rowsLoadingMode": {
-      "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" }
+      "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" },
+      "default": "\"client\"",
+      "deprecated": true,
+      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead."
     },
     "rowSpacingType": {
       "type": { "name": "enum", "description": "'border'<br>&#124;&nbsp;'margin'" },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -346,8 +346,6 @@
     },
     "onFetchRows": {
       "type": { "name": "func" },
-      "deprecated": true,
-      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridFetchRowsParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -475,8 +473,6 @@
     },
     "onRowsScrollEnd": {
       "type": { "name": "func" },
-      "deprecated": true,
-      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead.",
       "signature": {
         "type": "function(params: GridRowScrollEndParams, event: MuiEvent<{}>, details: GridCallbackDetails) => void",
         "describedArgs": ["params", "event", "details"]
@@ -548,9 +544,7 @@
     },
     "rowsLoadingMode": {
       "type": { "name": "enum", "description": "'client'<br>&#124;&nbsp;'server'" },
-      "default": "\"client\"",
-      "deprecated": true,
-      "deprecationInfo": "Use Server-side data <code>lazyLoading</code> instead."
+      "default": "\"client\""
     },
     "rowSpacingType": {
       "type": { "name": "enum", "description": "'border'<br>&#124;&nbsp;'margin'" },

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -625,7 +625,7 @@
       "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent selects all its filtered descendants automatically. - Deselecting a parent row deselects all its filtered descendants automatically.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all the filtered descendants of a parent selects the parent automatically. - Deselecting a descendant of a selected parent deselects the parent automatically.<br>Works with tree data and row grouping on the client-side only."
     },
     "rowsLoadingMode": {
-      "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading. * @default &quot;client&quot;"
+      "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading."
     },
     "rowSpacingType": {
       "description": "Sets the type of space between rows added by <code>getRowSpacing</code>."
@@ -634,7 +634,7 @@
       "description": "Override the height/width of the Data Grid inner scrollbar."
     },
     "scrollEndThreshold": {
-      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
+      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
     },
     "showCellVerticalBorder": {
       "description": "If <code>true</code>, vertical borders will be displayed between cells."

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -235,9 +235,6 @@
     "keepNonExistentRowsSelected": {
       "description": "If <code>true</code>, the selection model will retain selected rows that do not exist. Useful when using server side pagination and row selections need to be retained when changing pages."
     },
-    "lazyLoadingRequestThrottleMs": {
-      "description": "If positive, the Data Grid will throttle data source requests on rendered rows interval change."
-    },
     "loading": { "description": "If <code>true</code>, a loading overlay is displayed." },
     "localeText": {
       "description": "Set the locale text of the Data Grid. You can find all the translation keys supported in <a href=\"https://github.com/mui/mui-x/blob/HEAD/packages/x-data-grid/src/constants/localeTextConstants.ts\">the source</a> in the GitHub repository."
@@ -663,6 +660,9 @@
     },
     "unstable_lazyLoading": {
       "description": "Used together with <code>unstable_dataSource</code> to enable lazy loading. If enabled, the grid stops adding <code>paginationModel</code> to the data requests (<code>getRows</code>) and starts sending <code>start</code> and <code>end</code> values depending on the loading mode and the scroll position."
+    },
+    "unstable_lazyLoadingRequestThrottleMs": {
+      "description": "If positive, the Data Grid will throttle data source requests on rendered rows interval change."
     },
     "unstable_listColumn": {
       "description": "Definition of the column rendered when the <code>unstable_listView</code> prop is enabled."

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -634,7 +634,7 @@
       "description": "Override the height/width of the Data Grid inner scrollbar."
     },
     "scrollEndThreshold": {
-      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
+      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
     },
     "showCellVerticalBorder": {
       "description": "If <code>true</code>, vertical borders will be displayed between cells."

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -235,9 +235,6 @@
     "keepNonExistentRowsSelected": {
       "description": "If <code>true</code>, the selection model will retain selected rows that do not exist. Useful when using server side pagination and row selections need to be retained when changing pages."
     },
-    "lazyLoading": {
-      "description": "Used together with <code>unstable_dataSource</code> to enable lazy loading. If enabled, the grid stops adding <code>paginationModel</code> to the data requests (<code>getRows</code>) and starts sending <code>start</code> and <code>end</code> values depending on the loading mode and the scroll position."
-    },
     "lazyLoadingRequestThrottleMs": {
       "description": "If positive, the Data Grid will throttle data source requests on rendered rows interval change."
     },
@@ -634,7 +631,7 @@
       "description": "Override the height/width of the Data Grid inner scrollbar."
     },
     "scrollEndThreshold": {
-      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
+      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>unstable_lazyLoading</code>, it defines the area where the next data request is triggered."
     },
     "showCellVerticalBorder": {
       "description": "If <code>true</code>, vertical borders will be displayed between cells."
@@ -663,6 +660,9 @@
     },
     "treeData": {
       "description": "If <code>true</code>, the rows will be gathered in a tree structure according to the <code>getTreeDataPath</code> prop."
+    },
+    "unstable_lazyLoading": {
+      "description": "Used together with <code>unstable_dataSource</code> to enable lazy loading. If enabled, the grid stops adding <code>paginationModel</code> to the data requests (<code>getRows</code>) and starts sending <code>start</code> and <code>end</code> values depending on the loading mode and the scroll position."
     },
     "unstable_listColumn": {
       "description": "Definition of the column rendered when the <code>unstable_listView</code> prop is enabled."

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -576,7 +576,7 @@
       "description": "Override the height/width of the Data Grid inner scrollbar."
     },
     "scrollEndThreshold": {
-      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
+      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
     },
     "showCellVerticalBorder": {
       "description": "If <code>true</code>, vertical borders will be displayed between cells."

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -216,9 +216,6 @@
     "keepNonExistentRowsSelected": {
       "description": "If <code>true</code>, the selection model will retain selected rows that do not exist. Useful when using server side pagination and row selections need to be retained when changing pages."
     },
-    "lazyLoadingRequestThrottleMs": {
-      "description": "If positive, the Data Grid will throttle data source requests on rendered rows interval change."
-    },
     "loading": { "description": "If <code>true</code>, a loading overlay is displayed." },
     "localeText": {
       "description": "Set the locale text of the Data Grid. You can find all the translation keys supported in <a href=\"https://github.com/mui/mui-x/blob/HEAD/packages/x-data-grid/src/constants/localeTextConstants.ts\">the source</a> in the GitHub repository."
@@ -601,6 +598,9 @@
     },
     "unstable_lazyLoading": {
       "description": "Used together with <code>unstable_dataSource</code> to enable lazy loading. If enabled, the grid stops adding <code>paginationModel</code> to the data requests (<code>getRows</code>) and starts sending <code>start</code> and <code>end</code> values depending on the loading mode and the scroll position."
+    },
+    "unstable_lazyLoadingRequestThrottleMs": {
+      "description": "If positive, the Data Grid will throttle data source requests on rendered rows interval change."
     },
     "unstable_listColumn": {
       "description": "Definition of the column rendered when the <code>unstable_listView</code> prop is enabled."

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -567,7 +567,7 @@
       "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent selects all its filtered descendants automatically. - Deselecting a parent row deselects all its filtered descendants automatically.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all the filtered descendants of a parent selects the parent automatically. - Deselecting a descendant of a selected parent deselects the parent automatically.<br>Works with tree data and row grouping on the client-side only."
     },
     "rowsLoadingMode": {
-      "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading. * @default &quot;client&quot;"
+      "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading."
     },
     "rowSpacingType": {
       "description": "Sets the type of space between rows added by <code>getRowSpacing</code>."
@@ -576,7 +576,7 @@
       "description": "Override the height/width of the Data Grid inner scrollbar."
     },
     "scrollEndThreshold": {
-      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
+      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
     },
     "showCellVerticalBorder": {
       "description": "If <code>true</code>, vertical borders will be displayed between cells."

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -216,9 +216,6 @@
     "keepNonExistentRowsSelected": {
       "description": "If <code>true</code>, the selection model will retain selected rows that do not exist. Useful when using server side pagination and row selections need to be retained when changing pages."
     },
-    "lazyLoading": {
-      "description": "Used together with <code>unstable_dataSource</code> to enable lazy loading. If enabled, the grid stops adding <code>paginationModel</code> to the data requests (<code>getRows</code>) and starts sending <code>start</code> and <code>end</code> values depending on the loading mode and the scroll position."
-    },
     "lazyLoadingRequestThrottleMs": {
       "description": "If positive, the Data Grid will throttle data source requests on rendered rows interval change."
     },
@@ -576,7 +573,7 @@
       "description": "Override the height/width of the Data Grid inner scrollbar."
     },
     "scrollEndThreshold": {
-      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>lazyLoading</code>, it defines the area where the next data request is triggered."
+      "description": "Set the area in <code>px</code> at the bottom of the grid viewport where onRowsScrollEnd is called. If combined with <code>unstable_lazyLoading</code>, it defines the area where the next data request is triggered."
     },
     "showCellVerticalBorder": {
       "description": "If <code>true</code>, vertical borders will be displayed between cells."
@@ -601,6 +598,9 @@
     },
     "treeData": {
       "description": "If <code>true</code>, the rows will be gathered in a tree structure according to the <code>getTreeDataPath</code> prop."
+    },
+    "unstable_lazyLoading": {
+      "description": "Used together with <code>unstable_dataSource</code> to enable lazy loading. If enabled, the grid stops adding <code>paginationModel</code> to the data requests (<code>getRows</code>) and starts sending <code>start</code> and <code>end</code> values depending on the loading mode and the scroll position."
     },
     "unstable_listColumn": {
       "description": "Definition of the column rendered when the <code>unstable_listView</code> prop is enabled."

--- a/packages/x-data-grid-generator/src/hooks/serverUtils.ts
+++ b/packages/x-data-grid-generator/src/hooks/serverUtils.ts
@@ -40,8 +40,8 @@ export interface QueryOptions {
   pageSize?: number;
   filterModel?: GridFilterModel;
   sortModel?: GridSortModel;
-  firstRowToRender?: number;
-  lastRowToRender?: number;
+  start?: number;
+  end?: number;
 }
 
 export interface ServerSideQueryOptions {
@@ -50,8 +50,8 @@ export interface ServerSideQueryOptions {
   groupKeys?: string[];
   filterModel?: GridFilterModel;
   sortModel?: GridSortModel;
-  firstRowToRender?: number;
-  lastRowToRender?: number;
+  start?: number;
+  end?: number;
   groupFields?: string[];
 }
 
@@ -277,7 +277,7 @@ export const loadServerRows = (
   }
   const delay = randomInt(minDelay, maxDelay);
 
-  const { cursor, page = 0, pageSize, firstRowToRender, lastRowToRender } = queryOptions;
+  const { cursor, page = 0, pageSize, start, end } = queryOptions;
 
   let nextCursor;
   let firstRowIndex;
@@ -289,9 +289,9 @@ export const loadServerRows = (
   filteredRows = [...filteredRows].sort(rowComparator);
 
   const totalRowCount = filteredRows.length;
-  if (firstRowToRender !== undefined && lastRowToRender !== undefined) {
-    firstRowIndex = firstRowToRender;
-    lastRowIndex = lastRowToRender;
+  if (start !== undefined && end !== undefined) {
+    firstRowIndex = start;
+    lastRowIndex = end;
   } else if (!pageSize) {
     firstRowIndex = 0;
     lastRowIndex = filteredRows.length - 1;

--- a/packages/x-data-grid-generator/src/hooks/useMockServer.ts
+++ b/packages/x-data-grid-generator/src/hooks/useMockServer.ts
@@ -104,7 +104,7 @@ const getColumnsFromOptions = (options: ColumnsOptions): GridColDefGenerator[] |
   return columns;
 };
 
-function decodeParams(url: string): GridGetRowsParams {
+function decodeParams(url: string) {
   const params = new URL(url).searchParams;
   const decodedParams = {} as any;
   const array = Array.from(params.entries());
@@ -117,7 +117,7 @@ function decodeParams(url: string): GridGetRowsParams {
     }
   }
 
-  return decodedParams as GridGetRowsParams;
+  return decodedParams;
 }
 
 const getInitialState = (columns: GridColDefGenerator[], groupingField?: string) => {

--- a/packages/x-data-grid-generator/src/hooks/useMockServer.ts
+++ b/packages/x-data-grid-generator/src/hooks/useMockServer.ts
@@ -3,7 +3,6 @@ import { LRUCache } from 'lru-cache';
 import {
   getGridDefaultColumnTypes,
   GridRowModel,
-  GridGetRowsParams,
   GridGetRowsResponse,
   GridColDef,
   GridInitialState,

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -520,13 +520,6 @@ DataGridPremiumRaw.propTypes = {
    */
   keepNonExistentRowsSelected: PropTypes.bool,
   /**
-   * Used together with `unstable_dataSource` to enable lazy loading.
-   * If enabled, the grid stops adding `paginationModel` to the data requests (`getRows`)
-   * and starts sending `start` and `end` values depending on the loading mode and the scroll position.
-   * @default false
-   */
-  lazyLoading: PropTypes.bool,
-  /**
    * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
    * @default 500
    */
@@ -1030,7 +1023,7 @@ DataGridPremiumRaw.propTypes = {
   scrollbarSize: PropTypes.number,
   /**
    * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
-   * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
+   * If combined with `unstable_lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */
   scrollEndThreshold: PropTypes.number,
@@ -1110,6 +1103,13 @@ DataGridPremiumRaw.propTypes = {
     get: PropTypes.func.isRequired,
     set: PropTypes.func.isRequired,
   }),
+  /**
+   * Used together with `unstable_dataSource` to enable lazy loading.
+   * If enabled, the grid stops adding `paginationModel` to the data requests (`getRows`)
+   * and starts sending `start` and `end` values depending on the loading mode and the scroll position.
+   * @default false
+   */
+  unstable_lazyLoading: PropTypes.bool,
   /**
    * Definition of the column rendered when the `unstable_listView` prop is enabled.
    */

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -728,7 +728,6 @@ DataGridPremiumRaw.propTypes = {
    * @param {GridFetchRowsParams} params With all properties from [[GridFetchRowsParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onFetchRows: PropTypes.func,
   /**
@@ -856,7 +855,6 @@ DataGridPremiumRaw.propTypes = {
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onRowsScrollEnd: PropTypes.func,
   /**
@@ -1019,7 +1017,6 @@ DataGridPremiumRaw.propTypes = {
    * Set it to 'client' if you would like enable infnite loading.
    * Set it to 'server' if you would like to enable lazy loading.
    * @default "client"
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   rowsLoadingMode: PropTypes.oneOf(['client', 'server']),
   /**
@@ -1032,7 +1029,7 @@ DataGridPremiumRaw.propTypes = {
    */
   scrollbarSize: PropTypes.number,
   /**
-   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called.
+   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
    * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -520,11 +520,6 @@ DataGridPremiumRaw.propTypes = {
    */
   keepNonExistentRowsSelected: PropTypes.bool,
   /**
-   * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
-   * @default 500
-   */
-  lazyLoadingRequestThrottleMs: PropTypes.number,
-  /**
    * If `true`, a loading overlay is displayed.
    * @default false
    */
@@ -1110,6 +1105,11 @@ DataGridPremiumRaw.propTypes = {
    * @default false
    */
   unstable_lazyLoading: PropTypes.bool,
+  /**
+   * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
+   * @default 500
+   */
+  unstable_lazyLoadingRequestThrottleMs: PropTypes.number,
   /**
    * Definition of the column rendered when the `unstable_listView` prop is enabled.
    */

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -728,6 +728,7 @@ DataGridPremiumRaw.propTypes = {
    * @param {GridFetchRowsParams} params With all properties from [[GridFetchRowsParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onFetchRows: PropTypes.func,
   /**
@@ -855,6 +856,7 @@ DataGridPremiumRaw.propTypes = {
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onRowsScrollEnd: PropTypes.func,
   /**
@@ -1016,7 +1018,8 @@ DataGridPremiumRaw.propTypes = {
    * Loading rows can be processed on the server or client-side.
    * Set it to 'client' if you would like enable infnite loading.
    * Set it to 'server' if you would like to enable lazy loading.
-   * * @default "client"
+   * @default "client"
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   rowsLoadingMode: PropTypes.oneOf(['client', 'server']),
   /**
@@ -1029,7 +1032,7 @@ DataGridPremiumRaw.propTypes = {
    */
   scrollbarSize: PropTypes.number,
   /**
-   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
+   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called.
    * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/gridRowGroupingUtils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/gridRowGroupingUtils.ts
@@ -19,6 +19,7 @@ import {
   GRID_ROW_GROUPING_SINGLE_GROUPING_FIELD,
   getRowGroupingCriteriaFromGroupingField,
   isGroupingColumn,
+  GridStrategyGroup,
 } from '@mui/x-data-grid-pro/internals';
 import { DataGridPremiumProcessedProps } from '../../../models/dataGridPremiumProps';
 import {
@@ -211,7 +212,7 @@ export const setStrategyAvailability = (
 
   const strategy = dataSource ? RowGroupingStrategy.DataSource : RowGroupingStrategy.Default;
 
-  privateApiRef.current.setStrategyAvailability('rowTree', strategy, isAvailable);
+  privateApiRef.current.setStrategyAvailability(GridStrategyGroup.RowTree, strategy, isAvailable);
 };
 
 export const getCellGroupingCriteria = ({

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
@@ -10,6 +10,7 @@ import {
   GridPipeProcessor,
   GridRestoreStatePreProcessingContext,
   GridStateInitializer,
+  GridStrategyGroup,
 } from '@mui/x-data-grid-pro/internals';
 import { GridPrivateApiPremium } from '../../../models/gridApiPremium';
 import {
@@ -275,7 +276,9 @@ export const useGridRowGrouping = (
 
       // Refresh the row tree creation strategy processing
       // TODO: Add a clean way to re-run a strategy processing without publishing a private event
-      if (apiRef.current.getActiveStrategy('rowTree') === RowGroupingStrategy.Default) {
+      if (
+        apiRef.current.getActiveStrategy(GridStrategyGroup.RowTree) === RowGroupingStrategy.Default
+      ) {
         apiRef.current.publishEvent('activeStrategyProcessorChange', 'rowTreeCreation');
       }
     }

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -651,7 +651,6 @@ DataGridProRaw.propTypes = {
    * @param {GridFetchRowsParams} params With all properties from [[GridFetchRowsParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onFetchRows: PropTypes.func,
   /**
@@ -773,7 +772,6 @@ DataGridProRaw.propTypes = {
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onRowsScrollEnd: PropTypes.func,
   /**
@@ -926,7 +924,6 @@ DataGridProRaw.propTypes = {
    * Set it to 'client' if you would like enable infnite loading.
    * Set it to 'server' if you would like to enable lazy loading.
    * @default "client"
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   rowsLoadingMode: PropTypes.oneOf(['client', 'server']),
   /**
@@ -939,7 +936,7 @@ DataGridProRaw.propTypes = {
    */
   scrollbarSize: PropTypes.number,
   /**
-   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called.
+   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
    * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -651,6 +651,7 @@ DataGridProRaw.propTypes = {
    * @param {GridFetchRowsParams} params With all properties from [[GridFetchRowsParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onFetchRows: PropTypes.func,
   /**
@@ -772,6 +773,7 @@ DataGridProRaw.propTypes = {
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onRowsScrollEnd: PropTypes.func,
   /**
@@ -923,7 +925,8 @@ DataGridProRaw.propTypes = {
    * Loading rows can be processed on the server or client-side.
    * Set it to 'client' if you would like enable infnite loading.
    * Set it to 'server' if you would like to enable lazy loading.
-   * * @default "client"
+   * @default "client"
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   rowsLoadingMode: PropTypes.oneOf(['client', 'server']),
   /**
@@ -936,7 +939,7 @@ DataGridProRaw.propTypes = {
    */
   scrollbarSize: PropTypes.number,
   /**
-   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
+   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called.
    * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -476,11 +476,6 @@ DataGridProRaw.propTypes = {
    */
   keepNonExistentRowsSelected: PropTypes.bool,
   /**
-   * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
-   * @default 500
-   */
-  lazyLoadingRequestThrottleMs: PropTypes.number,
-  /**
    * If `true`, a loading overlay is displayed.
    * @default false
    */
@@ -1010,6 +1005,11 @@ DataGridProRaw.propTypes = {
    * @default false
    */
   unstable_lazyLoading: PropTypes.bool,
+  /**
+   * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
+   * @default 500
+   */
+  unstable_lazyLoadingRequestThrottleMs: PropTypes.number,
   /**
    * Definition of the column rendered when the `unstable_listView` prop is enabled.
    */

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -476,13 +476,6 @@ DataGridProRaw.propTypes = {
    */
   keepNonExistentRowsSelected: PropTypes.bool,
   /**
-   * Used together with `unstable_dataSource` to enable lazy loading.
-   * If enabled, the grid stops adding `paginationModel` to the data requests (`getRows`)
-   * and starts sending `start` and `end` values depending on the loading mode and the scroll position.
-   * @default false
-   */
-  lazyLoading: PropTypes.bool,
-  /**
    * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
    * @default 500
    */
@@ -937,7 +930,7 @@ DataGridProRaw.propTypes = {
   scrollbarSize: PropTypes.number,
   /**
    * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
-   * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
+   * If combined with `unstable_lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */
   scrollEndThreshold: PropTypes.number,
@@ -1010,6 +1003,13 @@ DataGridProRaw.propTypes = {
     get: PropTypes.func.isRequired,
     set: PropTypes.func.isRequired,
   }),
+  /**
+   * Used together with `unstable_dataSource` to enable lazy loading.
+   * If enabled, the grid stops adding `paginationModel` to the data requests (`getRows`)
+   * and starts sending `start` and `end` values depending on the loading mode and the scroll position.
+   * @default false
+   */
+  unstable_lazyLoading: PropTypes.bool,
   /**
    * Definition of the column rendered when the `unstable_listView` prop is enabled.
    */

--- a/packages/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
@@ -57,7 +57,7 @@ export const DATA_GRID_PRO_PROPS_DEFAULT_VALUES: DataGridProPropsWithDefaultValu
   treeData: false,
   unstable_listView: false,
   unstable_lazyLoading: false,
-  lazyLoadingRequestThrottleMs: 500,
+  unstable_lazyLoadingRequestThrottleMs: 500,
 };
 
 const defaultSlots = DATA_GRID_PRO_DEFAULT_SLOTS_COMPONENTS;

--- a/packages/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/DataGridPro/useDataGridProProps.ts
@@ -56,7 +56,7 @@ export const DATA_GRID_PRO_PROPS_DEFAULT_VALUES: DataGridProPropsWithDefaultValu
   scrollEndThreshold: 80,
   treeData: false,
   unstable_listView: false,
-  lazyLoading: false,
+  unstable_lazyLoading: false,
   lazyLoadingRequestThrottleMs: 500,
 };
 

--- a/packages/x-data-grid-pro/src/components/GridDataSourceTreeDataGroupingCell.tsx
+++ b/packages/x-data-grid-pro/src/components/GridDataSourceTreeDataGroupingCell.tsx
@@ -60,7 +60,7 @@ function GridTreeDataGroupingCellIcon(props: GridTreeDataGroupingCellIconProps) 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!rowNode.childrenExpanded) {
       // always fetch/get from cache the children when the node is expanded
-      apiRef.current.unstable_dataSource.fetchRows({ parentId: id });
+      apiRef.current.unstable_dataSource.fetchRows(id);
     } else {
       apiRef.current.setRowChildrenExpansion(id, !rowNode.childrenExpanded);
     }

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/cache.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/cache.ts
@@ -7,13 +7,6 @@ export type GridDataSourceCacheDefaultConfig = {
    * @default 300000 (5 minutes)
    */
   ttl?: number;
-  /**
-   * The number of rows to store in each cache entry. If not set, the whole array will be stored in a single cache entry.
-   * Setting this value to smallest page size will result in better cache hit rate.
-   * Has no effect if cursor pagination is used.
-   * @default undefined
-   */
-  chunkSize?: number;
 };
 
 function getKey(params: GridGetRowsParams) {
@@ -28,106 +21,34 @@ function getKey(params: GridGetRowsParams) {
 }
 
 export class GridDataSourceCacheDefault {
-  private cache: Record<
-    string,
-    {
-      value: GridGetRowsResponse;
-      expiry: number;
-      chunk: { startIndex: string | number; endIndex: number };
-    }
-  >;
+  private cache: Record<string, { value: GridGetRowsResponse; expiry: number }>;
 
   private ttl: number;
 
-  private chunkSize: number;
-
-  private getChunkRanges = (params: GridGetRowsParams) => {
-    if (this.chunkSize < 1 || typeof params.start !== 'number') {
-      return [{ startIndex: params.start, endIndex: params.end }];
-    }
-
-    // split the range into chunks
-    const chunkRanges: { startIndex: number; endIndex: number }[] = [];
-    for (let i = params.start; i < params.end; i += this.chunkSize) {
-      const endIndex = Math.min(i + this.chunkSize - 1, params.end);
-      chunkRanges.push({ startIndex: i, endIndex });
-    }
-
-    return chunkRanges;
-  };
-
-  constructor({ chunkSize, ttl = 300000 }: GridDataSourceCacheDefaultConfig) {
+  constructor({ ttl = 300000 }: GridDataSourceCacheDefaultConfig) {
     this.cache = {};
     this.ttl = ttl;
-    this.chunkSize = chunkSize || 0;
   }
 
   set(key: GridGetRowsParams, value: GridGetRowsResponse) {
-    const chunks = this.getChunkRanges(key);
+    const keyString = getKey(key);
     const expiry = Date.now() + this.ttl;
-
-    chunks.forEach((chunk) => {
-      const isLastChunk = chunk.endIndex === key.end;
-      const keyString = getKey({ ...key, start: chunk.startIndex, end: chunk.endIndex });
-      const chunkValue: GridGetRowsResponse = {
-        ...value,
-        pageInfo: {
-          ...value.pageInfo,
-          // If the original response had page info, update that information for all but last chunk and keep the original value for the last chunk
-          hasNextPage:
-            (value.pageInfo?.hasNextPage !== undefined && !isLastChunk) ||
-            value.pageInfo?.hasNextPage,
-          nextCursor:
-            value.pageInfo?.nextCursor !== undefined && !isLastChunk
-              ? value.rows[chunk.endIndex + 1].id
-              : value.pageInfo?.nextCursor,
-        },
-        rows:
-          typeof chunk.startIndex !== 'number' || typeof key.start !== 'number'
-            ? value.rows
-            : value.rows.slice(chunk.startIndex - key.start, chunk.endIndex - key.start + 1),
-      };
-
-      this.cache[keyString] = { value: chunkValue, expiry, chunk };
-    });
+    this.cache[keyString] = { value, expiry };
   }
 
   get(key: GridGetRowsParams): GridGetRowsResponse | undefined {
-    const chunks = this.getChunkRanges(key);
-
-    const startChunk = chunks.findIndex((chunk) => chunk.startIndex === key.start);
-    const endChunk = chunks.findIndex((chunk) => chunk.endIndex === key.end);
-
-    // If desired range cannot fit completely in chunks, then it is a cache miss
-    if (startChunk === -1 || endChunk === -1) {
+    const keyString = getKey(key);
+    const entry = this.cache[keyString];
+    if (!entry) {
       return undefined;
     }
 
-    const cachedResponses: (GridGetRowsResponse | null)[] = [];
-
-    for (let i = startChunk; i <= endChunk; i += 1) {
-      const keyString = getKey({ ...key, start: chunks[i].startIndex, end: chunks[i].endIndex });
-      const entry = this.cache[keyString];
-      const isCacheValid = entry?.value && Date.now() < entry.expiry;
-      cachedResponses.push(isCacheValid ? entry?.value : null);
-    }
-
-    // If any of the chunks is missing, then it is a cache miss
-    if (cachedResponses.some((response) => response === null)) {
+    if (Date.now() > entry.expiry) {
+      delete this.cache[keyString];
       return undefined;
     }
 
-    // Merge the chunks into a single response
-    return (cachedResponses as GridGetRowsResponse[]).reduce(
-      (acc: GridGetRowsResponse, response) => {
-        return {
-          rows: [...acc.rows, ...response.rows],
-          rowCount: response.rowCount,
-          pageInfo: response.pageInfo,
-        };
-      },
-      { rows: [], rowCount: 0, pageInfo: {} },
-    );
+    return entry.value;
   }
 
   clear() {

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/interfaces.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/interfaces.ts
@@ -1,15 +1,9 @@
 import { GridRowId } from '@mui/x-data-grid';
-import { GridDataSourceCache } from '../../../models';
+import { GridDataSourceCache, GridGetRowsParams } from '../../../models';
 
 export interface GridDataSourceState {
   loading: Record<GridRowId, boolean>;
   errors: Record<GridRowId, any>;
-}
-
-export interface FetchRowsOptions {
-  parentId?: GridRowId;
-  start?: number | string;
-  end?: number;
 }
 
 /**
@@ -29,11 +23,13 @@ export interface GridDataSourceApiBase {
    */
   setChildrenFetchError: (parentId: GridRowId, error: Error | null) => void;
   /**
-   * Fetches the rows from the server for with given options.
+   * Fetches the rows from the server.
    * If no `parentId` option is provided, it fetches the root rows.
-   * @param {FetchRowsOptions} options Options that allow setting the specific request params.
+   * Any missing parameter from `params` will be filled from the state (sorting, filtering, etc.).
+   * @param {GridRowId} parentId The id of the parent node.
+   * @param {Partial<GridGetRowsParams>} params Request parameters override.
    */
-  fetchRows: (options?: GridRowId | FetchRowsOptions) => void;
+  fetchRows: (parentId?: GridRowId, params?: Partial<GridGetRowsParams>) => void;
   /**
    * The data source cache object.
    */

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -136,7 +136,7 @@ export const useGridDataSource = (
       };
 
       const cacheKeys = cacheChunkManager.getCacheKeys(fetchParams);
-      const responses = cacheKeys.map(cache.get);
+      const responses = cacheKeys.map((cacheKey) => cache.get(cacheKey));
       const cachedData = responses.some((response) => response === undefined)
         ? undefined
         : CacheChunkManager.mergeResponses(responses as GridGetRowsResponse[]);

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -14,6 +14,7 @@ import {
   GridGetRowsResponse,
   gridRowGroupsToFetchSelector,
   GridStateInitializer,
+  GridStrategyGroup,
   GridStrategyProcessor,
   useGridRegisterStrategyProcessor,
 } from '@mui/x-data-grid/internals';
@@ -76,7 +77,7 @@ export const useGridDataSource = (
 ) => {
   const setStrategyAvailability = React.useCallback(() => {
     apiRef.current.setStrategyAvailability(
-      'dataSource',
+      GridStrategyGroup.DataSource,
       DataSourceRowsUpdateStrategy.Default,
       props.unstable_dataSource && !props.lazyLoading ? () => true : () => false,
     );
@@ -336,7 +337,8 @@ export const useGridDataSource = (
     GridEventListener<'strategyAvailabilityChange'>
   >(() => {
     setDefaultRowsUpdateStrategyActive(
-      apiRef.current.getActiveStrategy('dataSource') === DataSourceRowsUpdateStrategy.Default,
+      apiRef.current.getActiveStrategy(GridStrategyGroup.DataSource) ===
+        DataSourceRowsUpdateStrategy.Default,
     );
   }, [apiRef]);
 

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -72,16 +72,16 @@ export const useGridDataSource = (
     | 'paginationMode'
     | 'pageSizeOptions'
     | 'treeData'
-    | 'lazyLoading'
+    | 'unstable_lazyLoading'
   >,
 ) => {
   const setStrategyAvailability = React.useCallback(() => {
     apiRef.current.setStrategyAvailability(
       GridStrategyGroup.DataSource,
       DataSourceRowsUpdateStrategy.Default,
-      props.unstable_dataSource && !props.lazyLoading ? () => true : () => false,
+      props.unstable_dataSource && !props.unstable_lazyLoading ? () => true : () => false,
     );
-  }, [apiRef, props.lazyLoading, props.unstable_dataSource]);
+  }, [apiRef, props.unstable_lazyLoading, props.unstable_dataSource]);
 
   const [defaultRowsUpdateStrategyActive, setDefaultRowsUpdateStrategyActive] =
     React.useState(false);

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -98,7 +98,7 @@ export const useGridDataSource = (
         return;
       }
 
-      if (parentId) {
+      if (parentId && parentId !== GRID_ROOT_GROUP_ID) {
         nestedDataManager.queue([parentId]);
         return;
       }

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -104,7 +104,7 @@ export const useGridDataSource = (
   }, [paginationModel.pageSize, props.pageSizeOptions]);
 
   const cacheChunkManager = useLazyRef<CacheChunkManager, void>(
-    () => new CacheChunkManager({ chunkSize: cacheChunkSize }),
+    () => new CacheChunkManager(cacheChunkSize),
   ).current;
   const [cache, setCache] = React.useState<GridDataSourceCache>(() =>
     getCache(props.unstable_dataSourceCache),
@@ -136,7 +136,7 @@ export const useGridDataSource = (
       };
 
       const cacheKeys = cacheChunkManager.getCacheKeys(fetchParams);
-      const responses = cacheKeys.map((cacheKey) => cache.get(cacheKey));
+      const responses = cacheKeys.map(cache.get);
       const cachedData = responses.some((response) => response === undefined)
         ? undefined
         : CacheChunkManager.mergeResponses(responses as GridGetRowsResponse[]);

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -11,7 +11,6 @@ import {
   GridEventListener,
 } from '@mui/x-data-grid';
 import {
-  GridGetRowsParams,
   gridRowGroupsToFetchSelector,
   GridStateInitializer,
   GridStrategyProcessor,
@@ -306,7 +305,6 @@ export const useGridDataSource = (
         apiRef.current.setRowCount(response.rowCount);
       }
       apiRef.current.setRows(response.rows);
-      apiRef.current.publishEvent('rowsFetched');
     },
     [apiRef],
   );
@@ -359,9 +357,6 @@ export const useGridDataSource = (
     apiRef,
     'paginationModelChange',
     runIf(defaultRowsUpdateStrategyActive, () => fetchRows()),
-  );
-  useGridApiEventHandler(apiRef, 'getRows', (params: GridGetRowsParams) =>
-    fetchRows(GRID_ROOT_GROUP_ID, params),
   );
 
   const isFirstRender = React.useRef(true);

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -7,7 +7,6 @@ import {
   useGridSelector,
   gridPaginationModelSelector,
   GRID_ROOT_GROUP_ID,
-  useFirstRender,
   GridEventListener,
 } from '@mui/x-data-grid';
 import {
@@ -410,11 +409,7 @@ export const useGridDataSource = (
   }, [props.unstable_dataSourceCache]);
 
   React.useEffect(() => {
-    if (!isFirstRender.current) {
-      setStrategyAvailability();
-    } else {
-      isFirstRender.current = false;
-    }
+    setStrategyAvailability();
   }, [setStrategyAvailability]);
 
   React.useEffect(() => {
@@ -435,8 +430,4 @@ export const useGridDataSource = (
       scheduledGroups.current = groupsToAutoFetch.length;
     }
   }, [apiRef, nestedDataManager, groupsToAutoFetch]);
-
-  useFirstRender(() => {
-    setStrategyAvailability();
-  });
 };

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -137,13 +137,10 @@ export const useGridDataSource = (
 
       const cacheKeys = cacheChunkManager.getCacheKeys(fetchParams);
       const responses = cacheKeys.map((cacheKey) => cache.get(cacheKey));
-      const cachedData = responses.some((response) => response === undefined)
-        ? undefined
-        : CacheChunkManager.mergeResponses(responses as GridGetRowsResponse[]);
 
-      if (cachedData !== undefined) {
+      if (responses.every((response) => response !== undefined)) {
         apiRef.current.applyStrategyProcessor('dataSourceRowsUpdate', {
-          response: cachedData,
+          response: CacheChunkManager.mergeResponses(responses as GridGetRowsResponse[]),
           fetchParams,
         });
         return;

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -95,17 +95,14 @@ export const useGridDataSource = (
 
   const onError = props.unstable_onDataSourceError;
 
-  const cacheChunkSize = React.useMemo(() => {
+  const cacheChunkManager = useLazyRef<CacheChunkManager, void>(() => {
     const sortedPageSizeOptions = props.pageSizeOptions
       .map((option) => (typeof option === 'number' ? option : option.value))
       .sort((a, b) => a - b);
+    const cacheChunkSize = Math.min(paginationModel.pageSize, sortedPageSizeOptions[0]);
 
-    return Math.min(paginationModel.pageSize, sortedPageSizeOptions[0]);
-  }, [paginationModel.pageSize, props.pageSizeOptions]);
-
-  const cacheChunkManager = useLazyRef<CacheChunkManager, void>(
-    () => new CacheChunkManager(cacheChunkSize),
-  ).current;
+    return new CacheChunkManager(cacheChunkSize);
+  }).current;
   const [cache, setCache] = React.useState<GridDataSourceCache>(() =>
     getCache(props.unstable_dataSourceCache),
   );

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
@@ -9,15 +9,6 @@ export const runIf = (condition: boolean, fn: Function) => (params: unknown) => 
   }
 };
 
-export type GridDataSourceCacheChunkManagerConfig = {
-  /**
-   * The number of rows to store in each cache entry. If not set, the whole array will be stored in a single cache entry.
-   * Setting this value to smallest page size will result in better cache hit rate.
-   * Has no effect if cursor pagination is used.
-   */
-  chunkSize: number;
-};
-
 export enum RequestStatus {
   QUEUED,
   PENDING,
@@ -135,8 +126,14 @@ export class NestedDataManager {
 export class CacheChunkManager {
   private chunkSize: number;
 
-  constructor(config: GridDataSourceCacheChunkManagerConfig) {
-    this.chunkSize = config.chunkSize;
+  /**
+   * @param chunkSize The number of rows to store in each cache entry.
+   * If not set, the whole array will be stored in a single cache entry.
+   * Setting this value to smallest page size will result in better cache hit rate.
+   * Has no effect if cursor pagination is used.
+   */
+  constructor(chunkSize: number) {
+    this.chunkSize = chunkSize;
   }
 
   public getCacheKeys = (key: GridGetRowsParams) => {
@@ -190,13 +187,11 @@ export class CacheChunkManager {
     }
 
     return responses.reduce(
-      (acc, response) => {
-        return {
-          rows: [...acc.rows, ...response.rows],
-          rowCount: response.rowCount,
-          pageInfo: response.pageInfo,
-        };
-      },
+      (acc, response) => ({
+        rows: [...acc.rows, ...response.rows],
+        rowCount: response.rowCount,
+        pageInfo: response.pageInfo,
+      }),
       { rows: [], rowCount: 0, pageInfo: {} },
     );
   };

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
@@ -119,9 +119,9 @@ export class NestedDataManager {
 }
 
 /**
- * Provides better cache hit rate by splitting the data into smaller chunks
- * Splits the data into smaller chunks to be stored in the cache
- * Merges multiple cache entries into a single response
+ * Provides better cache hit rate by:
+ * 1. Splitting the data into smaller chunks to be stored in the cache (cache `set`)
+ * 2. Merging multiple cache entries into a single response to get the required chunk (cache `get`)
  */
 export class CacheChunkManager {
   private chunkSize: number;

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
@@ -16,6 +16,11 @@ export enum RequestStatus {
   UNKNOWN,
 }
 
+export enum DataSourceRowsUpdateStrategy {
+  Default = 'set-new-rows',
+  LazyLoading = 'replace-row-range',
+}
+
 /**
  * Fetches row children from the server with option to limit the number of concurrent requests
  * Determines the status of a request based on the enum `RequestStatus`

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/utils.ts
@@ -162,8 +162,9 @@ export class CacheChunkManager {
           ...response.pageInfo,
           // If the original response had page info, update that information for all but last chunk and keep the original value for the last chunk
           hasNextPage:
-            (response.pageInfo?.hasNextPage !== undefined && !isLastChunk) ||
-            response.pageInfo?.hasNextPage,
+            response.pageInfo?.hasNextPage !== undefined && !isLastChunk
+              ? true
+              : response.pageInfo?.hasNextPage,
           nextCursor:
             response.pageInfo?.nextCursor !== undefined && !isLastChunk
               ? response.rows[chunkKey.end + 1].id

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -344,6 +344,7 @@ export const useGridDataSourceLazyLoader = (
       if (loadingTrigger.current === LoadingTrigger.VIEWPORT) {
         // replace all rows with skeletons to maintain the same scroll position
         addSkeletonRows(true);
+        privateApiRef.current.setLoading(true);
       }
 
       const rangeParams =

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -12,7 +12,6 @@ import {
   gridPaginationModelSelector,
   gridDimensionsSelector,
   gridFilteredSortedRowIdsSelector,
-  useFirstRender,
 } from '@mui/x-data-grid';
 import {
   getVisibleRows,
@@ -507,16 +506,7 @@ export const useGridDataSourceLazyLoader = (
     runIf(lazyLoadingRowsUpdateStrategyActive, handleGridFilterModelChange),
   );
 
-  useFirstRender(() => {
-    setStrategyAvailability();
-  });
-
-  const isFirstRender = React.useRef(true);
   React.useEffect(() => {
-    if (!isFirstRender.current) {
-      setStrategyAvailability();
-    } else {
-      isFirstRender.current = false;
-    }
+    setStrategyAvailability();
   }, [setStrategyAvailability]);
 };

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -165,7 +165,7 @@ export const useGridDataSourceLazyLoader = (
 
     // fill the grid with skeleton rows
     for (let i = 0; i < pageRowCount - rootChildrenCount; i += 1) {
-      const skeletonId = getSkeletonRowId(i);
+      const skeletonId = getSkeletonRowId(i + rootChildrenCount); // to avoid duplicate keys on rebuild
       rootGroupChildren.push(skeletonId);
 
       const skeletonRowNode: GridSkeletonRowNode = {

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -107,7 +107,7 @@ export const useGridDataSourceLazyLoader = (
       filterModel,
     };
 
-    privateApiRef.current.publishEvent('getRows', getRowsParams);
+    privateApiRef.current.unstable_dataSource.fetchRows(GRID_ROOT_GROUP_ID, getRowsParams);
   }, [privateApiRef, sortModel, filterModel, paginationModel.pageSize]);
 
   const ensureValidRowCount = React.useCallback(
@@ -240,7 +240,6 @@ export const useGridDataSourceLazyLoader = (
       addSkeletonRows();
       privateApiRef.current.setLoading(false);
       privateApiRef.current.requestPipeProcessorsApplication('hydrateRows');
-      privateApiRef.current.publishEvent('rowsFetched');
     },
     [privateApiRef, filteredSortedRowIds, updateLoadingTrigger, addSkeletonRows],
   );
@@ -278,7 +277,10 @@ export const useGridDataSourceLazyLoader = (
         };
 
         privateApiRef.current.setLoading(true);
-        privateApiRef.current.publishEvent('getRows', adjustRowParams(getRowsParams));
+        privateApiRef.current.unstable_dataSource.fetchRows(
+          GRID_ROOT_GROUP_ID,
+          adjustRowParams(getRowsParams),
+        );
       }
     },
     [
@@ -341,7 +343,10 @@ export const useGridDataSourceLazyLoader = (
       getRowsParams.start = skeletonRowsSection.firstRowIndex;
       getRowsParams.end = skeletonRowsSection.lastRowIndex;
 
-      privateApiRef.current.publishEvent('getRows', adjustRowParams(getRowsParams));
+      privateApiRef.current.unstable_dataSource.fetchRows(
+        GRID_ROOT_GROUP_ID,
+        adjustRowParams(getRowsParams),
+      );
     },
     [
       privateApiRef,
@@ -387,7 +392,10 @@ export const useGridDataSourceLazyLoader = (
         rowsStale.current = true;
       }
 
-      privateApiRef.current.publishEvent('getRows', adjustRowParams(getRowsParams));
+      privateApiRef.current.unstable_dataSource.fetchRows(
+        GRID_ROOT_GROUP_ID,
+        adjustRowParams(getRowsParams),
+      );
     },
     [
       privateApiRef,
@@ -411,7 +419,7 @@ export const useGridDataSourceLazyLoader = (
       };
 
       privateApiRef.current.setLoading(true);
-      privateApiRef.current.publishEvent('getRows', getRowsParams);
+      privateApiRef.current.unstable_dataSource.fetchRows(GRID_ROOT_GROUP_ID, getRowsParams);
     },
     [privateApiRef, sortModel, paginationModel.pageSize],
   );

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -53,7 +53,7 @@ export const useGridDataSourceLazyLoader = (
     | 'pagination'
     | 'paginationMode'
     | 'unstable_dataSource'
-    | 'lazyLoading'
+    | 'unstable_lazyLoading'
     | 'lazyLoadingRequestThrottleMs'
     | 'scrollEndThreshold'
   >,
@@ -62,9 +62,9 @@ export const useGridDataSourceLazyLoader = (
     privateApiRef.current.setStrategyAvailability(
       GridStrategyGroup.DataSource,
       DataSourceRowsUpdateStrategy.LazyLoading,
-      props.unstable_dataSource && props.lazyLoading ? () => true : () => false,
+      props.unstable_dataSource && props.unstable_lazyLoading ? () => true : () => false,
     );
-  }, [privateApiRef, props.lazyLoading, props.unstable_dataSource]);
+  }, [privateApiRef, props.unstable_lazyLoading, props.unstable_dataSource]);
 
   const [lazyLoadingRowsUpdateStrategyActive, setLazyLoadingRowsUpdateStrategyActive] =
     React.useState(false);

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -219,7 +219,10 @@ export const useGridDataSourceLazyLoader = (
       }
 
       const { response, fetchParams } = params;
-      privateApiRef.current.setRowCount(response.rowCount === undefined ? -1 : response.rowCount);
+      const pageRowCount = privateApiRef.current.state.pagination.rowCount;
+      if (response.rowCount !== undefined || pageRowCount === undefined) {
+        privateApiRef.current.setRowCount(response.rowCount === undefined ? -1 : response.rowCount);
+      }
 
       if (rowsStale.current) {
         rowsStale.current = false;

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -18,6 +18,7 @@ import {
   getVisibleRows,
   GridGetRowsParams,
   gridRenderContextSelector,
+  GridStrategyGroup,
   GridStrategyProcessor,
   useGridRegisterStrategyProcessor,
 } from '@mui/x-data-grid/internals';
@@ -59,7 +60,7 @@ export const useGridDataSourceLazyLoader = (
 ): void => {
   const setStrategyAvailability = React.useCallback(() => {
     privateApiRef.current.setStrategyAvailability(
-      'dataSource',
+      GridStrategyGroup.DataSource,
       DataSourceRowsUpdateStrategy.LazyLoading,
       props.unstable_dataSource && props.lazyLoading ? () => true : () => false,
     );
@@ -428,7 +429,7 @@ export const useGridDataSourceLazyLoader = (
     GridEventListener<'strategyAvailabilityChange'>
   >(() => {
     setLazyLoadingRowsUpdateStrategyActive(
-      privateApiRef.current.getActiveStrategy('dataSource') ===
+      privateApiRef.current.getActiveStrategy(GridStrategyGroup.DataSource) ===
         DataSourceRowsUpdateStrategy.LazyLoading,
     );
   }, [privateApiRef]);

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -78,14 +78,6 @@ export const useGridDataSourceLazyLoader = (
   const loadingTrigger = React.useRef<LoadingTrigger | null>(null);
   const rowsStale = React.useRef<boolean>(false);
 
-  const heights = React.useMemo(
-    () => ({
-      viewport: dimensions.viewportInnerSize.height,
-      content: dimensions.contentSize.height,
-    }),
-    [dimensions.viewportInnerSize.height, dimensions.contentSize.height],
-  );
-
   // Adjust the render context range to fit the pagination model's page size
   // First row index should be decreased to the start of the page, end row index should be increased to the end of the page
   const adjustRowParams = React.useCallback(
@@ -272,8 +264,8 @@ export const useGridDataSourceLazyLoader = (
         return;
       }
 
-      const position = newScrollPosition.top + heights.viewport;
-      const target = heights.content - props.scrollEndThreshold;
+      const position = newScrollPosition.top + dimensions.viewportInnerSize.height;
+      const target = dimensions.contentSize.height - props.scrollEndThreshold;
 
       if (position >= target) {
         previousLastRowIndex.current = renderContext.lastRowIndex;
@@ -294,7 +286,7 @@ export const useGridDataSourceLazyLoader = (
       props.scrollEndThreshold,
       sortModel,
       filterModel,
-      heights,
+      dimensions,
       paginationModel.pageSize,
       renderContext.lastRowIndex,
       adjustRowParams,

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -54,7 +54,7 @@ export const useGridDataSourceLazyLoader = (
     | 'paginationMode'
     | 'unstable_dataSource'
     | 'unstable_lazyLoading'
-    | 'lazyLoadingRequestThrottleMs'
+    | 'unstable_lazyLoadingRequestThrottleMs'
     | 'scrollEndThreshold'
   >,
 ): void => {
@@ -397,8 +397,8 @@ export const useGridDataSourceLazyLoader = (
   );
 
   const throttledHandleRenderedRowsIntervalChange = React.useMemo(
-    () => throttle(handleRenderedRowsIntervalChange, props.lazyLoadingRequestThrottleMs),
-    [props.lazyLoadingRequestThrottleMs, handleRenderedRowsIntervalChange],
+    () => throttle(handleRenderedRowsIntervalChange, props.unstable_lazyLoadingRequestThrottleMs),
+    [props.unstable_lazyLoadingRequestThrottleMs, handleRenderedRowsIntervalChange],
   );
 
   const handleGridSortModelChange = React.useCallback<GridEventListener<'sortModelChange'>>(

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/useGridDataSourceTreeDataPreProcessors.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/useGridDataSourceTreeDataPreProcessors.tsx
@@ -11,6 +11,7 @@ import {
 import {
   GridPipeProcessor,
   GridRowsPartialUpdates,
+  GridStrategyGroup,
   GridStrategyProcessor,
   useGridRegisterPipeProcessor,
   useGridRegisterStrategyProcessor,
@@ -51,7 +52,7 @@ export const useGridDataSourceTreeDataPreProcessors = (
 ) => {
   const setStrategyAvailability = React.useCallback(() => {
     privateApiRef.current.setStrategyAvailability(
-      'rowTree',
+      GridStrategyGroup.RowTree,
       TreeDataStrategy.DataSource,
       props.treeData && props.unstable_dataSource ? () => true : () => false,
     );

--- a/packages/x-data-grid-pro/src/hooks/features/treeData/useGridTreeData.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/treeData/useGridTreeData.tsx
@@ -25,7 +25,7 @@ export const useGridTreeData = (
         }
 
         if (props.unstable_dataSource && !params.rowNode.childrenExpanded) {
-          apiRef.current.unstable_dataSource.fetchRows({ parentId: params.id });
+          apiRef.current.unstable_dataSource.fetchRows(params.id);
           return;
         }
 

--- a/packages/x-data-grid-pro/src/hooks/features/treeData/useGridTreeDataPreProcessors.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/treeData/useGridTreeDataPreProcessors.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/x-data-grid';
 import {
   GridPipeProcessor,
+  GridStrategyGroup,
   GridStrategyProcessor,
   useGridRegisterPipeProcessor,
   useGridRegisterStrategyProcessor,
@@ -51,7 +52,7 @@ export const useGridTreeDataPreProcessors = (
 ) => {
   const setStrategyAvailability = React.useCallback(() => {
     privateApiRef.current.setStrategyAvailability(
-      'rowTree',
+      GridStrategyGroup.RowTree,
       TreeDataStrategy.Default,
       props.treeData && !props.unstable_dataSource ? () => true : () => false,
     );

--- a/packages/x-data-grid-pro/src/internals/propValidation.ts
+++ b/packages/x-data-grid-pro/src/internals/propValidation.ts
@@ -34,7 +34,7 @@ export const propValidatorsDataGridPro: PropValidator<DataGridProProcessedProps>
   (props) =>
     (props.signature !== GridSignature.DataGrid &&
       (props.rowsLoadingMode === 'server' || props.onRowsScrollEnd) &&
-      props.lazyLoading &&
-      'MUI X: Usage of the client side lazy loading (`rowsLoadingMode="server"` or `onRowsScrollEnd=...`) cannot be used together with server side lazy loading `lazyLoading="true"`.') ||
+      props.unstable_lazyLoading &&
+      'MUI X: Usage of the client side lazy loading (`rowsLoadingMode="server"` or `onRowsScrollEnd=...`) cannot be used together with server side lazy loading `unstable_lazyLoading="true"`.') ||
     undefined,
 ];

--- a/packages/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -77,7 +77,7 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
     DataGridProSharedPropsWithDefaultValue {
   /**
    * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
-   * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
+   * If combined with `unstable_lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */
   scrollEndThreshold: number;
@@ -150,7 +150,7 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
    * and starts sending `start` and `end` values depending on the loading mode and the scroll position.
    * @default false
    */
-  lazyLoading: boolean;
+  unstable_lazyLoading: boolean;
   /**
    * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
    * @default 500

--- a/packages/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -76,7 +76,7 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
   extends DataGridPropsWithDefaultValues<R>,
     DataGridProSharedPropsWithDefaultValue {
   /**
-   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called.
+   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
    * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */
@@ -131,7 +131,6 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
    * Set it to 'client' if you would like enable infnite loading.
    * Set it to 'server' if you would like to enable lazy loading.
    * @default "client"
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   rowsLoadingMode: GridFeatureMode;
   /**
@@ -204,7 +203,6 @@ export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onRowsScrollEnd?: GridEventListener<'rowsScrollEnd'>;
   /**
@@ -256,7 +254,6 @@ export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel
    * @param {GridFetchRowsParams} params With all properties from [[GridFetchRowsParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
-   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onFetchRows?: GridEventListener<'fetchRows'>;
   /**

--- a/packages/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -76,7 +76,7 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
   extends DataGridPropsWithDefaultValues<R>,
     DataGridProSharedPropsWithDefaultValue {
   /**
-   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd is called.
+   * Set the area in `px` at the bottom of the grid viewport where onRowsScrollEnd (deprecated) is called.
    * If combined with `lazyLoading`, it defines the area where the next data request is triggered.
    * @default 80
    */
@@ -130,7 +130,8 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
    * Loading rows can be processed on the server or client-side.
    * Set it to 'client' if you would like enable infnite loading.
    * Set it to 'server' if you would like to enable lazy loading.
-   * * @default "client"
+   * @default "client"
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   rowsLoadingMode: GridFeatureMode;
   /**
@@ -203,6 +204,7 @@ export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel
    * @param {GridRowScrollEndParams} params With all properties from [[GridRowScrollEndParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onRowsScrollEnd?: GridEventListener<'rowsScrollEnd'>;
   /**
@@ -254,6 +256,7 @@ export interface DataGridProPropsWithoutDefaultValue<R extends GridValidRowModel
    * @param {GridFetchRowsParams} params With all properties from [[GridFetchRowsParams]].
    * @param {MuiEvent<{}>} event The event object.
    * @param {GridCallbackDetails} details Additional details for this callback.
+   * @deprecated Use Server-side data `lazyLoading` instead.
    */
   onFetchRows?: GridEventListener<'fetchRows'>;
   /**

--- a/packages/x-data-grid-pro/src/models/dataGridProProps.ts
+++ b/packages/x-data-grid-pro/src/models/dataGridProProps.ts
@@ -155,7 +155,7 @@ export interface DataGridProPropsWithDefaultValue<R extends GridValidRowModel = 
    * If positive, the Data Grid will throttle data source requests on rendered rows interval change.
    * @default 500
    */
-  lazyLoadingRequestThrottleMs: number;
+  unstable_lazyLoadingRequestThrottleMs: number;
 }
 
 interface DataGridProDataSourceProps {

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -61,7 +61,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
     const baselineProps = {
       unstable_dataSource: dataSource,
       columns: mockServer.columns,
-      lazyLoading: true,
+      unstable_lazyLoading: true,
       paginationModel: { page: 0, pageSize: 10 },
       disableVirtualization: true,
     };

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -95,7 +95,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       // The 11th row should be a skeleton
-      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-0');
+      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-10');
     });
 
     it('should make a new data source request once the skeleton rows are in the render context', async () => {
@@ -274,7 +274,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       setProps({ rowCount: 100 });
 
       // The 11th row should be a skeleton
-      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-0');
+      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-10');
     });
 
     it('should reset the grid if the rowCount becomes unknown', async () => {
@@ -285,7 +285,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       // The 11th row should not exist
-      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-0');
+      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-10');
 
       // make the rowCount unknown
       setProps({ rowCount: -1 });
@@ -331,7 +331,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       // wait until the rows are added
       await waitFor(() => expect(getRow(10)).not.to.be.undefined);
       // The 11th row should be a skeleton
-      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-0');
+      expect(getRow(10).dataset.id).to.equal('auto-generated-skeleton-row-root-10');
     });
   });
 });

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -40,8 +40,8 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
           const urlParams = new URLSearchParams({
             filterModel: JSON.stringify(params.filterModel),
             sortModel: JSON.stringify(params.sortModel),
-            firstRowToRender: `${params.start}`,
-            lastRowToRender: `${params.end}`,
+            start: `${params.start}`,
+            end: `${params.end}`,
           });
 
           const getRowsResponse = await fetchRows(
@@ -119,7 +119,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
       const initialSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
-      expect(initialSearchParams.get('lastRowToRender')).to.equal('9');
+      expect(initialSearchParams.get('end')).to.equal('9');
 
       apiRef.current.scrollToIndexes({ rowIndex: 10 });
 
@@ -128,7 +128,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       const beforeSortSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
-      expect(beforeSortSearchParams.get('lastRowToRender')).to.not.equal('9');
+      expect(beforeSortSearchParams.get('end')).to.not.equal('9');
 
       apiRef.current.sortColumn(mockServer.columns[0].field, 'asc');
 
@@ -137,9 +137,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       const afterSortSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
-      expect(afterSortSearchParams.get('lastRowToRender')).to.equal(
-        beforeSortSearchParams.get('lastRowToRender'),
-      );
+      expect(afterSortSearchParams.get('end')).to.equal(beforeSortSearchParams.get('end'));
     });
 
     it('should reset the scroll position when filter is applied', async () => {
@@ -155,7 +153,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
 
       const beforeFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
       // last row is not the first page anymore
-      expect(beforeFilteringSearchParams.get('firstRowToRender')).to.not.equal('0');
+      expect(beforeFilteringSearchParams.get('start')).to.not.equal('0');
 
       apiRef.current.setFilterModel({
         items: [
@@ -173,7 +171,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
 
       const afterFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
       // last row is the end of the first page
-      expect(afterFilteringSearchParams.get('firstRowToRender')).to.equal('0');
+      expect(afterFilteringSearchParams.get('end')).to.equal('0');
     });
   });
 
@@ -222,13 +220,13 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
 
       const beforeSortingSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
       // last row is not the first page anymore
-      expect(beforeSortingSearchParams.get('lastRowToRender')).to.not.equal('9');
+      expect(beforeSortingSearchParams.get('end')).to.not.equal('9');
 
       apiRef.current.sortColumn(mockServer.columns[0].field, 'asc');
 
       const afterSortingSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
       // last row is the end of the first page
-      expect(afterSortingSearchParams.get('lastRowToRender')).to.equal('9');
+      expect(afterSortingSearchParams.get('end')).to.equal('9');
     });
 
     it('should reset the scroll position when filter is applied', async () => {
@@ -243,7 +241,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
 
       const beforeFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
       // last row is not the first page anymore
-      expect(beforeFilteringSearchParams.get('lastRowToRender')).to.not.equal('9');
+      expect(beforeFilteringSearchParams.get('end')).to.not.equal('9');
 
       apiRef.current.setFilterModel({
         items: [
@@ -257,7 +255,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
 
       const afterFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
       // last row is the end of the first page
-      expect(afterFilteringSearchParams.get('lastRowToRender')).to.equal('9');
+      expect(afterFilteringSearchParams.get('end')).to.equal('9');
     });
   });
 

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -152,7 +152,7 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       const beforeFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
-      // last row is not the first page anymore
+      // first row is not the first page anymore
       expect(beforeFilteringSearchParams.get('start')).to.not.equal('0');
 
       apiRef.current.setFilterModel({
@@ -170,8 +170,8 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
       });
 
       const afterFilteringSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
-      // last row is the end of the first page
-      expect(afterFilteringSearchParams.get('end')).to.equal('0');
+      // first row is the start of the first page
+      expect(afterFilteringSearchParams.get('start')).to.equal('0');
     });
   });
 

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -297,22 +297,22 @@ describe('<DataGridPro /> - Data source lazy loader', () => {
     it('should reset the grid if the rowCount becomes smaller than the actual row count', async () => {
       // override rowCount
       transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
-      const { setProps } = render(
+      render(
         <TestDataSourceLazyLoader rowCount={100} paginationModel={{ page: 0, pageSize: 30 }} />,
       );
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
 
-      const getRowsEventSpy = spy();
-      apiRef.current.subscribeEvent('getRows', getRowsEventSpy);
+      // reset the spy call count
+      fetchRowsSpy.resetHistory();
 
       // reduce the rowCount to be more than the number of rows
-      setProps({ rowCount: 80 });
-      expect(getRowsEventSpy.callCount).to.equal(0);
+      apiRef.current.setRowCount(80);
+      expect(fetchRowsSpy.callCount).to.equal(0);
 
       // reduce the rowCount once more, but now to be less than the number of rows
-      setProps({ rowCount: 20 });
-      expect(getRowsEventSpy.callCount).to.equal(1);
+      apiRef.current.setRowCount(20);
+      await waitFor(() => expect(fetchRowsSpy.callCount).to.equal(1));
     });
 
     it('should allow setting the row count via API', async () => {

--- a/packages/x-data-grid-pro/src/typeOverloads/modules.ts
+++ b/packages/x-data-grid-pro/src/typeOverloads/modules.ts
@@ -3,7 +3,6 @@ import type {
   GridRowScrollEndParams,
   GridRowOrderChangeParams,
   GridFetchRowsParams,
-  GridGetRowsParams,
 } from '../models';
 import type { GridRenderHeaderFilterProps } from '../components/headerFiltering/GridHeaderFilterCell';
 import type { GridColumnPinningInternalCache } from '../hooks/features/columnPinning/gridColumnPinningInterface';
@@ -46,17 +45,6 @@ export interface GridEventLookupPro {
    * Used to trigger `onFetchRows`.
    */
   fetchRows: { params: GridFetchRowsParams };
-  // Data source
-  /**
-   * Fired to make a new request through the data source's `getRows` method.
-   * @ignore - do not document.
-   */
-  getRows: { params: GridGetRowsParams };
-  /**
-   * Fired when the data request is resolved either via the data source or from the cache.
-   * @ignore - do not document.
-   */
-  rowsFetched: {};
 }
 
 export interface GridPipeProcessingLookupPro {

--- a/packages/x-data-grid-pro/src/typeOverloads/modules.ts
+++ b/packages/x-data-grid-pro/src/typeOverloads/modules.ts
@@ -43,16 +43,17 @@ export interface GridEventLookupPro {
   rowOrderChange: { params: GridRowOrderChangeParams };
   /**
    * Fired when a new batch of rows is requested to be loaded. Called with a [[GridFetchRowsParams]] object.
+   * Used to trigger `onFetchRows`.
    */
   fetchRows: { params: GridFetchRowsParams };
   // Data source
   /**
-   * Fired when the grid needs to fetch a new batch of rows from the data source.
+   * Fired to make a new request through the data source's `getRows` method.
    * @ignore - do not document.
    */
   getRows: { params: GridGetRowsParams };
   /**
-   * Fired when the new data is successfully added to the grid either directly from the data source or from the cache
+   * Fired when the data request is resolved either via the data source or from the cache.
    * @ignore - do not document.
    */
   rowsFetched: {};

--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -48,7 +48,8 @@ const defaultLabelDisplayedRows: WrappedLabelDisplayedRows = ({ from, to, count,
   if (!estimated) {
     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
   }
-  return `${from}–${to} of ${count !== -1 ? count : `more than ${estimated > to ? estimated : to}`}`;
+  const estimateLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
+  return `${from}–${to} of ${count !== -1 ? count : estimateLabel}`;
 };
 
 // A mutable version of a readonly array.

--- a/packages/x-data-grid/src/components/GridPagination.tsx
+++ b/packages/x-data-grid/src/components/GridPagination.tsx
@@ -48,8 +48,7 @@ const defaultLabelDisplayedRows: WrappedLabelDisplayedRows = ({ from, to, count,
   if (!estimated) {
     return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
   }
-  const estimateLabel = estimated && estimated > to ? `around ${estimated}` : `more than ${to}`;
-  return `${from}–${to} of ${count !== -1 ? count : estimateLabel}`;
+  return `${from}–${to} of ${count !== -1 ? count : `more than ${estimated > to ? estimated : to}`}`;
 };
 
 // A mutable version of a readonly array.

--- a/packages/x-data-grid/src/hooks/core/strategyProcessing/gridStrategyProcessingApi.ts
+++ b/packages/x-data-grid/src/hooks/core/strategyProcessing/gridStrategyProcessingApi.ts
@@ -17,12 +17,16 @@ import { GridGetRowsParams, GridGetRowsResponse } from '../../../models/gridData
 
 export type GridStrategyProcessorName = keyof GridStrategyProcessingLookup;
 
-export type GridStrategyGroup =
-  GridStrategyProcessingLookup[keyof GridStrategyProcessingLookup]['group'];
+export enum GridStrategyGroup {
+  DataSource = 'dataSource',
+  RowTree = 'rowTree',
+}
+
+export type GridStrategyGroupValue = `${GridStrategyGroup}`;
 
 export interface GridStrategyProcessingLookup {
   dataSourceRowsUpdate: {
-    group: 'dataSource';
+    group: GridStrategyGroup.DataSource;
     params:
       | {
           response: GridGetRowsResponse;
@@ -35,22 +39,22 @@ export interface GridStrategyProcessingLookup {
     value: void;
   };
   rowTreeCreation: {
-    group: 'rowTree';
+    group: GridStrategyGroup.RowTree;
     params: GridRowTreeCreationParams;
     value: GridRowTreeCreationValue;
   };
   filtering: {
-    group: 'rowTree';
+    group: GridStrategyGroup.RowTree;
     params: GridFilteringMethodParams;
     value: GridFilteringMethodValue;
   };
   sorting: {
-    group: 'rowTree';
+    group: GridStrategyGroup.RowTree;
     params: GridSortingMethodParams;
     value: GridSortingMethodValue;
   };
   visibleRowsLookupCreation: {
-    group: 'rowTree';
+    group: GridStrategyGroup.RowTree;
     params: {
       tree: GridRowsState['tree'];
       filteredRowsLookup: GridFilterState['filteredRowsLookup'];
@@ -80,21 +84,21 @@ export interface GridStrategyProcessingApi {
   ) => () => void;
   /**
    * Set a callback to know if a strategy is available.
-   * @param {GridStrategyGroup} strategyGroup The group for which we set strategy availability.
+   * @param {GridStrategyGroupValue} strategyGroup The group for which we set strategy availability.
    * @param {string} strategyName The name of the strategy.
    * @param {boolean} callback A callback to know if this strategy is available.
    */
   setStrategyAvailability: (
-    strategyGroup: GridStrategyGroup,
+    strategyGroup: GridStrategyGroupValue,
     strategyName: string,
     callback: () => boolean,
   ) => void;
   /**
    * Returns the name of the active strategy of a given strategy group
-   * @param {GridStrategyGroup} strategyGroup The group from which we want the active strategy.
+   * @param {GridStrategyGroupValue} strategyGroup The group from which we want the active strategy.
    * @returns {string} The name of the active strategy.
    */
-  getActiveStrategy: (strategyGroup: GridStrategyGroup) => string;
+  getActiveStrategy: (strategyGroup: GridStrategyGroupValue) => string;
   /**
    * Run the processor registered for the active strategy.
    * @param {GridStrategyProcessorName} processorName The name of the processor to run.

--- a/packages/x-data-grid/src/hooks/core/strategyProcessing/gridStrategyProcessingApi.ts
+++ b/packages/x-data-grid/src/hooks/core/strategyProcessing/gridStrategyProcessingApi.ts
@@ -13,6 +13,7 @@ import {
   GridSortingMethodParams,
   GridSortingMethodValue,
 } from '../../features/sorting/gridSortingState';
+import { GridGetRowsParams, GridGetRowsResponse } from '../../../models/gridDataSource';
 
 export type GridStrategyProcessorName = keyof GridStrategyProcessingLookup;
 
@@ -20,6 +21,19 @@ export type GridStrategyGroup =
   GridStrategyProcessingLookup[keyof GridStrategyProcessingLookup]['group'];
 
 export interface GridStrategyProcessingLookup {
+  dataSourceRowsUpdate: {
+    group: 'dataSource';
+    params:
+      | {
+          response: GridGetRowsResponse;
+          fetchParams: GridGetRowsParams;
+        }
+      | {
+          error: Error;
+          fetchParams: GridGetRowsParams;
+        };
+    value: void;
+  };
   rowTreeCreation: {
     group: 'rowTree';
     params: GridRowTreeCreationParams;

--- a/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
+++ b/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
@@ -4,7 +4,7 @@ import {
   GridStrategyProcessor,
   GridStrategyProcessorName,
   GridStrategyProcessingApi,
-  GridStrategyProcessingLookup,
+  GridStrategyGroupValue,
   GridStrategyGroup,
 } from './gridStrategyProcessingApi';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
@@ -12,13 +12,13 @@ import { useGridApiMethod } from '../../utils/useGridApiMethod';
 export const GRID_DEFAULT_STRATEGY = 'none';
 
 export const GRID_STRATEGIES_PROCESSORS: {
-  [P in GridStrategyProcessorName]: GridStrategyProcessingLookup[P]['group'];
+  [P in GridStrategyProcessorName]: GridStrategyGroupValue;
 } = {
-  dataSourceRowsUpdate: 'dataSource',
-  rowTreeCreation: 'rowTree',
-  filtering: 'rowTree',
-  sorting: 'rowTree',
-  visibleRowsLookupCreation: 'rowTree',
+  dataSourceRowsUpdate: GridStrategyGroup.DataSource,
+  rowTreeCreation: GridStrategyGroup.RowTree,
+  filtering: GridStrategyGroup.RowTree,
+  sorting: GridStrategyGroup.RowTree,
+  visibleRowsLookupCreation: GridStrategyGroup.RowTree,
 };
 
 type UntypedStrategyProcessors = {
@@ -60,11 +60,11 @@ type UntypedStrategyProcessors = {
  * =====================================================================================================================
  *
  * Each processor name is part of a strategy group which can only have one active strategy at the time.
- * For now, there are two groupes named `rowTree` and `dataSource`.
+ * There are two active groups named `rowTree` and `dataSource`.
  */
 export const useGridStrategyProcessing = (apiRef: React.MutableRefObject<GridPrivateApiCommon>) => {
   const availableStrategies = React.useRef(
-    new Map<string, { group: GridStrategyGroup; isAvailable: () => boolean }>(),
+    new Map<string, { group: GridStrategyGroupValue; isAvailable: () => boolean }>(),
   );
   const strategiesCache = React.useRef<{
     [P in GridStrategyProcessorName]?: { [strategyName: string]: GridStrategyProcessor<any> };

--- a/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
+++ b/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridStrategyProcessing.ts
@@ -14,6 +14,7 @@ export const GRID_DEFAULT_STRATEGY = 'none';
 export const GRID_STRATEGIES_PROCESSORS: {
   [P in GridStrategyProcessorName]: GridStrategyProcessingLookup[P]['group'];
 } = {
+  dataSourceRowsUpdate: 'dataSource',
   rowTreeCreation: 'rowTree',
   filtering: 'rowTree',
   sorting: 'rowTree',
@@ -59,10 +60,7 @@ type UntypedStrategyProcessors = {
  * =====================================================================================================================
  *
  * Each processor name is part of a strategy group which can only have one active strategy at the time.
- * For now, there is only one strategy group named `rowTree` which customize
- * - row tree creation algorithm.
- * - sorting algorithm.
- * - filtering algorithm.
+ * For now, there are two groupes named `rowTree` and `dataSource`.
  */
 export const useGridStrategyProcessing = (apiRef: React.MutableRefObject<GridPrivateApiCommon>) => {
   const availableStrategies = React.useRef(

--- a/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -38,6 +38,7 @@ import {
   computeRowsUpdates,
 } from './gridRowsUtils';
 import { useGridRegisterPipeApplier } from '../../core/pipeProcessing';
+import { GridStrategyGroup } from '../../core/strategyProcessing';
 
 export const rowsStateInitializer: GridStateInitializer<
   Pick<DataGridProcessedProps, 'unstable_dataSource' | 'rows' | 'rowCount' | 'getRowId' | 'loading'>
@@ -561,7 +562,10 @@ export const useGridRows = (
   >(() => {
     // `rowTreeCreation` is the only processor ran when `strategyAvailabilityChange` is fired.
     // All the other processors listen to `rowsSet` which will be published by the `groupRows` method below.
-    if (apiRef.current.getActiveStrategy('rowTree') !== gridRowGroupingNameSelector(apiRef)) {
+    if (
+      apiRef.current.getActiveStrategy(GridStrategyGroup.RowTree) !==
+      gridRowGroupingNameSelector(apiRef)
+    ) {
       groupRows();
     }
   }, [apiRef, groupRows]);

--- a/packages/x-data-grid/src/internals/index.ts
+++ b/packages/x-data-grid/src/internals/index.ts
@@ -17,6 +17,7 @@ export { getValueOptions } from '../components/panel/filterPanel/filterPanelUtil
 export { useGridRegisterPipeProcessor } from '../hooks/core/pipeProcessing';
 export type { GridPipeProcessor } from '../hooks/core/pipeProcessing';
 export {
+  GridStrategyGroup,
   useGridRegisterStrategyProcessor,
   GRID_DEFAULT_STRATEGY,
 } from '../hooks/core/strategyProcessing';

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -613,7 +613,7 @@ describe('<DataGrid /> - Pagination', () => {
     it('should support server side pagination with estimated row count', () => {
       const { setProps } = render(<ServerPaginationGrid rowCount={-1} estimatedRowCount={2} />);
       expect(getColumnValues(0)).to.deep.equal(['0']);
-      expect(screen.getByText('1–1 of more than 2')).not.to.equal(null);
+      expect(screen.getByText('1–1 of around 2')).not.to.equal(null);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       expect(getColumnValues(0)).to.deep.equal(['1']);
       expect(screen.getByText('2–2 of more than 2')).not.to.equal(null);

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -613,7 +613,7 @@ describe('<DataGrid /> - Pagination', () => {
     it('should support server side pagination with estimated row count', () => {
       const { setProps } = render(<ServerPaginationGrid rowCount={-1} estimatedRowCount={2} />);
       expect(getColumnValues(0)).to.deep.equal(['0']);
-      expect(screen.getByText('1–1 of around 2')).not.to.equal(null);
+      expect(screen.getByText('1–1 of more than 2')).not.to.equal(null);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       expect(getColumnValues(0)).to.deep.equal(['1']);
       expect(screen.getByText('2–2 of more than 2')).not.to.equal(null);

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -40,7 +40,6 @@
   { "name": "ElementSize", "kind": "Interface" },
   { "name": "EMPTY_PINNED_COLUMN_FIELDS", "kind": "Variable" },
   { "name": "EMPTY_RENDER_CONTEXT", "kind": "Variable" },
-  { "name": "FetchRowsOptions", "kind": "Interface" },
   { "name": "FilterColumnsArgs", "kind": "Interface" },
   { "name": "FilterPanelPropsOverrides", "kind": "Interface" },
   { "name": "FocusElement", "kind": "Interface" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -39,7 +39,6 @@
   { "name": "ElementSize", "kind": "Interface" },
   { "name": "EMPTY_PINNED_COLUMN_FIELDS", "kind": "Variable" },
   { "name": "EMPTY_RENDER_CONTEXT", "kind": "Variable" },
-  { "name": "FetchRowsOptions", "kind": "Interface" },
   { "name": "FilterColumnsArgs", "kind": "Interface" },
   { "name": "FilterPanelPropsOverrides", "kind": "Interface" },
   { "name": "FocusElement", "kind": "Interface" },


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/8179
Resolves https://github.com/mui/mui-x/issues/10857
Resolves https://github.com/mui/mui-x/issues/10858

Preview: https://deploy-preview-13878--material-ui-x.netlify.app/x/react-data-grid/server-side-data/lazy-loading/

**Action items in progress:**

- [x] ~~Make initial end index dependent on the viewport~~ Use page size for the initial data load
- [x] Refine/fix issues when rows positions are changed after
  - [x] Sorting
  - [x] Filtering
- [x] Handle empty data set 
- [x] Update documentation and add more examples
  - [x] ~~Include https://github.com/mui/mui-x/issues/14227~~ (will be handled separately)
- [x] Improve caching
- [x] Lazy loading in combination with grouped rows / tree grid (will be handled in https://github.com/mui/mui-x/issues/14527)
- [x] Throttling requests
  - [x] With a fixed time
  - [x] Configuration
- [x] Update premium grid to use new processors/hooks
- [x] Check if lazy loading can be combined with infinite loading
  - [x] Support infinite loading
  - [x] Support switching between viewport and infinite loading
- [x] Error handling 
- [x] Tests
- [x] Add changelog

## Changelog

- 💫 Support [Server-side lazy loading](https://mui.com/x/react-data-grid/server-side-data/lazy-loading/) on the Data Grid. Use [data source](https://mui.com/x/react-data-grid/server-side-data/#data-source) to fetch a range of rows on demand and update the rows in the same way as described in [Infinite loading](https://mui.com/x/react-data-grid/row-updates/#infinite-loading) and [Lazy loading](https://mui.com/x/react-data-grid/row-updates/#lazy-loading) without the need to use any additional event listeners and callbacks.
- 🎯 Improved [data caching](https://mui.com/x/react-data-grid/server-side-data/#data-caching). Check out our [recommendations](https://mui.com/x/react-data-grid/server-side-data/#improving-the-cache-hit-rate) for improving the cache hit rate.