### PR TITLE
[DataGrid] refactor: basePopperV8

### DIFF
--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -1,5 +1,7 @@
+import * as React from 'react';
 import MUIBadge from '@mui/material/Badge';
 import MUICheckbox from '@mui/material/Checkbox';
+import MUIClickAwayListener from '@mui/material/ClickAwayListener';
 import MUIDivider from '@mui/material/Divider';
 import MUITextField from '@mui/material/TextField';
 import MUIFormControl from '@mui/material/FormControl';
@@ -8,6 +10,7 @@ import MUIButton from '@mui/material/Button';
 import MUIIconButton from '@mui/material/IconButton';
 import MUIInputAdornment from '@mui/material/InputAdornment';
 import MUITooltip from '@mui/material/Tooltip';
+import MUIPaper from '@mui/material/Paper';
 import MUIPopper from '@mui/material/Popper';
 import MUIInputLabel from '@mui/material/InputLabel';
 import MUIChip from '@mui/material/Chip';
@@ -40,8 +43,46 @@ import {
   GridDeleteForeverIcon,
 } from './icons';
 import type { GridIconSlotsComponent } from '../models';
-import type { GridBaseSlots } from '../models/gridSlotsComponent';
+import type { GridBaseSlots, GridSlotProps } from '../models/gridSlotsComponent';
 import MUISelectOption from './components/MUISelectOption';
+import { useGridRootProps } from '../hooks/utils/useGridRootProps';
+
+const PopperV8 = React.forwardRef<HTMLDivElement, GridSlotProps['basePopperV8']>((props, ref) => {
+  const rootProps = useGridRootProps();
+  const { children, onClose, ...other } = props;
+
+  // anchorEl FIXME
+  // const ownerState = rootProps; FIXME: pass to style overrides
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  return (
+    <MUIPopper
+      ref={ref}
+      placement="bottom-start"
+      anchorEl={null}
+      modifiers={undefined /* modifiers FIXME */}
+      {...other}
+    >
+      <MUIClickAwayListener mouseEvent="onMouseUp" onClickAway={onClose}>
+        <MUIPaper
+          elevation={8}
+          onKeyDown={handleKeyDown}
+        >
+          {children}
+        </MUIPaper>
+      </MUIClickAwayListener>
+    </MUIPopper>
+  );
+});
+
 
 const iconSlots: GridIconSlotsComponent = {
   booleanCellTrueIcon: GridCheckIcon,
@@ -94,6 +135,7 @@ const materialSlots: GridBaseSlots & GridIconSlotsComponent = {
   baseInputAdornment: MUIInputAdornment,
   baseTooltip: MUITooltip,
   basePopper: MUIPopper,
+  basePopperV8: PopperV8,
   baseInputLabel: MUIInputLabel,
   baseSelectOption: MUISelectOption,
   baseChip: MUIChip,

--- a/packages/x-data-grid/src/models/gridSlotsComponent.ts
+++ b/packages/x-data-grid/src/models/gridSlotsComponent.ts
@@ -66,6 +66,11 @@ export interface GridBaseSlots {
    */
   basePopper: React.JSXElementConstructor<GridSlotProps['basePopper']>;
   /**
+   * The custom PopperV8 component used in the grid.
+   * @default PopperV8
+   */
+  basePopperV8: React.JSXElementConstructor<GridSlotProps['basePopperV8']>;
+  /**
    * The custom InputLabel component used in the grid.
    * @default InputLabel
    */

--- a/packages/x-data-grid/src/models/gridSlotsComponentsProps.ts
+++ b/packages/x-data-grid/src/models/gridSlotsComponentsProps.ts
@@ -33,6 +33,11 @@ import type { GridRowCountProps } from '../components/GridRowCount';
 import type { GridColumnHeaderSortIconProps } from '../components/columnHeaders/GridColumnHeaderSortIcon';
 
 type DividerProps = {};
+type PopperV8Props = {
+  open: boolean;
+  children: React.ReactNode;
+  onClose: () => void;
+};
 
 // Overrides for module augmentation
 export interface BaseBadgePropsOverrides {}
@@ -81,6 +86,7 @@ export interface GridSlotProps {
   baseButton: ButtonProps & BaseButtonPropsOverrides;
   baseIconButton: IconButtonProps & BaseIconButtonPropsOverrides;
   basePopper: PopperProps & BasePopperPropsOverrides;
+  basePopperV8: PopperV8Props;
   baseTooltip: TooltipProps & BaseTooltipPropsOverrides;
   baseInputLabel: InputLabelProps & BaseInputLabelPropsOverrides;
   baseInputAdornment: InputAdornmentProps & BaseInputAdornmentPropsOverrides;


### PR DESCRIPTION
Make the Popper API generic to support more design-systems.

Status: This is blocked by the `styled` function usage.