### PR TITLE
[pickers] Clean definition of validation props

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
@@ -19,12 +19,12 @@ import {
   DayCalendarProps,
   ExportedUseViewsOptions,
 } from '@mui/x-date-pickers/internals';
-import { DayRangeValidationProps } from '../internals/models/dateRange';
 import { DateRange, RangePosition } from '../models';
 import { DateRangeCalendarClasses } from './dateRangeCalendarClasses';
 import { DateRangePickerDay, DateRangePickerDayProps } from '../DateRangePickerDay';
 import { UseRangePositionProps } from '../internals/hooks/useRangePosition';
 import { PickersRangeCalendarHeaderProps } from '../PickersRangeCalendarHeader';
+import { ExportedValidateDateRangeProps } from '../validation/validateDateRange';
 
 export interface DateRangeCalendarSlots<TDate extends PickerValidDate>
   extends PickersArrowSwitcherSlots,
@@ -62,8 +62,7 @@ export interface DateRangeCalendarSlotProps<TDate extends PickerValidDate>
 
 export interface ExportedDateRangeCalendarProps<TDate extends PickerValidDate>
   extends ExportedDayCalendarProps<TDate>,
-    BaseDateValidationProps<TDate>,
-    DayRangeValidationProps<TDate>,
+    ExportedValidateDateRangeProps<TDate>,
     TimezoneProps {
   /**
    * If `true`, after selecting `start` date calendar will not automatically switch to the month of `end` date.

--- a/packages/x-date-pickers-pro/src/DateRangePicker/shared.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/shared.tsx
@@ -43,8 +43,7 @@ export interface BaseDateRangePickerProps<TDate extends PickerValidDate>
       BasePickerInputProps<DateRange<TDate>, TDate, 'day', DateRangeValidationError>,
       'view' | 'views' | 'openTo' | 'onViewChange' | 'orientation'
     >,
-    ExportedDateRangeCalendarProps<TDate>,
-    BaseDateValidationProps<TDate> {
+    ExportedDateRangeCalendarProps<TDate> {
   /**
    * Overridable component slots.
    * @default {}

--- a/packages/x-date-pickers-pro/src/internals/models/dateTimeRange.ts
+++ b/packages/x-date-pickers-pro/src/internals/models/dateTimeRange.ts
@@ -1,19 +1,17 @@
 import {
-  BaseDateValidationProps,
-  TimeValidationProps,
   MakeOptional,
   UseFieldInternalProps,
-  DateTimeValidationProps,
   DateOrTimeViewWithMeridiem,
+  AmPmProps,
 } from '@mui/x-date-pickers/internals';
 import { PickerValidDate } from '@mui/x-date-pickers/models';
-import { DayRangeValidationProps } from './dateRange';
 import {
   DateTimeRangeValidationError,
   RangeFieldSection,
   DateRange,
   RangeFieldSeparatorProps,
 } from '../../models';
+import { ExportedValidateDateTimeRangeProps } from '../../validation/validateDateTimeRange';
 
 export interface UseDateTimeRangeFieldProps<
   TDate extends PickerValidDate,
@@ -32,16 +30,8 @@ export interface UseDateTimeRangeFieldProps<
       'format'
     >,
     RangeFieldSeparatorProps,
-    DayRangeValidationProps<TDate>,
-    TimeValidationProps<TDate>,
-    BaseDateValidationProps<TDate>,
-    DateTimeValidationProps<TDate> {
-  /**
-   * 12h/24h view for hour selection clock.
-   * @default utils.is12HourCycleInCurrentLocale()
-   */
-  ampm?: boolean;
-}
+    ExportedValidateDateTimeRangeProps<TDate>,
+    AmPmProps {}
 
 export type DateTimeRangePickerView = Exclude<DateOrTimeViewWithMeridiem, 'month' | 'year'>;
 

