### PR TITLE
[l10n] Improve Chinese (zh-CN) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -35,7 +35,7 @@
     "languageTag": "zh-CN",
     "importName": "zhCN",
     "localeName": "Chinese (Simplified)",
-    "missingKeysCount": 10,
+    "missingKeysCount": 0,
     "totalKeysCount": 132,
     "githubLink": "https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/locales/zhCN.ts"
   },

--- a/packages/x-data-grid/src/locales/zhCN.ts
+++ b/packages/x-data-grid/src/locales/zhCN.ts
@@ -31,15 +31,15 @@ const zhCNGrid: Partial<GridLocaleText> = {
   toolbarQuickFilterDeleteIconLabel: '清除',
 
   // Prompt toolbar field
-  // toolbarPromptControlPlaceholder: 'Type a prompt…',
-  // toolbarPromptControlWithRecordingPlaceholder: 'Type or record a prompt…',
-  // toolbarPromptControlRecordingPlaceholder: 'Listening for prompt…',
-  // toolbarPromptControlLabel: 'Prompt input',
-  // toolbarPromptControlRecordButtonDefaultLabel: 'Record',
-  // toolbarPromptControlRecordButtonActiveLabel: 'Stop recording',
-  // toolbarPromptControlSendActionLabel: 'Send',
-  // toolbarPromptControlSendActionAriaLabel: 'Send prompt',
-  // toolbarPromptControlErrorMessage: 'An error occurred while processing the request. Please try again with a different prompt.',
+  toolbarPromptControlPlaceholder: '输入提示词',
+  toolbarPromptControlWithRecordingPlaceholder: '输入提示词或点击录音',
+  toolbarPromptControlRecordingPlaceholder: '正在录音...',
+  toolbarPromptControlLabel: '提示词输入',
+  toolbarPromptControlRecordButtonDefaultLabel: '录音',
+  toolbarPromptControlRecordButtonActiveLabel: '停止录音',
+  toolbarPromptControlSendActionLabel: '发送',
+  toolbarPromptControlSendActionAriaLabel: '发送提示词',
+  toolbarPromptControlErrorMessage: '处理请求时出现错误。请使用其他提示词再试。',
 
   // Export selector toolbar button text
   toolbarExport: '导出',
@@ -53,7 +53,7 @@ const zhCNGrid: Partial<GridLocaleText> = {
   columnsManagementNoColumns: '没有列',
   columnsManagementShowHideAllText: '显示/隐藏所有',
   columnsManagementReset: '重置',
-  // columnsManagementDeleteIconLabel: 'Clear',
+  columnsManagementDeleteIconLabel: '清除',
 
   // Filter panel text
   filterPanelAddFilter: '添加筛选器',

--- a/packages/x-data-grid/src/locales/zhCN.ts
+++ b/packages/x-data-grid/src/locales/zhCN.ts
@@ -33,7 +33,7 @@ const zhCNGrid: Partial<GridLocaleText> = {
   // Prompt toolbar field
   toolbarPromptControlPlaceholder: '输入提示词',
   toolbarPromptControlWithRecordingPlaceholder: '输入提示词或点击录音',
-  toolbarPromptControlRecordingPlaceholder: '正在录音...',
+  toolbarPromptControlRecordingPlaceholder: '正在录音…',
   toolbarPromptControlLabel: '提示词输入',
   toolbarPromptControlRecordButtonDefaultLabel: '录音',
   toolbarPromptControlRecordButtonActiveLabel: '停止录音',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

improve Chinese (zh-CN) locale about prompt control labels

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- [x] Verify if the PR title respects the release format.
- [x] Update the documentation of supported locales by running `pnpm l10n`.
- [x] Clean files with `pnpm prettier`.
