### PR TITLE
[charts] Only access store values by using hooks

### DIFF
--- a/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
+++ b/packages/x-charts/src/ChartsAxis/ChartsAxis.tsx
@@ -89,9 +89,6 @@ function ChartsAxis(props: ChartsAxisProps) {
   const { topAxis, leftAxis, rightAxis, bottomAxis, slots, slotProps } = props;
   const { xAxis, xAxisIds, yAxis, yAxisIds } = useCartesianContext();
 
-  // TODO: use for plotting line without ticks or any thing
-  // const drawingArea = React.useContext(DrawingContext);
-
   const leftId = getAxisId(leftAxis === undefined ? yAxisIds[0] : leftAxis, yAxisIds[0]);
   const bottomId = getAxisId(bottomAxis === undefined ? xAxisIds[0] : bottomAxis, xAxisIds[0]);
   const topId = getAxisId(topAxis, xAxisIds[0]);

--- a/packages/x-charts/src/ChartsLegend/useAxis.ts
+++ b/packages/x-charts/src/ChartsLegend/useAxis.ts
@@ -1,11 +1,10 @@
 'use client';
-import * as React from 'react';
-import { ZAxisContext } from '../context/ZAxisContextProvider';
 import { AxisDefaultized } from '../models/axis';
 import { useCartesianContext } from '../context/CartesianProvider/useCartesianContext';
 
 import { ZAxisDefaultized } from '../models/z-axis';
 import { ColorLegendSelector } from './legend.types';
+import { useZAxis } from '../hooks/useZAxis';
 
 /**
  * Helper to select an axis definition according to its direction and id.
@@ -15,7 +14,7 @@ export function useAxis({
   axisId,
 }: ColorLegendSelector): ZAxisDefaultized | AxisDefaultized {
   const { xAxis, xAxisIds, yAxis, yAxisIds } = useCartesianContext();
-  const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
+  const { zAxis, zAxisIds } = useZAxis();
 
   switch (axisDirection) {
     case 'x': {

--- a/packages/x-charts/src/ChartsTooltip/useAxisTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/useAxisTooltip.tsx
@@ -1,8 +1,6 @@
 'use client';
-import * as React from 'react';
 import { useSeries } from '../hooks/useSeries';
 import { useCartesianContext } from '../context/CartesianProvider';
-import { ZAxisContext } from '../context/ZAxisContextProvider';
 import { useColorProcessor } from '../context/PluginProvider/useColorProcessor';
 import { SeriesId } from '../models/seriesType/common';
 import { CartesianChartSeriesType, ChartsSeriesConfig } from '../models/seriesType/config';
@@ -12,6 +10,7 @@ import { getLabel } from '../internals/getLabel';
 import { isCartesianSeriesType } from '../internals/isCartesian';
 import { utcFormatter } from './utils';
 import { useXAxis, useYAxis } from '../hooks/useAxis';
+import { useZAxis } from '../hooks/useZAxis';
 import {
   selectorChartsInteractionXAxis,
   selectorChartsInteractionYAxis,
@@ -52,7 +51,7 @@ export function useAxisTooltip(): null | UseAxisTooltipReturnValue {
 
   const { xAxis, yAxis } = useCartesianContext();
 
-  const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
+  const { zAxis, zAxisIds } = useZAxis();
   const colorProcessors = useColorProcessor();
 
   if (axisData === null) {

--- a/packages/x-charts/src/ChartsTooltip/useItemTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/useItemTooltip.tsx
@@ -1,8 +1,6 @@
 'use client';
-import * as React from 'react';
 import { useSeries } from '../hooks/useSeries';
 import { useCartesianContext } from '../context/CartesianProvider';
-import { ZAxisContext } from '../context/ZAxisContextProvider';
 import { useColorProcessor } from '../context/PluginProvider/useColorProcessor';
 import {
   ChartItemIdentifier,
@@ -15,6 +13,7 @@ import { CommonSeriesType } from '../models/seriesType/common';
 import { selectorChartsInteractionItem } from '../internals/plugins/featurePlugins/useChartInteraction';
 import { useSelector } from '../internals/store/useSelector';
 import { useStore } from '../internals/store/useStore';
+import { useZAxis } from '../hooks/useZAxis';
 
 export interface UseItemTooltipReturnValue<T extends ChartSeriesType> {
   identifier: ChartItemIdentifier<T>;
@@ -31,7 +30,7 @@ export function useItemTooltip<T extends ChartSeriesType>(): null | UseItemToolt
   const series = useSeries();
 
   const { xAxis, yAxis, xAxisIds, yAxisIds } = useCartesianContext();
-  const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
+  const { zAxis, zAxisIds } = useZAxis();
   const colorProcessors = useColorProcessor();
 
   const xAxisId = (series as any).xAxisId ?? xAxisIds[0];

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -1,13 +1,13 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { DrawingAreaContext } from '../context/DrawingAreaProvider';
 import { PieArcPlot, PieArcPlotProps, PieArcPlotSlotProps, PieArcPlotSlots } from './PieArcPlot';
 import { PieArcLabelPlotSlots, PieArcLabelPlotSlotProps, PieArcLabelPlot } from './PieArcLabelPlot';
 import { getPercentageValue } from '../internals/getPercentageValue';
 import { getPieCoordinates } from './getPieCoordinates';
 import { usePieSeries } from '../hooks/useSeries';
 import { useSkipAnimation } from '../context/AnimationProvider';
+import { useDrawingArea } from '../hooks';
 
 export interface PiePlotSlots extends PieArcPlotSlots, PieArcLabelPlotSlots {}
 
@@ -39,7 +39,7 @@ export interface PiePlotProps extends Pick<PieArcPlotProps, 'skipAnimation' | 'o
 function PiePlot(props: PiePlotProps) {
   const { skipAnimation: inSkipAnimation, slots, slotProps, onItemClick } = props;
   const seriesData = usePieSeries();
-  const { left, top, width, height } = React.useContext(DrawingAreaContext);
+  const { left, top, width, height } = useDrawingArea();
   const skipAnimation = useSkipAnimation(inSkipAnimation);
 
   if (seriesData === undefined) {

--- a/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { Scatter, ScatterProps } from './Scatter';
 import { useCartesianContext } from '../context/CartesianProvider';
 import getColor from './getColor';
-import { ZAxisContext } from '../context/ZAxisContextProvider';
 import { useScatterSeries } from '../hooks/useSeries';
+import { useZAxis } from '../hooks/useZAxis';
 
 export interface ScatterPlotSlots {
   scatter?: React.JSXElementConstructor<ScatterProps>;
@@ -42,7 +42,7 @@ function ScatterPlot(props: ScatterPlotProps) {
   const { slots, slotProps, onItemClick } = props;
   const seriesData = useScatterSeries();
   const axisData = useCartesianContext();
-  const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
+  const { zAxis, zAxisIds } = useZAxis();
 
   if (seriesData === undefined) {
     return null;

--- a/packages/x-charts/src/hooks/useColorScale.ts
+++ b/packages/x-charts/src/hooks/useColorScale.ts
@@ -1,8 +1,7 @@
 'use client';
-import * as React from 'react';
 import { useCartesianContext } from '../context/CartesianProvider';
 import { AxisScaleComputedConfig, ScaleName } from '../models/axis';
-import { ZAxisContext } from '../context/ZAxisContextProvider';
+import { useZAxis } from './useZAxis';
 
 export function useXColorScale<S extends ScaleName>(
   identifier?: number | string,
@@ -27,7 +26,7 @@ export function useYColorScale<S extends ScaleName>(
 export function useZColorScale<S extends ScaleName>(
   identifier?: number | string,
 ): AxisScaleComputedConfig[S]['colorScale'] | undefined {
-  const { zAxis, zAxisIds } = React.useContext(ZAxisContext);
+  const { zAxis, zAxisIds } = useZAxis();
 
   const id = typeof identifier === 'string' ? identifier : zAxisIds[identifier ?? 0];
 

--- a/packages/x-charts/src/hooks/useZAxis.ts
+++ b/packages/x-charts/src/hooks/useZAxis.ts
@@ -1,0 +1,8 @@
+'use client';
+import * as React from 'react';
+import { ZAxisContext } from '../context/ZAxisContextProvider';
+
+export const useZAxis = () => {
+  const data = React.useContext(ZAxisContext);
+  return data;
+};


### PR DESCRIPTION
From working on store refactoring, I noticed it would be simpler if we hide the data getter logic behind a hook

`useZAxis` get me the data, I don't care if it's a provider, a selector, or just a random value :)