### PR TITLE
[data grid][docs] Change demo name example

### DIFF
--- a/docs/data/data-grid/row-spanning/RowSpanningCustom.js
+++ b/docs/data/data-grid/row-spanning/RowSpanningCustom.js
@@ -59,14 +59,14 @@ const columns = [
 const rows = [
   {
     id: 1,
-    name: 'George Floyd',
+    name: 'Andrew Clark',
     designation: 'React Engineer',
     department: 'Engineering',
     age: 25,
   },
   {
     id: 2,
-    name: 'George Floyd',
+    name: 'Andrew Clark',
     designation: 'Technical Interviewer',
     department: 'Human resource',
     age: 25,

--- a/docs/data/data-grid/row-spanning/RowSpanningCustom.tsx
+++ b/docs/data/data-grid/row-spanning/RowSpanningCustom.tsx
@@ -59,14 +59,14 @@ const columns: GridColDef[] = [
 const rows = [
   {
     id: 1,
-    name: 'George Floyd',
+    name: 'Andrew Clark',
     designation: 'React Engineer',
     department: 'Engineering',
     age: 25,
   },
   {
     id: 2,
-    name: 'George Floyd',
+    name: 'Andrew Clark',
     designation: 'Technical Interviewer',
     department: 'Human resource',
     age: 25,


### PR DESCRIPTION
From #14124  - fixing name used in demo

- Before: https://deploy-preview-14821--material-ui-x.netlify.app/x/react-data-grid/row-spanning/#customizing-row-spanning-cells
- After: https://deploy-preview-14822--material-ui-x.netlify.app/x/react-data-grid/row-spanning/#customizing-row-spanning-cells