### PR TITLE
[charts] perf: getSymbol

### DIFF
--- a/packages/x-charts/src/internals/getSymbol.ts
+++ b/packages/x-charts/src/internals/getSymbol.ts
@@ -1,7 +1,14 @@
 export type SymbolsTypes = 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye';
-// Returns the index of a defined shape
-export function getSymbol(shape: SymbolsTypes): number {
-  const symbolNames = 'circle cross diamond square star triangle wye'.split(/ /);
 
-  return symbolNames.indexOf(shape) || 0;
+export function getSymbol(shape: SymbolsTypes): number {
+  switch (shape) {
+    case 'circle':   return 0;
+    case 'cross':    return 1;
+    case 'diamond':  return 2;
+    case 'square':   return 3;
+    case 'star':     return 4;
+    case 'triangle': return 5;
+    case 'wye':      return 6;
+    default:         return 0;
+  }
 }


### PR DESCRIPTION
From what I read in https://github.com/mui/mui-x/pull/15220, you seem to use this function in hot codepaths. It's going to hurt the performance to have that many memory allocations all over the place. Also the implementation has a small issue, `indexOf(...) || 0` is incorrect, the empty value of `indexOf()` is `-1`.

I benchmarked a [few different versions](https://jsben.ch/LLeJF) to illustrate the difference:

<img src="https://github.com/user-attachments/assets/4acc9605-5266-43ce-99ba-006f494a9f37" width="400" />

So even a change as small as moving the static line `const symbolNames = 'circle cross diamond square star triangle wye'.split(/ /)` to the outside of the function makes the function 2-3x faster, and diminishes the amount of time spent doing GC work.