### PR TITLE
[docs] Add a warning to promote the usage of `updateRows`

### DIFF
--- a/docs/data/data-grid/row-updates/row-updates.md
+++ b/docs/data/data-grid/row-updates/row-updates.md
@@ -12,6 +12,11 @@ It replaces the previous values. This approach has some drawbacks:
 
 {{"demo": "UpdateRowsProp.js", "bg": "inline"}}
 
+:::warning
+Updating the `rows` prop causes the Data Grid to recompute the row tree, resulting in losing the current tree information like the expanded rows state.
+Unless the recomputation is explicitly required, the API method `updateRows` should be used.
+:::
+
 ## The `updateRows` method
 
 If you want to only update part of the rows, you can use the `apiRef.current.updateRows` method.


### PR DESCRIPTION
Doubling down on the usage of `updateRows` API method due to multiple inquiries in this regard.

The most recent one: https://github.com/mui/mui-x/issues/13962