### PR TITLE
[codemod] Add missing `preset-safe` for the data-grid

### DIFF
--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -101,19 +101,19 @@ The list includes these transformers
 Renames the Tree View component to Simple Tree View
 
 ```diff
-- import { TreeView } from '@mui/x-tree-view';
-+ import { SimpleTreeView } from '@mui/x-tree-view';
+-import { TreeView } from '@mui/x-tree-view';
++import { SimpleTreeView } from '@mui/x-tree-view';
 
-- import { TreeView } from '@mui/x-tree-view/TreeView';
-+ import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+-import { TreeView } from '@mui/x-tree-view/TreeView';
++import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 
-  return (
--   <TreeView>
-+   <SimpleTreeView>
-      <TreeItem itemId="1" label="First item" />
--   </TreeView>
-+   </SimpleTreeView>
-  );
+ return (
+-  <TreeView>
++  <SimpleTreeView>
+     <TreeItem itemId="1" label="First item" />
+-  </TreeView>
++  </SimpleTreeView>
+ );
 ```
 
 #### `rename-tree-item-2`
@@ -121,11 +121,11 @@ Renames the Tree View component to Simple Tree View
 Renames the `TreeItem2` component to `TreeItem` (same for any subcomponents or utils like `useTreeItem2` or `TreeItem2Icon`).
 
 ```diff
-- import { TreeItem2 } from '@mui/x-tree-view';
-+ import { TreeItem } from '@mui/x-tree-view';
+-import { TreeItem2 } from '@mui/x-tree-view';
++import { TreeItem } from '@mui/x-tree-view';
 
-- import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
-+ import { TreeItem } from '@mui/x-tree-view/TreeItem';
+-import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
++import { TreeItem } from '@mui/x-tree-view/TreeItem';
 ```
 
 ### Charts codemods
@@ -151,10 +151,10 @@ The list includes these transformers
 Renames legend props to the corresponding slotProps.
 
 ```diff
-  <LineChart
--   legend={{ hiden: true}}
-+   slotProps={{ legend: { hiden: true} }}
-  />
+ <LineChart
+-  legend={{ hiden: true}}
++  slotProps={{ legend: { hiden: true} }}
+ />
 ```
 
 #### `rename-responsive-chart-container`
@@ -162,14 +162,14 @@ Renames legend props to the corresponding slotProps.
 Renames `ResponsiveChartContainer` and `ResponsiveChartContainerPro` by `ChartContainer` and `ChartContainerPro` which have the same behavior in v8.
 
 ```diff
-- import { ResponsiveChartContainer } from '@mui/x-charts/ResponsiveChartContainer';
-+ import { ChartContainer } from '@mui/x-charts/ChartContainer';
+-import { ResponsiveChartContainer } from '@mui/x-charts/ResponsiveChartContainer';
++import { ChartContainer } from '@mui/x-charts/ChartContainer';
 
-- <ResponsiveChartContainer>
-+ <ChartContainer>
-    <BarPlot />
-- </ResponsiveChartContainer>
-+ </ChartContainer>
+-<ResponsiveChartContainer>
++<ChartContainer>
+   <BarPlot />
+-</ResponsiveChartContainer>
++</ChartContainer>
 ```
 
 :::warning
@@ -178,8 +178,8 @@ Verify the git diff to remove the duplicate.
 
 ```diff
  import { ChartContainer } from '@mui/x-charts/ChartContainer';
-- import { ResponsiveChartContainer } from '@mui/x-charts/ResponsiveChartContainer';
-+ import { ChartContainer } from '@mui/x-charts/ChartContainer';
+-import { ResponsiveChartContainer } from '@mui/x-charts/ResponsiveChartContainer';
++import { ChartContainer } from '@mui/x-charts/ChartContainer';
 ```
 
 :::
@@ -189,16 +189,16 @@ Verify the git diff to remove the duplicate.
 Renames `labelFontSize` and `tickFontSize` props to the corresponding `xxxStyle` prop.
 
 ```diff
-  <ChartsXAxis
--   labelFontSize={18}
-+   labelStyle={{
-+     fontSize: 18
-+   }}
--   tickFontSize={20}
-+   tickStyle={{
-+     fontSize: 20
-+   }}
-  />
+ <ChartsXAxis
+-  labelFontSize={18}
++  labelStyle={{
++    fontSize: 18
++  }}
+-  tickFontSize={20}
++  tickStyle={{
++    fontSize: 20
++  }}
+ />
 ```
 
 ### Data Grid codemods
@@ -222,11 +222,11 @@ The list includes these transformers
 Remove feature flags for stabilized `experimentalFeatures`.
 
 ```diff
-  <DataGridPremium
--   experimentalFeatures={{
--     ariaV8: true,
--   }}
-  />
+ <DataGridPremium
+-  experimentalFeatures={{
+-    ariaV8: true,
+-  }}
+ />
 ```
 
 <!-- #default-branch-switch -->
