### PR TITLE
[pickers] Stop using utils in locales

### DIFF
--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -96,7 +96,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: props.localeText.openDatePickerDialogue,
+      propsTranslation: props.localeText?.openDatePickerDialogue,
     }),
     validator: validateDate,
   });

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -96,7 +96,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: translations.openDatePickerDialogue,
+      propsTranslation: props.localeText.openDatePickerDialogue,
     }),
     validator: validateDate,
   });

--- a/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -15,6 +15,7 @@ import { DateField } from '../DateField';
 import { extractValidationProps } from '../internals/utils/validation/extractValidationProps';
 import { renderDateViewCalendar } from '../dateViewRenderers';
 import { resolveDateFormat } from '../internals/utils/date-utils';
+import { buildGetOpenDialogAriaText } from '../locales/utils/getPickersLocalization';
 
 type DesktopDatePickerComponent = (<
   TDate extends PickerValidDate,
@@ -91,8 +92,12 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<
     props,
     valueManager: singleItemValueManager,
     valueType: 'date',
-    getOpenDialogAriaText:
-      props.localeText?.openDatePickerDialogue ?? translations.openDatePickerDialogue,
+    getOpenDialogAriaText: buildGetOpenDialogAriaText({
+      utils,
+      formatKey: 'fullDate',
+      contextTranslation: translations.openDatePickerDialogue,
+      propsTranslation: translations.openDatePickerDialogue,
+    }),
     validator: validateDate,
   });
 

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -41,6 +41,7 @@ import { DefaultizedProps } from '../internals/models/helpers';
 import { UsePickerViewsProps } from '../internals/hooks/usePicker/usePickerViews';
 import { isInternalTimeView } from '../internals/utils/time-utils';
 import { isDatePickerView } from '../internals/utils/date-utils';
+import { buildGetOpenDialogAriaText } from '../locales/utils/getPickersLocalization';
 
 const rendererInterceptor = function rendererInterceptor<
   TDate extends PickerValidDate,
@@ -226,8 +227,12 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<
     props,
     valueManager: singleItemValueManager,
     valueType: 'date-time',
-    getOpenDialogAriaText:
-      props.localeText?.openDatePickerDialogue ?? translations.openDatePickerDialogue,
+    getOpenDialogAriaText: buildGetOpenDialogAriaText({
+      utils,
+      formatKey: 'fullDate',
+      contextTranslation: translations.openDatePickerDialogue,
+      propsTranslation: translations.openDatePickerDialogue,
+    }),
     validator: validateDateTime,
     rendererInterceptor,
   });

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -231,7 +231,7 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: props.localeText.openDatePickerDialogue,
+      propsTranslation: props.localeText?.openDatePickerDialogue,
     }),
     validator: validateDateTime,
     rendererInterceptor,

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -231,7 +231,7 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: translations.openDatePickerDialogue,
+      propsTranslation: props.localeText.openDatePickerDialogue,
     }),
     validator: validateDateTime,
     rendererInterceptor,

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -133,8 +133,8 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<
     getOpenDialogAriaText: buildGetOpenDialogAriaText({
       utils,
       formatKey: 'fullTime',
-      contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: translations.openDatePickerDialogue,
+      contextTranslation: translations.openTimePickerDialogue,
+      propsTranslation: translations.openTimePickerDialogue,
     }),
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -134,7 +134,7 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<
       utils,
       formatKey: 'fullTime',
       contextTranslation: translations.openTimePickerDialogue,
-      propsTranslation: props.localeText.openTimePickerDialogue,
+      propsTranslation: props.localeText?.openTimePickerDialogue,
     }),
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -21,6 +21,7 @@ import { TimeViewWithMeridiem } from '../internals/models';
 import { resolveTimeFormat } from '../internals/utils/time-utils';
 import { resolveTimeViewsResponse } from '../internals/utils/date-time-utils';
 import { TimeView, PickerValidDate } from '../models';
+import { buildGetOpenDialogAriaText } from '../locales/utils/getPickersLocalization';
 
 type DesktopTimePickerComponent = (<
   TDate extends PickerValidDate,
@@ -129,8 +130,12 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<
     props,
     valueManager: singleItemValueManager,
     valueType: 'time',
-    getOpenDialogAriaText:
-      props.localeText?.openTimePickerDialogue ?? translations.openTimePickerDialogue,
+    getOpenDialogAriaText: buildGetOpenDialogAriaText({
+      utils,
+      formatKey: 'fullTime',
+      contextTranslation: translations.openDatePickerDialogue,
+      propsTranslation: translations.openDatePickerDialogue,
+    }),
     validator: validateTime,
   });
 

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -134,7 +134,7 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<
       utils,
       formatKey: 'fullTime',
       contextTranslation: translations.openTimePickerDialogue,
-      propsTranslation: translations.openTimePickerDialogue,
+      propsTranslation: props.localeText.openTimePickerDialogue,
     }),
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -93,7 +93,7 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: props.localeText.openDatePickerDialogue,
+      propsTranslation: props.localeText?.openDatePickerDialogue,
     }),
     validator: validateDate,
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -93,7 +93,7 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: translations.openDatePickerDialogue,
+      propsTranslation: props.localeText.openDatePickerDialogue,
     }),
     validator: validateDate,
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/MobileDatePicker.tsx
@@ -14,6 +14,7 @@ import { extractValidationProps } from '../internals/utils/validation/extractVal
 import { singleItemValueManager } from '../internals/utils/valueManagers';
 import { renderDateViewCalendar } from '../dateViewRenderers';
 import { resolveDateFormat } from '../internals/utils/date-utils';
+import { buildGetOpenDialogAriaText } from '../locales/utils/getPickersLocalization';
 
 type MobileDatePickerComponent = (<
   TDate extends PickerValidDate,
@@ -88,8 +89,12 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<
     props,
     valueManager: singleItemValueManager,
     valueType: 'date',
-    getOpenDialogAriaText:
-      props.localeText?.openDatePickerDialogue ?? translations.openDatePickerDialogue,
+    getOpenDialogAriaText: buildGetOpenDialogAriaText({
+      utils,
+      formatKey: 'fullDate',
+      contextTranslation: translations.openDatePickerDialogue,
+      propsTranslation: translations.openDatePickerDialogue,
+    }),
     validator: validateDate,
   });
 

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -108,7 +108,7 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: props.localeText.openDatePickerDialogue,
+      propsTranslation: props.localeText?.openDatePickerDialogue,
     }),
     validator: validateDateTime,
   });

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -108,7 +108,7 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<
       utils,
       formatKey: 'fullDate',
       contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: translations.openDatePickerDialogue,
+      propsTranslation: props.localeText.openDatePickerDialogue,
     }),
     validator: validateDateTime,
   });

--- a/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -18,6 +18,7 @@ import { extractValidationProps } from '../internals/utils/validation/extractVal
 import { renderDateViewCalendar } from '../dateViewRenderers';
 import { renderTimeViewClock } from '../timeViewRenderers';
 import { resolveDateTimeFormat } from '../internals/utils/date-time-utils';
