### PR TITLE
[DataGrid] Fix `onRowSelectionModelChange` not being called after row is removed

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -456,7 +456,7 @@ export const useGridRowSelection = (
 
       let hasChanged = false;
       currentSelection.forEach((id: GridRowId) => {
-        if (filteredRowsLookup[id] === false) {
+        if (filteredRowsLookup[id] !== true) {
           if (props.keepNonExistentRowsSelected) {
             return;
           }

--- a/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -701,7 +701,7 @@ describe('<DataGrid /> - Row selection', () => {
         rows: data.rows.slice(0, 1),
       });
 
-      expect(onRowSelectionModelChangeSpy.called).to.be.true;
+      expect(onRowSelectionModelChangeSpy.called).to.equal(true);
     });
 
     it('should retain the outdated selected rows when the rows prop changes when keepNonExistentRowsSelected is true', () => {

--- a/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSelection.DataGrid.test.tsx
@@ -683,6 +683,27 @@ describe('<DataGrid /> - Row selection', () => {
       expect(getSelectedRowIds()).to.deep.equal([0]);
     });
 
+    // Related to https://github.com/mui/mui-x/issues/14964
+    it('should call `onRowSelectionModelChange` when outdated selected rows are removed', () => {
+      const data = getBasicGridData(4, 2);
+      const onRowSelectionModelChangeSpy = spy();
+
+      const { setProps } = render(
+        <TestDataGridSelection
+          rowSelectionModel={[0, 1, 2]}
+          onRowSelectionModelChange={onRowSelectionModelChangeSpy}
+          checkboxSelection
+          {...data}
+        />,
+      );
+
+      setProps({
+        rows: data.rows.slice(0, 1),
+      });
+
+      expect(onRowSelectionModelChangeSpy.called).to.be.true;
+    });
+
     it('should retain the outdated selected rows when the rows prop changes when keepNonExistentRowsSelected is true', () => {
       const data = getBasicGridData(10, 2);
       const onRowSelectionModelChange = spy();


### PR DESCRIPTION
Fixes #14964 
- Before: https://codesandbox.io/p/sandbox/vigorous-oskar-rhgzlp
- After: https://codesandbox.io/p/sandbox/compassionate-black-forked-6sfvpm