### PR TITLE
[draft] Test generating doc using TypeDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "string-replace-loader": "^3.1.0",
     "terser-webpack-plugin": "^5.3.10",
     "tsx": "^4.19.2",
+    "typedoc": "^0.27.4",
     "typescript": "^5.7.2",
     "unist-util-visit": "^5.0.0",
     "util": "^0.12.5",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,8 @@
   "pnpm": {
     "patchedDependencies": {
       "karma-mocha@2.0.1": "patches/karma-mocha@2.0.1.patch",
-      "babel-plugin-replace-imports@1.0.2": "patches/babel-plugin-replace-imports@1.0.2.patch"
+      "babel-plugin-replace-imports@1.0.2": "patches/babel-plugin-replace-imports@1.0.2.patch",
+      "@shikijs/vscode-textmate@9.3.0": "patches/@shikijs__vscode-textmate@9.3.0.patch"
     }
   }
 }

--- a/patches/@shikijs__vscode-textmate@9.3.0.patch
+++ b/patches/@shikijs__vscode-textmate@9.3.0.patch
@@ -1,0 +1,14 @@
+diff --git a/package.json b/package.json
+index 072aac0e6c123935c867570ff8c098f150c22594..a6152eddcb8626e225db358e38503c814c0a56ce 100644
+--- a/package.json
++++ b/package.json
+@@ -9,7 +9,8 @@
+   "exports": {
+     ".": {
+       "import": "./dist/index.mjs",
+-      "types": "./dist/index.d.mts"
++      "types": "./dist/index.d.mts",
++      "default": "./dist/index.mjs"
+     }
+   },
+   "main": "./dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   '@types/node': ^20.17.9
 
 patchedDependencies:
+  '@shikijs/vscode-textmate@9.3.0':
+    hash: cq3qol55ube4gr2wwm2ef6cmxu
+    path: patches/@shikijs__vscode-textmate@9.3.0.patch
   babel-plugin-replace-imports@1.0.2:
     hash: 7wlacyoi44skuhtzjdjwgtjyxe
     path: patches/babel-plugin-replace-imports@1.0.2.patch
@@ -11779,7 +11782,7 @@ snapshots:
     dependencies:
       '@shikijs/engine-oniguruma': 1.24.2
       '@shikijs/types': 1.24.2
-      '@shikijs/vscode-textmate': 9.3.0
+      '@shikijs/vscode-textmate': 9.3.0(patch_hash=cq3qol55ube4gr2wwm2ef6cmxu)
 
   '@gitbeaker/core@38.12.1':
     dependencies:
@@ -12955,14 +12958,14 @@ snapshots:
   '@shikijs/engine-oniguruma@1.24.2':
     dependencies:
       '@shikijs/types': 1.24.2
-      '@shikijs/vscode-textmate': 9.3.0
+      '@shikijs/vscode-textmate': 9.3.0(patch_hash=cq3qol55ube4gr2wwm2ef6cmxu)
 
   '@shikijs/types@1.24.2':
     dependencies:
-      '@shikijs/vscode-textmate': 9.3.0
+      '@shikijs/vscode-textmate': 9.3.0(patch_hash=cq3qol55ube4gr2wwm2ef6cmxu)
       '@types/hast': 3.0.4
 
-  '@shikijs/vscode-textmate@9.3.0': {}
+  '@shikijs/vscode-textmate@9.3.0(patch_hash=cq3qol55ube4gr2wwm2ef6cmxu)': {}
 
   '@sigstore/bundle@2.3.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
+      typedoc:
+        specifier: ^0.27.4
+        version: 0.27.4(typescript@5.7.2)
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -2878,6 +2881,9 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
+  '@gerrit0/mini-shiki@1.24.2':
+    resolution: {integrity: sha512-kw11jMCKwS5+GMMDy/o7W6C1KwsxgHnPO/RXzNBUw000BzRvUhUSi5zE8D2Qq7/A7bfJysFenEVBHUR7aMSxUQ==}
+
   '@gitbeaker/core@38.12.1':
     resolution: {integrity: sha512-8XMVcBIdVAAoxn7JtqmZ2Ee8f+AZLcCPmqEmPFOXY2jPS84y/DERISg/+sbhhb18iRy+ZsZhpWgQ/r3CkYNJOQ==}
     engines: {node: '>=18.0.0'}
