### PR TITLE
[pickers] Fix left-right keyboard nav with `yearsOrder="desc"` and `direction="rtl"`

### DIFF
--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -226,7 +226,7 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate extends
   }, [selectedYear]);
 
   const verticalDirection = yearsOrder !== 'desc' ? yearsPerRow * 1 : yearsPerRow * -1;
-  const horizontalDirection = isRtl || yearsOrder === 'desc' ? -1 : 1;
+  const horizontalDirection = (isRtl && yearsOrder === 'asc') || (!isRtl && yearsOrder === 'desc') ? -1 : 1;
 
   const handleKeyDown = useEventCallback((event: React.KeyboardEvent, year: number) => {
     switch (event.key) {

--- a/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/YearCalendar.tsx
@@ -226,7 +226,8 @@ export const YearCalendar = React.forwardRef(function YearCalendar<TDate extends
   }, [selectedYear]);
 
   const verticalDirection = yearsOrder !== 'desc' ? yearsPerRow * 1 : yearsPerRow * -1;
-  const horizontalDirection = (isRtl && yearsOrder === 'asc') || (!isRtl && yearsOrder === 'desc') ? -1 : 1;
+  const horizontalDirection =
+    (isRtl && yearsOrder === 'asc') || (!isRtl && yearsOrder === 'desc') ? -1 : 1;
 
   const handleKeyDown = useEventCallback((event: React.KeyboardEvent, year: number) => {
     switch (event.key) {

--- a/packages/x-date-pickers/src/YearCalendar/tests/keyboard.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/keyboard.YearCalendar.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { spy } from 'sinon';
 import { expect } from 'chai';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
@@ -20,13 +19,11 @@ describe('<YearCalendar /> - Keyboard', () => {
     yearsOrder: 'asc' | 'desc' = 'asc',
     direction: 'ltr' | 'rtl' = 'ltr',
   ) {
-    const onChange = spy();
     const yearCalendar = (
       <YearCalendar
         value={adapterToUse.date('2000-01-01')}
         minDate={adapterToUse.date('1999-01-01')}
         maxDate={adapterToUse.date('2001-01-01')}
-        onChange={onChange}
         yearsOrder={yearsOrder}
       />
     );

--- a/packages/x-date-pickers/src/YearCalendar/tests/keyboard.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/keyboard.YearCalendar.test.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { spy } from 'sinon';
+import { expect } from 'chai';
+import { fireEvent, screen } from '@mui/internal-test-utils';
+import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
+import { createPickerRenderer, adapterToUse } from 'test/utils/pickers';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+/* eslint-disable material-ui/disallow-active-element-as-key-event-target */
+describe('<YearCalendar /> - Keyboard', () => {
+  const { render } = createPickerRenderer({ clock: 'fake', clockConfig: new Date(2000, 0, 1) });
+
+  const RTL_THEME = createTheme({
+    direction: 'rtl',
+  });
+
+  function changeYear(
+    keyPressed: string,
+    expectedValue: string,
+    yearsOrder: 'asc' | 'desc' = 'asc',
+    direction: 'ltr' | 'rtl' = 'ltr',
+  ) {
+    const onChange = spy();
+    const yearCalendar = (
+      <YearCalendar
+        value={adapterToUse.date('2000-01-01')}
+        minDate={adapterToUse.date('1999-01-01')}
+        maxDate={adapterToUse.date('2001-01-01')}
+        onChange={onChange}
+        yearsOrder={yearsOrder}
+      />
+    );
+
+    const elementsToRender =
+      direction === 'rtl' ? (
+        <ThemeProvider theme={RTL_THEME}>{yearCalendar}</ThemeProvider>
+      ) : (
+        yearCalendar
+      );
+
+    render(elementsToRender);
+    const startYear = screen.getByRole('radio', { checked: true });
+    fireEvent.focus(startYear);
+    fireEvent.keyDown(document.activeElement!, { key: keyPressed });
+    expect(document.activeElement?.textContent).to.equal(expectedValue);
+  }
+
+  it('should increase the year when pressing right and yearsOrder is asc (default)', () => {
+    changeYear('ArrowRight', '2001');
+  });
+
+  it('should decrease the year when pressing left and yearsOrder is asc (default)', () => {
+    changeYear('ArrowLeft', '1999');
+  });
+
+  it('should decrease the year when pressing right and yearsOrder is desc', () => {
+    changeYear('ArrowRight', '1999', 'desc');
+  });
+
+  it('should increase the year when pressing left and yearsOrder is desc', () => {
+    changeYear('ArrowLeft', '2001', 'desc');
+  });
+
+  it('should decrease the year when pressing right and yearsOrder is asc (default) and theme is RTL', () => {
+    changeYear('ArrowRight', '1999', 'asc', 'rtl');
+  });
+
+  it('should increase the year when pressing left and yearsOrder is asc (default) and theme is RTL', () => {
+    changeYear('ArrowLeft', '2001', 'asc', 'rtl');
+  });
+
+  it('should increase the year when pressing right and yearsOrder is desc and theme is RTL', () => {
+    changeYear('ArrowRight', '2001', 'desc', 'rtl');
+  });
+
+  it('should decrease the year when pressing left and yearsOrder is desc and theme is RTL', () => {
+    changeYear('ArrowLeft', '1999', 'desc', 'rtl');
+  });
+});


### PR DESCRIPTION
Hi @LukasTy @MBilalShafi ,

A thousand apologies, I had tested this during development but when yearsOrder was changed from a boolean to `asc` | `desc` the RTL horizontal direction check got borken.

Still works fine with the default settings but if `yearsOrder='desc'` is used with rtl now the left/right navigation is backwards when the theme is right to left.

Finally found a good place to test these under the localization docs page and this small change should make everything right (/x/react-date-pickers/adapters-locale/).

I will work on an update to the automated tests too that would catch this, but this quick fix for now.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
