### PR TITLE
[docs] Fix typo in Tree View docs

### DIFF
--- a/docs/data/tree-view/simple-tree-view/items/items.md
+++ b/docs/data/tree-view/simple-tree-view/items/items.md
@@ -51,7 +51,7 @@ Use the `disabled` prop on the Tree Item component to disable interaction and fo
 
 #### The disabledItemsFocusable prop
 
-Note that the demo above also includes a switch.
+Note that the demo below also includes a switch.
 This toggles the `disabledItemsFocusable` prop, which controls whether or not a disabled Tree Item can be focused.
 
 When this prop is set to false:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I was going through docs and observed this typo. Raising a PR to fix it.


Link to docs - https://mui.com/x/react-tree-view/simple-tree-view/items/#disabled-items
![image](https://github.com/user-attachments/assets/72cdd7a4-203d-4dde-a2b4-7af2def35a8b)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
