### PR TITLE
[charts] Allow `dataset` to be used with `ScatterChart`

### DIFF
--- a/docs/data/charts/scatter/ScatterDataset.js
+++ b/docs/data/charts/scatter/ScatterDataset.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { axisClasses } from '@mui/x-charts/ChartsAxis';
 
 const dataset = [
   {
@@ -80,6 +81,11 @@ const chartSetting = {
       label: 'rainfall (mm)',
     },
   ],
+  sx: {
+    [`.${axisClasses.left} .${axisClasses.label}`]: {
+      transform: 'translate(-20px, 0)',
+    },
+  },
   width: 500,
   height: 300,
 };

--- a/docs/data/charts/scatter/ScatterDataset.js
+++ b/docs/data/charts/scatter/ScatterDataset.js
@@ -1,0 +1,99 @@
+/* eslint-disable id-denylist */
+import * as React from 'react';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+
+const dataset = [
+  {
+    version: 'data-0',
+    a1: 329.39,
+    a2: 391.29,
+    b1: 443.28,
+    b2: 153.9,
+  },
+  {
+    version: 'data-1',
+    a1: 96.94,
+    a2: 139.6,
+    b1: 110.5,
+    b2: 217.8,
+  },
+  {
+    version: 'data-2',
+    a1: 336.35,
+    a2: 282.34,
+    b1: 175.23,
+    b2: 286.32,
+  },
+  {
+    version: 'data-3',
+    a1: 159.44,
+    a2: 384.85,
+    b1: 195.97,
+    b2: 325.12,
+  },
+  {
+    version: 'data-4',
+    a1: 188.86,
+    a2: 182.27,
+    b1: 351.77,
+    b2: 144.58,
+  },
+  {
+    version: 'data-5',
+    a1: 143.86,
+    a2: 360.22,
+    b1: 43.253,
+    b2: 146.51,
+  },
+  {
+    version: 'data-6',
+    a1: 202.02,
+    a2: 209.5,
+    b1: 376.34,
+    b2: 309.69,
+  },
+  {
+    version: 'data-7',
+    a1: 384.41,
+    a2: 258.93,
+    b1: 31.514,
+    b2: 236.38,
+  },
+  {
+    version: 'data-8',
+    a1: 256.76,
+    a2: 70.571,
+    b1: 231.31,
+    b2: 440.72,
+  },
+  {
+    version: 'data-9',
+    a1: 143.79,
+    a2: 419.02,
+    b1: 108.04,
+    b2: 20.29,
+  },
+];
+
+const chartSetting = {
+  yAxis: [
+    {
+      label: 'rainfall (mm)',
+    },
+  ],
+  width: 500,
+  height: 300,
+};
+
+export default function ScatterDataset() {
+  return (
+    <ScatterChart
+      dataset={dataset}
+      series={[
+        { idDataKey: 'version', xDataKey: 'a1', yDataKey: 'a2', label: 'Series A' },
+        { idDataKey: 'version', xDataKey: 'b1', yDataKey: 'b2', label: 'Series B' },
+      ]}
+      {...chartSetting}
+    />
+  );
+}

