### PR TITLE
[docs][data grid] Polish Server-side data section

### DIFF
--- a/docs/data/data-grid/column-spanning/column-spanning.md
+++ b/docs/data/data-grid/column-spanning/column-spanning.md
@@ -2,7 +2,6 @@
 
 <p class="description">Span cells across several columns.</p>
 
-
 By default, each cell takes up the width of one column.
 You can modify this behavior with column spanning.
 It allows cells to span multiple columns.

--- a/docs/data/data-grid/column-spanning/column-spanning.md
+++ b/docs/data/data-grid/column-spanning/column-spanning.md
@@ -2,6 +2,10 @@
 
 <p class="description">Span cells across several columns.</p>
 
+:::warning
+This feature is marked as **unstable**. While you can use this feature in production, the API could change in the future.
+:::
+
 By default, each cell takes up the width of one column.
 You can modify this behavior with column spanning.
 It allows cells to span multiple columns.

--- a/docs/data/data-grid/column-spanning/column-spanning.md
+++ b/docs/data/data-grid/column-spanning/column-spanning.md
@@ -2,10 +2,6 @@
 
 <p class="description">Span cells across several columns.</p>
 
-:::warning
-This feature is marked as **unstable**. While you can use this feature in production, the API could change in the future.
-:::
-
 By default, each cell takes up the width of one column.
 You can modify this behavior with column spanning.
 It allows cells to span multiple columns.

--- a/docs/data/data-grid/column-spanning/column-spanning.md
+++ b/docs/data/data-grid/column-spanning/column-spanning.md
@@ -2,6 +2,7 @@
 
 <p class="description">Span cells across several columns.</p>
 
+
 By default, each cell takes up the width of one column.
 You can modify this behavior with column spanning.
 It allows cells to span multiple columns.

--- a/docs/data/data-grid/list-view/list-view.md
+++ b/docs/data/data-grid/list-view/list-view.md
@@ -6,15 +6,15 @@ title: Data Grid - List view
 
 <p class="description">Display data in a single-column list view. Can be used to present a more compact grid on smaller screens and mobile devices.</p>
 
+:::warning
+This feature is marked as **unstable**. While you can use this feature in production, the API could change in the future.
+:::
+
 List view can be enabled by providing the `unstable_listView` prop.
 
 Unlike the default grid view, the list view makes no assumptions on how data is presented to end users.
 
 In order to display data in a list view, a `unstable_listColumn` prop must be provided with a `renderCell` function.
