### PR TITLE
[pickers] Fix `PickerValidDate` usage in `DateRangePickerToolbar`

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -59,6 +59,10 @@ const DateRangePickerToolbarContainer = styled('div', {
   display: 'flex',
 });
 
+type DateRangePickerToolbarComponent = (<TDate extends PickerValidDate>(
+  props: DateRangePickerToolbarProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => React.JSX.Element) & { propTypes?: any };
+
 /**
  * Demos:
  *
@@ -126,7 +130,7 @@ const DateRangePickerToolbar = React.forwardRef(function DateRangePickerToolbar<
       </DateRangePickerToolbarContainer>
     </DateRangePickerToolbarRoot>
   );
-});
+}) as DateRangePickerToolbarComponent;
 
 DateRangePickerToolbar.propTypes = {
   // ----------------------------- Warning --------------------------------


### PR DESCRIPTION
Fixes #14924
Same as #14896 but for `DateRangePickerToolbar`.

If someone could double check that he finds no `import("moment")` (or luxon or dayjs) in the bundle outside of the adapter file :cry: 