### PR TITLE
[charts] Fix charts vendor publish config

### DIFF
--- a/packages/x-charts-vendor/.npmignore
+++ b/packages/x-charts-vendor/.npmignore
@@ -5,6 +5,8 @@
 !/lib-vendor
 !/src
 !/d3-*
+!/delaunator.*
+!/robust-predicates.*
 !/internmap.js
 !LICENSE.txt
 !CHANGELOG.md

--- a/packages/x-charts-vendor/package.json
+++ b/packages/x-charts-vendor/package.json
@@ -55,7 +55,7 @@
     "rimraf": "^5.0.8"
   },
   "publishConfig": {
-    "provenance": true
+    "access": "public"
   },
   "scripts": {
     "build": "node ./scripts/build.js"


### PR DESCRIPTION
Publish config is necessary for publishing, it is blocked otherwise.

The `.npmignore` changes doesn't seem necessary (current 7.12.0) was released without those but seem to work correctly. Added them for sake of completeness. 