@@ -3853,6 +3859,15 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@shikijs/engine-oniguruma@1.24.2':
+    resolution: {integrity: sha512-ZN6k//aDNWRJs1uKB12pturKHh7GejKugowOFGAuG7TxDRLod1Bd5JhpOikOiFqPmKjKEPtEA6mRCf7q3ulDyQ==}
+
+  '@shikijs/types@1.24.2':
+    resolution: {integrity: sha512-bdeWZiDtajGLG9BudI0AHet0b6e7FbR0EsE4jpGaI0YwHm/XJunI9+3uZnzFtX65gsyJ6ngCIWUfA4NWRPnBkQ==}
+
+  '@shikijs/vscode-textmate@9.3.0':
+    resolution: {integrity: sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==}
+
   '@sigstore/bundle@2.3.2':
     resolution: {integrity: sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4153,6 +4168,9 @@ packages:
 
   '@types/gtag.js@0.0.20':
     resolution: {integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
@@ -7664,6 +7682,9 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   luxon@3.5.0:
     resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
     engines: {node: '>=12'}
@@ -9838,6 +9859,13 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typedoc@0.27.4:
+    resolution: {integrity: sha512-wXPQs1AYC2Crk+1XFpNuutLIkNWleokZf1UNf/X8w9KsMnirkvT+LzxTXDvfF6ug3TSLf3Xu5ZXRKGfoXPX7IA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x
+
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
@@ -10333,6 +10361,11 @@ packages:
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  yaml@2.6.1:
+    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
+    engines: {node: '>= 14'}
+    hasBin: true
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -11742,6 +11775,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
+  '@gerrit0/mini-shiki@1.24.2':
+    dependencies:
+      '@shikijs/engine-oniguruma': 1.24.2
+      '@shikijs/types': 1.24.2
+      '@shikijs/vscode-textmate': 9.3.0
+
   '@gitbeaker/core@38.12.1':
     dependencies:
       '@gitbeaker/requester-utils': 38.12.1
@@ -12913,6 +12952,18 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@shikijs/engine-oniguruma@1.24.2':
+    dependencies:
+      '@shikijs/types': 1.24.2
+      '@shikijs/vscode-textmate': 9.3.0
+
+  '@shikijs/types@1.24.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 9.3.0
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@9.3.0': {}
+
   '@sigstore/bundle@2.3.2':
     dependencies:
       '@sigstore/protobuf-specs': 0.3.2
@@ -13259,6 +13310,10 @@ snapshots:
       '@types/node': 20.17.9
 
   '@types/gtag.js@0.0.20': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/history@4.7.11': {}
 
@@ -17496,6 +17551,8 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lunr@2.3.9: {}
+
   luxon@3.5.0: {}
 
   lz-string@1.5.0: {}
@@ -20026,6 +20083,15 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typedoc@0.27.4(typescript@5.7.2):
+    dependencies:
+      '@gerrit0/mini-shiki': 1.24.2
+      lunr: 2.3.9
+      markdown-it: 14.1.0
+      minimatch: 9.0.5
+      typescript: 5.7.2
+      yaml: 2.6.1
+
   typescript@5.7.2: {}
 
   ua-parser-js@0.7.39: {}
@@ -20548,6 +20614,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.2: {}
+
+  yaml@2.6.1: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/scripts/tsDoc/index.ts
+++ b/scripts/tsDoc/index.ts
@@ -8,7 +8,7 @@ async function main() {
   const configFileName = ts.findConfigFile(
     path.dirname(entryPoint),
     ts.sys.fileExists,
-    'tsconfig.build.json',
+    'tsconfig.json',
   );
 
   if (!configFileName) {

--- a/scripts/tsDoc/index.ts
+++ b/scripts/tsDoc/index.ts
@@ -1,0 +1,47 @@
+import path from 'path';
+import { Application } from 'typedoc';
+import ts from 'typescript';
+
+async function main() {
+  const entryPoint = './packages/x-charts/src/index.ts';
+
+  const configFileName = ts.findConfigFile(
+    path.dirname(entryPoint),
+    ts.sys.fileExists,
+    'tsconfig.build.json',
+  );
+
+  if (!configFileName) {
+    throw new Error('Could not find a valid tsconfig.json');
+  }
+
+  // Application.bootstrap also exists, which will not load plugins
+  // Also accepts an array of option readers if you want to disable
+  // TypeDoc's tsconfig.json/package.json/typedoc.json option readers
+  const app = await Application.bootstrap({
+    entryPoints: [entryPoint],
+    // blockTags: ['@default'],
+    jsDocCompatibility: {
+      defaultTag: true,
+      exampleTag: true,
+      ignoreUnescapedBraces: true,
+    },
+    cleanOutputDir: true,
+    excludeTags: ['@internal'],
+    tsconfig: configFileName,
+  });
+
+  // May be undefined if errors are encountered.
+  const project = await app.convert();
+
+  if (project) {
+    const outputDir = 'generated-docs';
+    // Generate HTML rendered docs
+    await app.generateJson(project, `${outputDir}/docs.json`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/tsDoc/tsconfig.json
+++ b/scripts/tsDoc/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
I've stumbled upon TypeDoc @ https://typedoc.org/modules.html

I've added a minimal script that simply generates the `json` AST for the `charts`, though you can easily change which package it should run.

The AST is fairly complex, but it looks to have all the necessary information to build our docs page.

## Running the script

`pnpm i` then `pnpx tsx ./scripts/tsDoc`