### PR TITLE
[docs] Consistent use of UTC and timezones

### DIFF
--- a/changelogOld/CHANGELOG.v6.md
+++ b/changelogOld/CHANGELOG.v6.md
@@ -2188,7 +2188,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 
   It already contains [line](https://mui.com/x/react-charts/lines/), [bar](https://mui.com/x/react-charts/bars/), and [scatter](https://mui.com/x/react-charts/scatter/) charts, with basic customization features. Check out the [documentation](https://mui.com/x/react-charts/) to see what it can do, and open issues to get the feature you need implemented.
 
-- 🚀 Introducing UTC and timezone support for pickers.
+- 🚀 Introducing UTC and timezones support for pickers.
 
   <img width="774" src="https://github.com/mui/mui-x/assets/3165635/ad95a404-ee67-4aff-b996-ad6cbb322348" alt="Pickers time zone switching">
 

--- a/docs/data/date-pickers/timezone/timezone.md
+++ b/docs/data/date-pickers/timezone/timezone.md
@@ -11,7 +11,7 @@ packageName: '@mui/x-date-pickers'
 <p class="description">Date and Time Pickers support UTC and timezones.</p>
 
 :::warning
-UTC and timezone support is an ongoing topic.
+UTC and timezones support is an ongoing effort.
 
 Only `AdapterDayjs`, `AdapterLuxon` and `AdapterMoment` are currently compatible with UTC dates and timezones.
 :::
@@ -184,7 +184,7 @@ const date2 = DateTime.fromISO('2022-04-17T15:30', { zone: 'UTC' });
 const date3 = DateTime.fromSQL('2022-04-17 15:30:00', { zone: 'UTC' });
 ```
 
-Please check out the documentation of the [UTC and timezone on Luxon](https://moment.github.io/luxon/#/zones) for more details.
+Please check out the documentation of the [UTC and timezones on Luxon](https://moment.github.io/luxon/#/zones) for more details.
 :::
 
 You can then pass your UTC date to your picker:
@@ -234,7 +234,7 @@ const date1 = DateTime.fromISO('2022-04-17T15:30', { zone: 'America/New_York' })
 const date2 = DateTime.fromSQL('2022-04-17 15:30:00', { zone: 'America/New_York' });
 ```
 
-Please check out the documentation of the [UTC and timezone on Luxon](https://moment.github.io/luxon/#/zones) for more details.
+Please check out the documentation of the [UTC and timezones on Luxon](https://moment.github.io/luxon/#/zones) for more details.
 :::
 
 You can then pass your date in the wanted timezone to your picker:
@@ -262,7 +262,7 @@ function App() {
 {{"demo": "LuxonTimezone.js", "defaultCodeOpen": false}}
 
 :::info
-Please check out the documentation of the [UTC and timezone on Luxon](https://moment.github.io/luxon/#/zones) for more details on how to manipulate the timezones.
+Please check out the documentation of the [UTC and timezones on Luxon](https://moment.github.io/luxon/#/zones) for more details on how to manipulate the timezones.
 :::
 
 ## Usage with Moment

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -354,7 +354,7 @@ const pages: MuiPage[] = [
           },
           {
             pathname: '/x/react-date-pickers/timezone',
-            title: 'UTC and timezone',
+            title: 'UTC and timezones',
           },
           { pathname: '/x/react-date-pickers/calendar-systems' },
         ],


### PR DESCRIPTION
I was initially confused to not see the same thing between sidenav and h1

<img width="810" alt="SCR-20240818-bomm" src="https://github.com/user-attachments/assets/9b875007-d337-4f2f-a21b-81515a15b70b">

and went on to update the other instances.