### PR TITLE
[docs] Fix empty space issue in `PopularFeaturesDemo`

### DIFF
--- a/docs/data/data-grid/demo/PopularFeaturesDemo.js
+++ b/docs/data/data-grid/demo/PopularFeaturesDemo.js
@@ -526,10 +526,6 @@ export default function PopularFeaturesDemo() {
           [`& > div > div > div > div > div > .${gridClasses.cell}`]: {
             py: 1.5,
           },
-          // See https://github.com/mui/mui-x/issues/14989
-          [`& .${gridClasses.columnHeader}, & .${gridClasses.cell}`]: {
-            boxSizing: 'content-box',
-          },
           [`& .${gridClasses.columnHeaderTitle}`]: {
             fontWeight: 'medium',
           },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #14989

Before: https://mui.com/x/react-data-grid/demo/  (space appears on zoom level 90% or less)
After:  https://deploy-preview-15000--material-ui-x.netlify.app/x/react-data-grid/demo/
