### PR TITLE
[code-infra] Prevent relative imports across packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,10 +84,6 @@ const buildPackageRestrictedImports = (packageName, root, allowRootImports = tru
               group: [`${packageName}/*`, `${packageName}/**`],
               message: 'Use relative import instead',
             },
-            {
-              group: ['../../**/src/**'],
-              message: 'Relative imports from another package are not allowed.',
-            },
           ],
         },
       ],
@@ -140,6 +136,7 @@ module.exports = {
     ...(ENABLE_REACT_COMPILER_PLUGIN ? { 'react-compiler/react-compiler': 'error' } : {}),
     // TODO move to @mui/monorepo, codebase is moving away from default exports https://github.com/mui/material-ui/issues/21862
     'import/prefer-default-export': 'off',
+    'import/no-relative-packages': 'error',
     'import/no-restricted-paths': [
       'error',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -143,22 +143,13 @@ module.exports = {
     'import/no-restricted-paths': [
       'error',
       {
-        zones: [
-          ...[...chartsPackages, ...datePickersPackages, ...treeViewPackages].map(
-            (packageName) => ({
-              target: `./packages/${packageName}/src/**/!(*.test.*|*.spec.*)`,
-              from: `./packages/${packageName}/src/internals/index.ts`,
-              message: `Use a more specific import instead. E.g. import { MyInternal } from '../internals/MyInternal';`,
-            }),
-          ),
-          // ...[...chartsPackages, ...datePickersPackages, ...treeViewPackages].map(
-          //   (packageName) => ({
-          //     target: `./packages/${packageName}/src/**/!(*.test.*|*.spec.*)`,
-          //     from: `./packages/!(${packageName})/src/**`,
-          //     message: 'Imports from another package should use the package name directly.',
-          //   }),
-          // ),
-        ],
+        zones: [...chartsPackages, ...datePickersPackages, ...treeViewPackages].map(
+          (packageName) => ({
+            target: `./packages/${packageName}/src/**/!(*.test.*|*.spec.*)`,
+            from: `./packages/${packageName}/src/internals/index.ts`,
+            message: `Use a more specific import instead. E.g. import { MyInternal } from '../internals/MyInternal';`,
+          }),
+        ),
       },
     ],
     // TODO remove rule from here once it's merged in `@mui/monorepo/.eslintrc`

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,10 @@ const buildPackageRestrictedImports = (packageName, root, allowRootImports = tru
               group: [`${packageName}/*`, `${packageName}/**`],
               message: 'Use relative import instead',
             },
+            {
+              group: ['../../**/src/**'],
+              message: 'Relative imports from another package are not allowed.',
+            },
           ],
         },
       ],
@@ -139,13 +143,22 @@ module.exports = {
     'import/no-restricted-paths': [
       'error',
       {
-        zones: [...chartsPackages, ...datePickersPackages, ...treeViewPackages].map(
-          (packageName) => ({
-            target: `./packages/${packageName}/src/**/!(*.test.*|*.spec.*)`,
-            from: `./packages/${packageName}/src/internals/index.ts`,
-            message: `Use a more specific import instead. E.g. import { MyInternal } from '../internals/MyInternal';`,
-          }),
-        ),
+        zones: [
+          ...[...chartsPackages, ...datePickersPackages, ...treeViewPackages].map(
+            (packageName) => ({
+              target: `./packages/${packageName}/src/**/!(*.test.*|*.spec.*)`,
+              from: `./packages/${packageName}/src/internals/index.ts`,
+              message: `Use a more specific import instead. E.g. import { MyInternal } from '../internals/MyInternal';`,
+            }),
+          ),
+          // ...[...chartsPackages, ...datePickersPackages, ...treeViewPackages].map(
+          //   (packageName) => ({
+          //     target: `./packages/${packageName}/src/**/!(*.test.*|*.spec.*)`,
+          //     from: `./packages/!(${packageName})/src/**`,
+          //     message: 'Imports from another package should use the package name directly.',
+          //   }),
+          // ),
+        ],
       },
     ],
     // TODO remove rule from here once it's merged in `@mui/monorepo/.eslintrc`


### PR DESCRIPTION
This change should allow us to prevent issues like this: https://github.com/mui/mui-x/pull/15375/commits/0baadae71c09825e875753382b2516957d93e6bf

```tsx
import { SizeProvider } from '../../../../x-charts/src/context/SizeProvider';
```