### PR TITLE
[DataGrid] `printOptions` should respect `hideFooter` root prop

### DIFF
--- a/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -63,7 +63,10 @@ function buildPrintWindow(title?: string): HTMLIFrameElement {
  */
 export const useGridPrintExport = (
   apiRef: RefObject<GridPrivateApiCommunity>,
-  props: Pick<DataGridProcessedProps, 'pagination' | 'columnHeaderHeight' | 'headerFilterHeight'>,
+  props: Pick<
+    DataGridProcessedProps,
+    'pagination' | 'columnHeaderHeight' | 'headerFilterHeight' | 'hideFooter'
+  >,
 ): void => {
   const hasRootReference = apiRef.current.rootElementRef.current !== null;
   const logger = useGridLogger(apiRef, 'useGridPrintExport');
@@ -126,9 +129,9 @@ export const useGridPrintExport = (
       const normalizeOptions = {
         copyStyles: true,
         hideToolbar: false,
-        hideFooter: false,
         includeCheckboxes: false,
         ...options,
+        hideFooter: props.hideFooter || options?.hideFooter,
       };
 
       const printDoc = printWindow.contentDocument;

--- a/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -131,7 +131,6 @@ export const useGridPrintExport = (
         hideToolbar: false,
         includeCheckboxes: false,
         ...options,
-        hideFooter: props.hideFooter || options?.hideFooter,
       };
 
       const printDoc = printWindow.contentDocument;
@@ -158,14 +157,17 @@ export const useGridPrintExport = (
       let gridFooterElementHeight =
         gridRootElement!.querySelector<HTMLElement>(`.${gridClasses.footerContainer}`)
           ?.offsetHeight || 0;
+      const gridFooterElement = gridClone.querySelector<HTMLElement>(
+        `.${gridClasses.footerContainer}`,
+      );
 
       if (normalizeOptions.hideToolbar) {
         gridClone.querySelector(`.${gridClasses.toolbarContainer}`)?.remove();
         gridToolbarElementHeight = 0;
       }
 
-      if (normalizeOptions.hideFooter) {
-        gridClone.querySelector(`.${gridClasses.footerContainer}`)?.remove();
+      if (normalizeOptions.hideFooter && gridFooterElement) {
+        gridFooterElement.remove();
         gridFooterElementHeight = 0;
       }
 
@@ -179,14 +181,10 @@ export const useGridPrintExport = (
       // The height above does not include grid border width, so we need to exclude it
       gridClone.style.boxSizing = 'content-box';
 
-      if (!normalizeOptions.hideFooter) {
+      if (!normalizeOptions.hideFooter && gridFooterElement) {
         // the footer is always being placed at the bottom of the page as if all rows are exported
         // so if getRowsToExport is being used to only export a subset of rows then we need to
         // adjust the footer position to be correctly placed at the bottom of the grid
-        const gridFooterElement: HTMLElement | null = gridClone.querySelector(
-          `.${gridClasses.footerContainer}`,
-        )!;
-
         gridFooterElement.style.position = 'absolute';
         gridFooterElement.style.width = '100%';
         gridFooterElement.style.top = `${computedTotalHeight - gridFooterElementHeight}px`;

--- a/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -129,6 +129,7 @@ export const useGridPrintExport = (
       const normalizeOptions = {
         copyStyles: true,
         hideToolbar: false,
+        hideFooter: false,
         includeCheckboxes: false,
         ...options,
       };

--- a/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -63,10 +63,7 @@ function buildPrintWindow(title?: string): HTMLIFrameElement {
  */
 export const useGridPrintExport = (
   apiRef: RefObject<GridPrivateApiCommunity>,
-  props: Pick<
-    DataGridProcessedProps,
-    'pagination' | 'columnHeaderHeight' | 'headerFilterHeight' | 'hideFooter'
-  >,
+  props: Pick<DataGridProcessedProps, 'pagination' | 'columnHeaderHeight' | 'headerFilterHeight'>,
 ): void => {
   const hasRootReference = apiRef.current.rootElementRef.current !== null;
   const logger = useGridLogger(apiRef, 'useGridPrintExport');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #14861 
Currently, we are enforcing `hideFooter` in `printOptions` to false by default but it should also consider the `hideFooter` root prop value to avoid issues like this.

Before: https://stackblitz.com/edit/github-kbnsbh?file=src%2Fdemo.tsx
After: https://codesandbox.io/p/sandbox/mui-mui-x-x-data-grid-forked-9wx4pw