+import { buildGetOpenDialogAriaText } from '../locales/utils/getPickersLocalization';
 
 type MobileDateTimePickerComponent = (<
   TDate extends PickerValidDate,
@@ -103,8 +104,12 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<
     props,
     valueManager: singleItemValueManager,
     valueType: 'date-time',
-    getOpenDialogAriaText:
-      props.localeText?.openDatePickerDialogue ?? translations.openDatePickerDialogue,
+    getOpenDialogAriaText: buildGetOpenDialogAriaText({
+      utils,
+      formatKey: 'fullDate',
+      contextTranslation: translations.openDatePickerDialogue,
+      propsTranslation: translations.openDatePickerDialogue,
+    }),
     validator: validateDateTime,
   });
 

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -96,8 +96,8 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<
     getOpenDialogAriaText: buildGetOpenDialogAriaText({
       utils,
       formatKey: 'fullTime',
-      contextTranslation: translations.openDatePickerDialogue,
-      propsTranslation: translations.openDatePickerDialogue,
+      contextTranslation: translations.openTimePickerDialogue,
+      propsTranslation: translations.openTimePickerDialogue,
     }),
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -14,6 +14,7 @@ import { useMobilePicker } from '../internals/hooks/useMobilePicker';
 import { extractValidationProps } from '../internals/utils/validation/extractValidationProps';
 import { renderTimeViewClock } from '../timeViewRenderers';
 import { resolveTimeFormat } from '../internals/utils/time-utils';
+import { buildGetOpenDialogAriaText } from '../locales/utils/getPickersLocalization';
 
 type MobileTimePickerComponent = (<
   TDate extends PickerValidDate,
@@ -92,8 +93,12 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<
     props,
     valueManager: singleItemValueManager,
     valueType: 'time',
-    getOpenDialogAriaText:
-      props.localeText?.openTimePickerDialogue ?? translations.openTimePickerDialogue,
+    getOpenDialogAriaText: buildGetOpenDialogAriaText({
+      utils,
+      formatKey: 'fullTime',
+      contextTranslation: translations.openDatePickerDialogue,
+      propsTranslation: translations.openDatePickerDialogue,
+    }),
     validator: validateTime,
   });
 

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -97,7 +97,7 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<
       utils,
       formatKey: 'fullTime',
       contextTranslation: translations.openTimePickerDialogue,
-      propsTranslation: props.localeText.openTimePickerDialogue,
+      propsTranslation: props.localeText?.openTimePickerDialogue,
     }),
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/MobileTimePicker.tsx
@@ -97,7 +97,7 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<
       utils,
       formatKey: 'fullTime',
       contextTranslation: translations.openTimePickerDialogue,
-      propsTranslation: translations.openTimePickerDialogue,
+      propsTranslation: props.localeText.openTimePickerDialogue,
     }),
     validator: validateTime,
   });

--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -370,7 +370,12 @@ export function Clock<TDate extends PickerValidDate>(inProps: ClockProps<TDate>)
         )}
         <ClockWrapper
           aria-activedescendant={selectedId}
-          aria-label={translations.clockLabelText(type, value, utils)}
+          aria-label={translations.clockLabelText(
+            type,
+            value,
+            utils,
+            value == null ? null : utils.format(value, 'fullTime'),
+          )}
           ref={listboxRef}
           role="listbox"
           onKeyDown={handleKeyDown}

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -11,7 +11,6 @@ import {
   UseDesktopPickerProps,
   UseDesktopPickerSlotProps,
 } from './useDesktopPicker.types';
-import { useUtils } from '../useUtils';
 import { usePicker } from '../usePicker';
 import { LocalizationProvider } from '../../../LocalizationProvider';
 import { PickersLayout } from '../../../PickersLayout';
@@ -67,7 +66,6 @@ export const useDesktopPicker = <
     reduceAnimations,
   } = props;
 
-  const utils = useUtils<TDate>();
   const containerRef = React.useRef<HTMLDivElement>(null);
   const fieldRef = React.useRef<FieldRef<FieldSection>>(null);
 
@@ -113,7 +111,7 @@ export const useDesktopPicker = <
     additionalProps: {
       disabled: disabled || readOnly,
       onClick: open ? actions.onClose : actions.onOpen,
-      'aria-label': getOpenDialogAriaText(pickerFieldProps.value, utils),
+      'aria-label': getOpenDialogAriaText(pickerFieldProps.value),
       edge: inputAdornmentProps.position,
     },
     ownerState: props,

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
@@ -10,12 +10,7 @@ import {
 } from '../../models/props/basePickerProps';
 import { PickersPopperSlots, PickersPopperSlotProps } from '../../components/PickersPopper';
 import { UsePickerParams, UsePickerProps } from '../usePicker';
-import {
-  BaseSingleInputFieldProps,
-  FieldSection,
-  MuiPickersAdapter,
-  PickerValidDate,
-} from '../../../models';
+import { BaseSingleInputFieldProps, FieldSection, PickerValidDate } from '../../../models';
 import {
   ExportedPickersLayoutSlots,
   ExportedPickersLayoutSlotProps,

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.types.ts
@@ -151,5 +151,5 @@ export interface UseDesktopPickerParams<
     'valueManager' | 'valueType' | 'validator' | 'rendererInterceptor'
   > {
   props: TExternalProps;
-  getOpenDialogAriaText: (date: TDate | null, utils: MuiPickersAdapter<TDate>) => string;
+  getOpenDialogAriaText: (date: TDate | null) => string;
 }

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -10,7 +10,6 @@ import {
 } from './useMobilePicker.types';
 import { usePicker } from '../usePicker';
 import { onSpaceOrEnter } from '../../utils/utils';
-import { useUtils } from '../useUtils';
 import { LocalizationProvider } from '../../../LocalizationProvider';
 import { PickersLayout } from '../../../PickersLayout';
 import { InferError } from '../useValidation';
@@ -63,7 +62,6 @@ export const useMobilePicker = <
     localeText,
   } = props;
 
-  const utils = useUtils<TDate>();
   const fieldRef = React.useRef<FieldRef<FieldSection>>(null);
 
   const labelId = useId();
