### PR TITLE
[DataGrid] Fix scrollbar position not being updated after `scrollToIndexes`

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
@@ -70,8 +70,8 @@ const GridVirtualScrollbar = React.forwardRef<HTMLDivElement, GridVirtualScrollb
   function GridVirtualScrollbar(props, ref) {
     const apiRef = useGridPrivateApiContext();
     const rootProps = useGridRootProps();
-    const isLocked = React.useRef(false);
-    const lastPosition = React.useRef(0);
+    const lastPositionScroller = React.useRef(0);
+    const lastPositionScrollbar = React.useRef(0);
     const scrollbarRef = React.useRef<HTMLDivElement>(null);
     const contentRef = React.useRef<HTMLDivElement>(null);
     const classes = useUtilityClasses(rootProps, props.position);
@@ -96,34 +96,28 @@ const GridVirtualScrollbar = React.forwardRef<HTMLDivElement, GridVirtualScrollb
       const scroller = apiRef.current.virtualScrollerRef.current!;
       const scrollbar = scrollbarRef.current!;
 
-      if (scroller[propertyScroll] === lastPosition.current) {
+      if (scroller[propertyScroll] === lastPositionScroller.current) {
         return;
       }
-
-      if (isLocked.current) {
-        isLocked.current = false;
-        return;
-      }
-      isLocked.current = true;
 
       const value = scroller[propertyScroll] / contentSize;
       scrollbar[propertyScroll] = value * scrollbarInnerSize;
 
-      lastPosition.current = scroller[propertyScroll];
+      lastPositionScrollbar.current = scrollbar[propertyScroll];
     });
 
     const onScrollbarScroll = useEventCallback(() => {
       const scroller = apiRef.current.virtualScrollerRef.current!;
       const scrollbar = scrollbarRef.current!;
 
-      if (isLocked.current) {
-        isLocked.current = false;
+      if (scrollbar[propertyScroll] === lastPositionScrollbar.current) {
         return;
       }
-      isLocked.current = true;
 
       const value = scrollbar[propertyScroll] / scrollbarInnerSize;
       scroller[propertyScroll] = value * contentSize;
+
+      lastPositionScroller.current = scroller[propertyScroll];
     });
 
     useOnMount(() => {


### PR DESCRIPTION
Fixes #14830 

`scrollToIndexes` eventually ends up here
https://github.com/mui/mui-x/blob/52601483fbc978b1f3d0f99562b20d807889e06b/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts#L147-L152

`virtualScroller` gets the update and the scrollbar follows via an [event listener](https://github.com/mui/mui-x/blob/v7.19.0/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx#L133)

In this scenario, only `scrollbar` should be updated, since this was already done for the `scroller`. it looks like that, in some cases, `scroller` event gets executed first and it locks `scrollbar` update with the `isLocked` flag set to `true`.

I have changed this to work with the last position (it was already used in one event listener). This means that the event listeners will run as long as the elements are not at the right position.

As mentioned in the issue, it was already really hard to reproduce the bug, but I notice that after update, the scrollbar gets rendered and displayed after every click, while before it would update in the background.

Before: https://codesandbox.io/p/sandbox/trusting-night-rcm484
After: https://codesandbox.io/p/sandbox/ecstatic-hertz-94g86f