### PR TITLE
[TreeView] Fix hydration error

### DIFF
--- a/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.ts
+++ b/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.ts
@@ -8,11 +8,9 @@ export const useTreeViewId: TreeViewPlugin<UseTreeViewIdSignature> = ({
   state,
   setState,
 }) => {
-  const treeId = state.id.treeId;
-
   React.useEffect(() => {
     setState((prevState) => {
-      if (prevState.id.treeId === params.id) {
+      if (prevState.id.treeId === params.id && prevState.id.treeId !== undefined) {
         return prevState;
       }
 
@@ -22,6 +20,8 @@ export const useTreeViewId: TreeViewPlugin<UseTreeViewIdSignature> = ({
       };
     });
   }, [setState, params.id]);
+
+  const treeId = params.id ?? state.id.treeId;
 
   return {
     getRootProps: () => ({
@@ -37,4 +37,4 @@ useTreeViewId.params = {
   id: true,
 };
 
-useTreeViewId.getInitialState = ({ id }) => ({ id: { treeId: id ?? createTreeViewDefaultId() } });
+useTreeViewId.getInitialState = () => ({ id: { treeId: undefined } });

--- a/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.ts
+++ b/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.ts
@@ -37,4 +37,4 @@ useTreeViewId.params = {
   id: true,
 };
 
-useTreeViewId.getInitialState = () => ({ id: { treeId: undefined } });
+useTreeViewId.getInitialState = ({ id }) => ({ id: { treeId: id ?? undefined } });

--- a/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.types.ts
+++ b/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.types.ts
@@ -12,7 +12,7 @@ export type UseTreeViewIdDefaultizedParameters = UseTreeViewIdParameters;
 
 export interface UseTreeViewIdState {
   id: {
-    treeId: string;
+    treeId: string | undefined;
   };
 }
 


### PR DESCRIPTION
Fixes #14980
Extracted from #14210

Only sets the default id attribute after the hydration, like `useId` does