--- a/docs/data/charts/scatter/ScatterDataset.js
+++ b/docs/data/charts/scatter/ScatterDataset.js
@@ -89,8 +89,8 @@ export default function ScatterDataset() {
     <ScatterChart
       dataset={dataset}
       series={[
-        { idDataKey: 'version', xDataKey: 'a1', yDataKey: 'a2', label: 'Series A' },
-        { idDataKey: 'version', xDataKey: 'b1', yDataKey: 'b2', label: 'Series B' },
+        { datasetKeys: { id: 'version', x: 'a1', y: 'a2' }, label: 'Series A' },
+        { datasetKeys: { id: 'version', x: 'b1', y: 'b2' }, label: 'Series B' },
       ]}
       {...chartSetting}
     />

--- a/docs/data/charts/scatter/ScatterDataset.js
+++ b/docs/data/charts/scatter/ScatterDataset.js
@@ -1,4 +1,3 @@
-/* eslint-disable id-denylist */
 import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 

--- a/docs/data/charts/scatter/ScatterDataset.tsx
+++ b/docs/data/charts/scatter/ScatterDataset.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { axisClasses } from '@mui/x-charts/ChartsAxis';
 
 const dataset = [
   {
@@ -80,6 +81,11 @@ const chartSetting = {
       label: 'rainfall (mm)',
     },
   ],
+  sx: {
+    [`.${axisClasses.left} .${axisClasses.label}`]: {
+      transform: 'translate(-20px, 0)',
+    },
+  },
   width: 500,
   height: 300,
 };

--- a/docs/data/charts/scatter/ScatterDataset.tsx
+++ b/docs/data/charts/scatter/ScatterDataset.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable id-denylist */
+import * as React from 'react';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+
+const dataset = [
+  {
+    version: 'data-0',
+    a1: 329.39,
+    a2: 391.29,
+    b1: 443.28,
+    b2: 153.9,
+  },
+  {
+    version: 'data-1',
+    a1: 96.94,
+    a2: 139.6,
+    b1: 110.5,
+    b2: 217.8,
+  },
+  {
+    version: 'data-2',
+    a1: 336.35,
+    a2: 282.34,
+    b1: 175.23,
+    b2: 286.32,
+  },
+  {
+    version: 'data-3',
+    a1: 159.44,
+    a2: 384.85,
+    b1: 195.97,
+    b2: 325.12,
+  },
+  {
+    version: 'data-4',
+    a1: 188.86,
+    a2: 182.27,
+    b1: 351.77,
+    b2: 144.58,
+  },
+  {
+    version: 'data-5',
+    a1: 143.86,
+    a2: 360.22,
+    b1: 43.253,
+    b2: 146.51,
+  },
+  {
+    version: 'data-6',
+    a1: 202.02,
+    a2: 209.5,
+    b1: 376.34,
+    b2: 309.69,
+  },
+  {
+    version: 'data-7',
+    a1: 384.41,
+    a2: 258.93,
+    b1: 31.514,
+    b2: 236.38,
+  },
+  {
+    version: 'data-8',
+    a1: 256.76,
+    a2: 70.571,
+    b1: 231.31,
+    b2: 440.72,
+  },
+  {
+    version: 'data-9',
+    a1: 143.79,
+    a2: 419.02,
+    b1: 108.04,
+    b2: 20.29,
+  },
+];
+
+const chartSetting = {
+  yAxis: [
+    {
+      label: 'rainfall (mm)',
+    },
+  ],
+  width: 500,
+  height: 300,
+};
+
+export default function ScatterDataset() {
+  return (
+    <ScatterChart
+      dataset={dataset}
+      series={[
+        { idDataKey: 'version', xDataKey: 'a1', yDataKey: 'a2', label: 'Series A' },
+        { idDataKey: 'version', xDataKey: 'b1', yDataKey: 'b2', label: 'Series B' },
+      ]}
+      {...chartSetting}
+    />
+  );
+}

--- a/docs/data/charts/scatter/ScatterDataset.tsx
+++ b/docs/data/charts/scatter/ScatterDataset.tsx
@@ -89,8 +89,8 @@ export default function ScatterDataset() {
     <ScatterChart
       dataset={dataset}
       series={[
-        { idDataKey: 'version', xDataKey: 'a1', yDataKey: 'a2', label: 'Series A' },
-        { idDataKey: 'version', xDataKey: 'b1', yDataKey: 'b2', label: 'Series B' },
+        { datasetKeys: { id: 'version', x: 'a1', y: 'a2' }, label: 'Series A' },
+        { datasetKeys: { id: 'version', x: 'b1', y: 'b2' }, label: 'Series B' },
       ]}
       {...chartSetting}
     />

--- a/docs/data/charts/scatter/ScatterDataset.tsx
+++ b/docs/data/charts/scatter/ScatterDataset.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable id-denylist */
 import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 

--- a/docs/data/charts/scatter/ScatterDataset.tsx.preview
+++ b/docs/data/charts/scatter/ScatterDataset.tsx.preview
@@ -1,0 +1,8 @@
+<ScatterChart
+  dataset={dataset}
+  series={[
+    { idDataKey: 'version', xDataKey: 'a1', yDataKey: 'a2', label: 'Series A' },
+    { idDataKey: 'version', xDataKey: 'b1', yDataKey: 'b2', label: 'Series B' },
+  ]}
+  {...chartSetting}
+/>

--- a/docs/data/charts/scatter/ScatterDataset.tsx.preview
+++ b/docs/data/charts/scatter/ScatterDataset.tsx.preview
@@ -1,8 +1,8 @@
 <ScatterChart
   dataset={dataset}
   series={[
-    { idDataKey: 'version', xDataKey: 'a1', yDataKey: 'a2', label: 'Series A' },
-    { idDataKey: 'version', xDataKey: 'b1', yDataKey: 'b2', label: 'Series B' },
+    { datasetKeys: { id: 'version', x: 'a1', y: 'a2' }, label: 'Series A' },
+    { datasetKeys: { id: 'version', x: 'b1', y: 'b2' }, label: 'Series B' },
   ]}
   {...chartSetting}
 />

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -20,10 +20,10 @@ Those objects require `x`, `y`, and `id` properties.
 If your data is stored in an array of objects, you can use the `dataset` helper prop.
 It accepts an array of objects such as `dataset={[{a: 1, b: 32, c: 873}, {a: 2, b: 41, c: 182}, ...]}`.
 
-You can reuse this data when defining the series, the scatter series work a bit differently than in other charts though,
-you need to specify a key for the `x`, `y` and `id` properties. This is done with the `datasetKeys` properties.
-
-Which is an object that requires `x`, `y`, and `id` keys. With an optional `z` key.
+You can reuse this data when defining the series.
+The scatter series work a bit differently than in other charts.
+You need to specify the `datasetKeys` properties which is an object that requires `x`, `y`, and `id` keys.
+With an optional `z` key if needed.
 
 {{"demo": "ScatterDataset.js"}}
 

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -21,9 +21,9 @@ If your data is stored in an array of objects, you can use the `dataset` helper 
 It accepts an array of objects such as `dataset={[{a: 1, b: 32, c: 873}, {a: 2, b: 41, c: 182}, ...]}`.
 
 You can reuse this data when defining the series, the scatter series work a bit differently than in other charts though,
-you need to specify a key for the `x`, `y` and `id` properties. This is done with the `xDataKey`, `yDataKey` and `idDataKey` properties.
+you need to specify a key for the `x`, `y` and `id` properties. This is done with the `datasetKeys` properties.
 
-Additionally, you can specify a `zDataKey` to provide a third dimension to the scatter points.
+Which is an object that requires `x`, `y`, and `id` keys. With an optional `z` key.
 
 {{"demo": "ScatterDataset.js"}}
 

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -15,6 +15,18 @@ Those objects require `x`, `y`, and `id` properties.
 
 {{"demo": "BasicScatter.js"}}
 
+### Using a dataset
+
+If your data is stored in an array of objects, you can use the `dataset` helper prop.
+It accepts an array of objects such as `dataset={[{a: 1, b: 32, c: 873}, {a: 2, b: 41, c: 182}, ...]}`.
+
+You can reuse this data when defining the series, the scatter series work a bit differently than in other charts though,
+you need to specify a key for the `x`, `y` and `id` properties. This is done with the `xDataKey`, `yDataKey` and `idDataKey` properties.
+
+Additionally, you can specify a `zDataKey` to provide a third dimension to the scatter points.
+
+{{"demo": "ScatterDataset.js"}}
+
 ## Interaction
 
 Since scatter elements can be small, interactions do not require hovering exactly over an element.

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/docs/pages/x/api/charts/scatter-series-type.json
+++ b/docs/pages/x/api/charts/scatter-series-type.json
@@ -2,12 +2,13 @@
   "name": "ScatterSeriesType",
   "imports": ["import { ScatterSeriesType } from '@mui/x-charts'"],
   "properties": {
-    "data": { "type": { "description": "ScatterValueType[]" }, "required": true },
     "type": { "type": { "description": "'scatter'" }, "required": true },
     "color": { "type": { "description": "string" } },
+    "data": { "type": { "description": "ScatterValueType[]" } },
     "disableHover": { "type": { "description": "boolean" }, "default": "false" },
     "highlightScope": { "type": { "description": "Partial&lt;HighlightScope&gt;" } },
     "id": { "type": { "description": "SeriesId" } },
+    "idDataKey": { "type": { "description": "string" } },
     "label": {
       "type": { "description": "string | ((location: 'tooltip' | 'legend') =&gt; string)" }
     },
@@ -15,9 +16,12 @@
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisId": { "type": { "description": "string" } },
     "xAxisKey": { "type": { "description": "string" } },
+    "xDataKey": { "type": { "description": "string" } },
     "yAxisId": { "type": { "description": "string" } },
     "yAxisKey": { "type": { "description": "string" } },
+    "yDataKey": { "type": { "description": "string" } },
     "zAxisId": { "type": { "description": "string" } },
-    "zAxisKey": { "type": { "description": "string" } }
+    "zAxisKey": { "type": { "description": "string" } },
+    "zDataKey": { "type": { "description": "string" } }
   }
 }

--- a/docs/pages/x/api/charts/scatter-series-type.json
+++ b/docs/pages/x/api/charts/scatter-series-type.json
@@ -5,10 +5,14 @@
     "type": { "type": { "description": "'scatter'" }, "required": true },
     "color": { "type": { "description": "string" } },
     "data": { "type": { "description": "ScatterValueType[]" } },
+    "datasetKeys": {
+      "type": {
+        "description": "{<br />  /**<br />   * The key used to retrieve data from the dataset for the X axis.<br />   */<br />  x: string<br />  /**<br />   * The key used to retrieve data from the dataset for the Y axis.<br />   */<br />  y: string<br />  /**<br />   * The key used to retrieve data from the dataset for the Z axis.<br />   */<br />  z?: string<br />  /**<br />   * The key used to retrieve data from the dataset for the id.<br />   */<br />  id: string<br />}"
+      }
+    },
     "disableHover": { "type": { "description": "boolean" }, "default": "false" },
     "highlightScope": { "type": { "description": "Partial&lt;HighlightScope&gt;" } },
     "id": { "type": { "description": "SeriesId" } },
-    "idDataKey": { "type": { "description": "string" } },
     "label": {
       "type": { "description": "string | ((location: 'tooltip' | 'legend') =&gt; string)" }
     },
@@ -16,12 +20,9 @@
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisId": { "type": { "description": "string" } },
     "xAxisKey": { "type": { "description": "string" } },
-    "xDataKey": { "type": { "description": "string" } },
     "yAxisId": { "type": { "description": "string" } },
     "yAxisKey": { "type": { "description": "string" } },
-    "yDataKey": { "type": { "description": "string" } },
     "zAxisId": { "type": { "description": "string" } },
-    "zAxisKey": { "type": { "description": "string" } },
-    "zDataKey": { "type": { "description": "string" } }
+    "zAxisKey": { "type": { "description": "string" } }
   }
 }

