### PR TITLE
[core] Remove dead translation key

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -3,192 +3,192 @@
     "languageTag": "ar-SD",
     "importName": "arSD",
     "localeName": "Arabic (Sudan)",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/arSD.ts"
   },
   {
     "languageTag": "be-BY",
     "importName": "beBY",
     "localeName": "Belarusian",
-    "missingKeysCount": 45,
-    "totalKeysCount": 133,
+    "missingKeysCount": 44,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/beBY.ts"
   },
   {
     "languageTag": "bg-BG",
     "importName": "bgBG",
     "localeName": "Bulgarian",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/bgBG.ts"
   },
   {
     "languageTag": "zh-HK",
     "importName": "zhHK",
     "localeName": "Chinese (Hong Kong)",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/zhHK.ts"
   },
   {
     "languageTag": "zh-CN",
     "importName": "zhCN",
     "localeName": "Chinese (Simplified)",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/zhCN.ts"
   },
   {
     "languageTag": "zh-TW",
     "importName": "zhTW",
     "localeName": "Chinese (Taiwan)",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/zhTW.ts"
   },
   {
     "languageTag": "hr-HR",
     "importName": "hrHR",
     "localeName": "Croatian",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/hrHR.ts"
   },
   {
     "languageTag": "cs-CZ",
     "importName": "csCZ",
     "localeName": "Czech",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/csCZ.ts"
   },
   {
     "languageTag": "da-DK",
     "importName": "daDK",
     "localeName": "Danish",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/daDK.ts"
   },
   {
     "languageTag": "nl-NL",
     "importName": "nlNL",
     "localeName": "Dutch",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/nlNL.ts"
   },
   {
     "languageTag": "fi-FI",
     "importName": "fiFI",
     "localeName": "Finnish",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/fiFI.ts"
   },
   {
     "languageTag": "fr-FR",
     "importName": "frFR",
     "localeName": "French",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/frFR.ts"
   },
   {
     "languageTag": "de-DE",
     "importName": "deDE",
     "localeName": "German",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/deDE.ts"
   },
   {
     "languageTag": "el-GR",
     "importName": "elGR",
     "localeName": "Greek",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/elGR.ts"
   },
   {
     "languageTag": "he-IL",
     "importName": "heIL",
     "localeName": "Hebrew",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/heIL.ts"
   },
   {
     "languageTag": "hu-HU",
     "importName": "huHU",
     "localeName": "Hungarian",
-    "missingKeysCount": 17,
-    "totalKeysCount": 133,
+    "missingKeysCount": 16,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/huHU.ts"
   },
   {
     "languageTag": "is-IS",
     "importName": "isIS",
     "localeName": "Icelandic",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/isIS.ts"
   },
   {
     "languageTag": "it-IT",
     "importName": "itIT",
     "localeName": "Italian",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/itIT.ts"
   },
   {
     "languageTag": "ja-JP",
     "importName": "jaJP",
     "localeName": "Japanese",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/jaJP.ts"
   },
   {
     "languageTag": "ko-KR",
     "importName": "koKR",
     "localeName": "Korean",
-    "missingKeysCount": 46,
-    "totalKeysCount": 133,
+    "missingKeysCount": 45,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/koKR.ts"
   },
   {
     "languageTag": "nb-NO",
     "importName": "nbNO",
     "localeName": "Norwegian (Bokmål)",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/nbNO.ts"
   },
   {
     "languageTag": "nn-NO",
     "importName": "nnNO",
     "localeName": "Norwegian (Nynorsk)",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/nnNO.ts"
   },
   {
     "languageTag": "fa-IR",
     "importName": "faIR",
     "localeName": "Persian",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/faIR.ts"
   },
   {
     "languageTag": "pl-PL",
     "importName": "plPL",
     "localeName": "Polish",
-    "missingKeysCount": 22,
-    "totalKeysCount": 133,
+    "missingKeysCount": 21,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/plPL.ts"
   },
   {
@@ -196,7 +196,7 @@
     "importName": "ptPT",
     "localeName": "Portuguese",
     "missingKeysCount": 0,
-    "totalKeysCount": 133,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/ptPT.ts"
   },
   {
@@ -204,31 +204,31 @@
     "importName": "ptBR",
     "localeName": "Portuguese (Brazil)",
     "missingKeysCount": 0,
-    "totalKeysCount": 133,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/ptBR.ts"
   },
   {
     "languageTag": "ro-RO",
     "importName": "roRO",
     "localeName": "Romanian",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/roRO.ts"
   },
   {
     "languageTag": "ru-RU",
     "importName": "ruRU",
     "localeName": "Russian",
-    "missingKeysCount": 15,
-    "totalKeysCount": 133,
+    "missingKeysCount": 14,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/ruRU.ts"
   },
   {
     "languageTag": "sk-SK",
     "importName": "skSK",
     "localeName": "Slovak",
-    "missingKeysCount": 16,
-    "totalKeysCount": 133,
+    "missingKeysCount": 15,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/skSK.ts"
   },
   {
@@ -236,47 +236,47 @@
     "importName": "esES",
     "localeName": "Spanish",
     "missingKeysCount": 0,
-    "totalKeysCount": 133,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/esES.ts"
   },
   {
     "languageTag": "sv-SE",
     "importName": "svSE",
     "localeName": "Swedish",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/svSE.ts"
   },
   {
     "languageTag": "tr-TR",
     "importName": "trTR",
     "localeName": "Turkish",
-    "missingKeysCount": 13,
-    "totalKeysCount": 133,
+    "missingKeysCount": 12,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/trTR.ts"
   },
   {
     "languageTag": "uk-UA",
     "importName": "ukUA",
     "localeName": "Ukrainian",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/ukUA.ts"
   },
   {
     "languageTag": "ur-PK",
     "importName": "urPK",
     "localeName": "Urdu (Pakistan)",
-    "missingKeysCount": 19,
-    "totalKeysCount": 133,
+    "missingKeysCount": 18,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/urPK.ts"
   },
   {
     "languageTag": "vi-VN",
     "importName": "viVN",
     "localeName": "Vietnamese",
-    "missingKeysCount": 11,
-    "totalKeysCount": 133,
+    "missingKeysCount": 10,
+    "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/viVN.ts"
   }
 ]

