### PR TITLE
[test] Fix advanced list view regression test snapshot

### DIFF
--- a/docs/data/data-grid/list-view/ListViewAdvanced.js
+++ b/docs/data/data-grid/list-view/ListViewAdvanced.js
@@ -258,7 +258,13 @@ export default function ListViewAdvanced() {
   return (
     <React.Fragment>
       <CSSBaseline />
-      <div ref={containerRef} style={{ maxWidth: '100%' }}>
+      <div
+        ref={containerRef}
+        style={{
+          maxWidth: '100%',
+          height: 600,
+        }}
+      >
         <DataGridPremium
           apiRef={apiRef}
           rows={rows}

--- a/docs/data/data-grid/list-view/ListViewAdvanced.tsx
+++ b/docs/data/data-grid/list-view/ListViewAdvanced.tsx
@@ -275,7 +275,13 @@ export default function ListViewAdvanced() {
   return (
     <React.Fragment>
       <CSSBaseline />
-      <div ref={containerRef} style={{ maxWidth: '100%' }}>
+      <div
+        ref={containerRef}
+        style={{
+          maxWidth: '100%',
+          height: 600,
+        }}
+      >
         <DataGridPremium
           apiRef={apiRef}
           rows={rows}


### PR DESCRIPTION
The Argos test for the advanced list view demo is flaky https://app.argos-ci.com/mui/mui-x/builds/25941/116803997

I suspect this is due to there not being a height on the demo.