@@ -256,15 +256,15 @@ The list includes these transformers
 Renames `FieldValueType` to `PickerValueType`.
 
 ```diff
-- import { FieldValueType } from '@mui/x-date-pickers';
-+ import { PickerValueType } from '@mui/x-date-pickers';
+-import { FieldValueType } from '@mui/x-date-pickers';
++import { PickerValueType } from '@mui/x-date-pickers';
 
-  interface MyComponentProps {
--   valueType: FieldValueType;
-+   valueType: PickerValueType;
-    foo: string;
-    bar: number;
-  }
+ interface MyComponentProps {
+-  valueType: FieldValueType;
++  valueType: PickerValueType;
+   foo: string;
+   bar: number;
+ }
 ```
 
 <!-- #default-branch-switch -->
@@ -473,13 +473,13 @@ Renames the Tree View component to Simple Tree View
 -import { TreeView } from '@mui/x-tree-view/TreeView';
 +import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 
-   return (
--    <TreeView>
-+    <SimpleTreeView>
-       <TreeItem itemId="1" label="First item" />
--    </TreeView>
-+    </SimpleTreeView>
-   );
+ return (
+-  <TreeView>
++  <SimpleTreeView>
+     <TreeItem itemId="1" label="First item" />
+-  </TreeView>
++  </SimpleTreeView>
+ );
 ```
 
 #### `rename-use-tree-item`

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -227,12 +227,13 @@ npx @mui/x-codemod@latest v8.0.0/data-grid/remove-stabilized-experimentalFeature
 
 ### Pickers codemods
 
-#### `preset-safe` for pickers v8.0.0
+#### `preset-safe` for Pickers v8.0.0
 
-The `preset-safe` codemods for pickers.
+The `preset-safe` codemods for Pickers.
 
 ```bash
-npx @mui/x-codemod@latest v8.0.0/pickers/preset-safe <path|folder>
+<!-- #default-branch-switch -->
+npx @mui/x-codemod@next v8.0.0/pickers/preset-safe <path|folder>
 ```
 
 The list includes these transformers
@@ -256,7 +257,8 @@ Renames `FieldValueType` to `PickerValueType`.
 ```
 
 ```bash
-npx @mui/x-codemod@latest v8.0.0/pickers/rename-and-move-field-value-type <path>
+<!-- #default-branch-switch -->
+npx @mui/x-codemod@next v8.0.0/pickers/rename-and-move-field-value-type <path>
 ```
 
 ## v7.0.0

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -66,8 +66,10 @@ A combination of all important transformers for migrating v7 to v8.
 It runs codemods for all MUI X packages (Data Grid, Date and Time Pickers, Tree View, and Charts).
 To run codemods for a specific package, refer to the respective section.
 
+<!-- #default-branch-switch -->
+
 ```bash
-npx @mui/x-codemod@latest v8.0.0/preset-safe <path|folder>
+npx @mui/x-codemod@next v8.0.0/preset-safe <path|folder>
 ```
 
 The corresponding sub-sections are listed below
@@ -79,12 +81,14 @@ The corresponding sub-sections are listed below
 
 ### Tree View codemods
 
-#### `preset-safe` for tree view v8.0.0
+#### `preset-safe` for Tree View v8.0.0
 
-The `preset-safe` codemods for tree view.
+The `preset-safe` codemods for Tree View.
+
+<!-- #default-branch-switch -->
 
 ```bash
-npx @mui/x-codemod@latest v8.0.0/tree-view/preset-safe <path|folder>
+npx @mui/x-codemod@next v8.0.0/tree-view/preset-safe <path|folder>
 ```
 
 The list includes these transformers
