### PR TITLE
[DataGrid] Fix paste to selected cells

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
@@ -4,6 +4,7 @@ import {
   GridPipeProcessor,
   GridStateInitializer,
   getTotalHeaderHeight,
+  getVisibleRows,
   isNavigationKey,
   serializeCellValue,
   useGridRegisterPipeProcessor,
@@ -164,19 +165,29 @@ export const useGridCellSelection = (
   const getSelectedCellsAsArray = React.useCallback<
     GridCellSelectionApi['getSelectedCellsAsArray']
   >(() => {
-    const model = apiRef.current.getCellSelectionModel();
+    const selectionModel = apiRef.current.getCellSelectionModel();
     const idToIdLookup = gridRowsDataRowIdToIdLookupSelector(apiRef);
+    const visibleRows = getVisibleRows(apiRef, props);
+    const sortedEntries = visibleRows.rows.reduce((result, row) => {
+      if (row.id in selectionModel) {
+        result.push([row.id, selectionModel[row.id]])
+      }
+      return result;
+    }, [] as [GridRowId, Record<string, boolean>][])
 
-    return Object.entries(model).reduce<{ id: GridRowId; field: string }[]>(
-      (acc, [id, fields]) => [
-        ...acc,
-        ...Object.entries(fields).reduce<{ id: GridRowId; field: string }[]>(
-          (acc2, [field, isSelected]) => {
-            return isSelected ? [...acc2, { id: idToIdLookup[id], field }] : acc2;
+    return sortedEntries.reduce<{ id: GridRowId; field: string }[]>(
+      (selectedCells, [id, fields]) => {
+        selectedCells.push(...Object.entries(fields).reduce<{ id: GridRowId; field: string }[]>(
+          (selectedFields, [field, isSelected]) => {
+            if (isSelected) {
+              selectedFields.push({ id: idToIdLookup[id], field })
+            }
+            return selectedFields;
           },
           [],
-        ),
-      ],
+        ));
+        return selectedCells;
+      },
       [],
     );
   }, [apiRef]);

--- a/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/clipboard/useGridClipboardImport.ts
@@ -220,16 +220,25 @@ function defaultPasteResolver({
   const cellSelectionModel = apiRef.current.getCellSelectionModel();
   const selectedCellsArray = apiRef.current.getSelectedCellsAsArray();
   if (cellSelectionModel && selectedCellsArray.length > 1) {
-    Object.keys(cellSelectionModel).forEach((rowId, rowIndex) => {
+    let lastRowId = selectedCellsArray[0].id;
+    let rowIndex = 0;
+    let colIndex = -1;
+    selectedCellsArray.forEach(({ id: rowId, field }) => {
+      if (rowId !== lastRowId) {
+        lastRowId = rowId;
+        rowIndex += 1;
+        colIndex = -1;
+      }
+      colIndex += 1;
+
       const rowDataArr = pastedData[isSingleValuePasted ? 0 : rowIndex];
       const hasRowData = isSingleValuePasted ? true : rowDataArr !== undefined;
       if (!hasRowData) {
         return;
       }
-      Object.keys(cellSelectionModel[rowId]).forEach((field, colIndex) => {
-        const cellValue = isSingleValuePasted ? rowDataArr[0] : rowDataArr[colIndex];
-        updateCell({ rowId, field, pastedCellValue: cellValue });
-      });
+
+      const cellValue = isSingleValuePasted ? rowDataArr[0] : rowDataArr[colIndex];
+      updateCell({ rowId, field, pastedCellValue: cellValue });
     });
 
     return;


### PR DESCRIPTION
Closes #13703 

Fix pasting to multiple selected cells. The root cause is that the selection model is an unordered record of the selected cells, but we were `Object.entries()`'ing it, which didn't produce the same ordering as the visible rows.

Before: https://codesandbox.io/p/devbox/lck95j?file=%2Fsrc%2FDemo.tsx
After: