### PR TITLE
[core] Avoid visual regression when using `@mui/material@6`

### DIFF
--- a/docs/data/data-grid/row-height/ExpandableCells.js
+++ b/docs/data/data-grid/row-height/ExpandableCells.js
@@ -34,7 +34,7 @@ function ExpandableCell({ value }) {
         <Link
           type="button"
           component="button"
-          sx={{ fontSize: 'inherit' }}
+          sx={{ fontSize: 'inherit', letterSpacing: 'inherit' }}
           onClick={() => setExpanded(!expanded)}
         >
           {expanded ? 'view less' : 'view more'}

--- a/docs/data/data-grid/row-height/ExpandableCells.tsx
+++ b/docs/data/data-grid/row-height/ExpandableCells.tsx
@@ -39,7 +39,7 @@ function ExpandableCell({ value }: GridRenderCellParams) {
         <Link
           type="button"
           component="button"
-          sx={{ fontSize: 'inherit' }}
+          sx={{ fontSize: 'inherit', letterSpacing: 'inherit' }}
           onClick={() => setExpanded(!expanded)}
         >
           {expanded ? 'view less' : 'view more'}

--- a/docs/data/date-pickers/custom-field/BrowserV6Field.js
+++ b/docs/data/date-pickers/custom-field/BrowserV6Field.js
@@ -33,6 +33,9 @@ const BrowserField = React.forwardRef((props, ref) => {
         {
           display: 'flex',
           alignItems: 'center',
+          '& .MuiInputAdornment-root': {
+            height: 'auto',
+          },
         },
         sx || {},
       ]}

--- a/docs/data/date-pickers/custom-field/BrowserV6Field.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV6Field.tsx
@@ -63,6 +63,9 @@ const BrowserField = React.forwardRef(
           {
             display: 'flex',
             alignItems: 'center',
+            '& .MuiInputAdornment-root': {
+              height: 'auto',
+            },
           },
           sx || {},
         ]}

--- a/docs/data/date-pickers/custom-field/BrowserV6SingleInputRangeField.js
+++ b/docs/data/date-pickers/custom-field/BrowserV6SingleInputRangeField.js
@@ -63,7 +63,7 @@ const BrowserSingleInputDateRangeField = React.forwardRef((props, ref) => {
   textFieldProps.InputProps = {
     ...textFieldProps.InputProps,
     endAdornment: (
-      <InputAdornment position="end">
+      <InputAdornment position="end" sx={{ height: 'auto' }}>
         <IconButton onClick={onAdornmentClick}>
           <DateRangeIcon />
         </IconButton>

--- a/docs/data/date-pickers/custom-field/BrowserV6SingleInputRangeField.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV6SingleInputRangeField.tsx
@@ -118,7 +118,7 @@ const BrowserSingleInputDateRangeField = React.forwardRef(
     textFieldProps.InputProps = {
       ...textFieldProps.InputProps,
       endAdornment: (
-        <InputAdornment position="end">
+        <InputAdornment position="end" sx={{ height: 'auto' }}>
           <IconButton onClick={onAdornmentClick}>
             <DateRangeIcon />
           </IconButton>

--- a/docs/data/date-pickers/custom-field/BrowserV7Field.js
+++ b/docs/data/date-pickers/custom-field/BrowserV7Field.js
@@ -13,6 +13,9 @@ import { Unstable_PickersSectionList as PickersSectionList } from '@mui/x-date-p
 const BrowserFieldRoot = styled('div', { name: 'BrowserField', slot: 'Root' })({
   display: 'flex',
   alignItems: 'center',
+  '& .MuiInputAdornment-root': {
+    height: 'auto',
+  },
 });
 
 const BrowserFieldContent = styled('div', { name: 'BrowserField', slot: 'Content' })(

--- a/docs/data/date-pickers/custom-field/BrowserV7Field.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV7Field.tsx
@@ -21,6 +21,9 @@ import { Unstable_PickersSectionList as PickersSectionList } from '@mui/x-date-p
 const BrowserFieldRoot = styled('div', { name: 'BrowserField', slot: 'Root' })({
   display: 'flex',
   alignItems: 'center',
+  '& .MuiInputAdornment-root': {
+    height: 'auto',
+  },
 });
 
 const BrowserFieldContent = styled('div', { name: 'BrowserField', slot: 'Content' })(

--- a/docs/data/date-pickers/custom-field/BrowserV7SingleInputRangeField.js
+++ b/docs/data/date-pickers/custom-field/BrowserV7SingleInputRangeField.js
@@ -16,6 +16,9 @@ import { Unstable_PickersSectionList as PickersSectionList } from '@mui/x-date-p
 const BrowserFieldRoot = styled('div', { name: 'BrowserField', slot: 'Root' })({
   display: 'flex',
   alignItems: 'center',
+  '& .MuiInputAdornment-root': {
+    height: 'auto',
+  },
 });
 
 const BrowserFieldContent = styled('div', { name: 'BrowserField', slot: 'Content' })(

--- a/docs/data/date-pickers/custom-field/BrowserV7SingleInputRangeField.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV7SingleInputRangeField.tsx
@@ -30,6 +30,9 @@ import { BaseSingleInputFieldProps } from '@mui/x-date-pickers/models';
 const BrowserFieldRoot = styled('div', { name: 'BrowserField', slot: 'Root' })({
   display: 'flex',
   alignItems: 'center',
+  '& .MuiInputAdornment-root': {
+    height: 'auto',
+  },
 });
 
 const BrowserFieldContent = styled('div', { name: 'BrowserField', slot: 'Content' })(


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-x/pull/14142

When running visual regression tests with `@mui/material@6` we had 5 demos with visual diffs: https://app.argos-ci.com/mui/mui-x/builds/23408

This PR applies styles to ensure that these 5 demos have no visual differences between `@mui/material@5` and `@mui/material@6`.
The goal is to avoid manually checking the screenshots for false negatives.