### PR TITLE
[charts] Remove intrinsic size requirement

### DIFF
--- a/docs/data/migration/migration-charts-v7/migration-charts-v7.md
+++ b/docs/data/migration/migration-charts-v7/migration-charts-v7.md
@@ -120,3 +120,9 @@ This code has been removed in v8, which implies removing the following props: `a
 
 This should not impact your code.
 If you used axes in a pie chart please open an issue, we would be curious to get more information about the use-case.
+
+## Remove `resolveSizeBeforeRender` prop
+
+The `resolveSizeBeforeRender` prop has been removed from the `ChartContainer` component and all related charts.
+
+If you were using this prop, you can safely remove it.

--- a/docs/data/migration/migration-charts-v7/migration-charts-v7.md
+++ b/docs/data/migration/migration-charts-v7/migration-charts-v7.md
@@ -123,6 +123,5 @@ If you used axes in a pie chart please open an issue, we would be curious to get
 
 ## Remove `resolveSizeBeforeRender` prop
 
-The `resolveSizeBeforeRender` prop has been removed from the `ChartContainer` component and all related charts.
-
+The `resolveSizeBeforeRender` prop has been removed from all components.
 If you were using this prop, you can safely remove it.

--- a/docs/pages/x/api/charts/bar-chart-pro.json
+++ b/docs/pages/x/api/charts/bar-chart-pro.json
@@ -81,7 +81,6 @@
         "describedArgs": ["zoomData"]
       }
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -74,7 +74,6 @@
         "describedArgs": ["event", "barItemIdentifier"]
       }
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/chart-container-pro.json
+++ b/docs/pages/x/api/charts/chart-container-pro.json
@@ -39,7 +39,6 @@
       }
     },
     "plugins": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "skipAnimation": { "type": { "name": "bool" } },
     "width": { "type": { "name": "number" } },
     "xAxis": {

--- a/docs/pages/x/api/charts/chart-container.json
+++ b/docs/pages/x/api/charts/chart-container.json
@@ -32,7 +32,6 @@
       }
     },
     "plugins": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "skipAnimation": { "type": { "name": "bool" } },
     "width": { "type": { "name": "number" } },
     "xAxis": {

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -61,7 +61,6 @@
         "describedArgs": ["highlightedItem"]
       }
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/line-chart-pro.json
+++ b/docs/pages/x/api/charts/line-chart-pro.json
@@ -74,7 +74,6 @@
         "describedArgs": ["zoomData"]
       }
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -67,7 +67,6 @@
     },
     "onLineClick": { "type": { "name": "func" } },
     "onMarkClick": { "type": { "name": "func" } },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/pie-chart.json
+++ b/docs/pages/x/api/charts/pie-chart.json
@@ -34,7 +34,6 @@
       }
     },
     "onItemClick": { "type": { "name": "func" } },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "skipAnimation": { "type": { "name": "bool" } },
     "slotProps": { "type": { "name": "object" }, "default": "{}" },
     "slots": {

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -70,7 +70,6 @@
         "describedArgs": ["zoomData"]
       }
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -63,7 +63,6 @@
         "describedArgs": ["event", "scatterItemIdentifier"]
       }
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "rightAxis": {
       "type": { "name": "union", "description": "object<br>&#124;&nbsp;string" },
       "default": "null"

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -36,7 +36,6 @@
       "type": { "name": "enum", "description": "'bar'<br>&#124;&nbsp;'line'" },
       "default": "'line'"
     },
-    "resolveSizeBeforeRender": { "type": { "name": "bool" }, "default": "false" },
     "showHighlight": { "type": { "name": "bool" }, "default": "false" },
     "showTooltip": { "type": { "name": "bool" }, "default": "false" },
     "skipAnimation": { "type": { "name": "bool" } },

--- a/docs/translations/api-docs/charts/bar-chart-pro/bar-chart-pro.json
+++ b/docs/translations/api-docs/charts/bar-chart-pro/bar-chart-pro.json
@@ -57,9 +57,6 @@
       "description": "Callback fired when the zoom has changed.",
       "typeDescriptions": { "zoomData": "Updated zoom data." }
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/bar-chart/bar-chart.json
+++ b/docs/translations/api-docs/charts/bar-chart/bar-chart.json
@@ -53,9 +53,6 @@
         "barItemIdentifier": "The bar item identifier."
       }
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/chart-container-pro/chart-container-pro.json
+++ b/docs/translations/api-docs/charts/chart-container-pro/chart-container-pro.json
@@ -28,9 +28,6 @@
     "plugins": {
       "description": "An array of plugins defining how to preprocess data. If not provided, the container supports line, bar, scatter and pie charts."
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "series": {
       "description": "The array of series to display. Each type of series has its own specificity. Please refer to the appropriate docs page to learn more about it."
     },

--- a/docs/translations/api-docs/charts/chart-container/chart-container.json
+++ b/docs/translations/api-docs/charts/chart-container/chart-container.json
@@ -24,9 +24,6 @@
     "plugins": {
       "description": "An array of plugins defining how to preprocess data. If not provided, the container supports line, bar, scatter and pie charts."
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "series": {
       "description": "The array of series to display. Each type of series has its own specificity. Please refer to the appropriate docs page to learn more about it."
     },

--- a/docs/translations/api-docs/charts/heatmap/heatmap.json
+++ b/docs/translations/api-docs/charts/heatmap/heatmap.json
@@ -35,9 +35,6 @@
       "description": "The callback fired when the highlighted item changes.",
       "typeDescriptions": { "highlightedItem": "The newly highlighted item." }
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/line-chart-pro/line-chart-pro.json
+++ b/docs/translations/api-docs/charts/line-chart-pro/line-chart-pro.json
@@ -54,9 +54,6 @@
       "description": "Callback fired when the zoom has changed.",
       "typeDescriptions": { "zoomData": "Updated zoom data." }
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/line-chart/line-chart.json
+++ b/docs/translations/api-docs/charts/line-chart/line-chart.json
@@ -50,9 +50,6 @@
     },
     "onLineClick": { "description": "Callback fired when a line element is clicked." },
     "onMarkClick": { "description": "Callback fired when a mark element is clicked." },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/pie-chart/pie-chart.json
+++ b/docs/translations/api-docs/charts/pie-chart/pie-chart.json
@@ -24,9 +24,6 @@
       "typeDescriptions": { "highlightedItem": "The newly highlighted item." }
     },
     "onItemClick": { "description": "Callback fired when a pie arc is clicked." },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "series": {
       "description": "The series to display in the pie chart. An array of <a href='/x/api/charts/pie-series-type/'>PieSeriesType</a> objects."
     },

--- a/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
+++ b/docs/translations/api-docs/charts/scatter-chart-pro/scatter-chart-pro.json
@@ -48,9 +48,6 @@
       "description": "Callback fired when the zoom has changed.",
       "typeDescriptions": { "zoomData": "Updated zoom data." }
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
+++ b/docs/translations/api-docs/charts/scatter-chart/scatter-chart.json
@@ -44,9 +44,6 @@
         "scatterItemIdentifier": "The scatter item identifier."
       }
     },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "rightAxis": {
       "description": "Indicate which axis to display the right of the charts. Can be a string (the id of the axis) or an object <code>ChartsYAxisProps</code>."
     },

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -26,9 +26,6 @@
       "typeDescriptions": { "highlightedItem": "The newly highlighted item." }
     },
     "plotType": { "description": "Type of plot used." },
-    "resolveSizeBeforeRender": {
-      "description": "The chart will try to wait for the parent container to resolve its size before it renders for the first time.<br>This can be useful in some scenarios where the chart appear to grow after the first render, like when used inside a grid."
-    },
     "showHighlight": {
       "description": "Set to <code>true</code> to highlight the value. With line, it shows a point. With bar, it shows a highlight band."
     },

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -244,16 +244,6 @@ BarChartPro.propTypes = {
    */
   onZoomChange: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
+++ b/packages/x-charts-pro/src/ChartContainerPro/ChartContainerPro.tsx
@@ -96,16 +96,6 @@ ChartContainerPro.propTypes = {
    */
   plugins: PropTypes.arrayOf(PropTypes.object),
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * The array of series to display.
    * Each type of series has its own specificity.
    * Please refer to the appropriate docs page to learn more about it.

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -287,16 +287,6 @@ Heatmap.propTypes = {
    */
   onHighlightChange: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -315,16 +315,6 @@ LineChartPro.propTypes = {
    */
   onZoomChange: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -176,16 +176,6 @@ ScatterChartPro.propTypes = {
    */
   onZoomChange: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -262,16 +262,6 @@ BarChart.propTypes = {
    */
   onItemClick: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts/src/ChartContainer/ChartContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ChartContainer.tsx
@@ -82,16 +82,6 @@ ChartContainer.propTypes = {
    */
   plugins: PropTypes.arrayOf(PropTypes.object),
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * The array of series to display.
    * Each type of series has its own specificity.
    * Please refer to the appropriate docs page to learn more about it.

--- a/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
@@ -23,6 +23,10 @@ export const ResizableContainerRoot = styled('div', {
   alignItems: 'center',
   justifyContent: 'center',
   overflow: 'hidden',
+  '& svg': {
+    width: '100%',
+    height: '100%',
+  },
 }));
 
 /**
@@ -33,12 +37,9 @@ export const ResizableContainerRoot = styled('div', {
 function SvgSize() {
   const { width, height, left, right, top, bottom } = useDrawingArea();
 
-  const svgWidth = width + left + right;
-  const svgHeight = height + top + bottom;
-
   const svgView = {
-    width: svgWidth,
-    height: svgHeight,
+    width: width + left + right,
+    height: height + top + bottom,
     x: 0,
     y: 0,
   };

--- a/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { useSize } from '../context/SizeProvider';
 import type { SizeContextState } from '../context/SizeProvider';
+import { useDrawingArea } from '../hooks';
 
 /**
  * Wrapping div that take the shape of its parent.
@@ -22,11 +23,28 @@ export const ResizableContainerRoot = styled('div', {
   alignItems: 'center',
   justifyContent: 'center',
   overflow: 'hidden',
-  '&>svg': {
-    width: '100%',
-    height: '100%',
-  },
 }));
+
+/**
+ * This svg will fill the parent container. And prevent an SVG rendered with size 0.
+ *
+ * @ignore - internal component.
+ */
+function SvgSize() {
+  const { width, height, left, right, top, bottom } = useDrawingArea();
+
+  const svgWidth = width + left + right;
+  const svgHeight = height + top + bottom;
+
+  const svgView = {
+    width: svgWidth,
+    height: svgHeight,
+    x: 0,
+    y: 0,
+  };
+
+  return <svg viewBox={`${svgView.x} ${svgView.y} ${svgView.width} ${svgView.height}`} />;
+}
 
 /**
  * Wrapping div that take the shape of its parent.
@@ -42,7 +60,7 @@ function ResizableContainer(props: { children: React.ReactNode }) {
       ownerState={{ width: inWidth, height: inHeight }}
       ref={containerRef}
     >
-      {hasIntrinsicSize && props.children}
+      {hasIntrinsicSize ? props.children : <SvgSize />}
     </ResizableContainerRoot>
   );
 }

--- a/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
@@ -23,7 +23,7 @@ export const ResizableContainerRoot = styled('div', {
   alignItems: 'center',
   justifyContent: 'center',
   overflow: 'hidden',
-  '& svg': {
+  '&>svg': {
     width: '100%',
     height: '100%',
   },

--- a/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ResizableContainer.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { useSize } from '../context/SizeProvider';
 import type { SizeContextState } from '../context/SizeProvider';
-import { useDrawingArea } from '../hooks';
 
 /**
  * Wrapping div that take the shape of its parent.
@@ -30,30 +29,12 @@ export const ResizableContainerRoot = styled('div', {
 }));
 
 /**
- * This svg will fill the parent container. And prevent an SVG rendered with size 0.
- *
- * @ignore - internal component.
- */
-function SvgSize() {
-  const { width, height, left, right, top, bottom } = useDrawingArea();
-
-  const svgView = {
-    width: width + left + right,
-    height: height + top + bottom,
-    x: 0,
-    y: 0,
-  };
-
-  return <svg viewBox={`${svgView.x} ${svgView.y} ${svgView.width} ${svgView.height}`} />;
-}
-
-/**
  * Wrapping div that take the shape of its parent.
  *
  * @ignore - do not document.
  */
 function ResizableContainer(props: { children: React.ReactNode }) {
-  const { inHeight, inWidth, hasIntrinsicSize, containerRef } = useSize();
+  const { inHeight, inWidth, containerRef } = useSize();
 
   return (
     <ResizableContainerRoot
@@ -61,7 +42,7 @@ function ResizableContainer(props: { children: React.ReactNode }) {
       ownerState={{ width: inWidth, height: inHeight }}
       ref={containerRef}
     >
-      {hasIntrinsicSize ? props.children : <SvgSize />}
+      {props.children}
     </ResizableContainerRoot>
   );
 }

--- a/packages/x-charts/src/ChartsSurface/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface/ChartsSurface.tsx
@@ -44,6 +44,7 @@ const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(functi
 
   const svgWidth = width + left + right;
   const svgHeight = height + top + bottom;
+  const hasIntrinsicSize = width !== 0 && height !== 0;
 
   const svgView = {
     width: svgWidth,
@@ -64,7 +65,7 @@ const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(functi
       {title && <title>{title}</title>}
       {desc && <desc>{desc}</desc>}
       <ChartsAxesGradients />
-      {children}
+      {hasIntrinsicSize && children}
     </ChartsSurfaceStyles>
   );
 });

--- a/packages/x-charts/src/ChartsSurface/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface/ChartsSurface.tsx
@@ -7,6 +7,7 @@ import { useAxisEvents } from '../hooks/useAxisEvents';
 import { ChartsAxesGradients } from '../internals/components/ChartsAxesGradients';
 import { useDrawingArea } from '../hooks';
 import { useSurfaceRef } from '../context/SvgRefProvider';
+import { useSize } from '../context/SizeProvider';
 
 export interface ChartsSurfaceProps {
   className?: string;
@@ -36,6 +37,7 @@ const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(functi
   ref: React.Ref<SVGSVGElement>,
 ) {
   const { width, height, left, right, top, bottom } = useDrawingArea();
+  const { hasIntrinsicSize } = useSize();
   const surfaceRef = useSurfaceRef();
   const handleRef = useForkRef(surfaceRef, ref);
   const themeProps = useThemeProps({ props: inProps, name: 'MuiChartsSurface' });
@@ -44,7 +46,6 @@ const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(functi
 
   const svgWidth = width + left + right;
   const svgHeight = height + top + bottom;
-  const hasIntrinsicSize = width !== 0 && height !== 0;
 
   const svgView = {
     width: svgWidth,

--- a/packages/x-charts/src/ChartsSurface/ChartsSurface.tsx
+++ b/packages/x-charts/src/ChartsSurface/ChartsSurface.tsx
@@ -56,8 +56,6 @@ const ChartsSurface = React.forwardRef<SVGSVGElement, ChartsSurfaceProps>(functi
 
   return (
     <ChartsSurfaceStyles
-      width={svgWidth}
-      height={svgHeight}
       viewBox={`${svgView.x} ${svgView.y} ${svgView.width} ${svgView.height}`}
       className={className}
       {...other}

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -297,16 +297,6 @@ LineChart.propTypes = {
    */
   onMarkClick: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -211,16 +211,6 @@ PieChart.propTypes = {
    */
   onItemClick: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * The series to display in the pie chart.
    * An array of [[PieSeriesType]] objects.
    */

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -251,16 +251,6 @@ ScatterChart.propTypes = {
    */
   onItemClick: PropTypes.func,
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Indicate which axis to display the right of the charts.
    * Can be a string (the id of the axis) or an object `ChartsYAxisProps`.
    * @default null

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -318,16 +318,6 @@ SparkLineChart.propTypes = {
    */
   plotType: PropTypes.oneOf(['bar', 'line']),
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * Set to `true` to highlight the value.
    * With line, it shows a point.
    * With bar, it shows a highlight band.

--- a/packages/x-charts/src/context/ChartDataProvider/ChartDataProvider.tsx
+++ b/packages/x-charts/src/context/ChartDataProvider/ChartDataProvider.tsx
@@ -127,16 +127,6 @@ ChartDataProvider.propTypes = {
    */
   plugins: PropTypes.arrayOf(PropTypes.object),
   /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender: PropTypes.bool,
-  /**
    * The array of series to display.
    * Each type of series has its own specificity.
    * Please refer to the appropriate docs page to learn more about it.

--- a/packages/x-charts/src/context/ChartDataProvider/useChartDataProviderProps.ts
+++ b/packages/x-charts/src/context/ChartDataProvider/useChartDataProviderProps.ts
@@ -26,7 +26,6 @@ export const useChartDataProviderProps = (props: ChartDataProviderProps) => {
     plugins,
     children,
     skipAnimation,
-    resolveSizeBeforeRender,
   } = props;
 
   const [defaultizedXAxis, defaultizedYAxis] = useDefaultizeAxis(xAxis, yAxis, dataset);
@@ -68,7 +67,6 @@ export const useChartDataProviderProps = (props: ChartDataProviderProps) => {
   const sizeProviderProps: Omit<SizeProviderProps, 'children'> = {
     width,
     height,
-    resolveSizeBeforeRender,
   };
 
   return {

--- a/packages/x-charts/src/context/ChartDataProvider/useChartDataProviderProps.ts
+++ b/packages/x-charts/src/context/ChartDataProvider/useChartDataProviderProps.ts
@@ -26,6 +26,7 @@ export const useChartDataProviderProps = (props: ChartDataProviderProps) => {
     plugins,
     children,
     skipAnimation,
+    resolveSizeBeforeRender,
   } = props;
 
   const [defaultizedXAxis, defaultizedYAxis] = useDefaultizeAxis(xAxis, yAxis, dataset);
@@ -67,6 +68,7 @@ export const useChartDataProviderProps = (props: ChartDataProviderProps) => {
   const sizeProviderProps: Omit<SizeProviderProps, 'children'> = {
     width,
     height,
+    resolveSizeBeforeRender,
   };
 
   return {

--- a/packages/x-charts/src/context/SizeProvider/Size.types.ts
+++ b/packages/x-charts/src/context/SizeProvider/Size.types.ts
@@ -9,16 +9,6 @@ export interface SizeProviderProps {
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */
   height?: number;
-  /**
-   * The chart will try to wait for the parent container to resolve its size
-   * before it renders for the first time.
-   *
-   * This can be useful in some scenarios where the chart appear to grow after
-   * the first render, like when used inside a grid.
-   *
-   * @default false
-   */
-  resolveSizeBeforeRender?: boolean;
   children: React.ReactNode;
 }
 

--- a/packages/x-charts/src/context/SizeProvider/Size.types.ts
+++ b/packages/x-charts/src/context/SizeProvider/Size.types.ts
@@ -28,10 +28,6 @@ export interface SizeContextState extends Required<Pick<SizeProviderProps, 'heig
    */
   containerRef: React.RefObject<HTMLDivElement>;
   /**
-   * If the chart has a defined size.
-   */
-  hasIntrinsicSize: boolean;
-  /**
    * The input height of the chart in px.
    */
   inHeight?: number;

--- a/packages/x-charts/src/context/SizeProvider/Size.types.ts
+++ b/packages/x-charts/src/context/SizeProvider/Size.types.ts
@@ -28,6 +28,10 @@ export interface SizeContextState extends Required<Pick<SizeProviderProps, 'heig
    */
   containerRef: React.RefObject<HTMLDivElement>;
   /**
+   * If the chart has a defined size.
+   */
+  hasIntrinsicSize: boolean;
+  /**
    * The input height of the chart in px.
    */
   inHeight?: number;

--- a/packages/x-charts/src/context/SizeProvider/Size.types.ts
+++ b/packages/x-charts/src/context/SizeProvider/Size.types.ts
@@ -9,6 +9,16 @@ export interface SizeProviderProps {
    * The height of the chart in px. If not defined, it takes the height of the parent element.
    */
   height?: number;
+  /**
+   * The chart will try to wait for the parent container to resolve its size
+   * before it renders for the first time.
+   *
+   * This can be useful in some scenarios where the chart appear to grow after
+   * the first render, like when used inside a grid.
+   *
+   * @default false
+   */
+  resolveSizeBeforeRender?: boolean;
   children: React.ReactNode;
 }
 

--- a/packages/x-charts/src/context/SizeProvider/SizeContext.ts
+++ b/packages/x-charts/src/context/SizeProvider/SizeContext.ts
@@ -6,6 +6,7 @@ import { SizeContextState } from './Size.types';
 export const SizeContext = React.createContext<Initializable<SizeContextState>>({
   isInitialized: false,
   data: {
+    hasIntrinsicSize: false,
     containerRef: null as any,
     height: 0,
     width: 0,

--- a/packages/x-charts/src/context/SizeProvider/SizeContext.ts
+++ b/packages/x-charts/src/context/SizeProvider/SizeContext.ts
@@ -6,7 +6,6 @@ import { SizeContextState } from './Size.types';
 export const SizeContext = React.createContext<Initializable<SizeContextState>>({
   isInitialized: false,
   data: {
-    hasIntrinsicSize: false,
     containerRef: null as any,
     height: 0,
     width: 0,

--- a/packages/x-charts/src/context/SizeProvider/SizeProvider.tsx
+++ b/packages/x-charts/src/context/SizeProvider/SizeProvider.tsx
@@ -12,11 +12,7 @@ import { useChartContainerDimensions } from './useChartContainerDimensions';
  * This provider is also responsible for resolving the size of the container before rendering and if the parent size changes.
  */
 function SizeProvider(props: SizeProviderProps) {
-  const dimensions = useChartContainerDimensions(
-    props.width,
-    props.height,
-    props.resolveSizeBeforeRender,
-  );
+  const dimensions = useChartContainerDimensions(props.width, props.height);
 
   const value = React.useMemo(
     () => ({

--- a/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
+++ b/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
@@ -4,11 +4,9 @@ import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import ownerWindow from '@mui/utils/ownerWindow';
 
-export const useChartContainerDimensions = (
-  inWidth?: number,
-  inHeight?: number,
-  resolveSizeBeforeRender?: boolean,
-) => {
+const MAX_COMPUTE_RUN = 10;
+
+export const useChartContainerDimensions = (inWidth?: number, inHeight?: number) => {
   const hasInSize = inWidth !== undefined && inHeight !== undefined;
   const stateRef = React.useRef({ displayError: false, initialCompute: true, computeRun: 0 });
   const rootRef = React.useRef<HTMLDivElement>(null);
@@ -48,9 +46,8 @@ export const useChartContainerDimensions = (
     // computeRun is used to avoid infinite loops.
     if (
       hasInSize ||
-      !resolveSizeBeforeRender ||
       !stateRef.current.initialCompute ||
-      stateRef.current.computeRun > 20
+      stateRef.current.computeRun > MAX_COMPUTE_RUN
     ) {
       return;
     }
@@ -61,7 +58,7 @@ export const useChartContainerDimensions = (
     } else if (stateRef.current.initialCompute) {
       stateRef.current.initialCompute = false;
     }
-  }, [width, height, computeSize, resolveSizeBeforeRender, hasInSize]);
+  }, [width, height, computeSize, hasInSize]);
 
   useEnhancedEffect(() => {
     if (hasInSize) {
@@ -111,7 +108,6 @@ export const useChartContainerDimensions = (
       stateRef.current.displayError = false;
     }
   }
-
   const finalWidth = inWidth ?? width;
   const finalHeight = inHeight ?? height;
 
@@ -119,7 +115,7 @@ export const useChartContainerDimensions = (
     containerRef: rootRef,
     width: finalWidth,
     height: finalHeight,
-    hasIntrinsicSize: Boolean(finalWidth && finalHeight),
+    hasIntrinsicSize: Boolean(finalWidth > 0 && finalHeight > 0),
     inWidth,
     inHeight,
   };

--- a/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
+++ b/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
@@ -115,7 +115,7 @@ export const useChartContainerDimensions = (inWidth?: number, inHeight?: number)
     containerRef: rootRef,
     width: finalWidth,
     height: finalHeight,
-    hasIntrinsicSize: Boolean(finalWidth > 0 && finalHeight > 0),
+    hasIntrinsicSize: finalWidth > 0 && finalHeight > 0,
     inWidth,
     inHeight,
   };

--- a/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
+++ b/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
@@ -115,6 +115,7 @@ export const useChartContainerDimensions = (inWidth?: number, inHeight?: number)
     containerRef: rootRef,
     width: finalWidth,
     height: finalHeight,
+    hasIntrinsicSize: Boolean(finalWidth > 0 && finalHeight > 0),
     inWidth,
     inHeight,
   };

--- a/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
+++ b/packages/x-charts/src/context/SizeProvider/useChartContainerDimensions.ts
@@ -115,7 +115,6 @@ export const useChartContainerDimensions = (inWidth?: number, inHeight?: number)
     containerRef: rootRef,
     width: finalWidth,
     height: finalHeight,
-    hasIntrinsicSize: Boolean(finalWidth > 0 && finalHeight > 0),
     inWidth,
     inHeight,
   };


### PR DESCRIPTION
By removing the height/width attributes and making sure a SVG with some size renders if the size of the parent is unknown, we should be able to fill the entire width and height of the parent container even if it doesn't contain a defined height.

## Changelog

- Removed the `resolveSizeBeforeRender` prop from all charts component — [Learn more](https://next.mui.com/x/migration/migration-charts-v7/#remove-resolvesizebeforerender-prop)