--- a/docs/translations/api-docs/charts/scatter-series-type.json
+++ b/docs/translations/api-docs/charts/scatter-series-type.json
@@ -4,12 +4,14 @@
     "type": { "description": "" },
     "color": { "description": "" },
     "data": { "description": "" },
+    "datasetKeys": {
+      "description": "The keys used to retrieve data from the dataset.<br /><br />When this prop is provided, all of <code>x</code>, <code>y</code>, and <code>id</code> must be provided.<br />While <code>z</code> is optional."
+    },
     "disableHover": {
       "description": "If true, the interaction will not use element hover for this series."
     },
     "highlightScope": { "description": "The scope to apply when the series is highlighted." },
     "id": { "description": "" },
-    "idDataKey": { "description": "The key used to retrieve data from the dataset for the id." },
     "label": {
       "description": "The label to display on the tooltip or the legend. It can be a string or a function."
     },
@@ -19,12 +21,9 @@
     },
     "xAxisId": { "description": "The id of the x-axis used to render the series." },
     "xAxisKey": { "description": "The id of the x-axis used to render the series." },
-    "xDataKey": { "description": "The key used to retrieve data from the dataset for the X axis." },
     "yAxisId": { "description": "The id of the y-axis used to render the series." },
     "yAxisKey": { "description": "The id of the y-axis used to render the series." },
