### PR TITLE
[charts] Export data type in onAxisClick(_, data) callback

### DIFF
--- a/packages/x-charts/src/ChartsOnAxisClickHandler/ChartsOnAxisClickHandler.tsx
+++ b/packages/x-charts/src/ChartsOnAxisClickHandler/ChartsOnAxisClickHandler.tsx
@@ -6,7 +6,7 @@ import { useSeries } from '../hooks/useSeries';
 import { useSvgRef } from '../hooks';
 import { useCartesianContext } from '../context/CartesianProvider';
 
-type AxisData = {
+export type AxisData = {
   dataIndex: number;
   axisValue?: number | Date | string;
   seriesValues: Record<string, number | null | undefined>;

--- a/packages/x-charts/src/ChartsOnAxisClickHandler/ChartsOnAxisClickHandler.tsx
+++ b/packages/x-charts/src/ChartsOnAxisClickHandler/ChartsOnAxisClickHandler.tsx
@@ -6,7 +6,7 @@ import { useSeries } from '../hooks/useSeries';
 import { useSvgRef } from '../hooks';
 import { useCartesianContext } from '../context/CartesianProvider';
 
-export type AxisData = {
+export type ChartsAxisData = {
   dataIndex: number;
   axisValue?: number | Date | string;
   seriesValues: Record<string, number | null | undefined>;
@@ -19,7 +19,7 @@ export interface ChartsOnAxisClickHandlerProps {
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
    * @param {null | AxisData} data The data about the clicked axis and items associated with it.
    */
-  onAxisClick?: (event: MouseEvent, data: null | AxisData) => void;
+  onAxisClick?: (event: MouseEvent, data: null | ChartsAxisData) => void;
 }
 
 function ChartsOnAxisClickHandler(props: ChartsOnAxisClickHandlerProps) {

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -61,6 +61,7 @@
   { "name": "ChartsAxisClasses", "kind": "Interface" },
   { "name": "ChartsAxisClassKey", "kind": "TypeAlias" },
   { "name": "ChartsAxisContentProps", "kind": "TypeAlias" },
+  { "name": "ChartsAxisData", "kind": "TypeAlias" },
   { "name": "ChartsAxisHighlight", "kind": "Function" },
   { "name": "chartsAxisHighlightClasses", "kind": "Variable" },
   { "name": "ChartsAxisHighlightClasses", "kind": "Interface" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -59,6 +59,7 @@
   { "name": "ChartsAxisClasses", "kind": "Interface" },
   { "name": "ChartsAxisClassKey", "kind": "TypeAlias" },
   { "name": "ChartsAxisContentProps", "kind": "TypeAlias" },
+  { "name": "ChartsAxisData", "kind": "TypeAlias" },
   { "name": "ChartsAxisHighlight", "kind": "Function" },
   { "name": "chartsAxisHighlightClasses", "kind": "Variable" },
   { "name": "ChartsAxisHighlightClasses", "kind": "Interface" },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem

In a scenario where we'd like to have a controlled state that holds the axis data and make other components react to that state as we update it by clicking on the axes of the chart it would be very useful if we could re-use the `AxisData` type. But it was not exported when I checked the source code.

## Main Feature

This PR's purpose is to

- [x] export `ChartsAxisData` type making it possible to import it from the mui library

## Follow-ups After Review

- [x] renamed from `AxisData` to `ChartsAxisData` as per @oliviertassinari 's suggestion
- [x] ran `pnpm docs:api:build` which added the type to docs