### PR TITLE
[DataGrid] Introduce selectors with arguments

### DIFF
--- a/packages/x-data-grid-pro/src/components/GridDataSourceTreeDataGroupingCell.tsx
+++ b/packages/x-data-grid-pro/src/components/GridDataSourceTreeDataGroupingCell.tsx
@@ -8,12 +8,17 @@ import {
   GridDataSourceGroupNode,
   useGridSelector,
 } from '@mui/x-data-grid';
+import { useGridSelectorV8 } from '@mui/x-data-grid/internals';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 import { useGridPrivateApiContext } from '../hooks/utils/useGridPrivateApiContext';
 import { DataGridProProcessedProps } from '../models/dataGridProProps';
 import { GridPrivateApiPro } from '../models/gridApiPro';
 import { GridStatePro } from '../models/gridStatePro';
+import {
+  gridDataSourceErrorSelector,
+  gridDataSourceLoadingIdSelector,
+} from '../hooks/features/dataSource/gridDataSourceSelector';
 
 type OwnerState = DataGridProProcessedProps;
 
@@ -50,10 +55,8 @@ function GridTreeDataGroupingCellIcon(props: GridTreeDataGroupingCellIconProps) 
   const classes = useUtilityClasses(rootProps);
   const { rowNode, id, field, descendantCount } = props;
 
