### PR TITLE
[DataGrid] remove needless check in `useGridStateInitialization`

### DIFF
--- a/packages/x-data-grid/src/hooks/core/useGridStateInitialization.ts
+++ b/packages/x-data-grid/src/hooks/core/useGridStateInitialization.ts
@@ -74,12 +74,8 @@ export const useGridStateInitialization = <PrivateApi extends GridPrivateApiComm
 
       if (!ignoreSetState) {
         // We always assign it as we mutate rows for perf reason.
-        apiRef.current.state = newState;
-
-        if (apiRef.current.publishEvent) {
-          apiRef.current.publishEvent('stateChange', newState);
-        }
-
+        apiRef.current.state = newState;    
+        apiRef.current.publishEvent('stateChange', newState);     
         apiRef.current.store.update(newState);
       }
 

--- a/packages/x-data-grid/src/hooks/core/useGridStateInitialization.ts
+++ b/packages/x-data-grid/src/hooks/core/useGridStateInitialization.ts
@@ -74,8 +74,8 @@ export const useGridStateInitialization = <PrivateApi extends GridPrivateApiComm
 
       if (!ignoreSetState) {
         // We always assign it as we mutate rows for perf reason.
-        apiRef.current.state = newState;    
-        apiRef.current.publishEvent('stateChange', newState);     
+        apiRef.current.state = newState;
+        apiRef.current.publishEvent('stateChange', newState);
         apiRef.current.store.update(newState);
       }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
 `publishEvent` is always available during grid state initialization (because we are adding it in API synchronously before state initialization) so there is no need to check that.