### PR TITLE
[core] Remove renovate rule targeting only `next` releases of `@mui/docs`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -107,11 +107,6 @@
     {
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"]
-    },
-    {
-      "groupName": "@mui/docs",
-      "matchPackageNames": ["@mui/docs"],
-      "followTag": "next"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
It's no longer necessary given that `@mui/docs` is going to be released with the `latest` tag from now on.
https://www.npmjs.com/package/@mui/docs?activeTab=versions