@@ -126,12 +130,14 @@ Renames the `TreeItem2` component to `TreeItem` (same for any subcomponents or u
 
 ### Charts codemods
 
-#### `preset-safe` for charts v8.0.0
+#### `preset-safe` for Charts v8.0.0
 
-The `preset-safe` codemods for charts.
+The `preset-safe` codemods for Charts.
+
+<!-- #default-branch-switch -->
 
 ```bash
-npx @mui/x-codemod@latest v8.0.0/charts/preset-safe <path|folder>
+npx @mui/x-codemod@next v8.0.0/charts/preset-safe <path|folder>
 ```
 
 The list includes these transformers
@@ -201,8 +207,10 @@ Renames `labelFontSize` and `tickFontSize` props to the corresponding `xxxStyle`
 
 The `preset-safe` codemods for Data Grid.
 
+<!-- #default-branch-switch -->
+
 ```bash
-npx @mui/x-codemod@latest v8.0.0/data-grid/preset-safe <path|folder>
+npx @mui/x-codemod@next v8.0.0/data-grid/preset-safe <path|folder>
 ```
 
 The list includes these transformers
@@ -221,8 +229,10 @@ Remove feature flags for stabilized `experimentalFeatures`.
   />
 ```
 
+<!-- #default-branch-switch -->
+
 ```bash
-npx @mui/x-codemod@latest v8.0.0/data-grid/remove-stabilized-experimentalFeatures <path>
+npx @mui/x-codemod@next v8.0.0/data-grid/remove-stabilized-experimentalFeatures <path>
 ```
 
 ### Pickers codemods
@@ -231,8 +241,9 @@ npx @mui/x-codemod@latest v8.0.0/data-grid/remove-stabilized-experimentalFeature
 
 The `preset-safe` codemods for Pickers.
 
-```bash
 <!-- #default-branch-switch -->
+
+```bash
 npx @mui/x-codemod@next v8.0.0/pickers/preset-safe <path|folder>
 ```
 
@@ -256,8 +267,9 @@ Renames `FieldValueType` to `PickerValueType`.
   }
 ```
 
-```bash
 <!-- #default-branch-switch -->
+
+```bash
 npx @mui/x-codemod@next v8.0.0/pickers/rename-and-move-field-value-type <path>
 ```
 
@@ -282,9 +294,9 @@ The corresponding sub-sections are listed below
 
 ### Pickers codemods
 
-#### `preset-safe` for pickers v7.0.0
+#### `preset-safe` for Pickers v7.0.0
 
