### PR TITLE
[DataGrid] Fix content rendering for large rows while using automatic page size

### DIFF
--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
@@ -232,8 +232,9 @@ export const useGridPaginationModel = (
 
     const dimensions = apiRef.current.getRootDimensions();
 
-    const maximumPageSizeWithoutScrollBar = Math.floor(
-      dimensions.viewportInnerSize.height / rowHeight,
+    const maximumPageSizeWithoutScrollBar = Math.max(
+      1,
+      Math.floor(dimensions.viewportInnerSize.height / rowHeight),
     );
 
     apiRef.current.setPageSize(maximumPageSizeWithoutScrollBar);


### PR DESCRIPTION
 When either
 - zooming very close
 - the viewport get too small due to window resize or
 - row item is generally high and thus higher than DataGrid inner height

DataGrid should still at least show one row - even if it doesn't wholly fit.

Currently it does not show any content and displays wrong pagecount and pagesize.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).