@@ -128,7 +126,7 @@ export const useMobilePicker = <
   // TODO: Move to `useSlotProps` when https://github.com/mui/material-ui/pull/35088 will be merged
   fieldProps.inputProps = {
     ...fieldProps.inputProps,
-    'aria-label': getOpenDialogAriaText(pickerFieldProps.value, utils),
+    'aria-label': getOpenDialogAriaText(pickerFieldProps.value),
   } as typeof fieldProps.inputProps;
 
   const slotsForField = {

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.types.ts
@@ -11,12 +11,7 @@ import {
   PickersModalDialogSlotProps,
 } from '../../components/PickersModalDialog';
 import { UsePickerParams, UsePickerProps } from '../usePicker';
-import {
-  BaseSingleInputFieldProps,
-  FieldSection,
-  MuiPickersAdapter,
-  PickerValidDate,
-} from '../../../models';
+import { BaseSingleInputFieldProps, FieldSection, PickerValidDate } from '../../../models';
 import {
   ExportedPickersLayoutSlots,
   ExportedPickersLayoutSlotProps,

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.types.ts
@@ -112,5 +112,5 @@ export interface UseMobilePickerParams<
     'valueManager' | 'valueType' | 'validator'
   > {
   props: TExternalProps;
-  getOpenDialogAriaText: (date: TDate | null, utils: MuiPickersAdapter<TDate>) => string;
+  getOpenDialogAriaText: (date: TDate | null) => string;
 }

--- a/packages/x-date-pickers/src/locales/beBY.ts
+++ b/packages/x-date-pickers/src/locales/beBY.ts
@@ -60,13 +60,13 @@ const beBYPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Абраць дату, абрана дата  ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Абраць дату, абрана дата  ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Абраць дату',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Абраць час, абрыны час  ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Абраць час, абрыны час  ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Абраць час',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/beBY.ts
+++ b/packages/x-date-pickers/src/locales/beBY.ts
@@ -44,8 +44,8 @@ const beBYPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Абраць каляндарны перыяд',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Абярыце ${views[view]}. ${time === null ? 'Час не абраны' : `Абраны час ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Абярыце ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Час не абраны' : `Абраны час ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} гадзін`,
   minutesClockNumberText: (minutes) => `${minutes} хвілін`,
   secondsClockNumberText: (seconds) => `${seconds} секунд`,

--- a/packages/x-date-pickers/src/locales/caES.ts
+++ b/packages/x-date-pickers/src/locales/caES.ts
@@ -43,8 +43,8 @@ const caESPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Seleccionar rang de dates',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Selecciona ${views[view]}. ${time === null ? 'Hora no seleccionada' : `L'hora seleccionada és ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Selecciona ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Hora no seleccionada' : `L'hora seleccionada és ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} hores`,
   minutesClockNumberText: (minutes) => `${minutes} minuts`,
   secondsClockNumberText: (seconds) => `${seconds} segons`,

--- a/packages/x-date-pickers/src/locales/caES.ts
+++ b/packages/x-date-pickers/src/locales/caES.ts
@@ -59,13 +59,13 @@ const caESPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Tria la data, la data triada és ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Tria la data, la data triada és ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Tria la data',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Tria l'hora, l'hora triada és ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Tria l'hora, l'hora triada és ${formattedTime ?? utils.format(value, 'fullTime')}`
       : "Tria l'hora",
   fieldClearLabel: 'Netega el valor',
 

--- a/packages/x-date-pickers/src/locales/csCZ.ts
+++ b/packages/x-date-pickers/src/locales/csCZ.ts
@@ -60,13 +60,13 @@ const csCZPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vyberte datum, vybrané datum je ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Vyberte datum, vybrané datum je ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Vyberte datum',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vyberte čas, vybraný čas je ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Vyberte čas, vybraný čas je ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Vyberte čas',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/csCZ.ts
+++ b/packages/x-date-pickers/src/locales/csCZ.ts
@@ -44,8 +44,8 @@ const csCZPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Vyberete rozmezí dat',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view] ?? view} vybrány. ${time === null ? 'Není vybrán čas' : `Vybraný čas je ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view] ?? view} vybrány. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Není vybrán čas' : `Vybraný čas je ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} hodin`,
   minutesClockNumberText: (minutes) => `${minutes} minut`,
   secondsClockNumberText: (seconds) => `${seconds} sekund`,

--- a/packages/x-date-pickers/src/locales/daDK.ts
+++ b/packages/x-date-pickers/src/locales/daDK.ts
@@ -44,8 +44,8 @@ const daDKPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Vælg datointerval',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Vælg ${timeViews[view] ?? view}. ${time === null ? 'Intet tidspunkt valgt' : `Valgte tidspunkt er ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Vælg ${timeViews[view] ?? view}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Intet tidspunkt valgt' : `Valgte tidspunkt er ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} timer`,
   minutesClockNumberText: (minutes) => `${minutes} minutter`,
   secondsClockNumberText: (seconds) => `${seconds} sekunder`,

--- a/packages/x-date-pickers/src/locales/daDK.ts
+++ b/packages/x-date-pickers/src/locales/daDK.ts
@@ -60,13 +60,13 @@ const daDKPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vælg dato, valgte dato er ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Vælg dato, valgte dato er ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Vælg dato',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vælg tidspunkt, valgte tidspunkt er ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Vælg tidspunkt, valgte tidspunkt er ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Vælg tidspunkt',
   fieldClearLabel: 'ryd felt',
 

--- a/packages/x-date-pickers/src/locales/deDE.ts
+++ b/packages/x-date-pickers/src/locales/deDE.ts
@@ -44,8 +44,8 @@ const deDEPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Datumsbereich auswählen',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view] ?? view} auswählen. ${time === null ? 'Keine Uhrzeit ausgewählt' : `Gewählte Uhrzeit ist ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view] ?? view} auswählen. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Keine Uhrzeit ausgewählt' : `Gewählte Uhrzeit ist ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} ${timeViews.hours}`,
   minutesClockNumberText: (minutes) => `${minutes} ${timeViews.minutes}`,
   secondsClockNumberText: (seconds) => `${seconds}  ${timeViews.seconds}`,

--- a/packages/x-date-pickers/src/locales/deDE.ts
+++ b/packages/x-date-pickers/src/locales/deDE.ts
@@ -60,13 +60,13 @@ const deDEPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Datum auswählen, gewähltes Datum ist ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Datum auswählen, gewähltes Datum ist ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Datum auswählen',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Uhrzeit auswählen, gewählte Uhrzeit ist ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Uhrzeit auswählen, gewählte Uhrzeit ist ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Uhrzeit auswählen',
   fieldClearLabel: 'Wert leeren',
 

--- a/packages/x-date-pickers/src/locales/elGR.ts
+++ b/packages/x-date-pickers/src/locales/elGR.ts
@@ -59,13 +59,13 @@ const elGRPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Επιλέξτε ημερομηνία, η επιλεγμένη ημερομηνία είναι ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Επιλέξτε ημερομηνία, η επιλεγμένη ημερομηνία είναι ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Επιλέξτε ημερομηνία',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Επιλέξτε ώρα, η επιλεγμένη ώρα είναι ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Επιλέξτε ώρα, η επιλεγμένη ώρα είναι ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Επιλέξτε ώρα',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/elGR.ts
+++ b/packages/x-date-pickers/src/locales/elGR.ts
@@ -43,8 +43,8 @@ const elGRPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Επιλέξτε εύρος ημερομηνιών',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Επιλέξτε ${views[view]}. ${time === null ? 'Δεν έχει επιλεγεί ώρα' : `Η επιλεγμένη ώρα είναι ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Επιλέξτε ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Δεν έχει επιλεγεί ώρα' : `Η επιλεγμένη ώρα είναι ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} ώρες`,
   minutesClockNumberText: (minutes) => `${minutes} λεπτά`,
   secondsClockNumberText: (seconds) => `${seconds} δευτερόλεπτα`,

--- a/packages/x-date-pickers/src/locales/enUS.ts
+++ b/packages/x-date-pickers/src/locales/enUS.ts
@@ -37,9 +37,11 @@ const enUSPickers: PickersLocaleText<any> = {
   dateRangePickerToolbarTitle: 'Select date range',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
+  clockLabelText: (view, time, utils, formattedTime) =>
     `Select ${view}. ${
-      time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+      !formattedTime && (time === null || !utils.isValid(time))
+        ? 'No time selected'
+        : `Selected time is ${formattedTime ?? utils.format(time, 'fullTime')}`
     }`,
   hoursClockNumberText: (hours) => `${hours} hours`,
   minutesClockNumberText: (minutes) => `${minutes} minutes`,

--- a/packages/x-date-pickers/src/locales/enUS.ts
+++ b/packages/x-date-pickers/src/locales/enUS.ts
@@ -55,13 +55,13 @@ const enUSPickers: PickersLocaleText<any> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Choose date, selected date is ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Choose date, selected date is ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Choose date',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Choose time, selected time is ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Choose time, selected time is ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Choose time',
 
   fieldClearLabel: 'Clear value',

--- a/packages/x-date-pickers/src/locales/esES.ts
+++ b/packages/x-date-pickers/src/locales/esES.ts
@@ -43,8 +43,8 @@ const esESPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Seleccionar rango de fecha',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Seleccione ${views[view]}. ${time === null ? 'No hay hora seleccionada' : `La hora seleccionada es ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Seleccione ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'No hay hora seleccionada' : `La hora seleccionada es ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} horas`,
   minutesClockNumberText: (minutes) => `${minutes} minutos`,
   secondsClockNumberText: (seconds) => `${seconds} segundos`,

--- a/packages/x-date-pickers/src/locales/esES.ts
+++ b/packages/x-date-pickers/src/locales/esES.ts
@@ -59,13 +59,13 @@ const esESPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Elige fecha, la fecha elegida es ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Elige fecha, la fecha elegida es ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Elige fecha',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Elige hora, la hora elegida es ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Elige hora, la hora elegida es ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Elige hora',
   fieldClearLabel: 'Limpiar valor',
 

--- a/packages/x-date-pickers/src/locales/eu.ts
+++ b/packages/x-date-pickers/src/locales/eu.ts
@@ -59,13 +59,13 @@ const euPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Data aukeratu, aukeratutako data ${utils.format(value, 'fullDate')} da`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Data aukeratu, aukeratutako data ${formattedDate ?? utils.format(value, 'fullDate')} da`
       : 'Data aukeratu',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Ordua aukeratu, aukeratutako ordua ${utils.format(value, 'fullTime')} da`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Ordua aukeratu, aukeratutako ordua ${formattedTime ?? utils.format(value, 'fullTime')} da`
       : 'Ordua aukeratu',
   fieldClearLabel: 'Balioa garbitu',
 

--- a/packages/x-date-pickers/src/locales/eu.ts
+++ b/packages/x-date-pickers/src/locales/eu.ts
@@ -43,8 +43,8 @@ const euPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Data tartea aukeratu',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Aukeratu ${views[view]}. ${time === null ? 'Ez da ordurik aukertau' : `Aukeratutako ordua ${adapter.format(time, 'fullTime')} da`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Aukeratu ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Ez da ordurik aukertau' : `Aukeratutako ordua ${formattedTime ?? utils.format(time, 'fullTime')} da`}`,
   hoursClockNumberText: (hours) => `${hours} ordu`,
   minutesClockNumberText: (minutes) => `${minutes} minutu`,
   secondsClockNumberText: (seconds) => `${seconds} segundu`,

--- a/packages/x-date-pickers/src/locales/faIR.ts
+++ b/packages/x-date-pickers/src/locales/faIR.ts
@@ -43,8 +43,8 @@ const faIRPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'محدوده تاریخ را انتخاب کنید',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    ` را انتخاب کنید ${timeViews[view]}. ${time === null ? 'هیچ ساعتی انتخاب نشده است' : `ساعت انتخاب ${adapter.format(time, 'fullTime')} می باشد`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    ` را انتخاب کنید ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'هیچ ساعتی انتخاب نشده است' : `ساعت انتخاب ${formattedTime ?? utils.format(time, 'fullTime')} می باشد`}`,
   hoursClockNumberText: (hours) => `${hours} ساعت‌ها`,
   minutesClockNumberText: (minutes) => `${minutes} دقیقه‌ها`,
   secondsClockNumberText: (seconds) => `${seconds} ثانیه‌ها`,

--- a/packages/x-date-pickers/src/locales/faIR.ts
+++ b/packages/x-date-pickers/src/locales/faIR.ts
@@ -59,13 +59,13 @@ const faIRPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `تاریخ را انتخاب کنید، تاریخ انتخاب شده ${utils.format(value, 'fullDate')} می‌باشد`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `تاریخ را انتخاب کنید، تاریخ انتخاب شده ${formattedDate ?? utils.format(value, 'fullDate')} می‌باشد`
       : 'تاریخ را انتخاب کنید',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `ساعت را انتخاب کنید، ساعت انتخاب شده ${utils.format(value, 'fullTime')} می‌باشد`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `ساعت را انتخاب کنید، ساعت انتخاب شده ${formattedTime ?? utils.format(value, 'fullTime')} می‌باشد`
       : 'ساعت را انتخاب کنید',
   fieldClearLabel: 'پاک کردن مقدار',
 

--- a/packages/x-date-pickers/src/locales/fiFI.ts
+++ b/packages/x-date-pickers/src/locales/fiFI.ts
@@ -43,8 +43,8 @@ const fiFIPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Valitse aikaväli',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Valitse ${views[view]}. ${time === null ? 'Ei aikaa valittuna' : `Valittu aika on ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Valitse ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Ei aikaa valittuna' : `Valittu aika on ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} tuntia`,
   minutesClockNumberText: (minutes) => `${minutes} minuuttia`,
   secondsClockNumberText: (seconds) => `${seconds} sekuntia`,

--- a/packages/x-date-pickers/src/locales/fiFI.ts
+++ b/packages/x-date-pickers/src/locales/fiFI.ts
@@ -59,13 +59,13 @@ const fiFIPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Valitse päivä, valittu päivä on ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Valitse päivä, valittu päivä on ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Valitse päivä',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Valitse aika, valittu aika on ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Valitse aika, valittu aika on ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Valitse aika',
   fieldClearLabel: 'Tyhjennä arvo',
 

--- a/packages/x-date-pickers/src/locales/frFR.ts
+++ b/packages/x-date-pickers/src/locales/frFR.ts
@@ -59,13 +59,13 @@ const frFRPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Choisir la date, la date sélectionnée est ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Choisir la date, la date sélectionnée est ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Choisir la date',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Choisir l'heure, l'heure sélectionnée est ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, formattedTime) =>
+    formattedTime
+      ? `Choisir l'heure, l'heure sélectionnée est ${formattedTime ?? utils.format(value, 'fullTime')}`
       : "Choisir l'heure",
   fieldClearLabel: 'Effacer la valeur',
 

--- a/packages/x-date-pickers/src/locales/frFR.ts
+++ b/packages/x-date-pickers/src/locales/frFR.ts
@@ -43,8 +43,8 @@ const frFRPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Choisir la plage de dates',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Choix des ${views[view]}. ${time === null ? 'Aucune heure choisie' : `L'heure choisie est ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Choix des ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Aucune heure choisie' : `L'heure choisie est ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} heures`,
   minutesClockNumberText: (minutes) => `${minutes} minutes`,
   secondsClockNumberText: (seconds) => `${seconds} secondes`,
@@ -63,7 +63,7 @@ const frFRPickers: Partial<PickersLocaleText<any>> = {
     formattedDate || (value !== null && utils.isValid(value))
       ? `Choisir la date, la date sélectionnée est ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Choisir la date',
-  openTimePickerDialogue: (value, formattedTime) =>
+  openTimePickerDialogue: (value, utils, formattedTime) =>
     formattedTime
       ? `Choisir l'heure, l'heure sélectionnée est ${formattedTime ?? utils.format(value, 'fullTime')}`
       : "Choisir l'heure",

--- a/packages/x-date-pickers/src/locales/heIL.ts
+++ b/packages/x-date-pickers/src/locales/heIL.ts
@@ -43,8 +43,8 @@ const heILPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'בחירת טווח תאריכים',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `בחירת ${views[view]}. ${time === null ? 'לא נבחרה שעה' : `השעה הנבחרת היא ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `בחירת ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'לא נבחרה שעה' : `השעה הנבחרת היא ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} שעות`,
   minutesClockNumberText: (minutes) => `${minutes} דקות`,
   secondsClockNumberText: (seconds) => `${seconds} שניות`,

--- a/packages/x-date-pickers/src/locales/heIL.ts
+++ b/packages/x-date-pickers/src/locales/heIL.ts
@@ -59,13 +59,13 @@ const heILPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `בחירת תאריך, התאריך שנבחר הוא ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `בחירת תאריך, התאריך שנבחר הוא ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'בחירת תאריך',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `בחירת שעה, השעה שנבחרה היא ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `בחירת שעה, השעה שנבחרה היא ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'בחירת שעה',
   fieldClearLabel: 'נקה ערך',
 

--- a/packages/x-date-pickers/src/locales/huHU.ts
+++ b/packages/x-date-pickers/src/locales/huHU.ts
@@ -60,13 +60,13 @@ const huHUPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Válasszon dátumot, a kiválasztott dátum: ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Válasszon dátumot, a kiválasztott dátum: ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Válasszon dátumot',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Válasszon időt, a kiválasztott idő: ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Válasszon időt, a kiválasztott idő: ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Válasszon időt',
   fieldClearLabel: 'Tartalom ürítése',
 

--- a/packages/x-date-pickers/src/locales/huHU.ts
+++ b/packages/x-date-pickers/src/locales/huHU.ts
@@ -44,8 +44,8 @@ const huHUPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Dátumhatárok kiválasztása',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view] ?? view} kiválasztása. ${time === null ? 'Nincs kiválasztva idő' : `A kiválasztott idő ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view] ?? view} kiválasztása. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Nincs kiválasztva idő' : `A kiválasztott idő ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} ${timeViews.hours.toLowerCase()}`,
   minutesClockNumberText: (minutes) => `${minutes} ${timeViews.minutes.toLowerCase()}`,
   secondsClockNumberText: (seconds) => `${seconds}  ${timeViews.seconds.toLowerCase()}`,

