### PR TITLE
[fields] Make the hook like `useDateField` stable

### DIFF
--- a/docs/data/date-pickers/custom-field/BrowserV6Field.js
+++ b/docs/data/date-pickers/custom-field/BrowserV6Field.js
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
+import { useDateField } from '@mui/x-date-pickers/DateField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 
 const BrowserField = React.forwardRef((props, ref) => {

--- a/docs/data/date-pickers/custom-field/BrowserV6Field.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV6Field.tsx
@@ -5,10 +5,7 @@ import Box from '@mui/material/Box';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
-import {
-  unstable_useDateField as useDateField,
-  UseDateFieldProps,
-} from '@mui/x-date-pickers/DateField';
+import { useDateField, UseDateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 import {
   BaseSingleInputFieldProps,

--- a/docs/data/date-pickers/custom-field/BrowserV7Field.js
+++ b/docs/data/date-pickers/custom-field/BrowserV7Field.js
@@ -5,7 +5,7 @@ import { styled } from '@mui/material/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
+import { useDateField } from '@mui/x-date-pickers/DateField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 
 import { Unstable_PickersSectionList as PickersSectionList } from '@mui/x-date-pickers/PickersSectionList';

--- a/docs/data/date-pickers/custom-field/BrowserV7Field.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV7Field.tsx
@@ -5,10 +5,7 @@ import { styled } from '@mui/material/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
-import {
-  unstable_useDateField as useDateField,
-  UseDateFieldProps,
-} from '@mui/x-date-pickers/DateField';
+import { useDateField, UseDateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 import {
   BaseSingleInputPickersTextFieldProps,

--- a/docs/data/date-pickers/custom-field/JoyV6Field.js
+++ b/docs/data/date-pickers/custom-field/JoyV6Field.js
@@ -17,7 +17,7 @@ import FormLabel from '@mui/joy/FormLabel';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { unstable_useDateField as useDateField } from '@mui/x-date-pickers/DateField';
+import { useDateField } from '@mui/x-date-pickers/DateField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 
 const joyTheme = extendJoyTheme();

--- a/docs/data/date-pickers/custom-field/JoyV6Field.tsx
+++ b/docs/data/date-pickers/custom-field/JoyV6Field.tsx
@@ -17,10 +17,7 @@ import FormLabel from '@mui/joy/FormLabel';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
-import {
-  unstable_useDateField as useDateField,
-  UseDateFieldProps,
-} from '@mui/x-date-pickers/DateField';
+import { useDateField, UseDateFieldProps } from '@mui/x-date-pickers/DateField';
 import { useClearableField } from '@mui/x-date-pickers/hooks';
 import {
   BaseSingleInputFieldProps,

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/index.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/index.ts
@@ -1,5 +1,9 @@
+import { useSingleInputDateRangeField as useSingleInputDateRangeFieldExport } from './useSingleInputDateRangeField';
+
 export { SingleInputDateRangeField } from './SingleInputDateRangeField';
-export { useSingleInputDateRangeField as unstable_useSingleInputDateRangeField } from './useSingleInputDateRangeField';
+export const useSingleInputDateRangeField = useSingleInputDateRangeFieldExport;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_useSingleInputDateRangeField = useSingleInputDateRangeFieldExport;
 export type {
   UseSingleInputDateRangeFieldProps,
   SingleInputDateRangeFieldProps,

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/index.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/index.ts
@@ -1,5 +1,9 @@
+import { useSingleInputDateTimeRangeField as useSingleInputDateTimeRangeFieldExport } from './useSingleInputDateTimeRangeField';
+
 export { SingleInputDateTimeRangeField } from './SingleInputDateTimeRangeField';
-export { useSingleInputDateTimeRangeField as unstable_useSingleInputDateTimeRangeField } from './useSingleInputDateTimeRangeField';
+export const useSingleInputDateTimeRangeField = useSingleInputDateTimeRangeFieldExport;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_useSingleInputDateTimeRangeField = useSingleInputDateTimeRangeFieldExport;
 export type {
   UseSingleInputDateTimeRangeFieldProps,
   SingleInputDateTimeRangeFieldProps,

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/index.ts
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/index.ts
@@ -1,5 +1,9 @@
+import { useSingleInputTimeRangeField as useSingleInputTimeRangeFieldExport } from './useSingleInputTimeRangeField';
+
 export { SingleInputTimeRangeField } from './SingleInputTimeRangeField';
-export { useSingleInputTimeRangeField as unstable_useSingleInputTimeRangeField } from './useSingleInputTimeRangeField';
+export const useSingleInputTimeRangeField = useSingleInputTimeRangeFieldExport;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_useSingleInputTimeRangeField = useSingleInputTimeRangeFieldExport;
 export type {
   UseSingleInputTimeRangeFieldProps,
   SingleInputTimeRangeFieldProps,

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMultiInputRangeField/useMultiInputDateRangeField.ts
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMultiInputRangeField/useMultiInputDateRangeField.ts
@@ -1,8 +1,5 @@
 import useEventCallback from '@mui/utils/useEventCallback';
-import {
-  unstable_useDateField as useDateField,
-  UseDateFieldComponentProps,
-} from '@mui/x-date-pickers/DateField';
+import { useDateField, UseDateFieldComponentProps } from '@mui/x-date-pickers/DateField';
 import {
   useLocalizationContext,
   useValidation,

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMultiInputRangeField/useMultiInputDateTimeRangeField.ts
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMultiInputRangeField/useMultiInputDateTimeRangeField.ts
@@ -1,6 +1,6 @@
 import useEventCallback from '@mui/utils/useEventCallback';
 import {
-  unstable_useDateTimeField as useDateTimeField,
+  useDateTimeField,
   UseDateTimeFieldComponentProps,
 } from '@mui/x-date-pickers/DateTimeField';
 import {

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMultiInputRangeField/useMultiInputTimeRangeField.ts
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMultiInputRangeField/useMultiInputTimeRangeField.ts
@@ -1,8 +1,5 @@
 import useEventCallback from '@mui/utils/useEventCallback';
-import {
-  unstable_useTimeField as useTimeField,
-  UseTimeFieldComponentProps,
-} from '@mui/x-date-pickers/TimeField';
+import { useTimeField, UseTimeFieldComponentProps } from '@mui/x-date-pickers/TimeField';
 import {
   useLocalizationContext,
   useValidation,

--- a/packages/x-date-pickers/src/DateField/index.ts
+++ b/packages/x-date-pickers/src/DateField/index.ts
@@ -1,5 +1,9 @@
+import { useDateField as useDateFieldExport } from './useDateField';
+
 export { DateField } from './DateField';
-export { useDateField as unstable_useDateField } from './useDateField';
+export const useDateField = useDateFieldExport;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_useDateField = useDateFieldExport;
 export type {
   UseDateFieldProps,
   UseDateFieldComponentProps,

--- a/packages/x-date-pickers/src/DateTimeField/index.ts
+++ b/packages/x-date-pickers/src/DateTimeField/index.ts
@@ -1,5 +1,9 @@
+import { useDateTimeField as useDateTimeFieldExport } from './useDateTimeField';
+
 export { DateTimeField } from './DateTimeField';
-export { useDateTimeField as unstable_useDateTimeField } from './useDateTimeField';
+export const useDateTimeField = useDateTimeFieldExport;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_useDateTimeField = useDateTimeFieldExport;
 export type {
   UseDateTimeFieldProps,
   UseDateTimeFieldComponentProps,

--- a/packages/x-date-pickers/src/TimeField/index.ts
+++ b/packages/x-date-pickers/src/TimeField/index.ts
@@ -1,5 +1,9 @@
+import { useTimeField as useTimeFieldExport } from './useTimeField';
+
 export { TimeField } from './TimeField';
-export { useTimeField as unstable_useTimeField } from './useTimeField';
+export const useTimeField = useTimeFieldExport;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const unstable_useTimeField = useTimeFieldExport;
 export type {
   UseTimeFieldProps,
   UseTimeFieldComponentProps,


### PR DESCRIPTION
For the multi input range fields, I would like to get a decision on https://mui-org.slack.com/archives/C040YT7KB6H/p1725528462298159 first.
Even for single input range fields it would be better, because if we drop the multi input one, we might rename those to be `useDateRangeField` (and equivalent).