### PR TITLE
[docs] Fix missing punctuation on descriptions

### DIFF
--- a/docs/data/data-grid/joy-ui/joy-ui.md
+++ b/docs/data/data-grid/joy-ui/joy-ui.md
@@ -1,5 +1,5 @@
 # Data Grid - Joy UI
 
-<p class="description">Using the Data Grid with Joy UI components</p>
+<p class="description">Using the Data Grid with Joy UI components.</p>
 
 {{"demo": "GridJoyUISlots.js", "bg": "inline"}}

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -8,7 +8,7 @@ components: PickersSectionList, PickersTextField
 
 # Custom field
 
-<p class="description">The Date and Time Pickers let you customize the field by passing props or custom components</p>
+<p class="description">The Date and Time Pickers let you customize the field by passing props or custom components.</p>
 
 :::success
 See [Common concepts—Custom slots and subcomponents](/x/common-concepts/custom-components/) to learn how to use slots.

--- a/docs/data/date-pickers/custom-layout/custom-layout.md
+++ b/docs/data/date-pickers/custom-layout/custom-layout.md
@@ -8,7 +8,7 @@ packageName: '@mui/x-date-pickers'
 
 # Custom layout
 
-<p class="description">The Date and Time Pickers let you reorganize the layout</p>
+<p class="description">The Date and Time Pickers let you reorganize the layout.</p>
 
 :::success
 See [Common concepts—Custom slots and subcomponents](/x/common-concepts/custom-components/) to learn how to use slots.

--- a/docs/data/date-pickers/experimentation/experimentation.md
+++ b/docs/data/date-pickers/experimentation/experimentation.md
@@ -4,4 +4,4 @@ productId: x-date-pickers
 
 # Date and Time Pickers experimentation
 
-<p class="description">Demos not accessible through the navbar of the doc</p>
+<p class="description">Demos not accessible through the navbar of the doc.</p>


### PR DESCRIPTION
Make the next docs-infra upgrade easier for https://github.com/mui/material-ui/pull/44292.