### PR TITLE
[DataGrid] Also send the API with events in Premium

### DIFF
--- a/packages/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
+++ b/packages/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumProps.ts
@@ -4,6 +4,7 @@ import {
   DATA_GRID_PRO_PROPS_DEFAULT_VALUES,
   GRID_DEFAULT_LOCALE_TEXT,
   DataGridProProps,
+  GridSignature,
 } from '@mui/x-data-grid-pro';
 import { computeSlots, useProps } from '@mui/x-data-grid-pro/internals';
 import {
@@ -25,7 +26,7 @@ type GetDataGridProForcedProps = (
 ) => DataGridProForcedProps;
 
 const getDataGridPremiumForcedProps: GetDataGridProForcedProps = (themedProps) => ({
-  signature: 'DataGridPremium',
+  signature: GridSignature.DataGridPremium,
   ...(themedProps.unstable_dataSource
     ? {
         filterMode: 'server',

--- a/packages/x-data-grid/src/hooks/core/useGridApiInitialization.ts
+++ b/packages/x-data-grid/src/hooks/core/useGridApiInitialization.ts
@@ -120,7 +120,8 @@ export function useGridApiInitialization<
       }
 
       const details =
-        props.signature === GridSignature.DataGridPro
+        props.signature === GridSignature.DataGridPro ||
+        props.signature === GridSignature.DataGridPremium
           ? { api: privateApiRef.current.getPublicApi() }
           : {};
       privateApiRef.current.eventManager.emit(name, params, event, details);

--- a/packages/x-data-grid/src/hooks/utils/useGridApiEventHandler.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridApiEventHandler.ts
@@ -13,6 +13,7 @@ import type { GridApiCommon } from '../../models';
 enum GridSignature {
   DataGrid = 'DataGrid',
   DataGridPro = 'DataGridPro',
+  DataGridPremium = 'DataGridPremium',
 }
 
 interface RegistryContainer {


### PR DESCRIPTION
The code would only send it with Pro which would be a regression for clients switching from Pro to Premium.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
