### PR TITLE
[DataGrid] Fix scroll jump when holding down arrow keys

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
@@ -100,6 +100,8 @@ const GridVirtualScrollbar = React.forwardRef<HTMLDivElement, GridVirtualScrollb
         return;
       }
 
+      lastPosition.current = scroller[propertyScroll];
+
       if (isLocked.current) {
         isLocked.current = false;
         return;
@@ -108,8 +110,6 @@ const GridVirtualScrollbar = React.forwardRef<HTMLDivElement, GridVirtualScrollb
 
       const value = scroller[propertyScroll] / contentSize;
       scrollbar[propertyScroll] = value * scrollbarInnerSize;
-
-      lastPosition.current = scroller[propertyScroll];
     });
 
     const onScrollbarScroll = useEventCallback(() => {

--- a/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -60,8 +60,6 @@ export const useGridScroll = (
   const logger = useGridLogger(apiRef, 'useGridScroll');
   const colRef = apiRef.current.columnHeadersContainerRef;
   const virtualScrollerRef = apiRef.current.virtualScrollerRef!;
-  const virtualScrollbarHorizontalRef = apiRef.current.virtualScrollbarHorizontalRef!;
-  const virtualScrollbarVerticalRef = apiRef.current.virtualScrollbarVerticalRef!;
   const visibleSortedRows = useGridSelector(apiRef, gridExpandedSortedRowEntriesSelector);
 
   const scrollToIndexes = React.useCallback<GridScrollApi['scrollToIndexes']>(
@@ -156,37 +154,19 @@ export const useGridScroll = (
 
   const scroll = React.useCallback<GridScrollApi['scroll']>(
     (params: Partial<GridScrollParams>) => {
-      if (
-        virtualScrollerRef.current &&
-        virtualScrollbarHorizontalRef.current &&
-        params.left !== undefined &&
-        colRef.current
-      ) {
+      if (virtualScrollerRef.current && params.left !== undefined && colRef.current) {
         const direction = isRtl ? -1 : 1;
         colRef.current.scrollLeft = params.left;
         virtualScrollerRef.current.scrollLeft = direction * params.left;
-        virtualScrollbarHorizontalRef.current.scrollLeft = direction * params.left;
         logger.debug(`Scrolling left: ${params.left}`);
       }
-      if (
-        virtualScrollerRef.current &&
-        virtualScrollbarVerticalRef.current &&
-        params.top !== undefined
-      ) {
+      if (virtualScrollerRef.current && params.top !== undefined) {
         virtualScrollerRef.current.scrollTop = params.top;
-        virtualScrollbarVerticalRef.current.scrollTop = params.top;
         logger.debug(`Scrolling top: ${params.top}`);
       }
       logger.debug(`Scrolling, updating container, and viewport`);
     },
-    [
-      virtualScrollerRef,
-      virtualScrollbarHorizontalRef,
-      virtualScrollbarVerticalRef,
-      isRtl,
-      colRef,
-      logger,
-    ],
+    [virtualScrollerRef, isRtl, colRef, logger],
   );
 
   const getScrollPosition = React.useCallback<GridScrollApi['getScrollPosition']>(() => {


### PR DESCRIPTION
Fixes #15158 

Reverts https://github.com/mui/mui-x/pull/14888 (which _tried to_ fix another regression)

Scrollbar scroll positions are not set directly anymore as they are not the same number (heights of scroller and scrollbar do not match)
With smaller offsets from the top the difference is minimal, but it grows over time which is why the issue can be observed after a bit of scrolling.
The original code also impacts the performance as the values are recalculated a lot more than before the change. All this lead me to revert everything back to the state prior to https://github.com/mui/mui-x/pull/14877.

This brought back the very first [issue in the chain](https://github.com/mui/mui-x/issues/14830).

I found out that it is actually caused because of a stale value in `lastPosition`.
Following steps in #14830 sets the lock in `onScrollbarScroll`, which prevents any code being executed in `onScrollerScroll` so the `lastPosition` keeps the old value. Calling `scrollToIndexes` end up eventually in `onScrollerScroll`, but it does not see the position changed, preventing the scrollbar position change as well.

So, after all these updates, the only actual change is moving up the `lastPosition.current = scroller[propertyScroll];` assignment.

Internal scrollbar references are still there (comparing to the code prior to all changes), but they could be useful in future. If there are objections, I can remove them as well.

Following issues should not appear anymore
https://github.com/mui/mui-x/issues/15158
https://github.com/mui/mui-x/pull/14877#discussion_r1792444616
https://github.com/mui/mui-x/issues/14830

Before: https://codesandbox.io/p/sandbox/scroll-jump-before-2fdm8g
After: https://codesandbox.io/p/sandbox/scroll-jump-after-jvv95x