### PR TITLE
[DataGrid] Fix `columnHeadersContainerRef` being `undefined` before mount

### DIFF
--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -571,7 +571,6 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
 - The field `mainElementRef` is now always non-null.
 - The field `rootElementRef` is now always non-null.
 - The field `virtualScrollerRef` is now always non-null.
-- The field `columnHeadersContainerRef` is now always non-null.
 - The event `renderedRowsIntervalChange` params changed from `GridRenderedRowsIntervalChangeParams` to `GridRenderContext`, and the former has been removed.
 
 ### Changes to slots

--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -571,6 +571,7 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
 - The field `mainElementRef` is now always non-null.
 - The field `rootElementRef` is now always non-null.
 - The field `virtualScrollerRef` is now always non-null.
+- The field `columnHeadersContainerRef` is now always non-null.
 - The event `renderedRowsIntervalChange` params changed from `GridRenderedRowsIntervalChangeParams` to `GridRenderContext`, and the former has been removed.
 
 ### Changes to slots

--- a/packages/x-data-grid/src/components/GridHeaders.tsx
+++ b/packages/x-data-grid/src/components/GridHeaders.tsx
@@ -54,11 +54,7 @@ function GridHeaders() {
     cellTabIndexState === null
   );
 
-  const columnsContainerRef = React.useRef<HTMLDivElement>(null);
-
-  apiRef.current.register('private', {
-    columnHeadersContainerRef: columnsContainerRef,
-  });
+  const columnsContainerRef = apiRef.current.columnHeadersContainerRef;
 
   return (
     <rootProps.slots.columnHeaders

--- a/packages/x-data-grid/src/hooks/core/useGridRefs.ts
+++ b/packages/x-data-grid/src/hooks/core/useGridRefs.ts
@@ -7,6 +7,7 @@ export const useGridRefs = <PrivateApi extends GridPrivateApiCommon>(
   const rootElementRef = React.useRef<HTMLDivElement>(null);
   const mainElementRef = React.useRef<HTMLDivElement>(null);
   const virtualScrollerRef = React.useRef<HTMLDivElement>(null);
+  const columnHeadersContainerRef = React.useRef<HTMLDivElement>(null);
 
   apiRef.current.register('public', {
     rootElementRef,
@@ -15,5 +16,6 @@ export const useGridRefs = <PrivateApi extends GridPrivateApiCommon>(
   apiRef.current.register('private', {
     mainElementRef,
     virtualScrollerRef,
+    columnHeadersContainerRef,
   });
 };

--- a/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -57,7 +57,7 @@ export const useGridScroll = (
 ): void => {
   const theme = useTheme();
   const logger = useGridLogger(apiRef, 'useGridScroll');
-  const colRef = apiRef.current.columnHeadersContainerRef!;
+  const colRef = apiRef.current.columnHeadersContainerRef;
   const virtualScrollerRef = apiRef.current.virtualScrollerRef!;
   const visibleSortedRows = useGridSelector(apiRef, gridExpandedSortedRowEntriesSelector);
 

--- a/packages/x-data-grid/src/models/api/gridCoreApi.ts
+++ b/packages/x-data-grid/src/models/api/gridCoreApi.ts
@@ -75,7 +75,7 @@ export interface GridCorePrivateApi<
   /**
    * The React ref of the grid column container virtualized div element.
    */
-  columnHeadersContainerRef?: React.RefObject<HTMLDivElement>;
+  columnHeadersContainerRef: React.RefObject<HTMLDivElement>;
   /**
    * The React ref of the grid header filter row element.
    */


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/13811

Tests Pass in Demo with PR preview package:
https://codesandbox.io/p/devbox/github/samwato/codesandbox/tree/main/mui-x-issue-13811?file=%2Fsrc%2FDemo.test.tsx%3A12%2C1

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
