### PR TITLE
Update index.ts

### DIFF
--- a/packages/x-data-grid/src/internals/index.ts
+++ b/packages/x-data-grid/src/internals/index.ts
@@ -129,8 +129,7 @@ export { useGridVisibleRows, getVisibleRows } from '../hooks/utils/useGridVisibl
 export { useGridInitializeState } from '../hooks/utils/useGridInitializeState';
 export type { GridStateInitializer } from '../hooks/utils/useGridInitializeState';
 
-export type * from '../models/props/DataGridProps';
-export type * from '../models/gridDataSource';
+export type { DataGridProps, DataGridForcedPropsKey} from '../models/props/DataGridProps';
 export { getColumnsToExport, defaultGetRowsToExport } from '../hooks/features/export/utils';
 export * from '../utils/createControllablePromise';
 export { createSelector, createSelectorMemoized } from '../utils/createSelector';


### PR DESCRIPTION
When attempting to update from v6 to v7 of mui datagrid, we're getting an error caused by not yet implementing the latest version of TypeScript
`Only named exports may use 'export type'.`

This feels like a relatively small/simple fix to allow users to use the newer V7 version who cannot currently go through a larger upgrade.

- Removed `export type * from '../models/gridDataSource';` no types declared in gridDataSource
- Updated `'../models/props/DataGridProps'` import to be explicit

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
