### PR TITLE
[docs] Fix hard coded URL domain

### DIFF
--- a/docs/data/data-grid/editing/editing.md
+++ b/docs/data/data-grid/editing/editing.md
@@ -175,8 +175,9 @@ The value returned is used later as an argument on a call to `apiRef.current.upd
 />
 ```
 
-If you want to delete a row from the internal state of the Data Grid, you can return an additional property `_action: 'delete'` in the row object from the `processRowUpdate` callback. This will remove the row from the internal state of the Data Grid.
-It is a more performant way to delete a row as compared to updating the [`rows` prop](/x/react-data-grid/row-updates/#the-rows-prop) or using `setRows()` API method because `processRowUpdate` uses the [`updateRows()`](https://mui.com/x/react-data-grid/row-updates/#the-updaterows-method) under the hood which doesn't cause a full regeneration of the row tree.
+If you want to delete a row from the internal state of the Data Grid, you can return an additional property `_action: 'delete'` in the row object from the `processRowUpdate` callback.
+This removes the row from the internal state of the Data Grid.
+It is a more performant way to delete a row as compared to updating the [`rows` prop](/x/react-data-grid/row-updates/#the-rows-prop) or using `setRows()` API method because `processRowUpdate` uses the [`updateRows()`](/x/react-data-grid/row-updates/#the-updaterows-method) under the hood which doesn't cause a full regeneration of the row tree.
 
 ```tsx
 <DataGrid

--- a/docs/data/data-grid/filtering/header-filters.md
+++ b/docs/data/data-grid/filtering/header-filters.md
@@ -49,7 +49,7 @@ The following demo uses the `renderHeaderFilter` method to customize the header 
 
 ### Customize using `filterOperators`
 
-If the filter operator has a [custom `InputComponent`](/x/react-data-grid/filtering/#custom-input-component), the same component is being used for the header filter.
+If the filter operator has a [custom `InputComponent`](/x/react-data-grid/filtering/customization/#custom-input-component), the same component is being used for the header filter.
 
 When rendered as a header filter, the `InputComponent` also receives the `headerFilterMenu` and `clearButton` props that contain the filter operator menu and clear button.
 

--- a/docs/data/data-grid/filtering/header-filters.md
+++ b/docs/data/data-grid/filtering/header-filters.md
@@ -49,7 +49,7 @@ The following demo uses the `renderHeaderFilter` method to customize the header 
 
 ### Customize using `filterOperators`
 
-If the filter operator has a [custom `InputComponent`](https://mui.com/x/react-data-grid/filtering/#custom-input-component), the same component is being used for the header filter.
+If the filter operator has a [custom `InputComponent`](/x/react-data-grid/filtering/#custom-input-component), the same component is being used for the header filter.
 
 When rendered as a header filter, the `InputComponent` also receives the `headerFilterMenu` and `clearButton` props that contain the filter operator menu and clear button.
 

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -136,7 +136,7 @@ The data source changes how the existing server-side features like `filtering`, 
 **Without data source**
 
 When there's no data source, the features `filtering`, `sorting`, `pagination` work on `client` by default.
-In order for them to work with server-side data, you need to set them to `server` explicitly and provide the [`onFilterModelChange`](https://mui.com/x/react-data-grid/filtering/server-side/), [`onSortModelChange`](https://mui.com/x/react-data-grid/sorting/#server-side-sorting), [`onPaginationModelChange`](https://mui.com/x/react-data-grid/pagination/#server-side-pagination) event handlers to fetch the data from the server based on the updated variables.
+In order for them to work with server-side data, you need to set them to `server` explicitly and provide the [`onFilterModelChange`](/x/react-data-grid/filtering/server-side/), [`onSortModelChange`](/x/react-data-grid/sorting/#server-side-sorting), [`onPaginationModelChange`](/x/react-data-grid/pagination/#server-side-pagination) event handlers to fetch the data from the server based on the updated variables.
 
 ```tsx
 <DataGrid

--- a/docs/data/data-grid/state/state.md
+++ b/docs/data/data-grid/state/state.md
@@ -11,7 +11,7 @@ This prop has the same format as the returned value of `apiRef.current.exportSta
 The `initialState` can only be used to set the initial value of the state.
 The Data Grid will not react if you change the `initialState` value later on.
 
-If you need to fully control specific models, use the control props instead (for example [`prop.filterModel`](/x/react-data-grid/filtering/#controlled-filters) or [`prop.sortModel`](https://mui.com/x/react-data-grid/sorting/#controlled-sort-model)).
+If you need to fully control specific models, use the control props instead (for example [`prop.filterModel`](/x/react-data-grid/filtering/#controlled-filters) or [`prop.sortModel`](/x/react-data-grid/sorting/#controlled-sort-model)).
 You can find more information on the corresponding feature documentation page.
 :::
 

--- a/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
+++ b/docs/data/migration/migration-data-grid-v5/migration-data-grid-v5.md
@@ -167,7 +167,7 @@ The minimum supported Node.js version has been changed from 12.0.0 to 14.0.0, si
 
 - ✅ The `selectionChange` event was renamed to `rowSelectionChange`.
 - ✅ The `rowsScroll` event was renamed to `scrollPositionChange`.
-- The `columnVisibilityChange` event was removed. Use [`columnVisibilityModelChange`](https://mui.com/x/react-data-grid/events/#catalog-of-events) instead.
+- The `columnVisibilityChange` event was removed. Use [`columnVisibilityModelChange`](https://v6.mui.com/x/react-data-grid/events/#catalog-of-events) instead.
 - The `cellNavigationKeyDown` event was removed. Use `cellKeyDown` and check the key provided in the event argument.
 - The `columnHeaderNavigationKeyDown` event was removed. Use `columnHeaderKeyDown` and check the key provided in the event argument.
 - The `cellKeyDown` event will also be fired for keyboard events that occur inside components that use Portals.
@@ -200,7 +200,7 @@ To know more about the supported events and their signatures, check the [events 
 
 ### Columns
 
-- The `GridColDef['hide']` property was removed. Use [`columnVisibilityModel`](https://mui.com/x/react-data-grid/column-visibility/#initialize-the-visible-columns) instead.
+- The `GridColDef['hide']` property was removed. Use [`columnVisibilityModel`](https://v6.mui.com/x/react-data-grid/column-visibility/#initialize-the-visible-columns) instead.
 - Returning `null` in `column.renderCell` or `column.renderEditCell` now renders an empty cell instead of the default formatted value. To fall back to the default formatted value, return `undefined` instead of `null`.
 
   ```diff
@@ -225,7 +225,7 @@ To know more about the supported events and their signatures, check the [events 
 
   This prop accepts a callback that is called with the item from `valueOptions` and must return the string to use as new label.
 
-- The `date` and `dateTime` columns now only support `Date` objects as values. To parse a string value, use the [`valueGetter`](https://mui.com/x/react-data-grid/column-definition/#value-getter):
+- The `date` and `dateTime` columns now only support `Date` objects as values. To parse a string value, use the [`valueGetter`](https://v6.mui.com/x/react-data-grid/column-definition/#value-getter):
 
   ```tsx
   <DataGrid
@@ -423,14 +423,14 @@ Most of this breaking change is handled by `preset-safe` codemod but some furthe
   ```
 - The `editCellPropsChange` event was removed. If you still need it please file a new issue so we can propose an alternative.
 - The `cellEditCommit` event was removed and the `processRowUpdate` prop can be used in place. More information, check the [docs](https://mui.com/x/react-data-grid/editing/#server-side-persistence) section about the topic.
-- The `editRowsModel` and `onEditRowsModelChange` props were removed. The [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props can be used to achieve the same goal.
+- The `editRowsModel` and `onEditRowsModelChange` props were removed. The [`cellModesModel`](https://v6.mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://v6.mui.com/x/react-data-grid/editing/#controlled-mode) props can be used to achieve the same goal.
 - The `GridEditRowsModel` type was removed.
 - The following API methods were removed:
   - Use `apiRef.current.stopCellEditMode` to replace `apiRef.current.commitCellChange`
   - Use `apiRef.current.startCellEditMode` to replace `apiRef.current.setCellMode(id, field, 'edit')`
   - Use `apiRef.current.stopRowEditMode` to replace `apiRef.current.commitRowChange`
   - Use `apiRef.current.startRowMode` to replace `apiRef.current.setRowMode(id, 'edit')`
-  - Use the [`cellModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://mui.com/x/react-data-grid/editing/#controlled-mode) props to replace `apiRef.current.setEditRowsModel`.
+  - Use the [`cellModesModel`](https://v6.mui.com/x/react-data-grid/editing/#controlled-mode) or [`rowModesModel`](https://v6.mui.com/x/react-data-grid/editing/#controlled-mode) props to replace `apiRef.current.setEditRowsModel`.
 
 ### Other exports
 


### PR DESCRIPTION
A side quick win I noticed while wanting to help with #15251.

The objective of this change is to make sure the URLs keep working even when using the docs on a different domain, e.g. localhost and for `pnpm docs:link-check` to catch broken links.

Today, it's even more relevant in the way that the docs is versioned: with subdomains. Now unclear if we will keep using subdomains for docs versioning, using folders is also quite common.

@vladmoroz We likely don't want to start thinking now on how we will version Base UI docs. A good chunk of docs use subfolders (Material UI used subdomains so far), maybe they do this for SEO to reinforce backlinks on a single domain, or maybe to make it impossible to have duplication of other pages, e.g. marketing homepage.
Anyway, creating this page as we have time: https://www.notion.so/mui-org/docs-infra-How-to-version-docs-138cbfe7b66080f78d3bd679deec8fa9.