### PR TITLE
[DataGrid] Consider flex gap when auto resizing with `includeHeaders` option 

### DIFF
--- a/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -579,7 +579,7 @@ describe('<DataGridPro /> - Columns', () => {
       });
 
       it('.includeHeaders works', async () => {
-        await autosize({ includeHeaders: true }, [211, 233]);
+        await autosize({ includeHeaders: true }, [211, 235]);
       });
 
       it('.includeOutliers works', async () => {

--- a/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -579,7 +579,7 @@ describe('<DataGridPro /> - Columns', () => {
       });
 
       it('.includeHeaders works', async () => {
-        await autosize({ includeHeaders: true }, [211, 235]);
+        await autosize({ includeHeaders: true }, [211, 233]);
       });
 
       it('.includeOutliers works', async () => {

--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -216,7 +216,7 @@ function extractColumnWidths(
         const style = window.getComputedStyle(header, null);
         const titleContainerStyle = window.getComputedStyle(titleContainer, null);
         const paddingWidth = parseInt(style.paddingLeft, 10) + parseInt(style.paddingRight, 10);
-        const flexGap = iconContainer ? parseInt(titleContainerStyle.gap, 10) : 0;
+        const flexGap = iconContainer && !menuContainer ? parseInt(titleContainerStyle.gap, 10) : 0;
         const contentWidth = element.scrollWidth + 1;
         const width =
           contentWidth +

--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -208,19 +208,22 @@ function extractColumnWidths(
       const header = findGridHeader(apiRef.current, column.field);
       if (header) {
         const title = header.querySelector(`.${gridClasses.columnHeaderTitle}`);
+        const titleContainer = header.querySelector(`.${gridClasses.columnHeaderTitleContainer}`)!;
         const content = header.querySelector(`.${gridClasses.columnHeaderTitleContainerContent}`)!;
         const iconContainer = header.querySelector(`.${gridClasses.iconButtonContainer}`);
         const menuContainer = header.querySelector(`.${gridClasses.menuIcon}`);
         const element = title ?? content;
-
         const style = window.getComputedStyle(header, null);
+        const titleContainerStyle = window.getComputedStyle(titleContainer, null);
         const paddingWidth = parseInt(style.paddingLeft, 10) + parseInt(style.paddingRight, 10);
+        const flexGap = iconContainer ? parseInt(titleContainerStyle.gap, 10) : 0;
         const contentWidth = element.scrollWidth + 1;
         const width =
           contentWidth +
           paddingWidth +
           (iconContainer?.clientWidth ?? 0) +
-          (menuContainer?.clientWidth ?? 0);
+          (menuContainer?.clientWidth ?? 0) +
+          flexGap;
 
         filteredWidths.push(width);
       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/mui-x/issues/15266

Problem arises due to the change in the column header design [here](https://github.com/mui/mui-x/pull/14293/files#diff-e1db53193a627d36d1cd3f651a954ee1e32ecb93caa020446631d722bb1be75cR348). 
When the menu icon is present, the gap is not sufficient to cause the text to be clipped. However, when the menu icon is disabled using the `disableColumnMenu` prop, space is available for the columnHeaderTitleContainer to stretch completely, and a full gap of 2px is present. This causes the text to be clipped because we do not consider this gap during width calculation.

Not Related to this PR but might be helpful - https://github.com/mui/mui-x/pull/10666  

Before: https://codesandbox.io/p/sandbox/stupefied-hawking-6vsm9f
After: https://codesandbox.io/p/sandbox/mui-mui-x-x-data-grid-forked-6gvpf6