### PR TITLE
[DataGrid] Fix last separator not being hidden when grid is scrollable

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -456,7 +456,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
           fields={headerInfo.fields}
           colIndex={headerInfo.colIndex}
           depth={depth}
-          isLastColumn={headerInfo.colIndex === visibleColumns.length - headerInfo.fields.length}
+          isLastColumn={index === visibleColumnGroupHeader.length - 1}
           maxDepth={headerGroupingMaxDepth}
           height={dimensions.groupHeaderHeight}
           hasFocus={hasFocus}


### PR DESCRIPTION
Fixes #15529 

The `isLastColumn` value was not always correct, depending on the columns in view. This simplifies the check so that it only takes into account whether the column group is the last in the row.