### PR TITLE
[docs-infra] Type interface API pages

### DIFF
--- a/docs/scripts/api/buildInterfacesDocumentation.ts
+++ b/docs/scripts/api/buildInterfacesDocumentation.ts
@@ -191,6 +191,40 @@ type BuildApiInterfacesJsonOptions = BuildInterfacesCommonOptions & {
   interfacesWithDedicatedPage: DocumentedInterfaces;
 };
 
+export interface InterfaceApiContent {
+  /**
+   * The name of the documented interface.
+   */
+  name: string;
+  /**
+   * The array of way to import this interface.
+   */
+  imports: string[];
+  /**
+   * The HTML content of the demonstrations list.
+   */
+  demos?: string;
+  /**
+   * The mapping of property name to their typing.
+   */
+  properties: {
+    [property: string]: {
+      /**
+       * The initial type definition.
+       */
+      type: { description: string };
+      default?: string;
+      required?: true;
+      isProPlan?: true;
+      isPremiumPlan?: true;
+    };
+  };
+}
+
+export interface InterfaceApiTranslation {
+  interfaceDescription: string;
+  propertiesDescriptions: { [property: string]: { description: string } };
+}
 export async function buildApiInterfacesJson(options: BuildApiInterfacesJsonOptions) {
   const { projects, apiPagesFolder, folder, interfaces, interfacesWithDedicatedPage } = options;
 
@@ -295,14 +329,14 @@ export async function buildInterfacesDocumentationPage(
 
     const slug = kebabCase(parsedInterface.name);
 
-    const content = {
+    const content: InterfaceApiContent = {
       name: parsedInterface.name,
       imports: generateImportStatement(parsedInterface, projects),
       ...extractDemos(parsedInterface.tags.demos),
       properties: {},
     };
 
-    const translations = {
+    const translations: InterfaceApiTranslation = {
       interfaceDescription: renderMarkdown(
         linkify(
           escapeCell(parsedInterface.description || ''),

--- a/docs/src/modules/components/InterfaceApiPage.tsx
+++ b/docs/src/modules/components/InterfaceApiPage.tsx
@@ -6,33 +6,38 @@ import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import VerifiedRoundedIcon from '@mui/icons-material/VerifiedRounded';
 import { alpha } from '@mui/material/styles';
-import { useTranslate, useUserLanguage } from '@mui/docs/i18n';
+import { Translate, useTranslate, useUserLanguage } from '@mui/docs/i18n';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
 import { MarkdownElement } from '@mui/docs/MarkdownElement';
-import { SectionTitle } from '@mui/docs/SectionTitle';
-import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
-import PropertiesSection from 'docs/src/modules/components/ApiPage/sections/PropertiesSection';
-import { DEFAULT_API_LAYOUT_STORAGE_KEYS } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
+import { SectionTitle, SectionTitleProps } from '@mui/docs/SectionTitle';
+// @ts-expect-error The AppLayoutDocs is not yet typed
+import AppLayoutDocs from '@mui/monorepo/docs/src/modules/components/AppLayoutDocs';
+import PropertiesSection from '@mui/monorepo/docs/src/modules/components/ApiPage/sections/PropertiesSection';
+import { PropertyDefinition } from '@mui/monorepo/docs/src/modules/components/ApiPage/definitions/properties';
+import { LayoutStorageKeys } from '@mui/monorepo/docs/src/modules/components/ApiPage';
+import {
+  DEFAULT_API_LAYOUT_STORAGE_KEYS,
+  ApiDisplayOptions,
+} from '@mui/monorepo/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
+import {
+  InterfaceApiTranslation,
+  InterfaceApiContent,
+} from 'docsx/scripts/api/buildInterfacesDocumentation';
+import { TableOfContentsEntry } from '@mui/internal-markdown';
+import kebabCase from 'lodash/kebabCase';
 
-export function getTranslatedHeader(t, header) {
+type HeaderHash = 'demos' | 'import';
+
+export function getTranslatedHeader(t: Translate, header: HeaderHash) {
   const translations = {
     demos: t('api-docs.demos'),
     import: t('api-docs.import'),
   };
 
-  // TODO Drop runtime type-checking once we type-check this file
-  if (!translations.hasOwnProperty(header)) {
-    throw new TypeError(
-      `Unable to translate header '${header}'. Did you mean one of '${Object.keys(
-        translations,
-      ).join("', '")}'`,
-    );
-  }
-
   return translations[header] || header;
 }
 
-function Heading(props) {
+function Heading(props: Pick<SectionTitleProps<HeaderHash>, 'hash' | 'level'>) {
   const { hash, level = 'h2' } = props;
   const t = useTranslate();
 
@@ -44,7 +49,62 @@ Heading.propTypes = {
   level: PropTypes.string,
 };
 
-export default function ApiPage(props) {
+interface ApiPageProps {
+  descriptions: {
+    [lang: string]: InterfaceApiTranslation & {
+      // Table of Content added by the mapApiPageTranslations function
+      componentDescriptionToc: TableOfContentsEntry[];
+    };
+  };
+  pageContent: InterfaceApiContent;
+  defaultLayout?: ApiDisplayOptions;
+  /**
+   * The localStorage key used to save the user layout for each section.
+   * It's useful to dave different preferences on different pages.
+   * For example, the data grid has a different key that the core.
+   */
+  layoutStorageKey?: LayoutStorageKeys;
+}
+
+interface GetInterfaceApiDefinitionsParams {
+  interfaceName: string;
+  properties: InterfaceApiContent['properties'];
+  propertiesDescriptions: InterfaceApiTranslation['propertiesDescriptions'];
+  /**
+   * Add indicators that the properties is optional instead of showing it is required.
+   */
+  showOptionalAbbr?: boolean;
+}
+
+export function getInterfaceApiDefinitions(
+  params: GetInterfaceApiDefinitionsParams,
+): PropertyDefinition[] {
+  const { properties, propertiesDescriptions, interfaceName, showOptionalAbbr = false } = params;
+
+  return Object.entries(properties).map(([propertyName, propertyData]) => {
+    const isRequired = propertyData.required && !showOptionalAbbr;
+    const isOptional = !propertyData.required && showOptionalAbbr;
+
+    const typeName = propertyData.type.description;
+    const propDefault = propertyData.default;
+    const propDescription = propertiesDescriptions[propertyName];
+
+    return {
+      propName: propertyName,
+      hash: `${kebabCase(interfaceName)}-prop-${propertyName}`,
+      propertyName,
+      description: propDescription?.description,
+      isOptional,
+      isRequired,
+      typeName,
+      propDefault,
+      isProPlan: propertyData.isProPlan,
+      isPremiumPlan: propertyData.isPremiumPlan,
+    };
+  });
+}
+
+export default function ApiPage(props: ApiPageProps) {
   const {
     descriptions,
     pageContent,
@@ -54,21 +114,17 @@ export default function ApiPage(props) {
   const t = useTranslate();
   const userLanguage = useUserLanguage();
 
-  const { demos, filename = '', properties } = pageContent;
+  const { demos, properties } = pageContent;
 
-  const { componentDescription, propertiesDescriptions, interfaceDescription } =
-    descriptions[userLanguage];
+  const { propertiesDescriptions, interfaceDescription } = descriptions[userLanguage];
   const description = t('api-docs.pageDescription').replace(/{{name}}/, pageContent.name);
-
-  // Prefer linking the .tsx or .d.ts for the "Edit this page" link.
-  const apiSourceLocation = filename.replace('.js', '.d.ts');
 
   return (
     <AppLayoutDocs
       description={description}
       disableToc={false}
       toc={[]}
-      location={apiSourceLocation}
+      location=""
       title={`${pageContent.name} API`}
       disableAd
     >
@@ -131,26 +187,17 @@ export default function ApiPage(props) {
           language="jsx"
         />
 
-        {componentDescription ? (
-          <React.Fragment>
-            <br />
-            <br />
-            <span
-              dangerouslySetInnerHTML={{
-                __html: componentDescription,
-              }}
-            />
-          </React.Fragment>
-        ) : null}
         <PropertiesSection
-          properties={properties}
-          propertiesDescriptions={propertiesDescriptions}
-          componentName={pageContent.name}
+          properties={getInterfaceApiDefinitions({
+            propertiesDescriptions,
+            properties,
+            interfaceName: pageContent.name,
+            showOptionalAbbr: true,
+          })}
           title="api-docs.properties"
           titleHash="properties"
           defaultLayout={defaultLayout}
           layoutStorageKey={layoutStorageKey.props}
-          showOptionalAbbr
         />
       </MarkdownElement>
       <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
@@ -162,15 +209,13 @@ export default function ApiPage(props) {
   );
 }
 
-ApiPage.propTypes = {
-  defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
-  descriptions: PropTypes.object.isRequired,
-  layoutStorageKey: PropTypes.shape({
-    props: PropTypes.string,
-  }),
-  pageContent: PropTypes.object.isRequired,
-};
-
 if (process.env.NODE_ENV !== 'production') {
-  ApiPage.propTypes = exactProp(ApiPage.propTypes);
+  ApiPage.propTypes = exactProp({
+    defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
+    descriptions: PropTypes.object.isRequired,
+    layoutStorageKey: PropTypes.shape({
+      props: PropTypes.string,
+    }),
+    pageContent: PropTypes.object.isRequired,
+  });
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@mui/internal-markdown": "^1.0.8",
     "@mui/internal-test-utils": "^1.0.5",
     "@mui/material": "^5.16.5",
-    "@mui/monorepo": "github:mui/material-ui#4a82b6b0e0395db8fa0a0d49b6b76de4516b1579",
+    "@mui/monorepo": "github:alexfauquette/material-ui#2138bdaed6b8ebde46e6a1ce8953e467785b1694",
     "@mui/utils": "^5.16.5",
     "@next/eslint-plugin-next": "14.2.5",
     "@octokit/plugin-retry": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^5.16.5
         version: 5.16.5(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/monorepo':
-        specifier: github:mui/material-ui#4a82b6b0e0395db8fa0a0d49b6b76de4516b1579
-        version: https://codeload.github.com/mui/material-ui/tar.gz/4a82b6b0e0395db8fa0a0d49b6b76de4516b1579(encoding@0.1.13)
+        specifier: github:alexfauquette/material-ui#2138bdaed6b8ebde46e6a1ce8953e467785b1694
+        version: https://codeload.github.com/alexfauquette/material-ui/tar.gz/2138bdaed6b8ebde46e6a1ce8953e467785b1694(encoding@0.1.13)
       '@mui/utils':
         specifier: ^5.16.5
         version: 5.16.5(@types/react@18.3.3)(react@18.3.1)
@@ -3042,8 +3042,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/4a82b6b0e0395db8fa0a0d49b6b76de4516b1579':
-    resolution: {tarball: https://codeload.github.com/mui/material-ui/tar.gz/4a82b6b0e0395db8fa0a0d49b6b76de4516b1579}
+  '@mui/monorepo@https://codeload.github.com/alexfauquette/material-ui/tar.gz/2138bdaed6b8ebde46e6a1ce8953e467785b1694':
+    resolution: {tarball: https://codeload.github.com/alexfauquette/material-ui/tar.gz/2138bdaed6b8ebde46e6a1ce8953e467785b1694}
     version: 6.0.0-beta.4
     engines: {pnpm: 9.5.0}
 
@@ -11889,7 +11889,7 @@ snapshots:
       '@emotion/styled': 11.13.0(@emotion/react@11.13.0(@types/react@18.3.3)(react@18.3.1))(@types/react@18.3.3)(react@18.3.1)
       '@types/react': 18.3.3
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/4a82b6b0e0395db8fa0a0d49b6b76de4516b1579(encoding@0.1.13)':
+  '@mui/monorepo@https://codeload.github.com/alexfauquette/material-ui/tar.gz/2138bdaed6b8ebde46e6a1ce8953e467785b1694(encoding@0.1.13)':
     dependencies:
       '@googleapis/sheets': 8.0.0(encoding@0.1.13)
       '@netlify/functions': 2.8.1


### PR DESCRIPTION
PoC for https://github.com/mui/material-ui/pull/43128

I don't know why types are not found for stuff imported from 'docs/src/...' but should not be an issue when moved to the `@mui/docs` package