-The `preset-safe` codemods for pickers.
+The `preset-safe` codemods for Pickers.
 
 ```bash
 npx @mui/x-codemod@latest v7.0.0/pickers/preset-safe <path|folder>
@@ -583,9 +595,9 @@ The corresponding sub-sections are listed below
 
 ### Pickers codemods
 
-#### `preset-safe` for pickers v6.0.0
+#### `preset-safe` for Pickers v6.0.0
 
-The `preset-safe` codemods for pickers.
+The `preset-safe` codemods for Pickers.
 
 ```bash
 npx @mui/x-codemod@latest v6.0.0/pickers/preset-safe <path|folder>

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -74,6 +74,8 @@ The corresponding sub-sections are listed below
 
 - [`preset-safe-for-tree-view`](#preset-safe-for-tree-view-v800)
 - [`preset-safe-for-charts`](#preset-safe-for-charts-v800)
+- [`preset-safe-for-data-grid`](#preset-safe-for-data-grid-v800)
+- [`preset-safe-for-pickers`](#preset-safe-for-pickers-v800)
 
 ### Tree View codemods
 
@@ -95,19 +97,19 @@ The list includes these transformers
 Renames the Tree View component to Simple Tree View
 
 ```diff
--import { TreeView } from '@mui/x-tree-view';
-+import { SimpleTreeView } from '@mui/x-tree-view';
+- import { TreeView } from '@mui/x-tree-view';
++ import { SimpleTreeView } from '@mui/x-tree-view';
 
--import { TreeView } from '@mui/x-tree-view/TreeView';
-+import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
+- import { TreeView } from '@mui/x-tree-view/TreeView';
++ import { SimpleTreeView } from '@mui/x-tree-view/SimpleTreeView';
 
-   return (
--    <TreeView>
-+    <SimpleTreeView>
-       <TreeItem itemId="1" label="First item" />
--    </TreeView>
-+    </SimpleTreeView>
-   );
+  return (
+-   <TreeView>
++   <SimpleTreeView>
+      <TreeItem itemId="1" label="First item" />
+-   </TreeView>
++   </SimpleTreeView>
+  );
 ```
 
 #### `rename-tree-item-2`
@@ -115,11 +117,11 @@ Renames the Tree View component to Simple Tree View
 Renames the `TreeItem2` component to `TreeItem` (same for any subcomponents or utils like `useTreeItem2` or `TreeItem2Icon`).
 
 ```diff
--import { TreeItem2 } from '@mui/x-tree-view';
-+import { TreeItem } from '@mui/x-tree-view';
+- import { TreeItem2 } from '@mui/x-tree-view';
++ import { TreeItem } from '@mui/x-tree-view';
 
--import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
-+import { TreeItem } from '@mui/x-tree-view/TreeItem';
+- import { TreeItem2 } from '@mui/x-tree-view/TreeItem2';
++ import { TreeItem } from '@mui/x-tree-view/TreeItem';
 ```
 
 ### Charts codemods
@@ -159,7 +161,7 @@ Renames `ResponsiveChartContainer` and `ResponsiveChartContainerPro` by `ChartCo
 
 - <ResponsiveChartContainer>
 + <ChartContainer>
-   <BarPlot />
+    <BarPlot />
 - </ResponsiveChartContainer>
 + </ChartContainer>
 ```
@@ -212,15 +214,49 @@ The list includes these transformers
 Remove feature flags for stabilized `experimentalFeatures`.
 
 ```diff
- <DataGridPremium
--  experimentalFeatures={{
--    ariaV8: true,
--  }}
- />
+  <DataGridPremium
+-   experimentalFeatures={{
+-     ariaV8: true,
+-   }}
+  />
 ```
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/remove-stabilized-experimentalFeatures <path>
+```
+
+### Pickers codemods
+
+#### `preset-safe` for pickers v8.0.0
+
+The `preset-safe` codemods for pickers.
+
+```bash
+npx @mui/x-codemod@latest v8.0.0/pickers/preset-safe <path|folder>
+```
+
+The list includes these transformers
+
+- [`rename-and-move-field-value-type`](#rename-and-move-field-value-type)
+
+#### `rename-and-move-field-value-type`
+
+Renames `FieldValueType` to `PickerValueType`.
+
+```diff
+- import { FieldValueType } from '@mui/x-date-pickers';
++ import { PickerValueType } from '@mui/x-date-pickers';
+
+  interface MyComponentProps {
+-   valueType: FieldValueType;
++   valueType: PickerValueType;
+    foo: string;
+    bar: number;
+  }
+```
+
+```bash
+npx @mui/x-codemod@latest v8.0.0/pickers/rename-and-move-field-value-type <path>
 ```
 
 ## v7.0.0

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/actual.spec.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import * as React from 'react';
+import { DataGridPremium } from '@mui/x-data-grid-premium';
+
+// prettier-ignore
+<React.Fragment>
+  <DataGridPremium
+    experimentalFeatures={{
+      warnIfFocusStateIsNotSynced: true,
+      ariaV8: true,
+    }}
+  />
+  <DataGridPremium
+    experimentalFeatures={{
+      ariaV8: true,
+    }}
+  />
+  <DataGridPremium {...props} />
+</React.Fragment>;

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/expected.spec.tsx
@@ -1,0 +1,14 @@
+// @ts-nocheck
+import * as React from 'react';
+import { DataGridPremium } from '@mui/x-data-grid-premium';
+
+// prettier-ignore
+<React.Fragment>
+  <DataGridPremium
+    experimentalFeatures={{
+      warnIfFocusStateIsNotSynced: true,
+    }}
+  />
+  <DataGridPremium />
+  <DataGridPremium {...props} />
+</React.Fragment>;

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/index.ts
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/index.ts
@@ -1,0 +1,9 @@
+import removeExperimentalFeatures from '../remove-stabilized-experimentalFeatures';
+
+import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
+
+export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
+  file.source = removeExperimentalFeatures(file, api, options);
+
+  return file.source;
+}

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/preset-safe.test.ts
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/preset-safe.test.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from './index';
+import readFile from '../../../util/readFile';
+
+function read(fileName) {
+  return readFile(path.join(__dirname, fileName));
+}
+
+describe('v8.0.0/data-grid', () => {
+  describe('preset-safe', () => {
+    it('transforms code as needed', () => {
+      const actual = transform(
+        {
+          source: read('./actual.spec.tsx'),
+          path: require.resolve('./actual.spec.tsx'),
+        },
+        { jscodeshift: jscodeshift.withParser('tsx') },
+        {},
+      );
+
+      const expected = read('./expected.spec.tsx');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
+    it('should be idempotent for expression', () => {
+      const actual = transform(
+        {
+          source: read('./expected.spec.tsx'),
+          path: require.resolve('./expected.spec.tsx'),
+        },
+        { jscodeshift: jscodeshift.withParser('tsx') },
+        {},
+      );
+
+      const expected = read('./expected.spec.tsx');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+  });
+});

--- a/packages/x-codemod/src/v8.0.0/preset-safe/index.ts
+++ b/packages/x-codemod/src/v8.0.0/preset-safe/index.ts
@@ -1,12 +1,14 @@
 import transformTreeView from '../tree-view/preset-safe';
 import transformPickers from '../pickers/preset-safe';
 import transformCharts from '../charts/preset-safe';
+import transformDataGrid from '../data-grid/preset-safe';
 import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../types';
 
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
   file.source = transformTreeView(file, api, options);
   file.source = transformPickers(file, api, options);
   file.source = transformCharts(file, api, options);
+  file.source = transformDataGrid(file, api, options);
 
   return file.source;
 }


### PR DESCRIPTION
Adds missing `preset-safe` for the data grid
https://github.com/mui/mui-x/pull/15659 helped detect that

I have added pickers section to the readme

Also, I have aligned formatting for the diffs in the readme (spacing for changed and unchanged lines)