### PR TITLE
[DataGrid] fix boolean `is` filter operator

### DIFF
--- a/packages/x-data-grid/src/colDef/gridBooleanOperators.ts
+++ b/packages/x-data-grid/src/colDef/gridBooleanOperators.ts
@@ -6,7 +6,7 @@ export const getGridBooleanOperators = (): GridFilterOperator<any, boolean | nul
   {
     value: 'is',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (!filterItem.value) {
+      if (!filterItem.value && filterItem.value !== false) {
         return null;
       }
 

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
@@ -25,6 +25,19 @@ const BooleanOperatorContainer = styled('div')({
   },
 });
 
+/**
+ * Helper to convert a Boolean filter value to a string
+ * representation that can be used with the select component.
+ */
+const booleanFilterValueToString = (value: boolean | null) =>
+  !value && value !== false ? '' : String(value);
+
+/**
+ * Helper to convert the string values from the select component
+ * to a boolean value that can be used in the filter model.
+ */
+const stringToBooleanFilterValue = (value: string) => (value === '' ? null : value === 'true');
+
 function GridFilterInputBoolean(props: GridFilterInputBooleanProps) {
   const {
     item,
@@ -39,7 +52,10 @@ function GridFilterInputBoolean(props: GridFilterInputBooleanProps) {
     InputLabelProps,
     ...others
   } = props;
-  const [filterValueState, setFilterValueState] = React.useState(item.value || '');
+
+  const [filterValueState, setFilterValueState] = React.useState(
+    booleanFilterValueToString(item.value),
+  );
   const rootProps = useGridRootProps();
 
   const labelId = useId();
@@ -54,13 +70,18 @@ function GridFilterInputBoolean(props: GridFilterInputBooleanProps) {
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const value = event.target.value;
       setFilterValueState(value);
-      applyValue({ ...item, value });
+      applyValue({
+        ...item,
+        // Convert the string select value to a boolean or null
+        value: stringToBooleanFilterValue(value),
+      });
     },
     [applyValue, item],
   );
 
   React.useEffect(() => {
-    setFilterValueState(item.value || '');
+    // Convert the boolean or null value to a string for the select component
+    setFilterValueState(booleanFilterValueToString(item.value));
   }, [item.value]);
 
   const label = labelProp ?? apiRef.current.getLocaleText('filterPanelInputLabel');


### PR DESCRIPTION
1. Fixes the `is` filter operator for boolean columns to filter for the `false` value correctly (previously, this would clear the filter)
2. Fixes boolean filter values to be set as boolean values instead of strings by `<GridFilterInputBoolean />`

Fixes [#14076](https://github.com/mui/mui-x/issues/14076)


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Note:

The contribution doc (which redirects to the main MUI repo) recommends checking out `next` and raising PRs on to that. I tried doing that but realised the convention was to raise it on `master` based on recently merged PRs. Hope this works!
