### PR TITLE
[pickers] Add verification to disable skipped hours in spring forward DST

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
@@ -235,6 +235,11 @@ export const MultiSectionDigitalClock = React.forwardRef(function MultiSectionDi
         case 'hours': {
           const valueWithMeridiem = convertValueToMeridiem(rawValue, meridiemMode, ampm);
           const dateWithNewHours = utils.setHours(valueOrReferenceDate, valueWithMeridiem);
+
+          if (utils.getHours(dateWithNewHours) !== valueWithMeridiem) {
+            return true;
+          }
+
           const start = utils.setSeconds(utils.setMinutes(dateWithNewHours, 0), 0);
           const end = utils.setSeconds(utils.setMinutes(dateWithNewHours, 59), 59);
 

--- a/packages/x-date-pickers/src/TimeClock/TimeClock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/TimeClock.tsx
@@ -202,6 +202,11 @@ export const TimeClock = React.forwardRef(function TimeClock<TDate extends Picke
         case 'hours': {
           const valueWithMeridiem = convertValueToMeridiem(rawValue, meridiemMode, ampm);
           const dateWithNewHours = utils.setHours(valueOrReferenceDate, valueWithMeridiem);
+
+          if (utils.getHours(dateWithNewHours) !== valueWithMeridiem) {
+            return true;
+          }
+
           const start = utils.setSeconds(utils.setMinutes(dateWithNewHours, 0), 0);
           const end = utils.setSeconds(utils.setMinutes(dateWithNewHours, 59), 59);
 


### PR DESCRIPTION
(expects to) close #12403 

This is an approach to prevent current inconsistency when selecting a value that is skipped on spring forward DST event. 

Although it's debatable, perhaps hidding the value could make sense, but this wouldn't be a good UX for TimeClock. I'm verifying when the adapter doesn't return the same hour as the one of the option.

Before

https://github.com/user-attachments/assets/c92306b1-10f7-4b4a-97ea-28852cf01aed

After

https://github.com/user-attachments/assets/45180e9d-44de-4f5c-b266-c4370e6e1551


Missing
- [ ] Issue with TimeClock not rendering disabled hour in first render

https://github.com/user-attachments/assets/51500f65-a355-4951-ac21-53984c9af881

- [ ] Tests
