### PR TITLE
[docs] Use date library version from package dev dependencies for sandboxes

### DIFF
--- a/docs/src/modules/utils/postProcessImport.test.ts
+++ b/docs/src/modules/utils/postProcessImport.test.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
-import { DATE_ADAPTER_VERSIONS, ADAPTER_TO_LIBRARY, postProcessImport } from './postProcessImport';
+// eslint-disable-next-line import/no-relative-packages
+import pickersPackageJson from '../../../../packages/x-date-pickers/package.json';
+import { ADAPTER_TO_LIBRARY, postProcessImport } from './postProcessImport';
 
 describe('postProcessImport', () => {
   const ADAPTERS = ['AdapterDateFns', 'AdapterDayjs', 'AdapterLuxon', 'AdapterMoment'];
@@ -11,7 +13,7 @@ describe('postProcessImport', () => {
 
         const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
         expect(resolvedDep).to.deep.equal({
-          [expectedLibrary]: DATE_ADAPTER_VERSIONS[expectedLibrary],
+          [expectedLibrary]: pickersPackageJson.devDependencies[expectedLibrary],
         });
       });
     });
@@ -30,7 +32,7 @@ describe('postProcessImport', () => {
 
         const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
         expect(resolvedDep).to.deep.equal({
-          [expectedLibrary]: DATE_ADAPTER_VERSIONS[expectedLibrary],
+          [expectedLibrary]: pickersPackageJson.devDependencies[expectedLibrary],
         });
       });
     });
@@ -49,7 +51,7 @@ describe('postProcessImport', () => {
 
         const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
         expect(resolvedDep).to.deep.equal({
-          [expectedLibrary]: DATE_ADAPTER_VERSIONS[expectedLibrary],
+          [expectedLibrary]: pickersPackageJson.devDependencies[expectedLibrary],
         });
       });
     });

--- a/docs/src/modules/utils/postProcessImport.ts
+++ b/docs/src/modules/utils/postProcessImport.ts
@@ -1,11 +1,11 @@
 export const DATE_ADAPTER_VERSIONS: Record<string, string> = {
   'date-fns': '^2.30.0',
   'date-fns-jalali': '^2.30.0-0',
-  dayjs: '^1.11.10',
-  luxon: '^3.4.4',
-  moment: '^2.29.4',
-  'moment-hijri': '^2.1.2',
-  'moment-jalaali': '^0.10.0',
+  dayjs: '^1.11.13',
+  luxon: '^3.5.0',
+  moment: '^2.30.1',
+  'moment-hijri': '^3.0.0',
+  'moment-jalaali': '^0.10.1',
 } as const;
 
 export const ADAPTER_TO_LIBRARY: Record<string, string> = {

--- a/docs/src/modules/utils/postProcessImport.ts
+++ b/docs/src/modules/utils/postProcessImport.ts
@@ -1,14 +1,7 @@
-export const DATE_ADAPTER_VERSIONS: Record<string, string> = {
-  'date-fns': '^2.30.0',
-  'date-fns-jalali': '^2.30.0-0',
-  dayjs: '^1.11.13',
-  luxon: '^3.5.0',
-  moment: '^2.30.1',
-  'moment-hijri': '^3.0.0',
-  'moment-jalaali': '^0.10.1',
-} as const;
+// eslint-disable-next-line import/no-relative-packages
+import pickersPackageJson from '../../../../packages/x-date-pickers/package.json';
 
-export const ADAPTER_TO_LIBRARY: Record<string, string> = {
+export const ADAPTER_TO_LIBRARY: Record<string, keyof typeof pickersPackageJson.devDependencies> = {
   AdapterDateFns: 'date-fns',
   AdapterDateFnsJalali: 'date-fns-jalali',
   AdapterDayjs: 'dayjs',
@@ -34,7 +27,7 @@ export const postProcessImport = (importName: string): Record<string, string> | 
         `Can't determine required npm package for adapter '${dateAdapterMatch[1]}'`,
       );
     }
-    return { [packageName]: DATE_ADAPTER_VERSIONS[packageName] ?? 'latest' };
+    return { [packageName]: pickersPackageJson.devDependencies[packageName] ?? 'latest' };
   }
   return null;
 };


### PR DESCRIPTION
Sync/update versions resolved for use in sandboxes.