### PR TITLE
[DateRangePicker] Fix `currentMonthCalendarPosition` not scrolling to future sibling

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.test.tsx
@@ -487,6 +487,23 @@ describe('<DateRangeCalendar />', () => {
       clock.runToLast();
       expect(getPickerDay('1', 'April 2018')).not.to.equal(null);
     });
+
+    describe('prop: currentMonthCalendarPosition', () => {
+      it('should switch to the selected month when changing value from the outside', () => {
+        const { setProps } = render(
+          <DateRangeCalendar
+            value={[adapterToUse.date('2018-01-10'), adapterToUse.date('2018-01-15')]}
+            currentMonthCalendarPosition={2}
+          />,
+        );
+
+        setProps({
+          value: [adapterToUse.date('2018-02-11'), adapterToUse.date('2018-02-22')],
+        });
+        clock.runToLast();
+        expect(getPickerDay('1', 'February 2018')).not.to.equal(null);
+      });
+    });
   });
 
   ['readOnly', 'disabled'].forEach((prop) => {

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -386,7 +386,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar<
       return;
     }
 
-    const displayingMonthRange = calendars - 1;
+    const displayingMonthRange = calendars - currentMonthCalendarPosition;
     const currentMonthNumber = utils.getMonth(calendarState.currentMonth);
     const requestedMonthNumber = utils.getMonth(date);
 

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/MobileDateRangePicker.test.tsx
@@ -92,7 +92,12 @@ describe('<MobileDateRangePicker />', () => {
       );
 
       // Open the picker
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'start',
+        click: user.click,
+      });
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
@@ -133,7 +138,12 @@ describe('<MobileDateRangePicker />', () => {
       );
 
       // Open the picker
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'end' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'end',
+        click: user.click,
+      });
       expect(onChange.callCount).to.equal(0);
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
@@ -165,7 +175,12 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'end' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'end',
+        click: user.click,
+      });
 
       // Change the end date
       await user.click(screen.getByRole('gridcell', { name: '3' }));
@@ -196,7 +211,12 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'start',
+        click: user.click,
+      });
 
       // Change the start date (already tested)
       await user.click(screen.getByRole('gridcell', { name: '3' }));
@@ -229,7 +249,12 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'start',
+        click: user.click,
+      });
 
       // Change the start date (already tested)
       await user.click(screen.getByRole('gridcell', { name: '3' }));
@@ -263,7 +288,12 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'start',
+        click: user.click,
+      });
 
       // Clear the date
       await user.click(screen.getByText(/clear/i));
@@ -290,7 +320,12 @@ describe('<MobileDateRangePicker />', () => {
         />,
       );
 
-      openPicker({ type: 'date-range', variant: 'mobile', initialFocus: 'start' });
+      await openPicker({
+        type: 'date-range',
+        variant: 'mobile',
+        initialFocus: 'start',
+        click: user.click,
+      });
 
       // Clear the date
       await user.click(screen.getByText(/clear/i));

--- a/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, createRenderer, act } from '@mui/internal-test-utils';
+import { screen, createRenderer } from '@mui/internal-test-utils';
 import { DateCalendar, dayCalendarClasses } from '@mui/x-date-pickers/DateCalendar';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { createPickerRenderer, AdapterName, availableAdapters } from 'test/utils/pickers';
@@ -39,10 +39,8 @@ describe('<DateCalendar /> - localization', () => {
           'Sunday',
         );
 
-        act(() => {
-          setProps({
-            adapterLocale: adapterName === 'date-fns' ? fr : 'fr',
-          });
+        setProps({
+          adapterLocale: adapterName === 'date-fns' ? fr : 'fr',
         });
 
         expect(document.querySelector(`.${dayCalendarClasses.weekDayLabel}`)!.ariaLabel).to.equal(

--- a/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/localization.DateCalendar.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { screen, createRenderer } from '@mui/internal-test-utils';
+import { screen, createRenderer, act } from '@mui/internal-test-utils';
 import { DateCalendar, dayCalendarClasses } from '@mui/x-date-pickers/DateCalendar';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { createPickerRenderer, AdapterName, availableAdapters } from 'test/utils/pickers';
@@ -39,8 +39,10 @@ describe('<DateCalendar /> - localization', () => {
           'Sunday',
         );
 
-        setProps({
-          adapterLocale: adapterName === 'date-fns' ? fr : 'fr',
+        act(() => {
+          setProps({
+            adapterLocale: adapterName === 'date-fns' ? fr : 'fr',
+          });
         });
 
         expect(document.querySelector(`.${dayCalendarClasses.weekDayLabel}`)!.ariaLabel).to.equal(


### PR DESCRIPTION
fixes #14418
