### PR TITLE
[docs] Add `next` version links

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -212,6 +212,10 @@ function AppWrapper(props) {
       name: 'MUI X',
       versions: [
         {
+          text: `next`,
+          href: `https://next.mui.com${languagePrefix}/x/introduction/`,
+        },
+        {
           text: `v${process.env.LIB_VERSION}`,
           current: true,
         },
@@ -227,6 +231,10 @@ function AppWrapper(props) {
         name: 'Data Grid',
         versions: [
           {
+            text: `next`,
+            href: `https://next.mui.com${languagePrefix}/x/react-data-grid/`,
+          },
+          {
             text: `v${process.env.DATA_GRID_VERSION}`,
             current: true,
           },
@@ -240,6 +248,10 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Date Pickers',
         versions: [
+          {
+            text: `next`,
+            href: `https://next.mui.com${languagePrefix}/x/react-date-pickers/`,
+          },
           {
             text: `v${process.env.DATE_PICKERS_VERSION}`,
             current: true,
@@ -260,6 +272,10 @@ function AppWrapper(props) {
         name: 'Charts',
         versions: [
           {
+            text: `next`,
+            href: `https://next.mui.com${languagePrefix}/x/react-charts/`,
+          },
+          {
             text: `v${process.env.CHARTS_VERSION}`,
             current: true,
           },
@@ -271,6 +287,10 @@ function AppWrapper(props) {
         metadata: 'MUI X',
         name: 'Tree View',
         versions: [
+          {
+            text: `next`,
+            href: `https://next.mui.com${languagePrefix}/x/react-tree-view/`,
+          },
           {
             text: `v${process.env.TREE_VIEW_VERSION}`,
             current: true,


### PR DESCRIPTION
Add links to v8/next in the app header.

![Screenshot 2024-11-14 at 18 50 05](https://github.com/user-attachments/assets/7f17d15c-7727-49a5-a9fb-ccd142a8eb4f)
