### PR TITLE
[DataGridPremium] Fix incorrect rows selection count when selection propagation is enabled with row grouping

### DIFF
--- a/packages/x-data-grid-premium/src/tests/rowSelection.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/rowSelection.DataGridPremium.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent } from '@mui/internal-test-utils';
 import { getCell } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import {
@@ -120,6 +120,24 @@ describe('<DataGridPremium /> - Row selection', () => {
       ]);
       fireEvent.click(getCell(2, 0).querySelector('input')!);
       expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2]);
+    });
+
+    // Context: https://github.com/mui/mui-x/issues/15206
+    it('should keep the correct selection items and the selection count when rows are updated', () => {
+      render(<Test />);
+
+      const expectedKeys = ['auto-generated-row-category1/Cat B', 3, 4];
+      const expectedCount = 3;
+
+      fireEvent.click(getCell(1, 0).querySelector('input')!);
+      expect(apiRef.current.getSelectedRows()).to.have.keys(expectedKeys);
+      expect(apiRef.current.state.rowSelection.length).to.equal(expectedCount);
+
+      act(() => {
+        apiRef.current.updateRows([...rows]);
+      });
+      expect(apiRef.current.getSelectedRows()).to.have.keys(expectedKeys);
+      expect(apiRef.current.state.rowSelection.length).to.equal(expectedCount);
     });
 
     describe("prop: indeterminateCheckboxAction = 'select'", () => {


### PR DESCRIPTION
Fixes #15206 

The issue occurs when `rowSelectionPropagation` is used on a grid with grouped columns and the data is updated.
After update, new selection lookup is being created, but the autogenerated rows are being added multiple times to the selection lookup array

Thing is, API to fetch the selection list uses selector that returns a `Map`, which removes duplicate values, so the issue is only visible on the count (which operates on the actual array).

Now, the selection lookup is rebuilt using the `Map` as well.

Duplicate values are coming from checking the parent for selection for each grouped row