### PR TITLE
[code-infra] Remove redundant `@type/react-test-renderer` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "@types/node": "^20.17.9",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@types/react-test-renderer": "^18.3.0",
     "@types/requestidlecallback": "^0.3.7",
     "@types/sinon": "^17.0.3",
     "@types/yargs": "^17.0.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.1
-      '@types/react-test-renderer':
-        specifier: ^18.3.0
-        version: 18.3.0
       '@types/requestidlecallback':
         specifier: ^0.3.7
         version: 0.3.7
@@ -4249,9 +4246,6 @@ packages:
 
   '@types/react-router@5.1.20':
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
-
-  '@types/react-test-renderer@18.3.0':
-    resolution: {integrity: sha512-HW4MuEYxfDbOHQsVlY/XtOvNHftCVEPhJF2pQXXwcUiUF+Oyb0usgp48HSgpK5rt8m9KZb22yqOeZm+rrVG8gw==}
 
   '@types/react-transition-group@4.4.11':
     resolution: {integrity: sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==}
@@ -13372,10 +13366,6 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.3.12
-
-  '@types/react-test-renderer@18.3.0':
-    dependencies:
       '@types/react': 18.3.12
 
   '@types/react-transition-group@4.4.11':

--- a/renovate.json
+++ b/renovate.json
@@ -41,13 +41,7 @@
     },
     {
       "groupName": "React",
-      "matchPackageNames": [
-        "react",
-        "react-dom",
-        "react-is",
-        "@types/react",
-        "@types/react-dom"
-      ]
+      "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom"]
     },
     {
       "groupName": "React router",

--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,6 @@
         "react",
         "react-dom",
         "react-is",
-        "react-test-renderer",
         "@types/react",
         "@types/react-dom"
       ]


### PR DESCRIPTION
Follow-up on https://github.com/mui/material-ui/pull/42784.