### PR TITLE
Fix: Prevent error when deleting the last row in Data Grid

### DIFF
--- a/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -439,7 +439,7 @@ export const useGridFocus = (
 
         const nextRow =
           currentPage.rows[clamp(lastFocusedRowIndex, 0, currentPage.rows.length - 1)];
-        nextRowId = nextRow.id ?? null;
+        nextRowId = nextRow?.id ?? null;
       }
 
       apiRef.current.setState((state) => ({


### PR DESCRIPTION
Issue: Error When Deleting the Last Row
Description: When the last row in the Data Grid is deleted, an error occurs: Cannot read properties of undefined (reading 'id'). This happens because the grid tries to focus on a row that no longer exists.

Proposed Solution:

To fix this, we changed the code to safely access the id of the next row using optional chaining. This ensures that if there are no rows left, it won't throw an error.

Code Change:

`nextRowId = nextRow?.id ?? null; // Safely access the id `

This modification prevents errors and improves the handling of row deletions in the Data Grid.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
