### PR TITLE
[charts] Fix `ScatterChart` tooltip wrong defaults

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/contentDisplayed.test.tsx
+++ b/packages/x-charts/src/ChartsTooltip/contentDisplayed.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, fireEvent } from '@mui/internal-test-utils';
 import { BarChart } from '@mui/x-charts/BarChart';
-import { firePointerEvent } from '../tests/firePointerEvent';
 
 const config = {
   dataset: [
@@ -55,7 +54,7 @@ describe('ChartsTooltip', () => {
       const svg = document.querySelector<HTMLElement>('svg')!;
 
       fireEvent.pointerEnter(svg); // Trigger the tooltip
-      firePointerEvent(svg, 'pointermove', {
+      fireEvent.pointerMove(svg, {
         clientX: 198,
         clientY: 60,
       });
@@ -74,7 +73,7 @@ describe('ChartsTooltip', () => {
         '2',
       ]);
 
-      firePointerEvent(svg, 'pointermove', {
+      fireEvent.pointerMove(svg, {
         clientX: 201,
         clientY: 60,
       });
@@ -122,7 +121,7 @@ describe('ChartsTooltip', () => {
       const svg = document.querySelector<HTMLElement>('svg')!;
 
       fireEvent.pointerEnter(svg); // Trigger the tooltip
-      firePointerEvent(svg, 'pointermove', {
+      fireEvent.pointerMove(svg, {
         clientX: 150,
         clientY: 60,
       });
@@ -141,7 +140,7 @@ describe('ChartsTooltip', () => {
         '2',
       ]);
 
-      firePointerEvent(svg, 'pointermove', {
+      fireEvent.pointerMove(svg, {
         clientX: 150,
         clientY: 220,
       });
@@ -194,7 +193,7 @@ describe('ChartsTooltip', () => {
       fireEvent.pointerEnter(rectangles[0]);
 
       fireEvent.pointerEnter(svg); // Trigger the tooltip
-      firePointerEvent(svg, 'pointermove', {
+      fireEvent.pointerMove(svg, {
         clientX: 150,
         clientY: 60,
       }); // Only to set the tooltip position
@@ -239,7 +238,7 @@ describe('ChartsTooltip', () => {
       fireEvent.pointerEnter(rectangles[0]);
 
       fireEvent.pointerEnter(svg); // Trigger the tooltip
-      firePointerEvent(svg, 'pointermove', {
+      fireEvent.pointerMove(svg, {
         clientX: 150,
         clientY: 60,
       }); // Only to set the tooltip position

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -135,7 +135,7 @@ const ScatterChart = React.forwardRef(function ScatterChart(
         <ChartsOverlay {...overlayProps} />
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsAxisHighlight {...axisHighlightProps} />
-        {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
+        {!props.loading && <Tooltip trigger="item" {...props.slotProps?.tooltip} />}
         {children}
       </ZAxisContextProvider>
     </ChartContainer>


### PR DESCRIPTION
Fix regression from #15154 where the default tooltip was changed to `axis` for `ScatterChart`