### PR TITLE
[DataGrid] Fix Voice Over reading the column name twice

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
@@ -29,5 +29,5 @@ export const GRID_DETAIL_PANEL_TOGGLE_COL_DEF: GridColDef = {
     return expandedRowIds.includes(rowId);
   },
   renderCell: (params) => <GridDetailPanelToggleCell {...params} />,
-  renderHeader: (params) => <div aria-label={params.colDef.headerName} />,
+  renderHeader: ({ colDef }) => <div aria-label={colDef.headerName} />,
 };

--- a/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/detailPanel/gridDetailPanelToggleColDef.tsx
@@ -29,5 +29,5 @@ export const GRID_DETAIL_PANEL_TOGGLE_COL_DEF: GridColDef = {
     return expandedRowIds.includes(rowId);
   },
   renderCell: (params) => <GridDetailPanelToggleCell {...params} />,
-  renderHeader: () => null,
+  renderHeader: (params) => <div aria-label={params.colDef.headerName} />,
 };

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -36,7 +36,9 @@ const ColumnHeaderInnerTitle = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(function ColumnHeaderInnerTitle(props, ref) {
-  const { className, ...other } = props;
+  // Tooltip adds aria-label to the props, which is not needed since the children prop is a string
+  // See https://github.com/mui/mui-x/pull/14482
+  const { className, 'aria-label': ariaLabel, ...other } = props;
   const rootProps = useGridRootProps();
   const classes = useUtilityClasses(rootProps);
 

--- a/packages/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
@@ -109,7 +109,6 @@ const GridGenericColumnHeaderItem = React.forwardRef(function GridGenericColumnH
       tabIndex={tabIndex}
       aria-colindex={colIndex + 1}
       aria-sort={ariaSort}
-      aria-label={headerComponent == null ? label : undefined}
       {...other}
     >
       <div

--- a/packages/x-data-grid/src/tests/columnGrouping.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/columnGrouping.DataGrid.test.tsx
@@ -363,18 +363,16 @@ describe('<DataGrid /> - Column grouping', () => {
       fireEvent.click(screen.getByRole('button', { name: /Update columns/ }));
 
       const row1Headers = document.querySelectorAll<HTMLElement>(
-        '[aria-rowindex="1"] [role="columnheader"]',
+        '[aria-rowindex="1"] [role="columnheader"] .MuiDataGrid-columnHeaderTitle',
       );
       const row2Headers = document.querySelectorAll<HTMLElement>(
-        '[aria-rowindex="2"] [role="columnheader"]',
+        '[aria-rowindex="2"] [role="columnheader"] .MuiDataGrid-columnHeaderTitle',
       );
 
-      expect(
-        Array.from(row1Headers).map((header) => header.getAttribute('aria-label')),
-      ).to.deep.equal(['Group']);
-      expect(
-        Array.from(row2Headers).map((header) => header.getAttribute('aria-label')),
-      ).to.deep.equal(['field_1']);
+      expect(Array.from(row1Headers).map((header) => header.textContent)).to.deep.equal(['Group']);
+      expect(Array.from(row2Headers).map((header) => header.textContent)).to.deep.equal([
+        'field_1',
+      ]);
     });
   });
 


### PR DESCRIPTION
Fixes #9954 

`aria-label` was only added if the default header component was used (`GridColumnHeaderTitle`).
That component adds label as its content which is read by the voice over, so the `aria-label` is not needed at all.

