### PR TITLE
[DataGrid] Fix separator styles on touch devices

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -436,16 +436,17 @@ export const GridRootStyles = styled('div', {
     [`& .${c['columnSeparator--resizable']}`]: {
       cursor: 'col-resize',
       touchAction: 'none',
+      [`&.${c['columnSeparator--resizing']}`]: {
+        color: (t.vars || t).palette.primary.main,
+      },
       // Always appear as draggable on touch devices
       '@media (hover: none)': {
         [`& .${c.iconSeparator} rect`]: separatorIconDragStyles,
-        color: borderColor,
       },
-      [`&:hover, &.${c['columnSeparator--resizing']}`]: {
-        color: (t.vars || t).palette.primary.main,
-        [`& .${c.iconSeparator} rect`]: separatorIconDragStyles,
-        '@media (hover: none)': {
-          color: borderColor,
+      '@media (hover: hover)': {
+        '&:hover': {
+          color: (t.vars || t).palette.primary.main,
+          [`& .${c.iconSeparator} rect`]: separatorIconDragStyles,
         },
       },
       '& svg': {

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -299,12 +299,13 @@ export const GridRootStyles = styled('div', {
       `]: {
       [`& .${c.columnSeparator}`]: {
         opacity: 0,
-        '@media (hover: none)': {
+      },
+      // Show resizable separators at all times on touch devices
+      '@media (hover: none)': {
+        [`& .${c['columnSeparator--resizable']}`]: {
           opacity: 1,
-          color: (t.vars || t).palette.primary.main,
         },
       },
-      // Show resizable separators again when the column is hovered
       [`& .${c['columnSeparator--resizable']}:hover`]: {
         opacity: 1,
       },
@@ -411,6 +412,14 @@ export const GridRootStyles = styled('div', {
     },
     '@media (hover: none)': {
       [`& .${c.columnHeader}`]: columnHeaderStyles,
+      [`& .${c.columnHeader}:focus,
+        & .${c.columnHeader}:focus-within,
+        & .${c.columnHeader}:has(+ .${c.columnHeader}:focus),
+        & .${c.columnHeader}:has(+ .${c.columnHeader}:focus-within)`]: {
+        [`.${c['columnSeparator--resizable']}`]: {
+          color: (t.vars || t).palette.primary.main,
+        },
+      },
     },
     [`& .${c['columnSeparator--sideLeft']}`]: {
       left: columnSeparatorOffset,


### PR DESCRIPTION
Fixes a couple of issues found on touch devices, introduced here #14293

**Snag 1:** Double border caused by separator not being hidden when a cell is focused
| Before | After |
| --- | --- |
| <img width="386" alt="Screenshot 2024-09-03 at 21 13 36" src="https://github.com/user-attachments/assets/06397e0e-bb65-46e2-a78f-c2896e4b459d"> | <img width="387" alt="Screenshot 2024-09-03 at 21 13 27" src="https://github.com/user-attachments/assets/edc26bca-3013-4804-b8a5-0f2783cf4a1c"> |

**Snag 2:** Last separator always in "active" state
| Before | After |
| --- | --- |
| <img width="389" alt="Screenshot 2024-09-03 at 21 12 51" src="https://github.com/user-attachments/assets/4dc9c5dd-5d53-43c9-85a8-15ba65f474bf"> | <img width="387" alt="Screenshot 2024-09-03 at 21 13 00" src="https://github.com/user-attachments/assets/fe9defde-162f-42d4-bf6d-398496b181ba"> |


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
