### PR TITLE
[DateTimeRangePicker] Fix date format resolving from views on 24hr locales

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
@@ -173,7 +173,7 @@ const DesktopDateTimeRangePicker = React.forwardRef(function DesktopDateTimeRang
     ...defaultizedProps,
     views,
     viewRenderers,
-    format: resolveDateTimeFormat(utils, defaultizedProps),
+    format: resolveDateTimeFormat(utils, defaultizedProps, true),
     // force true to correctly handle `renderTimeViewClock` as a renderer
     ampmInClock: true,
     calendars: defaultizedProps.calendars ?? 1,

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
@@ -172,7 +172,7 @@ const MobileDateTimeRangePicker = React.forwardRef(function MobileDateTimeRangeP
   const props = {
     ...defaultizedProps,
     viewRenderers,
-    format: resolveDateTimeFormat(utils, defaultizedProps),
+    format: resolveDateTimeFormat(utils, defaultizedProps, true),
     // Force one calendar on mobile to avoid layout issues
     calendars: 1,
     // force true to correctly handle `renderTimeViewClock` as a renderer

--- a/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
@@ -22,14 +22,12 @@ export const resolveDateTimeFormat = <TDate extends PickerValidDate>(
     format?: string;
     views: readonly DateOrTimeViewWithMeridiem[];
     ampm: boolean;
-    value?: TDate | [TDate | null, TDate | null] | null;
   },
+  ignoreDateResolving?: boolean,
 ) => {
   if (format) {
     return format;
   }
-
-  const { value } = other;
 
   const dateViews: DateView[] = [];
   const timeViews: TimeView[] = [];
@@ -51,8 +49,8 @@ export const resolveDateTimeFormat = <TDate extends PickerValidDate>(
   }
 
   const timeFormat = resolveTimeFormat(utils, { views: timeViews, ...other });
-  const dateFormat = Array.isArray(value)
-    ? utils.formats.keyboardDate // default for DateTimeRangePicker
+  const dateFormat = ignoreDateResolving
+    ? utils.formats.keyboardDate
     : resolveDateFormat(utils, { views: dateViews, ...other }, false);
 
   return `${dateFormat} ${timeFormat}`;

--- a/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
@@ -22,7 +22,7 @@ export const resolveDateTimeFormat = <TDate extends PickerValidDate>(
     format?: string;
     views: readonly DateOrTimeViewWithMeridiem[];
     ampm: boolean;
-    value: TDate | TDate[];
+    value?: TDate | [TDate | null, TDate | null] | null;
   },
 ) => {
   if (format) {

--- a/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
@@ -7,7 +7,7 @@ import {
   TimeView,
 } from '../../models';
 import { resolveTimeFormat, isTimeView, isInternalTimeView } from './time-utils';
-import { resolveDateFormat } from './date-utils';
+import { isDatePickerView, resolveDateFormat } from './date-utils';
 import { DateOrTimeViewWithMeridiem } from '../models';
 import { DesktopOnlyTimePickerProps } from '../models/props/clock';
 import { DefaultizedProps } from '../models/helpers';
@@ -37,7 +37,7 @@ export const resolveDateTimeFormat = <TDate extends PickerValidDate>(
   views.forEach((view) => {
     if (isTimeView(view)) {
       timeViews.push(view as TimeView);
-    } else {
+    } else if (isDatePickerView(view)) {
       dateViews.push(view as DateView);
     }
   });

--- a/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
@@ -18,11 +18,18 @@ export const resolveDateTimeFormat = <TDate extends PickerValidDate>(
     views,
     format,
     ...other
-  }: { format?: string; views: readonly DateOrTimeViewWithMeridiem[]; ampm: boolean },
+  }: {
+    format?: string;
+    views: readonly DateOrTimeViewWithMeridiem[];
+    ampm: boolean;
+    value: TDate | TDate[];
+  },
 ) => {
   if (format) {
     return format;
   }
+
+  const { value } = other;
 
   const dateViews: DateView[] = [];
   const timeViews: TimeView[] = [];
@@ -44,7 +51,9 @@ export const resolveDateTimeFormat = <TDate extends PickerValidDate>(
   }
 
   const timeFormat = resolveTimeFormat(utils, { views: timeViews, ...other });
-  const dateFormat = resolveDateFormat(utils, { views: dateViews, ...other }, false);
+  const dateFormat = Array.isArray(value)
+    ? utils.formats.keyboardDate // default for DateTimeRangePicker
+    : resolveDateFormat(utils, { views: dateViews, ...other }, false);
 
   return `${dateFormat} ${timeFormat}`;
 };

--- a/packages/x-date-pickers/src/internals/utils/date-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.ts
@@ -177,7 +177,7 @@ export const resolveDateFormat = <TDate extends PickerValidDate>(
   }
 
   if (areViewsEqual(views, ['day'])) {
-    return formats.dayOfMonth;
+    return formats.keyboardDate;
   }
 
   if (areViewsEqual(views, ['month', 'year'])) {

--- a/packages/x-date-pickers/src/internals/utils/date-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-utils.ts
@@ -177,7 +177,7 @@ export const resolveDateFormat = <TDate extends PickerValidDate>(
   }
 
   if (areViewsEqual(views, ['day'])) {
-    return formats.keyboardDate;
+    return formats.dayOfMonth;
   }
 
   if (areViewsEqual(views, ['month', 'year'])) {


### PR DESCRIPTION
Fixes #14334.
For `DateTimeRangePickers` the ["day"] case returns an incorrect format.