### PR TITLE
[DataGrid] refactor: baseMenuList & baseMenuItem

### DIFF
--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -815,6 +815,18 @@
       "class": null
     },
     {
+      "name": "baseMenuList",
+      "description": "The custom MenuList component used in the grid.",
+      "default": "MenuList",
+      "class": null
+    },
+    {
+      "name": "baseMenuItem",
+      "description": "The custom MenuItem component used in the grid.",
+      "default": "MenuItem",
+      "class": null
+    },
+    {
       "name": "baseInputAdornment",
       "description": "The custom InputAdornment component used in the grid.",
       "default": "InputAdornment",

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -747,6 +747,18 @@
       "class": null
     },
     {
+      "name": "baseMenuList",
+      "description": "The custom MenuList component used in the grid.",
+      "default": "MenuList",
+      "class": null
+    },
+    {
+      "name": "baseMenuItem",
+      "description": "The custom MenuItem component used in the grid.",
+      "default": "MenuItem",
+      "class": null
+    },
+    {
       "name": "baseInputAdornment",
       "description": "The custom InputAdornment component used in the grid.",
       "default": "InputAdornment",

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -634,6 +634,18 @@
       "class": null
     },
     {
+      "name": "baseMenuList",
+      "description": "The custom MenuList component used in the grid.",
+      "default": "MenuList",
+      "class": null
+    },
+    {
+      "name": "baseMenuItem",
+      "description": "The custom MenuItem component used in the grid.",
+      "default": "MenuItem",
+      "class": null
+    },
+    {
       "name": "baseInputAdornment",
       "description": "The custom InputAdornment component used in the grid.",
       "default": "InputAdornment",

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -1239,6 +1239,8 @@
     "baseIconButton": "The custom IconButton component used in the grid.",
     "baseInputAdornment": "The custom InputAdornment component used in the grid.",
     "baseInputLabel": "The custom InputLabel component used in the grid.",
+    "baseMenuItem": "The custom MenuItem component used in the grid.",
+    "baseMenuList": "The custom MenuList component used in the grid.",
     "basePopper": "The custom Popper component used in the grid.",
     "baseSelect": "The custom Select component used in the grid.",
     "baseSelectOption": "The custom SelectOption component used in the grid.",

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -1177,6 +1177,8 @@
     "baseIconButton": "The custom IconButton component used in the grid.",
     "baseInputAdornment": "The custom InputAdornment component used in the grid.",
     "baseInputLabel": "The custom InputLabel component used in the grid.",
+    "baseMenuItem": "The custom MenuItem component used in the grid.",
+    "baseMenuList": "The custom MenuList component used in the grid.",
     "basePopper": "The custom Popper component used in the grid.",
     "baseSelect": "The custom Select component used in the grid.",
     "baseSelectOption": "The custom SelectOption component used in the grid.",

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -1057,6 +1057,8 @@
     "baseIconButton": "The custom IconButton component used in the grid.",
     "baseInputAdornment": "The custom InputAdornment component used in the grid.",
     "baseInputLabel": "The custom InputLabel component used in the grid.",
+    "baseMenuItem": "The custom MenuItem component used in the grid.",
+    "baseMenuList": "The custom MenuList component used in the grid.",
     "basePopper": "The custom Popper component used in the grid.",
     "baseSelect": "The custom Select component used in the grid.",
     "baseSelectOption": "The custom SelectOption component used in the grid.",

--- a/packages/x-data-grid-premium/src/components/GridColumnMenuAggregationItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridColumnMenuAggregationItem.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { GridColumnMenuItemProps, useGridSelector } from '@mui/x-data-grid-pro';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import { unstable_useId as useId } from '@mui/utils';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 import {
@@ -53,8 +51,8 @@ function GridColumnMenuAggregationItem(props: GridColumnMenuItemProps) {
     return '';
   }, [rootProps.aggregationFunctions, aggregationModel, colDef]);
 
-  const handleAggregationItemChange = (event: SelectChangeEvent<string | undefined>) => {
-    const newAggregationItem = event.target?.value || undefined;
+  const handleAggregationItemChange = (event: Event) => {
+    const newAggregationItem = (event.target as HTMLSelectElement | null)?.value || undefined;
     const currentModel = gridAggregationModelSelector(apiRef);
     const { [colDef.field]: columnItem, ...otherColumnItems } = currentModel;
     const newModel: GridAggregationModel =
@@ -69,26 +67,26 @@ function GridColumnMenuAggregationItem(props: GridColumnMenuItemProps) {
   const label = apiRef.current.getLocaleText('aggregationMenuItemHeader');
 
   return (
-    <MenuItem disableRipple>
+    <rootProps.slots.baseMenuItem disableRipple>
       <ListItemIcon>
         <rootProps.slots.columnMenuAggregationIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>
         <FormControl size="small" fullWidth sx={{ minWidth: 150 }}>
           <InputLabel id={`${id}-label`}>{label}</InputLabel>
-          <Select
+          <rootProps.slots.baseSelect
             labelId={`${id}-label`}
             id={`${id}-input`}
             value={selectedAggregationRule}
             label={label}
             color="primary"
-            onChange={handleAggregationItemChange}
+            onChange={handleAggregationItemChange as any}
             onBlur={(event) => event.stopPropagation()}
             fullWidth
           >
-            <MenuItem value="">...</MenuItem>
+            <rootProps.slots.baseMenuItem value="">...</rootProps.slots.baseMenuItem>
             {availableAggregationFunctions.map((aggFunc) => (
-              <MenuItem key={aggFunc} value={aggFunc}>
+              <rootProps.slots.baseMenuItem key={aggFunc} value={aggFunc}>
                 {getAggregationFunctionLabel({
                   apiRef,
                   aggregationRule: {
@@ -96,12 +94,12 @@ function GridColumnMenuAggregationItem(props: GridColumnMenuItemProps) {
                     aggregationFunction: rootProps.aggregationFunctions[aggFunc],
                   },
                 })}
-              </MenuItem>
+              </rootProps.slots.baseMenuItem>
             ))}
-          </Select>
+          </rootProps.slots.baseSelect>
         </FormControl>
       </ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 

--- a/packages/x-data-grid-premium/src/components/GridColumnMenuRowGroupItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridColumnMenuRowGroupItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import {
@@ -32,12 +31,16 @@ export function GridColumnMenuRowGroupItem(props: GridColumnMenuItemProps) {
     const groupedColumn = columnsLookup[field];
     const name = groupedColumn.headerName ?? field;
     return (
-      <MenuItem onClick={ungroupColumn} key={field} disabled={!groupedColumn.groupable}>
+      <rootProps.slots.baseMenuItem
+        onClick={ungroupColumn}
+        key={field}
+        disabled={!groupedColumn.groupable}
+      >
         <ListItemIcon>
           <rootProps.slots.columnMenuUngroupIcon fontSize="small" />
         </ListItemIcon>
         <ListItemText>{apiRef.current.getLocaleText('unGroupColumn')(name)}</ListItemText>
-      </MenuItem>
+      </rootProps.slots.baseMenuItem>
     );
   };
 

--- a/packages/x-data-grid-premium/src/components/GridColumnMenuRowUngroupItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridColumnMenuRowUngroupItem.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import {
@@ -36,21 +35,21 @@ export function GridColumnMenuRowUngroupItem(props: GridColumnMenuItemProps) {
 
   if (rowGroupingModel.includes(colDef.field)) {
     return (
-      <MenuItem onClick={ungroupColumn}>
+      <rootProps.slots.baseMenuItem onClick={ungroupColumn}>
         <ListItemIcon>
           <rootProps.slots.columnMenuUngroupIcon fontSize="small" />
         </ListItemIcon>
         <ListItemText>{apiRef.current.getLocaleText('unGroupColumn')(name)}</ListItemText>
-      </MenuItem>
+      </rootProps.slots.baseMenuItem>
     );
   }
 
   return (
-    <MenuItem onClick={groupColumn}>
+    <rootProps.slots.baseMenuItem onClick={groupColumn}>
       <ListItemIcon>
         <rootProps.slots.columnMenuGroupIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>{apiRef.current.getLocaleText('groupColumn')(name)}</ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }

--- a/packages/x-data-grid-premium/src/components/GridExcelExportMenuItem.tsx
+++ b/packages/x-data-grid-premium/src/components/GridExcelExportMenuItem.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MenuItem from '@mui/material/MenuItem';
 import { GridExportMenuItemProps } from '@mui/x-data-grid-pro';
 import { useGridApiContext } from '../hooks/utils/useGridApiContext';
+import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 import { GridExcelExportOptions } from '../hooks/features/export';
 
 export type GridExcelExportMenuItemProps = GridExportMenuItemProps<GridExcelExportOptions>;
 
 function GridExcelExportMenuItem(props: GridExcelExportMenuItemProps) {
   const apiRef = useGridApiContext();
+  const rootProps = useGridRootProps();
   const { hideMenu, options, ...other } = props;
 
   return (
-    <MenuItem
+    <rootProps.slots.baseMenuItem
       onClick={() => {
         apiRef.current.exportDataAsExcel(options);
         hideMenu?.();
@@ -20,7 +21,7 @@ function GridExcelExportMenuItem(props: GridExcelExportMenuItemProps) {
       {...other}
     >
       {apiRef.current.getLocaleText('toolbarExportExcel')}
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 

--- a/packages/x-data-grid-pro/src/components/GridColumnMenuPinningItem.tsx
+++ b/packages/x-data-grid-pro/src/components/GridColumnMenuPinningItem.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useRtl } from '@mui/system/RtlProvider';
 import PropTypes from 'prop-types';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { GridPinnedColumnPosition, GridColumnMenuItemProps } from '@mui/x-data-grid';
@@ -27,21 +26,21 @@ function GridColumnMenuPinningItem(props: GridColumnMenuItemProps) {
     onClick(event);
   };
   const pinToLeftMenuItem = (
-    <MenuItem onClick={pinColumn(GridPinnedColumnPosition.LEFT)}>
+    <rootProps.slots.baseMenuItem onClick={pinColumn(GridPinnedColumnPosition.LEFT)}>
       <ListItemIcon>
         <rootProps.slots.columnMenuPinLeftIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>{apiRef.current.getLocaleText('pinToLeft')}</ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 
   const pinToRightMenuItem = (
-    <MenuItem onClick={pinColumn(GridPinnedColumnPosition.RIGHT)}>
+    <rootProps.slots.baseMenuItem onClick={pinColumn(GridPinnedColumnPosition.RIGHT)}>
       <ListItemIcon>
         <rootProps.slots.columnMenuPinRightIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>{apiRef.current.getLocaleText('pinToRight')}</ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 
   if (!colDef) {
@@ -62,16 +61,16 @@ function GridColumnMenuPinningItem(props: GridColumnMenuItemProps) {
         : rootProps.slots.columnMenuPinRightIcon;
     return (
       <React.Fragment>
-        <MenuItem onClick={pinColumn(otherSide)}>
+        <rootProps.slots.baseMenuItem onClick={pinColumn(otherSide)}>
           <ListItemIcon>
             <Icon fontSize="small" />
           </ListItemIcon>
           <ListItemText>{apiRef.current.getLocaleText(label)}</ListItemText>
-        </MenuItem>
-        <MenuItem onClick={unpinColumn}>
+        </rootProps.slots.baseMenuItem>
+        <rootProps.slots.baseMenuItem onClick={unpinColumn}>
           <ListItemIcon />
           <ListItemText>{apiRef.current.getLocaleText('unpin')}</ListItemText>
-        </MenuItem>
+        </rootProps.slots.baseMenuItem>
       </React.Fragment>
     );
   }

--- a/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenu.tsx
+++ b/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterMenu.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MenuList from '@mui/material/MenuList';
-import MenuItem from '@mui/material/MenuItem';
 import { unstable_capitalize as capitalize, HTMLElementType } from '@mui/utils';
 import {
+  useGridRootProps,
   useGridApiContext,
   GridMenu,
   GridFilterOperator,
@@ -33,6 +32,7 @@ function GridHeaderFilterMenu({
   labelledBy,
 }: GridHeaderFilterMenuProps) {
   const apiRef = useGridApiContext();
+  const rootProps = useGridRootProps();
 
   const hideMenu = React.useCallback(() => {
     apiRef.current.hideHeaderFilterMenu();
@@ -56,7 +56,11 @@ function GridHeaderFilterMenu({
 
   return (
     <GridMenu placement="bottom-end" open={open} target={target} onClose={hideMenu}>
-      <MenuList aria-labelledby={labelledBy} id={id} onKeyDown={handleListKeyDown}>
+      <rootProps.slots.baseMenuList
+        aria-labelledby={labelledBy}
+        id={id}
+        onKeyDown={handleListKeyDown}
+      >
         {operators.map((op, i) => {
           const label =
             op?.headerLabel ??
@@ -65,7 +69,7 @@ function GridHeaderFilterMenu({
             );
 
           return (
-            <MenuItem
+            <rootProps.slots.baseMenuItem
               onClick={() => {
                 applyFilterChanges({ ...item, operator: op.value });
                 hideMenu();
@@ -75,10 +79,10 @@ function GridHeaderFilterMenu({
               key={`${field}-${op.value}`}
             >
               {label}
-            </MenuItem>
+            </rootProps.slots.baseMenuItem>
           );
         })}
-      </MenuList>
+      </rootProps.slots.baseMenuList>
     </GridMenu>
   );
 }

--- a/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCellItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { IconButtonProps } from '@mui/material/IconButton';
-import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
+import { MenuItemProps } from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 
@@ -70,10 +70,10 @@ const GridActionsCellItem = React.forwardRef<HTMLElement, GridActionsCellItemPro
     };
 
     return (
-      <MenuItem ref={ref} {...(other as any)} onClick={handleClick}>
+      <rootProps.slots.baseMenuItem ref={ref} {...(other as any)} onClick={handleClick}>
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
         {label}
-      </MenuItem>
+      </rootProps.slots.baseMenuItem>
     );
   },
 );

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuFilterItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuFilterItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { useGridApiContext } from '../../../../hooks/utils/useGridApiContext';
@@ -25,12 +24,12 @@ function GridColumnMenuFilterItem(props: GridColumnMenuItemProps) {
   }
 
   return (
-    <MenuItem onClick={showFilter}>
+    <rootProps.slots.baseMenuItem onClick={showFilter}>
       <ListItemIcon>
         <rootProps.slots.columnMenuFilterIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>{apiRef.current.getLocaleText('columnMenuFilter')}</ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuHideItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuHideItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { GridColumnMenuItemProps } from '../GridColumnMenuItemProps';
@@ -43,12 +42,12 @@ function GridColumnMenuHideItem(props: GridColumnMenuItemProps) {
   }
 
   return (
-    <MenuItem onClick={toggleColumn} disabled={disabled}>
+    <rootProps.slots.baseMenuItem onClick={toggleColumn} disabled={disabled}>
       <ListItemIcon>
         <rootProps.slots.columnMenuHideIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>{apiRef.current.getLocaleText('columnMenuHideColumn')}</ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuManageItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuManageItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { GridPreferencePanelsValue } from '../../../../hooks/features/preferencesPanel/gridPreferencePanelsValue';
@@ -26,12 +25,12 @@ function GridColumnMenuManageItem(props: GridColumnMenuItemProps) {
   }
 
   return (
-    <MenuItem onClick={showColumns}>
+    <rootProps.slots.baseMenuItem onClick={showColumns}>
       <ListItemIcon>
         <rootProps.slots.columnMenuManageColumnsIcon fontSize="small" />
       </ListItemIcon>
       <ListItemText>{apiRef.current.getLocaleText('columnMenuManageColumns')}</ListItemText>
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 

--- a/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuSortItem.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/menuItems/GridColumnMenuSortItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { useGridSelector } from '../../../../hooks/utils/useGridSelector';
@@ -55,26 +54,26 @@ function GridColumnMenuSortItem(props: GridColumnMenuItemProps) {
   return (
     <React.Fragment>
       {sortingOrder.includes('asc') && sortDirection !== 'asc' ? (
-        <MenuItem onClick={onSortMenuItemClick} data-value="asc">
+        <rootProps.slots.baseMenuItem onClick={onSortMenuItemClick} data-value="asc">
           <ListItemIcon>
             <rootProps.slots.columnMenuSortAscendingIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>{getLabel('columnMenuSortAsc')}</ListItemText>
-        </MenuItem>
+        </rootProps.slots.baseMenuItem>
       ) : null}
       {sortingOrder.includes('desc') && sortDirection !== 'desc' ? (
-        <MenuItem onClick={onSortMenuItemClick} data-value="desc">
+        <rootProps.slots.baseMenuItem onClick={onSortMenuItemClick} data-value="desc">
           <ListItemIcon>
             <rootProps.slots.columnMenuSortDescendingIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>{getLabel('columnMenuSortDesc')}</ListItemText>
-        </MenuItem>
+        </rootProps.slots.baseMenuItem>
       ) : null}
       {sortingOrder.includes(null) && sortDirection != null ? (
-        <MenuItem onClick={onSortMenuItemClick}>
+        <rootProps.slots.baseMenuItem onClick={onSortMenuItemClick}>
           <ListItemIcon />
           <ListItemText>{apiRef.current.getLocaleText('columnMenuUnsort')}</ListItemText>
-        </MenuItem>
+        </rootProps.slots.baseMenuItem>
       ) : null}
     </React.Fragment>
   );

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useId as useId, unstable_useForkRef as useForkRef } from '@mui/utils';
-import MenuList from '@mui/material/MenuList';
 import { ButtonProps } from '@mui/material/Button';
 import { TooltipProps } from '@mui/material/Tooltip';
-import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { gridDensitySelector } from '../../hooks/features/density/densitySelector';
 import { GridDensity } from '../../models/gridDensity';
@@ -97,14 +95,14 @@ const GridToolbarDensitySelector = React.forwardRef<
   }
 
   const densityElements = densityOptions.map<React.ReactElement>((option, index) => (
-    <MenuItem
+    <rootProps.slots.baseMenuItem
       key={index}
       onClick={() => handleDensityUpdate(option.value)}
       selected={option.value === density}
     >
       <ListItemIcon>{option.icon}</ListItemIcon>
       {option.label}
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   ));
 
   return (
@@ -137,7 +135,7 @@ const GridToolbarDensitySelector = React.forwardRef<
         onClose={handleDensitySelectorClose}
         position="bottom-start"
       >
-        <MenuList
+        <rootProps.slots.baseMenuList
           id={densityMenuId}
           className={gridClasses.menuList}
           aria-labelledby={densityButtonId}
@@ -145,7 +143,7 @@ const GridToolbarDensitySelector = React.forwardRef<
           autoFocusItem={open}
         >
           {densityElements}
-        </MenuList>
+        </rootProps.slots.baseMenuList>
       </GridMenu>
     </React.Fragment>
   );

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExport.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { ButtonProps } from '@mui/material/Button';
 import { TooltipProps } from '@mui/material/Tooltip';
-import MenuItem from '@mui/material/MenuItem';
+import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { GridCsvExportOptions, GridPrintExportOptions } from '../../models/gridExport';
 import { GridToolbarExportContainer } from './GridToolbarExportContainer';
@@ -37,10 +37,11 @@ export interface GridToolbarExportProps {
 
 function GridCsvExportMenuItem(props: GridCsvExportMenuItemProps) {
   const apiRef = useGridApiContext();
+  const rootProps = useGridRootProps();
   const { hideMenu, options, ...other } = props;
 
   return (
-    <MenuItem
+    <rootProps.slots.baseMenuItem
       onClick={() => {
         apiRef.current.exportDataAsCsv(options);
         hideMenu?.();
@@ -48,7 +49,7 @@ function GridCsvExportMenuItem(props: GridCsvExportMenuItemProps) {
       {...other}
     >
       {apiRef.current.getLocaleText('toolbarExportCSV')}
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 
@@ -75,10 +76,11 @@ GridCsvExportMenuItem.propTypes = {
 
 function GridPrintExportMenuItem(props: GridPrintExportMenuItemProps) {
   const apiRef = useGridApiContext();
+  const rootProps = useGridRootProps();
   const { hideMenu, options, ...other } = props;
 
   return (
-    <MenuItem
+    <rootProps.slots.baseMenuItem
       onClick={() => {
         apiRef.current.exportDataAsPrint(options);
         hideMenu?.();
@@ -86,7 +88,7 @@ function GridPrintExportMenuItem(props: GridPrintExportMenuItemProps) {
       {...other}
     >
       {apiRef.current.getLocaleText('toolbarExportPrint')}
-    </MenuItem>
+    </rootProps.slots.baseMenuItem>
   );
 }
 

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useId as useId, unstable_useForkRef as useForkRef } from '@mui/utils';
-import MenuList from '@mui/material/MenuList';
 import { ButtonProps } from '@mui/material/Button';
 import { TooltipProps } from '@mui/material/Tooltip';
 import { isHideMenuKey } from '../../utils/keyboardUtils';
@@ -85,7 +84,7 @@ const GridToolbarExportContainer = React.forwardRef<
         onClose={handleMenuClose}
         position="bottom-start"
       >
-        <MenuList
+        <rootProps.slots.baseMenuList
           id={exportMenuId}
           className={gridClasses.menuList}
           aria-labelledby={exportButtonId}
@@ -98,7 +97,7 @@ const GridToolbarExportContainer = React.forwardRef<
             }
             return React.cloneElement<any>(child, { hideMenu: handleMenuClose });
           })}
-        </MenuList>
+        </rootProps.slots.baseMenuList>
       </GridMenu>
     </React.Fragment>
   );

--- a/packages/x-data-grid/src/material/index.ts
+++ b/packages/x-data-grid/src/material/index.ts
@@ -1,6 +1,8 @@
 import MUIBadge from '@mui/material/Badge';
 import MUICheckbox from '@mui/material/Checkbox';
 import MUIDivider from '@mui/material/Divider';
+import MUIMenuList from '@mui/material/MenuList';
+import MUIMenuItem from '@mui/material/MenuItem';
 import MUITextField from '@mui/material/TextField';
 import MUIFormControl from '@mui/material/FormControl';
 import MUISelect from '@mui/material/Select';
@@ -86,6 +88,8 @@ const materialSlots: GridBaseSlots & GridIconSlotsComponent = {
   baseBadge: MUIBadge,
   baseCheckbox: MUICheckbox,
   baseDivider: MUIDivider,
+  baseMenuList: MUIMenuList,
+  baseMenuItem: MUIMenuItem,
   baseTextField: MUITextField,
   baseFormControl: MUIFormControl,
   baseSelect: MUISelect,

--- a/packages/x-data-grid/src/models/gridSlotsComponent.ts
+++ b/packages/x-data-grid/src/models/gridSlotsComponent.ts
@@ -26,6 +26,16 @@ export interface GridBaseSlots {
    */
   baseDivider: React.JSXElementConstructor<GridSlotProps['baseDivider']>;
   /**
+   * The custom MenuList component used in the grid.
+   * @default MenuList
+   */
+  baseMenuList: React.JSXElementConstructor<GridSlotProps['baseMenuList']>;
+  /**
+   * The custom MenuItem component used in the grid.
+   * @default MenuItem
+   */
+  baseMenuItem: React.JSXElementConstructor<GridSlotProps['baseMenuItem']>;
+  /**
    * The custom InputAdornment component used in the grid.
    * @default InputAdornment
    */

--- a/packages/x-data-grid/src/models/gridSlotsComponentsProps.ts
+++ b/packages/x-data-grid/src/models/gridSlotsComponentsProps.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import type { BadgeProps } from '@mui/material/Badge';
 import type { CheckboxProps } from '@mui/material/Checkbox';
+import type { MenuListProps } from '@mui/material/MenuList';
+import type { MenuItemProps } from '@mui/material/MenuItem';
 import type { TextFieldProps } from '@mui/material/TextField';
 import type { FormControlProps } from '@mui/material/FormControl';
 import type { SelectProps } from '@mui/material/Select';
@@ -38,6 +40,8 @@ type DividerProps = {};
 export interface BaseBadgePropsOverrides {}
 export interface BaseCheckboxPropsOverrides {}
 export interface BaseDividerPropsOverrides {}
+export interface BaseMenuListPropsOverrides {}
+export interface BaseMenuItemPropsOverrides {}
 export interface BaseTextFieldPropsOverrides {}
 export interface BaseFormControlPropsOverrides {}
 export interface BaseSelectPropsOverrides {}
@@ -74,6 +78,8 @@ export interface GridSlotProps {
   baseBadge: BadgeProps & BaseBadgePropsOverrides;
   baseCheckbox: CheckboxProps & BaseCheckboxPropsOverrides;
   baseDivider: DividerProps & BaseDividerPropsOverrides;
+  baseMenuList: MenuListProps & BaseMenuListPropsOverrides;
+  baseMenuItem: MenuItemProps & BaseMenuItemPropsOverrides;
   baseTextField: TextFieldProps & BaseTextFieldPropsOverrides;
   baseFormControl: FormControlProps & BaseFormControlPropsOverrides;
   baseSelect: SelectProps & BaseSelectPropsOverrides;

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -8,6 +8,8 @@
   { "name": "BaseIconButtonPropsOverrides", "kind": "Interface" },
   { "name": "BaseInputAdornmentPropsOverrides", "kind": "Interface" },
   { "name": "BaseInputLabelPropsOverrides", "kind": "Interface" },
+  { "name": "BaseMenuItemPropsOverrides", "kind": "Interface" },
+  { "name": "BaseMenuListPropsOverrides", "kind": "Interface" },
   { "name": "BasePopperPropsOverrides", "kind": "Interface" },
   { "name": "BaseSelectOptionPropsOverrides", "kind": "Interface" },
   { "name": "BaseSelectPropsOverrides", "kind": "Interface" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -8,6 +8,8 @@
   { "name": "BaseIconButtonPropsOverrides", "kind": "Interface" },
   { "name": "BaseInputAdornmentPropsOverrides", "kind": "Interface" },
   { "name": "BaseInputLabelPropsOverrides", "kind": "Interface" },
+  { "name": "BaseMenuItemPropsOverrides", "kind": "Interface" },
+  { "name": "BaseMenuListPropsOverrides", "kind": "Interface" },
   { "name": "BasePopperPropsOverrides", "kind": "Interface" },
   { "name": "BaseSelectOptionPropsOverrides", "kind": "Interface" },
   { "name": "BaseSelectPropsOverrides", "kind": "Interface" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -8,6 +8,8 @@
   { "name": "BaseIconButtonPropsOverrides", "kind": "Interface" },
   { "name": "BaseInputAdornmentPropsOverrides", "kind": "Interface" },
   { "name": "BaseInputLabelPropsOverrides", "kind": "Interface" },
+  { "name": "BaseMenuItemPropsOverrides", "kind": "Interface" },
+  { "name": "BaseMenuListPropsOverrides", "kind": "Interface" },
   { "name": "BasePopperPropsOverrides", "kind": "Interface" },
   { "name": "BaseSelectOptionPropsOverrides", "kind": "Interface" },
   { "name": "BaseSelectPropsOverrides", "kind": "Interface" },


### PR DESCRIPTION
Design-system agnostic related.

I've added `baseMenuList` & `baseMenuItem`. I did not introduce equivalents for `ListItemText` and `ListItemIcon` because I don't think I'll go with that API for the base slots, the API will probably look something like this instead:

```
<slots.baseMenuItem iconLeft={...} iconRight={...}>{text}</slots.baseMenuItem>
```

Because it's easier to adapt that API to the other design systems rather than the other way around.