### PR TITLE
[docs] Fix 404

### DIFF
--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -1,7 +1,7 @@
 ---
 title: Charts - Tooltip
 productId: x-charts
-components: ChartsAxisTooltipContent, ChartsItemTooltipContent, ChartsTooltip, DefaultChartsAxisTooltipContent, DefaultChartsItemTooltipContent, ChartsAxisHighlight
+components: ChartsTooltip, DefaultChartsAxisTooltipContent, DefaultChartsItemTooltipContent, ChartsAxisHighlight
 ---
 
 # Charts - Tooltip


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/75511647-3d76-4e6f-9569-2cb9987da89d)

Those 404 detected by hrefs are due to the API section in the tooltip https://mui.com/x/react-charts/tooltip/

![image](https://github.com/user-attachments/assets/d747e3f4-aeb5-4971-ad59-6751ea27bd37)

Those API pages got removed because they were nearly empty + wrong