### PR TITLE
[DataGrid] Align grid cell tooltip with the column header

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -7,8 +7,10 @@ import {
   unstable_ownerDocument as ownerDocument,
   unstable_capitalize as capitalize,
 } from '@mui/utils';
+import { tooltipClasses, TooltipProps } from '@mui/material/Tooltip';
 import { fastMemo } from '@mui/x-internals/fastMemo';
 import { useRtl } from '@mui/system/RtlProvider';
+import { isOverflown } from '../../utils/domUtils';
 import { doesSupportPreventScroll } from '../../utils/doesSupportPreventScroll';
 import { getDataGridUtilityClass, gridClasses } from '../../constants/gridClasses';
 import {
@@ -76,6 +78,7 @@ export type GridCellProps = {
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   onDragEnter?: React.DragEventHandler<HTMLDivElement>;
   onDragOver?: React.DragEventHandler<HTMLDivElement>;
+  slotProps?: { tooltip?: Partial<TooltipProps> };
   [x: string]: any; // TODO v7: remove this - it breaks type safety
 };
 
@@ -175,12 +178,26 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
     onKeyUp,
     onDragEnter,
     onDragOver,
+    slotProps,
     ...other
   } = props;
 
   const apiRef = useGridApiContext();
   const rootProps = useGridRootProps();
   const isRtl = useRtl();
+  const tooltipProps = slotProps?.tooltip || {
+    slotProps: {
+      popper: {
+        sx: {
+          [`&.${tooltipClasses.popper}[data-popper-placement*="bottom"] .${tooltipClasses.tooltip}`]:
+            {
+              marginTop: '-5px',
+            },
+        },
+      },
+    },
+  };
+  const [tooltip, setTooltip] = React.useState<string | null>(null);
 
   const field = column.field;
 
@@ -331,6 +348,20 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
   const isCellRowSpanned = hiddenCells[rowId]?.[field] ?? false;
   const rowSpan = spannedCells[rowId]?.[field] ?? 1;
 
