### PR TITLE
[l10n] Improve German (de-DE) locale

### DIFF
--- a/docs/data/data-grid/localization/data.json
+++ b/docs/data/data-grid/localization/data.json
@@ -99,7 +99,7 @@
     "languageTag": "de-DE",
     "importName": "deDE",
     "localeName": "German",
-    "missingKeysCount": 1,
+    "missingKeysCount": 0,
     "totalKeysCount": 123,
     "githubLink": "https://github.com/mui/mui-x/blob/v7.x/packages/x-data-grid/src/locales/deDE.ts"
   },

--- a/packages/x-data-grid/src/locales/deDE.ts
+++ b/packages/x-data-grid/src/locales/deDE.ts
@@ -43,7 +43,7 @@ const deDEGrid: Partial<GridLocaleText> = {
   columnsManagementNoColumns: 'Keine Spalten',
   columnsManagementShowHideAllText: 'Alle anzeigen/verbergen',
   columnsManagementReset: 'Zurücksetzen',
-  // columnsManagementDeleteIconLabel: 'Clear',
+  columnsManagementDeleteIconLabel: 'Löschen',
 
   // Filter panel text
   filterPanelAddFilter: 'Filter hinzufügen',


### PR DESCRIPTION
This PR adds the missing translation for the German (de-DE) locale in v7.x - https://github.com/mui/mui-x/issues/3211.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
