### PR TITLE
[code-infra] Prepare some tests to work in `vitest/playwright`

### DIFF
--- a/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
@@ -24,12 +24,13 @@ describe('<DataGridPro /> - Cell editing', () => {
 
   const defaultData = getBasicGridData(4, 2);
 
-  const renderEditCell = spy((() => <input />) as (
+  const defaultRenderEditCell = (() => <input />) as (
     props: GridRenderEditCellParams,
-  ) => React.ReactNode);
+  ) => React.ReactNode;
 
   function TestCase(props: Partial<DataGridProProps> & { columnProps?: Record<string, any> }) {
     apiRef = useGridApiRef();
+    const { columnProps = {}, ...rest } = props;
     return (
       <div style={{ width: 300, height: 300 }}>
         <DataGridPro
@@ -37,18 +38,19 @@ describe('<DataGridPro /> - Cell editing', () => {
           {...defaultData}
           columns={defaultData.columns.map((column) =>
             column.field === 'currencyPair'
-              ? { ...column, renderEditCell, editable: true, ...(props.columnProps ?? {}) }
+              ? {
+                  ...column,
+                  renderEditCell: defaultRenderEditCell,
+                  editable: true,
+                  ...columnProps,
+                }
               : column,
           )}
-          {...props}
+          {...rest}
         />
       </div>
     );
   }
-
-  afterEach(() => {
-    renderEditCell.resetHistory();
-  });
 
   describe('apiRef', () => {
     describe('startCellEditMode', () => {
@@ -68,14 +70,19 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should render the component given in renderEditCell', () => {
-        render(<TestCase />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ renderEditCell }} />);
         expect(renderEditCell.callCount).to.equal(0);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.callCount).not.to.equal(0);
       });
 
       it('should pass props to renderEditCell', () => {
-        render(<TestCase />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ renderEditCell }} />);
+
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
         expect(renderEditCell.lastCall.args[0].error).to.equal(false);
@@ -83,7 +90,10 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should empty the value if deleteValue is true', () => {
-        render(<TestCase />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ renderEditCell }} />);
+
         act(() =>
           apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair', deleteValue: true }),
         );
@@ -95,7 +105,10 @@ describe('<DataGridPro /> - Cell editing', () => {
 
     describe('setEditCellValue', () => {
       it('should update the value prop given to renderEditCell', async () => {
-        render(<TestCase />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ renderEditCell }} />);
+
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
         await act(() =>
@@ -109,7 +122,10 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...row,
           currencyPair: value.trim(),
         });
-        render(<TestCase columnProps={{ valueSetter }} />);
+
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ valueSetter, renderEditCell }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].row).to.deep.equal(defaultData.rows[0]);
         await act(() =>
@@ -123,7 +139,10 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it('should pass the new value through the value parser if defined', async () => {
         const valueParser = spy((value) => value.toLowerCase());
-        render(<TestCase columnProps={{ valueParser }} />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ valueParser, renderEditCell }} />);
+
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(valueParser.callCount).to.equal(0);
         await act(() =>
@@ -145,7 +164,9 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it('should set isProcessingProps to true before calling preProcessEditCellProps', async () => {
         const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
-        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         let promise: Promise<boolean> | null = null;
         // We want to flush updates before preProcessEditCellProps resolves
@@ -218,7 +239,9 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...props,
           foo: 'bar',
         });
-        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].foo).to.equal(undefined);
         await act(() =>
@@ -232,7 +255,9 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...props,
           value: 'foobar',
         });
