### PR TITLE
[DataGrid] Support minimal Overlay height when `autoHeight` prop is not used

### DIFF
--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -527,7 +527,7 @@ export const useGridVirtualScroller = () => {
       height: contentHeight,
     };
 
-    if (rootProps.autoHeight && currentPage.rows.length === 0) {
+    if ((rootProps.autoHeight && currentPage.rows.length === 0) || size.height === 0) {
       size.height = getMinimalContentHeight(apiRef); // Give room to show the overlay when there no rows.
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Resolves https://github.com/mui/mui-x/issues/14881

Since `autoHeight` is deprecated and now it is recommended to use [Flex parent container](https://mui.com/x/react-data-grid/layout/#flex-parent-container). 
we should probably also support minimal overlay height when someone is using a flex parent container or normally a data grid 
so that one doesn't need to set the height manually in a wrapper just to see the overlay.
