### PR TITLE
[pickers] Fix date and time merging to retain milliseconds

### DIFF
--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -247,7 +247,7 @@ describe('<DateCalendar />', () => {
 
       userEvent.mousePress(screen.getByRole('gridcell', { name: '2' }));
       expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(adapterToUse.date('2018-01-02T11:11:11'));
+      expect(onChange.lastCall.firstArg).toEqualDateTime(adapterToUse.date('2018-01-02T11:11:11.111'));
     });
 
     it('should complete weeks when showDaysOutsideCurrentMonth=true', () => {

--- a/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/DateCalendar.test.tsx
@@ -247,7 +247,9 @@ describe('<DateCalendar />', () => {
 
       userEvent.mousePress(screen.getByRole('gridcell', { name: '2' }));
       expect(onChange.callCount).to.equal(1);
-      expect(onChange.lastCall.firstArg).toEqualDateTime(adapterToUse.date('2018-01-02T11:11:11.111'));
+      expect(onChange.lastCall.firstArg).toEqualDateTime(
+        adapterToUse.date('2018-01-02T11:11:11.111'),
+      );
     });
 
     it('should complete weeks when showDaysOutsideCurrentMonth=true', () => {

--- a/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
@@ -34,7 +34,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2000-01-01'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2000-01-01'));
   });
 
   it('should return next 18th going from 10th', () => {
@@ -49,7 +49,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2018-08-18'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
 
   it('should return previous 18th going from 1st', () => {
@@ -64,7 +64,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2018-07-18'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2018-07-18'));
   });
 
   it('should return future 18th if disablePast', () => {
@@ -97,7 +97,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, today)).to.equal(true);
+    expect(result).toEqualDateTime(today);
   });
 
   it('should return now with given time part if disablePast and now is valid', () => {
@@ -147,7 +147,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2018-08-18'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
 
   it('should return next 18th after minDate', () => {
@@ -162,7 +162,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2018-08-18'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
 
   it('should return maxDate if it is before the date and valid', () => {
@@ -177,7 +177,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2018-07-18'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2018-07-18'));
   });
 
   it('should return previous 18th before maxDate', () => {
@@ -192,7 +192,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     })!;
 
-    expect(adapterToUse.isSameDay(result, adapterToUse.date('2018-07-18'))).to.equal(true);
+    expect(result).toEqualDateTime(adapterToUse.date('2018-07-18'));
   });
 
   it('should return null if minDate is after maxDate', () => {

--- a/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
@@ -119,7 +119,7 @@ describe('findClosestEnabledDate', () => {
     clock.reset();
   });
 
-  it('should fallback to today if disablePast+disableFuture and now is invalid', () => {
+  it('should return `null` when disablePast+disableFuture and now is invalid', () => {
     const today = adapterToUse.date();
     const result = findClosestEnabledDate({
       date: adapterToUse.date('2000-01-01'),
@@ -132,7 +132,7 @@ describe('findClosestEnabledDate', () => {
       timezone: 'default',
     });
 
-    expect(adapterToUse.isEqual(result, adapterToUse.date()));
+    expect(result).to.equal(null);
   });
 
   it('should return minDate if it is after the date and valid', () => {

--- a/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
@@ -32,7 +32,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2000-01-01'));
   });
@@ -47,7 +47,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
@@ -62,7 +62,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2018-07-18'));
   });
@@ -78,7 +78,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: true,
       timezone: 'default',
-    })!;
+    });
 
     expect(adapterToUse.isBefore(result, today)).to.equal(false);
     expect(adapterToUse.isBefore(result, adapterToUse.addDays(today, 31))).to.equal(true);
@@ -95,7 +95,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: true,
       disablePast: true,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(today);
   });
@@ -113,7 +113,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: true,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.addDays(tryDate, 1));
     clock.reset();
@@ -145,7 +145,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
@@ -160,7 +160,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
@@ -175,7 +175,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2018-07-18'));
   });
@@ -190,7 +190,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).toEqualDateTime(adapterToUse.date('2018-07-18'));
   });
@@ -205,7 +205,7 @@ describe('findClosestEnabledDate', () => {
       disableFuture: false,
       disablePast: false,
       timezone: 'default',
-    })!;
+    });
 
     expect(result).to.equal(null);
   });

--- a/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.test.ts
@@ -165,6 +165,24 @@ describe('findClosestEnabledDate', () => {
     expect(result).toEqualDateTime(adapterToUse.date('2018-08-18'));
   });
 
+  it('should keep the time of the `date` when `disablePast`', () => {
+    const clock = useFakeTimers({ now: new Date('2000-01-02T11:12:13.123Z') });
+
+    const result = findClosestEnabledDate({
+      date: adapterToUse.date('2000-01-01T11:12:13.550Z'),
+      minDate: adapterToUse.date('1900-01-01'),
+      maxDate: adapterToUse.date('2100-01-01'),
+      utils: adapterToUse,
+      isDateDisabled: () => false,
+      disableFuture: false,
+      disablePast: true,
+      timezone: 'default',
+    });
+
+    expect(result).toEqualDateTime(adapterToUse.date('2000-01-02T11:12:13.550Z'));
+    clock.reset();
+  });
+
   it('should return maxDate if it is before the date and valid', () => {
     const result = findClosestEnabledDate({
       date: adapterToUse.date('2050-01-01'),

--- a/packages/x-date-pickers/src/internals/utils/date-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.ts
@@ -17,6 +17,7 @@ export const mergeDateAndTime = <TDate extends PickerValidDate>(
   mergedDate = utils.setHours(mergedDate, utils.getHours(timeParam));
   mergedDate = utils.setMinutes(mergedDate, utils.getMinutes(timeParam));
   mergedDate = utils.setSeconds(mergedDate, utils.getSeconds(timeParam));
+  mergedDate = utils.setMilliseconds(mergedDate, utils.getMilliseconds(timeParam));
 
   return mergedDate;
 };


### PR DESCRIPTION
Fixes tests for some reason only failing with `mui@material` v6 seen in https://github.com/mui/mui-x/pull/14142.

- The util had missing `milliseconds` retaining.
- A test was incorrect and not testing anything. 🤷 🙈 