### PR TITLE
[DataGridPro] Fix `onColumnOrderChange` not being called when the column header element is unmounted due to virtualization

### DIFF
--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -176,17 +176,28 @@ function GridColumnHeaderItem(props: GridColumnHeaderItemProps) {
     [publish],
   );
 
+  const handleDragEnd = React.useCallback(
+    (event: DragEvent) => {
+      publish('columnHeaderDragEnd')(event);
+      event.currentTarget?.removeEventListener('dragend', handleDragEnd);
+    },
+    [publish],
+  );
+
   const draggableEventHandlers = React.useMemo(
     () =>
       isDraggable
         ? {
-            onDragStart: publish('columnHeaderDragStart'),
+            onDragStart: (event: React.DragEvent) => {
+              publish('columnHeaderDragStart')(event);
+              // TODO: fix types
+              event.currentTarget.addEventListener('dragend', handleDragEnd);
+            },
             onDragEnter: publish('columnHeaderDragEnter'),
             onDragOver: publish('columnHeaderDragOver'),
-            onDragEnd: publish('columnHeaderDragEnd'),
           }
         : {},
-    [isDraggable, publish],
+    [isDraggable, publish, handleDragEnd],
   );
 
   const columnHeaderSeparatorProps = React.useMemo(


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/14048