--- a/packages/x-date-pickers-pro/src/internals/models/timeRange.ts
+++ b/packages/x-date-pickers-pro/src/internals/models/timeRange.ts
@@ -1,9 +1,4 @@
-import {
-  BaseTimeValidationProps,
-  TimeValidationProps,
-  MakeOptional,
-  UseFieldInternalProps,
-} from '@mui/x-date-pickers/internals';
+import { MakeOptional, UseFieldInternalProps, AmPmProps } from '@mui/x-date-pickers/internals';
 import { PickerValidDate } from '@mui/x-date-pickers/models';
 import {
   TimeRangeValidationError,
@@ -11,6 +6,7 @@ import {
   DateRange,
   RangeFieldSeparatorProps,
 } from '../../models';
+import type { ExportedValidateTimeRangeProps } from '../../validation/validateTimeRange';
 
 export interface UseTimeRangeFieldProps<
   TDate extends PickerValidDate,
@@ -29,11 +25,5 @@ export interface UseTimeRangeFieldProps<
       'format'
     >,
     RangeFieldSeparatorProps,
-    TimeValidationProps<TDate>,
-    BaseTimeValidationProps {
-  /**
-   * 12h/24h view for hour selection clock.
-   * @default utils.is12HourCycleInCurrentLocale()
-   */
-  ampm?: boolean;
-}
+    ExportedValidateTimeRangeProps<TDate>,
+    AmPmProps {}

--- a/packages/x-date-pickers-pro/src/models/dateRange.ts
+++ b/packages/x-date-pickers-pro/src/models/dateRange.ts
@@ -1,13 +1,9 @@
-import {
-  BaseDateValidationProps,
-  MakeOptional,
-  UseFieldInternalProps,
-} from '@mui/x-date-pickers/internals';
+import { MakeOptional, UseFieldInternalProps } from '@mui/x-date-pickers/internals';
 import { PickerValidDate } from '@mui/x-date-pickers/models';
 import { RangeFieldSection, RangeFieldSeparatorProps } from './fields';
 import { DateRangeValidationError } from './validation';
 import { DateRange } from './range';
-import { DayRangeValidationProps } from '../internals/models/dateRange';
+import type { ExportedValidateDateRangeProps } from '../validation/validateDateRange';
 
 export interface UseDateRangeFieldProps<
   TDate extends PickerValidDate,
@@ -26,5 +22,4 @@ export interface UseDateRangeFieldProps<
       'format'
     >,
     RangeFieldSeparatorProps,
-    DayRangeValidationProps<TDate>,
-    BaseDateValidationProps<TDate> {}
+    ExportedValidateDateRangeProps<TDate> {}

--- a/packages/x-date-pickers-pro/src/validation/validateDateRange.ts
+++ b/packages/x-date-pickers-pro/src/validation/validateDateRange.ts
@@ -6,6 +6,13 @@ import { DayRangeValidationProps } from '../internals/models/dateRange';
 import { DateRangeValidationError, DateRange } from '../models';
 import { rangeValueManager } from '../internals/utils/valueManagers';
 
+/**
+ * Validation props used by the Date Range Picker, Date Range Field and Date Range Calendar components.
+ */
+export interface ExportedValidateDateRangeProps<TDate extends PickerValidDate>
+  extends DayRangeValidationProps<TDate>,
+    BaseDateValidationProps<TDate> {}
+
 export interface ValidateDateRangeProps<TDate extends PickerValidDate>
   extends DayRangeValidationProps<TDate>,
     Required<BaseDateValidationProps<TDate>> {}

--- a/packages/x-date-pickers-pro/src/validation/validateDateTimeRange.ts
+++ b/packages/x-date-pickers-pro/src/validation/validateDateTimeRange.ts
@@ -1,15 +1,23 @@
 import { PickerValidDate } from '@mui/x-date-pickers/models';
+import { DateTimeValidationProps } from '@mui/x-date-pickers/internals';
 import { validateDateTime, Validator } from '@mui/x-date-pickers/validation';
-import { BaseDateValidationProps, TimeValidationProps } from '@mui/x-date-pickers/internals';
 import { isRangeValid } from '../internals/utils/date-utils';
-import { DayRangeValidationProps } from '../internals/models/dateRange';
 import { DateTimeRangeValidationError, DateRange } from '../models';
 import { rangeValueManager } from '../internals/utils/valueManagers';
+import { ExportedValidateDateRangeProps, ValidateDateRangeProps } from './validateDateRange';
+import { ExportedValidateTimeRangeProps, ValidateTimeRangeProps } from './validateTimeRange';
+
+/**
+ * Validation props used by the Date Time Range Picker and Date Time Range Field.
+ */
+export interface ExportedValidateDateTimeRangeProps<TDate extends PickerValidDate>
+  extends ExportedValidateDateRangeProps<TDate>,
+    ExportedValidateTimeRangeProps<TDate>,
+    DateTimeValidationProps<TDate> {}
 
 export interface ValidateDateTimeRangeProps<TDate extends PickerValidDate>
-  extends DayRangeValidationProps<TDate>,
-    TimeValidationProps<TDate>,
-    Required<BaseDateValidationProps<TDate>> {}
+  extends ValidateDateRangeProps<TDate>,
+    ValidateTimeRangeProps<TDate> {}
 
 export const validateDateTimeRange: Validator<
   DateRange<any>,

--- a/packages/x-date-pickers-pro/src/validation/validateTimeRange.ts
+++ b/packages/x-date-pickers-pro/src/validation/validateTimeRange.ts
@@ -1,16 +1,26 @@
 import { validateTime, Validator } from '@mui/x-date-pickers/validation';
-import { BaseTimeValidationProps } from '@mui/x-date-pickers/internals';
+import { PickerValidDate } from '@mui/x-date-pickers/models';
+import { TimeValidationProps, BaseTimeValidationProps } from '@mui/x-date-pickers/internals';
 import { isRangeValid } from '../internals/utils/date-utils';
 import { TimeRangeValidationError, DateRange } from '../models';
 import { rangeValueManager } from '../internals/utils/valueManagers';
 
-export interface ValidateTimeRangeProps extends Required<BaseTimeValidationProps> {}
+/**
+ * Validation props used by the Time Range Picker and Time Range Field.
+ */
+export interface ExportedValidateTimeRangeProps<TDate extends PickerValidDate>
+  extends BaseTimeValidationProps,
+    TimeValidationProps<TDate> {}
+
+export interface ValidateTimeRangeProps<TDate extends PickerValidDate>
+  extends Required<BaseTimeValidationProps>,
+    TimeValidationProps<TDate> {}
 
 export const validateTimeRange: Validator<
   DateRange<any>,
   any,
   TimeRangeValidationError,
-  ValidateTimeRangeProps
+  ValidateTimeRangeProps<any>
 > = ({ adapter, value, timezone, props }) => {
   const [start, end] = value;
 

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.types.ts
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.types.ts
@@ -10,12 +10,7 @@ import {
 } from '../PickersCalendarHeader';
 import { DayCalendarSlots, DayCalendarSlotProps, ExportedDayCalendarProps } from './DayCalendar';
 import { DateCalendarClasses } from './dateCalendarClasses';
-import {
-  BaseDateValidationProps,
-  YearValidationProps,
-  MonthValidationProps,
-  DayValidationProps,
-} from '../internals/models/validation';
+import { BaseDateValidationProps } from '../internals/models/validation';
 import { ExportedUseViewsOptions } from '../internals/hooks/useViews';
 import { DateView, PickerValidDate, TimezoneProps } from '../models';
 import { DefaultizedProps } from '../internals/models/helpers';
@@ -29,6 +24,7 @@ import {
   MonthCalendarSlots,
   MonthCalendarSlotProps,
 } from '../MonthCalendar/MonthCalendar.types';
+import { ExportedValidateDateProps } from '../validation/validateDate';
 
 export interface DateCalendarSlots<TDate extends PickerValidDate>
   extends PickersCalendarHeaderSlots,
@@ -55,10 +51,7 @@ export interface ExportedDateCalendarProps<TDate extends PickerValidDate>
   extends ExportedDayCalendarProps<TDate>,
     ExportedMonthCalendarProps,
     ExportedYearCalendarProps,
-    BaseDateValidationProps<TDate>,
-    DayValidationProps<TDate>,
-    YearValidationProps<TDate>,
-    MonthValidationProps<TDate>,
+    ExportedValidateDateProps<TDate>,
     TimezoneProps {
   /**
    * If `true`, the picker and text field are disabled.

--- a/packages/x-date-pickers/src/DateField/DateField.types.ts
+++ b/packages/x-date-pickers/src/DateField/DateField.types.ts
@@ -14,12 +14,7 @@ import {
 } from '../models';
 import { UseFieldInternalProps } from '../internals/hooks/useField';
 import { MakeOptional } from '../internals/models/helpers';
-import {
-  BaseDateValidationProps,
-  DayValidationProps,
-  MonthValidationProps,
-  YearValidationProps,
-} from '../internals/models/validation';
+import { ExportedValidateDateProps } from '../validation/validateDate';
 
 export interface UseDateFieldProps<
   TDate extends PickerValidDate,
@@ -34,10 +29,7 @@ export interface UseDateFieldProps<
       >,
       'format'
     >,
-    DayValidationProps<TDate>,
-    MonthValidationProps<TDate>,
-    YearValidationProps<TDate>,
-    BaseDateValidationProps<TDate>,
+    ExportedValidateDateProps<TDate>,
     ExportedUseClearableFieldProps {}
 
 export type DateFieldProps<

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.types.ts
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.types.ts
@@ -10,19 +10,12 @@ import {
 import { UseFieldInternalProps } from '../internals/hooks/useField';
 import { MakeOptional } from '../internals/models/helpers';
 import {
-  BaseDateValidationProps,
-  BaseTimeValidationProps,
-  DateTimeValidationProps,
-  DayValidationProps,
-  MonthValidationProps,
-  TimeValidationProps,
-  YearValidationProps,
-} from '../internals/models/validation';
-import {
   ExportedUseClearableFieldProps,
   UseClearableFieldSlots,
   UseClearableFieldSlotProps,
 } from '../hooks/useClearableField';
+import { ExportedValidateDateTimeProps } from '../validation/validateDateTime';
+import { AmPmProps } from '../internals/models/props/time';
 
 export interface UseDateTimeFieldProps<
   TDate extends PickerValidDate,
@@ -37,20 +30,9 @@ export interface UseDateTimeFieldProps<
       >,
       'format'
     >,
-    DayValidationProps<TDate>,
-    MonthValidationProps<TDate>,
-    YearValidationProps<TDate>,
-    BaseDateValidationProps<TDate>,
-    TimeValidationProps<TDate>,
-    BaseTimeValidationProps,
-    DateTimeValidationProps<TDate>,
-    ExportedUseClearableFieldProps {
-  /**
-   * 12h/24h view for hour selection clock.
-   * @default utils.is12HourCycleInCurrentLocale()
-   */
-  ampm?: boolean;
-}
+    ExportedValidateDateTimeProps<TDate>,
+    ExportedUseClearableFieldProps,
+    AmPmProps {}
 
 export type DateTimeFieldProps<
   TDate extends PickerValidDate,

--- a/packages/x-date-pickers/src/DateTimePicker/shared.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/shared.tsx
@@ -31,7 +31,7 @@ import { PickerViewRendererLookup } from '../internals/hooks/usePicker/usePicker
 import { DateViewRendererProps } from '../dateViewRenderers';
 import { TimeViewRendererProps } from '../timeViewRenderers';
 import { applyDefaultViewProps } from '../internals/utils/views';
-import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/clock';
+import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/time';
 import { DateOrTimeViewWithMeridiem, TimeViewWithMeridiem } from '../internals/models';
 
 export interface BaseDateTimePickerSlots<TDate extends PickerValidDate>

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.types.ts
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePicker.types.ts
@@ -10,7 +10,7 @@ import {
 } from '../DateTimePicker/shared';
 import { MakeOptional } from '../internals/models/helpers';
 import { DateOrTimeView, PickerValidDate } from '../models';
-import { DesktopOnlyTimePickerProps } from '../internals/models/props/clock';
+import { DesktopOnlyTimePickerProps } from '../internals/models/props/time';
 import { DateOrTimeViewWithMeridiem } from '../internals/models';
 import {
   MultiSectionDigitalClockSlots,

--- a/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.types.ts
+++ b/packages/x-date-pickers/src/DesktopTimePicker/DesktopTimePicker.types.ts
@@ -10,7 +10,7 @@ import {
 } from '../TimePicker/shared';
 import { MakeOptional } from '../internals/models/helpers';
 import { TimeViewWithMeridiem } from '../internals/models';
-import { DesktopOnlyTimePickerProps } from '../internals/models/props/clock';
+import { DesktopOnlyTimePickerProps } from '../internals/models/props/time';
 import { DigitalClockSlots, DigitalClockSlotProps } from '../DigitalClock';
 import {
   MultiSectionDigitalClockSlots,

--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.types.ts
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.types.ts
@@ -6,7 +6,7 @@ import {
   BaseClockProps,
   DigitalClockOnlyProps,
   ExportedBaseClockProps,
-} from '../internals/models/props/clock';
+} from '../internals/models/props/time';
 import { PickerValidDate, TimeView } from '../models';
 
 export interface ExportedDigitalClockProps<TDate extends PickerValidDate>

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.types.ts
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.types.ts
@@ -6,7 +6,7 @@ import {
   BaseClockProps,
   ExportedBaseClockProps,
   MultiSectionDigitalClockOnlyProps,
-} from '../internals/models/props/clock';
+} from '../internals/models/props/time';
 import { MultiSectionDigitalClockSectionProps } from './MultiSectionDigitalClockSection';
 import { TimeViewWithMeridiem } from '../internals/models';
 import { PickerValidDate } from '../models';

--- a/packages/x-date-pickers/src/TimeClock/TimeClock.types.ts
+++ b/packages/x-date-pickers/src/TimeClock/TimeClock.types.ts
@@ -3,7 +3,7 @@ import {
   PickersArrowSwitcherSlots,
   PickersArrowSwitcherSlotProps,
 } from '../internals/components/PickersArrowSwitcher';
-import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/clock';
+import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/time';
 import { PickerValidDate, TimeView } from '../models';
 import { TimeViewWithMeridiem } from '../internals/models';
 

--- a/packages/x-date-pickers/src/TimeField/TimeField.types.ts
+++ b/packages/x-date-pickers/src/TimeField/TimeField.types.ts
@@ -3,7 +3,6 @@ import { SlotComponentProps } from '@mui/utils';
 import TextField from '@mui/material/TextField';
 import { UseFieldInternalProps } from '../internals/hooks/useField';
 import { MakeOptional } from '../internals/models/helpers';
-import { BaseTimeValidationProps, TimeValidationProps } from '../internals/models/validation';
 import {
   FieldSection,
   PickerValidDate,
@@ -15,6 +14,8 @@ import {
   UseClearableFieldSlots,
   UseClearableFieldSlotProps,
 } from '../hooks/useClearableField';
+import { ExportedValidateTimeProps } from '../validation/validateTime';
+import { AmPmProps } from '../internals/models/props/time';
 
 export interface UseTimeFieldProps<
   TDate extends PickerValidDate,
@@ -29,15 +30,9 @@ export interface UseTimeFieldProps<
       >,
       'format'
     >,
-    TimeValidationProps<TDate>,
-    BaseTimeValidationProps,
-    ExportedUseClearableFieldProps {
-  /**
-   * 12h/24h view for hour selection clock.
-   * @default utils.is12HourCycleInCurrentLocale()
-   */
-  ampm?: boolean;
-}
+    ExportedValidateTimeProps<TDate>,
+    ExportedUseClearableFieldProps,
+    AmPmProps {}
 
 export type TimeFieldProps<
   TDate extends PickerValidDate,

--- a/packages/x-date-pickers/src/TimePicker/shared.tsx
+++ b/packages/x-date-pickers/src/TimePicker/shared.tsx
@@ -15,7 +15,7 @@ import { PickerValidDate, TimeValidationError } from '../models';
 import { PickerViewRendererLookup } from '../internals/hooks/usePicker/usePickerViews';
 import { TimeViewRendererProps } from '../timeViewRenderers';
 import { applyDefaultViewProps } from '../internals/utils/views';
-import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/clock';
+import { BaseClockProps, ExportedBaseClockProps } from '../internals/models/props/time';
 import { TimeViewWithMeridiem } from '../internals/models';
 
 export interface BaseTimePickerSlots<TDate extends PickerValidDate> extends TimeClockSlots {

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -101,7 +101,7 @@ export type {
   BasePickerInputProps,
   BaseNonStaticPickerProps,
 } from './models/props/basePickerProps';
-export type { BaseClockProps, DesktopOnlyTimePickerProps } from './models/props/clock';
+export type { BaseClockProps, DesktopOnlyTimePickerProps, AmPmProps } from './models/props/time';
 export type { BaseTabsProps, ExportedBaseTabsProps } from './models/props/tabs';
 export type { BaseToolbarProps, ExportedBaseToolbarProps } from './models/props/toolbar';
 export type {

--- a/packages/x-date-pickers/src/internals/models/props/time.ts
+++ b/packages/x-date-pickers/src/internals/models/props/time.ts
@@ -1,21 +1,23 @@
 import { SxProps, Theme } from '@mui/material/styles';
-import { BaseTimeValidationProps, TimeValidationProps } from '../validation';
 import { PickerValidDate, TimeStepOptions, TimezoneProps } from '../../../models';
 import type { ExportedDigitalClockProps } from '../../../DigitalClock/DigitalClock.types';
 import type { ExportedMultiSectionDigitalClockProps } from '../../../MultiSectionDigitalClock/MultiSectionDigitalClock.types';
 import type { ExportedUseViewsOptions } from '../../hooks/useViews';
 import { TimeViewWithMeridiem } from '../common';
+import { ExportedValidateTimeProps } from '../../../validation/validateTime';
 
-export interface ExportedBaseClockProps<TDate extends PickerValidDate>
-  extends TimeValidationProps<TDate>,
-    BaseTimeValidationProps,
-    TimezoneProps {
+export interface AmPmProps {
   /**
    * 12h/24h view for hour selection clock.
    * @default utils.is12HourCycleInCurrentLocale()
    */
   ampm?: boolean;
 }
+
+export interface ExportedBaseClockProps<TDate extends PickerValidDate>
+  extends ExportedValidateTimeProps<TDate>,
+    TimezoneProps,
+    AmPmProps {}
 
 export interface BaseClockProps<TDate extends PickerValidDate, TView extends TimeViewWithMeridiem>
   extends ExportedUseViewsOptions<TView>,

--- a/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/date-time-utils.ts
@@ -9,7 +9,7 @@ import {
 import { resolveTimeFormat, isTimeView, isInternalTimeView } from './time-utils';
 import { isDatePickerView, resolveDateFormat } from './date-utils';
 import { DateOrTimeViewWithMeridiem } from '../models';
-import { DesktopOnlyTimePickerProps } from '../models/props/clock';
+import { DesktopOnlyTimePickerProps } from '../models/props/time';
 import { DefaultizedProps } from '../models/helpers';
 
 export const resolveDateTimeFormat = <TDate extends PickerValidDate>(

--- a/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
+++ b/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TimeClock, TimeClockProps } from '../TimeClock';
 import { PickerValidDate, TimeView } from '../models';
 import { DigitalClock, DigitalClockProps } from '../DigitalClock';
-import { BaseClockProps } from '../internals/models/props/clock';
+import { BaseClockProps } from '../internals/models/props/time';
 import {
   MultiSectionDigitalClock,
   MultiSectionDigitalClockProps,

--- a/packages/x-date-pickers/src/validation/validateDate.ts
+++ b/packages/x-date-pickers/src/validation/validateDate.ts
@@ -9,6 +9,15 @@ import { DateValidationError, PickerValidDate } from '../models';
 import { applyDefaultDate } from '../internals/utils/date-utils';
 import { singleItemValueManager } from '../internals/utils/valueManagers';
 
+/**
+ * Validation props used by the Date Picker, Date Field and Date Calendar components.
+ */
+export interface ExportedValidateDateProps<TDate extends PickerValidDate>
+  extends DayValidationProps<TDate>,
+    MonthValidationProps<TDate>,
+    YearValidationProps<TDate>,
+    BaseDateValidationProps<TDate> {}
+
 export interface ValidateDateProps<TDate extends PickerValidDate>
   extends DayValidationProps<TDate>,
     MonthValidationProps<TDate>,

--- a/packages/x-date-pickers/src/validation/validateDateTime.ts
+++ b/packages/x-date-pickers/src/validation/validateDateTime.ts
@@ -1,8 +1,17 @@
 import { Validator } from './useValidation';
-import { validateDate, ValidateDateProps } from './validateDate';
-import { validateTime, ValidateTimeProps } from './validateTime';
+import { ExportedValidateDateProps, validateDate, ValidateDateProps } from './validateDate';
+import { ExportedValidateTimeProps, validateTime, ValidateTimeProps } from './validateTime';
 import { DateTimeValidationError, PickerValidDate } from '../models';
 import { singleItemValueManager } from '../internals/utils/valueManagers';
+import { DateTimeValidationProps } from '../internals/models/validation';
+
+/**
+ * Validation props used by the Date Time Picker and Date Time Field components.
+ */
+export interface ExportedValidateDateTimeProps<TDate extends PickerValidDate>
+  extends ExportedValidateDateProps<TDate>,
+    ExportedValidateTimeProps<TDate>,
+    DateTimeValidationProps<TDate> {}
 
 export interface ValidateDateTimeProps<TDate extends PickerValidDate>
   extends ValidateDateProps<TDate>,

--- a/packages/x-date-pickers/src/validation/validateTime.ts
+++ b/packages/x-date-pickers/src/validation/validateTime.ts
@@ -4,6 +4,13 @@ import { BaseTimeValidationProps, TimeValidationProps } from '../internals/model
 import { PickerValidDate, TimeValidationError } from '../models';
 import { singleItemValueManager } from '../internals/utils/valueManagers';
 
+/**
+ * Validation props used by the Time Picker, Time Field and Clock components.
+ */
+export interface ExportedValidateTimeProps<TDate extends PickerValidDate>
+  extends BaseTimeValidationProps,
+    TimeValidationProps<TDate> {}
+
 export interface ValidateTimeProps<TDate extends PickerValidDate>
   extends Required<BaseTimeValidationProps>,
     TimeValidationProps<TDate> {}


### PR DESCRIPTION
Extracted from #15194

We had some duplication of the props needed to validate a date, to validate a time etc...
In #15194, I want to stop using interfaces like `UseDateFieldProps` to generate interfaces like `DatePickerFieldProps`, and I don't want to duplicate yet another time those interfaces.
So I added one interface per validator (e.g: `ExportedValidateDateProps`) that contains the props as they should be exposed by the component (picker, view, built-in field, custom field etc...). The next step would be to colocate the method to apply the default values, which are currently duplicated between fields and pickers (I did it in #14679 but I'll extract it of course).