### PR TITLE
[docs] Fix typo in usage of Moment guide for UTC and timezones

### DIFF
--- a/docs/data/date-pickers/timezone/timezone.md
+++ b/docs/data/date-pickers/timezone/timezone.md
@@ -272,7 +272,7 @@ Please check out the documentation of the [UTC and timezones on Luxon](https://m
 :::info
 **How to create a UTC date with Moment?**
 
-To create a UTC date, use the `dayjs.utc` method
+To create a UTC date, use the `moment.utc` method
 
 ```tsx
 const date = moment.utc('2022-04-17T15:30');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This pull request corrects a typo in the usage of Moment guide within the Date and Time Pickers documentation. It replaces the reference to `datejs.utc` with the correct usage of `moment.utc` for creating UTC dates. This small change improves the accuracy of the documentation and helps users avoid confusion when working with UTC and timezones.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
