### PR TITLE
[charts] Pass the axis index to extremum getter

### DIFF
--- a/packages/x-charts-pro/src/context/CartesianProviderPro/createAxisFilterMapper.ts
+++ b/packages/x-charts-pro/src/context/CartesianProviderPro/createAxisFilterMapper.ts
@@ -38,7 +38,7 @@ export const createAxisFilterMapper =
     if (scaleType === 'point' || scaleType === 'band') {
       extremums = [0, (axis.data?.length ?? 1) - 1];
     } else {
-      extremums = getAxisExtremum(axis, extremumGetter, axisIndex === 0, formattedSeries);
+      extremums = getAxisExtremum(axis, extremumGetter, axisIndex, formattedSeries);
     }
 
     let min: number | Date;

--- a/packages/x-charts/src/BarChart/extremums.test.ts
+++ b/packages/x-charts/src/BarChart/extremums.test.ts
@@ -26,6 +26,7 @@ const buildData = (
       id: 'id',
       data,
     },
+    axisIndex: 0,
     isDefaultAxis: true,
   };
 };

--- a/packages/x-charts/src/context/CartesianProvider/computeValue.ts
+++ b/packages/x-charts/src/context/CartesianProvider/computeValue.ts
@@ -89,7 +89,6 @@ export function computeValue({
   const completeAxis: DefaultizedAxisConfig<ChartsAxisProps> = {};
   allAxis.forEach((eachAxis, axisIndex) => {
     const axis = eachAxis as Readonly<AxisConfig<ScaleName, any, Readonly<ChartsAxisProps>>>;
-    const isDefaultAxis = axisIndex === 0;
     const zoomOption = zoomOptions?.[axis.id];
     const zoom = zoomData?.find(({ axisId }) => axisId === axis.id);
     const zoomRange: [number, number] = zoom ? [zoom.start, zoom.end] : [0, 100];
@@ -98,7 +97,7 @@ export function computeValue({
     const [minData, maxData] = getAxisExtremum(
       axis,
       extremumGetters,
-      isDefaultAxis,
+      axisIndex,
       formattedSeries,
       zoom === undefined && !zoomOption ? getFilters : undefined, // Do not apply filtering if zoom is already defined.
     );

--- a/packages/x-charts/src/context/CartesianProvider/getAxisExtremum.ts
+++ b/packages/x-charts/src/context/CartesianProvider/getAxisExtremum.ts
@@ -9,7 +9,7 @@ const axisExtremumCallback = <T extends CartesianChartSeriesType>(
   chartType: T,
   axis: AxisConfig,
   getters: ExtremumGettersConfig<T>,
-  isDefaultAxis: boolean,
+  axisIndex: number,
   formattedSeries: FormattedSeries,
   getFilters?: GetZoomAxisFilters,
 ): ExtremumGetterResult => {
@@ -19,7 +19,8 @@ const axisExtremumCallback = <T extends CartesianChartSeriesType>(
   const [minChartTypeData, maxChartTypeData] = getter?.({
     series,
     axis,
-    isDefaultAxis,
+    axisIndex,
+    isDefaultAxis: axisIndex === 0,
     getFilters,
   }) ?? [Infinity, -Infinity];
 
@@ -31,7 +32,7 @@ const axisExtremumCallback = <T extends CartesianChartSeriesType>(
 export const getAxisExtremum = (
   axis: AxisConfig,
   getters: ExtremumGettersConfig,
-  isDefaultAxis: boolean,
+  axisIndex: number,
   formattedSeries: FormattedSeries,
   getFilters?: GetZoomAxisFilters,
 ) => {
@@ -39,15 +40,7 @@ export const getAxisExtremum = (
 
   const extremums = charTypes.reduce<ExtremumGetterResult>(
     (acc, charType) =>
-      axisExtremumCallback(
-        acc,
-        charType,
-        axis,
-        getters,
-        isDefaultAxis,
-        formattedSeries,
-        getFilters,
-      ),
+      axisExtremumCallback(acc, charType, axis, getters, axisIndex, formattedSeries, getFilters),
     [Infinity, -Infinity],
   );
 

--- a/packages/x-charts/src/context/PluginProvider/ExtremumGetter.types.ts
+++ b/packages/x-charts/src/context/PluginProvider/ExtremumGetter.types.ts
@@ -13,6 +13,7 @@ export type ExtremumGettersConfig<T extends ChartSeriesType = CartesianChartSeri
 type ExtremumGetterParams<T extends ChartSeriesType> = {
   series: Record<SeriesId, ChartSeries<T>>;
   axis: AxisConfig;
+  axisIndex: number;
   isDefaultAxis: boolean;
   getFilters?: (params: {
     currentAxisId: AxisId | undefined;


### PR DESCRIPTION
Part of the Radar chart.

The radar will have one radial axis per radar direction, such that use can plot on different direction values with different scales. For example comparing the GDP/capit and the life expectancy of countries on the same radar implies different scales.

To map series value to the right axis, I need their index.

So for consistency I'm providing the same values to the cartesian axes