### PR TITLE
[release] v8 preparation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev --port 3001",
-    "deploy": "git push -f upstream master:docs-v7",
+    "deploy": "git push -f upstream master:docs-next",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "serve": "serve ./export -l 3010",
     "create-playground": "cpy --cwd=scripts playground.template.tsx ../../pages/playground --rename=index.tsx",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -30,9 +30,9 @@ LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
     // #default-branch-switch
-    // Use the "latest" npm tag for the master git branch
-    // Use the "next" npm tag for the next git branch
-    return 'latest';
+    // Use the "latest" npm tag for the master git branch after we start working on the next major version
+    // Use this once we branch off the vx branch
+    return 'next';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui/mui-x/commit/${shortSha}/@mui/${packageName}`;

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -212,6 +212,10 @@ function AppWrapper(props) {
       name: 'MUI X',
       versions: [
         {
+          text: 'next',
+          href: `https://next.mui.com${languagePrefix}/x/introduction/`,
+        },
+        {
           text: `v${process.env.LIB_VERSION}`,
           current: true,
         },
@@ -227,6 +231,10 @@ function AppWrapper(props) {
         name: 'Data Grid',
         versions: [
           {
+            text: 'next',
+            href: `https://next.mui.com${languagePrefix}/x/introduction/`,
+          },
+          {
             text: `v${process.env.DATA_GRID_VERSION}`,
             current: true,
           },
@@ -240,6 +248,10 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Date Pickers',
         versions: [
+          {
+            text: 'next',
+            href: `https://next.mui.com${languagePrefix}/x/react-date-pickers/`,
+          },
           {
             text: `v${process.env.DATE_PICKERS_VERSION}`,
             current: true,
@@ -260,6 +272,10 @@ function AppWrapper(props) {
         name: 'Charts',
         versions: [
           {
+            text: 'next',
+            href: `https://next.mui.com${languagePrefix}/x/react-charts/`,
+          },
+          {
             text: `v${process.env.CHARTS_VERSION}`,
             current: true,
           },
@@ -271,6 +287,10 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Tree View',
         versions: [
+          {
+            text: 'next',
+            href: `https://next.mui.com${languagePrefix}/x/react-tree-view/`,
+          },
           {
             text: `v${process.env.TREE_VIEW_VERSION}`,
             current: true,

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -206,21 +206,26 @@ function AppWrapper(props) {
   const pageContextValue = React.useMemo(() => {
     const { activePage, activePageParents } = findActivePage(pages, router.pathname);
     const languagePrefix = pageProps.userLanguage === 'en' ? '' : `/${pageProps.userLanguage}`;
+    const productIdSubpathMap = {
+      introduction: '/x/introduction',
+      'x-data-grid': '/x/react-data-grid',
+      'x-date-pickers': '/x/react-date-pickers',
+      'x-charts': '/x/react-charts',
+      'x-tree-view': '/x/react-tree-view',
+    };
+
+    const getVersionOptions = (id, versions) =>
+      versions.map((version) => ({
+        text: version,
+        href: `https://${version !== process.env.LIB_VERSION ? `${version}.` : ''}mui.com${languagePrefix}${productIdSubpathMap[id]}/`,
+        current: version.length > 4, // excludes 'next' and all 'vx' versions, but includes 'vx.x.x'
+      }));
 
     let productIdentifier = {
       metadata: '',
       name: 'MUI X',
       versions: [
-        {
-          text: 'next',
-          href: `https://next.mui.com${languagePrefix}/x/introduction/`,
-        },
-        {
-          text: `v${process.env.LIB_VERSION}`,
-          current: true,
-        },
-        { text: 'v6', href: `https://v6.mui.com${languagePrefix}/x/introduction/` },
-        { text: 'v5', href: `https://v5.mui.com${languagePrefix}/x/introduction/` },
+        ...getVersionOptions('introduction', ['next', `v${process.env.LIB_VERSION}`, 'v6', 'v5']),
         { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
       ],
     };
@@ -230,16 +235,12 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Data Grid',
         versions: [
-          {
-            text: 'next',
-            href: `https://next.mui.com${languagePrefix}/x/introduction/`,
-          },
-          {
-            text: `v${process.env.DATA_GRID_VERSION}`,
-            current: true,
-          },
-          { text: 'v6', href: `https://v6.mui.com${languagePrefix}/x/react-data-grid/` },
-          { text: 'v5', href: `https://v5.mui.com${languagePrefix}/x/react-data-grid/` },
+          ...getVersionOptions('x-data-grid', [
+            'next',
+            `v${process.env.DATA_GRID_VERSION}`,
+            'v6',
+            'v5',
+          ]),
           { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
         ],
       };
@@ -248,18 +249,11 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Date Pickers',
         versions: [
-          {
-            text: 'next',
-            href: `https://next.mui.com${languagePrefix}/x/react-date-pickers/`,
-          },
-          {
-            text: `v${process.env.DATE_PICKERS_VERSION}`,
-            current: true,
-          },
-          {
-            text: 'v6',
-            href: `https://v6.mui.com${languagePrefix}/x/react-date-pickers/`,
-          },
+          ...getVersionOptions('x-date-pickers', [
+            'next',
+            `v${process.env.DATE_PICKERS_VERSION}`,
+            'v6',
+          ]),
           {
             text: 'v5',
             href: `https://v5.mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
@@ -270,31 +264,14 @@ function AppWrapper(props) {
       productIdentifier = {
         metadata: 'MUI X',
         name: 'Charts',
-        versions: [
-          {
-            text: 'next',
-            href: `https://next.mui.com${languagePrefix}/x/react-charts/`,
-          },
-          {
-            text: `v${process.env.CHARTS_VERSION}`,
-            current: true,
-          },
-          { text: 'v6', href: `https://v6.mui.com${languagePrefix}/x/react-charts/` },
-        ],
+        versions: getVersionOptions('x-charts', ['next', `v${process.env.CHARTS_VERSION}`, 'v6']),
       };
     } else if (productId === 'x-tree-view') {
       productIdentifier = {
         metadata: 'MUI X',
         name: 'Tree View',
         versions: [
-          {
-            text: 'next',
-            href: `https://next.mui.com${languagePrefix}/x/react-tree-view/`,
-          },
-          {
-            text: `v${process.env.TREE_VIEW_VERSION}`,
-            current: true,
-          },
+          ...getVersionOptions('x-tree-view', ['next', `v${process.env.TREE_VIEW_VERSION}`]),
           {
             text: 'v6',
             href: `https://v6.mui.com${languagePrefix}/x/react-tree-view/getting-started`,

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -218,7 +218,7 @@ function AppWrapper(props) {
         if (version === process.env.LIB_VERSION) {
           return {
             current: true,
-            text: version,
+            text: `v${version}`,
             href: `${languagePrefix}${productIdSubpathMap[id]}/`,
           };
         }

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -53,7 +53,7 @@ ponyfillGlobal.muiDocConfig = {
     return newDeps;
   },
   csbGetVersions: (versions, { muiCommitRef }) => {
-    const output = {
+    return {
       ...versions,
       '@mui/x-data-grid': getMuiPackageVersion('x-data-grid', muiCommitRef),
       '@mui/x-data-grid-pro': getMuiPackageVersion('x-data-grid-pro', muiCommitRef),
@@ -68,7 +68,6 @@ ponyfillGlobal.muiDocConfig = {
       '@mui/x-internals': getMuiPackageVersion('x-internals', muiCommitRef),
       exceljs: 'latest',
     };
-    return output;
   },
   postProcessImport,
 };

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -214,17 +214,25 @@ function AppWrapper(props) {
     };
 
     const getVersionOptions = (id, versions) =>
-      versions.map((version) => ({
-        text: version,
-        href: `https://${version !== process.env.LIB_VERSION ? `${version}.` : ''}mui.com${languagePrefix}${productIdSubpathMap[id]}/`,
-        current: version.length > 4, // excludes 'next' and all 'vx' versions, but includes 'vx.x.x'
-      }));
+      versions.map((version) => {
+        if (version === process.env.LIB_VERSION) {
+          return {
+            current: true,
+            text: version,
+            href: `${languagePrefix}${productIdSubpathMap[id]}/`,
+          };
+        }
+        return {
+          text: version,
+          href: `https://${version}.mui.com${languagePrefix}${productIdSubpathMap[id]}/`,
+        };
+      });
 
     let productIdentifier = {
       metadata: '',
       name: 'MUI X',
       versions: [
-        ...getVersionOptions('introduction', ['next', `v${process.env.LIB_VERSION}`, 'v6', 'v5']),
+        ...getVersionOptions('introduction', ['next', process.env.LIB_VERSION, 'v6', 'v5']),
         { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
       ],
     };
@@ -234,12 +242,7 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Data Grid',
         versions: [
-          ...getVersionOptions('x-data-grid', [
-            'next',
-            `v${process.env.DATA_GRID_VERSION}`,
-            'v6',
-            'v5',
-          ]),
+          ...getVersionOptions('x-data-grid', ['next', process.env.DATA_GRID_VERSION, 'v6', 'v5']),
           { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
         ],
       };
@@ -248,11 +251,7 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Date Pickers',
         versions: [
-          ...getVersionOptions('x-date-pickers', [
-            'next',
-            `v${process.env.DATE_PICKERS_VERSION}`,
-            'v6',
-          ]),
+          ...getVersionOptions('x-date-pickers', ['next', process.env.DATE_PICKERS_VERSION, 'v6']),
           {
             text: 'v5',
             href: `https://v5.mui.com${languagePrefix}/x/react-date-pickers/getting-started/`,
@@ -263,14 +262,14 @@ function AppWrapper(props) {
       productIdentifier = {
         metadata: 'MUI X',
         name: 'Charts',
-        versions: getVersionOptions('x-charts', ['next', `v${process.env.CHARTS_VERSION}`, 'v6']),
+        versions: getVersionOptions('x-charts', ['next', process.env.CHARTS_VERSION, 'v6']),
       };
     } else if (productId === 'x-tree-view') {
       productIdentifier = {
         metadata: 'MUI X',
         name: 'Tree View',
         versions: [
-          ...getVersionOptions('x-tree-view', ['next', `v${process.env.TREE_VIEW_VERSION}`]),
+          ...getVersionOptions('x-tree-view', ['next', process.env.TREE_VIEW_VERSION]),
           {
             text: 'v6',
             href: `https://v6.mui.com${languagePrefix}/x/react-tree-view/getting-started`,

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -30,8 +30,8 @@ LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
     // #default-branch-switch
-    // Use the "latest" npm tag for the master git branch after we start working on the next major version
-    // Use this once we branch off the vx branch
+    // Use the "next" tag for the master git branch after we start working on the next major version
+    // Once the major release is finished we can go back to "latest"
     return 'next';
   }
   const shortSha = commitRef.slice(0, 8);

--- a/docs/src/modules/components/ChartsInstallationInstructions.js
+++ b/docs/src/modules/components/ChartsInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #default-branch-switch
 
 const packages = {
-  Community: '@mui/x-charts',
-  Pro: '@mui/x-charts-pro',
+  Community: '@mui/x-charts@next',
+  Pro: '@mui/x-charts-pro@next',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -4,9 +4,9 @@ import InstallationInstructions from './InstallationInstructions';
 // #default-branch-switch
 
 const packages = {
-  Community: '@mui/x-data-grid',
-  Pro: '@mui/x-data-grid-pro',
-  Premium: '@mui/x-data-grid-premium',
+  Community: '@mui/x-data-grid@next',
+  Pro: '@mui/x-data-grid-pro@next',
+  Premium: '@mui/x-data-grid-premium@next',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #default-branch-switch
 
 const packages = {
-  Community: '@mui/x-date-pickers',
-  Pro: '@mui/x-date-pickers-pro',
+  Community: '@mui/x-date-pickers@next',
+  Pro: '@mui/x-date-pickers-pro@next',
 };
 
 const peerDependency = {

--- a/docs/src/modules/components/TreeViewInstallationInstructions.js
+++ b/docs/src/modules/components/TreeViewInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #default-branch-switch
 
 const packages = {
-  Community: '@mui/x-tree-view',
-  Pro: '@mui/x-tree-view-pro',
+  Community: '@mui/x-tree-view@next',
+  Pro: '@mui/x-tree-view-pro@next',
 };
 
 export default function TreeViewInstallationInstructions() {

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "release:version": "lerna version --exact --no-changelog --no-push --no-git-tag-version --no-private",
     "release:build": "lerna run --parallel --no-private --scope \"@mui/*\" build",
-    "release:publish": "pnpm publish --recursive --tag latest",
-    "release:publish:dry-run": "pnpm publish --recursive --tag latest --registry=\"http://localhost:4873/\"",
+    "release:publish": "pnpm publish --recursive --tag next",
+    "release:publish:dry-run": "pnpm publish --recursive --tag next --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag.mjs",
     "validate": "concurrently \"pnpm prettier && pnpm eslint\" \"pnpm proptypes\" \"pnpm docs:typescript:formatted\" \"pnpm docs:api\"",
     "clean:node_modules": "rimraf --glob \"**/node_modules\""

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -42,7 +42,7 @@ To pass more options directly to jscodeshift, use `--jscodeshift=...`. For examp
 // single option
 npx @mui/x-codemod@next --jscodeshift=--run-in-band
 // multiple options
-npx @mui/x-codemod@nexy --jscodeshift=--cpus=1 --jscodeshift=--print --jscodeshift=--dry --jscodeshift=--verbose=2
+npx @mui/x-codemod@next --jscodeshift=--cpus=1 --jscodeshift=--print --jscodeshift=--dry --jscodeshift=--verbose=2
 ```
 
 See all available options [here](https://github.com/facebook/jscodeshift#usage-cli).

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -13,7 +13,7 @@ This repository contains a collection of codemod scripts based for use with
 <!-- #default-branch-switch -->
 
 ```bash
-npx @mui/x-codemod@latest <codemod> <paths...>
+npx @mui/x-codemod@next <codemod> <paths...>
 
 Applies a `@mui/x-codemod` to the specified paths
 
@@ -29,8 +29,8 @@ Options:
   --jscodeshift Pass options directly to jscodeshift                  [array]
 
 Examples:
-  npx @mui/x-codemod@latest v7.0.0/preset-safe src
-  npx @mui/x-codemod@latest v6.0.0/component-rename-prop src --
+  npx @mui/x-codemod@next v7.0.0/preset-safe src
+  npx @mui/x-codemod@next v6.0.0/component-rename-prop src --
   --component=DataGrid --from=prop --to=newProp
 ```
 
@@ -40,9 +40,9 @@ To pass more options directly to jscodeshift, use `--jscodeshift=...`. For examp
 
 ```bash
 // single option
-npx @mui/x-codemod@latest --jscodeshift=--run-in-band
+npx @mui/x-codemod@nexy --jscodeshift=--run-in-band
 // multiple options
-npx @mui/x-codemod@latest --jscodeshift=--cpus=1 --jscodeshift=--print --jscodeshift=--dry --jscodeshift=--verbose=2
+npx @mui/x-codemod@nexy --jscodeshift=--cpus=1 --jscodeshift=--print --jscodeshift=--dry --jscodeshift=--verbose=2
 ```
 
 See all available options [here](https://github.com/facebook/jscodeshift#usage-cli).
@@ -53,7 +53,7 @@ Options to [recast](https://github.com/benjamn/recast)'s printer can be provided
 through jscodeshift's `printOptions` command line argument
 
 ```bash
-npx @mui/x-codemod@latest <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
+npx @mui/x-codemod@next <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"double\"}'"
 ```
 
 ## v7.0.0

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -40,7 +40,7 @@ To pass more options directly to jscodeshift, use `--jscodeshift=...`. For examp
 
 ```bash
 // single option
-npx @mui/x-codemod@nexy --jscodeshift=--run-in-band
+npx @mui/x-codemod@next --jscodeshift=--run-in-band
 // multiple options
 npx @mui/x-codemod@nexy --jscodeshift=--cpus=1 --jscodeshift=--print --jscodeshift=--dry --jscodeshift=--verbose=2
 ```


### PR DESCRIPTION
This is to prepare for the next major release:

- [x] Switched tags where needed
- [x] Changed deploy target for the next docs
- [x] Added next version to version select

I did also introduce a little helper to get the docs paths for the components

Please call out anything that I might have missed.

Related notion page: https://www.notion.so/mui-org/MUI-X-Major-version-release-process-a27f296dfb9e4b33bdb767f3d6e8018c?pvs=4