### PR TITLE
[DataGrid] Remove try/catch from `GridCell` due to performance issues

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -30,7 +30,6 @@ import { useGridSelector, objectShallowCompare } from '../../hooks/utils/useGrid
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { gridFocusCellSelector } from '../../hooks/features/focus/gridFocusStateSelector';
-import { MissingRowIdError } from '../../hooks/features/rows/useGridParamsApi';
 import type { DataGridProcessedProps } from '../../models/props/DataGridProps';
 import { shouldCellShowLeftBorder, shouldCellShowRightBorder } from '../../utils/cellBorderUtils';
 import { GridPinnedColumnPosition } from '../../hooks/features/columns/gridColumnsInterfaces';
@@ -196,19 +195,17 @@ const GridCell = React.forwardRef<HTMLDivElement, GridCellProps>(function GridCe
       // This is required because `.getCellParams` tries to get the `state.rows.tree` entry
       // associated with `rowId`/`fieldId`, but this selector runs after the state has been
       // updated, while `rowId`/`fieldId` reference an entry in the old state.
-      try {
-        const result = apiRef.current.getCellParams<any, any, any, GridTreeNodeWithRender>(
-          rowId,
-          field,
-        );
-        result.api = apiRef.current;
-        return result;
-      } catch (error) {
-        if (error instanceof MissingRowIdError) {
-          return EMPTY_CELL_PARAMS;
-        }
-        throw error;
+      const row = apiRef.current.getRow(rowId);
+      if (!row) {
+        return EMPTY_CELL_PARAMS;
       }
+
+      const result = apiRef.current.getCellParams<any, any, any, GridTreeNodeWithRender>(
+        rowId,
+        field,
+      );
+      result.api = apiRef.current;
+      return result;
     },
     objectShallowCompare,
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes the performance issue described in #15615 

We had about 150ms of scripting overhead when updating rows fast on typing via external filters (e.g. typing 5 letters, so 5 updates = 150ms in ~1s of user interaction). The larger the viewport, the larger the overhead. After this small change, all of it is gone, and it's mostly layout updates now.