--- a/packages/x-data-grid/src/constants/localeTextConstants.ts
+++ b/packages/x-data-grid/src/constants/localeTextConstants.ts
@@ -34,7 +34,6 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
   toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   toolbarPromptControlLabel: 'Prompt input',
-  toolbarPromptControlDeleteIconLabel: 'Clear',
   toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/arSD.ts
+++ b/packages/x-data-grid/src/locales/arSD.ts
@@ -36,7 +36,6 @@ const arSDGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/beBY.ts
+++ b/packages/x-data-grid/src/locales/beBY.ts
@@ -59,7 +59,6 @@ const beBYGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/bgBG.ts
+++ b/packages/x-data-grid/src/locales/bgBG.ts
@@ -35,7 +35,6 @@ const bgBGGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/csCZ.ts
+++ b/packages/x-data-grid/src/locales/csCZ.ts
@@ -43,7 +43,6 @@ const csCZGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/daDK.ts
+++ b/packages/x-data-grid/src/locales/daDK.ts
@@ -36,7 +36,6 @@ const daDKGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/deDE.ts
+++ b/packages/x-data-grid/src/locales/deDE.ts
@@ -36,7 +36,6 @@ const deDEGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/elGR.ts
+++ b/packages/x-data-grid/src/locales/elGR.ts
@@ -36,7 +36,6 @@ const elGRGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/esES.ts
+++ b/packages/x-data-grid/src/locales/esES.ts
@@ -36,7 +36,6 @@ const esESGrid: Partial<GridLocaleText> = {
   toolbarPromptControlWithRecordingPlaceholder: 'Escriba o grabe un prompt…',
   toolbarPromptControlRecordingPlaceholder: 'Esperando por un prompt…',
   toolbarPromptControlLabel: 'Introduzca un prompt',
-  toolbarPromptControlDeleteIconLabel: 'Limpiar',
   toolbarPromptControlRecordButtonDefaultLabel: 'Grabar',
   toolbarPromptControlRecordButtonActiveLabel: 'Parar de grabar',
   toolbarPromptControlSendActionLabel: 'Enviar',

--- a/packages/x-data-grid/src/locales/faIR.ts
+++ b/packages/x-data-grid/src/locales/faIR.ts
@@ -36,7 +36,6 @@ const faIRGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/fiFI.ts
+++ b/packages/x-data-grid/src/locales/fiFI.ts
@@ -36,7 +36,6 @@ const fiFIGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/frFR.ts
+++ b/packages/x-data-grid/src/locales/frFR.ts
@@ -36,7 +36,6 @@ const frFRGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/heIL.ts
+++ b/packages/x-data-grid/src/locales/heIL.ts
@@ -36,7 +36,6 @@ const heILGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/hrHR.ts
+++ b/packages/x-data-grid/src/locales/hrHR.ts
@@ -43,7 +43,6 @@ const hrHRGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/huHU.ts
+++ b/packages/x-data-grid/src/locales/huHU.ts
@@ -35,7 +35,6 @@ const huHUGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/isIS.ts
+++ b/packages/x-data-grid/src/locales/isIS.ts
@@ -36,7 +36,6 @@ const isISGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/itIT.ts
+++ b/packages/x-data-grid/src/locales/itIT.ts
@@ -36,7 +36,6 @@ const itITGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/jaJP.ts
+++ b/packages/x-data-grid/src/locales/jaJP.ts
@@ -35,7 +35,6 @@ const jaJPGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/koKR.ts
+++ b/packages/x-data-grid/src/locales/koKR.ts
@@ -35,7 +35,6 @@ const koKRGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/nbNO.ts
+++ b/packages/x-data-grid/src/locales/nbNO.ts
@@ -36,7 +36,6 @@ const nbNOGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/nlNL.ts
+++ b/packages/x-data-grid/src/locales/nlNL.ts
@@ -36,7 +36,6 @@ const nlNLGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/nnNO.ts
+++ b/packages/x-data-grid/src/locales/nnNO.ts
@@ -36,7 +36,6 @@ const nnNOGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/plPL.ts
+++ b/packages/x-data-grid/src/locales/plPL.ts
@@ -35,7 +35,6 @@ const plPLGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/ptBR.ts
+++ b/packages/x-data-grid/src/locales/ptBR.ts
@@ -36,7 +36,6 @@ const ptBRGrid: Partial<GridLocaleText> = {
   toolbarPromptControlWithRecordingPlaceholder: 'Digite ou grave um prompt…',
   toolbarPromptControlRecordingPlaceholder: 'Ouvindo o prompt…',
   toolbarPromptControlLabel: 'Entrada de prompt',
-  toolbarPromptControlDeleteIconLabel: 'Limpar',
   toolbarPromptControlRecordButtonDefaultLabel: 'Gravar',
   toolbarPromptControlRecordButtonActiveLabel: 'Parar gravação',
   toolbarPromptControlSendActionLabel: 'Enviar',

--- a/packages/x-data-grid/src/locales/ptPT.ts
+++ b/packages/x-data-grid/src/locales/ptPT.ts
@@ -36,7 +36,6 @@ const ptPTGrid: Partial<GridLocaleText> = {
   toolbarPromptControlWithRecordingPlaceholder: 'Digite ou grave um prompt…',
   toolbarPromptControlRecordingPlaceholder: 'Ouvindo o prompt…',
   toolbarPromptControlLabel: 'Entrada de prompt',
-  toolbarPromptControlDeleteIconLabel: 'Limpar',
   toolbarPromptControlRecordButtonDefaultLabel: 'Gravar',
   toolbarPromptControlRecordButtonActiveLabel: 'Parar gravação',
   toolbarPromptControlSendActionLabel: 'Enviar',

--- a/packages/x-data-grid/src/locales/roRO.ts
+++ b/packages/x-data-grid/src/locales/roRO.ts
@@ -36,7 +36,6 @@ const roROGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/ruRU.ts
+++ b/packages/x-data-grid/src/locales/ruRU.ts
@@ -60,7 +60,6 @@ const ruRUGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/skSK.ts
+++ b/packages/x-data-grid/src/locales/skSK.ts
@@ -43,7 +43,6 @@ const skSKGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/svSE.ts
+++ b/packages/x-data-grid/src/locales/svSE.ts
@@ -36,7 +36,6 @@ const svSEGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/trTR.ts
+++ b/packages/x-data-grid/src/locales/trTR.ts
@@ -35,7 +35,6 @@ const trTRGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/ukUA.ts
+++ b/packages/x-data-grid/src/locales/ukUA.ts
@@ -60,7 +60,6 @@ const ukUAGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/urPK.ts
+++ b/packages/x-data-grid/src/locales/urPK.ts
@@ -36,7 +36,6 @@ const urPKGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/viVN.ts
+++ b/packages/x-data-grid/src/locales/viVN.ts
@@ -36,7 +36,6 @@ const viVNGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/zhCN.ts
+++ b/packages/x-data-grid/src/locales/zhCN.ts
@@ -35,7 +35,6 @@ const zhCNGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/zhHK.ts
+++ b/packages/x-data-grid/src/locales/zhHK.ts
@@ -36,7 +36,6 @@ const zhHKGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/locales/zhTW.ts
+++ b/packages/x-data-grid/src/locales/zhTW.ts
@@ -35,7 +35,6 @@ const zhTWGrid: Partial<GridLocaleText> = {
   // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
   // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
   // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlDeleteIconLabel: 'Clear',
   // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
   // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
   // toolbarPromptControlSendActionLabel: 'Send',

--- a/packages/x-data-grid/src/models/api/gridLocaleTextApi.ts
+++ b/packages/x-data-grid/src/models/api/gridLocaleTextApi.ts
@@ -46,7 +46,6 @@ export interface GridLocaleText {
   toolbarPromptControlWithRecordingPlaceholder: string;
   toolbarPromptControlRecordingPlaceholder: string;
   toolbarPromptControlLabel: string;
-  toolbarPromptControlDeleteIconLabel: string;
   toolbarPromptControlRecordButtonDefaultLabel: string;
   toolbarPromptControlRecordButtonActiveLabel: string;
   toolbarPromptControlSendActionLabel: string;


### PR DESCRIPTION
The key doesn't seem to be used. It was added #15401. I guess we can remove it?

I also wonder:

- if we should we use a // Common structure for the data grid like used for the pickers: https://github.com/mui/mui-x/blob/483fc6a466116c339ecbce300ee9a967ac086d85/packages/x-date-pickers/src/locales/enUS.ts#L87-L88
  We start to have quite some duplication for clear: x3. https://github.com/search?q=repo%3Amui%2Fmui-x+Clear+path%3A%2F%5Epackages%5C%2Fx-data-grid%5C%2Fsrc%5C%2Fconstants%5C%2F%2F&type=code.

- if we should add translation keys for unstable features. People then tends to create PRs to translate those, but it can be noise until it's stable.