--- a/packages/x-date-pickers/src/locales/isIS.ts
+++ b/packages/x-date-pickers/src/locales/isIS.ts
@@ -43,8 +43,8 @@ const isISPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Velja tímabil',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Velja ${timeViews[view]}. ${time === null ? 'Enginn tími valinn' : `Valinn tími er ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Velja ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Enginn tími valinn' : `Valinn tími er ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} klukkustundir`,
   minutesClockNumberText: (minutes) => `${minutes} mínútur`,
   secondsClockNumberText: (seconds) => `${seconds} sekúndur`,

--- a/packages/x-date-pickers/src/locales/isIS.ts
+++ b/packages/x-date-pickers/src/locales/isIS.ts
@@ -59,13 +59,13 @@ const isISPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Velja dagsetningu, valin dagsetning er ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Velja dagsetningu, valin dagsetning er ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Velja dagsetningu',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Velja tíma, valinn tími er ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Velja tíma, valinn tími er ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Velja tíma',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/itIT.ts
+++ b/packages/x-date-pickers/src/locales/itIT.ts
@@ -59,13 +59,13 @@ const itITPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Scegli la data, la data selezionata è ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Scegli la data, la data selezionata è ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Scegli la data',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Scegli l'ora, l'ora selezionata è ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Scegli l'ora, l'ora selezionata è ${formattedTime ?? utils.format(value, 'fullTime')}`
       : "Scegli l'ora",
   fieldClearLabel: 'Cancella valore',
 