-
-:::warning
-This feature is under development and is marked as **unstable**. While you can use the list view feature in production, the API could change in the future.
-:::
 
 {{"demo": "ListView.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/list-view/list-view.md
+++ b/docs/data/data-grid/list-view/list-view.md
@@ -2,7 +2,7 @@
 title: Data Grid - List view
 ---
 
-# Data Grid - List view [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+# Data Grid - List view [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🧪
 
 <p class="description">Display data in a single-column list view. Can be used to present a more compact grid on smaller screens and mobile devices.</p>
 

--- a/docs/data/data-grid/row-spanning/row-spanning.md
+++ b/docs/data/data-grid/row-spanning/row-spanning.md
@@ -2,6 +2,10 @@
 
 <p class="description">Span cells across several rows.</p>
 
+:::warning
+This feature is marked as **unstable**. While you can use this feature in production, the API could change in the future.
+:::
+
 By default, each cell in a Data Grid takes up the height of one row.
 The row spanning feature makes it possible for a cell to fill multiple rows in a single column.
 

--- a/docs/data/data-grid/row-spanning/row-spanning.md
+++ b/docs/data/data-grid/row-spanning/row-spanning.md
@@ -1,4 +1,4 @@
-# Data Grid - Row spanning
+# Data Grid - Row spanning 🧪
 
 <p class="description">Span cells across several rows.</p>
 

--- a/docs/data/data-grid/server-side-data/ServerSideDataGrid.js
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGrid.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DataGridPro } from '@mui/x-data-grid-pro';
 import { useMockServer } from '@mui/x-data-grid-generator';
 
-function ServerSideDataGrid() {
+export default function ServerSideDataGrid() {
   const { columns, initialState, fetchRows } = useMockServer(
     {},
     { useCursorPagination: false },
@@ -51,5 +51,3 @@ function ServerSideDataGrid() {
     </div>
   );
 }
-
-export default ServerSideDataGrid;

--- a/docs/data/data-grid/server-side-data/ServerSideDataGrid.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGrid.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DataGridPro, GridDataSource } from '@mui/x-data-grid-pro';
 import { useMockServer } from '@mui/x-data-grid-generator';
 
-function ServerSideDataGrid() {
+export default function ServerSideDataGrid() {
   const { columns, initialState, fetchRows } = useMockServer(
     {},
     { useCursorPagination: false },
@@ -51,5 +51,3 @@ function ServerSideDataGrid() {
     </div>
   );
 }
-
-export default ServerSideDataGrid;

--- a/docs/data/data-grid/server-side-data/ServerSideDataGrid.tsx.preview
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGridPro
+  columns={columns}
+  unstable_dataSource={dataSource}
+  pagination
+  initialState={initialStateWithPagination}
+  pageSizeOptions={[10, 20, 50]}
+/>

--- a/docs/data/data-grid/server-side-data/ServerSideDataGridTTL.js
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGridTTL.js
@@ -4,7 +4,7 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 
 const lowTTLCache = new GridDataSourceCacheDefault({ ttl: 1000 * 10 }); // 10 seconds
 
-function ServerSideDataGridTTL() {
+export default function ServerSideDataGridTTL() {
   const { columns, initialState, fetchRows } = useMockServer(
     {},
     { useCursorPagination: false },
@@ -54,5 +54,3 @@ function ServerSideDataGridTTL() {
     </div>
   );
 }
-
-export default ServerSideDataGridTTL;

--- a/docs/data/data-grid/server-side-data/ServerSideDataGridTTL.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGridTTL.tsx
@@ -8,7 +8,7 @@ import { useMockServer } from '@mui/x-data-grid-generator';
 
 const lowTTLCache = new GridDataSourceCacheDefault({ ttl: 1000 * 10 }); // 10 seconds
 
-function ServerSideDataGridTTL() {
+export default function ServerSideDataGridTTL() {
   const { columns, initialState, fetchRows } = useMockServer(
     {},
     { useCursorPagination: false },
@@ -58,5 +58,3 @@ function ServerSideDataGridTTL() {
     </div>
   );
 }
-
-export default ServerSideDataGridTTL;

--- a/docs/data/data-grid/server-side-data/ServerSideDataGridTTL.tsx.preview
+++ b/docs/data/data-grid/server-side-data/ServerSideDataGridTTL.tsx.preview
@@ -1,0 +1,8 @@
+<DataGridPro
+  columns={columns}
+  unstable_dataSource={dataSource}
+  unstable_dataSourceCache={lowTTLCache}
+  pagination
+  initialState={initialStateWithPagination}
+  pageSizeOptions={[10, 20, 50]}
+/>

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -132,7 +132,7 @@ The code has been significantly reduced, the need for managing the controlled st
 
 The data source changes how the existing server-side features like `filtering`, `sorting`, and `pagination` work.
 
-**Without data source**
+### Without data source
 
 When there's no data source, the features `filtering`, `sorting`, `pagination` work on `client` by default.
 In order for them to work with server-side data, you need to set them to `server` explicitly and provide the [`onFilterModelChange`](https://mui.com/x/react-data-grid/filtering/server-side/), [`onSortModelChange`](https://mui.com/x/react-data-grid/sorting/#server-side-sorting), [`onPaginationModelChange`](https://mui.com/x/react-data-grid/pagination/#server-side-pagination) event handlers to fetch the data from the server based on the updated variables.
@@ -157,7 +157,7 @@ In order for them to work with server-side data, you need to set them to `server
 />
 ```
 
-**With data source**
+### With data source
 
 With the data source, the features `filtering`, `sorting`, `pagination` are automatically set to `server`.
 
@@ -187,9 +187,7 @@ Open info section of the browser console to see the requests being made and the 
 The data source caches fetched data by default.
 This means that if the user navigates to a page or expands a node that has already been fetched, the grid will not call the `getRows` function again to avoid unnecessary calls to the server.
 
-The `GridDataSourceCacheDefault` is used by default which is a simple in-memory cache that stores the data in a plain object. It can be seen in action in the demo below.
-
-{{"demo": "ServerSideDataGrid.js", "bg": "inline"}}
+The `GridDataSourceCacheDefault` is used by default which is a simple in-memory cache that stores the data in a plain object. It can be seen in action in the [demo above](#with-data-source).
 
 ### Customize the cache lifetime
 

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -2,7 +2,7 @@
 title: React Data Grid - Server-side data
 ---
 
-# Data Grid - Server-side data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+# Data Grid - Server-side data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🧪
 
 <p class="description">The Data Grid server-side data.</p>
 

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -88,8 +88,9 @@ Let's take a look at the minimal `GridDataSource` interface configuration.
 interface GridDataSource {
   /**
    * This method will be called when the grid needs to fetch some rows.
-   * @param {GridGetRowsParams} params The parameters required to fetch the rows
-   * @returns {Promise<GridGetRowsResponse>} A promise that resolves to the data of type [GridGetRowsResponse]
+   * @param {GridGetRowsParams} params The parameters required to fetch the rows.
+   * @returns {Promise<GridGetRowsResponse>} A promise that resolves to the data of
+   * type [GridGetRowsResponse].
    */
   getRows(params: GridGetRowsParams): Promise<GridGetRowsResponse>;
 }
@@ -167,7 +168,8 @@ When the corresponding models update, the Data Grid calls the `getRows` method w
 ```tsx
 <DataGridPro
   columns={columns}
-  unstable_dataSource={customDataSource} // automatically sets `sortingMode="server"`, `filterMode="server"`, `paginationMode="server"`
+  // automatically sets `sortingMode="server"`, `filterMode="server"`, `paginationMode="server"`
+  unstable_dataSource={customDataSource}
 />
 ```
 

--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -6,6 +6,12 @@ title: React Data Grid - Server-side data
 
 <p class="description">The Data Grid server-side data.</p>
 
+:::warning
+This feature is under development and is marked as **unstable**.
+While you can use this feature in production, the API could change in the future.
+Feel free to subscribe or comment on the official GitHub [umbrella issue](https://github.com/mui/mui-x/issues/8179).
+:::
+
 ## Introduction
 
 Server-side data management in React can become complex with growing datasets.
@@ -71,14 +77,6 @@ Trying to solve these problems one after the other can make the code complex and
 The idea for a centralized data source is to simplify server-side data fetching.
 It's an abstraction layer between the Data Grid and the server, providing a simple interface for interacting with the server.
 Think of it like an intermediary handling the communication between the Data Grid (client) and the actual data source (server).
-
-:::warning
-
-This feature is under development and is marked as **unstable**.
-The information shared on this page could change in the future.
-Feel free to subscribe or comment on the official GitHub [umbrella issue](https://github.com/mui/mui-x/issues/8179).
-
-:::
 
 It has an initial set of required methods that you need to implement. The Data Grid will use these methods internally to fetch a subset of data when needed.
 

--- a/docs/data/data-grid/server-side-data/row-grouping.md
+++ b/docs/data/data-grid/server-side-data/row-grouping.md
@@ -2,7 +2,7 @@
 title: React Server-side row grouping
 ---
 
-# Data Grid - Server-side row grouping [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+# Data Grid - Server-side row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
 
 <p class="description">Lazy-loaded row grouping with server-side data source.</p>
 
@@ -20,14 +20,14 @@ Similar to the [tree data](/x/react-data-grid/server-side-data/tree-data/), you 
 ```tsx
 const customDataSource: GridDataSource = {
   getRows: async (params) => {
-    // Fetch the data from the server
+    // Fetch the data from the server.
   },
   getGroupKey: (row) => {
-    // Return the group key for the row, e.g. `name`
+    // Return the group key for the row, e.g. `name`.
     return row.name;
   },
   getChildrenCount: (row) => {
-    // Return the number of children for the row
+    // Return the number of children for the row.
     return row.childrenCount;
   },
 };
@@ -45,7 +45,7 @@ const getRows: async (params) => {
   });
   const getRowsResponse = await fetchRows(
     // Server should group the data based on `groupFields` and
-    // extract the rows for the nested level based on `groupKeys`
+    // extract the rows for the nested level based on `groupKeys`.
     `https://mui.com/x/api/data-grid?${urlParams.toString()}`,
   );
   return {
@@ -74,7 +74,7 @@ This example shows error handling with toast notifications and default error mes
 ## Group expansion
 
 The group expansion works similar to the [data source tree data](/x/react-data-grid/server-side-data/tree-data/#group-expansion).
-The following demo uses `defaultGroupingExpansionDepth='-1'` to expand all the groups.
+The following demo uses `defaultGroupingExpansionDepth={-1}` to expand all the groups.
 
 {{"demo": "ServerSideRowGroupingGroupExpansion.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/server-side-data/row-grouping.md
+++ b/docs/data/data-grid/server-side-data/row-grouping.md
@@ -2,7 +2,7 @@
 title: React Server-side row grouping
 ---
 
-# Data Grid - Server-side row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')
+# Data Grid - Server-side row grouping [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🧪
 
 <p class="description">Lazy-loaded row grouping with server-side data source.</p>
 

--- a/docs/data/data-grid/server-side-data/tree-data.md
+++ b/docs/data/data-grid/server-side-data/tree-data.md
@@ -20,14 +20,14 @@ The data source also requires some additional props to handle tree data:
 ```tsx
 const customDataSource: GridDataSource = {
   getRows: async (params) => {
-    // Fetch the data from the server
+    // Fetch the data from the server.
   },
   getGroupKey: (row) => {
-    // Return the group key for the row, e.g. `name`
+    // Return the group key for the row, e.g. `name`.
     return row.name;
   },
   getChildrenCount: (row) => {
-    // Return the number of children for the row
+    // Return the number of children for the row.
     return row.childrenCount;
   },
 };
@@ -39,11 +39,11 @@ Use `groupKeys` on the server to extract the rows for a given nested level.
 ```tsx
 const getRows: async (params) => {
   const urlParams = new URLSearchParams({
-    // Example: JSON.stringify(['Billy Houston', 'Lora Dean'])
+    // Example: JSON.stringify(['Billy Houston', 'Lora Dean']).
     groupKeys: JSON.stringify(params.groupKeys),
   });
   const getRowsResponse = await fetchRows(
-    // Server should extract the rows for the nested level based on `groupKeys`
+    // Server should extract the rows for the nested level based on `groupKeys`.
     `https://mui.com/x/api/data-grid?${urlParams.toString()}`,
   );
   return {

--- a/docs/data/data-grid/server-side-data/tree-data.md
+++ b/docs/data/data-grid/server-side-data/tree-data.md
@@ -78,7 +78,7 @@ The demo below shows a toast apart from the default error message in the groupin
 The idea behind the group expansion is the same as explained in the [Row grouping](/x/react-data-grid/row-grouping/#group-expansion) section.
 The difference is that the data is not initially available and is fetched automatically after the Data Grid is mounted based on the props `defaultGroupingExpansionDepth` and `isGroupExpandedByDefault` in a waterfall manner.
 
-The following demo uses `defaultGroupingExpansionDepth='-1'` to expand all levels of the tree by default.
+The following demo uses `defaultGroupingExpansionDepth={-1}` to expand all levels of the tree by default.
 
 {{"demo": "ServerSideTreeDataGroupExpansion.js", "bg": "inline"}}
 

--- a/docs/data/data-grid/server-side-data/tree-data.md
+++ b/docs/data/data-grid/server-side-data/tree-data.md
@@ -2,7 +2,7 @@
 title: React Server-side tree data
 ---
 
-# Data Grid - Server-side tree data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
+# Data Grid - Server-side tree data [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🧪
 
 <p class="description">Tree data lazy-loading with server-side data source.</p>
 

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -62,7 +62,7 @@ const pages: MuiPage[] = [
               { pathname: '/x/react-data-grid/row-definition' },
               { pathname: '/x/react-data-grid/row-updates' },
               { pathname: '/x/react-data-grid/row-height' },
-              { pathname: '/x/react-data-grid/row-spanning', newFeature: true },
+              { pathname: '/x/react-data-grid/row-spanning', unstable: true },
               { pathname: '/x/react-data-grid/master-detail', plan: 'pro' },
               { pathname: '/x/react-data-grid/row-ordering', plan: 'pro' },
               { pathname: '/x/react-data-grid/row-pinning', plan: 'pro' },

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -140,9 +140,10 @@ const pages: MuiPage[] = [
           {
             pathname: '/x/react-data-grid/server-side-data-group',
             title: 'Server-side data',
+            unstable: true,
             plan: 'pro',
             children: [
-              { pathname: '/x/react-data-grid/server-side-data', title: 'Overview' },
+              { pathname: '/x/react-data-grid/server-side-data', title: 'Overview', plan: 'pro', },
               { pathname: '/x/react-data-grid/server-side-data/tree-data', plan: 'pro' },
               {
                 pathname: '/x/react-data-grid/server-side-data/lazy-loading',
@@ -157,7 +158,6 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-data-grid/server-side-data/row-grouping',
                 plan: 'premium',
-                planned: true,
               },
               {
                 pathname: '/x/react-data-grid/server-side-data/aggregation',

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -143,7 +143,7 @@ const pages: MuiPage[] = [
             unstable: true,
             plan: 'pro',
             children: [
-              { pathname: '/x/react-data-grid/server-side-data', title: 'Overview', plan: 'pro', },
+              { pathname: '/x/react-data-grid/server-side-data', title: 'Overview', plan: 'pro' },
               { pathname: '/x/react-data-grid/server-side-data/tree-data', plan: 'pro' },
               {
                 pathname: '/x/react-data-grid/server-side-data/lazy-loading',

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -140,11 +140,19 @@ const pages: MuiPage[] = [
           {
             pathname: '/x/react-data-grid/server-side-data-group',
             title: 'Server-side data',
-            unstable: true,
             plan: 'pro',
             children: [
-              { pathname: '/x/react-data-grid/server-side-data', title: 'Overview', plan: 'pro' },
-              { pathname: '/x/react-data-grid/server-side-data/tree-data', plan: 'pro' },
+              {
+                pathname: '/x/react-data-grid/server-side-data',
+                title: 'Overview',
+                plan: 'pro',
+                unstable: true,
+              },
+              {
+                pathname: '/x/react-data-grid/server-side-data/tree-data',
+                plan: 'pro',
+                unstable: true,
+              },
               {
                 pathname: '/x/react-data-grid/server-side-data/lazy-loading',
                 plan: 'pro',
@@ -158,6 +166,7 @@ const pages: MuiPage[] = [
               {
                 pathname: '/x/react-data-grid/server-side-data/row-grouping',
                 plan: 'premium',
+                unstable: true,
               },
               {
                 pathname: '/x/react-data-grid/server-side-data/aggregation',

--- a/docs/pages/x/react-data-grid/server-side-data/aggregation.js
+++ b/docs/pages/x/react-data-grid/server-side-data/aggregation.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/data-grid/server-side-data/aggregation.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }

--- a/docs/pages/x/react-data-grid/server-side-data/index.js
+++ b/docs/pages/x/react-data-grid/server-side-data/index.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/data-grid/server-side-data/index.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }

--- a/docs/pages/x/react-data-grid/server-side-data/infinite-loading.js
+++ b/docs/pages/x/react-data-grid/server-side-data/infinite-loading.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/data-grid/server-side-data/infinite-loading.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }

--- a/docs/pages/x/react-data-grid/server-side-data/lazy-loading.js
+++ b/docs/pages/x/react-data-grid/server-side-data/lazy-loading.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/data-grid/server-side-data/lazy-loading.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }

--- a/docs/pages/x/react-data-grid/server-side-data/row-grouping.js
+++ b/docs/pages/x/react-data-grid/server-side-data/row-grouping.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/data-grid/server-side-data/row-grouping.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }

--- a/docs/pages/x/react-data-grid/server-side-data/tree-data.js
+++ b/docs/pages/x/react-data-grid/server-side-data/tree-data.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docsx/data/data-grid/server-side-data/tree-data.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return <MarkdownDocs disableAd {...pageProps} />;
 }

--- a/packages/x-data-grid/src/models/gridDataSource.ts
+++ b/packages/x-data-grid/src/models/gridDataSource.ts
@@ -42,7 +42,7 @@ export interface GridGetRowsResponse {
   rowCount?: number;
   /**
    * Additional `pageInfo` for advanced use-cases.
-   * `hasNextPage`: When row count is unknown/estimated, `hasNextPage` will be used to check if more records are available on server
+   * `hasNextPage`: When row count is unknown/estimated, `hasNextPage` will be used to check if more records are available on server.
    */
   pageInfo?: {
     hasNextPage?: boolean;
@@ -53,25 +53,25 @@ export interface GridGetRowsResponse {
 export interface GridDataSource {
   /**
    * This method will be called when the grid needs to fetch some rows.
-   * @param {GridGetRowsParams} params The parameters required to fetch the rows
-   * @returns {Promise<GridGetRowsResponse>} A promise that resolves to the data of type [GridGetRowsResponse]
+   * @param {GridGetRowsParams} params The parameters required to fetch the rows.
+   * @returns {Promise<GridGetRowsResponse>} A promise that resolves to the data of type [GridGetRowsResponse].
    */
   getRows(params: GridGetRowsParams): Promise<GridGetRowsResponse>;
   /**
    * This method will be called when the user updates a row [Not yet implemented].
-   * @param {GridRowModel} updatedRow The updated row
-   * @returns {Promise<any>} If resolved (synced on the backend), the grid will update the row and mutate the cache
+   * @param {GridRowModel} updatedRow The updated row.
+   * @returns {Promise<any>} If resolved (synced on the backend), the grid will update the row and mutate the cache.
    */
   updateRow?(updatedRow: GridRowModel): Promise<any>;
   /**
    * Used to group rows by their parent group. Replaces `getTreeDataPath` used in client side tree-data.
-   * @param {GridRowModel} row The row to get the group key of
-   * @returns {string} The group key for the row
+   * @param {GridRowModel} row The row to get the group key of.
+   * @returns {string} The group key for the row.
    */
   getGroupKey?: (row: GridRowModel) => string;
   /**
    * Used to determine the number of children a row has on server.
-   * @param {GridRowModel} row The row to check the number of children
+   * @param {GridRowModel} row The row to check the number of children.
    * @returns {number} The number of children the row has.
    * If the children count is not available for some reason, but there are some children, `getChildrenCount` should return `-1`.
    */
@@ -81,14 +81,14 @@ export interface GridDataSource {
 export interface GridDataSourceCache {
   /**
    * Set the cache entry for the given key.
-   * @param {GridGetRowsParams} key The key of type `GridGetRowsParams`
-   * @param {GridGetRowsResponse} value The value to be stored in the cache
+   * @param {GridGetRowsParams} key The key of type `GridGetRowsParams`.
+   * @param {GridGetRowsResponse} value The value to be stored in the cache.
    */
   set: (key: GridGetRowsParams, value: GridGetRowsResponse) => void;
   /**
    * Get the cache entry for the given key.
-   * @param {GridGetRowsParams} key The key of type `GridGetRowsParams`
-   * @returns {GridGetRowsResponse} The value stored in the cache
+   * @param {GridGetRowsParams} key The key of type `GridGetRowsParams`.
+   * @returns {GridGetRowsResponse} The value stored in the cache.
    */
   get: (key: GridGetRowsParams) => GridGetRowsResponse | undefined;
   /**


### PR DESCRIPTION
Issues I saw in https://master--material-ui-x.netlify.app/x/react-data-grid/server-side-data/ during the last monthly meeting presentation. Faster to open a PR.

Preview: https://deploy-preview-15330--material-ui-x.netlify.app/x/react-data-grid/server-side-data/

**Off-topic**

- There are JS errors on that page http://0.0.0.0:3001/x/react-data-grid/server-side-data/

<img width="912" alt="SCR-20241108-bamc" src="https://github.com/user-attachments/assets/823c6750-f33e-4bad-8672-1008e49da9d7">

- The page transition speed between those docs pages is way too slow, >300ms on a high-end laptop. It seems to be a wide spread issue. It's incredibly annoying from a UX perspective, root cause is part of it is docs-infra, part of it is MUI System, part of it is data grid. Great would be 100ms or lower.