### PR TITLE
[docs] Update `SparkLineChart` reference not being correctly capitalised

### DIFF
--- a/docs/data/charts/sparkline/sparkline.md
+++ b/docs/data/charts/sparkline/sparkline.md
@@ -11,7 +11,7 @@ components: SparkLineChart
 ## Basics
 
 A sparkline is a small chart drawn without axes or coordinates, that presents the general shape of a variation in a simplified way.
-The `<SparklineChart />` requires only the `data` props which is an array of numbers.
+The `<SparkLineChart />` requires only the `data` props which is an array of numbers.
 You can also switch from line to a bar plot with `plotType="bar"`.
 
 {{"demo": "BasicSparkLine.js"}}


### PR DESCRIPTION
Fixing capitalization error

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [~x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
