### PR TITLE
[core] Support `@mui/utils` v6

### DIFF
--- a/packages/x-charts-pro/package.json
+++ b/packages/x-charts-pro/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-charts": "workspace:*",
     "@mui/x-charts-vendor": "workspace:*",
     "@mui/x-internals": "workspace:*",

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-charts-vendor": "workspace:*",
     "@mui/x-internals": "workspace:*",
     "@react-spring/rafz": "^9.7.4",

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-data-grid": "workspace:*",
     "@mui/x-data-grid-pro": "workspace:*",
     "@mui/x-internals": "workspace:*",

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-data-grid": "workspace:*",
     "@mui/x-internals": "workspace:*",
     "@mui/x-license": "workspace:*",

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-internals": "workspace:*",
     "clsx": "^2.1.1",
     "prop-types": "^15.8.1",

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-date-pickers": "workspace:*",
     "@mui/x-internals": "workspace:*",
     "@mui/x-license": "workspace:*",

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-internals": "workspace:*",
     "@types/react-transition-group": "^4.4.11",
     "clsx": "^2.1.1",

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6"
+    "@mui/utils": "^5.16.6 || ^6.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0"

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6"
+    "@mui/utils": "^5.16.6 || ^6.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0"

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-internals": "workspace:*",
     "@mui/x-license": "workspace:*",
     "@mui/x-tree-view": "workspace:*",

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6",
+    "@mui/utils": "^5.16.6 || ^6.0.0",
     "@mui/x-internals": "workspace:*",
     "@types/react-transition-group": "^4.4.11",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -740,7 +740,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-charts-vendor':
         specifier: workspace:*
@@ -805,7 +805,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-charts':
         specifier: workspace:*
@@ -990,7 +990,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1087,7 +1087,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-data-grid':
         specifier: workspace:*
@@ -1155,7 +1155,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-data-grid':
         specifier: workspace:*
@@ -1214,7 +1214,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1300,7 +1300,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-date-pickers':
         specifier: workspace:*
@@ -1420,7 +1420,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1473,7 +1473,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1)
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       '@mui/x-internals':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1374,7 +1374,7 @@ importers:
         specifier: ^7.25.7
         version: 7.25.7
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       react:
         specifier: ^17.0.0 || ^18.0.0
@@ -1394,7 +1394,7 @@ importers:
         specifier: ^7.25.7
         version: 7.25.7
       '@mui/utils':
-        specifier: ^5.16.6
+        specifier: ^5.16.6 || ^6.0.0
         version: 5.16.6(@types/react@18.3.4)(react@18.3.1)
       react:
         specifier: ^17.0.0 || ^18.0.0


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

> Feel free to change the PR title, this fix applies to all mui-x products not just DataGrid

closes #14866

## Root cause

From https://codesandbox.io/p/sandbox/elegant-tree-xspyf2?file=%2Finitialize.ts%3A5%2C1,

It's the inconsistency of `@mui/utils` version.
- `@mui/material` => `@mui/utils` v6
- `@mui-x/data-grid` => `@mui/utils` v5

That's why configuring the classNameGenerator from `@mui/material` (using `@mui/utils` v6) does not affect DataGrid which is using `@mui/utils` v5.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