--- a/packages/x-date-pickers/src/locales/itIT.ts
+++ b/packages/x-date-pickers/src/locales/itIT.ts
@@ -43,8 +43,8 @@ const itITPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Seleziona intervallo di date',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Seleziona ${views[view]}. ${time === null ? 'Nessun orario selezionato' : `L'ora selezionata è ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Seleziona ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Nessun orario selezionato' : `L'ora selezionata è ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} ore`,
   minutesClockNumberText: (minutes) => `${minutes} minuti`,
   secondsClockNumberText: (seconds) => `${seconds} secondi`,

--- a/packages/x-date-pickers/src/locales/jaJP.ts
+++ b/packages/x-date-pickers/src/locales/jaJP.ts
@@ -44,8 +44,8 @@ const jaJPPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: '日付の範囲を選択',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view] ?? view}を選択してください ${time === null ? '時間が選択されていません' : `選択した時間は ${adapter.format(time, 'fullTime')} です`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view] ?? view}を選択してください ${!formattedTime && (time === null || !utils.isValid(time)) ? '時間が選択されていません' : `選択した時間は ${formattedTime ?? utils.format(time, 'fullTime')} です`}`,
   hoursClockNumberText: (hours) => `${hours} ${timeViews.hours}`,
   minutesClockNumberText: (minutes) => `${minutes} ${timeViews.minutes}`,
   secondsClockNumberText: (seconds) => `${seconds} ${timeViews.seconds}`,

--- a/packages/x-date-pickers/src/locales/jaJP.ts
+++ b/packages/x-date-pickers/src/locales/jaJP.ts
@@ -60,13 +60,13 @@ const jaJPPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `日付を選択してください。選択した日付は ${utils.format(value, 'fullDate')} です`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `日付を選択してください。選択した日付は ${formattedDate ?? utils.format(value, 'fullDate')} です`
       : '日付を選択してください',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `時間を選択してください。選択した時間は ${utils.format(value, 'fullTime')} です`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `時間を選択してください。選択した時間は ${formattedTime ?? utils.format(value, 'fullTime')} です`
       : '時間を選択してください',
   fieldClearLabel: 'クリア',
 

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -43,8 +43,8 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: '날짜 범위 선택하기',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${views[view]} 선택하세요. ${time === null ? '시간을 선택하지 않았습니다.' : `현재 선택된 시간은 ${adapter.format(time, 'fullTime')}입니다.`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${views[view]} 선택하세요. ${!formattedTime && (time === null || !utils.isValid(time)) ? '시간을 선택하지 않았습니다.' : `현재 선택된 시간은 ${formattedTime ?? utils.format(time, 'fullTime')}입니다.`}`,
   hoursClockNumberText: (hours) => `${hours}시`,
   minutesClockNumberText: (minutes) => `${minutes}분`,
   secondsClockNumberText: (seconds) => `${seconds}초`,

--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -59,13 +59,13 @@ const koKRPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `날짜를 선택하세요. 현재 선택된 날짜는 ${utils.format(value, 'fullDate')}입니다.`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `날짜를 선택하세요. 현재 선택된 날짜는 ${formattedDate ?? utils.format(value, 'fullDate')}입니다.`
       : '날짜를 선택하세요',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `시간을 선택하세요. 현재 선택된 시간은 ${utils.format(value, 'fullTime')}입니다.`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `시간을 선택하세요. 현재 선택된 시간은 ${formattedTime ?? utils.format(value, 'fullTime')}입니다.`
       : '시간을 선택하세요',
   fieldClearLabel: '지우기',
 

--- a/packages/x-date-pickers/src/locales/kzKZ.ts
+++ b/packages/x-date-pickers/src/locales/kzKZ.ts
@@ -60,13 +60,13 @@ const kzKZPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Күнді таңдаңыз, таңдалған күн ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Күнді таңдаңыз, таңдалған күн ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Күнді таңдаңыз',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Уақытты таңдаңыз, таңдалған уақыт ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Уақытты таңдаңыз, таңдалған уақыт ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Уақытты таңдаңыз',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/kzKZ.ts
+++ b/packages/x-date-pickers/src/locales/kzKZ.ts
@@ -44,8 +44,8 @@ const kzKZPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Кезеңді таңдаңыз',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view]} таңдау. ${time === null ? 'Уақыт таңдалмаған' : `Таңдалған уақыт ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view]} таңдау. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Уақыт таңдалмаған' : `Таңдалған уақыт ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} сағат`,
   minutesClockNumberText: (minutes) => `${minutes} минут`,
   secondsClockNumberText: (seconds) => `${seconds} секунд`,

--- a/packages/x-date-pickers/src/locales/mk.ts
+++ b/packages/x-date-pickers/src/locales/mk.ts
@@ -53,13 +53,13 @@ const mkPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Избери датум, избраниот датум е ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Избери датум, избраниот датум е ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Избери датум',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Избери време, избраното време е ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Избери време, избраното време е ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Избери време',
   fieldClearLabel: 'Избриши',
 

--- a/packages/x-date-pickers/src/locales/mk.ts
+++ b/packages/x-date-pickers/src/locales/mk.ts
@@ -37,8 +37,8 @@ const mkPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Избери временски опсег',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Select ${view}. ${time === null ? 'Нема избрано време' : `Избраното време е ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Select ${view}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Нема избрано време' : `Избраното време е ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} часа`,
   minutesClockNumberText: (minutes) => `${minutes} минути`,
   secondsClockNumberText: (seconds) => `${seconds} секунди`,

