### PR TITLE
[docs] Disable ad in `Rich Tree View-Ordering` page

### DIFF
--- a/docs/pages/x/react-tree-view/rich-tree-view/ordering.js
+++ b/docs/pages/x/react-tree-view/rich-tree-view/ordering.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/tree-view/rich-tree-view/ordering/ordering.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }


### PR DESCRIPTION
I saw this from https://github.com/mui/mui-x/releases/tag/v7.12.0

<img width="668" alt="SCR-20240806-lsty" src="https://github.com/user-attachments/assets/fa55051a-0f20-472c-84a6-39933518ed17">

https://mui.com/x/react-tree-view/rich-tree-view/ordering/