### PR TITLE
[DataGrid] Remove unused `resize` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ We'd like to offer a big thanks to the 16 contributors who made this release pos
 - 🐞 Bugfixes
 - 📚 Documentation improvements
 
-### Breaking change
-
 Special thanks go out to the community contributors who have helped make this release possible:
 @CarlosLopezLg, @headironc, @hendrikpeilke, @k-rajat19, @lhilgert9, @viktormelin.
 Following are all team members who have contributed to this release:
@@ -56,7 +54,7 @@ Same changes as in `@mui/x-data-grid-pro@v8.0.0-alpha.1`, plus:
 #### Breaking change
 
 - The `FieldValueType` type has been renamed to `PickerValueType` — [Learn more](https://next.mui.com/x/migration/migration-pickers-v7/#renamed-variables).
-- The `toolbar` and `layout` slots no longer receive the  `disabled` and `readOnly` props — [Learn more](https://next.mui.com/x/migration/migration-pickers-v7/#slots-breaking-changes).
+- The `toolbar` and `layout` slots no longer receive the `disabled` and `readOnly` props — [Learn more](https://next.mui.com/x/migration/migration-pickers-v7/#slots-breaking-changes).
 
 #### `@mui/x-date-pickers@v8.0.0-alpha.1`
 
@@ -64,9 +62,9 @@ Same changes as in `@mui/x-data-grid-pro@v8.0.0-alpha.1`, plus:
 - [pickers] React 19 support (#15342) @arminmeh
 - [pickers] Add new properties to `PickerOwnerState` and `PickerContextValue` (#15415) @flaviendelangle
 - [pickers] Always use `props.value` when it changes (#15490) @flaviendelangle
-- [pickers] Ensure internal value timezone is updated  (#15435) @LukasTy
+- [pickers] Ensure internal value timezone is updated (#15435) @LukasTy
 - [pickers] Fix unused code in `<PickersToolbar />` component (#15515) @LukasTy
-- [pickers] Remove  `FieldValueType` in favor of `PickerValueType` (#15259) @arthurbalduini
+- [pickers] Remove `FieldValueType` in favor of `PickerValueType` (#15259) @arthurbalduini
 - [pickers] Remove the form props from the layout and the toolbar slots (#15492) @flaviendelangle
 - [pickers] Use `props.referenceDate` timezone when `props.value` and `props.defaultValue` are not defined (#15532) @flaviendelangle
 - [TimePicker] Prevent mouse events after `touchend` event (#15346) @arthurbalduini
@@ -82,12 +80,14 @@ Same changes as in `@mui/x-date-pickers@v8.0.0-alpha.1`, plus:
 #### Breaking change
 
 - The DX of the Tooltip customization has been refactored
+
   - The `tooltip` prop has been removed in favor of `slotProps.tooltip` for consistency.
-  - The `popper`, `axisContent`,  and `itemContent` slots have been removed in favor of the `tooltip` slot which overrides the entire tooltip.
+  - The `popper`, `axisContent`, and `itemContent` slots have been removed in favor of the `tooltip` slot which overrides the entire tooltip.
     - To override the tooltip content, use the `useItemTooltip` or `useAxisTooltip` hook to get the data, and wrap your component in `ChartsTooltipContainer` to follow the pointer position.
     - To override the tooltip placement, use the `ChartsItemTooltipContent` or `ChartsItemTooltipContent` to get default data and place them in your custom tooltip.
 
 - The library now uses the SVG `filter` attribute instead of `d3-color` for color manipulation.
+
   - This modification impacts the `LinePlot`, `AreaPlot`, and `BarPlot` components.
     If you've customized the `fill` of those elements, you might need to override it by using the CSS `filter`.
   - The `theme.styleOverride` is removed for `MuiLineElement`, `MuiAreaElement`, and `MuiBarElement` to improve performance.

--- a/docs/pages/x/api/data-grid/grid-api.json
+++ b/docs/pages/x/api/data-grid/grid-api.json
@@ -246,7 +246,6 @@
       "isPremiumPlan": true
     },
     "resetRowHeights": { "type": { "description": "() =&gt; void" }, "required": true },
-    "resize": { "type": { "description": "() =&gt; void" }, "required": true },
     "restoreState": {
       "type": { "description": "(stateToRestore: InitialState) =&gt; void" },
       "required": true

--- a/docs/translations/api-docs/data-grid/grid-api.json
+++ b/docs/translations/api-docs/data-grid/grid-api.json
@@ -127,9 +127,6 @@
     "publishEvent": { "description": "Emits an event." },
     "removeRowGroupingCriteria": { "description": "Remove the field from the row grouping model." },
     "resetRowHeights": { "description": "Forces the recalculation of the heights of all rows." },
-    "resize": {
-      "description": "Triggers a resize of the component and recalculation of width and height."
-    },
     "restoreState": { "description": "Inject the given values into the state of the DataGrid." },
     "scroll": {
       "description": "Triggers the viewport to scroll to the given positions (in pixels)."

--- a/packages/x-data-grid/src/hooks/features/dimensions/gridDimensionsApi.ts
+++ b/packages/x-data-grid/src/hooks/features/dimensions/gridDimensionsApi.ts
@@ -86,10 +86,6 @@ export interface GridDimensions {
 
 export interface GridDimensionsApi {
   /**
-   * Triggers a resize of the component and recalculation of width and height.
-   */
-  resize: () => void;
-  /**
    * Returns the dimensions of the grid
    * @returns {GridDimensions} The dimension information of the grid. If `null`, the grid is not ready yet.
    */

--- a/packages/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -3,7 +3,6 @@ import {
   unstable_ownerDocument as ownerDocument,
   unstable_useEnhancedEffect as useEnhancedEffect,
   unstable_useEventCallback as useEventCallback,
-  unstable_ownerWindow as ownerWindow,
 } from '@mui/utils';
 import { throttle } from '@mui/x-internals/throttle';
 import { GridEventListener } from '../../../models/events';
@@ -125,32 +124,12 @@ export function useGridDimensions(
     () => throttle(setSavedSize, props.resizeThrottleMs),
     [props.resizeThrottleMs],
   );
-  const previousSize = React.useRef<ElementSize>();
 
   const getRootDimensions = () => apiRef.current.state.dimensions;
 
   const setDimensions = useEventCallback((dimensions: GridDimensions) => {
     apiRef.current.setState((state) => ({ ...state, dimensions }));
   });
-
-  const resize = React.useCallback(() => {
-    const element = apiRef.current.mainElementRef.current;
-    if (!element) {
-      return;
-    }
-
-    const computedStyle = ownerWindow(element).getComputedStyle(element);
-
-    const newSize = {
-      width: parseFloat(computedStyle.width) || 0,
-      height: parseFloat(computedStyle.height) || 0,
-    };
-
-    if (!previousSize.current || !areElementSizesEqual(previousSize.current, newSize)) {
-      apiRef.current.publishEvent('resize', newSize);
-      previousSize.current = newSize;
-    }
-  }, [apiRef]);
 
   const getViewportPageSize = React.useCallback(() => {
     const dimensions = gridDimensionsSelector(apiRef.current.state);
@@ -304,7 +283,6 @@ export function useGridDimensions(
   ]);
 
   const apiPublic: GridDimensionsApi = {
-    resize,
     getRootDimensions,
   };
 


### PR DESCRIPTION
We stopped using it in https://github.com/mui/mui-x/pull/15549, and it's not needed anymore.

## Changelog

#### Breaking change

- The `apiRef.current.resize` method was removed.