### PR TITLE
[TreeView] Use `useDefaultProps` instead of `useThemeProps`

### DIFF
--- a/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
+++ b/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
@@ -2,12 +2,13 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
-import { useLicenseVerifier, Watermark } from '@mui/x-license';
 import useSlotProps from '@mui/utils/useSlotProps';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
+import { useLicenseVerifier, Watermark } from '@mui/x-license';
 import { TreeItem, TreeItemProps } from '@mui/x-tree-view/TreeItem';
 import { useTreeView, TreeViewProvider } from '@mui/x-tree-view/internals';
 import { warnOnce } from '@mui/x-internals/warning';
-import { styled, createUseThemeProps } from '../internals/zero-styled';
+import { styled } from '../internals/zero-styled';
 import { getRichTreeViewProUtilityClass } from './richTreeViewProClasses';
 import { RichTreeViewProProps } from './RichTreeViewPro.types';
 import {
@@ -15,8 +16,6 @@ import {
   RichTreeViewProPluginSignatures,
 } from './RichTreeViewPro.plugins';
 import { getReleaseInfo } from '../internals/utils/releaseInfo';
-
-const useThemeProps = createUseThemeProps('MuiRichTreeViewPro');
 
 const useUtilityClasses = <R extends {}, Multiple extends boolean | undefined>(
   ownerState: RichTreeViewProProps<R, Multiple>,
@@ -108,7 +107,7 @@ const RichTreeViewPro = React.forwardRef(function RichTreeViewPro<
   R extends {},
   Multiple extends boolean | undefined = undefined,
 >(inProps: RichTreeViewProProps<R, Multiple>, ref: React.Ref<HTMLUListElement>) {
-  const props = useThemeProps({ props: inProps, name: 'MuiRichTreeViewPro' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiRichTreeViewPro' });
 
   useLicenseVerifier('x-tree-view-pro', releaseInfo);
 

--- a/packages/x-tree-view-pro/src/internals/zero-styled/index.ts
+++ b/packages/x-tree-view-pro/src/internals/zero-styled/index.ts
@@ -1,8 +1,1 @@
-import { useThemeProps } from '@mui/material/styles';
-
 export { styled } from '@mui/material/styles';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function createUseThemeProps(name: string) {
-  return useThemeProps;
-}

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
@@ -3,16 +3,15 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
 import useSlotProps from '@mui/utils/useSlotProps';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
 import { warnOnce } from '@mui/x-internals/warning';
 import { getRichTreeViewUtilityClass } from './richTreeViewClasses';
 import { RichTreeViewProps } from './RichTreeView.types';
-import { styled, createUseThemeProps } from '../internals/zero-styled';
+import { styled } from '../internals/zero-styled';
 import { useTreeView } from '../internals/useTreeView';
 import { TreeViewProvider } from '../internals/TreeViewProvider';
 import { RICH_TREE_VIEW_PLUGINS, RichTreeViewPluginSignatures } from './RichTreeView.plugins';
 import { TreeItem, TreeItemProps } from '../TreeItem';
-
-const useThemeProps = createUseThemeProps('MuiRichTreeView');
 
 const useUtilityClasses = <R extends {}, Multiple extends boolean | undefined>(
   ownerState: RichTreeViewProps<R, Multiple>,
@@ -76,7 +75,7 @@ const RichTreeView = React.forwardRef(function RichTreeView<
   R extends {},
   Multiple extends boolean | undefined = undefined,
 >(inProps: RichTreeViewProps<R, Multiple>, ref: React.Ref<HTMLUListElement>) {
-  const props = useThemeProps({ props: inProps, name: 'MuiRichTreeView' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiRichTreeView' });
 
   if (process.env.NODE_ENV !== 'production') {
     if ((props as any).children != null) {

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -3,15 +3,14 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
 import useSlotProps from '@mui/utils/useSlotProps';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
 import { warnOnce } from '@mui/x-internals/warning';
-import { styled, createUseThemeProps } from '../internals/zero-styled';
+import { styled } from '../internals/zero-styled';
 import { getSimpleTreeViewUtilityClass } from './simpleTreeViewClasses';
 import { SimpleTreeViewProps } from './SimpleTreeView.types';
 import { useTreeView } from '../internals/useTreeView';
 import { TreeViewProvider } from '../internals/TreeViewProvider';
 import { SIMPLE_TREE_VIEW_PLUGINS, SimpleTreeViewPluginSignatures } from './SimpleTreeView.plugins';
-
-const useThemeProps = createUseThemeProps('MuiSimpleTreeView');
 
 const useUtilityClasses = <Multiple extends boolean | undefined>(
   ownerState: SimpleTreeViewProps<Multiple>,
@@ -56,7 +55,7 @@ const EMPTY_ITEMS: any[] = [];
 const SimpleTreeView = React.forwardRef(function SimpleTreeView<
   Multiple extends boolean | undefined = undefined,
 >(inProps: SimpleTreeViewProps<Multiple>, ref: React.Ref<HTMLUListElement>) {
-  const props = useThemeProps({ props: inProps, name: 'MuiSimpleTreeView' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiSimpleTreeView' });
   const ownerState = props as SimpleTreeViewProps<any>;
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -13,7 +13,8 @@ import resolveComponentProps from '@mui/utils/resolveComponentProps';
 import useSlotProps from '@mui/utils/useSlotProps';
 import unsupportedProp from '@mui/utils/unsupportedProp';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
-import { styled, createUseThemeProps } from '../internals/zero-styled';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
+import { styled } from '../internals/zero-styled';
 import { TreeItemContent } from './TreeItemContent';
 import { treeItemClasses, getTreeItemUtilityClass } from './treeItemClasses';
 import {
@@ -30,8 +31,6 @@ import { useTreeItemState } from './useTreeItemState';
 import { isTargetInDescendants } from '../internals/utils/tree';
 import { TreeViewItemPluginSlotPropsEnhancerParams } from '../internals/models';
 import { generateTreeItemIdAttribute } from '../internals/corePlugins/useTreeViewId/useTreeViewId.utils';
-
-const useThemeProps = createUseThemeProps('MuiTreeItem');
 
 const useUtilityClasses = (ownerState: TreeItemOwnerState) => {
   const { classes } = ownerState;
@@ -205,7 +204,7 @@ export const TreeItem = React.forwardRef(function TreeItem(
   } = useTreeViewContext<TreeItemMinimalPlugins, TreeItemOptionalPlugins>();
   const depthContext = React.useContext(TreeViewItemDepthContext);
 
-  const props = useThemeProps({ props: inProps, name: 'MuiTreeItem' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTreeItem' });
 
   const {
     children,

--- a/packages/x-tree-view/src/TreeItem2/TreeItem2.tsx
+++ b/packages/x-tree-view/src/TreeItem2/TreeItem2.tsx
@@ -9,7 +9,8 @@ import MuiCheckbox, { CheckboxProps } from '@mui/material/Checkbox';
 import useSlotProps from '@mui/utils/useSlotProps';
 import { shouldForwardProp } from '@mui/system/createStyled';
 import composeClasses from '@mui/utils/composeClasses';
-import { styled, createUseThemeProps } from '../internals/zero-styled';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
+import { styled } from '../internals/zero-styled';
 import { TreeItem2Props, TreeItem2OwnerState } from './TreeItem2.types';
 import {
   useTreeItem2,
@@ -22,8 +23,6 @@ import { TreeItem2Icon } from '../TreeItem2Icon';
 import { TreeItem2DragAndDropOverlay } from '../TreeItem2DragAndDropOverlay';
 import { TreeItem2Provider } from '../TreeItem2Provider';
 import { TreeItem2LabelInput } from '../TreeItem2LabelInput';
-
-const useThemeProps = createUseThemeProps('MuiTreeItem2');
 
 export const TreeItem2Root = styled('li', {
   name: 'MuiTreeItem2',
@@ -229,7 +228,7 @@ export const TreeItem2 = React.forwardRef(function TreeItem2(
   inProps: TreeItem2Props,
   forwardedRef: React.Ref<HTMLLIElement>,
 ) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTreeItem2' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTreeItem2' });
 
   const { id, itemId, label, disabled, children, slots = {}, slotProps = {}, ...other } = props;
 

--- a/packages/x-tree-view/src/TreeItem2DragAndDropOverlay/TreeItem2DragAndDropOverlay.tsx
+++ b/packages/x-tree-view/src/TreeItem2DragAndDropOverlay/TreeItem2DragAndDropOverlay.tsx
@@ -24,16 +24,16 @@ const TreeItem2DragAndDropOverlayRoot = styled('div', {
       style: {
         marginLeft: 'calc(var(--TreeView-indentMultiplier) * var(--TreeView-itemDepth))',
         borderRadius: theme.shape.borderRadius,
-        backgroundColor: alpha((theme.vars || theme).palette.primary.dark, 0.15),
+        backgroundColor: alpha(theme.palette.primary.dark, 0.15),
       },
     },
     {
       props: { action: 'reorder-above' },
       style: {
         marginLeft: 'calc(var(--TreeView-indentMultiplier) * var(--TreeView-itemDepth))',
-        borderTop: `1px solid ${alpha((theme.vars || theme).palette.grey[900], 0.6)}`,
+        borderTop: `1px solid ${alpha(theme.palette.grey[900], 0.6)}`,
         ...theme.applyStyles('dark', {
-          borderTopColor: alpha((theme.vars || theme).palette.grey[100], 0.6),
+          borderTopColor: alpha(theme.palette.grey[100], 0.6),
         }),
       },
     },
@@ -41,9 +41,9 @@ const TreeItem2DragAndDropOverlayRoot = styled('div', {
       props: { action: 'reorder-below' },
       style: {
         marginLeft: 'calc(var(--TreeView-indentMultiplier) * var(--TreeView-itemDepth))',
-        borderBottom: `1px solid ${alpha((theme.vars || theme).palette.grey[900], 0.6)}`,
+        borderBottom: `1px solid ${alpha(theme.palette.grey[900], 0.6)}`,
         ...theme.applyStyles('dark', {
-          borderBottomColor: alpha((theme.vars || theme).palette.grey[100], 0.6),
+          borderBottomColor: alpha(theme.palette.grey[100], 0.6),
         }),
       },
     },
@@ -52,9 +52,9 @@ const TreeItem2DragAndDropOverlayRoot = styled('div', {
       style: {
         marginLeft:
           'calc(var(--TreeView-indentMultiplier) * calc(var(--TreeView-itemDepth) - 1))' as any,
-        borderBottom: `1px solid ${alpha((theme.vars || theme).palette.grey[900], 0.6)}`,
+        borderBottom: `1px solid ${alpha(theme.palette.grey[900], 0.6)}`,
         ...theme.applyStyles('dark', {
-          borderBottomColor: alpha((theme.vars || theme).palette.grey[900], 0.6),
+          borderBottomColor: alpha(theme.palette.grey[900], 0.6),
         }),
       },
     },

--- a/packages/x-tree-view/src/TreeView/TreeView.tsx
+++ b/packages/x-tree-view/src/TreeView/TreeView.tsx
@@ -2,12 +2,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';
-import { styled, createUseThemeProps } from '../internals/zero-styled';
+import { useDefaultProps } from '@mui/material/DefaultPropsProvider';
+import { styled } from '../internals/zero-styled';
 import { getTreeViewUtilityClass } from './treeViewClasses';
 import { TreeViewProps } from './TreeView.types';
 import { SimpleTreeView, SimpleTreeViewRoot } from '../SimpleTreeView';
-
-const useThemeProps = createUseThemeProps('MuiTreeView');
 
 const useUtilityClasses = <Multiple extends boolean | undefined>(
   ownerState: TreeViewProps<Multiple>,
@@ -70,7 +69,7 @@ const TreeView = React.forwardRef(function TreeView<
     warn();
   }
 
-  const props = useThemeProps({ props: inProps, name: 'MuiTreeView' });
+  const props = useDefaultProps({ props: inProps, name: 'MuiTreeView' });
 
   const classes = useUtilityClasses(props);
 

--- a/packages/x-tree-view/src/internals/zero-styled/index.ts
+++ b/packages/x-tree-view/src/internals/zero-styled/index.ts
@@ -1,8 +1,1 @@
-import { useThemeProps } from '@mui/material/styles';
-
 export { styled } from '@mui/material/styles';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function createUseThemeProps(name: string) {
-  return useThemeProps;
-}


### PR DESCRIPTION
Use the new API introduced by the core team.

We need to bump `@mui/material` deps to use `5.16.0` or above in order to support it, which makes this a breaking change.

I'm opening this PR to check with the core if the approach is good before preparing the one for the pickers to merge it at the beginning of the alpha.