-        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
         await act(() =>
@@ -243,7 +268,9 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it('should set isProcessingProps to false after calling preProcessEditCellProps', async () => {
         const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => props;
-        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase columnProps={{ preProcessEditCellProps, renderEditCell }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         let promise: Promise<boolean> | null = null;
         // We want to flush updates before preProcessEditCellProps resolves
@@ -312,7 +339,11 @@ describe('<DataGridPro /> - Cell editing', () => {
         clock.withFakeTimers();
 
         it('should debounce multiple changes if debounceMs > 0', () => {
-          render(<TestCase />);
+          const renderEditCell = spy((() => <input />) as (
+            props: GridRenderEditCellParams,
+          ) => React.ReactNode);
+
+          render(<TestCase columnProps={{ renderEditCell }} />);
           act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
           expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
           renderEditCell.resetHistory();
@@ -669,7 +700,9 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it('should run all pending value mutations before calling processRowUpdate', async () => {
         const processRowUpdate = spy(() => new Promise(() => {}));
-        render(<TestCase processRowUpdate={processRowUpdate} />);
+        const renderEditCell = spy(defaultRenderEditCell);
+
+        render(<TestCase processRowUpdate={processRowUpdate} columnProps={{ renderEditCell }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(
           () =>

--- a/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/cellEditing.DataGridPro.test.tsx
@@ -28,9 +28,7 @@ describe('<DataGridPro /> - Cell editing', () => {
     props: GridRenderEditCellParams,
   ) => React.ReactNode);
 
-  let columnProps: any = {};
-
-  function TestCase(props: Partial<DataGridProProps>) {
+  function TestCase(props: Partial<DataGridProProps> & { columnProps?: Record<string, any> }) {
     apiRef = useGridApiRef();
     return (
       <div style={{ width: 300, height: 300 }}>
@@ -39,7 +37,7 @@ describe('<DataGridPro /> - Cell editing', () => {
           {...defaultData}
           columns={defaultData.columns.map((column) =>
             column.field === 'currencyPair'
-              ? { ...column, renderEditCell, editable: true, ...columnProps }
+              ? { ...column, renderEditCell, editable: true, ...(props.columnProps ?? {}) }
               : column,
           )}
           {...props}
@@ -50,7 +48,6 @@ describe('<DataGridPro /> - Cell editing', () => {
 
   afterEach(() => {
     renderEditCell.resetHistory();
-    columnProps = {};
   });
 
   describe('apiRef', () => {
@@ -112,8 +109,7 @@ describe('<DataGridPro /> - Cell editing', () => {
           ...row,
           currencyPair: value.trim(),
         });
-        columnProps.valueSetter = valueSetter;
-        render(<TestCase />);
+        render(<TestCase columnProps={{ valueSetter }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].row).to.deep.equal(defaultData.rows[0]);
         await act(() =>
@@ -126,14 +122,14 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should pass the new value through the value parser if defined', async () => {
-        columnProps.valueParser = spy((value) => value.toLowerCase());
-        render(<TestCase />);
+        const valueParser = spy((value) => value.toLowerCase());
+        render(<TestCase columnProps={{ valueParser }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        expect(columnProps.valueParser.callCount).to.equal(0);
+        expect(valueParser.callCount).to.equal(0);
         await act(() =>
           apiRef.current.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        expect(columnProps.valueParser.callCount).to.equal(1);
+        expect(valueParser.callCount).to.equal(1);
         expect(renderEditCell.lastCall.args[0].value).to.equal('usd gbp');
       });
 
@@ -148,10 +144,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should set isProcessingProps to true before calling preProcessEditCellProps', async () => {
-        columnProps.preProcessEditCellProps = spy(
-          ({ props }: GridPreProcessEditCellProps) => props,
-        );
-        render(<TestCase />);
+        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         let promise: Promise<boolean> | null = null;
         // We want to flush updates before preProcessEditCellProps resolves
@@ -167,10 +161,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should call preProcessEditCellProps with the correct params', async () => {
-        columnProps.preProcessEditCellProps = spy(
-          ({ props }: GridPreProcessEditCellProps) => props,
-        );
-        render(<TestCase />);
+        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => props);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
           apiRef.current.setEditCellValue({
@@ -179,7 +171,7 @@ describe('<DataGridPro /> - Cell editing', () => {
             value: 'USD GBP',
           }),
         );
-        const args = columnProps.preProcessEditCellProps.lastCall.args[0];
+        const args = preProcessEditCellProps.lastCall.args[0];
         expect(args.id).to.equal(0);
         expect(args.row).to.deep.equal(defaultData.rows[0]);
         expect(args.hasChanged).to.equal(true);
@@ -192,14 +184,19 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should not publish onCellEditStop if field has error', async () => {
-        columnProps.preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = spy(({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           error: true,
         }));
 
         const handleEditCellStop = spy();
 
-        render(<TestCase onCellEditStop={handleEditCellStop} />);
+        render(
+          <TestCase
+            onCellEditStop={handleEditCellStop}
+            columnProps={{ preProcessEditCellProps }}
+          />,
+        );
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
           apiRef.current.setEditCellValue({
@@ -217,11 +214,11 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should pass to renderEditCell the props returned by preProcessEditCellProps', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           foo: 'bar',
         });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].foo).to.equal(undefined);
         await act(() =>
@@ -231,11 +228,11 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should not pass to renderEditCell the value returned by preProcessEditCellProps', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           value: 'foobar',
         });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(renderEditCell.lastCall.args[0].value).to.equal('USDGBP');
         await act(() =>
@@ -245,8 +242,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should set isProcessingProps to false after calling preProcessEditCellProps', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => props;
-        render(<TestCase />);
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => props;
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         let promise: Promise<boolean> | null = null;
         // We want to flush updates before preProcessEditCellProps resolves
@@ -263,11 +260,11 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should return false if preProcessEditCellProps sets an error', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           error: true,
         });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(
           await act(() =>
@@ -280,13 +277,13 @@ describe('<DataGridPro /> - Cell editing', () => {
         ).to.equal(false);
       });
 
-      it('should return false if the cell left the edit mode while calling preProcessEditCellProps', (done) => {
+      it('should return false if the cell left the edit mode while calling preProcessEditCellProps', async () => {
         let resolveCallback: () => void;
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) =>
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) =>
           new Promise((resolve) => {
             resolveCallback = () => resolve(props);
           });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
 
         let promise: Promise<boolean>;
@@ -298,11 +295,6 @@ describe('<DataGridPro /> - Cell editing', () => {
           }) as Promise<boolean>;
         });
 
-        promise!.then((result) => {
-          expect(result).to.equal(false);
-          done();
-        });
-
         act(() =>
           apiRef.current.stopCellEditMode({
             id: 0,
@@ -312,6 +304,8 @@ describe('<DataGridPro /> - Cell editing', () => {
         );
 
         resolveCallback!();
+
+        expect(await act(async () => promise)).to.equal(false);
       });
 
       describe('with debounceMs > 0', () => {
@@ -363,11 +357,11 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it('should update the row with the new value stored', async () => {
         render(<TestCase />);
-        act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
-        await act(() =>
+        await act(async () => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
+        await act(async () =>
           apiRef.current.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
         );
-        act(() => apiRef.current.stopCellEditMode({ id: 0, field: 'currencyPair' }));
+        await act(async () => apiRef.current.stopCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(getCell(0, 1).textContent).to.equal('USD GBP');
       });
 
@@ -389,11 +383,11 @@ describe('<DataGridPro /> - Cell editing', () => {
 
       it('should do nothing if props are still being processed and ignoreModifications=false', async () => {
         let resolveCallback: () => void;
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) =>
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) =>
           new Promise((resolve) => {
             resolveCallback = () => resolve(props);
           });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
 
         let promise: Promise<boolean>;
@@ -415,11 +409,11 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should do nothing if props contain error=true', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           error: true,
         });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
           apiRef.current.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
@@ -429,12 +423,17 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should keep mode=edit if props of any column contains error=true', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           error: true,
         });
         const onCellModesModelChange = spy();
-        render(<TestCase onCellModesModelChange={onCellModesModelChange} />);
+        render(
+          <TestCase
+            onCellModesModelChange={onCellModesModelChange}
+            columnProps={{ preProcessEditCellProps }}
+          />,
+        );
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
           apiRef.current.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
@@ -446,11 +445,11 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should allow a 2nd call if the first call was when error=true', async () => {
-        columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+        const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
           ...props,
           error: props.value.length === 0,
         });
-        render(<TestCase />);
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
 
         await act(() =>
@@ -580,12 +579,12 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should pass the new value through the value setter before calling processRowUpdate', async () => {
-        columnProps.valueSetter = spy<GridValueSetter>((value, row) => ({
+        const valueSetter = spy<GridValueSetter>((value, row) => ({
           ...row,
           _currencyPair: value,
         }));
         const processRowUpdate = spy(() => new Promise(() => {}));
-        render(<TestCase processRowUpdate={processRowUpdate} />);
+        render(<TestCase processRowUpdate={processRowUpdate} columnProps={{ valueSetter }} />);
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         await act(() =>
           apiRef.current.setEditCellValue({ id: 0, field: 'currencyPair', value: 'USD GBP' }),
@@ -596,13 +595,13 @@ describe('<DataGridPro /> - Cell editing', () => {
           currencyPair: 'USDGBP',
           _currencyPair: 'USD GBP',
         });
-        expect(columnProps.valueSetter.lastCall.args[0]).to.equal('USD GBP');
-        expect(columnProps.valueSetter.lastCall.args[1]).to.deep.equal(defaultData.rows[0]);
+        expect(valueSetter.lastCall.args[0]).to.equal('USD GBP');
+        expect(valueSetter.lastCall.args[1]).to.deep.equal(defaultData.rows[0]);
       });
 
       it('should move focus to the cell below when cellToFocusAfter=below', async () => {
-        columnProps.renderEditCell = (props: GridCellProps) => <CustomEditComponent {...props} />;
-        render(<TestCase />);
+        const renderEditCellProp = (props: GridCellProps) => <CustomEditComponent {...props} />;
+        render(<TestCase columnProps={{ renderEditCell: renderEditCellProp }} />);
 
         act(() => apiRef.current.startCellEditMode({ id: 0, field: 'currencyPair' }));
         expect(getCell(0, 1).querySelector('input')).toHaveFocus();
@@ -617,7 +616,7 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should move focus to the cell on the right when cellToFocusAfter=right', async () => {
-        columnProps.renderEditCell = (props: GridCellProps) => <CustomEditComponent {...props} />;
+        const renderEditCellProp = (props: GridCellProps) => <CustomEditComponent {...props} />;
         render(
           <TestCase
             {...getBasicGridData(1, 3)}
@@ -626,6 +625,7 @@ describe('<DataGridPro /> - Cell editing', () => {
               { field: 'currencyPair', editable: true },
               { field: 'price1M', editable: true },
             ]}
+            columnProps={{ renderEditCell: renderEditCellProp }}
           />,
         );
 
@@ -642,7 +642,7 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should move focus to the cell on the left when cellToFocusAfter=left', async () => {
-        columnProps.renderEditCell = (props: GridCellProps) => <CustomEditComponent {...props} />;
+        const renderEditCellProp = (props: GridCellProps) => <CustomEditComponent {...props} />;
         render(
           <TestCase
             {...getBasicGridData(1, 3)}
@@ -651,6 +651,7 @@ describe('<DataGridPro /> - Cell editing', () => {
               { field: 'currencyPair', editable: true },
               { field: 'price1M', editable: true },
             ]}
+            columnProps={{ renderEditCell: renderEditCellProp }}
           />,
         );
 
@@ -1011,8 +1012,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should call stopCellEditMode with ignoreModifications=false if the props are being processed', async () => {
-        columnProps.preProcessEditCellProps = () => new Promise(() => {});
-        render(<TestCase />);
+        const preProcessEditCellProps = () => new Promise(() => {});
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         const spiedStopCellEditMode = spyApi(apiRef.current, 'stopCellEditMode');
         fireEvent.doubleClick(getCell(0, 1));
         await act(
@@ -1088,8 +1089,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should call stopCellEditMode with ignoreModifications=false if the props are being processed', async () => {
-        columnProps.preProcessEditCellProps = () => new Promise(() => {});
-        render(<TestCase />);
+        const preProcessEditCellProps = () => new Promise(() => {});
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         const spiedStopCellEditMode = spyApi(apiRef.current, 'stopCellEditMode');
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
@@ -1137,8 +1138,8 @@ describe('<DataGridPro /> - Cell editing', () => {
       });
 
       it('should call stopCellEditMode with ignoreModifications=false if the props are being processed', async () => {
-        columnProps.preProcessEditCellProps = () => new Promise(() => {});
-        render(<TestCase />);
+        const preProcessEditCellProps = () => new Promise(() => {});
+        render(<TestCase columnProps={{ preProcessEditCellProps }} />);
         const spiedStopCellEditMode = spyApi(apiRef.current, 'stopCellEditMode');
         const cell = getCell(0, 1);
         fireUserEvent.mousePress(cell);
@@ -1240,11 +1241,11 @@ describe('<DataGridPro /> - Cell editing', () => {
     });
 
     it('should not mutate the cellModesModel prop if props of any column contains error=true', async () => {
-      columnProps.preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
+      const preProcessEditCellProps = ({ props }: GridPreProcessEditCellProps) => ({
         ...props,
         error: true,
       });
-      const { setProps } = render(<TestCase />);
+      const { setProps } = render(<TestCase columnProps={{ preProcessEditCellProps }} />);
       const cell = getCell(0, 1);
       fireEvent.mouseUp(cell);
       fireEvent.click(cell);

--- a/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -165,13 +165,12 @@ describe('<DataGridPro /> - Columns', () => {
       fireEvent.doubleClick(separator);
       await microtasks();
       expect(onColumnWidthChange.callCount).to.be.at.least(2);
-      const widthArgs = onColumnWidthChange.args.map((arg) => Math.round(arg[0].width));
-      expect(widthArgs).to.deep.equal([120, 64]);
-      const colDefWidthArgs = onColumnWidthChange.args.map((arg) =>
-        Math.round(arg[0].colDef.width),
-      );
-      const isColDefWidth64Present = colDefWidthArgs.some((width) => width === 64);
-      expect(isColDefWidth64Present).to.equal(true);
+      const widthArgs = onColumnWidthChange.args.map((arg) => arg[0].width);
+      const isWidth114Present = widthArgs.some((width) => width === 114);
+      expect(isWidth114Present).to.equal(true);
+      const colDefWidthArgs = onColumnWidthChange.args.map((arg) => arg[0].colDef.width);
+      const isColDefWidth114Present = colDefWidthArgs.some((width) => width === 114);
+      expect(isColDefWidth114Present).to.equal(true);
     });
 
     it('should not affect other cell elements that are not part of the main DataGrid instance', () => {
@@ -450,57 +449,52 @@ describe('<DataGridPro /> - Columns', () => {
       },
       {
         id: 1,
-        brand: 'Puma',
+        brand: 'Adidas',
       },
       {
         id: 2,
+        brand: 'Puma',
+      },
+      {
+        id: 3,
         brand: 'Lululemon Athletica',
       },
     ];
-    const buildColumns = () => {
-      const columns = [
-        { field: 'id', headerName: 'This is the ID column' },
-        { field: 'brand', headerName: 'This is the brand column' },
-      ];
-      const getWidths = () => {
-        return columns.map((_, i) => parseInt(getColumnHeaderCell(i).style.width, 10));
-      };
-      return {
-        columns,
-        getWidths,
-      };
+    const columns = [
+      { field: 'id', headerName: 'This is the ID column' },
+      { field: 'brand', headerName: 'This is the brand column' },
+    ];
+
+    const getWidths = () => {
+      return columns.map((_, i) => parseInt(getColumnHeaderCell(i).style.width, 10));
     };
 
     it('should work through the API', async () => {
-      const { columns, getWidths } = buildColumns();
       render(<Test rows={rows} columns={columns} />);
       await apiRef.current.autosizeColumns();
       await microtasks();
-      expect(getWidths()).to.deep.equal([155, 177]);
+      expect(getWidths()).to.deep.equal([211, 233]);
     });
 
     it('should work through double-clicking the separator', async () => {
-      const { columns, getWidths } = buildColumns();
       render(<Test rows={rows} columns={columns} />);
       const separator = document.querySelectorAll(
         `.${gridClasses['columnSeparator--resizable']}`,
       )[1];
       fireEvent.doubleClick(separator);
       await microtasks();
-      expect(getWidths()).to.deep.equal([100, 177]);
+      expect(getWidths()).to.deep.equal([100, 233]);
     });
 
     it('should work on mount', async () => {
-      const { columns, getWidths } = buildColumns();
       render(<Test rows={rows} columns={columns} autosizeOnMount />);
       await microtasks(); /* first effect after render */
       await microtasks(); /* async autosize operation */
-      expect(getWidths()).to.deep.equal([155, 177]);
+      expect(getWidths()).to.deep.equal([211, 233]);
     });
 
     describe('options', () => {
       const autosize = async (options: GridAutosizeOptions | undefined, widths: number[]) => {
-        const { columns, getWidths } = buildColumns();
         render(<Test rows={rows} columns={columns} />);
         await apiRef.current.autosizeColumns({ includeHeaders: false, ...options });
         await microtasks();
@@ -508,11 +502,11 @@ describe('<DataGridPro /> - Columns', () => {
       };
 
       it('.columns works', async () => {
-        await autosize({ columns: ['id'] }, [50, 100]);
+        await autosize({ columns: [columns[0].field] }, [50, 100]);
       });
 
       it('.includeHeaders works', async () => {
-        await autosize({ includeHeaders: true }, [155, 177]);
+        await autosize({ includeHeaders: true }, [211, 233]);
       });
 
       it('.includeOutliers works', async () => {
@@ -524,7 +518,7 @@ describe('<DataGridPro /> - Columns', () => {
       });
 
       it('.expand works', async () => {
-        await autosize({ expand: true }, [101, 196]);
+        await autosize({ expand: true }, [134, 148]);
       });
     });
   });
@@ -542,7 +536,6 @@ describe('<DataGridPro /> - Columns', () => {
 
       act(() => apiRef.current.setColumnWidth('brand', 300));
       expect(gridColumnLookupSelector(apiRef).brand.computedWidth).to.equal(300);
-      // @ts-expect-error privateApi is not defined
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnLookupSelector(apiRef).brand.computedWidth).to.equal(300);
     });
@@ -564,7 +557,6 @@ describe('<DataGridPro /> - Columns', () => {
       expect(gridColumnFieldsSelector(apiRef).indexOf('brand')).to.equal(2);
       act(() => apiRef.current.setColumnIndex('brand', 1));
       expect(gridColumnFieldsSelector(apiRef).indexOf('brand')).to.equal(1);
-      // @ts-expect-error privateApi is not defined
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnFieldsSelector(apiRef).indexOf('brand')).to.equal(1);
     });
@@ -579,7 +571,6 @@ describe('<DataGridPro /> - Columns', () => {
 
       act(() => apiRef.current.updateColumns([{ field: 'id' }]));
       expect(gridColumnFieldsSelector(apiRef)).to.deep.equal(['__check__', 'brand', 'id']);
-      // @ts-expect-error privateApi is not defined
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnFieldsSelector(apiRef)).to.deep.equal(['__check__', 'brand', 'id']);
     });

--- a/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -165,12 +165,13 @@ describe('<DataGridPro /> - Columns', () => {
       fireEvent.doubleClick(separator);
       await microtasks();
       expect(onColumnWidthChange.callCount).to.be.at.least(2);
-      const widthArgs = onColumnWidthChange.args.map((arg) => arg[0].width);
-      const isWidth114Present = widthArgs.some((width) => width === 114);
-      expect(isWidth114Present).to.equal(true);
-      const colDefWidthArgs = onColumnWidthChange.args.map((arg) => arg[0].colDef.width);
-      const isColDefWidth114Present = colDefWidthArgs.some((width) => width === 114);
-      expect(isColDefWidth114Present).to.equal(true);
+      const widthArgs = onColumnWidthChange.args.map((arg) => Math.round(arg[0].width));
+      expect(widthArgs).to.deep.equal([120, 64]);
+      const colDefWidthArgs = onColumnWidthChange.args.map((arg) =>
+        Math.round(arg[0].colDef.width),
+      );
+      const isColDefWidth64Present = colDefWidthArgs.some((width) => width === 64);
+      expect(isColDefWidth64Present).to.equal(true);
     });
 
     it('should not affect other cell elements that are not part of the main DataGrid instance', () => {
@@ -449,52 +450,57 @@ describe('<DataGridPro /> - Columns', () => {
       },
       {
         id: 1,
-        brand: 'Adidas',
-      },
-      {
-        id: 2,
         brand: 'Puma',
       },
       {
-        id: 3,
+        id: 2,
         brand: 'Lululemon Athletica',
       },
     ];
-    const columns = [
-      { field: 'id', headerName: 'This is the ID column' },
-      { field: 'brand', headerName: 'This is the brand column' },
-    ];
-
-    const getWidths = () => {
-      return columns.map((_, i) => parseInt(getColumnHeaderCell(i).style.width, 10));
+    const buildColumns = () => {
+      const columns = [
+        { field: 'id', headerName: 'This is the ID column' },
+        { field: 'brand', headerName: 'This is the brand column' },
+      ];
+      const getWidths = () => {
+        return columns.map((_, i) => parseInt(getColumnHeaderCell(i).style.width, 10));
+      };
+      return {
+        columns,
+        getWidths,
+      };
     };
 
     it('should work through the API', async () => {
+      const { columns, getWidths } = buildColumns();
       render(<Test rows={rows} columns={columns} />);
       await apiRef.current.autosizeColumns();
       await microtasks();
-      expect(getWidths()).to.deep.equal([211, 233]);
+      expect(getWidths()).to.deep.equal([155, 177]);
     });
 
     it('should work through double-clicking the separator', async () => {
+      const { columns, getWidths } = buildColumns();
       render(<Test rows={rows} columns={columns} />);
       const separator = document.querySelectorAll(
         `.${gridClasses['columnSeparator--resizable']}`,
       )[1];
       fireEvent.doubleClick(separator);
       await microtasks();
-      expect(getWidths()).to.deep.equal([100, 233]);
+      expect(getWidths()).to.deep.equal([100, 177]);
     });
 
     it('should work on mount', async () => {
+      const { columns, getWidths } = buildColumns();
       render(<Test rows={rows} columns={columns} autosizeOnMount />);
       await microtasks(); /* first effect after render */
       await microtasks(); /* async autosize operation */
-      expect(getWidths()).to.deep.equal([211, 233]);
+      expect(getWidths()).to.deep.equal([155, 177]);
     });
 
     describe('options', () => {
       const autosize = async (options: GridAutosizeOptions | undefined, widths: number[]) => {
+        const { columns, getWidths } = buildColumns();
         render(<Test rows={rows} columns={columns} />);
         await apiRef.current.autosizeColumns({ includeHeaders: false, ...options });
         await microtasks();
@@ -502,11 +508,11 @@ describe('<DataGridPro /> - Columns', () => {
       };
 
       it('.columns works', async () => {
-        await autosize({ columns: [columns[0].field] }, [50, 100]);
+        await autosize({ columns: ['id'] }, [50, 100]);
       });
 
       it('.includeHeaders works', async () => {
-        await autosize({ includeHeaders: true }, [211, 233]);
+        await autosize({ includeHeaders: true }, [155, 177]);
       });
 
       it('.includeOutliers works', async () => {
@@ -518,7 +524,7 @@ describe('<DataGridPro /> - Columns', () => {
       });
 
       it('.expand works', async () => {
-        await autosize({ expand: true }, [134, 148]);
+        await autosize({ expand: true }, [101, 196]);
       });
     });
   });
@@ -536,6 +542,7 @@ describe('<DataGridPro /> - Columns', () => {
 
       act(() => apiRef.current.setColumnWidth('brand', 300));
       expect(gridColumnLookupSelector(apiRef).brand.computedWidth).to.equal(300);
+      // @ts-expect-error privateApi is not defined
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnLookupSelector(apiRef).brand.computedWidth).to.equal(300);
     });
@@ -557,6 +564,7 @@ describe('<DataGridPro /> - Columns', () => {
       expect(gridColumnFieldsSelector(apiRef).indexOf('brand')).to.equal(2);
       act(() => apiRef.current.setColumnIndex('brand', 1));
       expect(gridColumnFieldsSelector(apiRef).indexOf('brand')).to.equal(1);
+      // @ts-expect-error privateApi is not defined
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnFieldsSelector(apiRef).indexOf('brand')).to.equal(1);
     });
@@ -571,6 +579,7 @@ describe('<DataGridPro /> - Columns', () => {
 
       act(() => apiRef.current.updateColumns([{ field: 'id' }]));
       expect(gridColumnFieldsSelector(apiRef)).to.deep.equal(['__check__', 'brand', 'id']);
+      // @ts-expect-error privateApi is not defined
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnFieldsSelector(apiRef)).to.deep.equal(['__check__', 'brand', 'id']);
     });


### PR DESCRIPTION
Porting a change from https://github.com/mui/mui-x/pull/14508

Basically making the render independent from other test runs by not having a globally defined variable for the test.

Also removes `done()` from two tests 😅 

~~### Scrollbars~~

~~The changes on [columns.DataGridPro.test.tsx](https://github.com/mui/mui-x/pull/14926/files#diff-ed2f26687dbce52b79ed6f7fed0b2b2b20a4f3807c1c6537477ef24775c581ab) are due to playwright [not displaying scrollbars by default](https://github.com/microsoft/playwright/issues/5778).~~

~~If it is desirable to display the scrollbars, then I can revert this and force playwright to show them in headless mode instead.~~