### PR TITLE
[docs] Fix Pickers theme augmentation example

### DIFF
--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -161,9 +161,14 @@ import type {} from '@mui/x-date-pickers-pro/themeAugmentation';
 const theme = createTheme({
   components: {
     MuiDatePicker: {
+      defaultProps: {
+        displayWeekNumber: true,
+      },
+    },
+    MuiDateRangeCalendar: {
       styleOverrides: {
         root: {
-          backgroundColor: 'red',
+          backgroundColor: '#f0f0f0',
         },
       },
     },


### PR DESCRIPTION
Fix #15654.

The docs theme augmentation example is incorrect.
The provided code never did anything, and at some point, we removed the keys for `styleOverrides`, where they did not work, which makes this code example completely broken. 🙈 