### PR TITLE
[charts] Allow `SeriesValueFormatter` to return `null` value

### DIFF
--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -13,7 +13,7 @@ export type SeriesValueFormatterContext = {
 export type SeriesValueFormatter<TValue> = (
   value: TValue,
   context: SeriesValueFormatterContext,
-) => string;
+) => string | null;
 
 export type CommonSeriesType<TValue> = {
   id?: SeriesId;
@@ -22,7 +22,7 @@ export type CommonSeriesType<TValue> = {
    * Formatter used to render values in tooltip or other data display.
    * @param {TValue} value The series' value to render.
    * @param {SeriesValueFormatterContext} context The rendering context of the value.
-   * @returns {string} The string to display.
+   * @returns {string | null} The string to display or null if the value should not be shown.
    */
   valueFormatter?: SeriesValueFormatter<TValue>;
   /**


### PR DESCRIPTION
# TL;DR

A. Omit irrelevant tooltip values by updating the SeriesValueFormatter type to allow retuning `null` values
B. Usage: update `valueFormatter` function to return null if the value is irrelevant

# Problem

Use case: when displaying multiple series with the same label/color on a stacked bar chart it can be useful to omit the series that have no value for a given stack.

Note: I am interested in seeing 'axis' tooltip not 'item'

```
const series = [
  { ... , valueFormatter: (v: number | null) => v ? `${v} 分` : '-' }
]
```

The screenshot below shows the tooltip of a stack that has "MOVING", "STOPPED", and "MOVING"

In this example the order of these events matter both on the x axis and y axis so it was decided to split the multiple "MOVING" data into separate series

When hovering over the tooltip it becomes polluted with irrelevant '-' values.

<img width="478" alt="Screenshot 2024-10-22 at 19 22 50" src="https://github.com/user-attachments/assets/52d3be31-b47b-478e-bf9b-3c6b4483d209">

I am able to filter out the values by passing `null` as a return but I get a type error which I was able to ignore using `!`

```
const series = [
  { ... , valueFormatter: (v: number | null) => v ? `${v} 分` : null! }
]
```

With this I can visualize only the data that is displayed on the chart

<img width="471" alt="Screenshot 2024-10-22 at 19 22 16" src="https://github.com/user-attachments/assets/d2609a9d-f2d1-4d12-ae10-e11b36d7b4d2">

# Solution

Since forcing the return of `null` didn't break but actually fixed my issue I wrote this PR to update the type to match the already allowed and expected behavior