--- a/packages/x-date-pickers/src/locales/nbNO.ts
+++ b/packages/x-date-pickers/src/locales/nbNO.ts
@@ -59,13 +59,13 @@ const nbNOPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Velg dato, valgt dato er ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Velg dato, valgt dato er ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Velg dato',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Velg tid, valgt tid er ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Velg tid, valgt tid er ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Velg tid',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/nbNO.ts
+++ b/packages/x-date-pickers/src/locales/nbNO.ts
@@ -43,8 +43,8 @@ const nbNOPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Velg datoperiode',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Velg ${timeViews[view]}. ${time === null ? 'Ingen tid valgt' : `Valgt tid er ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Velg ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Ingen tid valgt' : `Valgt tid er ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} timer`,
   minutesClockNumberText: (minutes) => `${minutes} minutter`,
   secondsClockNumberText: (seconds) => `${seconds} sekunder`,

--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -43,8 +43,8 @@ const nlNLPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Selecteer datumbereik',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Selecteer ${timeViews[view]}. ${time === null ? 'Geen tijd geselecteerd' : `Geselecteerde tijd is ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Selecteer ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Geen tijd geselecteerd' : `Geselecteerde tijd is ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} uren`,
   minutesClockNumberText: (minutes) => `${minutes} minuten`,
   secondsClockNumberText: (seconds) => `${seconds} seconden`,

--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -59,13 +59,13 @@ const nlNLPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Kies datum, geselecteerde datum is ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Kies datum, geselecteerde datum is ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Kies datum',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Kies tijd, geselecteerde tijd is ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Kies tijd, geselecteerde tijd is ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Kies tijd',
   fieldClearLabel: 'Wissen',
 

--- a/packages/x-date-pickers/src/locales/nnNO.ts
+++ b/packages/x-date-pickers/src/locales/nnNO.ts
@@ -59,13 +59,13 @@ const nnNOPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vel dato, vald dato er ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Vel dato, vald dato er ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Vel dato',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vel tid, vald tid er ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Vel tid, vald tid er ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Vel tid',
   fieldClearLabel: 'Fjern verdi',
 

--- a/packages/x-date-pickers/src/locales/nnNO.ts
+++ b/packages/x-date-pickers/src/locales/nnNO.ts
@@ -43,8 +43,8 @@ const nnNOPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Vel datoperiode',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Vel ${timeViews[view]}. ${time === null ? 'Ingen tid vald' : `Vald tid er ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Vel ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Ingen tid vald' : `Vald tid er ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} timar`,
   minutesClockNumberText: (minutes) => `${minutes} minuttar`,
   secondsClockNumberText: (seconds) => `${seconds} sekundar`,

--- a/packages/x-date-pickers/src/locales/plPL.ts
+++ b/packages/x-date-pickers/src/locales/plPL.ts
@@ -43,8 +43,8 @@ const plPLPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Wybierz zakres dat',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Wybierz ${timeViews[view]}. ${time === null ? 'Nie wybrano czasu' : `Wybrany czas to ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Wybierz ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Nie wybrano czasu' : `Wybrany czas to ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} godzin`,
   minutesClockNumberText: (minutes) => `${minutes} minut`,
   secondsClockNumberText: (seconds) => `${seconds} sekund`,

--- a/packages/x-date-pickers/src/locales/plPL.ts
+++ b/packages/x-date-pickers/src/locales/plPL.ts
@@ -59,13 +59,13 @@ const plPLPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
+  openDatePickerDialogue: (value, utils, formattedDate) =>
     value != null && utils.isValid(value)
-      ? `Wybierz datę, obecnie wybrana data to ${utils.format(value, 'fullDate')}`
+      ? `Wybierz datę, obecnie wybrana data to ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Wybierz datę',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Wybierz czas, obecnie wybrany czas to ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Wybierz czas, obecnie wybrany czas to ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Wybierz czas',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -43,8 +43,8 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Selecione o intervalo entre datas',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Selecione ${timeViews[view]}. ${time === null ? 'Hora não selecionada' : `Selecionado a hora ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Selecione ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Hora não selecionada' : `Selecionado a hora ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} horas`,
   minutesClockNumberText: (minutes) => `${minutes} minutos`,
   secondsClockNumberText: (seconds) => `${seconds} segundos`,

--- a/packages/x-date-pickers/src/locales/ptBR.ts
+++ b/packages/x-date-pickers/src/locales/ptBR.ts
@@ -59,13 +59,13 @@ const ptBRPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Escolha uma data, data selecionada ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Escolha uma data, data selecionada ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Escolha uma data',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Escolha uma hora, hora selecionada ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Escolha uma hora, hora selecionada ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Escolha uma hora',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/roRO.ts
+++ b/packages/x-date-pickers/src/locales/roRO.ts
@@ -60,13 +60,13 @@ const roROPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Selectați data, data selectată este ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Selectați data, data selectată este ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Selectați data',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Selectați ora, ora selectată este ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Selectați ora, ora selectată este ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Selectați ora',
   fieldClearLabel: 'Golire conținut',
 

--- a/packages/x-date-pickers/src/locales/roRO.ts
+++ b/packages/x-date-pickers/src/locales/roRO.ts
@@ -44,8 +44,8 @@ const roROPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Selectați intervalul de date',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Selectați ${timeViews[view] ?? view}. ${time === null ? 'Nicio oră selectată' : `Ora selectată este ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Selectați ${timeViews[view] ?? view}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Nicio oră selectată' : `Ora selectată este ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} ${timeViews.hours}`,
   minutesClockNumberText: (minutes) => `${minutes} ${timeViews.minutes}`,
   secondsClockNumberText: (seconds) => `${seconds}  ${timeViews.seconds}`,

--- a/packages/x-date-pickers/src/locales/ruRU.ts
+++ b/packages/x-date-pickers/src/locales/ruRU.ts
@@ -44,8 +44,8 @@ const ruRUPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Выбрать период',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Выбрать ${timeViews[view]}. ${time === null ? 'Время не выбрано' : `Выбрано время ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Выбрать ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Время не выбрано' : `Выбрано время ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} часов`,
   minutesClockNumberText: (minutes) => `${minutes} минут`,
   secondsClockNumberText: (seconds) => `${seconds} секунд`,

--- a/packages/x-date-pickers/src/locales/ruRU.ts
+++ b/packages/x-date-pickers/src/locales/ruRU.ts
@@ -60,13 +60,13 @@ const ruRUPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Выберите дату, выбрана дата ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Выберите дату, выбрана дата ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Выберите дату',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Выберите время, выбрано время ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Выберите время, выбрано время ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Выберите время',
   fieldClearLabel: 'Очистить значение',
 

--- a/packages/x-date-pickers/src/locales/skSK.ts
+++ b/packages/x-date-pickers/src/locales/skSK.ts
@@ -60,13 +60,13 @@ const skSKPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vyberte dátum, vybraný dátum je ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Vyberte dátum, vybraný dátum je ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Vyberte dátum',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Vyberte čas, vybraný čas je ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Vyberte čas, vybraný čas je ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Vyberte čas',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/skSK.ts
+++ b/packages/x-date-pickers/src/locales/skSK.ts
@@ -44,8 +44,8 @@ const skSKPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Vyberete rozmedzie dátumov',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view] ?? view} vybraný. ${time === null ? 'Nie je vybraný čas' : `Vybraný čas je ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view] ?? view} vybraný. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Nie je vybraný čas' : `Vybraný čas je ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} hodín`,
   minutesClockNumberText: (minutes) => `${minutes} minút`,
   secondsClockNumberText: (seconds) => `${seconds} sekúnd`,

