### PR TITLE
[code-infra] Typecheck nested folders in playground

### DIFF
--- a/docs/pages/playground/tsconfig.json
+++ b/docs/pages/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["*"],
+  "include": ["**/*"],
   "exclude": []
 }


### PR DESCRIPTION
I use `playground/components` for some reusable testing components, and they are full of red squiggly lines. NO MORE!