### PR TITLE
[data grid] Fix CSV export for `null` and `undefined` values

### DIFF
--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -5,8 +5,11 @@ import type { GridStateColDef } from '../../../../models/colDef/gridColDef';
 import type { GridApiCommunity } from '../../../../models/api/gridApiCommunity';
 import { warnOnce } from '../../../../internals/utils/warning';
 
-function sanitizeCellValue(value: unknown, csvOptions: CSVOptions): string {
-  const valueStr = typeof value === 'string' ? value : `${value}`;
+function sanitizeCellValue(value: unknown, csvOptions: CSVOptions):string{
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const valueStr = typeof value === 'string' ? value :`${value}`;
 
   if (csvOptions.shouldAppendQuotes || csvOptions.escapeFormulas) {
     const escapedValue = valueStr.replace(/"/g, '""');
@@ -58,7 +61,7 @@ type CSVOptions = Required<
 >;
 
 type CSVRowOptions = {
-  sanitizeCellValue?: (value: any, csvOptions: CSVOptions) => any;
+  sanitizeCellValue?: (value: unknown, csvOptions: CSVOptions) => string;
   csvOptions: CSVOptions;
 };
 class CSVRow {

--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -5,11 +5,11 @@ import type { GridStateColDef } from '../../../../models/colDef/gridColDef';
 import type { GridApiCommunity } from '../../../../models/api/gridApiCommunity';
 import { warnOnce } from '../../../../internals/utils/warning';
 
-function sanitizeCellValue(value: unknown, csvOptions: CSVOptions):string{
+function sanitizeCellValue(value: unknown, csvOptions: CSVOptions): string {
   if (value === null || value === undefined) {
     return '';
   }
-  const valueStr = typeof value === 'string' ? value :`${value}`;
+  const valueStr = typeof value === 'string' ? value : `${value}`;
 
   if (csvOptions.shouldAppendQuotes || csvOptions.escapeFormulas) {
     const escapedValue = valueStr.replace(/"/g, '""');

--- a/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/x-data-grid/src/hooks/features/export/serializers/csvSerializer.ts
@@ -79,9 +79,7 @@ class CSVRow {
     if (!this.isEmpty) {
       this.rowString += this.options.csvOptions.delimiter;
     }
-    if (value === null || value === undefined) {
-      this.rowString += '';
-    } else if (typeof this.options.sanitizeCellValue === 'function') {
+    if (typeof this.options.sanitizeCellValue === 'function') {
       this.rowString += this.options.sanitizeCellValue(value, this.options.csvOptions);
     } else {
       this.rowString += value;

--- a/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -185,6 +185,4 @@ describe('<DataGrid /> - Export', () => {
       expect(screen.queryByRole('menuitem', { name: 'Download as CSV' })).to.equal(null);
     });
   });
-
-  describe('serializeCellValue', () => {});
 });

--- a/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -117,6 +117,31 @@ describe('<DataGrid /> - Export', () => {
         ].join('\r\n'),
       );
     });
+
+    it('should export `undefined` and `null` values as blank', async () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid
+            columns={[{ field: 'name' }]}
+            rows={[
+              { id: 0, name: 'Name' },
+              { id: 1, name: undefined },
+              { id: 2, name: null },
+              { id: 3, name: 1234 },
+            ]}
+            slots={{ toolbar: GridToolbar }}
+          />
+        </div>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+      clock.runToLast();
+      expect(screen.queryByRole('menu')).not.to.equal(null);
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Download as CSV' }));
+      expect(spyCreateObjectURL.callCount).to.equal(1);
+      const csv = await spyCreateObjectURL.lastCall.firstArg.text();
+
+      expect(csv).to.equal(['Name', '', '', '1234'].join('\r\n'));
+    });
   });
 
   describe('component: GridToolbarExport', () => {
@@ -160,4 +185,6 @@ describe('<DataGrid /> - Export', () => {
       expect(screen.queryByRole('menuitem', { name: 'Download as CSV' })).to.equal(null);
     });
   });
+
+  describe('serializeCellValue', () => {});
 });

--- a/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/export.DataGrid.test.tsx
@@ -140,7 +140,7 @@ describe('<DataGrid /> - Export', () => {
       expect(spyCreateObjectURL.callCount).to.equal(1);
       const csv = await spyCreateObjectURL.lastCall.firstArg.text();
 
-      expect(csv).to.equal(['Name', '', '', '1234'].join('\r\n'));
+      expect(csv).to.equal(['name', 'Name', '', '', '1234'].join('\r\n'));
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes #14082

this issue comes from the changes done in #13560 , the motive of that PR is to  convert any non-string value into a string using template literals but it also converts `null` and `undefined` values into strings which then exported to CSV as a string.
I have added a check for these values.
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
