### PR TITLE
[license] Use `console.log` for the error message on Codesandbox to avoid rendering error

### DIFF
--- a/packages/x-license/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license/src/utils/licenseErrorMessageUtils.ts
@@ -9,9 +9,10 @@
  */
 const isCodeSandbox =
   typeof window !== 'undefined' && window.location.hostname.endsWith('.csb.app');
-const logger = isCodeSandbox ? console.log : console.error;
 
 function showError(message: string[]) {
+  // eslint-disable-next-line no-console
+  const logger = isCodeSandbox ? console.log : console.error;
   logger(
     [
       '*************************************************************',

--- a/packages/x-license/src/utils/licenseErrorMessageUtils.ts
+++ b/packages/x-license/src/utils/licenseErrorMessageUtils.ts
@@ -1,5 +1,18 @@
+/**
+ * Workaround for the codesadbox preview error.
+ *
+ * Once these issues are resolved
+ * https://github.com/mui/mui-x/issues/15765
+ * https://github.com/codesandbox/codesandbox-client/issues/8673
+ *
+ * `showError` can simply use `console.error` again.
+ */
+const isCodeSandbox =
+  typeof window !== 'undefined' && window.location.hostname.endsWith('.csb.app');
+const logger = isCodeSandbox ? console.log : console.error;
+
 function showError(message: string[]) {
-  console.error(
+  logger(
     [
       '*************************************************************',
       '',


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/15765

It is a workaround until https://github.com/codesandbox/codesandbox-client/issues/8673 is resolved

FYI @flaviendelangle 
It should fix the Codesandbox of [this example](https://mui.com/x/react-tree-view/rich-tree-view/ordering/#enable-drag-amp-drop-re-ordering) as well