### PR TITLE
[charts-pro] Fix missing typeOverload

### DIFF
--- a/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
+++ b/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
@@ -13,7 +13,7 @@ import {
   AnimationProvider,
 } from '@mui/x-charts/internals';
 import { useLicenseVerifier } from '@mui/x-license/useLicenseVerifier';
-import {} from '../typeOverloads';
+import type {} from '../typeOverloads';
 import { getReleaseInfo } from '../internals/utils/releaseInfo';
 import { CartesianProviderPro } from '../context/CartesianProviderPro';
 import { ZoomProps, ZoomProvider } from '../context/ZoomProvider';

--- a/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
+++ b/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
@@ -13,6 +13,7 @@ import {
   AnimationProvider,
 } from '@mui/x-charts/internals';
 import { useLicenseVerifier } from '@mui/x-license/useLicenseVerifier';
+import {} from '../typeOverloads';
 import { getReleaseInfo } from '../internals/utils/releaseInfo';
 import { CartesianProviderPro } from '../context/CartesianProviderPro';
 import { ZoomProps, ZoomProvider } from '../context/ZoomProvider';


### PR DESCRIPTION
Fix #15386

I'm adding the import into the definition, of the pro container since it's the common component to all pro charts