### PR TITLE
[DataGrid] Add recipe for persisting filters in local storage

### DIFF
--- a/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.js
+++ b/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.js
@@ -51,10 +51,7 @@ const usePersistedFilterModel = () => {
   }, [filterModelString]);
 
   return React.useMemo(
-    () => ({
-      filterModel,
-      setFilterModel: filterModelStore.update,
-    }),
+    () => [filterModel, filterModelStore.update],
     [filterModel, filterModelStore.update],
   );
 };
@@ -66,7 +63,7 @@ export default function FilteringLocalStorage() {
     rowLength: 100,
   });
 
-  const { filterModel, setFilterModel } = usePersistedFilterModel();
+  const [filterModel, setFilterModel] = usePersistedFilterModel();
 
   const onFilterModelChange = React.useCallback(
     (newFilterModel) => {

--- a/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.js
+++ b/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.js
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+const createFilterModelStore = () => {
+  let listeners = [];
+  const lsKey = 'gridFilterModel';
+  const emptyModel = 'null';
+
+  return {
+    subscribe: (callback) => {
+      listeners.push(callback);
+      return () => {
+        listeners = listeners.filter((listener) => listener !== callback);
+      };
+    },
+    getSnapshot: () => {
+      try {
+        return localStorage.getItem(lsKey) || emptyModel;
+      } catch (error) {
+        return emptyModel;
+      }
+    },
+    getServerSnapshot: () => {
+      return emptyModel;
+    },
+    update: (filterModel) => {
+      localStorage.setItem(lsKey, JSON.stringify(filterModel));
+      listeners.forEach((listener) => listener());
+    },
+  };
+};
+
+const usePersistedFilterModel = () => {
+  const [filterModelStore] = React.useState(createFilterModelStore);
+
+  const filterModelString = React.useSyncExternalStore(
+    filterModelStore.subscribe,
+    filterModelStore.getSnapshot,
+    filterModelStore.getServerSnapshot,
+  );
+
+  const filterModel = React.useMemo(() => {
+    try {
+      return JSON.parse(filterModelString) || undefined;
+    } catch (error) {
+      return undefined;
+    }
+  }, [filterModelString]);
+
+  return React.useMemo(
+    () => ({
+      filterModel,
+      setFilterModel: filterModelStore.update,
+    }),
+    [filterModel, filterModelStore.update],
+  );
+};
+
+export default function FilteringLocalStorage() {
+  const { data } = useDemoData({
+    dataSet: 'Employee',
+    visibleFields: VISIBLE_FIELDS,
+    rowLength: 100,
+  });
+
+  const { filterModel, setFilterModel } = usePersistedFilterModel();
+
+  const onFilterModelChange = React.useCallback(
+    (newFilterModel) => {
+      setFilterModel(newFilterModel);
+    },
+    [setFilterModel],
+  );
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        slots={{ toolbar: GridToolbar }}
+        filterModel={filterModel}
+        onFilterModelChange={onFilterModelChange}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.tsx
+++ b/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.tsx
@@ -58,10 +58,7 @@ const usePersistedFilterModel = () => {
   }, [filterModelString]);
 
   return React.useMemo(
-    () => ({
-      filterModel,
-      setFilterModel: filterModelStore.update,
-    }),
+    () => [filterModel, filterModelStore.update] as const,
     [filterModel, filterModelStore.update],
   );
 };
@@ -73,7 +70,7 @@ export default function FilteringLocalStorage() {
     rowLength: 100,
   });
 
-  const { filterModel, setFilterModel } = usePersistedFilterModel();
+  const [filterModel, setFilterModel] = usePersistedFilterModel();
 
   const onFilterModelChange = React.useCallback<
     NonNullable<DataGridProps['onFilterModelChange']>

--- a/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.tsx
+++ b/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  DataGridProps,
+  GridFilterModel,
+  GridToolbar,
+} from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+const createFilterModelStore = () => {
+  let listeners: Array<() => void> = [];
+  const lsKey = 'gridFilterModel';
+  const emptyModel = 'null';
+
+  return {
+    subscribe: (callback: () => void) => {
+      listeners.push(callback);
+      return () => {
+        listeners = listeners.filter((listener) => listener !== callback);
+      };
+    },
+    getSnapshot: () => {
+      try {
+        return localStorage.getItem(lsKey) || emptyModel;
+      } catch (error) {
+        return emptyModel;
+      }
+    },
+
+    getServerSnapshot: () => {
+      return emptyModel;
+    },
+
+    update: (filterModel: GridFilterModel) => {
+      localStorage.setItem(lsKey, JSON.stringify(filterModel));
+      listeners.forEach((listener) => listener());
+    },
+  };
+};
+
+const usePersistedFilterModel = () => {
+  const [filterModelStore] = React.useState(createFilterModelStore);
+
+  const filterModelString = React.useSyncExternalStore(
+    filterModelStore.subscribe,
+    filterModelStore.getSnapshot,
+    filterModelStore.getServerSnapshot,
+  );
+
+  const filterModel = React.useMemo(() => {
+    try {
+      return (JSON.parse(filterModelString) as GridFilterModel) || undefined;
+    } catch (error) {
+      return undefined;
+    }
+  }, [filterModelString]);
+
+  return React.useMemo(
+    () => ({
+      filterModel,
+      setFilterModel: filterModelStore.update,
+    }),
+    [filterModel, filterModelStore.update],
+  );
+};
+
+export default function FilteringLocalStorage() {
+  const { data } = useDemoData({
+    dataSet: 'Employee',
+    visibleFields: VISIBLE_FIELDS,
+    rowLength: 100,
+  });
+
+  const { filterModel, setFilterModel } = usePersistedFilterModel();
+
+  const onFilterModelChange = React.useCallback<
+    NonNullable<DataGridProps['onFilterModelChange']>
+  >(
+    (newFilterModel) => {
+      setFilterModel(newFilterModel);
+    },
+    [setFilterModel],
+  );
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        slots={{ toolbar: GridToolbar }}
+        filterModel={filterModel}
+        onFilterModelChange={onFilterModelChange}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.tsx.preview
+++ b/docs/data/data-grid/filtering-recipes/FilteringLocalStorage.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  slots={{ toolbar: GridToolbar }}
+  filterModel={filterModel}
+  onFilterModelChange={onFilterModelChange}
+/>

--- a/docs/data/data-grid/filtering-recipes/filtering-recipes.md
+++ b/docs/data/data-grid/filtering-recipes/filtering-recipes.md
@@ -6,6 +6,14 @@ title: Data Grid - Filtering customization recipes
 
 <p class="description">Advanced filtering customization recipes.</p>
 
+## Persisting filters in local storage
+
+You can persist the filters in the local storage to keep the filters applied after the page is reloaded.
+
+In the demo below, the [`React.useSyncExternalStore` hook](https://react.dev/reference/react/useSyncExternalStore) is used to synchronize the filters with the local storage.
+
+{{"demo": "FilteringLocalStorage.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Quick filter outside of the grid
 
 The [Quick Filter](/x/react-data-grid/filtering/quick-filter/) component is typically used in the Data Grid's Toolbar component slot.


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/14206

Preview: https://deploy-preview-14208--material-ui-x.netlify.app/x/react-data-grid/filtering-recipes/#persisting-filters-in-local-storage