### PR TITLE
[data grid] Remove dead code in internal GridPreferencesPanel

### DIFF
--- a/packages/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
@@ -6,10 +6,7 @@ import { GridPreferencePanelsValue } from '../../hooks/features/preferencesPanel
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 
-export const GridPreferencesPanel = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(function GridPreferencesPanel(props, ref) {
+export const GridPreferencesPanel = function GridPreferencesPanel() {
   const apiRef = useGridApiContext();
   const columns = useGridSelector(apiRef, gridColumnDefinitionsSelector);
   const rootProps = useGridRootProps();
@@ -23,16 +20,14 @@ export const GridPreferencesPanel = React.forwardRef<
 
   return (
     <rootProps.slots.panel
-      ref={ref}
       as={rootProps.slots.basePopper}
       open={columns.length > 0 && preferencePanelState.open}
       id={preferencePanelState.panelId}
       aria-labelledby={preferencePanelState.labelId}
       {...rootProps.slotProps?.panel}
-      {...props}
       {...rootProps.slotProps?.basePopper}
     >
       {panelContent}
     </rootProps.slots.panel>
   );
-});
+};

--- a/packages/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
@@ -6,7 +6,7 @@ import { GridPreferencePanelsValue } from '../../hooks/features/preferencesPanel
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 
-export const GridPreferencesPanel = function GridPreferencesPanel() {
+export function GridPreferencesPanel() {
   const apiRef = useGridApiContext();
   const columns = useGridSelector(apiRef, gridColumnDefinitionsSelector);
   const rootProps = useGridRootProps();

--- a/packages/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPreferencesPanel.tsx
@@ -30,4 +30,4 @@ export function GridPreferencesPanel() {
       {panelContent}
     </rootProps.slots.panel>
   );
-};
+}


### PR DESCRIPTION
props and ref are not used anywhere, so its safe to remove them

A leftover from #11228.