### PR TITLE
[DataGrid] Inject default Col Def values before updating the column state

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -349,10 +349,10 @@ export const createColumnsState = ({
     columnsToUpsertLookup[field] = true;
     columnsToKeep[field] = true;
     let existingState = columnsState.lookup[field];
-
+    const defaultColTypeDef = { ...getDefaultColTypeDef(newColumn.type) };
     if (existingState == null) {
       existingState = {
-        ...getDefaultColTypeDef(newColumn.type),
+        ...defaultColTypeDef,
         field,
         hasBeenResized: false,
       };
@@ -364,7 +364,7 @@ export const createColumnsState = ({
     // If the column type has changed - merge the existing state with the default column type definition
     if (existingState && existingState.type !== newColumn.type) {
       existingState = {
-        ...getDefaultColTypeDef(newColumn.type),
+        ...defaultColTypeDef,
         field,
       };
     }
@@ -380,7 +380,13 @@ export const createColumnsState = ({
       }
     });
 
-    columnsState.lookup[field] = resolveProps(existingState, { ...newColumn, hasBeenResized });
+    const newColumnWithDefaultValues = resolveProps(defaultColTypeDef, newColumn);
+
+    columnsState.lookup[field] = {
+      ...existingState,
+      ...newColumnWithDefaultValues,
+      hasBeenResized,
+    };
   });
 
   if (keepOnlyColumnsToUpsert && !isInsideStateInitializer) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/mui-x/issues/15317
Before: https://stackblitz.com/edit/github-3rk5go-nd8osk?file=src%2Fdemo.tsx
After: https://codesandbox.io/p/sandbox/mui-mui-x-x-data-grid-forked-m49n6j

Fixes https://github.com/mui/mui-x/issues/14446
Before: https://codesandbox.io/p/sandbox/wispy-paper-mfjzqs?file=%2Fsrc%2FDemo.tsx%3A1%2C1-23%2C1
After: https://codesandbox.io/p/sandbox/mui-mui-x-x-data-grid-forked-4lk7v4

Change done in https://github.com/mui/mui-x/pull/14456 is a bit misleading,  `existingState` does not contains default col def values rather it contains the default values which are overridden by the values passed in a column prop.

Closes #15409 
