### PR TITLE
[data grid] Fix typo on the `rowSelectionPropagation` feature

### DIFF
--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -321,13 +321,13 @@ type GridRowSelectionPropagation = {
 
 When `rowSelectionPropagation.descendants` is set to `true`.
 
-- Selecting a parent would auto-select all its filtered descendants.
-- Deselecting a parent row would auto-deselect all its filtered descendants.
+- Selecting a parent selects all its filtered descendants automatically.
+- Deselecting a parent row deselects all its filtered descendants automatically.
 
 When `rowSelectionPropagation.parents` is set to `true`.
 
-- Selecting all the filtered descendants of a parent will auto-select the parent.
-- Deselecting a descendant of a selected parent will auto-deselect the parent.
+- Selecting all the filtered descendants of a parent selects the parent automatically.
+- Deselecting a descendant of a selected parent deselects the parent automatically.
 
 The example below demonstrates the usage of the `rowSelectionPropagation` prop.
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -326,8 +326,8 @@ When `rowSelectionPropagation.descendants` is set to `true`.
 
 When `rowSelectionPropagation.parents` is set to `true`.
 
-- Selecting all the filtered descendants of a parent would auto-select the parent.
-- Deselecting a descendant of a selected parent would auto-deselect the parent.
+- Selecting all the filtered descendants of a parent will auto-select the parent.
+- Deselecting a descendant of a selected parent will auto-deselect the parent.
 
 The example below demonstrates the usage of the `rowSelectionPropagation` prop.
 

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -619,7 +619,7 @@
     "rowSelection": { "description": "If <code>false</code>, the row selection mode is disabled." },
     "rowSelectionModel": { "description": "Sets the row selection model of the Data Grid." },
     "rowSelectionPropagation": {
-      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent will auto-select all its filtered descendants. - Deselecting a parent will auto-deselect all its filtered descendants.<br>When <code>rowSelectionPropagation.parents=true</code> - Selecting all descendants of a parent would auto-select it. - Deselecting a descendant of a selected parent would deselect the parent.<br>Works with tree data and row grouping on the client-side only."
+      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent will auto-select all its filtered descendants. - Deselecting a parent will auto-deselect all its filtered descendants.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all descendants of a parent will auto-select it. - Deselecting a descendant of a selected parent will deselect the parent.<br>Works with tree data and row grouping on the client-side only."
     },
     "rowsLoadingMode": {
       "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading. * @default &quot;client&quot;"

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -619,7 +619,7 @@
     "rowSelection": { "description": "If <code>false</code>, the row selection mode is disabled." },
     "rowSelectionModel": { "description": "Sets the row selection model of the Data Grid." },
     "rowSelectionPropagation": {
-      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent will auto-select all its filtered descendants. - Deselecting a parent will auto-deselect all its filtered descendants.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all descendants of a parent will auto-select it. - Deselecting a descendant of a selected parent will deselect the parent.<br>Works with tree data and row grouping on the client-side only."
+      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent selects all its filtered descendants automatically. - Deselecting a parent row deselects all its filtered descendants automatically.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all the filtered descendants of a parent selects the parent automatically. - Deselecting a descendant of a selected parent deselects the parent automatically.<br>Works with tree data and row grouping on the client-side only."
     },
     "rowsLoadingMode": {
       "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading. * @default &quot;client&quot;"

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -561,7 +561,7 @@
     "rowSelection": { "description": "If <code>false</code>, the row selection mode is disabled." },
     "rowSelectionModel": { "description": "Sets the row selection model of the Data Grid." },
     "rowSelectionPropagation": {
-      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent will auto-select all its filtered descendants. - Deselecting a parent will auto-deselect all its filtered descendants.<br>When <code>rowSelectionPropagation.parents=true</code> - Selecting all descendants of a parent would auto-select it. - Deselecting a descendant of a selected parent would deselect the parent.<br>Works with tree data and row grouping on the client-side only."
+      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent will auto-select all its filtered descendants. - Deselecting a parent will auto-deselect all its filtered descendants.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all descendants of a parent will auto-select it. - Deselecting a descendant of a selected parent will deselect the parent.<br>Works with tree data and row grouping on the client-side only."
     },
     "rowsLoadingMode": {
       "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading. * @default &quot;client&quot;"

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -561,7 +561,7 @@
     "rowSelection": { "description": "If <code>false</code>, the row selection mode is disabled." },
     "rowSelectionModel": { "description": "Sets the row selection model of the Data Grid." },
     "rowSelectionPropagation": {
-      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent will auto-select all its filtered descendants. - Deselecting a parent will auto-deselect all its filtered descendants.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all descendants of a parent will auto-select it. - Deselecting a descendant of a selected parent will deselect the parent.<br>Works with tree data and row grouping on the client-side only."
+      "description": "When <code>rowSelectionPropagation.descendants</code> is set to <code>true</code>. - Selecting a parent selects all its filtered descendants automatically. - Deselecting a parent row deselects all its filtered descendants automatically.<br>When <code>rowSelectionPropagation.parents</code> is set to <code>true</code> - Selecting all the filtered descendants of a parent selects the parent automatically. - Deselecting a descendant of a selected parent deselects the parent automatically.<br>Works with tree data and row grouping on the client-side only."
     },
     "rowsLoadingMode": {
       "description": "Loading rows can be processed on the server or client-side. Set it to &#39;client&#39; if you would like enable infnite loading. Set it to &#39;server&#39; if you would like to enable lazy loading. * @default &quot;client&quot;"

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -994,12 +994,12 @@ DataGridPremiumRaw.propTypes = {
   ]),
   /**
    * When `rowSelectionPropagation.descendants` is set to `true`.
-   * - Selecting a parent will auto-select all its filtered descendants.
-   * - Deselecting a parent will auto-deselect all its filtered descendants.
+   * - Selecting a parent selects all its filtered descendants automatically.
+   * - Deselecting a parent row deselects all its filtered descendants automatically.
    *
    * When `rowSelectionPropagation.parents` is set to `true`
-   * - Selecting all descendants of a parent will auto-select it.
-   * - Deselecting a descendant of a selected parent will deselect the parent.
+   * - Selecting all the filtered descendants of a parent selects the parent automatically.
+   * - Deselecting a descendant of a selected parent deselects the parent automatically.
    *
    * Works with tree data and row grouping on the client-side only.
    * @default { parents: false, descendants: false }

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -997,9 +997,9 @@ DataGridPremiumRaw.propTypes = {
    * - Selecting a parent will auto-select all its filtered descendants.
    * - Deselecting a parent will auto-deselect all its filtered descendants.
    *
-   * When `rowSelectionPropagation.parents=true`
-   * - Selecting all descendants of a parent would auto-select it.
-   * - Deselecting a descendant of a selected parent would deselect the parent.
+   * When `rowSelectionPropagation.parents` is set to `true`
+   * - Selecting all descendants of a parent will auto-select it.
+   * - Deselecting a descendant of a selected parent will deselect the parent.
    *
    * Works with tree data and row grouping on the client-side only.
    * @default { parents: false, descendants: false }

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -903,9 +903,9 @@ DataGridProRaw.propTypes = {
    * - Selecting a parent will auto-select all its filtered descendants.
    * - Deselecting a parent will auto-deselect all its filtered descendants.
    *
-   * When `rowSelectionPropagation.parents=true`
-   * - Selecting all descendants of a parent would auto-select it.
-   * - Deselecting a descendant of a selected parent would deselect the parent.
+   * When `rowSelectionPropagation.parents` is set to `true`
+   * - Selecting all descendants of a parent will auto-select it.
+   * - Deselecting a descendant of a selected parent will deselect the parent.
    *
    * Works with tree data and row grouping on the client-side only.
    * @default { parents: false, descendants: false }

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -900,12 +900,12 @@ DataGridProRaw.propTypes = {
   ]),
   /**
    * When `rowSelectionPropagation.descendants` is set to `true`.
-   * - Selecting a parent will auto-select all its filtered descendants.
-   * - Deselecting a parent will auto-deselect all its filtered descendants.
+   * - Selecting a parent selects all its filtered descendants automatically.
+   * - Deselecting a parent row deselects all its filtered descendants automatically.
    *
    * When `rowSelectionPropagation.parents` is set to `true`
-   * - Selecting all descendants of a parent will auto-select it.
-   * - Deselecting a descendant of a selected parent will deselect the parent.
+   * - Selecting all the filtered descendants of a parent selects the parent automatically.
+   * - Deselecting a descendant of a selected parent deselects the parent automatically.
    *
    * Works with tree data and row grouping on the client-side only.
    * @default { parents: false, descendants: false }

--- a/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts
@@ -69,8 +69,8 @@ export function getCheckboxPropsSelector(groupId: GridRowId, autoSelectParents: 
         };
       }
 
-      let selectableDescendentsCount = 0;
-      let selectedDescendentsCount = 0;
+      let selectableDescendantsCount = 0;
+      let selectedDescendantsCount = 0;
       const startIndex = sortedRowIds.findIndex((id) => id === groupId) + 1;
       for (
         let index = startIndex;
@@ -79,19 +79,19 @@ export function getCheckboxPropsSelector(groupId: GridRowId, autoSelectParents: 
       ) {
         const id = sortedRowIds[index];
         if (filteredRowsLookup[id] !== false) {
-          selectableDescendentsCount += 1;
+          selectableDescendantsCount += 1;
           if (rowSelectionLookup[id] !== undefined) {
-            selectedDescendentsCount += 1;
+            selectedDescendantsCount += 1;
           }
         }
       }
       return {
         isIndeterminate:
-          (selectedDescendentsCount > 0 && selectedDescendentsCount < selectableDescendentsCount) ||
-          (selectedDescendentsCount === selectableDescendentsCount &&
+          (selectedDescendantsCount > 0 && selectedDescendantsCount < selectableDescendantsCount) ||
+          (selectedDescendantsCount === selectableDescendantsCount &&
             rowSelectionLookup[groupId] === undefined),
         isChecked: autoSelectParents
-          ? selectedDescendentsCount > 0
+          ? selectedDescendantsCount > 0
           : rowSelectionLookup[groupId] === groupId,
       };
     },

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -845,9 +845,9 @@ export interface DataGridProSharedPropsWithDefaultValue {
    * - Selecting a parent will auto-select all its filtered descendants.
    * - Deselecting a parent will auto-deselect all its filtered descendants.
    *
-   * When `rowSelectionPropagation.parents=true`
-   * - Selecting all descendants of a parent would auto-select it.
-   * - Deselecting a descendant of a selected parent would deselect the parent.
+   * When `rowSelectionPropagation.parents` is set to `true`
+   * - Selecting all descendants of a parent will auto-select it.
+   * - Deselecting a descendant of a selected parent will deselect the parent.
    *
    * Works with tree data and row grouping on the client-side only.
    * @default { parents: false, descendants: false }

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -842,12 +842,12 @@ export interface DataGridProSharedPropsWithDefaultValue {
   headerFilters: boolean;
   /**
    * When `rowSelectionPropagation.descendants` is set to `true`.
-   * - Selecting a parent will auto-select all its filtered descendants.
-   * - Deselecting a parent will auto-deselect all its filtered descendants.
+   * - Selecting a parent selects all its filtered descendants automatically.
+   * - Deselecting a parent row deselects all its filtered descendants automatically.
    *
    * When `rowSelectionPropagation.parents` is set to `true`
-   * - Selecting all descendants of a parent will auto-select it.
-   * - Deselecting a descendant of a selected parent will deselect the parent.
+   * - Selecting all the filtered descendants of a parent selects the parent automatically.
+   * - Deselecting a descendant of a selected parent deselects the parent automatically.
    *
    * Works with tree data and row grouping on the client-side only.
    * @default { parents: false, descendants: false }


### PR DESCRIPTION
Noticed those while working on #14899

## Other proposed change

I'm also not a fan of having that many flat params on `findRowsToSelect` and `findRowsToDeselect`.
I feel like it would be a lot more readable:

1. Passing `props.rowSelectionPropagation` to the function  (right now if you are searching the codebase, this concept can be named `rowSelectionPropagation.descendants` or `autoSelectDescendants` depending on where you are looking for)
2. Moving to an object (it's subjective, but for this method I think the perf overhead is negligible, feel free to ignore this one)

```tsx
findRowsToSelect({
    apiRef,
    tree,
    id,
    rowSelectionPropagation,
    addRow,
});
```