### PR TITLE
[docs] Use `PickersTextField` in the customization playground

### DIFF
--- a/docs/data/date-pickers/date-picker/examplesConfig.styling.tsx
+++ b/docs/data/date-pickers/date-picker/examplesConfig.styling.tsx
@@ -265,24 +265,25 @@ export const datePickerExamples: PickersSubcomponentType = {
     },
     slots: ['root', 'monthButton'],
   },
-  TextField: {
+  PickersTextField: {
     examples: {
       customTheme: {
         type: 'info',
         comments:
-          'This approach would change the styles of all the TextField components in the application. Consider using a nested theme with this style wrapping your local picker component to isolate this override',
+          'This approach would change the styles of all the PickersTextField components in the application. Consider using a nested theme with this style wrapping your local picker component to isolate this override',
       },
       sxProp: {
         type: 'success',
         parentSlot: 'textField',
         current: true,
-        comments: 'You can apply the sx prop to the `TextField` via slotProps',
+        comments:
+          'You can apply the sx prop to the `PickersTextField` via slotProps',
       },
       styledComponents: {
         type: 'success',
         parentSlot: 'textField',
-        parentComponent: 'TextField',
-        comments: 'You can style the `TextField` component directly',
+        parentComponent: 'PickersTextField',
+        comments: 'You can style the `PickersTextField` component directly',
         current: true,
       },
     },


### PR DESCRIPTION
Part of #15263.

Currently, we render Pickers in the demo with `enableAccessibleFieldDOMStructure` set to `true`.
This makes the customization to not apply in case of the `TextField` slot, because the theme entry is different (`MuiPickersTextField` instead of `MuiTextField`).

| Before | After |
|--------|--------|
| ![Screenshot 2024-11-05 at 18 35 11](https://github.com/user-attachments/assets/a4a5c5ae-ae24-431a-9d85-dd32449d13a0) | ![Screenshot 2024-11-05 at 18 35 33](https://github.com/user-attachments/assets/33c8f8c0-cdbd-4826-950b-831c556ae4aa) |

WDYT about the link to the Material Text field customization page?
Does it still make sense? 🤔 