### PR TITLE
[DataGrid] Update aggregation label styling

### DIFF
--- a/packages/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -45,7 +45,7 @@ const GridAggregationFunctionLabel = styled('div', {
     color: theme.palette.text.secondary,
     position: 'absolute',
     top: '50%',
-    transform: 'translateY(40%)',
+    transform: 'translateY(50%)',
   };
 });
 

--- a/packages/x-data-grid-premium/src/components/GridAggregationHeader.tsx
+++ b/packages/x-data-grid-premium/src/components/GridAggregationHeader.tsx
@@ -42,11 +42,10 @@ const GridAggregationFunctionLabel = styled('div', {
   return {
     fontSize: theme.typography.caption.fontSize,
     lineHeight: theme.typography.caption.fontSize,
+    color: theme.palette.text.secondary,
     position: 'absolute',
-    bottom: 4,
-    fontWeight: theme.typography.fontWeightMedium,
-    color: (theme.vars || theme).palette.primary.dark,
-    textTransform: 'uppercase',
+    top: '50%',
+    transform: 'translateY(40%)',
   };
 });
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/5530 and https://github.com/mui/mui-x/issues/9104

### Problem

Aggregation labels are currently quite prominent in the header cell due to their color, font-weight and transformation to uppercase - this doesn't make sense hierarchically as they should not have equal or more importance than the header title itself.

The other issue we have is that the aggregation label is too close to the header title when the grid `density` is set to `compact`.

![before](https://github.com/user-attachments/assets/e66e755b-a21c-4d6c-89ce-1ef42e87808c)

### Solution

This PR updates the aggregation label style to use the secondary text color, regular font-weight, and removes the text transformation.

Removing the text transformation also makes the casing for the aggregation consistent with how the option is displayed in the column menu select.

![localhost_3001_playground_(Styling Screenshot)](https://github.com/user-attachments/assets/7309b2d5-c54e-4448-8101-e0a23c63c766)

**Note:** ideally there would be more space below the aggregation label, too, as it is too close to the border. Perhaps we could solve that here, or separately as part of this issue? https://github.com/mui/mui-x/issues/5274

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-13950--material-ui-x.netlify.app/x/react-data-grid/aggregation/