+  let cellText = tooltip;
+  const handleMouseOver = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
+    publish('cellMouseOver', onMouseOver);
+
+    if (cellText && cellRef?.current) {
+      const isOver = isOverflown(cellRef.current);
+      if (isOver && tooltip !== cellText) {
+        setTooltip(cellText);
+      } else if (!isOver && tooltip) {
+        setTooltip(null);
+      }
+    }
+  }, [tooltip, cellText, publish, onMouseOver]);
+
   const style = React.useMemo(() => {
     if (isNotVisible) {
       return {
@@ -433,7 +464,6 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
   }
 
   let children: React.ReactNode;
-  let title: string | undefined;
 
   if (editCellState === null && column.renderCell) {
     children = column.renderCell(cellParams);
@@ -464,7 +494,7 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
   if (children === undefined) {
     const valueString = valueToRender?.toString();
     children = valueString;
-    title = valueString;
+    cellText = valueString;
   }
 
   if (React.isValidElement(children) && canManageOwnFocus) {
@@ -479,31 +509,37 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
       };
 
   return (
-    <div
-      ref={handleRef}
-      className={clsx(classes.root, classNames, className)}
-      role="gridcell"
-      data-field={field}
-      data-colindex={colIndex}
-      aria-colindex={colIndex + 1}
-      aria-colspan={colSpan}
-      aria-rowspan={rowSpan}
-      style={style}
-      title={title}
-      tabIndex={tabIndex}
-      onClick={publish('cellClick', onClick)}
-      onDoubleClick={publish('cellDoubleClick', onDoubleClick)}
-      onMouseOver={publish('cellMouseOver', onMouseOver)}
-      onMouseDown={publishMouseDown('cellMouseDown')}
-      onMouseUp={publishMouseUp('cellMouseUp')}
-      onKeyDown={publish('cellKeyDown', onKeyDown)}
-      onKeyUp={publish('cellKeyUp', onKeyUp)}
-      {...draggableEventHandlers}
-      {...other}
-      onFocus={handleFocus}
+    <rootProps.slots.baseTooltip
+      title={tooltip}
+      enterDelay={1000}
+      {...tooltipProps}
+      {...rootProps.slotProps?.baseTooltip}
     >
-      {children}
-    </div>
+      <div
+        ref={handleRef}
+        className={clsx(classes.root, classNames, className)}
+        role="gridcell"
+        data-field={field}
+        data-colindex={colIndex}
+        aria-colindex={colIndex + 1}
+        aria-colspan={colSpan}
+        aria-rowspan={rowSpan}
+        style={style}
+        tabIndex={tabIndex}
+        onClick={publish('cellClick', onClick)}
+        onDoubleClick={publish('cellDoubleClick', onDoubleClick)}
+        onMouseOver={handleMouseOver}
+        onMouseDown={publishMouseDown('cellMouseDown')}
+        onMouseUp={publishMouseUp('cellMouseUp')}
+        onKeyDown={publish('cellKeyDown', onKeyDown)}
+        onKeyUp={publish('cellKeyUp', onKeyUp)}
+        {...draggableEventHandlers}
+        {...other}
+        onFocus={handleFocus}
+      >
+        {children}
+      </div>
+    </rootProps.slots.baseTooltip>
   );
 });
 
@@ -538,6 +574,7 @@ GridCell.propTypes = {
   rowId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   sectionIndex: PropTypes.number.isRequired,
   sectionLength: PropTypes.number.isRequired,
+  slotProps: PropTypes.object,
   width: PropTypes.number.isRequired,
 } as any;
 

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -349,18 +349,21 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
   const rowSpan = spannedCells[rowId]?.[field] ?? 1;
 
   let cellText = tooltip;
-  const handleMouseOver = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
-    publish('cellMouseOver', onMouseOver);
+  const handleMouseOver = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(
+    (event) => {
+      publish('cellMouseOver', onMouseOver)(event);
 
-    if (cellText && cellRef?.current) {
-      const isOver = isOverflown(cellRef.current);
-      if (isOver && tooltip !== cellText) {
-        setTooltip(cellText);
-      } else if (!isOver && tooltip) {
-        setTooltip(null);
+      if (cellText && cellRef?.current) {
+        const isOver = isOverflown(cellRef.current);
+        if (isOver && tooltip !== cellText) {
+          setTooltip(cellText);
+        } else if (!isOver && tooltip) {
+          setTooltip(null);
+        }
       }
-    }
-  }, [tooltip, cellText, publish, onMouseOver]);
+    },
+    [tooltip, cellText, publish, onMouseOver],
+  );
 
   const style = React.useMemo(() => {
     if (isNotVisible) {

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -179,6 +179,7 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
     onDragEnter,
     onDragOver,
     slotProps,
+    'aria-label': ariaLabel,
     ...other
   } = props;
 
@@ -527,6 +528,7 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
         aria-colindex={colIndex + 1}
         aria-colspan={colSpan}
         aria-rowspan={rowSpan}
+        aria-label={ariaLabel}
         style={style}
         tabIndex={tabIndex}
         onClick={publish('cellClick', onClick)}

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -30,6 +30,12 @@ const GridColumnHeaderTitleRoot = styled('div', {
   whiteSpace: 'nowrap',
   fontWeight: 'var(--unstable_DataGrid-headWeight)',
   lineHeight: 'normal',
+  // To prevent Safari adding its own tooltip for truncated text
+  // https://zzz.buzz/2017/07/31/prevent-tooltip-over-truncated-text-in-safari/
+  '::after': {
+    content: '""',
+    display: 'block',
+  },
 });
 
 const ColumnHeaderInnerTitle = React.forwardRef<

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -63,18 +63,18 @@ function GridColumnHeaderTitle(props: GridColumnHeaderTitleProps) {
   const { label, description } = props;
   const rootProps = useGridRootProps();
   const titleRef = React.useRef<HTMLDivElement>(null);
-  const [tooltip, setTooltip] = React.useState('');
+  const [tooltip, setTooltip] = React.useState<string | null>(null);
 
   const handleMouseOver = React.useCallback<React.MouseEventHandler<HTMLDivElement>>(() => {
     if (!description && titleRef?.current) {
       const isOver = isOverflown(titleRef.current);
-      if (isOver) {
+      if (isOver && tooltip !== label) {
         setTooltip(label);
-      } else {
-        setTooltip('');
+      } else if (!isOver && tooltip) {
+        setTooltip(null);
       }
     }
-  }, [description, label]);
+  }, [tooltip, description, label]);
 
   return (
     <rootProps.slots.baseTooltip


### PR DESCRIPTION
While working on #9954 I have noticed that sometimes the cell values are read twice as well.
This occurs because of the `title` prop that was added in #7671 
Accessibility tools were already [showing warnings](https://github.com/mui/mui-x/pull/7682#issuecomment-1546766912) for this approach.

Since column header component is using tooltip to show the whole content, I have added the same to the cells and removed the `title` prop.

This introduced a small UX issue, since the cell text content is added directly to the cell container to [reduce the number of nodes](https://github.com/mui/mui-x/pull/12013). Tooltip shows up way below the cell, because it has a default margin relative to the target element.

I have added a default `slotProp` value for the `Tooltip` component, to render it just a bit over the bottom border
```typescript
const tooltipProps = slotProps?.tooltip || {
  slotProps: {
    popper: {
      sx: {
        [`&.${tooltipClasses.popper}[data-popper-placement*="bottom"] .${tooltipClasses.tooltip}`]:
          {
            marginTop: '-5px',
          },
      },
    },
  },
};
```
**With default margins**
<img width="826" alt="before" src="https://github.com/user-attachments/assets/a57a276d-4fd1-4b49-bceb-61e0369b02e9">
**With mt = -5px**
<img width="862" alt="after" src="https://github.com/user-attachments/assets/74c69a2a-39dc-4b20-af23-c549a50ca5d9">

To allow changes, I repeated [this pattern](https://github.com/mui/mui-x/blob/v7.15.0/packages/x-data-grid/src/components/toolbar/GridToolbarColumnsButton.tsx#L17) (but with default)

Issue that should bring this topic even further #7323 