### PR TITLE
[docs] Add docs for `mobilePaper` and `desktopPaper` pickers slots

### DIFF
--- a/docs/data/date-pickers/custom-components/PaperComponent.js
+++ b/docs/data/date-pickers/custom-components/PaperComponent.js
@@ -6,9 +6,12 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 
-function CustomPaper(props) {
-  return <Paper {...props} />;
-}
+const CustomPaper = React.forwardRef(function CustomPaper(props, ref) {
+  // @ts-ignore
+  const { ownerState, ...other } = props;
+
+  return <Paper {...other} ref={ref} elevation={2} square />;
+});
 
 export default function PaperComponent() {
   return (
@@ -22,9 +25,7 @@ export default function PaperComponent() {
         />
         <MobileDatePicker
           label="Mobile variant"
-          slotProps={{
-            mobilePaper: { sx: { border: '5px red solid' } },
-          }}
+          slots={{ mobilePaper: CustomPaper }}
         />
       </DemoContainer>
     </LocalizationProvider>

--- a/docs/data/date-pickers/custom-components/PaperComponent.js
+++ b/docs/data/date-pickers/custom-components/PaperComponent.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
+
+function CustomPaper(props) {
+  return <Paper {...props} />;
+}
+
+export default function PaperComponent() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={['DatePicker', 'DatePicker']}>
+        <DesktopDatePicker
+          label="Desktop variant"
+          slots={{
+            desktopPaper: CustomPaper,
+          }}
+        />
+        <MobileDatePicker
+          label="Mobile variant"
+          slotProps={{
+            mobilePaper: { sx: { border: '5px red solid' } },
+          }}
+        />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-components/PaperComponent.tsx
+++ b/docs/data/date-pickers/custom-components/PaperComponent.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import Paper, { PaperProps } from '@mui/material/Paper';
+import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
+
+const CustomPaper = React.forwardRef(function CustomPaper(
+  props: PaperProps,
+  ref: React.Ref<HTMLDivElement>,
+) {
+  // @ts-ignore
+  const { ownerState, ...other } = props;
+
+  return <Paper {...other} ref={ref} elevation={2} square />;
+});
+
+export default function PaperComponent() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={['DatePicker', 'DatePicker']}>
+        <DesktopDatePicker
+          label="Desktop variant"
+          slots={{
+            desktopPaper: CustomPaper,
+          }}
+        />
+        <MobileDatePicker
+          label="Mobile variant"
+          slots={{ mobilePaper: CustomPaper }}
+        />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-components/PaperComponent.tsx.preview
+++ b/docs/data/date-pickers/custom-components/PaperComponent.tsx.preview
@@ -6,7 +6,5 @@
 />
 <MobileDatePicker
   label="Mobile variant"
-  slotProps={{
-    mobilePaper: { sx: { border: '5px red solid' } },
-  }}
+  slots={{ mobilePaper: CustomPaper }}
 />

--- a/docs/data/date-pickers/custom-components/PaperComponent.tsx.preview
+++ b/docs/data/date-pickers/custom-components/PaperComponent.tsx.preview
@@ -1,0 +1,12 @@
+<DesktopDatePicker
+  label="Desktop variant"
+  slots={{
+    desktopPaper: CustomPaper,
+  }}
+/>
+<MobileDatePicker
+  label="Mobile variant"
+  slotProps={{
+    mobilePaper: { sx: { border: '5px red solid' } },
+  }}
+/>

--- a/docs/data/date-pickers/custom-components/PaperComponentProps.js
+++ b/docs/data/date-pickers/custom-components/PaperComponentProps.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
+
+export default function PaperComponentProps() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={['DatePicker', 'DatePicker']}>
+        <DesktopDatePicker
+          label="Desktop variant"
+          slotProps={{
+            desktopPaper: { sx: { border: '5px red solid' } },
+          }}
+        />
+        <MobileDatePicker
+          label="Mobile variant"
+          slotProps={{
+            mobilePaper: { sx: { border: '5px red solid' } },
+          }}
+        />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-components/PaperComponentProps.tsx
+++ b/docs/data/date-pickers/custom-components/PaperComponentProps.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { DemoContainer } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
+import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
+
+export default function PaperComponentProps() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DemoContainer components={['DatePicker', 'DatePicker']}>
+        <DesktopDatePicker
+          label="Desktop variant"
+          slotProps={{
+            desktopPaper: { sx: { border: '5px red solid' } },
+          }}
+        />
+        <MobileDatePicker
+          label="Mobile variant"
+          slotProps={{
+            mobilePaper: { sx: { border: '5px red solid' } },
+          }}
+        />
+      </DemoContainer>
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/custom-components/PaperComponentProps.tsx.preview
+++ b/docs/data/date-pickers/custom-components/PaperComponentProps.tsx.preview
@@ -1,0 +1,12 @@
+<DesktopDatePicker
+  label="Desktop variant"
+  slotProps={{
+    desktopPaper: { sx: { border: '5px red solid' } },
+  }}
+/>
+<MobileDatePicker
+  label="Mobile variant"
+  slotProps={{
+    mobilePaper: { sx: { border: '5px red solid' } },
+  }}
+/>

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -223,6 +223,26 @@ You can pass custom components to replace the icons, as shown below:
 
 {{"demo": "ArrowSwitcherComponent.js", "defaultCodeOpen": false}}
 
+## Paper
+
+The `desktopPaper` and `mobilePaper` slots allow you to customize the paper component used to wrap the view content.
+
+### Component props
+
+You can pass props to the paper slots as shown below:
+
+{{"demo": "PaperComponentProps.js", "defaultCodeOpen": false}}
+
+### Component
+
+You can pass a custom component to the paper slots, as shown below:
+
+{{"demo": "PaperComponent.js", "defaultCodeOpen": false}}
+
+:::warning
+The component passed to the `desktopPaper` slot should support receiving a `ref`.
+:::
+
 ## Shortcuts
 
 You can add shortcuts to every Picker component.


### PR DESCRIPTION
Part of #14512

Providing a custom component for those slots would only be interesting when ditching Material Design
One could even argue that we should not use the `@mui/material` component here given how simple it is and instead rely on some theme primitives, but this is out of the scope of this PR.