### PR TITLE
[charts] Fix scatter dataset with missing data

### DIFF
--- a/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent } from '@mui/internal-test-utils/createRenderer';
+import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils/createRenderer';
 import { describeConformance } from 'test/utils/describeConformance';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { expect } from 'chai';
@@ -85,5 +85,53 @@ describe('<ScatterChart />', () => {
     fireEvent.pointerEnter(marks[4]);
     cells = document.querySelectorAll<HTMLElement>('.MuiChartsTooltip-root td');
     expect([...cells].map((cell) => cell.textContent)).to.deep.equal(['', '', '(5, 5)']);
+  });
+
+  it('should support dataset with missing values', async function test() {
+    if (isJSDOM) {
+      this.skip();
+    }
+
+    // x from 500 to 600
+    // y from 100 to 200
+    const dataset = [
+      {
+        version: 'data-0',
+        a1: 500,
+        a2: 100,
+      },
+      {
+        version: 'data-1',
+        a1: 600,
+        a2: 200,
+      },
+      {
+        version: 'data-2',
+        // Item with missing x-values
+        // a1: 500,
+        a2: 200,
+      },
+      {
+        version: 'data-2',
+        // Item with missing y-values
+        a1: 500,
+        // a2: 200,
+      },
+    ];
+
+    render(
+      <ScatterChart
+        dataset={dataset}
+        series={[{ datasetKeys: { id: 'version', x: 'a1', y: 'a2' }, label: 'Series A' }]}
+        width={500}
+        height={300}
+      />,
+    );
+
+    const labelX = await screen.findByText('100');
+    expect(labelX).toBeVisible();
+
+    const labelY = await screen.findByText('600');
+    expect(labelY).toBeVisible();
   });
 });

--- a/packages/x-charts/src/ScatterChart/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/extremums.ts
@@ -6,13 +6,10 @@ import {
 const mergeMinMax = (
   acc: ExtremumGetterResult,
   val: ExtremumGetterResult,
-): ExtremumGetterResult => {
-  return [
-    val[0] === null ? acc[0] : Math.min(acc[0], val[0]),
-    val[1] === null ? acc[1] : Math.min(acc[1], val[1]),
-  ];
-};
-
+): ExtremumGetterResult => [
+  val[0] === null ? acc[0] : Math.min(acc[0], val[0]),
+  val[1] === null ? acc[1] : Math.max(acc[1], val[1]),
+];
 export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {
   const { series, axis, isDefaultAxis, getFilters } = params;
 

--- a/packages/x-charts/src/ScatterChart/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/extremums.ts
@@ -7,7 +7,10 @@ const mergeMinMax = (
   acc: ExtremumGetterResult,
   val: ExtremumGetterResult,
 ): ExtremumGetterResult => {
-  return [Math.min(acc[0], val[0]), Math.max(acc[1], val[1])];
+  return [
+    val[0] === null ? acc[0] : Math.min(acc[0], val[0]),
+    val[1] === null ? acc[1] : Math.min(acc[1], val[1]),
+  ];
 };
 
 export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {

--- a/packages/x-charts/src/ScatterChart/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/extremums.ts
@@ -10,6 +10,7 @@ const mergeMinMax = (
   val[0] === null ? acc[0] : Math.min(acc[0], val[0]),
   val[1] === null ? acc[1] : Math.max(acc[1], val[1]),
 ];
+
 export const getExtremumX: ExtremumGetter<'scatter'> = (params) => {
   const { series, axis, isDefaultAxis, getFilters } = params;
 

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -23,8 +23,8 @@ const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }, dataset)
         ? (seriesData.data ?? [])
         : (dataset?.map((d) => {
             return {
-              x: d[datasetKeys.x],
-              y: d[datasetKeys.y],
+              x: d[datasetKeys.x] ?? null,
+              y: d[datasetKeys.y] ?? null,
               z: datasetKeys.z && d[datasetKeys.z],
               id: d[datasetKeys.id],
             } as ScatterValueType;


### PR DESCRIPTION
Fix #15801

I hesitated to keep `undefined` values to be able to distinguish `undefined` and `null`.
But a scatter point where either x or y is not defined is impossible to represent

```js
Math.min(null, null) // returns 0
Math.min(undefined, null) // returns NaN
```

If you're ok with the fix I will add a test to prevent future regression