### PR TITLE
[TreeView] Move the `expansionTrigger` variable from the context value to the state

### DIFF
--- a/packages/x-tree-view/src/internals/models/plugin.ts
+++ b/packages/x-tree-view/src/internals/models/plugin.ts
@@ -112,7 +112,7 @@ type PluginPropertyWithDependencies<
 export type TreeViewUsedParams<TSignature extends TreeViewAnyPluginSignature> =
   PluginPropertyWithDependencies<TSignature, 'params'>;
 
-type TreeViewUsedDefaultizedParams<TSignature extends TreeViewAnyPluginSignature> =
+export type TreeViewUsedDefaultizedParams<TSignature extends TreeViewAnyPluginSignature> =
   PluginPropertyWithDependencies<TSignature, 'defaultizedParams'>;
 
 export type TreeViewUsedInstance<TSignature extends TreeViewAnyPluginSignature> =

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.selectors.ts
@@ -24,3 +24,13 @@ export const selectorIsItemExpandable = createSelector(
   [selectorItemMeta],
   (itemMeta) => itemMeta?.expandable ?? false,
 );
+
+/**
+ * Get the slot that triggers the item's expansion when clicked.
+ * @param {TreeViewState<[UseTreeViewExpansionSignature]>} state The state of the tree view.
+ * @returns {'content' | 'iconContainer'} The slot that triggers the item's expansion when clicked. Is `null` if the item is not expandable.
+ */
+export const selectorItemExpansionTrigger = createSelector(
+  [selectorExpansion],
+  (expansionState) => expansionState.expansionTrigger,
+);

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.types.ts
@@ -75,11 +75,8 @@ export type UseTreeViewExpansionDefaultizedParameters = DefaultizedProps<
 export interface UseTreeViewExpansionState {
   expansion: {
     expandedItemsMap: Map<string, true>;
+    expansionTrigger: 'content' | 'iconContainer';
   };
-}
-
-interface UseTreeViewExpansionContextValue {
-  expansion: Pick<UseTreeViewExpansionParameters, 'expansionTrigger'>;
 }
 
 export type UseTreeViewExpansionSignature = TreeViewPluginSignature<{
@@ -89,7 +86,6 @@ export type UseTreeViewExpansionSignature = TreeViewPluginSignature<{
   publicAPI: UseTreeViewExpansionPublicAPI;
   modelNames: 'expandedItems';
   state: UseTreeViewExpansionState;
-  contextValue: UseTreeViewExpansionContextValue;
   dependencies: [UseTreeViewItemsSignature];
   optionalDependencies: [UseTreeViewLabelSignature];
 }>;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.utils.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewExpansion/useTreeViewExpansion.utils.ts
@@ -1,4 +1,6 @@
 import { TreeViewItemId } from '../../../models';
+import { TreeViewUsedDefaultizedParams } from '../../models';
+import { UseTreeViewExpansionSignature } from './useTreeViewExpansion.types';
 
 export const createExpandedItemsMap = (expandedItems: string[]) => {
   const expandedItemsMap = new Map<TreeViewItemId, true>();
@@ -7,4 +9,22 @@ export const createExpandedItemsMap = (expandedItems: string[]) => {
   });
 
   return expandedItemsMap;
+};
+
+export const getExpansionTrigger = ({
+  isItemEditable,
+  expansionTrigger,
+}: Pick<
+  TreeViewUsedDefaultizedParams<UseTreeViewExpansionSignature>,
+  'isItemEditable' | 'expansionTrigger'
+>) => {
+  if (expansionTrigger) {
+    return expansionTrigger;
+  }
+
+  if (isItemEditable) {
+    return 'iconContainer';
+  }
+
+  return 'content';
 };

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
@@ -30,6 +30,7 @@ import { selectorIsItemTheDefaultFocusableItem } from '../internals/plugins/useT
 import { generateTreeItemIdAttribute } from '../internals/corePlugins/useTreeViewId/useTreeViewId.utils';
 import { selectorCanItemBeFocused } from '../internals/plugins/useTreeViewItems/useTreeViewItems.selectors';
 import { selectorTreeViewId } from '../internals/corePlugins/useTreeViewId/useTreeViewId.selectors';
+import { selectorItemExpansionTrigger } from '../internals/plugins/useTreeViewExpansion/useTreeViewExpansion.selectors';
 
 export const useTreeItem = <
   TSignatures extends UseTreeItemMinimalPlugins = UseTreeItemMinimalPlugins,
@@ -41,7 +42,6 @@ export const useTreeItem = <
     runItemPlugins,
     items: { onItemClick },
     selection: { disableSelection, checkboxSelection },
-    expansion: { expansionTrigger },
     label: labelContext,
     instance,
     publicAPI,
@@ -162,7 +162,7 @@ export const useTreeItem = <
       if (event.defaultMuiPrevented || checkboxRef.current?.contains(event.target as HTMLElement)) {
         return;
       }
-      if (expansionTrigger === 'content') {
+      if (selectorItemExpansionTrigger(store.value) === 'content') {
         interactions.handleExpansion(event);
       }
 
@@ -190,7 +190,7 @@ export const useTreeItem = <
       if (event.defaultMuiPrevented) {
         return;
       }
-      if (expansionTrigger === 'iconContainer') {
+      if (selectorItemExpansionTrigger(store.value) === 'iconContainer') {
         interactions.handleExpansion(event);
       }
     };

--- a/test/utils/tree-view/fakeContextValue.ts
+++ b/test/utils/tree-view/fakeContextValue.ts
@@ -30,7 +30,6 @@ export const getFakeContextValue = (
   rootRef: {
     current: null,
   },
-  expansion: { expansionTrigger: 'content' },
   store: new TreeViewStore({
     cacheKey: { id: 1 },
     id: { treeId: 'mui-tree-view-1', providedTreeId: undefined },
@@ -41,7 +40,7 @@ export const getFakeContextValue = (
       itemOrderedChildrenIdsLookup: {},
       itemChildrenIndexesLookup: {},
     },
-    expansion: { expandedItemsMap: new Map() },
+    expansion: { expandedItemsMap: new Map(), expansionTrigger: 'content' },
     selection: { selectedItemsMap: new Map() },
     focus: { focusedItemId: null, defaultFocusableItemId: null },
   }),


### PR DESCRIPTION
There is no need for this variable in the render.