### PR TITLE
[DataGridPro] Fix pagination state not updating if the data source response has no rows

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -95,7 +95,7 @@ export const useGridDataSource = (
       if (cachedData !== undefined) {
         const rows = cachedData.rows;
         apiRef.current.setRows(rows);
-        if (cachedData.rowCount) {
+        if (cachedData.rowCount !== undefined) {
           apiRef.current.setRowCount(cachedData.rowCount);
         }
         return;
@@ -109,7 +109,7 @@ export const useGridDataSource = (
       try {
         const getRowsResponse = await getRows(fetchParams);
         apiRef.current.unstable_dataSource.cache.set(fetchParams, getRowsResponse);
-        if (getRowsResponse.rowCount) {
+        if (getRowsResponse.rowCount !== undefined) {
           apiRef.current.setRowCount(getRowsResponse.rowCount);
         }
         apiRef.current.setRows(getRowsResponse.rows);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

This PR resolves an issue where the pagination displays an incorrect number of rows when fetching data from an API using the `unstable_dataSource` prop.

**Reproduction:**

1. Visit Server side data docs, [with data source](https://mui.com/x/react-data-grid/server-side-data/#:~:text=Copy-,With%20data%20source,-With%20the%20data) section
2. Apply a filter that matches no items (for instance, quantity = 9999)

**Actual behavior:**

1. The displayed rows counter shows 100 items
2. You can navigate between pages

![image](https://github.com/user-attachments/assets/ef15be5f-581e-4778-905f-e50bbc2df117)

This contrasts with client-side pagination, where the counter shows “0–0 of 0” when no results are found after applying a filter.

**Expected behavior:**

The rows counter should reflect the actual number of available rows, showing “0–0 of 0” when no data matches the applied filter, consistent with client-side pagination.

![image](https://github.com/user-attachments/assets/3078d067-af50-4345-bac3-34bb797f8667)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
