### PR TITLE
[charts] Remove `xAxisKey`, `yAxisKey`, and `zAxisKey`

### DIFF
--- a/docs/pages/x/api/charts/bar-series-type.json
+++ b/docs/pages/x/api/charts/bar-series-type.json
@@ -17,8 +17,6 @@
     "stackOrder": { "type": { "description": "StackOrderType" }, "default": "'none'" },
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisId": { "type": { "description": "string" } },
-    "xAxisKey": { "type": { "description": "string" } },
-    "yAxisId": { "type": { "description": "string" } },
-    "yAxisKey": { "type": { "description": "string" } }
+    "yAxisId": { "type": { "description": "string" } }
   }
 }

--- a/docs/pages/x/api/charts/line-series-type.json
+++ b/docs/pages/x/api/charts/line-series-type.json
@@ -22,8 +22,6 @@
     "stackOrder": { "type": { "description": "StackOrderType" }, "default": "'none'" },
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisId": { "type": { "description": "string" } },
-    "xAxisKey": { "type": { "description": "string" } },
-    "yAxisId": { "type": { "description": "string" } },
-    "yAxisKey": { "type": { "description": "string" } }
+    "yAxisId": { "type": { "description": "string" } }
   }
 }

--- a/docs/pages/x/api/charts/scatter-series-type.json
+++ b/docs/pages/x/api/charts/scatter-series-type.json
@@ -19,10 +19,7 @@
     "markerSize": { "type": { "description": "number" } },
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisId": { "type": { "description": "string" } },
-    "xAxisKey": { "type": { "description": "string" } },
     "yAxisId": { "type": { "description": "string" } },
-    "yAxisKey": { "type": { "description": "string" } },
-    "zAxisId": { "type": { "description": "string" } },
-    "zAxisKey": { "type": { "description": "string" } }
+    "zAxisId": { "type": { "description": "string" } }
   }
 }

--- a/docs/translations/api-docs/charts/bar-series-type.json
+++ b/docs/translations/api-docs/charts/bar-series-type.json
@@ -22,8 +22,6 @@
       "description": "Formatter used to render values in tooltip or other data display."
     },
     "xAxisId": { "description": "The id of the x-axis used to render the series." },
-    "xAxisKey": { "description": "The id of the x-axis used to render the series." },
-    "yAxisId": { "description": "The id of the y-axis used to render the series." },
-    "yAxisKey": { "description": "The id of the y-axis used to render the series." }
+    "yAxisId": { "description": "The id of the y-axis used to render the series." }
   }
 }

--- a/docs/translations/api-docs/charts/line-series-type.json
+++ b/docs/translations/api-docs/charts/line-series-type.json
@@ -37,8 +37,6 @@
       "description": "Formatter used to render values in tooltip or other data display."
     },
     "xAxisId": { "description": "The id of the x-axis used to render the series." },
-    "xAxisKey": { "description": "The id of the x-axis used to render the series." },
-    "yAxisId": { "description": "The id of the y-axis used to render the series." },
-    "yAxisKey": { "description": "The id of the y-axis used to render the series." }
+    "yAxisId": { "description": "The id of the y-axis used to render the series." }
   }
 }

--- a/docs/translations/api-docs/charts/scatter-series-type.json
+++ b/docs/translations/api-docs/charts/scatter-series-type.json
@@ -20,10 +20,7 @@
       "description": "Formatter used to render values in tooltip or other data display."
     },
     "xAxisId": { "description": "The id of the x-axis used to render the series." },
-    "xAxisKey": { "description": "The id of the x-axis used to render the series." },
     "yAxisId": { "description": "The id of the y-axis used to render the series." },
