### PR TITLE
[test] Fix `AdapterDayjs` coverage calculation

### DIFF
--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts
@@ -277,6 +277,8 @@ export class AdapterDayjs implements MuiPickersAdapter<Dayjs, string> {
     const timezone = this.getTimezone(value);
     if (timezone !== 'UTC') {
       const fixedValue = value.tz(this.cleanTimezone(timezone), true);
+      // TODO: Simplify the case when we raise the `dayjs` peer dep to 1.11.12 (https://github.com/iamkun/dayjs/releases/tag/v1.11.12)
+      /* istanbul ignore next */
       // @ts-ignore
       if (fixedValue.$offset === (value.$offset ?? 0)) {
         return value;


### PR DESCRIPTION
> [!NOTE]
> This is to unblock the existing failing PRs.

Ignore [this line](https://app.codecov.io/gh/mui/mui-x/commit/5b4890961904b946bb7dccfd26b5e44b016d88e7/blob/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.ts#L281) in test coverage calculation which started happening after https://github.com/mui/mui-x/pull/13919 got merged.


We should be able to remove the ignore once we bump the `dayjs` peer dependency version on the next major and simplify the code.