### PR TITLE
[DataGrid] Refactor: remove useless copy

### DIFF
--- a/packages/x-data-grid/src/internals/utils/useProps.ts
+++ b/packages/x-data-grid/src/internals/utils/useProps.ts
@@ -32,8 +32,5 @@ function groupForwardedProps<
 }
 
 export function useProps<T extends Record<string, any>>(allProps: T) {
-  return React.useMemo(() => {
-    const { ...themedProps } = allProps;
-    return groupForwardedProps(themedProps);
-  }, [allProps]);
+  return React.useMemo(() => groupForwardedProps(allProps), [allProps]);
 }


### PR DESCRIPTION
Noticed this while working on https://github.com/mui/mui-x/issues/10033 and https://github.com/mui/material-ui/pull/43120.

We are making a copy to pass to the function, but the callee never mutates its argument (like basically all functions in our codebase) so there is no need to copy.