### PR TITLE
[pickers] Feature for Farsi digits format

### DIFF
--- a/packages/x-date-pickers/src/locales/faIR.ts
+++ b/packages/x-date-pickers/src/locales/faIR.ts
@@ -2,6 +2,11 @@ import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
 import { TimeViewWithMeridiem } from '../internals/models';
 
+const latinToPersianDigits = (str) => {
+  const persianDigits = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
+  return str.replace(/\d/g, (digit) => persianDigits[parseInt(digit, 10)])
+}
+
 const timeViews: Record<TimeViewWithMeridiem, string> = {
   hours: 'ساعت‌ها',
   minutes: 'دقیقه‌ها',
@@ -45,18 +50,18 @@ const faIRPickers: Partial<PickersLocaleText<any>> = {
   // Clock labels
   clockLabelText: (view, time, adapter) =>
     ` را انتخاب کنید ${timeViews[view]}. ${time === null ? 'هیچ ساعتی انتخاب نشده است' : `ساعت انتخاب ${adapter.format(time, 'fullTime')} می باشد`}`,
-  hoursClockNumberText: (hours) => `${hours} ساعت‌ها`,
-  minutesClockNumberText: (minutes) => `${minutes} دقیقه‌ها`,
-  secondsClockNumberText: (seconds) => `${seconds} ثانیه‌ها`,
+  hoursClockNumberText: (hours) => `${latinToPersianDigits(hours)} ساعت‌ها`,
+  minutesClockNumberText: (minutes) => `${latinToPersianDigits(minutes)} دقیقه‌ها`,
+  secondsClockNumberText: (seconds) => `${latinToPersianDigits(seconds)} ثانیه‌ها`,
 
   // Digital clock labels
   selectViewText: (view) => ` را انتخاب کنید ${timeViews[view]}`,
 
   // Calendar labels
   calendarWeekNumberHeaderLabel: 'عدد هفته',
-  calendarWeekNumberHeaderText: '#',
-  calendarWeekNumberAriaLabelText: (weekNumber) => `هفته ${weekNumber}`,
-  calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
+  calendarWeekNumberHeaderText: latinToPersianDigits('#'),
+  calendarWeekNumberAriaLabelText: (weekNumber) => `هفته ${latinToPersianDigits(weekNumber)}`,
+  calendarWeekNumberText: (weekNumber) => `${latinToPersianDigits(weekNumber)}`,
 
   // Open picker labels
   openDatePickerDialogue: (value, utils) =>

--- a/packages/x-date-pickers/src/locales/faIR.ts
+++ b/packages/x-date-pickers/src/locales/faIR.ts
@@ -2,10 +2,10 @@ import { PickersLocaleText } from './utils/pickersLocaleTextApi';
 import { getPickersLocalization } from './utils/getPickersLocalization';
 import { TimeViewWithMeridiem } from '../internals/models';
 
-const latinToPersianDigits = (str) => {
+const latinToPersianDigits = (str: string) => {
   const persianDigits = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
-  return str.replace(/\d/g, (digit) => persianDigits[parseInt(digit, 10)])
-}
+  return str.replace(/\d/g, (digit: string) => persianDigits[parseInt(digit, 10)]);
+};
 
 const timeViews: Record<TimeViewWithMeridiem, string> = {
   hours: 'ساعت‌ها',
@@ -59,9 +59,10 @@ const faIRPickers: Partial<PickersLocaleText<any>> = {
 
   // Calendar labels
   calendarWeekNumberHeaderLabel: 'عدد هفته',
-  calendarWeekNumberHeaderText: latinToPersianDigits('#'),
-  calendarWeekNumberAriaLabelText: (weekNumber) => `هفته ${latinToPersianDigits(weekNumber)}`,
-  calendarWeekNumberText: (weekNumber) => `${latinToPersianDigits(weekNumber)}`,
+  calendarWeekNumberHeaderText: '#',
+  calendarWeekNumberAriaLabelText: (weekNumber) =>
+    `هفته ${latinToPersianDigits(weekNumber.toString())}`,
+  calendarWeekNumberText: (weekNumber) => `${latinToPersianDigits(weekNumber.toString())}`,
 
   // Open picker labels
   openDatePickerDialogue: (value, utils) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Added a function to convert Latin digits to Farsi ones

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
