### PR TITLE
[l10n] Improve Dutch (nl-NL) locale

### DIFF
--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -70,7 +70,7 @@ const nlNLPickers: Partial<PickersLocaleText> = {
   dateTableLabel: 'kies datum',
 
   // Field section placeholders
-  fieldYearPlaceholder: (params) => 'Y'.repeat(params.digitAmount),
+  fieldYearPlaceholder: (params) => 'J'.repeat(params.digitAmount),
   fieldMonthPlaceholder: (params) => (params.contentType === 'letter' ? 'MMMM' : 'MM'),
   fieldDayPlaceholder: () => 'DD',
   fieldWeekDayPlaceholder: (params) => (params.contentType === 'letter' ? 'EEEE' : 'EE'),

--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -90,7 +90,7 @@ const nlNLPickers: Partial<PickersLocaleText> = {
   meridiem: 'Middag',
 
   // Common
-  empty: 'Legen',
+  empty: 'Leeg',
 };
 
 export const nlNL = getPickersLocalization(nlNLPickers);

--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -74,7 +74,7 @@ const nlNLPickers: Partial<PickersLocaleText> = {
   fieldMonthPlaceholder: (params) => (params.contentType === 'letter' ? 'MMMM' : 'MM'),
   fieldDayPlaceholder: () => 'DD',
   fieldWeekDayPlaceholder: (params) => (params.contentType === 'letter' ? 'EEEE' : 'EE'),
-  fieldHoursPlaceholder: () => 'hh',
+  fieldHoursPlaceholder: () => 'uu',
   fieldMinutesPlaceholder: () => 'mm',
   fieldSecondsPlaceholder: () => 'ss',
   fieldMeridiemPlaceholder: () => 'aa',

--- a/packages/x-date-pickers/src/locales/nlNL.ts
+++ b/packages/x-date-pickers/src/locales/nlNL.ts
@@ -25,10 +25,10 @@ const nlNLPickers: Partial<PickersLocaleText> = {
   // DateRange labels
   start: 'Start',
   end: 'Einde',
-  startDate: 'Start datum',
-  startTime: 'Start tijd',
-  endDate: 'Eind datum',
-  endTime: 'Eind tijd',
+  startDate: 'Startdatum',
+  startTime: 'Starttijd',
+  endDate: 'Einddatum',
+  endTime: 'Eindtijd',
 
   // Action bar
   cancelButtonLabel: 'Annuleren',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- Update placeholders from:
   - `Y` (Year) to `J` (Jaar)
   - `hh` (Hour) to `uu` (Uur)
- Fix compound words: Words like `start date` are a single word in dutch (`startdatum`).
- The translation key `empty` indicates an empty state, not the verb "to empty". It's used for `aria-valuetext` to indicate an empty value.