### PR TITLE
[pickers] Ensure internal value timezone is updated 

### DIFF
--- a/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
@@ -57,9 +57,9 @@ export const rangeValueManager: RangePickerValueManager = {
   defaultErrorState: [null, null],
   getTimezone: (utils, value) => {
     const timezoneStart =
-      value[0] == null || !utils.isValid(value[0]) ? null : utils.getTimezone(value[0]);
+      value[0] == null || !utils.isValid(value[0]) ? 'default' : utils.getTimezone(value[0]);
     const timezoneEnd =
-      value[1] == null || !utils.isValid(value[1]) ? null : utils.getTimezone(value[1]);
+      value[1] == null || !utils.isValid(value[1]) ? 'default' : utils.getTimezone(value[1]);
 
     if (timezoneStart != null && timezoneEnd != null && timezoneStart !== timezoneEnd) {
       throw new Error('MUI X: The timezone of the start and the end date should be the same.');

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/timezone.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/timezone.MobileTimePicker.test.tsx
@@ -21,5 +21,21 @@ describe('<MobileTimePicker /> - Timezone', () => {
 
       expect(screen.getByTestId('hours')).to.have.text('11');
     });
+
+    it('should use the updated timezone prop for the value displayed in the toolbar', () => {
+      const { setProps } = render(
+        <MobileTimePicker
+          timezone="default"
+          defaultValue={adapter.date('2022-04-17T15:30')}
+          open
+        />,
+      );
+
+      expect(screen.getByTestId('hours')).to.have.text('03');
+
+      setProps({ timezone: 'America/New_York' });
+
+      expect(screen.getByTestId('hours')).to.have.text('11');
+    });
   });
 });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -240,6 +240,16 @@ export const usePickerValue = <
     };
   });
 
+  React.useEffect(() => {
+    const newTimezone = valueManager.getTimezone(utils, inValueWithTimezoneToRender);
+    if (valueManager.getTimezone(utils, dateState.draft) !== newTimezone) {
+      setDateState((prev) => ({
+        ...prev,
+        draft: valueManager.setTimezone(utils, newTimezone, prev.draft),
+      }));
+    }
+  }, [inValueWithTimezoneToRender]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const { getValidationErrorForNewValue } = useValidation({
     props,
     validator,

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
@@ -109,9 +109,9 @@ export interface PickerValueManager<TValue, TError> {
    @template TValue
    @param {MuiPickersAdapter} utils The utils to manipulate the date.
    @param {TValue} value The current value.
-   @returns {string | null} The timezone of the current value.
+   @returns {string} The timezone of the current value. `default` if the value is empty.
    */
-  getTimezone: (utils: MuiPickersAdapter, value: TValue) => string | null;
+  getTimezone: (utils: MuiPickersAdapter, value: TValue) => string;
   /**
    * Change the timezone of the dates inside a value.
    @template TValue

--- a/packages/x-date-pickers/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers/src/internals/utils/valueManagers.ts
@@ -38,7 +38,7 @@ export const singleItemValueManager: SingleItemPickerValueManager = {
   hasError: (error) => error != null,
   defaultErrorState: null,
   getTimezone: (utils, value) =>
-    value == null || !utils.isValid(value) ? null : utils.getTimezone(value),
+    value == null || !utils.isValid(value) ? 'default' : utils.getTimezone(value),
   setTimezone: (utils, timezone, value) =>
     value == null ? null : utils.setTimezone(value, timezone),
 };


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/15412.

Related to https://github.com/mui/mui-x/pull/13481.