### PR TITLE
[docs][tree view] Fix layout shift image

### DIFF
--- a/docs/data/tree-view/tree-item-customization/tree-item-customization.md
+++ b/docs/data/tree-view/tree-item-customization/tree-item-customization.md
@@ -17,10 +17,10 @@ Each Tree Item component is shaped by a series of composable slots.
 Hover over them in the demo below to see each slot.
 
 <span class="only-light-mode" style="border: 1px solid rgb(232, 234, 238); border-radius:12px">
-<img src="/static/x/tree-view-illustrations/tree-item-light.png" alt="Tree Item anatomy" loading="lazy"   >
+  <img src="/static/x/tree-view-illustrations/tree-item-light.png" width="1632" height="644" alt="Tree Item anatomy" loading="lazy" style="display: block;">
 </span>
 <span class="only-dark-mode" style="border: 1px solid rgb(29, 33, 38); border-radius:12px">
-<img src="/static/x/tree-view-illustrations/tree-item-dark.png" alt="Tree Item anatomy" loading="lazy"   >
+  <img src="/static/x/tree-view-illustrations/tree-item-dark.png" width="1632" height="644" alt="Tree Item anatomy" loading="lazy" style="display: block;">
 </span>
 
 ### Content


### PR DESCRIPTION
Patch #15066. It's buggy, it creates a layout shift, so the anchor links don't work correct:

https://github.com/user-attachments/assets/b68bc57b-0fa0-485e-a87d-8ab35523482c

After: https://deploy-preview-15626--material-ui-x.netlify.app/x/react-tree-view/tree-item-customization/