### PR TITLE
[infra] Create `ESLint plugins` renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,17 @@
     },
     {
       "groupName": "ESLint plugins",
-      "matchPackagePatterns": "eslint-plugin-*"
+      "matchPackageNames": [
+        "eslint-plugin-filenames",
+        "eslint-plugin-import",
+        "eslint-plugin-jsdoc",
+        "eslint-plugin-jsx-a11y",
+        "eslint-plugin-mocha",
+        "eslint-plugin-prettier",
+        "eslint-plugin-react",
+        "eslint-plugin-react-hooks",
+        "eslint-plugin-testing-library"
+      ]
     },
     {
       "groupName": "@types/node",

--- a/renovate.json
+++ b/renovate.json
@@ -55,17 +55,7 @@
     },
     {
       "groupName": "ESLint plugins",
-      "matchPackageNames": [
-        "eslint-plugin-filenames",
-        "eslint-plugin-import",
-        "eslint-plugin-jsdoc",
-        "eslint-plugin-jsx-a11y",
-        "eslint-plugin-mocha",
-        "eslint-plugin-prettier",
-        "eslint-plugin-react",
-        "eslint-plugin-react-hooks",
-        "eslint-plugin-testing-library"
-      ]
+      "matchPackagePatterns": ["eslint-plugin-*", "!eslint-plugin-react-compiler"]
     },
     {
       "groupName": "@types/node",

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,10 @@
       "matchPackagePatterns": "@typescript-eslint/*"
     },
     {
+      "groupName": "ESLint plugins",
+      "matchPackagePatterns": "eslint-plugin-*"
+    },
+    {
       "groupName": "@types/node",
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "< 21.0.0"


### PR DESCRIPTION
We have numerous `eslint-plugin-*` dependencies that keep producing conflicts after merging one of the bump PRs.

https://github.com/mui/mui-x/blob/a198b26371fa8ed6185175426e983efffd2b1e3a/package.json#L144-L154

Having them grouped should ease such bumps. 🤞 
