### PR TITLE
[TimePicker] Prevent mouse events after `touchend` event

### DIFF
--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -270,6 +270,7 @@ export function Clock(inProps: ClockProps) {
       setTime(event, 'finish');
       isMoving.current = false;
     }
+    event.preventDefault();
   };
 
   const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
Closes #15338 

After the introduction of #14305 the addition of touchStart causes touchEnd event to [trigger mouse events](https://www.w3.org/TR/touch-events/#list-of-touchevent-types) leading to the bug reported.
Unfortunately the test environment does not simulate  this behavior, otherwise it would have been catched by [this test](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/TimeClock/tests/TimeClock.test.tsx#L537)

Since we do not expose the event handlers on this component, I wouldn't expect issues on preventing this behavior that is, although a bit weird, the correct one.

Could be cherry-picked to v7