### PR TITLE
[DataGrid] Allow to control the indeterminate checkbox behavior

### DIFF
--- a/docs/data/data-grid/row-selection/CheckboxSelectionIndeterminateGrid.js
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionIndeterminateGrid.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+export default function CheckboxSelectionIndeterminateGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 10,
+    maxColumns: 5,
+  });
+
+  return (
+    <div style={{ width: '100%', height: 300 }}>
+      <DataGrid {...data} checkboxSelection indeterminateCheckboxAction="select" />
+    </div>
+  );
+}

--- a/docs/data/data-grid/row-selection/CheckboxSelectionIndeterminateGrid.tsx
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionIndeterminateGrid.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+export default function CheckboxSelectionIndeterminateGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 10,
+    maxColumns: 5,
+  });
+
+  return (
+    <div style={{ width: '100%', height: 300 }}>
+      <DataGrid {...data} checkboxSelection indeterminateCheckboxAction="select" />
+    </div>
+  );
+}

--- a/docs/data/data-grid/row-selection/CheckboxSelectionIndeterminateGrid.tsx.preview
+++ b/docs/data/data-grid/row-selection/CheckboxSelectionIndeterminateGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid {...data} checkboxSelection indeterminateCheckboxAction="select" />

--- a/docs/data/data-grid/row-selection/row-selection.md
+++ b/docs/data/data-grid/row-selection/row-selection.md
@@ -64,6 +64,13 @@ Always set the `checkboxSelection` prop to `true` even when providing a custom c
 Otherwise, the data grid might remove your column.
 :::
 
+### Customize indeterminate checkbox behavior
+
+The parent checkboxes (like "Select All" checkbox) when clicked in an indeterminate state will deselect the selected rows.
+You can customize this behavior by using the [`indeterminateCheckboxAction` prop](/x/api/data-grid/data-grid/#data-grid-prop-indeterminateCheckboxAction).
+
+{{"demo": "CheckboxSelectionIndeterminateGrid.js", "bg": "inline"}}
+
 ### Visible rows selection [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
 
 By default, when you click the "Select All" checkbox, all rows in the data grid are selected.

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -181,6 +181,10 @@
       },
       "default": "false"
     },
+    "indeterminateCheckboxBehavior": {
+      "type": { "name": "enum", "description": "'deselect'<br>&#124;&nbsp;'select'" },
+      "default": "\"select\""
+    },
     "initialState": { "type": { "name": "object" } },
     "isCellEditable": {
       "type": { "name": "func" },

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -181,9 +181,9 @@
       },
       "default": "false"
     },
-    "indeterminateCheckboxBehavior": {
+    "indeterminateCheckboxAction": {
       "type": { "name": "enum", "description": "'deselect'<br>&#124;&nbsp;'select'" },
-      "default": "\"select\""
+      "default": "\"deselect\""
     },
     "initialState": { "type": { "name": "object" } },
     "isCellEditable": {

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -155,6 +155,10 @@
       },
       "default": "false"
     },
+    "indeterminateCheckboxBehavior": {
+      "type": { "name": "enum", "description": "'deselect'<br>&#124;&nbsp;'select'" },
+      "default": "\"select\""
+    },
     "initialState": { "type": { "name": "object" } },
     "isCellEditable": {
       "type": { "name": "func" },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -155,9 +155,9 @@
       },
       "default": "false"
     },
-    "indeterminateCheckboxBehavior": {
+    "indeterminateCheckboxAction": {
       "type": { "name": "enum", "description": "'deselect'<br>&#124;&nbsp;'select'" },
-      "default": "\"select\""
+      "default": "\"deselect\""
     },
     "initialState": { "type": { "name": "object" } },
     "isCellEditable": {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -123,9 +123,9 @@
       },
       "default": "false"
     },
-    "indeterminateCheckboxBehavior": {
+    "indeterminateCheckboxAction": {
       "type": { "name": "enum", "description": "'deselect'<br>&#124;&nbsp;'select'" },
-      "default": "\"select\""
+      "default": "\"deselect\""
     },
     "initialState": { "type": { "name": "object" } },
     "isCellEditable": {

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -123,6 +123,10 @@
       },
       "default": "false"
     },
