### PR TITLE
[docs] Remove relience of abbreviations

### DIFF
--- a/docs/data/data-grid/pagination/CursorPaginationGrid.js
+++ b/docs/data/data-grid/pagination/CursorPaginationGrid.js
@@ -110,7 +110,7 @@ export default function CursorPaginationGrid() {
           aria-labelledby="demo-cursor-pagination-buttons-group-label"
           name="cursor-pagination-buttons-group"
           value={rowCountType}
-          onChange={(e) => setRowCountType(e.target.value)}
+          onChange={(event) => setRowCountType(event.target.value)}
         >
           <FormControlLabel value="known" control={<Radio />} label="Known" />
           <FormControlLabel value="unknown" control={<Radio />} label="Unknown" />

--- a/docs/data/data-grid/pagination/CursorPaginationGrid.tsx
+++ b/docs/data/data-grid/pagination/CursorPaginationGrid.tsx
@@ -117,7 +117,7 @@ export default function CursorPaginationGrid() {
           aria-labelledby="demo-cursor-pagination-buttons-group-label"
           name="cursor-pagination-buttons-group"
           value={rowCountType}
-          onChange={(e) => setRowCountType(e.target.value as RowCountType)}
+          onChange={(event) => setRowCountType(event.target.value as RowCountType)}
         >
           <FormControlLabel value="known" control={<Radio />} label="Known" />
           <FormControlLabel value="unknown" control={<Radio />} label="Unknown" />

--- a/docs/data/data-grid/server-side-data/ServerSideErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideErrorHandling.js
@@ -98,7 +98,7 @@ export default function ServerSideErrorHandling() {
           control={
             <Checkbox
               checked={shouldRequestsFail}
-              onChange={(e) => setShouldRequestsFail(e.target.checked)}
+              onChange={(event) => setShouldRequestsFail(event.target.checked)}
             />
           }
           label="Make the requests fail"

--- a/docs/data/data-grid/server-side-data/ServerSideErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideErrorHandling.tsx
@@ -104,7 +104,7 @@ export default function ServerSideErrorHandling() {
           control={
             <Checkbox
               checked={shouldRequestsFail}
-              onChange={(e) => setShouldRequestsFail(e.target.checked)}
+              onChange={(event) => setShouldRequestsFail(event.target.checked)}
             />
           }
           label="Make the requests fail"

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataErrorHandling.js
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataErrorHandling.js
@@ -78,7 +78,7 @@ export default function ServerSideTreeDataErrorHandling() {
           control={
             <Checkbox
               checked={shouldRequestsFail}
-              onChange={(e) => setShouldRequestsFail(e.target.checked)}
+              onChange={(event) => setShouldRequestsFail(event.target.checked)}
             />
           }
           label="Make the requests fail"

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataErrorHandling.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataErrorHandling.tsx
@@ -83,7 +83,7 @@ export default function ServerSideTreeDataErrorHandling() {
           control={
             <Checkbox
               checked={shouldRequestsFail}
-              onChange={(e) => setShouldRequestsFail(e.target.checked)}
+              onChange={(event) => setShouldRequestsFail(event.target.checked)}
             />
           }
           label="Make the requests fail"

--- a/docs/src/modules/components/CustomizationPlayground.tsx
+++ b/docs/src/modules/components/CustomizationPlayground.tsx
@@ -360,7 +360,7 @@ const CustomizationPlayground = function CustomizationPlayground({
                     id="select-component"
                     label=""
                     value={selectedDemo}
-                    onChange={(e) => selectDemo(e.target.value as string)}
+                    onChange={(event) => selectDemo(event.target.value as string)}
                   >
                     {Object.keys(examples || {}).map((item) => (
                       <MenuItem key={item} value={item}>


### PR DESCRIPTION
This is a general guideline we have in the codebase, we avoid variable abbreviations so noobies can better understand what variable they are manipulating. Now, there is also value in having this always the same it's more intuitive.

I have noticed this from this tweet: https://x.com/ericclemmons/status/1823108565285941266, which could suggest that we should have TanStack Query integration demos. Issue created: #14227.