### PR TITLE
[infra] Added `secrets: inherit` to workflow call

### DIFF
--- a/.github/workflows/new-issue-triage.yml
+++ b/.github/workflows/new-issue-triage.yml
@@ -18,6 +18,7 @@ jobs:
     needs: issue_cleanup
     if: needs.issue_cleanup.outputs.orderId != ''
     uses: mui/mui-public/.github/workflows/issues_order-id-validation.yml@master
+    secrets: inherit
     with:
       orderId: ${{ needs.issue_cleanup.outputs.orderId }}
     permissions:


### PR DESCRIPTION
the last missing piece.
Even though the other workflow is being called from the same organisation and should have the same access to the secrets we need to explicitly pass this. A bit weird! 🤷🏼 