### PR TITLE
[docs] Fix what's new link to use absolute URL

### DIFF
--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -6,7 +6,7 @@ import treeViewComponentApi from './tree-view-component-api-pages';
 
 const pages: MuiPage[] = [
   {
-    pathname: '/x/whats-new',
+    pathname: 'https://mui.com/x/whats-new/',
     title: "What's new in MUI X",
   },
   {


### PR DESCRIPTION
Per the playbook in #9727, I believe that the long-term goal is to have a blog infra that supports change for different product scopes: https://www.notion.so/mui-org/docs-infra-Improving-the-blog-infrastructure-bcae2b15493f4daba0758adf499f7793?pvs=4#d041fb05b6184dc68d7f9df7c9100b60. 

In any cases, when going to https://v6.mui.com/x/introduction/, we want the link to point to the most up to date content.