### PR TITLE
[DataGridPro] Fix double top border in header filters

### DIFF
--- a/packages/x-data-grid/src/components/GridScrollbarFillerCell.tsx
+++ b/packages/x-data-grid/src/components/GridScrollbarFillerCell.tsx
@@ -5,16 +5,19 @@ import { gridClasses } from '../constants';
 const classes = {
   root: gridClasses.scrollbarFiller,
   header: gridClasses['scrollbarFiller--header'],
+  borderTop: gridClasses['scrollbarFiller--borderTop'],
   borderBottom: gridClasses['scrollbarFiller--borderBottom'],
   pinnedRight: gridClasses['scrollbarFiller--pinnedRight'],
 };
 
 function GridScrollbarFillerCell({
   header,
-  borderBottom = true,
+  borderTop = true,
+  borderBottom,
   pinnedRight,
 }: {
   header?: boolean;
+  borderTop?: boolean;
   borderBottom?: boolean;
   pinnedRight?: boolean;
 }) {
@@ -24,6 +27,7 @@ function GridScrollbarFillerCell({
       className={clsx(
         classes.root,
         header && classes.header,
+        borderTop && classes.borderTop,
         borderBottom && classes.borderBottom,
         pinnedRight && classes.pinnedRight,
       )}

--- a/packages/x-data-grid/src/components/GridScrollbarFillerCell.tsx
+++ b/packages/x-data-grid/src/components/GridScrollbarFillerCell.tsx
@@ -5,17 +5,17 @@ import { gridClasses } from '../constants';
 const classes = {
   root: gridClasses.scrollbarFiller,
   header: gridClasses['scrollbarFiller--header'],
-  borderTop: gridClasses['scrollbarFiller--borderTop'],
+  borderBottom: gridClasses['scrollbarFiller--borderBottom'],
   pinnedRight: gridClasses['scrollbarFiller--pinnedRight'],
 };
 
 function GridScrollbarFillerCell({
   header,
-  borderTop = true,
+  borderBottom = true,
   pinnedRight,
 }: {
   header?: boolean;
-  borderTop?: boolean;
+  borderBottom?: boolean;
   pinnedRight?: boolean;
 }) {
   return (
@@ -24,7 +24,7 @@ function GridScrollbarFillerCell({
       className={clsx(
         classes.root,
         header && classes.header,
-        borderTop && classes.borderTop,
+        borderBottom && classes.borderBottom,
         pinnedRight && classes.pinnedRight,
       )}
     />

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -429,7 +429,7 @@ export const GridRootStyles = styled('div', {
     [`& .${c.headerFilterRow}`]: {
       [`& .${c.columnHeader}`]: {
         boxSizing: 'border-box',
-        borderTop: '1px solid var(--DataGrid-rowBorderColor)',
+        borderBottom: '1px solid var(--DataGrid-rowBorderColor)',
       },
     },
 
@@ -686,8 +686,8 @@ export const GridRootStyles = styled('div', {
     [`& .${c.filler}`]: {
       flex: 1,
     },
-    [`& .${c['filler--borderTop']}`]: {
-      borderTop: '1px solid var(--DataGrid-rowBorderColor)',
+    [`& .${c['filler--borderBottom']}`]: {
+      borderBottom: '1px solid var(--DataGrid-rowBorderColor)',
     },
 
     /* Hide grid rows, row filler, and vertical scrollbar when skeleton overlay is visible */

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -492,7 +492,7 @@ export const GridRootStyles = styled('div', {
       borderTopColor: 'transparent',
     },
     [`& .${c['pinnedRows--top']} :first-of-type`]: {
-      [`& .${c.cell}, .${c['scrollbarFiller']}`]: {
+      [`& .${c.cell}, .${c.scrollbarFiller}`]: {
         borderTop: 'none',
       },
     },

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -673,8 +673,8 @@ export const GridRootStyles = styled('div', {
     [`.${c.scrollbarFiller}`]: {
       minWidth: 'calc(var(--DataGrid-hasScrollY) * var(--DataGrid-scrollbarSize))',
       alignSelf: 'stretch',
-      [`&.${c['scrollbarFiller--borderTop']}`]: {
-        borderTop: '1px solid var(--rowBorderColor)',
+      [`&.${c['scrollbarFiller--borderBottom']}`]: {
+        borderBottom: '1px solid var(--DataGrid-rowBorderColor)',
       },
       [`&.${c['scrollbarFiller--pinnedRight']}`]: {
         backgroundColor: 'var(--DataGrid-pinnedBackground)',

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -491,6 +491,11 @@ export const GridRootStyles = styled('div', {
     [`& .${c['virtualScrollerContent--overflowed']} .${c['row--lastVisible']} .${c.cell}`]: {
       borderTopColor: 'transparent',
     },
+    [`& .${c['pinnedRows--top']} :first-of-type`]: {
+      [`& .${c.cell}, .${c['scrollbarFiller']}`]: {
+        borderTop: 'none',
+      },
+    },
     [`&.${c['root--disableUserSelection']} .${c.cell}`]: {
       userSelect: 'none',
     },
@@ -673,6 +678,9 @@ export const GridRootStyles = styled('div', {
     [`.${c.scrollbarFiller}`]: {
       minWidth: 'calc(var(--DataGrid-hasScrollY) * var(--DataGrid-scrollbarSize))',
       alignSelf: 'stretch',
+      [`&.${c['scrollbarFiller--borderTop']}`]: {
+        borderTop: '1px solid var(--DataGrid-rowBorderColor)',
+      },
       [`&.${c['scrollbarFiller--borderBottom']}`]: {
         borderBottom: '1px solid var(--DataGrid-rowBorderColor)',
       },

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -543,6 +543,11 @@ export interface GridClasses {
   'scrollbarFiller--header': string;
   /**
    * @ignore - do not document.
+   * Styles applied to the scrollbar filler cell, with a border top.
+   */
+  'scrollbarFiller--borderTop': string;
+  /**
+   * @ignore - do not document.
    * Styles applied to the scrollbar filler cell, with a border bottom.
    */
   'scrollbarFiller--borderBottom': string;
@@ -763,6 +768,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'scrollbar--horizontal',
   'scrollbarFiller',
   'scrollbarFiller--header',
+  'scrollbarFiller--borderTop',
   'scrollbarFiller--borderBottom',
   'scrollbarFiller--pinnedRight',
   'selectedRowCount',

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -543,9 +543,9 @@ export interface GridClasses {
   'scrollbarFiller--header': string;
   /**
    * @ignore - do not document.
-   * Styles applied to the scrollbar filler cell, with a border top.
+   * Styles applied to the scrollbar filler cell, with a border bottom.
    */
-  'scrollbarFiller--borderTop': string;
+  'scrollbarFiller--borderBottom': string;
   /**
    * @ignore - do not document.
    * Styles applied to the scrollbar filler cell.
@@ -763,7 +763,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'scrollbar--horizontal',
   'scrollbarFiller',
   'scrollbarFiller--header',
-  'scrollbarFiller--borderTop',
+  'scrollbarFiller--borderBottom',
   'scrollbarFiller--pinnedRight',
   'selectedRowCount',
   'sortIcon',

--- a/packages/x-data-grid/src/constants/gridClasses.ts
+++ b/packages/x-data-grid/src/constants/gridClasses.ts
@@ -297,10 +297,10 @@ export interface GridClasses {
    */
   filler: string;
   /**
-   * Styles applied to the filler row with top border.
+   * Styles applied to the filler row with bottom border.
    * @ignore - do not document.
    */
-  'filler--borderTop': string;
+  'filler--borderBottom': string;
   /**
    * Styles applied to the filler row pinned left section.
    * @ignore - do not document.
@@ -709,7 +709,7 @@ export const gridClasses = generateUtilityClasses<GridClassKey>('MuiDataGrid', [
   'editBooleanCell',
   'editInputCell',
   'filler',
-  'filler--borderTop',
+  'filler--borderBottom',
   'filler--pinnedLeft',
   'filler--pinnedRight',
   'filterForm',

--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -28,7 +28,6 @@ import {
   gridColumnPositionsSelector,
   gridVisiblePinnedColumnDefinitionsSelector,
 } from '../columns';
-import { gridPinnedRowsSelector } from '../rows/gridRowsSelector';
 import { GridGroupingStructure } from '../columnGrouping/gridColumnGroupsInterfaces';
 import { gridColumnGroupsUnwrappedModelSelector } from '../columnGrouping/gridColumnGroupsSelector';
 import { GridScrollbarFillerCell as ScrollbarFiller } from '../../../components/GridScrollbarFillerCell';
@@ -106,7 +105,6 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
   const columnPositions = useGridSelector(apiRef, gridColumnPositionsSelector);
   const renderContext = useGridSelector(apiRef, gridRenderContextColumnsSelector);
   const pinnedColumns = useGridSelector(apiRef, gridVisiblePinnedColumnDefinitionsSelector);
-  const pinnedRows = useGridSelector(apiRef, gridPinnedRowsSelector);
   const offsetLeft = computeOffsetLeft(
     columnPositions,
     renderContext,

--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -183,7 +183,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
     params: GetHeadersParams | undefined,
     children: React.ReactNode,
     leftOverflow: number,
-    borderTop: boolean = false,
+    borderBottom: boolean = false,
   ) => {
     const isPinnedRight = params?.position === GridPinnedColumnPosition.RIGHT;
     const isNotPinned = params?.position === undefined;
@@ -201,12 +201,13 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         {isNotPinned && (
           <div
             role="presentation"
-            className={clsx(gridClasses.filler, borderTop && gridClasses['filler--borderTop'])}
+            className={clsx(
+              gridClasses.filler,
+              borderBottom && gridClasses['filler--borderBottom'],
+            )}
           />
         )}
-        {hasScrollbarFiller && (
-          <ScrollbarFiller header borderTop={borderTop} pinnedRight={isPinnedRight} />
-        )}
+        {hasScrollbarFiller && <ScrollbarFiller header pinnedRight={isPinnedRight} />}
       </React.Fragment>
     );
   };

--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -207,7 +207,14 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
             )}
           />
         )}
-        {hasScrollbarFiller && <ScrollbarFiller header pinnedRight={isPinnedRight} />}
+        {hasScrollbarFiller && (
+          <ScrollbarFiller
+            header
+            pinnedRight={isPinnedRight}
+            borderBottom={borderBottom}
+            borderTop={false}
+          />
+        )}
       </React.Fragment>
     );
   };
@@ -301,7 +308,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         role="row"
         aria-rowindex={headerGroupingMaxDepth + 1}
         ownerState={rootProps}
-        className={pinnedRows.top.length === 0 ? gridClasses['row--borderBottom'] : undefined}
+        className={gridClasses['row--borderBottom']}
       >
         {leftRenderContext &&
           getColumnHeaders(


### PR DESCRIPTION
Spotted while working on #14373 

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5df35892-c3ca-49d7-bf3d-9909e91e0638) | ![image](https://github.com/user-attachments/assets/dcf23510-2a41-478e-b5d9-dfda0d993f1b) |

Before Preview: https://deploy-preview-14366--material-ui-x.netlify.app/x/react-data-grid/filtering/header-filters/
After Preview: https://deploy-preview-14375--material-ui-x.netlify.app/x/react-data-grid/filtering/header-filters/

### Fixes

1. Double top border in header filters
2. Messed up scrollbar fillers' borders