### PR TITLE
[DataGridPro] Fix row pre-processing running with a stale data source

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import useLazyRef from '@mui/utils/useLazyRef';
 import { GridEventListener } from '../../../models/events';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';
@@ -73,6 +74,7 @@ export const useGridRows = (
     | 'pagination'
     | 'paginationMode'
     | 'loading'
+    | 'unstable_dataSource'
   >,
 ): void => {
   if (process.env.NODE_ENV !== 'production') {
@@ -536,15 +538,20 @@ export const useGridRows = (
     throttledRowsChange,
   ]);
 
+  const previousDataSource = useLazyRef(() => props.unstable_dataSource);
   const handleStrategyProcessorChange = React.useCallback<
     GridEventListener<'activeStrategyProcessorChange'>
   >(
     (methodName) => {
+      if (props.unstable_dataSource && props.unstable_dataSource !== previousDataSource.current) {
+        previousDataSource.current = props.unstable_dataSource;
+        return;
+      }
       if (methodName === 'rowTreeCreation') {
         groupRows();
       }
     },
-    [groupRows],
+    [groupRows, previousDataSource, props.unstable_dataSource],
   );
 
   const handleStrategyActivityChange = React.useCallback<


### PR DESCRIPTION
Fixes #14793
- Before: https://codesandbox.io/p/sandbox/hopeful-chandrasekhar-8xgvr4
- After: https://codesandbox.io/p/sandbox/modern-sound-zrlx8s

When a new data source is passed, the strategy processor gets updated and row preprocessing is re-triggered with the old data due to the binding with `activeStrategyProcessorChange` event.
The PR skips automatically re-running the pre-processing when the data source is updated.