-    "yAxisKey": { "description": "The id of the y-axis used to render the series." },
-    "zAxisId": { "description": "The id of the z-axis used to render the series." },
-    "zAxisKey": { "description": "The id of the z-axis used to render the series." }
+    "zAxisId": { "description": "The id of the z-axis used to render the series." }
   }
 }

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -103,8 +103,8 @@ const useAggregatedData = (): {
 
   const data = stackingGroups.flatMap(({ ids: groupIds }, groupIndex) => {
     return groupIds.flatMap((seriesId) => {
-      const xAxisId = series[seriesId].xAxisId ?? series[seriesId].xAxisKey ?? defaultXAxisId;
-      const yAxisId = series[seriesId].yAxisId ?? series[seriesId].yAxisKey ?? defaultYAxisId;
+      const xAxisId = series[seriesId].xAxisId ?? defaultXAxisId;
+      const yAxisId = series[seriesId].yAxisId ?? defaultYAxisId;
 
       const xAxisConfig = xAxis[xAxisId];
       const yAxisConfig = yAxis[yAxisId];

--- a/packages/x-charts/src/BarChart/extremums.ts
+++ b/packages/x-charts/src/BarChart/extremums.ts
@@ -28,7 +28,7 @@ const getValueExtremum =
 
     return Object.keys(series)
       .filter((seriesId) => {
-        const yAxisId = series[seriesId].yAxisId ?? series[seriesId].yAxisKey;
+        const yAxisId = series[seriesId].yAxisId;
         return yAxisId === axis.id || (isDefaultAxis && yAxisId === undefined);
       })
       .reduce(
@@ -38,8 +38,8 @@ const getValueExtremum =
           const filter = getFilters?.({
             currentAxisId: axis.id,
             isDefaultAxis,
-            seriesXAxisId: series[seriesId].xAxisId ?? series[seriesId].xAxisKey,
-            seriesYAxisId: series[seriesId].yAxisId ?? series[seriesId].yAxisKey,
+            seriesXAxisId: series[seriesId].xAxisId,
+            seriesYAxisId: series[seriesId].yAxisId,
           });
 
           const [seriesMin, seriesMax] = stackedData?.reduce(

--- a/packages/x-charts/src/ChartsOnAxisClickHandler/ChartsOnAxisClickHandler.tsx
+++ b/packages/x-charts/src/ChartsOnAxisClickHandler/ChartsOnAxisClickHandler.tsx
@@ -55,8 +55,8 @@ function ChartsOnAxisClickHandler(props: ChartsOnAxisClickHandlerProps) {
           series[seriesType]?.seriesOrder.forEach((seriesId) => {
             const seriesItem = series[seriesType]!.series[seriesId];
 
-            const providedXAxisId = seriesItem.xAxisId ?? seriesItem.xAxisKey;
-            const providedYAxisId = seriesItem.yAxisId ?? seriesItem.yAxisKey;
+            const providedXAxisId = seriesItem.xAxisId;
+            const providedYAxisId = seriesItem.yAxisId;
 
             const axisKey = isXaxis ? providedXAxisId : providedYAxisId;
             if (axisKey === undefined || axisKey === USED_AXIS_ID) {

--- a/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
@@ -77,8 +77,8 @@ function ChartsAxisTooltipContent(props: {
         series[seriesType]!.seriesOrder.forEach((seriesId) => {
           const item = series[seriesType]!.series[seriesId];
 
-          const providedXAxisId = item.xAxisId ?? item.xAxisKey;
-          const providedYAxisId = item.yAxisId ?? item.yAxisKey;
+          const providedXAxisId = item.xAxisId;
+          const providedYAxisId = item.yAxisId;
 
           const axisKey = isXaxis ? providedXAxisId : providedYAxisId;
 
@@ -87,8 +87,7 @@ function ChartsAxisTooltipContent(props: {
 
             const xAxisId = providedXAxisId ?? xAxisIds[0];
             const yAxisId = providedYAxisId ?? yAxisIds[0];
-            const zAxisId =
-              (seriesToAdd as any).zAxisId ?? (seriesToAdd as any).zAxisKey ?? zAxisIds[0];
+            const zAxisId = (seriesToAdd as any).zAxisId ?? zAxisIds[0];
 
             const getColor =
               colorProcessors[seriesType]?.(

--- a/packages/x-charts/src/ChartsTooltip/ChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsItemTooltipContent.tsx
@@ -54,9 +54,9 @@ function ChartsItemTooltipContent<T extends ChartSeriesType>(
   const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
   const colorProcessors = useColorProcessor();
 
-  const xAxisId = (series as any).xAxisId ?? (series as any).xAxisKey ?? xAxisIds[0];
-  const yAxisId = (series as any).yAxisId ?? (series as any).yAxisKey ?? yAxisIds[0];
-  const zAxisId = (series as any).zAxisId ?? (series as any).zAxisKey ?? zAxisIds[0];
+  const xAxisId = (series as any).xAxisId ?? xAxisIds[0];
+  const yAxisId = (series as any).yAxisId ?? yAxisIds[0];
+  const zAxisId = (series as any).zAxisId ?? zAxisIds[0];
 
   const getColor =
     colorProcessors[series.type]?.(

--- a/packages/x-charts/src/ChartsTooltip/useAxisTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/useAxisTooltip.tsx
@@ -61,8 +61,8 @@ export function useAxisTooltip(): null | UseAxisTooltipReturnValue {
       return seriesOfType.seriesOrder.map((seriesId) => {
         const seriesToAdd = seriesOfType.series[seriesId]!;
 
-        const providedXAxisId = seriesToAdd.xAxisId ?? seriesToAdd.xAxisKey;
-        const providedYAxisId = seriesToAdd.yAxisId ?? seriesToAdd.yAxisKey;
+        const providedXAxisId = seriesToAdd.xAxisId;
+        const providedYAxisId = seriesToAdd.yAxisId;
 
         const axisKey = isXaxis ? providedXAxisId : providedYAxisId;
 
@@ -70,8 +70,7 @@ export function useAxisTooltip(): null | UseAxisTooltipReturnValue {
         if (axisKey === undefined || axisKey === USED_AXIS_ID) {
           const xAxisId = providedXAxisId ?? xAxisIds[0];
           const yAxisId = providedYAxisId ?? yAxisIds[0];
-          const zAxisId =
-            (seriesToAdd as any).zAxisId ?? (seriesToAdd as any).zAxisKey ?? zAxisIds[0];
+          const zAxisId = (seriesToAdd as any).zAxisId ?? zAxisIds[0];
 
           const color =
             colorProcessors[seriesType]?.(

--- a/packages/x-charts/src/ChartsTooltip/useItemTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/useItemTooltip.tsx
@@ -29,9 +29,9 @@ export function useItemTooltip<T extends ChartSeriesType>(): null | UseItemToolt
   const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
   const colorProcessors = useColorProcessor();
 
-  const xAxisId = (series as any).xAxisId ?? (series as any).xAxisKey ?? xAxisIds[0];
-  const yAxisId = (series as any).yAxisId ?? (series as any).yAxisKey ?? yAxisIds[0];
-  const zAxisId = (series as any).zAxisId ?? (series as any).zAxisKey ?? zAxisIds[0];
+  const xAxisId = (series as any).xAxisId ?? xAxisIds[0];
+  const yAxisId = (series as any).yAxisId ?? yAxisIds[0];
+  const zAxisId = (series as any).zAxisId ?? zAxisIds[0];
 
   if (!item || item.dataIndex === undefined) {
     return null;

--- a/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
+++ b/packages/x-charts/src/ChartsVoronoiHandler/ChartsVoronoiHandler.tsx
@@ -64,10 +64,10 @@ function ChartsVoronoiHandler(props: ChartsVoronoiHandlerProps) {
     voronoiRef.current = {};
     let points: number[] = [];
     seriesOrder.forEach((seriesId) => {
-      const { data, xAxisId, yAxisId, xAxisKey, yAxisKey } = series[seriesId];
+      const { data, xAxisId, yAxisId } = series[seriesId];
 
-      const xScale = xAxis[xAxisId ?? xAxisKey ?? defaultXAxisId].scale;
-      const yScale = yAxis[yAxisId ?? yAxisKey ?? defaultYAxisId].scale;
+      const xScale = xAxis[xAxisId ?? defaultXAxisId].scale;
+      const yScale = yAxis[yAxisId ?? defaultYAxisId].scale;
 
       const getXPosition = getValueToPositionMapper(xScale);
       const getYPosition = getValueToPositionMapper(yScale);

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -56,18 +56,13 @@ const useAggregatedData = () => {
         .reverse() // Revert stacked area for a more pleasant animation
         .map((seriesId) => {
           const {
-            xAxisId: xAxisIdProp,
-            yAxisId: yAxisIdProp,
-            xAxisKey = defaultXAxisId,
-            yAxisKey = defaultYAxisId,
+            xAxisId = defaultXAxisId,
+            yAxisId = defaultYAxisId,
             stackedData,
             data,
             connectNulls,
             baseline,
           } = series[seriesId];
-
-          const xAxisId = xAxisIdProp ?? xAxisKey;
-          const yAxisId = yAxisIdProp ?? yAxisKey;
 
           const xScale = getValueToPositionMapper(xAxis[xAxisId].scale);
           const yScale = yAxis[yAxisId].scale;

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -70,17 +70,12 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
       {stackingGroups.flatMap(({ ids: groupIds }) => {
         return groupIds.flatMap((seriesId) => {
           const {
-            xAxisId: xAxisIdProp,
-            yAxisId: yAxisIdProp,
-            xAxisKey = defaultXAxisId,
-            yAxisKey = defaultYAxisId,
+            xAxisId = defaultXAxisId,
+            yAxisId = defaultYAxisId,
             stackedData,
             data,
             disableHighlight,
           } = series[seriesId];
-
-          const xAxisId = xAxisIdProp ?? xAxisKey;
-          const yAxisId = yAxisIdProp ?? yAxisKey;
 
           if (disableHighlight || data[highlightedIndex] == null) {
             return null;

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -54,17 +54,12 @@ const useAggregatedData = () => {
     return stackingGroups.flatMap(({ ids: groupIds }) => {
       return groupIds.flatMap((seriesId) => {
         const {
-          xAxisId: xAxisIdProp,
-          yAxisId: yAxisIdProp,
-          xAxisKey = defaultXAxisId,
-          yAxisKey = defaultYAxisId,
+          xAxisId = defaultXAxisId,
+          yAxisId = defaultYAxisId,
           stackedData,
           data,
           connectNulls,
         } = series[seriesId];
-
-        const xAxisId = xAxisIdProp ?? xAxisKey;
-        const yAxisId = yAxisIdProp ?? yAxisKey;
 
         const xScale = getValueToPositionMapper(xAxis[xAxisId].scale);
         const yScale = yAxis[yAxisId].scale;

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -93,10 +93,8 @@ function MarkPlot(props: MarkPlotProps) {
       {stackingGroups.flatMap(({ ids: groupIds }) => {
         return groupIds.map((seriesId) => {
           const {
-            xAxisId: xAxisIdProp,
-            yAxisId: yAxisIdProp,
-            xAxisKey = defaultXAxisId,
-            yAxisKey = defaultYAxisId,
+            xAxisId = defaultXAxisId,
+            yAxisId = defaultYAxisId,
             stackedData,
             data,
             showMark = true,
@@ -105,9 +103,6 @@ function MarkPlot(props: MarkPlotProps) {
           if (showMark === false) {
             return null;
           }
-
-          const xAxisId = xAxisIdProp ?? xAxisKey;
-          const yAxisId = yAxisIdProp ?? yAxisKey;
 
           const xScale = getValueToPositionMapper(xAxis[xAxisId].scale);
           const yScale = yAxis[yAxisId].scale;

--- a/packages/x-charts/src/LineChart/extremums.ts
+++ b/packages/x-charts/src/LineChart/extremums.ts
@@ -36,7 +36,7 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
 
   return Object.keys(series)
     .filter((seriesId) => {
-      const yAxisId = series[seriesId].yAxisId ?? series[seriesId].yAxisKey;
+      const yAxisId = series[seriesId].yAxisId;
       return yAxisId === axis.id || (isDefaultAxis && yAxisId === undefined);
     })
     .reduce(
@@ -47,8 +47,8 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
         const filter = getFilters?.({
           currentAxisId: axis.id,
           isDefaultAxis,
-          seriesXAxisId: series[seriesId].xAxisId ?? series[seriesId].xAxisKey,
-          seriesYAxisId: series[seriesId].yAxisId ?? series[seriesId].yAxisKey,
+          seriesXAxisId: series[seriesId].xAxisId,
+          seriesYAxisId: series[seriesId].yAxisId,
         });
 
         // Since this series is not used to display an area, we do not consider the base (the d[0]).

--- a/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
@@ -59,17 +59,16 @@ function ScatterPlot(props: ScatterPlotProps) {
   return (
     <React.Fragment>
       {seriesOrder.map((seriesId) => {
-        const { id, xAxisKey, yAxisKey, zAxisKey, xAxisId, yAxisId, zAxisId, markerSize, color } =
-          series[seriesId];
+        const { id, xAxisId, yAxisId, zAxisId, markerSize, color } = series[seriesId];
 
         const colorGetter = getColor(
           series[seriesId],
-          xAxis[xAxisId ?? xAxisKey ?? defaultXAxisId],
-          yAxis[yAxisId ?? yAxisKey ?? defaultYAxisId],
-          zAxis[zAxisId ?? zAxisKey ?? defaultZAxisId],
+          xAxis[xAxisId ?? defaultXAxisId],
+          yAxis[yAxisId ?? defaultYAxisId],
+          zAxis[zAxisId ?? defaultZAxisId],
         );
-        const xScale = xAxis[xAxisId ?? xAxisKey ?? defaultXAxisId].scale;
-        const yScale = yAxis[yAxisId ?? yAxisKey ?? defaultYAxisId].scale;
+        const xScale = xAxis[xAxisId ?? defaultXAxisId].scale;
+        const yScale = yAxis[yAxisId ?? defaultYAxisId].scale;
         return (
           <ScatterItems
             key={id}

--- a/packages/x-charts/src/ScatterChart/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/extremums.ts
@@ -15,7 +15,7 @@ export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {
 
   return Object.keys(series)
     .filter((seriesId) => {
-      const axisId = series[seriesId].xAxisId ?? series[seriesId].xAxisKey;
+      const axisId = series[seriesId].xAxisId;
       return axisId === axis.id || (axisId === undefined && isDefaultAxis);
     })
     .reduce(
@@ -23,8 +23,8 @@ export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {
         const filter = getFilters?.({
           currentAxisId: axis.id,
           isDefaultAxis,
-          seriesXAxisId: series[seriesId].xAxisId ?? series[seriesId].xAxisKey,
-          seriesYAxisId: series[seriesId].yAxisId ?? series[seriesId].yAxisKey,
+          seriesXAxisId: series[seriesId].xAxisId,
+          seriesYAxisId: series[seriesId].yAxisId,
         });
 
         const seriesMinMax = series[seriesId].data?.reduce<ExtremumGetterResult>(
@@ -47,7 +47,7 @@ export const getExtremumY: ExtremumGetter<'scatter'> = (params) => {
 
   return Object.keys(series)
     .filter((seriesId) => {
-      const axisId = series[seriesId].yAxisId ?? series[seriesId].yAxisKey;
+      const axisId = series[seriesId].yAxisId;
       return axisId === axis.id || (axisId === undefined && isDefaultAxis);
     })
     .reduce(
@@ -55,8 +55,8 @@ export const getExtremumY: ExtremumGetter<'scatter'> = (params) => {
         const filter = getFilters?.({
           currentAxisId: axis.id,
           isDefaultAxis,
-          seriesXAxisId: series[seriesId].xAxisId ?? series[seriesId].xAxisKey,
-          seriesYAxisId: series[seriesId].yAxisId ?? series[seriesId].yAxisKey,
+          seriesXAxisId: series[seriesId].xAxisId,
+          seriesYAxisId: series[seriesId].yAxisId,
         });
 
         const seriesMinMax = series[seriesId].data?.reduce<ExtremumGetterResult>(

--- a/packages/x-charts/src/models/seriesType/common.ts
+++ b/packages/x-charts/src/models/seriesType/common.ts
@@ -36,16 +36,6 @@ export type CommonDefaultizedProps = 'id' | 'valueFormatter' | 'data';
 export type CartesianSeriesType = {
   /**
    * The id of the x-axis used to render the series.
-   * @deprecated Use `xAxisId` instead
-   */
-  xAxisKey?: string;
-  /**
-   * The id of the y-axis used to render the series.
-   * @deprecated Use `xAxisId` instead
-   */
-  yAxisKey?: string;
-  /**
-   * The id of the x-axis used to render the series.
    */
   xAxisId?: string;
   /**

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -26,11 +26,6 @@ export interface ScatterSeriesType extends CommonSeriesType<ScatterValueType>, C
   disableHover?: boolean;
   /**
    * The id of the z-axis used to render the series.
-   * @deprecated Use `zAxisId` instead.
-   */
-  zAxisKey?: string;
-  /**
-   * The id of the z-axis used to render the series.
    */
   zAxisId?: string;
 


### PR DESCRIPTION
### Changelog

The  `xAxisKey`, `yAxisKey`, and `zAxisKey` properties got deprecated in favor of  `xAxisId`, `yAxisId`, and `zAxisId`.
Those deprecated properties are now removed.