--- a/packages/x-date-pickers/src/locales/svSE.ts
+++ b/packages/x-date-pickers/src/locales/svSE.ts
@@ -59,13 +59,13 @@ const svSEPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Välj datum, valt datum är ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Välj datum, valt datum är ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Välj datum',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Välj tid, vald tid är ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Välj tid, vald tid är ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Välj tid',
   fieldClearLabel: 'Rensa värde',
 

--- a/packages/x-date-pickers/src/locales/svSE.ts
+++ b/packages/x-date-pickers/src/locales/svSE.ts
@@ -43,8 +43,8 @@ const svSEPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Välj datumintervall',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Välj ${timeViews[view]}. ${time === null ? 'Ingen tid vald' : `Vald tid är ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Välj ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Ingen tid vald' : `Vald tid är ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} timmar`,
   minutesClockNumberText: (minutes) => `${minutes} minuter`,
   secondsClockNumberText: (seconds) => `${seconds} sekunder`,

--- a/packages/x-date-pickers/src/locales/trTR.ts
+++ b/packages/x-date-pickers/src/locales/trTR.ts
@@ -43,8 +43,8 @@ const trTRPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Tarih aralığı seçin',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view]} seç.  ${time === null ? 'Zaman seçilmedi' : `Seçilen zaman: ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view]} seç.  ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Zaman seçilmedi' : `Seçilen zaman: ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} saat`,
   minutesClockNumberText: (minutes) => `${minutes} dakika`,
   secondsClockNumberText: (seconds) => `${seconds} saniye`,

--- a/packages/x-date-pickers/src/locales/trTR.ts
+++ b/packages/x-date-pickers/src/locales/trTR.ts
@@ -59,13 +59,13 @@ const trTRPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Tarih seçin, seçilen tarih: ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Tarih seçin, seçilen tarih: ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Tarih seç',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Saat seçin, seçilen saat: ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Saat seçin, seçilen saat: ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Saat seç',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/ukUA.ts
+++ b/packages/x-date-pickers/src/locales/ukUA.ts
@@ -43,8 +43,8 @@ const ukUAPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Вибрати календарний період',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Вибрати ${timeViews[view]}. ${time === null ? 'Час не вибраний' : `Вибрано час ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Вибрати ${timeViews[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Час не вибраний' : `Вибрано час ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} годин`,
   minutesClockNumberText: (minutes) => `${minutes} хвилин`,
   secondsClockNumberText: (seconds) => `${seconds} секунд`,

--- a/packages/x-date-pickers/src/locales/ukUA.ts
+++ b/packages/x-date-pickers/src/locales/ukUA.ts
@@ -59,13 +59,13 @@ const ukUAPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Оберіть дату, обрана дата  ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Оберіть дату, обрана дата  ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Оберіть дату',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Оберіть час, обраний час  ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Оберіть час, обраний час  ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Оберіть час',
   fieldClearLabel: 'Очистити дані',
 

