### PR TITLE
[x-data-grid][hooks] Change test dom check from /jsdom/ to /jsdom|HappyDOM/.

### DIFF
--- a/packages/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -329,7 +329,7 @@ export function useGridDimensions(
       rootDimensionsRef.current = size;
 
       // jsdom has no layout capabilities
-      const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+      const isJSDOM = /jsdom|HappyDOM/.test(window.navigator.userAgent);
 
       if (size.height === 0 && !errorShown.current && !props.autoHeight && !isJSDOM) {
         logger.error(

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -92,7 +92,7 @@ type ScrollCache = ReturnType<typeof createScrollCache>;
 let isJSDOM = false;
 try {
   if (typeof window !== 'undefined') {
-    isJSDOM = /jsdom/.test(window.navigator.userAgent);
+    isJSDOM = /jsdom|HappyDOM/.test(window.navigator.userAgent);
   }
 } catch (_) {
   /* ignore */


### PR DESCRIPTION
This change enables testing with Happy DOM without annoying warnings popping up. Fixes #10374.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Changelog

Detect HappyDOM like jsdom through the user agent string to avoid width and height warnings during tests.
