### PR TITLE
[TreeView] Fix invalid test for items reordering

### DIFF
--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.test.tsx
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.test.tsx
@@ -156,7 +156,7 @@ describeTreeView<
         experimentalFeatures: { indentationAtItemLevel: true, itemsReordering: true },
         items: [{ id: '1' }, { id: '2' }, { id: '3' }],
         itemsReordering: true,
-        canMoveItemToNewPosition: () => false,
+        isItemReorderable: () => false,
       });
 
       dragEvents.fullDragSequence(view.getItemRoot('1'), view.getItemContent('2'));
@@ -168,7 +168,7 @@ describeTreeView<
         experimentalFeatures: { indentationAtItemLevel: true, itemsReordering: true },
         items: [{ id: '1' }, { id: '2' }, { id: '3' }],
         itemsReordering: true,
-        canMoveItemToNewPosition: () => true,
+        isItemReorderable: () => true,
       });
 
       dragEvents.fullDragSequence(view.getItemRoot('1'), view.getItemContent('2'));


### PR DESCRIPTION
Extracted from #14210

The `describe` says the tests are testing `isItemReorderable`, not `canMoveItemToNewPosition`.