-    "yDataKey": { "description": "The key used to retrieve data from the dataset for the Y axis." },
     "zAxisId": { "description": "The id of the z-axis used to render the series." },
-    "zAxisKey": { "description": "The id of the z-axis used to render the series." },
-    "zDataKey": { "description": "The key used to retrieve data from the dataset for the Z axis." }
+    "zAxisKey": { "description": "The id of the z-axis used to render the series." }
   }
 }

--- a/docs/translations/api-docs/charts/scatter-series-type.json
+++ b/docs/translations/api-docs/charts/scatter-series-type.json
@@ -1,14 +1,15 @@
 {
   "interfaceDescription": "",
   "propertiesDescriptions": {
-    "data": { "description": "" },
     "type": { "description": "" },
     "color": { "description": "" },
+    "data": { "description": "" },
     "disableHover": {
       "description": "If true, the interaction will not use element hover for this series."
     },
     "highlightScope": { "description": "The scope to apply when the series is highlighted." },
     "id": { "description": "" },
+    "idDataKey": { "description": "The key used to retrieve data from the dataset for the id." },
     "label": {
       "description": "The label to display on the tooltip or the legend. It can be a string or a function."
     },
@@ -18,9 +19,12 @@
     },
     "xAxisId": { "description": "The id of the x-axis used to render the series." },
     "xAxisKey": { "description": "The id of the x-axis used to render the series." },
+    "xDataKey": { "description": "The key used to retrieve data from the dataset for the X axis." },
     "yAxisId": { "description": "The id of the y-axis used to render the series." },
     "yAxisKey": { "description": "The id of the y-axis used to render the series." },
+    "yDataKey": { "description": "The key used to retrieve data from the dataset for the Y axis." },
     "zAxisId": { "description": "The id of the z-axis used to render the series." },
-    "zAxisKey": { "description": "The id of the z-axis used to render the series." }
+    "zAxisKey": { "description": "The id of the z-axis used to render the series." },
+    "zDataKey": { "description": "The key used to retrieve data from the dataset for the Z axis." }
   }
 }

