### PR TITLE
[pickers] Improve `PickersLayout` styles consistency

### DIFF
--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import DialogActions, { DialogActionsProps } from '@mui/material/DialogActions';
 import { usePickersTranslations } from '../hooks/usePickersTranslations';
@@ -19,6 +20,12 @@ export interface PickersActionBarProps extends DialogActionsProps {
   onCancel: () => void;
   onSetToday: () => void;
 }
+
+const PickersActionBarRoot = styled(DialogActions, {
+  name: 'MuiPickersLayout',
+  slot: 'ActionBar',
+  overridesResolver: (_, styles) => [styles.actionBar],
+})({});
 
 /**
  * Demos:
@@ -74,7 +81,7 @@ function PickersActionBar(props: PickersActionBarProps) {
     }
   });
 
-  return <DialogActions {...other}>{buttons}</DialogActions>;
+  return <PickersActionBarRoot {...other}>{buttons}</PickersActionBarRoot>;
 }
 
 PickersActionBar.propTypes = {

--- a/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
+++ b/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import List, { ListProps } from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -50,6 +51,12 @@ export interface PickersShortcutsProps<TValue> extends ExportedPickersShortcutPr
   isValid: (value: TValue) => boolean;
 }
 
+const PickersShortcutsRoot = styled(List, {
+  name: 'MuiPickersLayout',
+  slot: 'Shortcuts',
+  overridesResolver: (_, styles) => [styles.shortcuts],
+})({});
+
 /**
  * Demos:
  *
@@ -80,7 +87,7 @@ function PickersShortcuts<TValue>(props: PickersShortcutsProps<TValue>) {
   });
 
   return (
-    <List
+    <PickersShortcutsRoot
       dense
       sx={[
         {
@@ -99,7 +106,7 @@ function PickersShortcuts<TValue>(props: PickersShortcutsProps<TValue>) {
           </ListItem>
         );
       })}
-    </List>
+    </PickersShortcutsRoot>
   );
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


I noticed a few styling inconsistencies that were causing issues for customization. 
1. the `actionBar` and `shortcuts` could not be customized with styleOverrides
2. applying some of the toolbar, actionBar and shortcuts styles in the `PickersLayoutRoot` by targeting classes was causing some specificity issues => you could only override the grid structure by overriding the `PickersLayoutRoot` styled entirely. 