-  const loadingSelector = (state: GridStatePro) => state.dataSource.loading[id] ?? false;
-  const errorSelector = (state: GridStatePro) => state.dataSource.errors[id];
-  const isDataLoading = useGridSelector(apiRef, loadingSelector);
-  const error = useGridSelector(apiRef, errorSelector);
+  const isDataLoading = useGridSelectorV8(apiRef, gridDataSourceLoadingIdSelector, id);
+  const error = useGridSelectorV8(apiRef, gridDataSourceErrorSelector, id);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!rowNode.childrenExpanded) {

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/gridDataSourceSelector.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/gridDataSourceSelector.ts
@@ -3,8 +3,9 @@ import {
   gridFilterModelSelector,
   gridSortModelSelector,
   gridPaginationModelSelector,
+  GridRowId,
 } from '@mui/x-data-grid';
-import { createSelector } from '@mui/x-data-grid/internals';
+import { createSelector, createArgumentsSelector } from '@mui/x-data-grid/internals';
 import { GridStatePro } from '../../../models/gridStatePro';
 
 const computeStartEnd = (paginationModel: GridPaginationModel) => {
@@ -37,7 +38,17 @@ export const gridDataSourceLoadingSelector = createSelector(
   (dataSource) => dataSource.loading,
 );
 
+export const gridDataSourceLoadingIdSelector = createArgumentsSelector<GridRowId>()(
+  gridDataSourceStateSelector,
+  (dataSource, id) => dataSource.loading[id] ?? false,
+);
+
 export const gridDataSourceErrorsSelector = createSelector(
   gridDataSourceStateSelector,
   (dataSource) => dataSource.errors,
+);
+
+export const gridDataSourceErrorSelector = createArgumentsSelector<GridRowId>()(
+  gridDataSourceStateSelector,
+  (dataSource, id) => dataSource.errors[id],
 );

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/gridDataSourceSelector.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/gridDataSourceSelector.ts
@@ -5,7 +5,7 @@ import {
   gridPaginationModelSelector,
   GridRowId,
 } from '@mui/x-data-grid';
-import { createSelector, createArgumentsSelector } from '@mui/x-data-grid/internals';
+import { createSelector, createSelectorV8 } from '@mui/x-data-grid/internals';
 import { GridStatePro } from '../../../models/gridStatePro';
 
 const computeStartEnd = (paginationModel: GridPaginationModel) => {
@@ -38,9 +38,9 @@ export const gridDataSourceLoadingSelector = createSelector(
   (dataSource) => dataSource.loading,
 );
 
-export const gridDataSourceLoadingIdSelector = createArgumentsSelector<GridRowId>()(
+export const gridDataSourceLoadingIdSelector = createSelectorV8(
   gridDataSourceStateSelector,
-  (dataSource, id) => dataSource.loading[id] ?? false,
+  (dataSource, id: GridRowId) => dataSource.loading[id] ?? false,
 );
 
 export const gridDataSourceErrorsSelector = createSelector(
@@ -48,7 +48,7 @@ export const gridDataSourceErrorsSelector = createSelector(
   (dataSource) => dataSource.errors,
 );
 
-export const gridDataSourceErrorSelector = createArgumentsSelector<GridRowId>()(
+export const gridDataSourceErrorSelector = createSelectorV8(
   gridDataSourceStateSelector,
-  (dataSource, id) => dataSource.errors[id],
+  (dataSource, id: GridRowId) => dataSource.errors[id],
 );

--- a/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
@@ -15,15 +15,9 @@ function isOutputSelector<Api extends GridApiCommon, T>(
 
 type Selector<Api extends GridApiCommon, Args, T> =
   | ((state: Api['state']) => T)
-  | OutputSelector<Api['state'], T>
   | OutputArgumentsSelector<Api['state'], Args, T>;
 
-function isArgumentsSelector<Api extends GridApiCommon, Args, T>(
-  selector: any,
-): selector is OutputArgumentsSelector<Api['state'], Args, T> {
-  return selector.acceptsArguments;
-}
-
+// TODO v8: Remove this function
 function applySelector<Api extends GridApiCommon, T>(
   apiRef: React.MutableRefObject<Api>,
   selector: ((state: Api['state']) => T) | OutputSelector<Api['state'], T>,
@@ -34,6 +28,7 @@ function applySelector<Api extends GridApiCommon, T>(
   return selector(apiRef.current.state);
 }
 
+// TODO v8: Rename this function to `applySelector`
 function applySelectorV8<Api extends GridApiCommon, Args, T>(
   apiRef: React.MutableRefObject<Api>,
   selector: Selector<Api, Args, T>,
@@ -41,10 +36,7 @@ function applySelectorV8<Api extends GridApiCommon, Args, T>(
   instanceId: GridCoreApi['instanceId'],
 ) {
   if (isOutputSelector(selector)) {
-    if (isArgumentsSelector(selector)) {
-      return selector(apiRef, args);
-    }
-    return selector(apiRef);
+    return selector(apiRef, args);
   }
   return selector(apiRef.current.state, instanceId);
 }
@@ -54,6 +46,7 @@ export const objectShallowCompare = fastObjectShallowCompare;
 
 const createRefs = () => ({ state: null, equals: null, selector: null }) as any;
 
+// TODO v8: Remove this function
 export const useGridSelector = <Api extends GridApiCommon, T>(
   apiRef: React.MutableRefObject<Api>,
   selector: ((state: Api['state']) => T) | OutputSelector<Api['state'], T>,
@@ -100,6 +93,7 @@ export const useGridSelector = <Api extends GridApiCommon, T>(
   return state;
 };
 
+// TODO v8: Rename this function to `useGridSelector`
 export const useGridSelectorV8 = <Api extends GridApiCommon, Args, T>(
   apiRef: React.MutableRefObject<Api>,
   selector: Selector<Api, Args, T>,

--- a/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
@@ -97,7 +97,7 @@ export const useGridSelector = <Api extends GridApiCommon, T>(
 export const useGridSelectorV8 = <Api extends GridApiCommon, Args, T>(
   apiRef: React.MutableRefObject<Api>,
   selector: Selector<Api, Args, T>,
-  args: Args = {} as Args,
+  args: Args = undefined as Args,
   equals: (a: T, b: T) => boolean = defaultCompare,
 ) => {
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { fastObjectShallowCompare } from '@mui/x-internals/fastObjectShallowCompare';
 import type { GridApiCommon } from '../../models/api/gridApiCommon';
-import { OutputSelector, OutputArgumentsSelector } from '../../utils/createSelector';
+import { OutputSelector, OutputSelectorV8 } from '../../utils/createSelector';
 import { useLazyRef } from './useLazyRef';
 import { useOnMount } from './useOnMount';
 import { warnOnce } from '../../internals/utils/warning';
@@ -15,7 +15,7 @@ function isOutputSelector<Api extends GridApiCommon, T>(
 
 type Selector<Api extends GridApiCommon, Args, T> =
   | ((state: Api['state']) => T)
-  | OutputArgumentsSelector<Api['state'], Args, T>;
+  | OutputSelectorV8<Api['state'], Args, T>;
 
 // TODO v8: Remove this function
 function applySelector<Api extends GridApiCommon, T>(

--- a/packages/x-data-grid/src/internals/index.ts
+++ b/packages/x-data-grid/src/internals/index.ts
@@ -139,7 +139,13 @@ export type * from '../models/props/DataGridProps';
 export type * from '../models/gridDataSource';
 export { getColumnsToExport, defaultGetRowsToExport } from '../hooks/features/export/utils';
 export * from '../utils/createControllablePromise';
-export { createSelector, createSelectorMemoized } from '../utils/createSelector';
+export {
+  createSelector,
+  createArgumentsSelector,
+  createSelectorMemoized,
+  createArgumentsSelectorMemoized,
+} from '../utils/createSelector';
+export { useGridSelectorV8 } from '../hooks/utils/useGridSelector';
 export { gridRowGroupsToFetchSelector } from '../hooks/features/rows/gridRowsSelector';
 export {
   findParentElementFromClassName,

--- a/packages/x-data-grid/src/internals/index.ts
+++ b/packages/x-data-grid/src/internals/index.ts
@@ -141,9 +141,9 @@ export { getColumnsToExport, defaultGetRowsToExport } from '../hooks/features/ex
 export * from '../utils/createControllablePromise';
 export {
   createSelector,
-  createArgumentsSelector,
+  createSelectorV8,
   createSelectorMemoized,
-  createArgumentsSelectorMemoized,
+  createSelectorMemoizedV8,
 } from '../utils/createSelector';
 export { useGridSelectorV8 } from '../hooks/utils/useGridSelector';
 export { gridRowGroupsToFetchSelector } from '../hooks/features/rows/gridRowsSelector';

--- a/packages/x-data-grid/src/utils/createSelector.ts
+++ b/packages/x-data-grid/src/utils/createSelector.ts
@@ -5,13 +5,15 @@ import { warnOnce } from '../internals/utils/warning';
 
 type CacheKey = { id: number };
 
+// TODO v8: Remove this type
 export interface OutputSelector<State, Result> {
   (apiRef: React.MutableRefObject<{ state: State; instanceId: GridCoreApi['instanceId'] }>): Result;
   (state: State, instanceId: GridCoreApi['instanceId']): Result;
   acceptsApiRef: boolean;
 }
 
-export interface OutputArgumentsSelector<State, Args, Result> {
+// TODO v8: Rename this type to `OutputSelector`
+export interface OutputSelectorV8<State, Args, Result> {
   (
     apiRef: React.MutableRefObject<{ state: State; instanceId: GridCoreApi['instanceId'] }>,
     args: Args,
@@ -35,6 +37,7 @@ type StateFromSelectorList<Selectors extends readonly any[]> = Selectors extends
     : StateFromSelectorList<R>
   : {};
 
+// TODO v8: Remove this type
 type SelectorArgs<Selectors extends ReadonlyArray<Selector<any>>, Result> =
   // Input selectors as a separate array
   | [selectors: [...Selectors], combiner: (...args: SelectorResultArray<Selectors>) => Result]
@@ -46,7 +49,8 @@ type SelectorResultArrayWithArgs<Selectors extends ReadonlyArray<Selector<any>>,
   Args,
 ];
 
-type ArgumentsSelectorArgs<Selectors extends ReadonlyArray<Selector<any>>, Args, Result> =
+// TODO v8: Rename this type to `SelectorArgs`
+type SelectorArgsV8<Selectors extends ReadonlyArray<Selector<any>>, Args, Result> =
   // Input selectors as a separate array
   | [
       selectors: [...Selectors],
@@ -55,17 +59,19 @@ type ArgumentsSelectorArgs<Selectors extends ReadonlyArray<Selector<any>>, Args,
   // Input selectors as separate inline arguments
   | [...Selectors, (...args: SelectorResultArrayWithArgs<Selectors, Args>) => Result];
 
+// TODO v8: Remove this type
 type CreateSelectorFunction = <Selectors extends ReadonlyArray<Selector<any>>, Result>(
   ...items: SelectorArgs<Selectors, Result>
 ) => OutputSelector<StateFromSelectorList<Selectors>, Result>;
 
-type CreateArgumentsSelectorFunction = <
+// TODO v8: Rename this type to `CreateSelectorFunction`
+type CreateSelectorFunctionV8 = <
   Selectors extends ReadonlyArray<Selector<any>>,
   Args,
   Result,
 >(
-  ...items: ArgumentsSelectorArgs<Selectors, Args, Result>
-) => OutputArgumentsSelector<StateFromSelectorList<Selectors>, Args, Result>;
+  ...items: SelectorArgsV8<Selectors, Args, Result>
+) => OutputSelectorV8<StateFromSelectorList<Selectors>, Args, Result>;
 
 const cache = new WeakMap<CacheKey, Map<any[], any>>();
 
@@ -75,6 +81,7 @@ function checkIsAPIRef(value: any) {
 
 const DEFAULT_INSTANCE_ID = { id: 'default' };
 
+// TODO v8: Remove this function
 export const createSelector = ((
   a: Function,
   b: Function,
@@ -156,6 +163,7 @@ export const createSelector = ((
   return selector;
 }) as unknown as CreateSelectorFunction;
 
+// TODO v8: Rename this function to `createSelector`
 export const createSelectorV8 = ((
   a: Function,
   b: Function,
@@ -235,8 +243,9 @@ export const createSelectorV8 = ((
   selector.acceptsApiRef = true;
 
   return selector;
-}) as unknown as CreateArgumentsSelectorFunction;
+}) as unknown as CreateSelectorFunctionV8;
 
+// TODO v8: Remove this function
 export const createSelectorMemoized: CreateSelectorFunction = (...args: any) => {
   const selector = (stateOrApiRef: any, instanceId?: any) => {
     const isAPIRef = checkIsAPIRef(stateOrApiRef);
@@ -281,7 +290,8 @@ export const createSelectorMemoized: CreateSelectorFunction = (...args: any) => 
   return selector;
 };
 
-export const createSelectorMemoizedV8: CreateArgumentsSelectorFunction = (...args: any) => {
+// TODO v8: Rename this function to `createSelectorMemoized`
+export const createSelectorMemoizedV8: CreateSelectorFunctionV8 = (...args: any) => {
   const selector = (stateOrApiRef: any, selectorArgs: any, instanceId?: any) => {
     const isAPIRef = checkIsAPIRef(stateOrApiRef);
     const cacheKey = isAPIRef

--- a/packages/x-data-grid/src/utils/createSelector.ts
+++ b/packages/x-data-grid/src/utils/createSelector.ts
@@ -59,8 +59,9 @@ type CreateSelectorFunction = <Selectors extends ReadonlyArray<Selector<any>>, R
   ...items: SelectorArgs<Selectors, Result>
 ) => OutputSelector<StateFromSelectorList<Selectors>, Result>;
 
-type CreateArgumentsSelectorFunction = <Args = void>() => <
+type CreateArgumentsSelectorFunction = <
   Selectors extends ReadonlyArray<Selector<any>>,
+  Args,
   Result,
 >(
   ...items: ArgumentsSelectorArgs<Selectors, Args, Result>
@@ -155,87 +156,86 @@ export const createSelector = ((
   return selector;
 }) as unknown as CreateSelectorFunction;
 
-export const createArgumentsSelector = (() =>
-  (
-    a: Function,
-    b: Function,
-    c?: Function,
-    d?: Function,
-    e?: Function,
-    f?: Function,
-    ...other: any[]
-  ) => {
-    if (other.length > 0) {
-      throw new Error('Unsupported number of selectors');
-    }
+export const createSelectorV8 = ((
+  a: Function,
+  b: Function,
+  c?: Function,
+  d?: Function,
+  e?: Function,
+  f?: Function,
+  ...other: any[]
+) => {
+  if (other.length > 0) {
+    throw new Error('Unsupported number of selectors');
+  }
 
-    let selector: any;
+  let selector: any;
 
-    if (a && b && c && d && e && f) {
-      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
-        const isAPIRef = checkIsAPIRef(stateOrApiRef);
-        const instanceId =
-          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
-        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
-        const va = a(state, args, instanceId);
-        const vb = b(state, args, instanceId);
-        const vc = c(state, args, instanceId);
-        const vd = d(state, args, instanceId);
-        const ve = e(state, args, instanceId);
-        return f(va, vb, vc, vd, ve, args);
-      };
-    } else if (a && b && c && d && e) {
-      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
-        const isAPIRef = checkIsAPIRef(stateOrApiRef);
-        const instanceId =
-          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
-        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
-        const va = a(state, args, instanceId);
-        const vb = b(state, args, instanceId);
-        const vc = c(state, args, instanceId);
-        const vd = d(state, args, instanceId);
-        return e(va, vb, vc, vd, args);
-      };
-    } else if (a && b && c && d) {
-      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
-        const isAPIRef = checkIsAPIRef(stateOrApiRef);
-        const instanceId =
-          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
-        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
-        const va = a(state, args, instanceId);
-        const vb = b(state, args, instanceId);
-        const vc = c(state, args, instanceId);
-        return d(va, vb, vc, args);
-      };
-    } else if (a && b && c) {
-      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
-        const isAPIRef = checkIsAPIRef(stateOrApiRef);
-        const instanceId =
-          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
-        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
-        const va = a(state, args, instanceId);
-        const vb = b(state, args, instanceId);
-        return c(va, vb, args);
-      };
-    } else if (a && b) {
-      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
-        const isAPIRef = checkIsAPIRef(stateOrApiRef);
-        const instanceId =
-          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
-        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
-        const va = a(state, args, instanceId);
-        return b(va, args);
-      };
-    } else {
-      throw new Error('Missing arguments');
-    }
+  if (a && b && c && d && e && f) {
+    selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+      const isAPIRef = checkIsAPIRef(stateOrApiRef);
+      const instanceId =
+        instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+      const va = a(state, args, instanceId);
+      const vb = b(state, args, instanceId);
+      const vc = c(state, args, instanceId);
+      const vd = d(state, args, instanceId);
+      const ve = e(state, args, instanceId);
+      return f(va, vb, vc, vd, ve, args);
+    };
+  } else if (a && b && c && d && e) {
+    selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+      const isAPIRef = checkIsAPIRef(stateOrApiRef);
+      const instanceId =
+        instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+      const va = a(state, args, instanceId);
+      const vb = b(state, args, instanceId);
+      const vc = c(state, args, instanceId);
+      const vd = d(state, args, instanceId);
+      return e(va, vb, vc, vd, args);
+    };
+  } else if (a && b && c && d) {
+    selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+      const isAPIRef = checkIsAPIRef(stateOrApiRef);
+      const instanceId =
+        instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+      const va = a(state, args, instanceId);
+      const vb = b(state, args, instanceId);
+      const vc = c(state, args, instanceId);
+      return d(va, vb, vc, args);
+    };
+  } else if (a && b && c) {
+    selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+      const isAPIRef = checkIsAPIRef(stateOrApiRef);
+      const instanceId =
+        instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+      const va = a(state, args, instanceId);
+      const vb = b(state, args, instanceId);
+      return c(va, vb, args);
+    };
+  } else if (a && b) {
+    selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+      const isAPIRef = checkIsAPIRef(stateOrApiRef);
+      const instanceId =
+        instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+      const va = a(state, args, instanceId);
+      return b(va, args);
+    };
+  } else {
+    throw new Error('Missing arguments');
+  }
 
-    // We use this property to detect if the selector was created with createSelector
-    // or it's only a simple function the receives the state and returns part of it.
-    selector.acceptsApiRef = true;
+  // We use this property to detect if the selector was created with createSelector
+  // or it's only a simple function the receives the state and returns part of it.
+  selector.acceptsApiRef = true;
 
-    return selector;
-  }) as unknown as CreateArgumentsSelectorFunction;
+  return selector;
+}) as unknown as CreateArgumentsSelectorFunction;
 
 export const createSelectorMemoized: CreateSelectorFunction = (...args: any) => {
   const selector = (stateOrApiRef: any, instanceId?: any) => {
@@ -281,48 +281,46 @@ export const createSelectorMemoized: CreateSelectorFunction = (...args: any) => 
   return selector;
 };
 
-export const createArgumentsSelectorMemoized: CreateArgumentsSelectorFunction =
-  () =>
-  (...args: any) => {
-    const selector = (stateOrApiRef: any, selectorArgs: any, instanceId?: any) => {
-      const isAPIRef = checkIsAPIRef(stateOrApiRef);
-      const cacheKey = isAPIRef
-        ? stateOrApiRef.current.instanceId
-        : (instanceId ?? DEFAULT_INSTANCE_ID);
-      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+export const createSelectorMemoizedV8: CreateArgumentsSelectorFunction = (...args: any) => {
+  const selector = (stateOrApiRef: any, selectorArgs: any, instanceId?: any) => {
+    const isAPIRef = checkIsAPIRef(stateOrApiRef);
+    const cacheKey = isAPIRef
+      ? stateOrApiRef.current.instanceId
+      : (instanceId ?? DEFAULT_INSTANCE_ID);
+    const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
 
-      if (process.env.NODE_ENV !== 'production') {
-        if (cacheKey.id === 'default') {
-          warnOnce([
-            'MUI X: A selector was called without passing the instance ID, which may impact the performance of the grid.',
-            'To fix, call it with `apiRef`, for example `mySelector(apiRef)`, or pass the instance ID explicitly, for example `mySelector(state, apiRef.current.instanceId)`.',
-          ]);
-        }
+    if (process.env.NODE_ENV !== 'production') {
+      if (cacheKey.id === 'default') {
+        warnOnce([
+          'MUI X: A selector was called without passing the instance ID, which may impact the performance of the grid.',
+          'To fix, call it with `apiRef`, for example `mySelector(apiRef)`, or pass the instance ID explicitly, for example `mySelector(state, apiRef.current.instanceId)`.',
+        ]);
       }
+    }
 
-      const cacheArgsInit = cache.get(cacheKey);
-      const cacheArgs = cacheArgsInit ?? new Map();
-      const cacheFn = cacheArgs?.get(args);
+    const cacheArgsInit = cache.get(cacheKey);
+    const cacheArgs = cacheArgsInit ?? new Map();
+    const cacheFn = cacheArgs?.get(args);
 
-      if (cacheArgs && cacheFn) {
-        // We pass the cache key because the called selector might have as
-        // dependency another selector created with this `createSelector`.
-        return cacheFn(state, selectorArgs, cacheKey);
-      }
+    if (cacheArgs && cacheFn) {
+      // We pass the cache key because the called selector might have as
+      // dependency another selector created with this `createSelector`.
+      return cacheFn(state, selectorArgs, cacheKey);
+    }
 
-      const fn = reselectCreateSelector(...args);
+    const fn = reselectCreateSelector(...args);
 
-      if (!cacheArgsInit) {
-        cache.set(cacheKey, cacheArgs);
-      }
-      cacheArgs.set(args, fn);
+    if (!cacheArgsInit) {
+      cache.set(cacheKey, cacheArgs);
+    }
+    cacheArgs.set(args, fn);
 
-      return fn(state, selectorArgs, cacheKey);
-    };
-
-    // We use this property to detect if the selector was created with createSelector
-    // or it's only a simple function the receives the state and returns part of it.
-    selector.acceptsApiRef = true;
-
-    return selector;
+    return fn(state, selectorArgs, cacheKey);
   };
+
+  // We use this property to detect if the selector was created with createSelector
+  // or it's only a simple function the receives the state and returns part of it.
+  selector.acceptsApiRef = true;
+
+  return selector;
+};

--- a/packages/x-data-grid/src/utils/createSelector.ts
+++ b/packages/x-data-grid/src/utils/createSelector.ts
@@ -11,6 +11,16 @@ export interface OutputSelector<State, Result> {
   acceptsApiRef: boolean;
 }
 
+export interface OutputArgumentsSelector<State, Args, Result> {
+  (
+    apiRef: React.MutableRefObject<{ state: State; instanceId: GridCoreApi['instanceId'] }>,
+    args: Args,
+  ): Result;
+  (state: State, instanceId: GridCoreApi['instanceId']): Result;
+  acceptsApiRef: boolean;
+  acceptsArguments: boolean;
+}
+
 type StateFromSelector<T> = T extends (first: infer F, ...args: any[]) => any
   ? F extends { state: infer F2 }
     ? F2
@@ -32,9 +42,30 @@ type SelectorArgs<Selectors extends ReadonlyArray<Selector<any>>, Result> =
   // Input selectors as separate inline arguments
   | [...Selectors, (...args: SelectorResultArray<Selectors>) => Result];
 
+type SelectorResultArrayWithArgs<Selectors extends ReadonlyArray<Selector<any>>, Args> = [
+  ...SelectorResultArray<Selectors>,
+  Args,
+];
+
+type ArgumentsSelectorArgs<Selectors extends ReadonlyArray<Selector<any>>, Args, Result> =
+  // Input selectors as a separate array
+  | [
+      selectors: [...Selectors],
+      combiner: (...args: SelectorResultArrayWithArgs<Selectors, Args>) => Result,
+    ]
+  // Input selectors as separate inline arguments
+  | [...Selectors, (...args: SelectorResultArrayWithArgs<Selectors, Args>) => Result];
+
 type CreateSelectorFunction = <Selectors extends ReadonlyArray<Selector<any>>, Result>(
   ...items: SelectorArgs<Selectors, Result>
 ) => OutputSelector<StateFromSelectorList<Selectors>, Result>;
+
+type CreateArgumentsSelectorFunction = <Args = void>() => <
+  Selectors extends ReadonlyArray<Selector<any>>,
+  Result,
+>(
+  ...items: ArgumentsSelectorArgs<Selectors, Args, Result>
+) => OutputArgumentsSelector<StateFromSelectorList<Selectors>, Args, Result>;
 
 const cache = new WeakMap<CacheKey, Map<any[], any>>();
 
@@ -125,6 +156,89 @@ export const createSelector = ((
   return selector;
 }) as unknown as CreateSelectorFunction;
 
+export const createArgumentsSelector = (() =>
+  (
+    a: Function,
+    b: Function,
+    c?: Function,
+    d?: Function,
+    e?: Function,
+    f?: Function,
+    ...other: any[]
+  ) => {
+    if (other.length > 0) {
+      throw new Error('Unsupported number of selectors');
+    }
+
+    let selector: any;
+
+    if (a && b && c && d && e && f) {
+      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+        const isAPIRef = checkIsAPIRef(stateOrApiRef);
+        const instanceId =
+          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+        const va = a(state, args, instanceId);
+        const vb = b(state, args, instanceId);
+        const vc = c(state, args, instanceId);
+        const vd = d(state, args, instanceId);
+        const ve = e(state, args, instanceId);
+        return f(va, vb, vc, vd, ve, args);
+      };
+    } else if (a && b && c && d && e) {
+      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+        const isAPIRef = checkIsAPIRef(stateOrApiRef);
+        const instanceId =
+          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+        const va = a(state, args, instanceId);
+        const vb = b(state, args, instanceId);
+        const vc = c(state, args, instanceId);
+        const vd = d(state, args, instanceId);
+        return e(va, vb, vc, vd, args);
+      };
+    } else if (a && b && c && d) {
+      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+        const isAPIRef = checkIsAPIRef(stateOrApiRef);
+        const instanceId =
+          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+        const va = a(state, args, instanceId);
+        const vb = b(state, args, instanceId);
+        const vc = c(state, args, instanceId);
+        return d(va, vb, vc, args);
+      };
+    } else if (a && b && c) {
+      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+        const isAPIRef = checkIsAPIRef(stateOrApiRef);
+        const instanceId =
+          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+        const va = a(state, args, instanceId);
+        const vb = b(state, args, instanceId);
+        return c(va, vb, args);
+      };
+    } else if (a && b) {
+      selector = (stateOrApiRef: any, args: any, instanceIdParam: any) => {
+        const isAPIRef = checkIsAPIRef(stateOrApiRef);
+        const instanceId =
+          instanceIdParam ?? (isAPIRef ? stateOrApiRef.current.instanceId : DEFAULT_INSTANCE_ID);
+        const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+        const va = a(state, args, instanceId);
+        return b(va, args);
+      };
+    } else {
+      throw new Error('Missing arguments');
+    }
+
+    // We use this property to detect if the selector was created with createSelector
+    // or it's only a simple function the receives the state and returns part of it.
+    selector.acceptsApiRef = true;
+    selector.acceptsArguments = true;
+
+    return selector;
+  }) as unknown as CreateArgumentsSelectorFunction;
+
 export const createSelectorMemoized: CreateSelectorFunction = (...args: any) => {
   const selector = (stateOrApiRef: any, instanceId?: any) => {
     const isAPIRef = checkIsAPIRef(stateOrApiRef);
@@ -168,3 +282,50 @@ export const createSelectorMemoized: CreateSelectorFunction = (...args: any) => 
 
   return selector;
 };
+
+export const createArgumentsSelectorMemoized: CreateArgumentsSelectorFunction =
+  () =>
+  (...args: any) => {
+    const selector = (stateOrApiRef: any, selectorArgs: any, instanceId?: any) => {
+      const isAPIRef = checkIsAPIRef(stateOrApiRef);
+      const cacheKey = isAPIRef
+        ? stateOrApiRef.current.instanceId
+        : (instanceId ?? DEFAULT_INSTANCE_ID);
+      const state = isAPIRef ? stateOrApiRef.current.state : stateOrApiRef;
+
+      if (process.env.NODE_ENV !== 'production') {
+        if (cacheKey.id === 'default') {
+          warnOnce([
+            'MUI X: A selector was called without passing the instance ID, which may impact the performance of the grid.',
+            'To fix, call it with `apiRef`, for example `mySelector(apiRef)`, or pass the instance ID explicitly, for example `mySelector(state, apiRef.current.instanceId)`.',
+          ]);
+        }
+      }
+
+      const cacheArgsInit = cache.get(cacheKey);
+      const cacheArgs = cacheArgsInit ?? new Map();
+      const cacheFn = cacheArgs?.get(args);
+
+      if (cacheArgs && cacheFn) {
+        // We pass the cache key because the called selector might have as
+        // dependency another selector created with this `createSelector`.
+        return cacheFn(state, selectorArgs, cacheKey);
+      }
+
+      const fn = reselectCreateSelector(...args);
+
+      if (!cacheArgsInit) {
+        cache.set(cacheKey, cacheArgs);
+      }
+      cacheArgs.set(args, fn);
+
+      return fn(state, selectorArgs, cacheKey);
+    };
+
+    // We use this property to detect if the selector was created with createSelector
+    // or it's only a simple function the receives the state and returns part of it.
+    selector.acceptsApiRef = true;
+    selector.acceptsArguments = true;
+
+    return selector;
+  };

--- a/packages/x-data-grid/src/utils/createSelector.ts
+++ b/packages/x-data-grid/src/utils/createSelector.ts
@@ -18,7 +18,6 @@ export interface OutputArgumentsSelector<State, Args, Result> {
   ): Result;
   (state: State, instanceId: GridCoreApi['instanceId']): Result;
   acceptsApiRef: boolean;
-  acceptsArguments: boolean;
 }
 
 type StateFromSelector<T> = T extends (first: infer F, ...args: any[]) => any
@@ -234,7 +233,6 @@ export const createArgumentsSelector = (() =>
     // We use this property to detect if the selector was created with createSelector
     // or it's only a simple function the receives the state and returns part of it.
     selector.acceptsApiRef = true;
-    selector.acceptsArguments = true;
 
     return selector;
   }) as unknown as CreateArgumentsSelectorFunction;
@@ -325,7 +323,6 @@ export const createArgumentsSelectorMemoized: CreateArgumentsSelectorFunction =
     // We use this property to detect if the selector was created with createSelector
     // or it's only a simple function the receives the state and returns part of it.
     selector.acceptsApiRef = true;
-    selector.acceptsArguments = true;
 
     return selector;
   };

--- a/packages/x-data-grid/src/utils/createSelector.ts
+++ b/packages/x-data-grid/src/utils/createSelector.ts
@@ -65,11 +65,7 @@ type CreateSelectorFunction = <Selectors extends ReadonlyArray<Selector<any>>, R
 ) => OutputSelector<StateFromSelectorList<Selectors>, Result>;
 
 // TODO v8: Rename this type to `CreateSelectorFunction`
-type CreateSelectorFunctionV8 = <
-  Selectors extends ReadonlyArray<Selector<any>>,
-  Args,
-  Result,
->(
+type CreateSelectorFunctionV8 = <Selectors extends ReadonlyArray<Selector<any>>, Args, Result>(
   ...items: SelectorArgsV8<Selectors, Args, Result>
 ) => OutputSelectorV8<StateFromSelectorList<Selectors>, Args, Result>;
 


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-x/pull/13757/
Related discussion: https://github.com/mui/mui-x/pull/13757/files#r1686750062

## Changelog

- Add new v8 variants of `useGridSelector`, `createSelector`, and `createSelectorMemoized` named as `useGridSelectorV8`, `createSelectorV8`, and `createSelectorMemoizedV8`. Selectors created with `createSelectorV8` or `createSelectorMemoizedV8` must be used with `useGridSelectorV8` for them to work properly. These new variants will replace the existing props in v8.

## Todos

- [x] Add the breaking changes to umbrella issue