--- a/packages/x-charts/src/ScatterChart/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/extremums.ts
@@ -27,7 +27,7 @@ export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {
           seriesYAxisId: series[seriesId].yAxisId ?? series[seriesId].yAxisKey,
         });
 
-        const seriesMinMax = series[seriesId].data.reduce<ExtremumGetterResult>(
+        const seriesMinMax = series[seriesId].data?.reduce<ExtremumGetterResult>(
           (accSeries, d, dataIndex) => {
             if (filter && !filter(d, dataIndex)) {
               return accSeries;
@@ -36,7 +36,7 @@ export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {
           },
           [Infinity, -Infinity],
         );
-        return mergeMinMax(acc, seriesMinMax);
+        return mergeMinMax(acc, seriesMinMax ?? [Infinity, -Infinity]);
       },
       [Infinity, -Infinity],
     );
@@ -59,7 +59,7 @@ export const getExtremumY: ExtremumGetter<'scatter'> = (params) => {
           seriesYAxisId: series[seriesId].yAxisId ?? series[seriesId].yAxisKey,
         });
 
-        const seriesMinMax = series[seriesId].data.reduce<ExtremumGetterResult>(
+        const seriesMinMax = series[seriesId].data?.reduce<ExtremumGetterResult>(
           (accSeries, d, dataIndex) => {
             if (filter && !filter(d, dataIndex)) {
               return accSeries;
@@ -68,7 +68,7 @@ export const getExtremumY: ExtremumGetter<'scatter'> = (params) => {
           },
           [Infinity, -Infinity],
         );
-        return mergeMinMax(acc, seriesMinMax);
+        return mergeMinMax(acc, seriesMinMax ?? [Infinity, -Infinity]);
       },
       [Infinity, -Infinity],
     );

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -1,9 +1,55 @@
-import { defaultizeValueFormatter } from '../internals/defaultizeValueFormatter';
 import { SeriesFormatter } from '../context/PluginProvider/SeriesFormatter.types';
+import { ScatterValueType } from '../models';
 
-const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }) => {
+const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }, dataset) => {
+  const completeSeries = Object.fromEntries(
+    Object.entries(series).map(([seriesId, seriesData]) => {
+      const xDataKey = seriesData.xDataKey;
+      const yDataKey = seriesData.yDataKey;
+      const zDataKey = seriesData.zDataKey;
+      const idDataKey = seriesData.idDataKey;
+
+      const keys = [xDataKey, yDataKey, idDataKey];
+      const hasStringKeys = keys.some((key) => typeof key === 'string');
+      const hasNonStringKeys = keys.some((key) => typeof key !== 'string');
+      if (hasStringKeys && hasNonStringKeys) {
+        throw new Error(
+          [
+            `MUI X: scatter series with id='${seriesId}' has inconsistent data keys.`,
+            'Either provide all data keys or none.',
+          ].join('\n'),
+        );
+      }
+
+      const data = !hasStringKeys
+        ? (seriesData.data ?? [])
+        : (dataset?.map((d) => {
+            const x = d[xDataKey!]!;
+            const y = d[yDataKey!]!;
+            const z = d[zDataKey ?? ''];
+            const id = d[idDataKey!]!;
+
+            return {
+              x,
+              y,
+              z,
+              id,
+            } as ScatterValueType;
+          }) ?? []);
+
+      return [
+        seriesId,
+        {
+          ...seriesData,
+          data,
+          valueFormatter: seriesData.valueFormatter ?? ((v) => `(${v.x}, ${v.y})`),
+        },
+      ];
+    }),
+  );
+
   return {
-    series: defaultizeValueFormatter(series, (v) => `(${v.x}, ${v.y})`),
+    series: completeSeries,
     seriesOrder,
   };
 };

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -10,30 +10,24 @@ const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }, dataset)
       const idDataKey = seriesData?.datasetKeys?.id;
 
       const keys = [xDataKey, yDataKey, idDataKey];
