### PR TITLE
[code-infra] Use concurrency 1 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,8 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: pnpm typescript:ci
+          environment:
+            NODE_OPTIONS: --max-old-space-size=3584
   test_e2e:
     <<: *default-job
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,6 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: pnpm typescript:ci
-          environment:
-            NODE_OPTIONS: --max-old-space-size=1536
   test_e2e:
     <<: *default-job
     docker:

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:regressions:server": "serve test/regressions -p 5001",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 1 --no-bail --no-sort typescript",
     "use-react-version": "node scripts/useReactVersion.mjs",
     "build:codesandbox": "lerna run --concurrency 3 --no-private --scope \"@mui/*\" build",
     "install:codesandbox": "pnpm install --no-frozen-lockfile",


### PR DESCRIPTION
This should fix the issues where typescript checks are failing in CI

Circle CI only runs on 2 cpus: https://discuss.circleci.com/t/debugging-random-node-js-build-failures/39667

We should generally run `CPU_COUNT - 1` concurrent processes, which leaves us at `1` for circleci

`max-old-space-size` has no effect on scripts that spawn multiple processes, so we can remove it in this instance.