### PR TITLE
[docs] Fix peer dependency range

### DIFF
--- a/packages/x-charts-pro/README.md
+++ b/packages/x-charts-pro/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-charts-pro
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-charts/README.md
+++ b/packages/x-charts/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-charts
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-data-grid-premium/README.md
+++ b/packages/x-data-grid-premium/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-data-grid-premium
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-data-grid-pro/README.md
+++ b/packages/x-data-grid-pro/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-data-grid-pro
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-data-grid/README.md
+++ b/packages/x-data-grid/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-data-grid
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -30,11 +30,11 @@ npm install luxon
 npm install moment
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -30,11 +30,11 @@ npm install luxon
 npm install moment
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-tree-view-pro/README.md
+++ b/packages/x-tree-view-pro/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-tree-view-pro
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },

--- a/packages/x-tree-view/README.md
+++ b/packages/x-tree-view/README.md
@@ -11,11 +11,11 @@ Install the package in your project directory with:
 npm install @mui/x-tree-view
 ```
 
-This component has the following peer dependencies that you will need to install as well.
+This component has the following peer dependencies that you need to install as well.
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14",
+  "@mui/material": "^5.15.14 || ^6.0.0",
   "react": "^17.0.0 || ^18.0.0",
   "react-dom": "^17.0.0 || ^18.0.0"
 },


### PR DESCRIPTION
I noticed this in https://www.npmjs.com/package/@mui/x-charts, it's a turn-off for adopting the lib. This was forgotten in #14142.

**Off-topic.** we might miss React 19 here in the peer dependency, needed to use Next.js 15.