### PR TITLE
[core] Fix Pickers `pl-PL` translation after cherry-pick from master

### DIFF
--- a/packages/x-date-pickers/src/locales/plPL.ts
+++ b/packages/x-date-pickers/src/locales/plPL.ts
@@ -59,10 +59,14 @@ const plPLPickers: Partial<PickersLocaleText<any>> = {
   calendarWeekNumberText: (weekNumber) => `${weekNumber}`,
 
   // Open picker labels
-  openDatePickerDialogue: (formattedDate) =>
-    formattedDate ? `Wybierz datę, obecnie wybrana data to ${formattedDate}` : 'Wybierz datę',
-  openTimePickerDialogue: (formattedTime) =>
-    formattedTime ? `Wybierz czas, obecnie wybrany czas to ${formattedTime}` : 'Wybierz czas',
+  openDatePickerDialogue: (value, utils, formattedDate) =>
+    value != null && utils.isValid(value)
+      ? `Wybierz datę, obecnie wybrana data to ${formattedDate ?? utils.format(value, 'fullDate')}`
+      : 'Wybierz datę',
+  openTimePickerDialogue: (value, utils, formattedTime) =>
+    formattedTime || (value !== null && utils.isValid(value))
+      ? `Wybierz czas, obecnie wybrany czas to ${formattedTime ?? utils.format(value, 'fullTime')}`
+      : 'Wybierz czas',
   fieldClearLabel: 'Wyczyść',
 
   // Table labels


### PR DESCRIPTION
Follow-up on https://github.com/mui/mui-x/pull/15177

The cherry-pick unintentionally had a couple of changes that break this translation.
https://github.com/mui/mui-x/pull/15177/files#diff-47123d13580721e9d46a57634e5160492a9b30970bb1b01fbc2d06aec81e135fR62-R65