### PR TITLE
[docs] Fixed typo in Recipes Row Grouping

### DIFF
--- a/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
+++ b/docs/data/data-grid/recipes-row-grouping/recipes-row-grouping.md
@@ -26,7 +26,7 @@ To sort the row groups by the number of child rows, you can override it using `g
 
 {{"demo": "RowGroupingSortByChildRows.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Dispaying child row count in footer
+## Displaying child row count in footer
 
 By default, the row count in the footer is the number of top level rows that are visible after filtering.
 


### PR DESCRIPTION
Changed "Dispaying" to "Displaying"
The following docs section had a typo, which I proposed to fix.
https://mui.com/x/react-data-grid/recipes-row-grouping/#dispaying-child-row-count-in-footer
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
