### PR TITLE
[charts] Do not remove mouse position for mouseUp event

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -57,8 +57,10 @@ export function useMouseTracker() {
       return () => {};
     }
 
-    const handleOut = () => {
-      setMousePosition(null);
+    const handleOut = (event: PointerEvent) => {
+      if (event.pointerType !== 'mouse') {
+        setMousePosition(null);
+      }
     };
 
     const handleMove = (event: PointerEvent) => {


### PR DESCRIPTION
Fix #14157

The other option would be to use the `touchend`