### PR TITLE
[fields] Move the `minutesStep` to the `UseFieldInternalProps` interface

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.ts
@@ -34,9 +34,7 @@ export const useField = <
     any,
     TEnableAccessibleFieldDOMStructure,
     any
-  > & {
-    minutesStep?: number;
-  },
+  >,
 >(
   params: UseFieldParams<
     TValue,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -137,6 +137,11 @@ export interface UseFieldInternalProps<
    * @default false
    */
   disabled?: boolean;
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep?: number;
 }
 
 export interface UseFieldCommonAdditionalProps
@@ -454,9 +459,7 @@ export type UseFieldTextField<TEnableAccessibleFieldDOMStructure extends boolean
     any,
     TEnableAccessibleFieldDOMStructure,
     any
-  > & {
-    minutesStep?: number;
-  },
+  >,
 >(
   params: UseFieldTextFieldParams<
     TValue,


### PR DESCRIPTION
@alexfauquette was there a reason not to have it there?

EDIT: OK I found it, now the date fields have the prop :laughing: 
Closing this PR until I find a better way to remove this weirdness