### PR TITLE
[charts] Fix internal spelling typo

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsAxisTooltipContent.tsx
@@ -25,17 +25,17 @@ export interface ChartsAxisTooltipContentProps {
 
 function ChartsAxisTooltipContent(props: ChartsAxisTooltipContentProps) {
   const { classes: propClasses, sx } = props;
-  const tootlipData = useAxisTooltip();
+  const tooltipData = useAxisTooltip();
   const xAxis = useXAxis();
   const yAxis = useYAxis();
 
   const classes = useUtilityClasses(propClasses);
 
-  if (tootlipData === null) {
+  if (tooltipData === null) {
     return null;
   }
 
-  const { axisDirection, axisValue, axisFormattedValue, seriesItems } = tootlipData;
+  const { axisDirection, axisValue, axisFormattedValue, seriesItems } = tooltipData;
 
   const axis = axisDirection === 'x' ? xAxis : yAxis;
 


### PR DESCRIPTION
## Changelog
Fixed a speling typos mistake in `ChartsAxisTooltipContent` component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
