### PR TITLE
[DataGrid] Move `rowGroupingModelChange` handler to respective hook

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
@@ -284,6 +284,7 @@ export const useGridRowGrouping = (
   useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
   useGridApiEventHandler(apiRef, 'columnsChange', checkGroupingColumnsModelDiff);
   useGridApiEventHandler(apiRef, 'rowGroupingModelChange', checkGroupingColumnsModelDiff);
+  useGridApiEventHandler(apiRef, 'rowGroupingModelChange', () => apiRef.current.unstable_dataSource.fetchRows());
 
   /*
    * EFFECTS

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
@@ -284,7 +284,9 @@ export const useGridRowGrouping = (
   useGridApiEventHandler(apiRef, 'cellKeyDown', handleCellKeyDown);
   useGridApiEventHandler(apiRef, 'columnsChange', checkGroupingColumnsModelDiff);
   useGridApiEventHandler(apiRef, 'rowGroupingModelChange', checkGroupingColumnsModelDiff);
-  useGridApiEventHandler(apiRef, 'rowGroupingModelChange', () => apiRef.current.unstable_dataSource.fetchRows());
+  useGridApiEventHandler(apiRef, 'rowGroupingModelChange', () =>
+    apiRef.current.unstable_dataSource.fetchRows(),
+  );
 
   /*
    * EFFECTS

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -275,7 +275,6 @@ export const useGridDataSource = (
     'paginationModelChange',
     runIfServerMode(props.paginationMode, fetchRows),
   );
-  useGridApiEventHandler(apiRef, 'rowGroupingModelChange', () => fetchRows());
 
   const isFirstRender = React.useRef(true);
   React.useEffect(() => {


### PR DESCRIPTION
Fixes codesandbox (`@mui/x-data-grid-pro`) build issue.

Seems a better solution than https://github.com/mui/mui-x/pull/15109#discussion_r1816182013