### PR TITLE
[core] Fix Netlify build cache issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,6 @@
 [build.environment]
   NODE_VERSION = "18"
   NODE_OPTIONS = "--max_old_space_size=4096"
-  PNPM_FLAGS = "--shamefully-hoist"
 
 [[plugins]]
   package = "./packages/netlify-plugin-cache-docs"


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/pull/14104

Netlify docs say the [`--shamefully-hoist ` flag is required for Next.js + pnpm setup](https://docs.netlify.com/frameworks/next-js/overview/#pnpm-support), but as pointed out by @Janpot this guide doesn't apply to us since we build+export and just host a static site.