### PR TITLE
[core] Allow only v5.x for `MUI Core` renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -90,7 +90,8 @@
         "@mui/system",
         "@mui/types",
         "@mui/utils"
-      ]
+      ],
+      "allowedVersions": "< 6.0.0"
     },
     {
       "groupName": "MUI Internal",


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/pull/14363.
While and if we stick to using `v5.x` to avoid the noise from renovate. 👍 