### PR TITLE
[charts] hide empty arcs in the PieChart

### DIFF
--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -118,6 +118,7 @@ function PieArc(props: PieArcProps) {
             outerRadius: oR,
           })!,
       )}
+      visibility={to([startAngle, endAngle], (sA, eA) => (sA === eA ? 'hidden' : 'visible'))}
       onClick={onClick}
       cursor={onClick ? 'pointer' : 'unset'}
       ownerState={ownerState}


### PR DESCRIPTION
Fix #13887

To test

```jsx
import * as React from "react";
import { PieChart } from "@mui/x-charts/PieChart";

const data = [
  { id: 0, value: 0, label: "series A" },
  { id: 1, value: 15, label: "series B" },
  { id: 2, value: 0, label: "series C" },
];

export default function PieActiveArc() {
  return (
    <PieChart
      series={[
        {
          data,
          highlightScope: { faded: "global", highlighted: "item" },
          faded: { innerRadius: 30, additionalRadius: -30, color: "gray" },
        },
      ]}
      height={200}
    />
  );
}

```