### PR TITLE
[tree-view] Fix the `@mui/x-tree-view-pro` published folder

### DIFF
--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -15,7 +15,8 @@
   },
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "directory": "build"
   },
   "keywords": [
     "react",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1481,6 +1481,7 @@ importers:
       rimraf:
         specifier: ^5.0.9
         version: 5.0.10
+    publishDirectory: build
 
   test:
     devDependencies:


### PR DESCRIPTION
Fix #14147

Try to run `pnpm install @mui/x-tree-view-pro` you will see in your `node_modules` that it's not the correct folder that is added if you compare with the data grid ones :)