### PR TITLE
[test] Remove dead `act()` logic

### DIFF
--- a/packages/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/detailPanel.DataGridPro.test.tsx
@@ -489,9 +489,7 @@ describe('<DataGridPro /> - Detail panel', () => {
       <TestCase getDetailPanelContent={() => <DetailPanel />} detailPanelExpandedRowIds={[0]} />,
     );
     expect(screen.getByTestId(`detail-panel-content`).textContent).to.equal(`${counter}`);
-    act(() => {
-      setProps({ detailPanelExpandedRowIds: [1] });
-    });
+    setProps({ detailPanelExpandedRowIds: [1] });
     expect(screen.getByTestId(`detail-panel-content`).textContent).to.equal(`${counter}`);
   });
 


### PR DESCRIPTION
`setProps()` seems to call https://github.com/mui/material-ui/blob/dcc17031aa37b251678c39628b15637ec758d6b4/packages-internal/test-utils/src/createRenderer.tsx#L316 which seems to call https://github.com/testing-library/react-hooks-testing-library/blob/1e01273374af4e48a0feb1f2233bf6c76d742167/src/dom/pure.ts#L22 so this looks like dead code.

This was added in #8097.

I have noticed this in #14442 while I was quickly checking the CLA signed workflow, I looked at the PR diff and this seemed odd to me.