-      const hasStringKeys = keys.some((key) => typeof key === 'string');
       const hasNonStringKeys = keys.some((key) => typeof key !== 'string');
-      if (hasStringKeys && hasNonStringKeys) {
+      if (seriesData?.datasetKeys && hasNonStringKeys) {
         throw new Error(
           [
-            `MUI X: scatter series with id='${seriesId}' has inconsistent data keys.`,
-            'Either provide all data keys or none.',
+            `MUI X: scatter series with id='${seriesId}' has incomplete datasetKeys.`,
+            'You should provide x, y, and id keys.',
           ].join('\n'),
         );
       }
 
-      const data = !hasStringKeys
+      const data = !seriesData?.datasetKeys
         ? (seriesData.data ?? [])
         : (dataset?.map((d) => {
-            const x = d[xDataKey!]!;
-            const y = d[yDataKey!]!;
-            const z = d[zDataKey ?? ''];
-            const id = d[idDataKey!]!;
-
             return {
-              x,
-              y,
-              z,
-              id,
+              x: d[xDataKey!],
+              y: d[yDataKey!],
+              z: zDataKey && d[zDataKey],
+              id: d[idDataKey!],
             } as ScatterValueType;
           }) ?? []);
 

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -4,10 +4,10 @@ import { ScatterValueType } from '../models';
 const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }, dataset) => {
   const completeSeries = Object.fromEntries(
     Object.entries(series).map(([seriesId, seriesData]) => {
-      const xDataKey = seriesData.xDataKey;
-      const yDataKey = seriesData.yDataKey;
-      const zDataKey = seriesData.zDataKey;
-      const idDataKey = seriesData.idDataKey;
+      const xDataKey = seriesData?.datasetKeys?.x;
+      const yDataKey = seriesData?.datasetKeys?.y;
+      const zDataKey = seriesData?.datasetKeys?.z;
+      const idDataKey = seriesData?.datasetKeys?.id;
 
       const keys = [xDataKey, yDataKey, idDataKey];
       const hasStringKeys = keys.some((key) => typeof key === 'string');

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -4,30 +4,29 @@ import { ScatterValueType } from '../models';
 const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }, dataset) => {
   const completeSeries = Object.fromEntries(
     Object.entries(series).map(([seriesId, seriesData]) => {
-      const xDataKey = seriesData?.datasetKeys?.x;
-      const yDataKey = seriesData?.datasetKeys?.y;
-      const zDataKey = seriesData?.datasetKeys?.z;
-      const idDataKey = seriesData?.datasetKeys?.id;
+      const datasetKeys = seriesData?.datasetKeys;
 
-      const keys = [xDataKey, yDataKey, idDataKey];
-      const hasNonStringKeys = keys.some((key) => typeof key !== 'string');
-      if (seriesData?.datasetKeys && hasNonStringKeys) {
+      const missingKeys = (['x', 'y', 'id'] as const).filter(
+        (key) => typeof datasetKeys?.[key] !== 'string',
+      );
+
+      if (seriesData?.datasetKeys && missingKeys.length > 0) {
         throw new Error(
           [
             `MUI X: scatter series with id='${seriesId}' has incomplete datasetKeys.`,
-            'You should provide x, y, and id keys.',
+            `Properties ${missingKeys.map((key) => `"${key}"`).join(', ')} are missing.`,
           ].join('\n'),
         );
       }
 
-      const data = !seriesData?.datasetKeys
+      const data = !datasetKeys
         ? (seriesData.data ?? [])
         : (dataset?.map((d) => {
             return {
-              x: d[xDataKey!],
-              y: d[yDataKey!],
-              z: zDataKey && d[zDataKey],
-              id: d[idDataKey!],
+              x: d[datasetKeys.x],
+              y: d[datasetKeys.y],
+              z: datasetKeys.z && d[datasetKeys.z],
+              id: d[datasetKeys.id],
             } as ScatterValueType;
           }) ?? []);
 

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -33,22 +33,31 @@ export interface ScatterSeriesType extends CommonSeriesType<ScatterValueType>, C
    * The id of the z-axis used to render the series.
    */
   zAxisId?: string;
+
   /**
-   * The key used to retrieve data from the dataset for the X axis.
+   * The keys used to retrieve data from the dataset.
+   *
+   * When this prop is provided, all of `x`, `y`, and `id` must be provided.
+   * While `z` is optional.
    */
-  xDataKey?: string;
-  /**
-   * The key used to retrieve data from the dataset for the Y axis.
-   */
-  yDataKey?: string;
-  /**
-   * The key used to retrieve data from the dataset for the Z axis.
-   */
-  zDataKey?: string;
-  /**
-   * The key used to retrieve data from the dataset for the id.
-   */
-  idDataKey?: string;
+  datasetKeys?: {
+    /**
+     * The key used to retrieve data from the dataset for the X axis.
+     */
+    x: string;
+    /**
+     * The key used to retrieve data from the dataset for the Y axis.
+     */
+    y: string;
+    /**
+     * The key used to retrieve data from the dataset for the Z axis.
+     */
+    z?: string;
+    /**
+     * The key used to retrieve data from the dataset for the id.
+     */
+    id: string;
+  };
 }
 
 /**

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -13,7 +13,7 @@ export type ScatterValueType = {
 
 export interface ScatterSeriesType extends CommonSeriesType<ScatterValueType>, CartesianSeriesType {
   type: 'scatter';
-  data: ScatterValueType[];
+  data?: ScatterValueType[];
   markerSize?: number;
   /**
    * The label to display on the tooltip or the legend. It can be a string or a function.
@@ -33,6 +33,22 @@ export interface ScatterSeriesType extends CommonSeriesType<ScatterValueType>, C
    * The id of the z-axis used to render the series.
    */
   zAxisId?: string;
+  /**
+   * The key used to retrieve data from the dataset for the X axis.
+   */
+  xDataKey?: string;
+  /**
+   * The key used to retrieve data from the dataset for the Y axis.
+   */
+  yDataKey?: string;
+  /**
+   * The key used to retrieve data from the dataset for the Z axis.
+   */
+  zDataKey?: string;
+  /**
+   * The key used to retrieve data from the dataset for the id.
+   */
+  idDataKey?: string;
 }
 
 /**


### PR DESCRIPTION
Resolves #14333

Uses a single object signature. As it more accurately leverage typescript to force users to provide all keys when the object exists.

```tsx
type DatasetKeys = {
  x: string,
  y: string,
  z?: string,
  id: string
}

type ScatterChart = {
  datasetKeys?: DatasetKeys
}
```