### PR TITLE
[DataGrid] Reduce dev checks

### DIFF
--- a/packages/x-data-grid/src/utils/createSelector.ts
+++ b/packages/x-data-grid/src/utils/createSelector.ts
@@ -11,6 +11,10 @@ const reselectCreateSelector = createSelectorCreator({
     maxSize: 1,
     equalityCheck: Object.is,
   },
+  devModeChecks: {
+    inputStabilityCheck: 'once',
+    identityFunctionCheck: 'once',
+  },
 });
 
 // TODO v8: Remove this type


### PR DESCRIPTION
Follow-up of https://github.com/mui/mui-x/pull/14410#discussion_r1738858426

Reselect creates [a full memoized selector](https://github.com/reduxjs/reselect/blob/88e7ffd7d46a1aebf866210075c322a0f424bbe1/src/devModeChecks/inputStabilityCheck.ts#L33) and a ton of allocations on every selector call in v5, I think dev mode will feel too slow in some cases with those changes.