### PR TITLE
[DateTimeRangePicker] Use time in `referenceDate` when selecting date

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -264,6 +264,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar(
         rangePosition,
         allowRangeFlip,
         shouldMergeDateAndTime: true,
+        referenceDate,
       });
 
       const isNextSectionAvailable = availableRangePositions.includes(nextSelection);

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
@@ -39,6 +39,22 @@ describe('<DesktopDateTimeRangePicker />', () => {
       expect(expectFieldValueV7(startSectionsContainer, '01/11/2018 04:05 PM'));
       expect(expectFieldValueV7(endSectionsContainer, '01/11/2018 05:10 PM'));
     });
+
+    it('should use time from `referenceDate` when selecting the day', () => {
+      render(
+        <DesktopDateTimeRangePicker referenceDate={adapterToUse.date('2022-04-14T14:15:00')} />,
+      );
+
+      openPicker({ type: 'date-time-range', variant: 'desktop', initialFocus: 'start' });
+
+      fireEvent.click(screen.getByRole('gridcell', { name: '11' }));
+
+      expect(screen.getByRole('option', { name: '2 hours', selected: true })).not.to.equal(null);
+      expect(screen.getByRole('option', { name: '15 minutes', selected: true })).not.to.equal(null);
+      expect(screen.getByRole('option', { name: 'PM', selected: true })).not.to.equal(null);
+      const startSectionsContainer = getFieldSectionsContainer(0);
+      expect(expectFieldValueV7(startSectionsContainer, '04/11/2022 02:15 PM'));
+    });
   });
 
   describe('disabled dates', () => {

--- a/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.test.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.test.ts
@@ -19,6 +19,15 @@ describe('date-range-manager', () => {
       expectedNextSelection: 'end' as const,
     },
     {
+      range: [null, null],
+      rangePosition: 'start' as const,
+      newDate: start2018,
+      expectedRange: [start2018At4PM, null],
+      expectedNextSelection: 'end' as const,
+      shouldMergeDateAndTime: true,
+      referenceDate: start2018At4PM,
+    },
+    {
       range: [start2018, null],
       rangePosition: 'start' as const,
       newDate: end2019,
@@ -99,7 +108,16 @@ describe('date-range-manager', () => {
       expectedNextSelection: 'start' as const,
     },
   ].forEach(
-    ({ range, rangePosition, newDate, expectedRange, allowRangeFlip, expectedNextSelection }) => {
+    ({
+      range,
+      rangePosition,
+      newDate,
+      expectedRange,
+      allowRangeFlip,
+      expectedNextSelection,
+      shouldMergeDateAndTime,
+      referenceDate,
+    }) => {
       it(`calculateRangeChange should return ${expectedRange} when selecting ${rangePosition} of ${range} with user input ${newDate}`, () => {
         expect(
           calculateRangeChange({
@@ -108,6 +126,8 @@ describe('date-range-manager', () => {
             newDate,
             rangePosition,
             allowRangeFlip,
+            shouldMergeDateAndTime,
+            referenceDate,
           }),
         ).to.deep.equal({
           nextSelection: expectedNextSelection,

--- a/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
@@ -14,6 +14,7 @@ interface CalculateRangeChangeOptions {
    */
   allowRangeFlip?: boolean;
   shouldMergeDateAndTime?: boolean;
+  referenceDate?: PickerValidDate;
 }
 
 interface CalculateRangeChangeResponse {
@@ -28,6 +29,7 @@ export function calculateRangeChange({
   rangePosition,
   allowRangeFlip = false,
   shouldMergeDateAndTime = false,
+  referenceDate,
 }: CalculateRangeChangeOptions): CalculateRangeChangeResponse {
   const [start, end] = range;
 
@@ -41,21 +43,26 @@ export function calculateRangeChange({
     }
   }
 
+  const newSelectedDate =
+    referenceDate && selectedDate && shouldMergeDateAndTime
+      ? mergeDateAndTime(utils, selectedDate, referenceDate)
+      : selectedDate;
+
   if (rangePosition === 'start') {
     const truthyResult: CalculateRangeChangeResponse = allowRangeFlip
-      ? { nextSelection: 'start', newRange: [end!, selectedDate] }
-      : { nextSelection: 'end', newRange: [selectedDate, null] };
-    return Boolean(end) && utils.isAfter(selectedDate!, end!)
+      ? { nextSelection: 'start', newRange: [end!, newSelectedDate] }
+      : { nextSelection: 'end', newRange: [newSelectedDate, null] };
+    return Boolean(end) && utils.isAfter(newSelectedDate!, end!)
       ? truthyResult
-      : { nextSelection: 'end', newRange: [selectedDate, end] };
+      : { nextSelection: 'end', newRange: [newSelectedDate, end] };
   }
 
   const truthyResult: CalculateRangeChangeResponse = allowRangeFlip
-    ? { nextSelection: 'end', newRange: [selectedDate, start!] }
-    : { nextSelection: 'end', newRange: [selectedDate, null] };
-  return Boolean(start) && utils.isBeforeDay(selectedDate!, start!)
+    ? { nextSelection: 'end', newRange: [newSelectedDate, start!] }
+    : { nextSelection: 'end', newRange: [newSelectedDate, null] };
+  return Boolean(start) && utils.isBeforeDay(newSelectedDate!, start!)
     ? truthyResult
-    : { nextSelection: 'start', newRange: [start, selectedDate] };
+    : { nextSelection: 'start', newRange: [start, newSelectedDate] };
 }
 
 export function calculateRangePreview(options: CalculateRangeChangeOptions): PickerRangeValue {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/15405.