### PR TITLE
[docs-infra] Bump @mui/internal-markdown to support nested demo imports

### DIFF
--- a/docs/data/data-grid/joy-ui/joy-ui.md
+++ b/docs/data/data-grid/joy-ui/joy-ui.md
@@ -1,5 +1,5 @@
 # Data Grid - Joy UI
 
-<p class="description">Using the Data Grid with Joy UI components</p>
+<p class="description">Using the Data Grid with Joy UI components.</p>
 
 {{"demo": "GridJoyUISlots.js", "bg": "inline"}}

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -8,7 +8,7 @@ components: PickersSectionList, PickersTextField
 
 # Custom field
 
-<p class="description">The Date and Time Pickers let you customize the field by passing props or custom components</p>
+<p class="description">The Date and Time Pickers let you customize the field by passing props or custom components.</p>
 
 :::success
 See [Common concepts—Custom slots and subcomponents](/x/common-concepts/custom-components/) to learn how to use slots.

--- a/docs/data/date-pickers/custom-layout/custom-layout.md
+++ b/docs/data/date-pickers/custom-layout/custom-layout.md
@@ -8,7 +8,7 @@ packageName: '@mui/x-date-pickers'
 
 # Custom layout
 
-<p class="description">The Date and Time Pickers let you reorganize the layout</p>
+<p class="description">The Date and Time Pickers let you reorganize the layout.</p>
 
 :::success
 See [Common concepts—Custom slots and subcomponents](/x/common-concepts/custom-components/) to learn how to use slots.

--- a/docs/data/date-pickers/experimentation/experimentation.md
+++ b/docs/data/date-pickers/experimentation/experimentation.md
@@ -4,4 +4,4 @@ productId: x-date-pickers
 
 # Date and Time Pickers experimentation
 
-<p class="description">Demos not accessible through the navbar of the doc</p>
+<p class="description">Demos not accessible through the navbar of the doc.</p>

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.13.0",
-    "@mui/docs": "6.1.4",
+    "@mui/docs": "6.1.6",
     "@mui/icons-material": "^5.16.7",
     "@mui/joy": "^5.0.0-beta.48",
     "@mui/lab": "^5.0.0-alpha.173",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^5.16.7",
     "@mui/internal-babel-plugin-resolve-imports": "1.0.18",
-    "@mui/internal-markdown": "^1.0.17",
+    "@mui/internal-markdown": "^1.0.19",
     "@mui/internal-test-utils": "^1.0.17",
     "@mui/material": "^5.16.7",
     "@mui/monorepo": "github:mui/material-ui#7aa841466a01b745012e59e9d201ed50807a022e",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: 1.0.18
         version: 1.0.18(@babel/core@7.25.8)
       '@mui/internal-markdown':
