### PR TITLE
[docs] Fix type of `scaleType` in AxisConfig API page

### DIFF
--- a/docs/pages/x/api/charts/axis-config.json
+++ b/docs/pages/x/api/charts/axis-config.json
@@ -3,7 +3,7 @@
   "imports": ["import { AxisConfig } from '@mui/x-charts'"],
   "properties": {
     "id": { "type": { "description": "AxisId" }, "required": true },
-    "scaleType": { "type": { "description": "'band'" }, "required": true },
+    "scaleType": { "type": { "description": "'linear' | 'band' | 'point' | 'log' | 'pow' | 'sqrt' | 'time' | 'utc'" }, "required": true },
     "colorMap": {
       "type": { "description": "OrdinalColorConfig | ContinuousColorConfig | PiecewiseColorConfig" }
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixed typings of `scaleType` property in AxisConfig api page. 

Fixes #13634 