### PR TITLE
[charts] Fix log scale with `null` data

### DIFF
--- a/packages/x-charts/src/BarChart/extremums.test.ts
+++ b/packages/x-charts/src/BarChart/extremums.test.ts
@@ -20,6 +20,7 @@ const buildData = (
             ]
           : [],
         layout,
+        valueFormatter: () => '',
       },
     },
     axis: {

--- a/packages/x-charts/src/LineChart/extremums.ts
+++ b/packages/x-charts/src/LineChart/extremums.ts
@@ -12,11 +12,15 @@ type GetValues = (d: [number, number]) => [number, number];
 
 function getSeriesExtremums(
   getValues: GetValues,
+  data: (number | null)[],
   stackedData: [number, number][],
   filter?: ExtremumFilter,
 ): [number, number] {
   return stackedData.reduce<[number, number]>(
     (seriesAcc, stackedValue, index) => {
+      if (data[index] === null) {
+        return seriesAcc;
+      }
       const [base, value] = getValues(stackedValue);
       if (
         filter &&
@@ -41,7 +45,7 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
     })
     .reduce(
       (acc, seriesId) => {
-        const { area, stackedData } = series[seriesId];
+        const { area, stackedData, data } = series[seriesId];
         const isArea = area !== undefined;
 
         const filter = getFilters?.({
@@ -57,7 +61,7 @@ export const getExtremumY: ExtremumGetter<'line'> = (params) => {
             ? (d) => d
             : (d) => [d[1], d[1]];
 
-        const seriesExtremums = getSeriesExtremums(getValues, stackedData, filter);
+        const seriesExtremums = getSeriesExtremums(getValues, data, stackedData, filter);
 
         const [seriesMin, seriesMax] = seriesExtremums;
         return [Math.min(seriesMin, acc[0]), Math.max(seriesMax, acc[1])];

--- a/packages/x-charts/src/context/PluginProvider/ExtremumGetter.types.ts
+++ b/packages/x-charts/src/context/PluginProvider/ExtremumGetter.types.ts
@@ -1,6 +1,6 @@
 import type {
   CartesianChartSeriesType,
-  ChartSeries,
+  ChartSeriesDefaultized,
   ChartSeriesType,
 } from '../../models/seriesType/config';
 import type { AxisConfig, AxisId } from '../../models/axis';
@@ -11,7 +11,7 @@ export type ExtremumGettersConfig<T extends ChartSeriesType = CartesianChartSeri
 };
 
 type ExtremumGetterParams<T extends ChartSeriesType> = {
-  series: Record<SeriesId, ChartSeries<T>>;
+  series: Record<SeriesId, ChartSeriesDefaultized<T>>;
   axis: AxisConfig;
   axisIndex: number;
   isDefaultAxis: boolean;


### PR DESCRIPTION
Fix #15322

A `null` leads to a stack `[0, 0]` which make the domain includes 0.

Thsi PR add a check to ignore en element when it comes from a `null` data point