### PR TITLE
[charts] Remove axis from the pie chart

### DIFF
--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -4,21 +4,6 @@
       "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" },
       "required": true
     },
-    "axisHighlight": {
-      "type": {
-        "name": "shape",
-        "description": "{ x?: 'band'<br>&#124;&nbsp;'line'<br>&#124;&nbsp;'none', y?: 'band'<br>&#124;&nbsp;'line'<br>&#124;&nbsp;'none' }"
-      },
-      "default": "{ x: 'none', y: 'none' }",
-      "seeMoreLink": {
-        "url": "https://mui.com/x/react-charts/highlighting",
-        "text": "highlighting docs"
-      }
-    },
-    "bottomAxis": {
-      "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
-      "default": "null"
-    },
     "colors": {
       "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" },
       "default": "blueberryTwilightPalette"
@@ -31,10 +16,6 @@
         "name": "shape",
         "description": "{ dataIndex?: number, seriesId?: number<br>&#124;&nbsp;string }"
       }
-    },
-    "leftAxis": {
-      "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
-      "default": "null"
     },
     "legend": {
       "type": {
@@ -62,10 +43,6 @@
     },
     "onItemClick": { "type": { "name": "func" } },
     "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
-    "rightAxis": {
-      "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
-      "default": "null"
-    },
     "skipAnimation": { "type": { "name": "bool" } },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {
@@ -80,10 +57,6 @@
       },
       "default": "{ trigger: 'item' }",
       "seeMoreLink": { "url": "https://mui.com/x/react-charts/tooltip/", "text": "tooltip docs" }
-    },
-    "topAxis": {
-      "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
-      "default": "null"
     },
     "width": { "type": { "name": "number" } },
     "xAxis": {
@@ -110,30 +83,6 @@
       "name": "axisContent",
       "description": "Custom component for displaying tooltip content when triggered by axis event.",
       "default": "DefaultChartsAxisTooltipContent",
-      "class": null
-    },
-    {
-      "name": "axisLabel",
-      "description": "Custom component for axis label.",
-      "default": "ChartsText",
-      "class": null
-    },
-    {
-      "name": "axisLine",
-      "description": "Custom component for the axis main line.",
-      "default": "'line'",
-      "class": null
-    },
-    {
-      "name": "axisTick",
-      "description": "Custom component for the axis tick.",
-      "default": "'line'",
-      "class": null
-    },
-    {
-      "name": "axisTickLabel",
-      "description": "Custom component for tick label.",
-      "default": "ChartsText",
       "class": null
     },
     {

--- a/docs/translations/api-docs/charts/pie-chart/pie-chart.json
+++ b/docs/translations/api-docs/charts/pie-chart/pie-chart.json
@@ -1,13 +1,6 @@
 {
   "componentDescription": "",
   "propDescriptions": {
-    "axisHighlight": {
-      "description": "The configuration of axes highlight.",
-      "seeMoreText": "See {{link}} for more details."
-    },
-    "bottomAxis": {
-      "description": "Indicate which axis to display the bottom of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>."
-    },
     "colors": { "description": "Color palette used to colorize multiple series." },
     "dataset": {
       "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property."
@@ -20,9 +13,6 @@
     },
     "highlightedItem": {
       "description": "The item currently highlighted. Turns highlighting into a controlled prop."
-    },
-    "leftAxis": {
-      "description": "Indicate which axis to display the left of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },
     "legend": { "description": "The props of the legend." },
     "loading": { "description": "If <code>true</code>, a loading overlay is displayed." },
@@ -37,9 +27,6 @@
     "resolveSizeBeforeRender": {
       "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
     },
-    "rightAxis": {
-      "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
-    },
     "series": {
       "description": "The series to display in the pie chart. An array of <a href='/x/api/charts/pie-series-type/'>PieSeriesType</a> objects."
     },
@@ -51,9 +38,6 @@
     "tooltip": {
       "description": "The configuration of the tooltip.",
       "seeMoreText": "See {{link}} for more details."
-    },
-    "topAxis": {
-      "description": "Indicate which axis to display the top of the charts. Can be a string (the id of the axis) or an object <code>ChartsXAxisProps</code>."
     },
     "width": {
       "description": "The width of the chart in px. If not defined, it takes the width of the parent element."
@@ -68,10 +52,6 @@
   "classDescriptions": {},
   "slotDescriptions": {
     "axisContent": "Custom component for displaying tooltip content when triggered by axis event.",
-    "axisLabel": "Custom component for axis label.",
-    "axisLine": "Custom component for the axis main line.",
-    "axisTick": "Custom component for the axis tick.",
-    "axisTickLabel": "Custom component for tick label.",
     "itemContent": "Custom component for displaying tooltip content when triggered by item event.",
     "legend": "Custom rendering of the legend.",
     "loadingOverlay": "Overlay component rendered when the chart is in a loading state.",

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -158,21 +158,6 @@ PieChart.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
   // ----------------------------------------------------------------------
-  /**
-   * The configuration of axes highlight.
-   * @see See {@link https://mui.com/x/react-charts/highlighting highlighting docs} for more details.
-   * @default { x: 'none', y: 'none' }
-   */
-  axisHighlight: PropTypes.shape({
-    x: PropTypes.oneOf(['band', 'line', 'none']),
-    y: PropTypes.oneOf(['band', 'line', 'none']),
-  }),
-  /**
-   * Indicate which axis to display the bottom of the charts.
-   * Can be a string (the id of the axis) or an object `ChartsXAxisProps`.
-   * @default null
-   */
-  bottomAxis: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   children: PropTypes.node,
   className: PropTypes.string,
   /**
@@ -202,12 +187,6 @@ PieChart.propTypes = {
     dataIndex: PropTypes.number,
     seriesId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }),
-  /**
-   * Indicate which axis to display the left of the charts.
-   * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
-   * @default null
-   */
-  leftAxis: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   /**
    * The props of the legend.
    * @default { direction: 'column', position: { vertical: 'middle', horizontal: 'right' } }
@@ -277,12 +256,6 @@ PieChart.propTypes = {
    */
   resolveSizeBeforeRender: PropTypes.bool,
   /**
-   * Indicate which axis to display the right of the charts.
-   * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
-   * @default null
-   */
-  rightAxis: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  /**
    * The series to display in the pie chart.
    * An array of [[PieSeriesType]] objects.
    */
@@ -321,12 +294,6 @@ PieChart.propTypes = {
     slots: PropTypes.object,
     trigger: PropTypes.oneOf(['axis', 'item', 'none']),
   }),
-  /**
-   * Indicate which axis to display the top of the charts.
-   * Can be a string (the id of the axis) or an object `ChartsXAxisProps`.
-   * @default null
-   */
-  topAxis: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   viewBox: PropTypes.shape({
     height: PropTypes.number,
     width: PropTypes.number,

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -7,10 +7,8 @@ import {
   ResponsiveChartContainer,
   ResponsiveChartContainerProps,
 } from '../ResponsiveChartContainer';
-import { ChartsAxis, ChartsAxisProps } from '../ChartsAxis/ChartsAxis';
 import { PieSeriesType } from '../models/seriesType';
 import { MakeOptional } from '../models/helpers';
-import { DEFAULT_X_AXIS_KEY } from '../constants';
 import {
   ChartsTooltip,
   ChartsTooltipProps,
@@ -23,15 +21,8 @@ import {
   ChartsLegendSlotProps,
   ChartsLegendSlots,
 } from '../ChartsLegend';
-import { ChartsAxisHighlight, ChartsAxisHighlightProps } from '../ChartsAxisHighlight';
 import { PiePlot, PiePlotProps, PiePlotSlotProps, PiePlotSlots } from './PiePlot';
 import { PieValueType } from '../models/seriesType/pie';
-import {
-  ChartsAxisSlots,
-  ChartsAxisSlotProps,
-  ChartsXAxisProps,
-  ChartsYAxisProps,
-} from '../models/axis';
 import {
   ChartsOverlay,
   ChartsOverlayProps,
@@ -40,15 +31,13 @@ import {
 } from '../ChartsOverlay';
 
 export interface PieChartSlots
-  extends ChartsAxisSlots,
-    PiePlotSlots,
+  extends PiePlotSlots,
     ChartsLegendSlots,
     ChartsTooltipSlots<'pie'>,
     ChartsOverlaySlots {}
 
 export interface PieChartSlotProps
-  extends ChartsAxisSlotProps,
-    PiePlotSlotProps,
+  extends PiePlotSlotProps,
     ChartsLegendSlotProps,
     ChartsTooltipSlotProps<'pie'>,
     ChartsOverlaySlotProps {}
@@ -58,21 +47,8 @@ export interface PieChartProps
       ResponsiveChartContainerProps,
       'series' | 'leftAxis' | 'bottomAxis' | 'plugins' | 'zAxis'
     >,
-    Omit<ChartsAxisProps, 'slots' | 'slotProps'>,
     Omit<ChartsOverlayProps, 'slots' | 'slotProps'>,
     Pick<PiePlotProps, 'skipAnimation'> {
-  /**
-   * Indicate which axis to display the bottom of the charts.
-   * Can be a string (the id of the axis) or an object `ChartsXAxisProps`.
-   * @default null
-   */
-  bottomAxis?: null | string | ChartsXAxisProps;
-  /**
-   * Indicate which axis to display the left of the charts.
-   * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
-   * @default null
-   */
-  leftAxis?: null | string | ChartsYAxisProps;
   /**
    * The series to display in the pie chart.
    * An array of [[PieSeriesType]] objects.
@@ -84,12 +60,6 @@ export interface PieChartProps
    * @default { trigger: 'item' }
    */
   tooltip?: ChartsTooltipProps<'pie'>;
-  /**
-   * The configuration of axes highlight.
-   * @see See {@link https://mui.com/x/react-charts/highlighting highlighting docs} for more details.
-   * @default { x: 'none', y: 'none' }
-   */
-  axisHighlight?: ChartsAxisHighlightProps;
   /**
    * The props of the legend.
    * @default { direction: 'column', position: { vertical: 'middle', horizontal: 'right' } }
@@ -137,13 +107,8 @@ const PieChart = React.forwardRef(function PieChart(inProps: PieChartProps, ref)
     colors,
     sx,
     tooltip = { trigger: 'item' },
-    axisHighlight = { x: 'none', y: 'none' },
     skipAnimation,
     legend: legendProps,
-    topAxis = null,
-    leftAxis = null,
-    rightAxis = null,
-    bottomAxis = null,
     children,
     slots,
     slotProps,
@@ -171,40 +136,17 @@ const PieChart = React.forwardRef(function PieChart(inProps: PieChartProps, ref)
       width={width}
       height={height}
       margin={margin}
-      xAxis={
-        xAxis ?? [
-          {
-            id: DEFAULT_X_AXIS_KEY,
-            scaleType: 'point',
-            data: [...new Array(Math.max(...series.map((s) => s.data.length)))].map(
-              (_, index) => index,
-            ),
-          },
-        ]
-      }
-      yAxis={yAxis}
       colors={colors}
       sx={sx}
-      disableAxisListener={
-        tooltip?.trigger !== 'axis' && axisHighlight?.x === 'none' && axisHighlight?.y === 'none'
-      }
+      disableAxisListener
       highlightedItem={highlightedItem}
       onHighlightChange={onHighlightChange}
       className={className}
       skipAnimation={skipAnimation}
     >
-      <ChartsAxis
-        topAxis={topAxis}
-        leftAxis={leftAxis}
-        rightAxis={rightAxis}
-        bottomAxis={bottomAxis}
-        slots={slots}
-        slotProps={slotProps}
-      />
       <PiePlot slots={slots} slotProps={slotProps} onItemClick={onItemClick} />
       <ChartsOverlay loading={loading} slots={slots} slotProps={slotProps} />
       <ChartsLegend {...legend} slots={slots} slotProps={slotProps} />
-      <ChartsAxisHighlight {...axisHighlight} />
       {!loading && <ChartsTooltip {...tooltip} slots={slots} slotProps={slotProps} />}
       {children}
     </ResponsiveChartContainer>


### PR DESCRIPTION
## Changelog


- The Pie Chart lost all props and render linked to axes because pie chart does not need cartesian axes. If you used it, you can still add them back with composition. PLease consider opening an issue to share with use your usecase.