+    "indeterminateCheckboxBehavior": {
+      "type": { "name": "enum", "description": "'deselect'<br>&#124;&nbsp;'select'" },
+      "default": "\"select\""
+    },
     "initialState": { "type": { "name": "object" } },
     "isCellEditable": {
       "type": { "name": "func" },

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -202,6 +202,9 @@
     "ignoreValueFormatterDuringExport": {
       "description": "If <code>true</code>, the Data Grid will not use <code>valueFormatter</code> when exporting to CSV or copying to clipboard. If an object is provided, you can choose to ignore the <code>valueFormatter</code> for CSV export or clipboard export."
     },
+    "indeterminateCheckboxBehavior": {
+      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it If <code>deselect</code>, it will deselect all the rows under it Works only if <code>checkboxSelection</code> is enabled."
+    },
     "initialState": {
       "description": "The initial state of the DataGridPremium. The data in it is set in the state on initialization but isn&#39;t controlled. If one of the data in <code>initialState</code> is also being controlled, then the control state wins."
     },

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -202,8 +202,8 @@
     "ignoreValueFormatterDuringExport": {
       "description": "If <code>true</code>, the Data Grid will not use <code>valueFormatter</code> when exporting to CSV or copying to clipboard. If an object is provided, you can choose to ignore the <code>valueFormatter</code> for CSV export or clipboard export."
     },
-    "indeterminateCheckboxBehavior": {
-      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it If <code>deselect</code>, it will deselect all the rows under it Works only if <code>checkboxSelection</code> is enabled."
+    "indeterminateCheckboxAction": {
+      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it. If <code>deselect</code>, it will deselect all the rows under it. Works only if <code>checkboxSelection</code> is enabled."
     },
     "initialState": {
       "description": "The initial state of the DataGridPremium. The data in it is set in the state on initialization but isn&#39;t controlled. If one of the data in <code>initialState</code> is also being controlled, then the control state wins."

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -183,8 +183,8 @@
     "ignoreValueFormatterDuringExport": {
       "description": "If <code>true</code>, the Data Grid will not use <code>valueFormatter</code> when exporting to CSV or copying to clipboard. If an object is provided, you can choose to ignore the <code>valueFormatter</code> for CSV export or clipboard export."
     },
-    "indeterminateCheckboxBehavior": {
-      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it If <code>deselect</code>, it will deselect all the rows under it Works only if <code>checkboxSelection</code> is enabled."
+    "indeterminateCheckboxAction": {
+      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it. If <code>deselect</code>, it will deselect all the rows under it. Works only if <code>checkboxSelection</code> is enabled."
     },
     "initialState": {
       "description": "The initial state of the DataGridPro. The data in it will be set in the state on initialization but will not be controlled. If one of the data in <code>initialState</code> is also being controlled, then the control state wins."

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -183,6 +183,9 @@
     "ignoreValueFormatterDuringExport": {
       "description": "If <code>true</code>, the Data Grid will not use <code>valueFormatter</code> when exporting to CSV or copying to clipboard. If an object is provided, you can choose to ignore the <code>valueFormatter</code> for CSV export or clipboard export."
     },
+    "indeterminateCheckboxBehavior": {
+      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it If <code>deselect</code>, it will deselect all the rows under it Works only if <code>checkboxSelection</code> is enabled."
+    },
     "initialState": {
       "description": "The initial state of the DataGridPro. The data in it will be set in the state on initialization but will not be controlled. If one of the data in <code>initialState</code> is also being controlled, then the control state wins."
     },

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -136,8 +136,8 @@
     "ignoreValueFormatterDuringExport": {
       "description": "If <code>true</code>, the Data Grid will not use <code>valueFormatter</code> when exporting to CSV or copying to clipboard. If an object is provided, you can choose to ignore the <code>valueFormatter</code> for CSV export or clipboard export."
     },
-    "indeterminateCheckboxBehavior": {
-      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it If <code>deselect</code>, it will deselect all the rows under it Works only if <code>checkboxSelection</code> is enabled."
+    "indeterminateCheckboxAction": {
+      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it. If <code>deselect</code>, it will deselect all the rows under it. Works only if <code>checkboxSelection</code> is enabled."
     },
     "initialState": {
       "description": "The initial state of the DataGrid. The data in it will be set in the state on initialization but will not be controlled. If one of the data in <code>initialState</code> is also being controlled, then the control state wins."

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -136,6 +136,9 @@
     "ignoreValueFormatterDuringExport": {
       "description": "If <code>true</code>, the Data Grid will not use <code>valueFormatter</code> when exporting to CSV or copying to clipboard. If an object is provided, you can choose to ignore the <code>valueFormatter</code> for CSV export or clipboard export."
     },
+    "indeterminateCheckboxBehavior": {
+      "description": "If <code>select</code>, a group header checkbox in indeterminate state (like &quot;Select All&quot; checkbox) will select all the rows under it If <code>deselect</code>, it will deselect all the rows under it Works only if <code>checkboxSelection</code> is enabled."
+    },
     "initialState": {
       "description": "The initial state of the DataGrid. The data in it will be set in the state on initialization but will not be controlled. If one of the data in <code>initialState</code> is also being controlled, then the control state wins."
     },

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -473,6 +473,14 @@ DataGridPremiumRaw.propTypes = {
     PropTypes.bool,
   ]),
   /**
+   * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
+   * will select all the rows under it
+   * If `deselect`, it will deselect all the rows under it
+   * Works only if `checkboxSelection` is enabled.
+   * @default "select"
+   */
+  indeterminateCheckboxBehavior: PropTypes.oneOf(['deselect', 'select']),
+  /**
    * The initial state of the DataGridPremium.
    * The data in it is set in the state on initialization but isn't controlled.
    * If one of the data in `initialState` is also being controlled, then the control state wins.

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -474,12 +474,12 @@ DataGridPremiumRaw.propTypes = {
   ]),
   /**
    * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
-   * will select all the rows under it
-   * If `deselect`, it will deselect all the rows under it
+   * will select all the rows under it.
+   * If `deselect`, it will deselect all the rows under it.
    * Works only if `checkboxSelection` is enabled.
-   * @default "select"
+   * @default "deselect"
    */
-  indeterminateCheckboxBehavior: PropTypes.oneOf(['deselect', 'select']),
+  indeterminateCheckboxAction: PropTypes.oneOf(['deselect', 'select']),
   /**
    * The initial state of the DataGridPremium.
    * The data in it is set in the state on initialization but isn't controlled.

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -428,6 +428,14 @@ DataGridProRaw.propTypes = {
     PropTypes.bool,
   ]),
   /**
+   * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
+   * will select all the rows under it
+   * If `deselect`, it will deselect all the rows under it
+   * Works only if `checkboxSelection` is enabled.
+   * @default "select"
+   */
+  indeterminateCheckboxBehavior: PropTypes.oneOf(['deselect', 'select']),
+  /**
    * The initial state of the DataGridPro.
    * The data in it will be set in the state on initialization but will not be controlled.
    * If one of the data in `initialState` is also being controlled, then the control state wins.

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -429,12 +429,12 @@ DataGridProRaw.propTypes = {
   ]),
   /**
    * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
-   * will select all the rows under it
-   * If `deselect`, it will deselect all the rows under it
+   * will select all the rows under it.
+   * If `deselect`, it will deselect all the rows under it.
    * Works only if `checkboxSelection` is enabled.
-   * @default "select"
+   * @default "deselect"
    */
-  indeterminateCheckboxBehavior: PropTypes.oneOf(['deselect', 'select']),
+  indeterminateCheckboxAction: PropTypes.oneOf(['deselect', 'select']),
   /**
    * The initial state of the DataGridPro.
    * The data in it will be set in the state on initialization but will not be controlled.

--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -62,14 +62,13 @@ describe('<DataGridPro /> - Row selection', () => {
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 
-    it('should unselect all rows of all the pages if 1 row of another page is selected', () => {
+    it('should select all rows of all the pages if 1 row of another page is selected', () => {
       render(
         <TestDataGridSelection
           checkboxSelection
           initialState={{ pagination: { paginationModel: { pageSize: 2 } } }}
           pagination
           pageSizeOptions={[2]}
-          indeterminateCheckboxBehavior='deselect'
         />,
       );
       fireEvent.click(getCell(0, 0).querySelector('input')!);
@@ -79,8 +78,8 @@ describe('<DataGridPro /> - Row selection', () => {
         name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.length(0);
-      expect(selectAllCheckbox.checked).to.equal(false);
+      expect(apiRef.current.getSelectedRows()).to.have.keys([0, 1, 2, 3]);
+      expect(selectAllCheckbox.checked).to.equal(true);
     });
 
     it('should select all visible rows if pagination is not enabled', () => {
@@ -169,7 +168,7 @@ describe('<DataGridPro /> - Row selection', () => {
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 
-    it('should unselect all the rows of the current page if 1 row of the current page is selected', () => {
+    it('should select all the rows of the current page if 1 row of the current page is selected', () => {
       render(
         <TestDataGridSelection
           checkboxSelection
@@ -177,7 +176,6 @@ describe('<DataGridPro /> - Row selection', () => {
           pagination
           checkboxSelectionVisibleOnly
           pageSizeOptions={[2]}
-          indeterminateCheckboxBehavior='deselect'
         />,
       );
 
@@ -190,8 +188,8 @@ describe('<DataGridPro /> - Row selection', () => {
         name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
-      expect(selectAllCheckbox.checked).to.equal(false);
+      expect(apiRef.current.getSelectedRows()).to.have.length(4);
+      expect(selectAllCheckbox.checked).to.equal(true);
     });
 
     it('should not set the header checkbox in a indeterminate state when some rows of other pages are not selected', () => {

--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -188,7 +188,7 @@ describe('<DataGridPro /> - Row selection', () => {
         name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.length(4);
+      expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2, 3]);
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 

--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -69,6 +69,7 @@ describe('<DataGridPro /> - Row selection', () => {
           initialState={{ pagination: { paginationModel: { pageSize: 2 } } }}
           pagination
           pageSizeOptions={[2]}
+          indeterminateCheckboxBehavior='deselect'
         />,
       );
       fireEvent.click(getCell(0, 0).querySelector('input')!);
@@ -176,6 +177,7 @@ describe('<DataGridPro /> - Row selection', () => {
           pagination
           checkboxSelectionVisibleOnly
           pageSizeOptions={[2]}
+          indeterminateCheckboxBehavior='deselect'
         />,
       );
 

--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -62,7 +62,7 @@ describe('<DataGridPro /> - Row selection', () => {
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 
-    it('should select all rows of all the pages if 1 row of another page is selected', () => {
+    it('should unselect all rows of all the pages if 1 row of another page is selected', () => {
       render(
         <TestDataGridSelection
           checkboxSelection
@@ -78,8 +78,8 @@ describe('<DataGridPro /> - Row selection', () => {
         name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.keys([0, 1, 2, 3]);
-      expect(selectAllCheckbox.checked).to.equal(true);
+      expect(apiRef.current.getSelectedRows()).to.have.length(0);
+      expect(selectAllCheckbox.checked).to.equal(false);
     });
 
     it('should select all visible rows if pagination is not enabled', () => {
@@ -168,7 +168,7 @@ describe('<DataGridPro /> - Row selection', () => {
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 
-    it('should select all the rows of the current page if 1 row of the current page is selected', () => {
+    it('should unselect all the rows of the current page if 1 row of the current page is selected', () => {
       render(
         <TestDataGridSelection
           checkboxSelection
@@ -188,8 +188,8 @@ describe('<DataGridPro /> - Row selection', () => {
         name: /select all rows/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2, 3]);
-      expect(selectAllCheckbox.checked).to.equal(true);
+      expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
+      expect(selectAllCheckbox.checked).to.equal(false);
     });
 
     it('should not set the header checkbox in a indeterminate state when some rows of other pages are not selected', () => {

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -356,12 +356,12 @@ DataGridRaw.propTypes = {
   ]),
   /**
    * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
-   * will select all the rows under it
-   * If `deselect`, it will deselect all the rows under it
+   * will select all the rows under it.
+   * If `deselect`, it will deselect all the rows under it.
    * Works only if `checkboxSelection` is enabled.
-   * @default "select"
+   * @default "deselect"
    */
-  indeterminateCheckboxBehavior: PropTypes.oneOf(['deselect', 'select']),
+  indeterminateCheckboxAction: PropTypes.oneOf(['deselect', 'select']),
   /**
    * The initial state of the DataGrid.
    * The data in it will be set in the state on initialization but will not be controlled.

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -355,6 +355,14 @@ DataGridRaw.propTypes = {
     PropTypes.bool,
   ]),
   /**
+   * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
+   * will select all the rows under it
+   * If `deselect`, it will deselect all the rows under it
+   * Works only if `checkboxSelection` is enabled.
+   * @default "select"
+   */
+  indeterminateCheckboxBehavior: PropTypes.oneOf(['deselect', 'select']),
+  /**
    * The initial state of the DataGrid.
    * The data in it will be set in the state on initialization but will not be controlled.
    * If one of the data in `initialState` is also being controlled, then the control state wins.

--- a/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -58,7 +58,8 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
   hideFooterSelectedRowCount: false,
   ignoreDiacritics: false,
   ignoreValueFormatterDuringExport: false,
-  indeterminateCheckboxBehavior: 'select',
+  // TODO v8: Update to 'select'
+  indeterminateCheckboxAction: 'deselect',
   keepColumnPositionIfDraggedOutside: false,
   keepNonExistentRowsSelected: false,
   loading: false,

--- a/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
+++ b/packages/x-data-grid/src/DataGrid/useDataGridProps.ts
@@ -58,6 +58,7 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
   hideFooterSelectedRowCount: false,
   ignoreDiacritics: false,
   ignoreValueFormatterDuringExport: false,
+  indeterminateCheckboxBehavior: 'select',
   keepColumnPositionIfDraggedOutside: false,
   keepNonExistentRowsSelected: false,
   loading: false,

--- a/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -130,7 +130,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLButtonElement, GridColumnHeaderP
     );
 
     const checked =
-      rootProps.indeterminateCheckboxBehavior === 'select'
+      rootProps.indeterminateCheckboxAction === 'select'
         ? isChecked && !isIndeterminate
         : isChecked;
 

--- a/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -129,11 +129,16 @@ const GridHeaderCheckbox = React.forwardRef<HTMLButtonElement, GridColumnHeaderP
       isChecked ? 'checkboxSelectionUnselectAllRows' : 'checkboxSelectionSelectAllRows',
     );
 
+    const checked =
+      rootProps.indeterminateCheckboxBehavior === 'select'
+        ? isChecked && !isIndeterminate
+        : isChecked;
+
     return (
       <rootProps.slots.baseCheckbox
         ref={ref}
         indeterminate={isIndeterminate}
-        checked={isChecked}
+        checked={checked}
         onChange={handleChange}
         className={classes.root}
         inputProps={{ 'aria-label': label }}

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -245,6 +245,14 @@ export interface DataGridPropsWithDefaultValues<R extends GridValidRowModel = an
    */
   ignoreDiacritics: boolean;
   /**
+   * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
+   * will select all the rows under it
+   * If `deselect`, it will deselect all the rows under it
+   * Works only if `checkboxSelection` is enabled.
+   * @default "select"
+   */
+  indeterminateCheckboxBehavior: 'select' | 'deselect';
+  /**
    * If `true`, the selection model will retain selected rows that do not exist.
    * Useful when using server side pagination and row selections need to be retained
    * when changing pages.

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -246,12 +246,12 @@ export interface DataGridPropsWithDefaultValues<R extends GridValidRowModel = an
   ignoreDiacritics: boolean;
   /**
    * If `select`, a group header checkbox in indeterminate state (like "Select All" checkbox)
-   * will select all the rows under it
-   * If `deselect`, it will deselect all the rows under it
+   * will select all the rows under it.
+   * If `deselect`, it will deselect all the rows under it.
    * Works only if `checkboxSelection` is enabled.
-   * @default "select"
+   * @default "deselect"
    */
-  indeterminateCheckboxBehavior: 'select' | 'deselect';
+  indeterminateCheckboxAction: 'select' | 'deselect';
   /**
    * If `true`, the selection model will retain selected rows that do not exist.
    * Useful when using server side pagination and row selections need to be retained

--- a/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -404,6 +404,28 @@ describe('<DataGrid /> - Row selection', () => {
         expect(grid('selectedRowCount')?.textContent).to.equal('1 row selected');
       });
     });
+
+    describe('prop: indeterminateCheckboxBehavior = "select"', () => {
+      it('should select all the rows when clicking on "Select All" checkbox in indeterminate state', () => {
+        render(<TestDataGridSelection checkboxSelection indeterminateCheckboxBehavior="select" />);
+        const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all rows' });
+        fireEvent.click(screen.getAllByRole('checkbox', { name: /select row/i })[0]);
+        fireEvent.click(selectAllCheckbox);
+        expect(getSelectedRowIds()).to.deep.equal([0, 1, 2, 3]);
+      });
+    });
+
+    describe('prop: indeterminateCheckboxBehavior = "deselect"', () => {
+      it('should deselect all the rows when clicking on "Select All" checkbox in indeterminate state', () => {
+        render(
+          <TestDataGridSelection checkboxSelection indeterminateCheckboxBehavior="deselect" />,
+        );
+        const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all rows' });
+        fireEvent.click(screen.getAllByRole('checkbox', { name: /select row/i })[0]);
+        fireEvent.click(selectAllCheckbox);
+        expect(getSelectedRowIds()).to.deep.equal([]);
+      });
+    });
   });
 
   describe('prop: checkboxSelection = true (multi selection), with keyboard events', () => {

--- a/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -405,9 +405,9 @@ describe('<DataGrid /> - Row selection', () => {
       });
     });
 
-    describe('prop: indeterminateCheckboxBehavior = "select"', () => {
+    describe('prop: indeterminateCheckboxAction = "select"', () => {
       it('should select all the rows when clicking on "Select All" checkbox in indeterminate state', () => {
-        render(<TestDataGridSelection checkboxSelection indeterminateCheckboxBehavior="select" />);
+        render(<TestDataGridSelection checkboxSelection indeterminateCheckboxAction="select" />);
         const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all rows' });
         fireEvent.click(screen.getAllByRole('checkbox', { name: /select row/i })[0]);
         fireEvent.click(selectAllCheckbox);
@@ -415,11 +415,9 @@ describe('<DataGrid /> - Row selection', () => {
       });
     });
 
-    describe('prop: indeterminateCheckboxBehavior = "deselect"', () => {
+    describe('prop: indeterminateCheckboxAction = "deselect"', () => {
       it('should deselect all the rows when clicking on "Select All" checkbox in indeterminate state', () => {
-        render(
-          <TestDataGridSelection checkboxSelection indeterminateCheckboxBehavior="deselect" />,
-        );
+        render(<TestDataGridSelection checkboxSelection indeterminateCheckboxAction="deselect" />);
         const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all rows' });
         fireEvent.click(screen.getAllByRole('checkbox', { name: /select row/i })[0]);
         fireEvent.click(selectAllCheckbox);


### PR DESCRIPTION
Extracted from [#13757](https://github.com/mui/mui-x/pull/13757#discussion_r1689400378) as suggested by @arminmeh
Part of #7753 

https://deploy-preview-14247--material-ui-x.netlify.app/x/react-data-grid/row-selection/#customize-indeterminate-checkbox-behavior

Todo:
- [x] Add to the v8 breaking changes umbrella [issue](https://github.com/mui/mui-x/issues/13188)