### PR TITLE
[docs] Fix Vale errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,8 +143,8 @@ Same changes as in `@mui/x-date-pickers@7.11.0`, plus:
 - [charts] Defaultize axis on top level `useChartContainerProps` (#13817) @JCQuintas
 - [charts] Fix charts not passing `className` to root element (#13647) @JCQuintas
 - [charts] Generate API documentation for pro components (#13822) @alexfauquette
-- [charts] Improve zoomed highlight behaviour (unreleased) (#13868) @JCQuintas
-- [charts] Allow zoom on Y axis and add zoom options to configure zooming behaviour (unreleased) (#13726) @JCQuintas
+- [charts] Improve zoomed highlight behavior (unreleased) (#13868) @JCQuintas
+- [charts] Allow zoom on Y axis and add zoom options to configure zooming behavior (unreleased) (#13726) @JCQuintas
 - [charts] Disable animations while zooming (unreleased) (#13807) @JCQuintas
 
 ### Tree View
@@ -617,7 +617,7 @@ Same changes as in `@mui/x-date-pickers@7.6.2`.
 
 #### `@mui/x-charts@7.6.2`
 
-- [charts] Add `Initializable` type and behaviour to allow checking if a complex context has been initialized. (#13365) @JCQuintas
+- [charts] Add `Initializable` type and behavior to allow checking if a complex context has been initialized. (#13365) @JCQuintas
 - [charts] Fix some props not working in `xAxis` and `yAxis` (#13372) @Valyok26
 - [charts] Harmonize charts types (#13366) @alexfauquette
 - [charts] Introduce plugins system (#13367) @alexfauquette
@@ -625,7 +625,7 @@ Same changes as in `@mui/x-date-pickers@7.6.2`.
 
 ### Docs
 
-- [docs] Add badges like in Material UI @oliviertassinari
+- [docs] Add badges like in Material UI @oliviertassinari
 - [docs] Update twitter.com to x.com @oliviertassinari
 - [docs] Fix the description of `tickInterval` (#13355) @alexfauquette
 - [docs] Adjust the code example for `quickFilterValues` (#12919) @michelengelen

--- a/docs/data/data-grid/overlays/overlays.md
+++ b/docs/data/data-grid/overlays/overlays.md
@@ -50,21 +50,21 @@ An animated placeholder of the data grid.
 
 ### Custom component
 
-If you want to customize the no rows overlay, a component can be passed to the `loadingOverlay` slot.
+If you want to customize the no-rows overlay, a component can be passed to the `loadingOverlay` slot.
 
-In the following demo, a labelled determinate [CircularProgress](/material-ui/react-progress/#circular-determinate) component is rendered in place of the default loading overlay, with some additional _Loading rows…_ text.
+In the following demo, a labeled determinate [CircularProgress](/material-ui/react-progress/#circular-determinate) component is rendered in place of the default loading overlay, with some additional _Loading rows…_ text.
 
 {{"demo": "LoadingOverlayCustom.js", "bg": "inline"}}
 
 ## No rows overlay
 
-The no rows overlay is displayed when the data grid has no rows.
+The no-rows overlay is displayed when the data grid has no rows.
 
 {{"demo": "NoRowsOverlay.js", "bg": "inline"}}
 
 ### Custom component
 
-If you want to customize the no rows overlay, a component can be passed to the `noRowsOverlay` slot and rendered in place.
+If you want to customize the no-rows overlay, a component can be passed to the `noRowsOverlay` slot and rendered in place.
 
 In the following demo, an illustration is added on top of the default "No rows" message.
 
@@ -72,7 +72,7 @@ In the following demo, an illustration is added on top of the default "No rows" 
 
 ## No results overlay
 
-The no results overlay is displayed when the data grid has no results after filtering.
+The no-results overlay is displayed when the data grid has no results after filtering.
 
 {{"demo": "NoResultsOverlay.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -58,7 +58,7 @@ This example only scratches the surface with a lot of problems still unsolved li
 
 - Performance optimization
 - Caching data/deduping requests
-- More complex use-cases on the server like grouping, tree data, etc.
+- More complex use cases on the server like grouping, tree data, etc.
 - Server-side row editing
 - Lazy loading of data
 - Handling updates to the data like row editing, row deletion, etc.
@@ -70,17 +70,17 @@ Trying to solve these problems one after the other can make the code complex and
 
 The idea for a centralized data source is to simplify server-side data fetching.
 It's an abstraction layer between the Data Grid and the server, providing a simple interface for interacting with the server.
-Think of it like a middleman handling the communication between the Data Grid (client) and the actual data source (server).
+Think of it like an intermediary handling the communication between the Data Grid (client) and the actual data source (server).
 
 :::warning
 
 This feature is under development and is marked as **unstable**.
-The information shared on this page could change in future.
+The information shared on this page could change in the future.
 Feel free to subscribe or comment on the official GitHub [umbrella issue](https://github.com/mui/mui-x/issues/8179).
 
 :::
 
-It has an initial set of required methods that you need to implement. The data grid will use these methods internally to fetch a sub-set of data when needed.
+It has an initial set of required methods that you need to implement. The data grid will use these methods internally to fetch a subset of data when needed.
 
 Let's take a look at the minimal `GridDataSource` interface configuration.
 
@@ -177,7 +177,7 @@ The following demo showcases this behavior.
 
 :::info
 The data source demos use a utility function `useMockServer` to simulate the server-side data fetching.
-In a real-world scenario, you should replace this with your own server-side data fetching logic.
+In a real-world scenario, you should replace this with your own server-side data-fetching logic.
 
 Open info section of the browser console to see the requests being made and the data being fetched in response.
 :::
@@ -187,7 +187,7 @@ Open info section of the browser console to see the requests being made and the 
 The data source caches fetched data by default.
 This means that if the user navigates to a page or expands a node that has already been fetched, the grid will not call the `getRows` function again to avoid unnecessary calls to the server.
 
-The `GridDataSourceCacheDefault` is used by default which is a simple in-memory cache that stores the data in a plain object. It could be seen in action in the demo below.
+The `GridDataSourceCacheDefault` is used by default which is a simple in-memory cache that stores the data in a plain object. It can be seen in action in the demo below.
 
 {{"demo": "ServerSideDataGrid.js", "bg": "inline"}}
 
@@ -211,7 +211,7 @@ const lowTTLCache = new GridDataSourceCacheDefault({ ttl: 1000 * 10 }); // 10 se
 
 ### Custom cache
 
-To provide a custom cache, use `unstable_dataSourceCache` prop, which could be either written from scratch or based out of another cache library.
+To provide a custom cache, use `unstable_dataSourceCache` prop, which could be either written from scratch or based on another cache library.
 This prop accepts a generic interface of type `GridDataSourceCache`.
 
 ```tsx

--- a/packages/x-internals/README.md
+++ b/packages/x-internals/README.md
@@ -1,4 +1,4 @@
 # @mui/x-internals
 
-Shared utilities used by MUI X packages.
+Shared utilities used by MUI X packages.
 This package should never be installed or used directly.


### PR DESCRIPTION
Those errors can be seen by running

`vale sync && git ls-files | grep -h ".md$" | xargs vale --filter='.Level=="error"'`

It's not in the CI yet because we share the config with the monorepo HEAD, which could mean breaking the CI in MUI X as soon as a PR is merged in the monorepo.

https://github.com/mui/mui-x/blob/c8845a254adff01c2799a3cc991345c7ea04cfe7/.vale.ini#L10

We will need to change this.