-        specifier: ^1.0.17
-        version: 1.0.17
+        specifier: ^1.0.19
+        version: 1.0.22
       '@mui/internal-test-utils':
         specifier: ^1.0.17
         version: 1.0.17(@babel/core@7.25.8)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -429,8 +429,8 @@ importers:
         specifier: ^11.13.0
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/docs':
-        specifier: 6.1.4
-        version: 6.1.4(53xkipdzpp66uriexrip26qzlm)
+        specifier: 6.1.6
+        version: 6.1.6(53xkipdzpp66uriexrip26qzlm)
       '@mui/icons-material':
         specifier: ^5.16.7
         version: 5.16.7(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
@@ -2374,6 +2374,10 @@ packages:
     resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.26.0':
+    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.25.7':
     resolution: {integrity: sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==}
     engines: {node: '>=6.9.0'}
@@ -3025,8 +3029,8 @@ packages:
   '@mui/core-downloads-tracker@5.16.7':
     resolution: {integrity: sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==}
 
-  '@mui/docs@6.1.4':
-    resolution: {integrity: sha512-pUMMy4Hxx1se+gG0stiX/ICphFfOx9RC3bKI4da11iUNVsSaUfYaCtiPc296BUbilaTMcQ82v8jYu+AOexHT3w==}
+  '@mui/docs@6.1.6':
+    resolution: {integrity: sha512-RSDuaanoDUHYSAjm+Stia9MvDHVElw0cFC4lo/Ekw8cZ22ke90KB6YKE7hqnqr2+knUfBvOcQxLJrJfkLElyiQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@mui/base': '*'
@@ -3061,8 +3065,8 @@ packages:
   '@mui/internal-docs-utils@1.0.14':
     resolution: {integrity: sha512-jb8RyzoGkV8zvTJndB4An95WCasbDwmDiTibw2YQaUh3+4XiAX3jS2XUB9ab3BxMv3TDCCywL5g0viB1bxQVBw==}
 
-  '@mui/internal-markdown@1.0.17':
-    resolution: {integrity: sha512-sws1OTUvJxNZ04mTYgahB7Z35yWcAEzVQxqqnOB+tPgDL/iMLtMQXB6wEFbW77e/P3O6Y/XOe7FhHXnK46vYTQ==}
+  '@mui/internal-markdown@1.0.22':
+    resolution: {integrity: sha512-js8VF3uDbHjV3gByPVZBcVF0sGkKM22MhFoxKw+W0nGMj6cy1+68Jg3jspFz38diGRqv4lElz9rL31YjY45U9w==}
 
   '@mui/internal-scripts@1.0.24':
     resolution: {integrity: sha512-omDYril4RiR8PSmPWkja16BjNyGkcj7N9sK1Ul9pSVpKSw8LF4BUxLOkF5NzAfDxNQgoZp+7DJPWBm9c/hmC+A==}
@@ -7571,8 +7575,8 @@ packages:
     resolution: {integrity: sha512-wgp8yesWjFBL7bycA3hxwHRdsZGJhjhyP1dSxKVKrza0EPFYtn+mHtkVy6dvP1kGSjovyG5B8yNP6Frj0UFUJg==}
     engines: {node: '>=18'}
 
-  marked@14.1.3:
-    resolution: {integrity: sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==}
+  marked@15.0.3:
+    resolution: {integrity: sha512-Ai0cepvl2NHnTcO9jYDtcOEtVBNVYR31XnEA3BndO7f5As1wzpcOceSUM8FDkNLJNIODcLpDTWay/qQhqbuMvg==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -11158,6 +11162,10 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@babel/runtime@7.26.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
   '@babel/template@7.25.7':
     dependencies:
       '@babel/code-frame': 7.25.7
@@ -11790,12 +11798,12 @@ snapshots:
 
   '@mui/core-downloads-tracker@5.16.7': {}
 
-  '@mui/docs@6.1.4(53xkipdzpp66uriexrip26qzlm)':
+  '@mui/docs@6.1.6(53xkipdzpp66uriexrip26qzlm)':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       '@mui/base': 5.0.0-beta.40(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/icons-material': 5.16.7(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
-      '@mui/internal-markdown': 1.0.17
+      '@mui/internal-markdown': 1.0.22
       '@mui/material': 5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       chai: 5.1.1
@@ -11827,11 +11835,11 @@ snapshots:
       rimraf: 6.0.1
       typescript: 5.6.3
 
-  '@mui/internal-markdown@1.0.17':
+  '@mui/internal-markdown@1.0.22':
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.0
       lodash: 4.17.21
-      marked: 14.1.3
+      marked: 15.0.3
       prismjs: 1.29.0
 
   '@mui/internal-scripts@1.0.24':
@@ -17276,7 +17284,7 @@ snapshots:
       markdown-it: 14.1.0
       markdownlint-micromark: 0.1.10
 
-  marked@14.1.3: {}
+  marked@15.0.3: {}
 
   mdast-util-from-markdown@2.0.1:
     dependencies:


### PR DESCRIPTION
Update the `@mui/internal-markdown` to benefit from the nested import support. Also bump the `@mui/docs` to avoid duplicated dependencies

Broken demo was reported in #15736 (https://mui.com/x/react-charts/tooltip/#tooltip-position)
