### PR TITLE
[DataGrid] Fix height inequality on first row

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -451,10 +451,6 @@ export const GridRootStyles = styled('div', {
 
       '--rowBorderColor': 'var(--DataGrid-rowBorderColor)',
 
-      [`&.${c['row--firstVisible']}`]: {
-        '--rowBorderColor': 'transparent',
-      },
-
       '&:hover': {
         backgroundColor: (t.vars || t).palette.action.hover,
         // Reset on touch devices, it doesn't add specificity

--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
@@ -52,6 +52,11 @@ const GridVirtualScrollerRenderZone = React.forwardRef<
       className={clsx(classes.root, className)}
       ownerState={rootProps}
       style={{
+        /**
+         * We need to set the margin to -1px to prevent a double border with the header section
+         * @see: https://github.com/mui/mui-x/issues/14195
+         */
+        marginTop: '-1px',
         transform: `translate3d(0, ${offsetTop}px, 0)`,
       }}
       {...other}


### PR DESCRIPTION
this change includes:
- remove the transparent border color on first visible row
- moved the `GridVirtualScrollerRenderZone` 1 px up to hide the duplicate border

Fixes #14195 