### PR TITLE
[TreeView] Fix the parameters passed for the `canMoveItemToNewPosition` prop

### DIFF
--- a/docs/translations/api-docs/tree-view/rich-tree-view-pro/rich-tree-view-pro.json
+++ b/docs/translations/api-docs/tree-view/rich-tree-view-pro/rich-tree-view-pro.json
@@ -8,7 +8,7 @@
       "description": "Used to determine if a given item can move to some new position.",
       "typeDescriptions": {
         "params": "The params describing the item re-ordering.",
-        "params.itemId": "The id of the item to check.",
+        "params.itemId": "The id of the item that is being moved to a new position.",
         "params.oldPosition": "The old position of the item.",
         "params.newPosition": "The new position of the item.",
         "boolean": "<code>true</code> if the item can move to the new position."

--- a/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
+++ b/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
@@ -195,7 +195,7 @@ RichTreeViewPro.propTypes = {
   /**
    * Used to determine if a given item can move to some new position.
    * @param {object} params The params describing the item re-ordering.
-   * @param {string} params.itemId The id of the item to check.
+   * @param {string} params.itemId The id of the item that is being moved to a new position.
    * @param {TreeViewItemReorderPosition} params.oldPosition The old position of the item.
    * @param {TreeViewItemReorderPosition} params.newPosition The new position of the item.
    * @returns {boolean} `true` if the item can move to the new position.

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.test.tsx
@@ -180,6 +180,23 @@ describeTreeView<
   });
 
   describe('canMoveItemToNewPosition prop', () => {
+    it.only('should call canMoveItemToNewPosition with the correct parameters', () => {
+      const canMoveItemToNewPosition = spy();
+      const response = render({
+        experimentalFeatures: { indentationAtItemLevel: true, itemsReordering: true },
+        items: [{ id: '1' }, { id: '2' }, { id: '3' }],
+        itemsReordering: true,
+        canMoveItemToNewPosition,
+      });
+
+      dragEvents.fullDragSequence(response.getItemRoot('1'), response.getItemContent('2'));
+      expect(canMoveItemToNewPosition.lastCall.firstArg).to.deep.equal({
+        itemId: '1',
+        oldPosition: { parentId: null, index: 0 },
+        newPosition: { parentId: null, index: 1 },
+      });
+    });
+
     it('should not allow to drop an item when canMoveItemToNewPosition returns false', () => {
       const response = render({
         experimentalFeatures: { indentationAtItemLevel: true, itemsReordering: true },

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.test.tsx
@@ -180,7 +180,7 @@ describeTreeView<
   });
 
   describe('canMoveItemToNewPosition prop', () => {
-    it.only('should call canMoveItemToNewPosition with the correct parameters', () => {
+    it('should call canMoveItemToNewPosition with the correct parameters', () => {
       const canMoveItemToNewPosition = spy();
       const response = render({
         experimentalFeatures: { indentationAtItemLevel: true, itemsReordering: true },

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
@@ -84,7 +84,7 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
           isValid = false;
         } else if (canMoveItemToNewPosition) {
           isValid = canMoveItemToNewPosition({
-            itemId: state.itemsReordering!.draggedItemId,
+            itemId: state.itemsReordering.draggedItemId,
             oldPosition,
             newPosition: positionAfterAction,
           });

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
@@ -84,7 +84,7 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
           isValid = false;
         } else if (canMoveItemToNewPosition) {
           isValid = canMoveItemToNewPosition({
-            itemId,
+            itemId: state.itemsReordering!.draggedItemId,
             oldPosition,
             newPosition: positionAfterAction,
           });

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
@@ -55,18 +55,19 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
 
   const getDroppingTargetValidActions = React.useCallback(
     (itemId: string) => {
-      if (!state.itemsReordering) {
+      const itemsReordering = state.itemsReordering;
+      if (!itemsReordering) {
         throw new Error('There is no ongoing reordering.');
       }
 
-      if (itemId === state.itemsReordering.draggedItemId) {
+      if (itemId === itemsReordering.draggedItemId) {
         return {};
       }
 
       const canMoveItemToNewPosition = params.canMoveItemToNewPosition;
       const targetItemMeta = instance.getItemMeta(itemId);
       const targetItemIndex = instance.getItemIndex(targetItemMeta.id);
-      const draggedItemMeta = instance.getItemMeta(state.itemsReordering.draggedItemId);
+      const draggedItemMeta = instance.getItemMeta(itemsReordering.draggedItemId);
       const draggedItemIndex = instance.getItemIndex(draggedItemMeta.id);
 
       const oldPosition: TreeViewItemReorderPosition = {
@@ -84,7 +85,7 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
           isValid = false;
         } else if (canMoveItemToNewPosition) {
           isValid = canMoveItemToNewPosition({
-            itemId: state.itemsReordering.draggedItemId,
+            itemId: itemsReordering.draggedItemId,
             oldPosition,
             newPosition: positionAfterAction,
           });

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
@@ -79,7 +79,7 @@ export interface UseTreeViewItemsReorderingParameters {
   /**
    * Used to determine if a given item can move to some new position.
    * @param {object} params The params describing the item re-ordering.
-   * @param {string} params.itemId The id of the item to check.
+   * @param {string} params.itemId The id of the item that is being moved to a new position.
    * @param {TreeViewItemReorderPosition} params.oldPosition The old position of the item.
    * @param {TreeViewItemReorderPosition} params.newPosition The new position of the item.
    * @returns {boolean} `true` if the item can move to the new position.

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
@@ -109,7 +109,7 @@ export type UseTreeViewItemsReorderingDefaultizedParameters = DefaultizedProps<
 >;
 
 export interface UseTreeViewItemsReorderingState {
-  itemsReordering: {
+  readonly itemsReordering: {
     draggedItemId: string;
     targetItemId: string;
     newPosition: TreeViewItemReorderPosition | null;

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
@@ -109,7 +109,7 @@ export type UseTreeViewItemsReorderingDefaultizedParameters = DefaultizedProps<
 >;
 
 export interface UseTreeViewItemsReorderingState {
-  readonly itemsReordering: {
+  itemsReordering: {
     draggedItemId: string;
     targetItemId: string;
     newPosition: TreeViewItemReorderPosition | null;

--- a/packages/x-tree-view/src/internals/models/plugin.ts
+++ b/packages/x-tree-view/src/internals/models/plugin.ts
@@ -10,7 +10,7 @@ import { TreeViewItemId } from '../../models';
 export interface TreeViewPluginOptions<TSignature extends TreeViewAnyPluginSignature> {
   instance: TreeViewUsedInstance<TSignature>;
   params: TreeViewUsedDefaultizedParams<TSignature>;
-  readonly state: TreeViewUsedState<TSignature>;
+  state: TreeViewUsedState<TSignature>;
   slots: TSignature['slots'];
   slotProps: TSignature['slotProps'];
   experimentalFeatures: TreeViewUsedExperimentalFeatures<TSignature>;

--- a/packages/x-tree-view/src/internals/models/plugin.ts
+++ b/packages/x-tree-view/src/internals/models/plugin.ts
@@ -10,7 +10,7 @@ import { TreeViewItemId } from '../../models';
 export interface TreeViewPluginOptions<TSignature extends TreeViewAnyPluginSignature> {
   instance: TreeViewUsedInstance<TSignature>;
   params: TreeViewUsedDefaultizedParams<TSignature>;
-  state: TreeViewUsedState<TSignature>;
+  readonly state: TreeViewUsedState<TSignature>;
   slots: TSignature['slots'];
   slotProps: TSignature['slotProps'];
   experimentalFeatures: TreeViewUsedExperimentalFeatures<TSignature>;


### PR DESCRIPTION
Fixes #14175