### PR TITLE
[DataGrid] Spread forwardedProps onto grid element

### DIFF
--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -54,13 +54,7 @@ const DataGridRaw = React.forwardRef(function DataGrid<R extends GridValidRowMod
   }
   return (
     <GridContextProvider privateApiRef={privateApiRef} configuration={configuration} props={props}>
-      <GridRoot
-        className={props.className}
-        style={props.style}
-        sx={props.sx}
-        ref={ref}
-        {...props.forwardedProps}
-      >
+      <GridRoot className={props.className} style={props.style} sx={props.sx} ref={ref}>
         <GridHeader />
         <GridBody />
         <GridFooterPlaceholder />

--- a/packages/x-data-grid/src/components/virtualization/GridMainContainer.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridMainContainer.tsx
@@ -39,6 +39,7 @@ export const GridMainContainer = React.forwardRef<
       className={props.className}
       tabIndex={-1}
       {...ariaAttributes}
+      {...rootProps.forwardedProps}
     >
       <GridPanelAnchor role="presentation" data-id="gridPanelAnchor" />
       {props.children}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #13522

Looking at the historical changes, the `aria-*` and `data-*` props were originally on the `GridRoot` component when it had the role of "grid". This PR moves the `rootProps.forwardedProps` back to that element which has moved into the `GridMainContainer` component.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
