### PR TITLE
[data grid] Fix overlay not showing

### DIFF
--- a/packages/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/x-data-grid/src/components/base/GridOverlays.tsx
@@ -32,7 +32,6 @@ const GridOverlayWrapperRoot = styled('div', {
         top: 'var(--DataGrid-headersTotalHeight)',
         left: 0,
         width: 0, // To stay above the content instead of shifting it down
-        // height: 0, // To stay above the content instead of shifting it down
         zIndex:
           overlayType === 'loadingOverlay'
             ? 5 // Should be above pinned columns, pinned rows, and detail panel

--- a/packages/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/x-data-grid/src/components/base/GridOverlays.tsx
@@ -32,7 +32,7 @@ const GridOverlayWrapperRoot = styled('div', {
         top: 'var(--DataGrid-headersTotalHeight)',
         left: 0,
         width: 0, // To stay above the content instead of shifting it down
-        height: 0, // To stay above the content instead of shifting it down
+        // height: 0, // To stay above the content instead of shifting it down
         zIndex:
           overlayType === 'loadingOverlay'
             ? 5 // Should be above pinned columns, pinned rows, and detail panel


### PR DESCRIPTION
Fixes #15169 

removed height property from styled that prevents the overlay to stretch the parent height

This introduces a slight flash of height change during rerendering, since both components are mounted together briefly. 
We could also prevent that with a conditional rendering like this:
```diff
diff --git a/packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx b/packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
index 38859f1f8..e51d3b9f1 100644
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx
@@ -99,17 +99,20 @@ function GridVirtualScroller(props: GridVirtualScrollerProps) {
           <rootProps.slots.pinnedRows position="top" virtualScroller={virtualScroller} />
         </TopContainer>

-        <Overlays {...overlaysProps} />
-
-        <Content {...getContentProps()}>
-          <RenderZone {...getRenderZoneProps()}>
-            {rows}
-            {<rootProps.slots.detailPanels virtualScroller={virtualScroller} />}
-          </RenderZone>
-        </Content>
-
-        <SpaceFiller rowsLength={rows.length} />
-
+        {rows.length === 0 ? (
+          <Overlays {...overlaysProps} />
+        ) : (
+          <React.Fragment>
+            <Content {...getContentProps()}>
+              <RenderZone {...getRenderZoneProps()}>
+                {rows}
+                {<rootProps.slots.detailPanels virtualScroller={virtualScroller} />}
+              </RenderZone>
+            </Content>
+
+            <SpaceFiller rowsLength={rows.length} />
+          </React.Fragment>
+        )}
         <BottomContainer>
           <rootProps.slots.pinnedRows position="bottom" virtualScroller={virtualScroller} />
         </BottomContainer>
```

Thoughts @KenanYusuf @cherniavskii ?