--- a/packages/x-date-pickers/src/locales/urPK.ts
+++ b/packages/x-date-pickers/src/locales/urPK.ts
@@ -43,8 +43,8 @@ const urPKPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'تاریخوں کی رینج منتخب کریں',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `${timeViews[view]} منتخب کریں ${time === null ? 'کوئی وقت منتخب نہیں' : `منتخب وقت ہے ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `${timeViews[view]} منتخب کریں ${!formattedTime && (time === null || !utils.isValid(time)) ? 'کوئی وقت منتخب نہیں' : `منتخب وقت ہے ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} گھنٹے`,
   minutesClockNumberText: (minutes) => `${minutes} منٹ`,
   secondsClockNumberText: (seconds) => `${seconds} سیکنڈ`,

--- a/packages/x-date-pickers/src/locales/urPK.ts
+++ b/packages/x-date-pickers/src/locales/urPK.ts
@@ -59,13 +59,13 @@ const urPKPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `تاریخ منتخب کریں، منتخب شدہ تاریخ ہے ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `تاریخ منتخب کریں، منتخب شدہ تاریخ ہے ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'تاریخ منتخب کریں',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `وقت منتخب کریں، منتخب شدہ وقت ہے ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `وقت منتخب کریں، منتخب شدہ وقت ہے ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'وقت منتخب کریں',
   // fieldClearLabel: 'Clear value',
 

--- a/packages/x-date-pickers/src/locales/utils/getPickersLocalization.ts
+++ b/packages/x-date-pickers/src/locales/utils/getPickersLocalization.ts
@@ -21,11 +21,13 @@ export const buildGetOpenDialogAriaText = <TDate extends PickerValidDate>(params
     utils: MuiPickersAdapter<TDate>,
     formattedValue: string | null,
   ) => string;
-  propsTranslation: (
-    date: TDate | null,
-    utils: MuiPickersAdapter<TDate>,
-    formattedValue: string | null,
-  ) => string;
+  propsTranslation:
+    | ((
+        date: TDate | null,
+        utils: MuiPickersAdapter<TDate>,
+        formattedValue: string | null,
+      ) => string)
+    | undefined;
 }) => {
   const { utils, formatKey, contextTranslation, propsTranslation } = params;
 

--- a/packages/x-date-pickers/src/locales/utils/getPickersLocalization.ts
+++ b/packages/x-date-pickers/src/locales/utils/getPickersLocalization.ts
@@ -31,9 +31,8 @@ export const buildGetOpenDialogAriaText = <TDate extends PickerValidDate>(params
 
   return (value: TDate | null) => {
     const formattedValue =
-      value !== null && utils.isValid(value) ? utils.formatByString(value, formatKey) : null;
+      value !== null && utils.isValid(value) ? utils.format(value, formatKey) : null;
     const translation = propsTranslation ?? contextTranslation;
-
     return translation(value, utils, formattedValue);
   };
 };

--- a/packages/x-date-pickers/src/locales/utils/getPickersLocalization.ts
+++ b/packages/x-date-pickers/src/locales/utils/getPickersLocalization.ts
@@ -1,3 +1,4 @@
+import { AdapterFormats, MuiPickersAdapter, PickerValidDate } from '../../models';
 import { PickersLocaleText } from './pickersLocaleTextApi';
 
 export const getPickersLocalization = (pickersTranslations: Partial<PickersLocaleText<any>>) => {
@@ -9,5 +10,30 @@ export const getPickersLocalization = (pickersTranslations: Partial<PickersLocal
         },
       },
     },
+  };
+};
+
+export const buildGetOpenDialogAriaText = <TDate extends PickerValidDate>(params: {
+  utils: MuiPickersAdapter<TDate>;
+  formatKey: keyof AdapterFormats;
+  contextTranslation: (
+    date: TDate | null,
+    utils: MuiPickersAdapter<TDate>,
+    formattedValue: string | null,
+  ) => string;
+  propsTranslation: (
+    date: TDate | null,
+    utils: MuiPickersAdapter<TDate>,
+    formattedValue: string | null,
+  ) => string;
+}) => {
+  const { utils, formatKey, contextTranslation, propsTranslation } = params;
+
+  return (value: TDate | null) => {
+    const formattedValue =
+      value !== null && utils.isValid(value) ? utils.formatByString(value, formatKey) : null;
+    const translation = propsTranslation ?? contextTranslation;
+
+    return translation(value, utils, formattedValue);
   };
 };

--- a/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
+++ b/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
@@ -70,8 +70,28 @@ export interface PickersComponentAgnosticLocaleText<TDate extends PickerValidDat
   selectViewText: (view: TimeViewWithMeridiem) => string;
 
   // Open picker labels
-  openDatePickerDialogue: (date: TDate | null, utils: MuiPickersAdapter<TDate>) => string;
-  openTimePickerDialogue: (date: TDate | null, utils: MuiPickersAdapter<TDate>) => string;
+  openDatePickerDialogue: (
+    /**
+     * @deprecated Use `formattedTime` instead
+     */
+    date: TDate | null,
+    /**
+     * @deprecated Use `formattedTime` instead
+     */
+    utils: MuiPickersAdapter<TDate>,
+    formattedDate: string | null,
+  ) => string;
+  openTimePickerDialogue: (
+    /**
+     * @deprecated Use `formattedTime` instead
+     */
+    date: TDate | null,
+    /**
+     * @deprecated Use `formattedTime` instead
+     */
+    utils: MuiPickersAdapter<TDate>,
+    formattedTime: string | null,
+  ) => string;
 
   // Clear button label
   fieldClearLabel: string;

--- a/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
+++ b/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
@@ -63,7 +63,13 @@ export interface PickersComponentAgnosticLocaleText<TDate extends PickerValidDat
   // Clock labels
   clockLabelText: (
     view: TimeView,
+    /**
+     * @deprecated Use `formattedTime` instead
+     */
     time: TDate | null,
+    /**
+     * @deprecated Use `formattedTime` instead
+     */
     utils: MuiPickersAdapter<TDate>,
     // TODO v8: Make it required
     formattedTime?: string | null,

--- a/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
+++ b/packages/x-date-pickers/src/locales/utils/pickersLocaleTextApi.ts
@@ -61,7 +61,13 @@ export interface PickersComponentAgnosticLocaleText<TDate extends PickerValidDat
   todayButtonLabel: string;
 
   // Clock labels
-  clockLabelText: (view: TimeView, time: TDate | null, adapter: MuiPickersAdapter<TDate>) => string;
+  clockLabelText: (
+    view: TimeView,
+    time: TDate | null,
+    utils: MuiPickersAdapter<TDate>,
+    // TODO v8: Make it required
+    formattedTime?: string | null,
+  ) => string;
   hoursClockNumberText: (hours: string) => string;
   minutesClockNumberText: (minutes: string) => string;
   secondsClockNumberText: (seconds: string) => string;
@@ -79,6 +85,7 @@ export interface PickersComponentAgnosticLocaleText<TDate extends PickerValidDat
      * @deprecated Use `formattedTime` instead
      */
     utils: MuiPickersAdapter<TDate>,
+    // TODO v8: Make it required
     formattedDate: string | null,
   ) => string;
   openTimePickerDialogue: (
@@ -90,6 +97,7 @@ export interface PickersComponentAgnosticLocaleText<TDate extends PickerValidDat
      * @deprecated Use `formattedTime` instead
      */
     utils: MuiPickersAdapter<TDate>,
+    // TODO v8: Make it required
     formattedTime: string | null,
   ) => string;
 

--- a/packages/x-date-pickers/src/locales/viVN.ts
+++ b/packages/x-date-pickers/src/locales/viVN.ts
@@ -43,8 +43,8 @@ const viVNPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: 'Chọn khoảng ngày',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `Chọn ${views[view]}. ${time === null ? 'Không có giờ được chọn' : `Giờ được chọn là ${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `Chọn ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? 'Không có giờ được chọn' : `Giờ được chọn là ${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours} giờ`,
   minutesClockNumberText: (minutes) => `${minutes} phút`,
   secondsClockNumberText: (seconds) => `${seconds} giây`,

--- a/packages/x-date-pickers/src/locales/viVN.ts
+++ b/packages/x-date-pickers/src/locales/viVN.ts
@@ -59,13 +59,13 @@ const viVNPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Chọn ngày, ngày đã chọn là ${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `Chọn ngày, ngày đã chọn là ${formattedDate ?? utils.format(value, 'fullDate')}`
       : 'Chọn ngày',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `Chọn giờ, giờ đã chọn là ${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Chọn giờ, giờ đã chọn là ${formattedTime ?? utils.format(value, 'fullTime')}`
       : 'Chọn giờ',
   fieldClearLabel: 'Xóa giá trị',
 

--- a/packages/x-date-pickers/src/locales/zhCN.ts
+++ b/packages/x-date-pickers/src/locales/zhCN.ts
@@ -41,8 +41,8 @@ const zhCNPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: '选择时间范围',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `选择 ${views[view]}. ${time === null ? '未选择时间' : `已选择${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `选择 ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? '未选择时间' : `已选择${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours}小时`,
   minutesClockNumberText: (minutes) => `${minutes}分钟`,
   secondsClockNumberText: (seconds) => `${seconds}秒`,

--- a/packages/x-date-pickers/src/locales/zhCN.ts
+++ b/packages/x-date-pickers/src/locales/zhCN.ts
@@ -57,13 +57,13 @@ const zhCNPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `选择日期，已选择${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `选择日期，已选择${formattedDate ?? utils.format(value, 'fullDate')}`
       : '选择日期',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `选择时间，已选择${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `选择时间，已选择${formattedTime ?? utils.format(value, 'fullTime')}`
       : '选择时间',
   fieldClearLabel: '清除',
 

--- a/packages/x-date-pickers/src/locales/zhHK.ts
+++ b/packages/x-date-pickers/src/locales/zhHK.ts
@@ -57,13 +57,13 @@ const zhHKPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `選擇日期，已選擇${utils.format(value, 'fullDate')}`
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    formattedDate || (value !== null && utils.isValid(value))
+      ? `選擇日期，已選擇${formattedDate ?? utils.format(value, 'fullDate')}`
       : '選擇日期',
-  openTimePickerDialogue: (value, utils) =>
-    value !== null && utils.isValid(value)
-      ? `選擇時間，已選擇${utils.format(value, 'fullTime')}`
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `選擇時間，已選擇${formattedTime ?? utils.format(value, 'fullTime')}`
       : '選擇時間',
   fieldClearLabel: '清除',
 

--- a/packages/x-date-pickers/src/locales/zhHK.ts
+++ b/packages/x-date-pickers/src/locales/zhHK.ts
@@ -41,8 +41,8 @@ const zhHKPickers: Partial<PickersLocaleText<any>> = {
   dateRangePickerToolbarTitle: '選擇時間範圍',
 
   // Clock labels
-  clockLabelText: (view, time, adapter) =>
-    `選擇 ${views[view]}. ${time === null ? '未選擇時間' : `已選擇${adapter.format(time, 'fullTime')}`}`,
+  clockLabelText: (view, time, utils, formattedTime) =>
+    `選擇 ${views[view]}. ${!formattedTime && (time === null || !utils.isValid(time)) ? '未選擇時間' : `已選擇${formattedTime ?? utils.format(time, 'fullTime')}`}`,
   hoursClockNumberText: (hours) => `${hours}小時`,
   minutesClockNumberText: (minutes) => `${minutes}分鐘`,
   secondsClockNumberText: (seconds) => `${seconds}秒`,


### PR DESCRIPTION
Fixes #13768

I need to avoid 2 type of breaking changes

1. For the people overriding the locale (they must still receive `value` and `utils`)
2. For the people overriding a component that calls this translation (the built-in locale must still work even if they don't pass `formattedDate` yet)

So I'm handling both the old and the new format in each locale.
This is not clean code, but we can clean it easily during the alpha and the end result will be even better than before this PR.

## New DX

### In v7

```ts
const translations = useTranslations();
// TS will complain since we are not passing the utils, but it will work with any built-in locale
const label = translations.openTimePickerDialogue(value, {} as any, value == null ? null : value.format('MM/DD/YYY'));
```

### In v8

```ts
const translations = useTranslations();
// TS will complain since we are not passing the utils, but it will work with any built-in locale
const label = translations.openTimePickerDialogue(value == null ? null : value.format('MM/DD/YYY'));
```

## Follow up

- In v8 alpha: Remove `value` and `utils` params from `openDatePickerDialogue`, `openTimePickerDialogue` and `clockLabelText` 