### PR TITLE
[docs] Fix outdated SECURITY.md page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,15 @@
 
 The versions of the project that are currently supported with security updates.
 
-| Version | Supported          |
-| ------: | :----------------- |
-|     6.x | :white_check_mark: |
-|     5.x | :white_check_mark: |
-|   < 5.0 | :x:                |
+| MUI X version | Release    | Supported                            |
+| ------------: | :--------- | :----------------------------------- |
+|        ^7.0.0 | 2024-03-23 | :white_check_mark: Stable major      |
+|        ^6.0.0 | 2023-03-03 | :white_check_mark: Long-term support |
+|        ^5.0.0 | 2021-11-23 | :x:                                  |
+|        ^4.0.0 | 2021-09-28 | :x:                                  |
+|        ^3.0.0 | /          | :x:                                  |
+|        ^2.0.0 | /          | :x:                                  |
+|        ^1.0.0 | /          | :x:                                  |
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,6 @@ The versions of the project that are currently supported with security updates.
 |        ^6.0.0 | 2023-03-03 | :white_check_mark: Long-term support |
 |        ^5.0.0 | 2021-11-23 | :x:                                  |
 |        ^4.0.0 | 2021-09-28 | :x:                                  |
-|        ^3.0.0 | /          | :x:                                  |
-|        ^2.0.0 | /          | :x:                                  |
-|        ^1.0.0 | /          | :x:                                  |
 
 ## Reporting a vulnerability
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -94,13 +94,15 @@ This includes issues introduced by external sources, like browser upgrades or ch
 
 ### Supported versions
 
-- MUI X v7: ✅ Stable major (Continuous support).
-- MUI X v6: ⚠️ Long-term support (Guaranteed Support for security issues and regressions).
-- MUI X v5: 🅧 No longer supported.
-- MUI X v4: 🅧 No longer supported.
-- MUI X v3: 🅧 Never existed.
-- MUI X v2: 🅧 Never existed.
-- MUI X v1: 🅧 Never existed.
+| MUI X version | Release    | Supported                                                           |
+| ------------: | :--------- | :------------------------------------------------------------------ |
+|        ^7.0.0 | 2024-03-23 | ✅ Stable major (Continuous support)                                |
+|        ^6.0.0 | 2023-03-03 | ⚠️ Long-term support (Support for security issues and regressions). |
+|        ^5.0.0 | 2021-11-23 | ❌                                                                  |
+|        ^4.0.0 | 2021-09-28 | ❌                                                                  |
+|        ^3.0.0 | /          | ❌                                                                  |
+|        ^2.0.0 | /          | ❌                                                                  |
+|        ^1.0.0 | /          | ❌                                                                  |
 
 ## Community
 

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -100,9 +100,6 @@ This includes issues introduced by external sources, like browser upgrades or ch
 |        ^6.0.0 | 2023-03-03 | ⚠️ Long-term support (Support for security issues and regressions). |
 |        ^5.0.0 | 2021-11-23 | ❌                                                                  |
 |        ^4.0.0 | 2021-09-28 | ❌                                                                  |
-|        ^3.0.0 | /          | ❌                                                                  |
-|        ^2.0.0 | /          | ❌                                                                  |
-|        ^1.0.0 | /          | ❌                                                                  |
 
 ## Community
 


### PR DESCRIPTION
I have noticed this from https://github.com/mui/mui-x/issues/new/choose, it leads to https://github.com/mui/mui-x/security/policy.

<img width="209" alt="SCR-20240807-bpri" src="https://github.com/user-attachments/assets/8bbe8bd8-ea3e-45a5-be3c-0f2a98c32428">

I was confused: What about v7?

---

On the policy itself we should use for LTS, I think that we can't keep the same policy as before. We used to support the last two majors, but this was from a time when we would release a major every year or two. We moved to a faster release frequency. I suspect that we want to cover 2 years, in between Node.js and Angular: https://www.notion.so/mui-org/sales-Paid-LTS-11b1534f8ed940d29d8b4464be6bf264?pvs=4#340d90259efd4e2abf0f4ea8e2f924d8.