### PR TITLE
[code-infra] Update Babel config to match closer to Core

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -122,6 +122,9 @@ module.exports = function getBabelConfig(api) {
   return {
     assumptions: {
       noDocumentAll: true,
+      setPublicClassFields: true,
+      privateFieldsAsProperties: true,
+      objectRestNoSymbols: true,
       setSpreadProperties: true,
     },
     presets,

--- a/babel.config.js
+++ b/babel.config.js
@@ -58,12 +58,6 @@ module.exports = function getBabelConfig(api) {
 
   const plugins = [
     'babel-plugin-optimize-clsx',
-    // Need the following 3 transforms for all targets in .browserslistrc.
-    // With our usage the transpiled loose mode is equivalent to spec mode.
-    ['@babel/plugin-transform-class-properties', { loose: true }],
-    ['@babel/plugin-transform-private-methods', { loose: true }],
-    ['@babel/plugin-transform-private-property-in-object', { loose: true }],
-    ['@babel/plugin-transform-object-rest-spread', { loose: true }],
     [
       '@babel/plugin-transform-runtime',
       {
@@ -128,11 +122,7 @@ module.exports = function getBabelConfig(api) {
   return {
     assumptions: {
       noDocumentAll: true,
-      // TODO: Replace "loose" mode with these:
-      // setPublicClassFields: true,
-      // privateFieldsAsProperties: true,
-      // objectRestNoSymbols: true,
-      // setSpreadProperties: true,
+      setSpreadProperties: true,
     },
     presets,
     plugins,

--- a/babel.config.js
+++ b/babel.config.js
@@ -122,9 +122,9 @@ module.exports = function getBabelConfig(api) {
   return {
     assumptions: {
       noDocumentAll: true,
-      setPublicClassFields: true,
-      privateFieldsAsProperties: true,
-      objectRestNoSymbols: true,
+      // setPublicClassFields: true,
+      // privateFieldsAsProperties: true,
+      // objectRestNoSymbols: true,
       setSpreadProperties: true,
     },
     presets,


### PR DESCRIPTION
Replicate https://github.com/mui/material-ui/pull/43286. I got confused by this comment: "This change is already done in X but I haven't had time to do it here as well." I didn't see where.

Preview: https://deploy-preview-14350--material-ui-x.netlify.app/x/react-data-grid/