### PR TITLE
[tree view][docs] Fix scroll demos disorientation

### DIFF
--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemDOMElement.js
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemDOMElement.js
@@ -42,7 +42,7 @@ export default function ApiMethodGetItemDOMElement() {
     apiRef.current.focusItem(event, 'charts-community');
     apiRef.current
       .getItemDOMElement('charts-community')
-      ?.scrollIntoView({ block: 'center' });
+      ?.scrollIntoView({ block: 'nearest' });
   };
 
   return (

--- a/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemDOMElement.tsx
+++ b/docs/data/tree-view/rich-tree-view/items/ApiMethodGetItemDOMElement.tsx
@@ -42,7 +42,7 @@ export default function ApiMethodGetItemDOMElement() {
     apiRef.current!.focusItem(event, 'charts-community');
     apiRef
       .current!.getItemDOMElement('charts-community')
-      ?.scrollIntoView({ block: 'center' });
+      ?.scrollIntoView({ block: 'nearest' });
   };
 
   return (

--- a/docs/data/tree-view/simple-tree-view/items/ApiMethodGetItemDOMElement.js
+++ b/docs/data/tree-view/simple-tree-view/items/ApiMethodGetItemDOMElement.js
@@ -12,7 +12,7 @@ export default function ApiMethodGetItemDOMElement() {
     apiRef.current.focusItem(event, 'charts-community');
     apiRef.current
       .getItemDOMElement('charts-community')
-      ?.scrollIntoView({ block: 'center' });
+      ?.scrollIntoView({ block: 'nearest' });
   };
 
   return (

--- a/docs/data/tree-view/simple-tree-view/items/ApiMethodGetItemDOMElement.tsx
+++ b/docs/data/tree-view/simple-tree-view/items/ApiMethodGetItemDOMElement.tsx
@@ -12,7 +12,7 @@ export default function ApiMethodGetItemDOMElement() {
     apiRef.current!.focusItem(event, 'charts-community');
     apiRef
       .current!.getItemDOMElement('charts-community')
-      ?.scrollIntoView({ block: 'center' });
+      ?.scrollIntoView({ block: 'nearest' });
   };
 
   return (


### PR DESCRIPTION
I got confused playing with the demo of https://mui.com/x/react-tree-view/simple-tree-view/items/#imperative-api. I clicked on the button and got lost, it took me to click 2 more times on the button to understand this demo.

Before

https://github.com/user-attachments/assets/e46403cf-5cec-404b-a3b2-61a084c250a8

After

https://github.com/user-attachments/assets/84db071e-cbba-4db8-8abb-04d2cc1002c7

---

**Off-topic**. @samuelsycamore I think this could be a small example of work / responsibility we could envision to structure to "Docs" team to grow around, meaning to be accountable for the end-to-end experience of the docs.