### PR TITLE
[infra] Revert `vale` action `paths` filtering

### DIFF
--- a/.github/workflows/vale-action.yml
+++ b/.github/workflows/vale-action.yml
@@ -1,9 +1,6 @@
 name: Vale action
 
-on:
-  pull_request:
-    paths:
-      - 'docs/data/**.md'
+on: [pull_request]
 
 permissions: {}
 


### PR DESCRIPTION
Revert the `paths` filter, because it skips the action and [keeps that item in a pending state](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore). 🙈
> If a workflow is skipped due to path filtering, [branch filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore), or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

We already have a filter to run `vale` only on `docs/data`, it should be enough. 🤞 

<img width="875" alt="Screenshot 2024-07-30 at 16 54 31" src="https://github.com/user-attachments/assets/8620cee8-f510-447c-9c95-9cb51f0bad0d">
