### PR TITLE
[pickers] Use `usePickerContext()` and `usePickerActionsContext()` to get the actions in the `actionBar` slot and in internal components

### DIFF
--- a/docs/data/date-pickers/custom-components/ActionBarComponent.js
+++ b/docs/data/date-pickers/custom-components/ActionBarComponent.js
@@ -9,11 +9,16 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 
-import { usePickerTranslations } from '@mui/x-date-pickers/hooks';
+import {
+  usePickerActionsContext,
+  usePickerTranslations,
+} from '@mui/x-date-pickers/hooks';
 
 function CustomActionBar(props) {
-  const { onAccept, onClear, onCancel, onSetToday, actions, className } = props;
+  const { actions, className } = props;
   const translations = usePickerTranslations();
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
   const id = useId();
@@ -28,7 +33,7 @@ function CustomActionBar(props) {
         return (
           <MenuItem
             onClick={() => {
-              onClear();
+              clearValue();
               setAnchorEl(null);
             }}
             key={actionType}
@@ -42,7 +47,7 @@ function CustomActionBar(props) {
           <MenuItem
             onClick={() => {
               setAnchorEl(null);
-              onCancel();
+              cancelValueChanges();
             }}
             key={actionType}
           >
@@ -55,7 +60,7 @@ function CustomActionBar(props) {
           <MenuItem
             onClick={() => {
               setAnchorEl(null);
-              onAccept();
+              acceptValueChanges();
             }}
             key={actionType}
           >
@@ -68,7 +73,7 @@ function CustomActionBar(props) {
           <MenuItem
             onClick={() => {
               setAnchorEl(null);
-              onSetToday();
+              setValueToToday();
             }}
             key={actionType}
           >

--- a/docs/data/date-pickers/custom-components/ActionBarComponent.tsx
+++ b/docs/data/date-pickers/custom-components/ActionBarComponent.tsx
@@ -9,11 +9,16 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { PickersActionBarProps } from '@mui/x-date-pickers/PickersActionBar';
-import { usePickerTranslations } from '@mui/x-date-pickers/hooks';
+import {
+  usePickerActionsContext,
+  usePickerTranslations,
+} from '@mui/x-date-pickers/hooks';
 
 function CustomActionBar(props: PickersActionBarProps) {
-  const { onAccept, onClear, onCancel, onSetToday, actions, className } = props;
+  const { actions, className } = props;
   const translations = usePickerTranslations();
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
   const open = Boolean(anchorEl);
   const id = useId();
@@ -28,7 +33,7 @@ function CustomActionBar(props: PickersActionBarProps) {
         return (
           <MenuItem
             onClick={() => {
-              onClear();
+              clearValue();
               setAnchorEl(null);
             }}
             key={actionType}
@@ -41,7 +46,7 @@ function CustomActionBar(props: PickersActionBarProps) {
           <MenuItem
             onClick={() => {
               setAnchorEl(null);
-              onCancel();
+              cancelValueChanges();
             }}
             key={actionType}
           >
@@ -53,7 +58,7 @@ function CustomActionBar(props: PickersActionBarProps) {
           <MenuItem
             onClick={() => {
               setAnchorEl(null);
-              onAccept();
+              acceptValueChanges();
             }}
             key={actionType}
           >
@@ -65,7 +70,7 @@ function CustomActionBar(props: PickersActionBarProps) {
           <MenuItem
             onClick={() => {
               setAnchorEl(null);
-              onSetToday();
+              setValueToToday();
             }}
             key={actionType}
           >

--- a/docs/data/date-pickers/custom-layout/AddComponent.js
+++ b/docs/data/date-pickers/custom-layout/AddComponent.js
@@ -8,7 +8,6 @@ import ListItemText from '@mui/material/ListItemText';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
-
 import RestaurantIcon from '@mui/icons-material/Restaurant';
 import {
   usePickerLayout,
@@ -17,17 +16,22 @@ import {
   PickersLayoutContentWrapper,
 } from '@mui/x-date-pickers/PickersLayout';
 
+import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';
+
 function ActionList(props) {
-  const { onAccept, onClear, onCancel, onSetToday } = props;
+  const { className } = props;
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
+
   const actions = [
-    { text: 'Accept', method: onAccept },
-    { text: 'Clear', method: onClear },
-    { text: 'Cancel', method: onCancel },
-    { text: 'Today', method: onSetToday },
+    { text: 'Accept', method: acceptValueChanges },
+    { text: 'Clear', method: clearValue },
+    { text: 'Cancel', method: cancelValueChanges },
+    { text: 'Today', method: setValueToToday },
   ];
 
   return (
-    <List>
+    <List className={className}>
       {actions.map(({ text, method }) => (
         <ListItem key={text} disablePadding>
           <ListItemButton onClick={method}>

--- a/docs/data/date-pickers/custom-layout/AddComponent.tsx
+++ b/docs/data/date-pickers/custom-layout/AddComponent.tsx
@@ -8,7 +8,6 @@ import ListItemText from '@mui/material/ListItemText';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
-import { PickersActionBarProps } from '@mui/x-date-pickers/PickersActionBar';
 import RestaurantIcon from '@mui/icons-material/Restaurant';
 import {
   PickersLayoutProps,
@@ -18,17 +17,23 @@ import {
   PickersLayoutContentWrapper,
 } from '@mui/x-date-pickers/PickersLayout';
 import { DateView } from '@mui/x-date-pickers/models';
+import { PickersActionBarProps } from '@mui/x-date-pickers/PickersActionBar';
+import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';
 
 function ActionList(props: PickersActionBarProps) {
-  const { onAccept, onClear, onCancel, onSetToday } = props;
+  const { className } = props;
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
+
   const actions = [
-    { text: 'Accept', method: onAccept },
-    { text: 'Clear', method: onClear },
-    { text: 'Cancel', method: onCancel },
-    { text: 'Today', method: onSetToday },
+    { text: 'Accept', method: acceptValueChanges },
+    { text: 'Clear', method: clearValue },
+    { text: 'Cancel', method: cancelValueChanges },
+    { text: 'Today', method: setValueToToday },
   ];
+
   return (
-    <List>
+    <List className={className}>
       {actions.map(({ text, method }) => (
         <ListItem key={text} disablePadding>
           <ListItemButton onClick={method}>

--- a/docs/data/date-pickers/custom-layout/MovingActions.js
+++ b/docs/data/date-pickers/custom-layout/MovingActions.js
@@ -8,13 +8,18 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { pickersLayoutClasses } from '@mui/x-date-pickers/PickersLayout';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 
+import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';
+
 function ActionList(props) {
-  const { onAccept, onClear, onCancel, onSetToday, className } = props;
+  const { className } = props;
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
+
   const actions = [
-    { text: 'Accept', method: onAccept },
-    { text: 'Clear', method: onClear },
-    { text: 'Cancel', method: onCancel },
-    { text: 'Today', method: onSetToday },
+    { text: 'Accept', method: acceptValueChanges },
+    { text: 'Clear', method: clearValue },
+    { text: 'Cancel', method: cancelValueChanges },
+    { text: 'Today', method: setValueToToday },
   ];
 
   return (

--- a/docs/data/date-pickers/custom-layout/MovingActions.tsx
+++ b/docs/data/date-pickers/custom-layout/MovingActions.tsx
@@ -8,15 +8,20 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { pickersLayoutClasses } from '@mui/x-date-pickers/PickersLayout';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { PickersActionBarProps } from '@mui/x-date-pickers/PickersActionBar';
+import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';
 
 function ActionList(props: PickersActionBarProps) {
-  const { onAccept, onClear, onCancel, onSetToday, className } = props;
+  const { className } = props;
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
+
   const actions = [
-    { text: 'Accept', method: onAccept },
-    { text: 'Clear', method: onClear },
-    { text: 'Cancel', method: onCancel },
-    { text: 'Today', method: onSetToday },
+    { text: 'Accept', method: acceptValueChanges },
+    { text: 'Clear', method: clearValue },
+    { text: 'Cancel', method: cancelValueChanges },
+    { text: 'Today', method: setValueToToday },
   ];
+
   return (
     // Propagate the className such that CSS selectors can be applied
     <List className={className}>

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -375,7 +375,7 @@ const theme = createTheme({
 
   :::success
   The `usePickerContext` also contain all the actions returned by `usePickerActionsContext`.
-  The only difference is that `usePickerActionsContext` only contain variables with stable references that won't cause a re-render of your component.
+  The only difference is that `usePickerActionsContext` only contains variables with stable references that won't cause a re-render of your component.
   :::
 
 ### Slot: `toolbar`

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -364,7 +364,7 @@ const theme = createTheme({
 
    // This contains a small behavior change.
    // If the picker is not controlled and has a default value,
-   // Then opening it and calling `acceptValueChanges` without any change will call `onAccept` with the default value.
+   // opening it and calling `acceptValueChanges` without any change will call `onAccept` with the default value.
    // Whereas before, opening it and calling `onDimiss` without any change would not have called `onAccept`.
   -const { onDismiss } = props;
   +const { acceptValueChanges } = usePickerActionsContext();

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -420,7 +420,7 @@ const theme = createTheme({
 
   :::success
   The `usePickerContext` also contain all the actions returned by `usePickerActionsContext`.
-  The only difference is that `usePickerActionsContext` only contain variables with stable references that won't cause a re-render of your component.
+  The only difference is that `usePickerActionsContext` only contains variables with stable references that won't cause a re-render of your component.
   :::
 
 ## Renamed variables and types

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -400,7 +400,7 @@ const theme = createTheme({
 
 ### Slot: `actionBar`
 
-- The component passed to the `actionBar` slot no longer receives an `onClear`, `onSetToday`, `onAccept` and `onCancel` props, instead you can use the `usePickerActionsContext` or the `usePickerContext` hooks:
+- The component passed to the `actionBar` slot no longer receives an `onClear`, `onSetToday`, `onAccept` and `onCancel` props. You can use the `usePickerActionsContext` or the `usePickerContext` hooks instead:
 
   ```diff
   +import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -363,14 +363,12 @@ const theme = createTheme({
   +}
 
    // This contains a small behavior change.
-   // `onDismiss` was only calling the onAccept prop of your picker if the value had changed since the opening of the picker.
-   // With this code snippet, the onAccept prop will always be called.
+   // If the picker is not controlled and has a default value,
+   // Then opening it and calling `acceptValueChanges` without any change will call `onAccept` with the default value.
+   // Whereas before, opening it and calling `onDimiss` without any change would not have called `onAccept`.
   -const { onDismiss } = props;
-  +const { acceptValueChanges, setOpen } = usePickerActionsContext();
-  +const onDismiss = event => {
-  +  acceptValueChanges();
-  +  setOpen(false);
-  +}
+  +const { acceptValueChanges } = usePickerActionsContext();
+  +const onDismiss = acceptValueChanges
   ```
 
   :::success

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -398,7 +398,7 @@ const theme = createTheme({
 
 ### Slot: `actionBar`
 
-- The component passed to the `actionBar` slot no longer receives an `onClear`, `onSetToday`, `onAccept` and `onCancel` props. You can use the `usePickerActionsContext` or the `usePickerContext` hooks instead:
+- The component passed to the `actionBar` slot no longer receives the `onClear`, `onSetToday`, `onAccept` and `onCancel` props. You can use the `usePickerActionsContext` or the `usePickerContext` hooks instead:
 
   ```diff
   +import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -309,7 +309,7 @@ const theme = createTheme({
    }
   ```
 
-- The component passed to the `layout` slot no longer receives an `orientation` and `isLandscape` props, instead you can use the `usePickerContext` hook:
+- The component passed to the `layout` slot no longer receives the `orientation` and `isLandscape` props, instead you can use the `usePickerContext` hook:
 
   ```diff
   -console.log(props.orientation);

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -331,7 +331,7 @@ const theme = createTheme({
   +console.log(variant);
   ```
 
-- The component passed to the `layout` slot no longer receives an `onClear`, `onSetToday`, `onAccept`, `onCancel`, `onOpen`, `onClose` and `onDismiss` props, instead you can use the `usePickerActionsContext` or the `usePickerContext` hooks:
+- The component passed to the `layout` slot no longer receives the `onClear`, `onSetToday`, `onAccept`, `onCancel`, `onOpen`, `onClose` and `onDismiss` props, instead you can use the `usePickerActionsContext` or the `usePickerContext` hooks:
 
   ```diff
   +import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -309,7 +309,7 @@ const theme = createTheme({
    }
   ```
 
-- The component passed to the `layout` slot no longer receives an `orientation` and the `isLandscape` props, instead you can use the `usePickerContext` hook:
+- The component passed to the `layout` slot no longer receives an `orientation` and `isLandscape` props, instead you can use the `usePickerContext` hook:
 
   ```diff
   -console.log(props.orientation);
@@ -331,6 +331,53 @@ const theme = createTheme({
   +console.log(variant);
   ```
 
+- The component passed to the `layout` slot no longer receives an `onClear`, `onSetToday`, `onAccept`, `onCancel`, `onOpen`, `onClose` and `onDismiss` props, instead you can use the `usePickerActionsContext` or the `usePickerContext` hooks:
+
+  ```diff
+  +import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';
+
+  -const { onClear } = props;
+  +const { clearValue } = usePickerActionsContext();
+
+  -const { onSetToday } = props;
+  +const { setValueToToday } = usePickerActionsContext();
+
+  -const { onAccept } = props;
+  +const { acceptValueChanges } = usePickerActionsContext();
+
+  -const { onCancel } = props;
+  +const { cancelValueChanges } = usePickerActionsContext();
+
+  -const { onOpen } = props;
+  +const { setOpen } = usePickerActionsContext();
+  +const onOpen = event => {
+  +  event.preventDefault();
+  +  setOpen(true);
+  +}
+
+  -props.onClose();
+  +const { setOpen } = usePickerActionsContext();
+  +const onClose = event => {
+  +  event.preventDefault();
+  +  setOpen(false);
+  +}
+
+   // This contains a small behavior change.
+   // `onDismiss` was only calling the onAccept prop of your picker if the value had changed since the opening of the picker.
+   // With this code snippet, the onAccept prop will always be called.
+  -const { onDismiss } = props;
+  +const { acceptValueChanges, setOpen } = usePickerActionsContext();
+  +const onDismiss = event => {
+  +  acceptValueChanges();
+  +  setOpen(false);
+  +}
+  ```
+
+  :::success
+  The `usePickerContext` also contain all the actions returned by `usePickerActionsContext`.
+  The only difference is that `usePickerActionsContext` only contain variables with stable references that won't cause a re-render of your component.
+  :::
+
 ### Slot: `toolbar`
 
 - The component passed to the `toolbar` slot no longer receives a `disabled` prop, instead you can use the `usePickerContext` hook:
@@ -350,6 +397,31 @@ const theme = createTheme({
   +const { readOnly } = usePickerContext();
   +console.log(readOnly);
   ```
+
+### Slot: `actionBar`
+
+- The component passed to the `actionBar` slot no longer receives an `onClear`, `onSetToday`, `onAccept` and `onCancel` props, instead you can use the `usePickerActionsContext` or the `usePickerContext` hooks:
+
+  ```diff
+  +import { usePickerActionsContext } from '@mui/x-date-pickers/hooks';
+
+  -const { onClear } = props;
+  +const { clearValue } = usePickerActionsContext();
+
+  -const { onSetToday } = props;
+  +const { setValueToToday } = usePickerActionsContext();
+
+  -const { onAccept } = props;
+  +const { acceptValueChanges } = usePickerActionsContext();
+
+  -const { onCancel } = props;
+  +const { cancelValueChanges } = usePickerActionsContext();
+  ```
+
+  :::success
+  The `usePickerContext` also contain all the actions returned by `usePickerActionsContext`.
+  The only difference is that `usePickerActionsContext` only contain variables with stable references that won't cause a re-render of your component.
+  :::
 
 ## Renamed variables and types
 

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -90,8 +90,6 @@ export const useDesktopRangePicker = <
   }
 
   const {
-    open,
-    actions,
     layoutProps,
     providerProps,
     renderCurrentView,
@@ -127,7 +125,8 @@ export const useDesktopRangePicker = <
         return;
       }
 
-      actions.onDismiss();
+      // This direct access to `providerProps` will go away once the range fields stop having their views in a tooltip.
+      providerProps.privateContextValue.dismissViews();
     });
   };
 
@@ -170,8 +169,9 @@ export const useDesktopRangePicker = <
   >({
     variant: 'desktop',
     fieldType,
-    open,
-    actions,
+    // These direct access to `providerProps` will go away once the range fields handle the picker opening
+    open: providerProps.contextValue.open,
+    setOpen: providerProps.contextValue.setOpen,
     readOnly,
     disableOpenPicker,
     label,
@@ -215,8 +215,6 @@ export const useDesktopRangePicker = <
         containerRef={popperRef}
         anchorEl={anchorRef.current}
         onBlur={handleBlur}
-        {...actions}
-        open={open}
         slots={slots}
         slotProps={slotProps}
         shouldRestoreFocus={shouldRestoreFocus}

--- a/packages/x-date-pickers-pro/src/internals/hooks/useEnrichedRangePickerFieldProps.ts
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useEnrichedRangePickerFieldProps.ts
@@ -20,7 +20,7 @@ import {
 import { PickersInputLocaleText } from '@mui/x-date-pickers/locales';
 import {
   onSpaceOrEnter,
-  UsePickerResponse,
+  UsePickerValueContextValue,
   PickerVariant,
   DateOrTimeViewWithMeridiem,
   BaseSingleInputFieldProps,
@@ -91,7 +91,7 @@ export interface UseEnrichedRangePickerFieldPropsParams<
   TView extends DateOrTimeViewWithMeridiem,
   TEnableAccessibleFieldDOMStructure extends boolean,
   TError,
-> extends Pick<UsePickerResponse<PickerRangeValue, TView, any>, 'open' | 'actions'>,
+> extends Pick<UsePickerValueContextValue, 'open' | 'setOpen'>,
     UseRangePositionResponse {
   variant: PickerVariant;
   fieldType: FieldType;
@@ -124,7 +124,7 @@ const useMultiInputFieldSlotProps = <
 >({
   variant,
   open,
-  actions,
+  setOpen,
   readOnly,
   labelId,
   disableOpenPicker,
@@ -180,7 +180,8 @@ const useMultiInputFieldSlotProps = <
     event.stopPropagation();
     onRangePositionChange('start');
     if (!readOnly && !disableOpenPicker) {
-      actions.onOpen(event);
+      event.preventDefault();
+      setOpen(true);
     }
   };
 
@@ -188,7 +189,8 @@ const useMultiInputFieldSlotProps = <
     event.stopPropagation();
     onRangePositionChange('end');
     if (!readOnly && !disableOpenPicker) {
-      actions.onOpen(event);
+      event.preventDefault();
+      setOpen(true);
     }
   };
 
@@ -297,7 +299,7 @@ const useSingleInputFieldSlotProps = <
 >({
   variant,
   open,
-  actions,
+  setOpen,
   readOnly,
   labelId,
   disableOpenPicker,
@@ -371,7 +373,8 @@ const useSingleInputFieldSlotProps = <
     event.stopPropagation();
 
     if (!readOnly && !disableOpenPicker) {
-      actions.onOpen(event);
+      event.preventDefault();
+      setOpen(true);
     }
   };
 

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -86,8 +86,6 @@ export const useMobileRangePicker = <
   }
 
   const {
-    open,
-    actions,
     layoutProps,
     providerProps,
     renderCurrentView,
@@ -145,8 +143,9 @@ export const useMobileRangePicker = <
   >({
     variant: 'mobile',
     fieldType,
-    open,
-    actions,
+    // These direct access to `providerProps` will go away once the range fields handle the picker opening
+    open: providerProps.contextValue.open,
+    setOpen: providerProps.contextValue.setOpen,
     readOnly,
     labelId,
     disableOpenPicker,
@@ -213,7 +212,7 @@ export const useMobileRangePicker = <
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
       <Field {...enrichedFieldProps} />
-      <PickersModalDialog {...actions} open={open} slots={slots} slotProps={slotProps}>
+      <PickersModalDialog slots={slots} slotProps={slotProps}>
         <Layout
           {...layoutProps}
           {...slotProps?.layout}

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePickerLayout.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/DesktopDateTimePickerLayout.tsx
@@ -73,15 +73,8 @@ DesktopDateTimePickerLayout.propTypes = {
   classes: PropTypes.object,
   className: PropTypes.string,
   isValid: PropTypes.func.isRequired,
-  onAccept: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  onClear: PropTypes.func.isRequired,
-  onClose: PropTypes.func.isRequired,
-  onDismiss: PropTypes.func.isRequired,
-  onOpen: PropTypes.func.isRequired,
   onSelectShortcut: PropTypes.func.isRequired,
-  onSetToday: PropTypes.func.isRequired,
   onViewChange: PropTypes.func.isRequired,
   /**
    * The props used for each component slot.

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.test.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.test.tsx
@@ -4,122 +4,61 @@ import { spy } from 'sinon';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { PickersActionBar } from '@mui/x-date-pickers/PickersActionBar';
 import { createPickerRenderer } from 'test/utils/pickers';
+import { PickerActionsContext } from '../internals/components/PickerProvider';
 
 describe('<PickersActionBar />', () => {
   const { render } = createPickerRenderer({ clock: 'fake' });
 
+  const renderWithContext = (element: React.ReactElement) => {
+    const spys = {
+      setOpen: spy(),
+      clearValue: spy(),
+      setValueToToday: spy(),
+      acceptValueChanges: spy(),
+      cancelValueChanges: spy(),
+    };
+
+    render(<PickerActionsContext.Provider value={spys}>{element}</PickerActionsContext.Provider>);
+
+    return spys;
+  };
+
   it('should not render buttons if actions array is empty', () => {
-    const onAccept = () => {};
-    const onClear = () => {};
-    const onCancel = () => {};
-    const onSetToday = () => {};
-    render(
-      <PickersActionBar
-        actions={[]}
-        onAccept={onAccept}
-        onClear={onClear}
-        onCancel={onCancel}
-        onSetToday={onSetToday}
-      />,
-    );
+    renderWithContext(<PickersActionBar actions={[]} />);
 
     expect(screen.queryByRole('button')).to.equal(null);
   });
 
   it('should render button for "clear" action calling the associated callback', () => {
-    const onAccept = spy();
-    const onClear = spy();
-    const onCancel = spy();
-    const onSetToday = spy();
-
-    render(
-      <PickersActionBar
-        actions={['clear']}
-        onAccept={onAccept}
-        onClear={onClear}
-        onCancel={onCancel}
-        onSetToday={onSetToday}
-      />,
-    );
+    const { clearValue } = renderWithContext(<PickersActionBar actions={['clear']} />);
 
     fireEvent.click(screen.getByText(/clear/i));
-    expect(onClear.callCount).to.equal(1);
+    expect(clearValue.callCount).to.equal(1);
   });
 
   it('should render button for "cancel" action calling the associated callback', () => {
-    const onAccept = spy();
-    const onClear = spy();
-    const onCancel = spy();
-    const onSetToday = spy();
-
-    render(
-      <PickersActionBar
-        actions={['cancel']}
-        onAccept={onAccept}
-        onClear={onClear}
-        onCancel={onCancel}
-        onSetToday={onSetToday}
-      />,
-    );
+    const { cancelValueChanges } = renderWithContext(<PickersActionBar actions={['cancel']} />);
 
     fireEvent.click(screen.getByText(/cancel/i));
-    expect(onCancel.callCount).to.equal(1);
+    expect(cancelValueChanges.callCount).to.equal(1);
   });
 
   it('should render button for "accept" action calling the associated callback', () => {
-    const onAccept = spy();
-    const onClear = spy();
-    const onCancel = spy();
-    const onSetToday = spy();
-
-    render(
-      <PickersActionBar
-        actions={['accept']}
-        onAccept={onAccept}
-        onClear={onClear}
-        onCancel={onCancel}
-        onSetToday={onSetToday}
-      />,
-    );
+    const { acceptValueChanges } = renderWithContext(<PickersActionBar actions={['accept']} />);
 
     fireEvent.click(screen.getByText(/ok/i));
-    expect(onAccept.callCount).to.equal(1);
+    expect(acceptValueChanges.callCount).to.equal(1);
   });
 
   it('should render button for "today" action calling the associated callback', () => {
-    const onAccept = spy();
-    const onClear = spy();
-    const onCancel = spy();
-    const onSetToday = spy();
-
-    render(
-      <PickersActionBar
-        actions={['today']}
-        onAccept={onAccept}
-        onClear={onClear}
-        onCancel={onCancel}
-        onSetToday={onSetToday}
-      />,
-    );
+    const { setValueToToday } = renderWithContext(<PickersActionBar actions={['today']} />);
 
     fireEvent.click(screen.getByText(/today/i));
-    expect(onSetToday.callCount).to.equal(1);
+    expect(setValueToToday.callCount).to.equal(1);
   });
 
   it('should respect actions order', () => {
-    const onAccept = () => {};
-    const onClear = () => {};
-    const onCancel = () => {};
-    const onSetToday = () => {};
-    render(
-      <PickersActionBar
-        actions={['today', 'accept', 'clear', 'cancel']}
-        onAccept={onAccept}
-        onClear={onClear}
-        onCancel={onCancel}
-        onSetToday={onSetToday}
-      />,
-    );
+    renderWithContext(<PickersActionBar actions={['today', 'accept', 'clear', 'cancel']} />);
 
     const buttons = screen.getAllByRole('button');
 

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -5,6 +5,7 @@ import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import DialogActions, { DialogActionsProps } from '@mui/material/DialogActions';
 import { usePickerTranslations } from '../hooks/usePickerTranslations';
+import { usePickerActionsContext } from '../hooks';
 
 export type PickersActionBarAction = 'clear' | 'cancel' | 'accept' | 'today';
 
@@ -15,10 +16,6 @@ export interface PickersActionBarProps extends DialogActionsProps {
    * @default `['cancel', 'accept']` for mobile and `[]` for desktop
    */
   actions?: PickersActionBarAction[];
-  onAccept: () => void;
-  onClear: () => void;
-  onCancel: () => void;
-  onSetToday: () => void;
 }
 
 const PickersActionBarRoot = styled(DialogActions, {
@@ -38,9 +35,11 @@ const PickersActionBarRoot = styled(DialogActions, {
  * - [PickersActionBar API](https://mui.com/x/api/date-pickers/pickers-action-bar/)
  */
 function PickersActionBar(props: PickersActionBarProps) {
-  const { onAccept, onClear, onCancel, onSetToday, actions, ...other } = props;
+  const { actions, ...other } = props;
 
   const translations = usePickerTranslations();
+  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
+    usePickerActionsContext();
 
   if (actions == null || actions.length === 0) {
     return null;
@@ -50,28 +49,28 @@ function PickersActionBar(props: PickersActionBarProps) {
     switch (actionType) {
       case 'clear':
         return (
-          <Button data-testid="clear-action-button" onClick={onClear} key={actionType}>
+          <Button data-testid="clear-action-button" onClick={clearValue} key={actionType}>
             {translations.clearButtonLabel}
           </Button>
         );
 
       case 'cancel':
         return (
-          <Button onClick={onCancel} key={actionType}>
+          <Button onClick={cancelValueChanges} key={actionType}>
             {translations.cancelButtonLabel}
           </Button>
         );
 
       case 'accept':
         return (
-          <Button onClick={onAccept} key={actionType}>
+          <Button onClick={acceptValueChanges} key={actionType}>
             {translations.okButtonLabel}
           </Button>
         );
 
       case 'today':
         return (
-          <Button data-testid="today-action-button" onClick={onSetToday} key={actionType}>
+          <Button data-testid="today-action-button" onClick={setValueToToday} key={actionType}>
             {translations.todayButtonLabel}
           </Button>
         );
@@ -100,10 +99,6 @@ PickersActionBar.propTypes = {
    * @default false
    */
   disableSpacing: PropTypes.bool,
-  onAccept: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  onClear: PropTypes.func.isRequired,
-  onSetToday: PropTypes.func.isRequired,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -154,15 +154,8 @@ PickersLayout.propTypes = {
   classes: PropTypes.object,
   className: PropTypes.string,
   isValid: PropTypes.func.isRequired,
-  onAccept: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
-  onClear: PropTypes.func.isRequired,
-  onClose: PropTypes.func.isRequired,
-  onDismiss: PropTypes.func.isRequired,
-  onOpen: PropTypes.func.isRequired,
   onSelectShortcut: PropTypes.func.isRequired,
-  onSetToday: PropTypes.func.isRequired,
   onViewChange: PropTypes.func.isRequired,
   /**
    * The props used for each component slot.

--- a/packages/x-date-pickers/src/PickersLayout/usePickerLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/usePickerLayout.tsx
@@ -48,10 +48,6 @@ const usePickerLayout = <TValue extends PickerValidValue, TView extends DateOrTi
   const isRtl = useRtl();
 
   const {
-    onAccept,
-    onClear,
-    onCancel,
-    onSetToday,
     view,
     views,
     onViewChange,
@@ -81,10 +77,6 @@ const usePickerLayout = <TValue extends PickerValidValue, TView extends DateOrTi
     elementType: ActionBar,
     externalSlotProps: slotProps?.actionBar,
     additionalProps: {
-      onAccept,
-      onClear,
-      onCancel,
-      onSetToday,
       actions: variant === 'desktop' ? [] : (['cancel', 'accept'] as PickersActionBarAction[]),
     },
     className: classes.actionBar,

--- a/packages/x-date-pickers/src/hooks/index.tsx
+++ b/packages/x-date-pickers/src/hooks/index.tsx
@@ -7,9 +7,7 @@ export type {
 } from './useClearableField';
 
 export { usePickerTranslations } from './usePickerTranslations';
-
 export { useSplitFieldProps } from './useSplitFieldProps';
-
 export { useParsedFormat } from './useParsedFormat';
-
 export { usePickerContext } from './usePickerContext';
+export { usePickerActionsContext } from './usePickerActionsContext';

--- a/packages/x-date-pickers/src/hooks/usePickerActionsContext.ts
+++ b/packages/x-date-pickers/src/hooks/usePickerActionsContext.ts
@@ -1,0 +1,20 @@
+'use client';
+import * as React from 'react';
+import { PickerActionsContext } from '../internals/components/PickerProvider';
+
+/**
+ * Returns a sub-set of the context passed by the picker that wraps the current component.
+ * If only contain the actions and never causes a re-render of the component using it.
+ */
+export const usePickerActionsContext = () => {
+  const value = React.useContext(PickerActionsContext);
+  if (value == null) {
+    throw new Error(
+      [
+        'MUI X: The `usePickerActionsContext` can only be called in fields that are used as a slot of a picker component',
+      ].join('\n'),
+    );
+  }
+
+  return value;
+};

--- a/packages/x-date-pickers/src/hooks/usePickerActionsContext.ts
+++ b/packages/x-date-pickers/src/hooks/usePickerActionsContext.ts
@@ -4,7 +4,7 @@ import { PickerActionsContext } from '../internals/components/PickerProvider';
 
 /**
  * Returns a subset of the context passed by the picker wrapping the current component.
- * If only contain the actions and never causes a re-render of the component using it.
+ * It only contains the actions and never causes a re-render of the component using it.
  */
 export const usePickerActionsContext = () => {
   const value = React.useContext(PickerActionsContext);

--- a/packages/x-date-pickers/src/hooks/usePickerActionsContext.ts
+++ b/packages/x-date-pickers/src/hooks/usePickerActionsContext.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { PickerActionsContext } from '../internals/components/PickerProvider';
 
 /**
- * Returns a sub-set of the context passed by the picker that wraps the current component.
+ * Returns a subset of the context passed by the picker wrapping the current component.
  * If only contain the actions and never causes a re-render of the component using it.
  */
 export const usePickerActionsContext = () => {

--- a/packages/x-date-pickers/src/internals/components/PickerProvider.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerProvider.tsx
@@ -3,9 +3,15 @@ import { PickerOwnerState } from '../../models';
 import { PickersInputLocaleText } from '../../locales';
 import { LocalizationProvider } from '../../LocalizationProvider';
 import { PickerOrientation, PickerVariant } from '../models';
-import type { UsePickerValueContextValue } from '../hooks/usePicker/usePickerValue.types';
+import type {
+  UsePickerValueActionsContextValue,
+  UsePickerValueContextValue,
+  UsePickerValuePrivateContextValue,
+} from '../hooks/usePicker/usePickerValue.types';
 
 export const PickerContext = React.createContext<PickerContextValue | null>(null);
+
+export const PickerActionsContext = React.createContext<PickerActionsContextValue | null>(null);
 
 export const PickerPrivateContext = React.createContext<PickerPrivateContextValue>({
   ownerState: {
@@ -16,6 +22,7 @@ export const PickerPrivateContext = React.createContext<PickerPrivateContextValu
     pickerVariant: 'desktop',
     pickerOrientation: 'portrait',
   },
+  dismissViews: () => {},
 });
 
 /**
@@ -26,19 +33,22 @@ export const PickerPrivateContext = React.createContext<PickerPrivateContextValu
  * @ignore - do not document.
  */
 export function PickerProvider(props: PickerProviderProps) {
-  const { contextValue, privateContextValue, localeText, children } = props;
+  const { contextValue, actionsContextValue, privateContextValue, localeText, children } = props;
 
   return (
     <PickerContext.Provider value={contextValue}>
-      <PickerPrivateContext.Provider value={privateContextValue}>
-        <LocalizationProvider localeText={localeText}>{children}</LocalizationProvider>
-      </PickerPrivateContext.Provider>
+      <PickerActionsContext.Provider value={actionsContextValue}>
+        <PickerPrivateContext.Provider value={privateContextValue}>
+          <LocalizationProvider localeText={localeText}>{children}</LocalizationProvider>
+        </PickerPrivateContext.Provider>
+      </PickerActionsContext.Provider>
     </PickerContext.Provider>
   );
 }
 
 export interface PickerProviderProps {
   contextValue: PickerContextValue;
+  actionsContextValue: PickerActionsContextValue;
   privateContextValue: PickerPrivateContextValue;
   localeText: PickersInputLocaleText | undefined;
   children: React.ReactNode;
@@ -71,7 +81,10 @@ export interface PickerContextValue extends UsePickerValueContextValue {
    */
   orientation: PickerOrientation;
 }
-export interface PickerPrivateContextValue {
+
+export interface PickerActionsContextValue extends UsePickerValueActionsContextValue {}
+
+export interface PickerPrivateContextValue extends UsePickerValuePrivateContextValue {
   /**
    * The ownerState of the picker.
    */

--- a/packages/x-date-pickers/src/internals/components/PickersModalDialog.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersModalDialog.tsx
@@ -6,7 +6,8 @@ import { PaperProps as MuiPaperProps } from '@mui/material/Paper';
 import { TransitionProps as MuiTransitionProps } from '@mui/material/transitions';
 import { styled } from '@mui/material/styles';
 import { DIALOG_WIDTH } from '../constants/dimensions';
-import { UsePickerValueActions } from '../hooks/usePicker/usePickerValue.types';
+import { usePickerContext } from '../../hooks';
+import { usePickerPrivateContext } from '../hooks/usePickerPrivateContext';
 
 export interface PickersModalDialogSlots {
   /**
@@ -41,7 +42,7 @@ export interface PickersModalDialogSlotProps {
   mobileTransition?: Partial<MuiTransitionProps>;
 }
 
-export interface PickersModalDialogProps extends UsePickerValueActions {
+export interface PickersModalDialogProps {
   /**
    * Overridable component slots.
    * @default {}
@@ -52,7 +53,6 @@ export interface PickersModalDialogProps extends UsePickerValueActions {
    * @default {}
    */
   slotProps?: PickersModalDialogSlotProps;
-  open: boolean;
 }
 
 const PickersModalDialogRoot = styled(MuiDialog)({
@@ -72,7 +72,10 @@ const PickersModalDialogContent = styled(DialogContent)({
 });
 
 export function PickersModalDialog(props: React.PropsWithChildren<PickersModalDialogProps>) {
-  const { children, onDismiss, open, slots, slotProps } = props;
+  const { children, slots, slotProps } = props;
+
+  const { open } = usePickerContext();
+  const { dismissViews } = usePickerPrivateContext();
 
   const Dialog = slots?.dialog ?? PickersModalDialogRoot;
   const Transition = slots?.mobileTransition ?? Fade;
@@ -80,7 +83,7 @@ export function PickersModalDialog(props: React.PropsWithChildren<PickersModalDi
   return (
     <Dialog
       open={open}
-      onClose={onDismiss}
+      onClose={dismissViews}
       {...slotProps?.dialog}
       TransitionComponent={Transition}
       TransitionProps={slotProps?.mobileTransition}

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -60,8 +60,6 @@ export const useDesktopPicker = <
   const isToolbarHidden = innerSlotProps?.toolbar?.hidden ?? false;
 
   const {
-    open,
-    actions,
     hasUIView,
     layoutProps,
     providerProps,
@@ -95,7 +93,11 @@ export const useDesktopPicker = <
     externalSlotProps: innerSlotProps?.openPickerButton,
     additionalProps: {
       disabled: disabled || readOnly,
-      onClick: open ? actions.onClose : actions.onOpen,
+      // This direct access to `providerProps` will go away in https://github.com/mui/mui-x/pull/15671
+      onClick: (event: React.UIEvent) => {
+        event.preventDefault();
+        providerProps.contextValue.setOpen((prevOpen) => !prevOpen);
+      },
       'aria-label': getOpenDialogAriaText(pickerFieldProps.value),
       edge: inputAdornmentProps.position,
     },
@@ -135,7 +137,7 @@ export const useDesktopPicker = <
       sx,
       label,
       name,
-      focused: open ? true : undefined,
+      focused: providerProps.contextValue.open ? true : undefined,
       ...(isToolbarHidden && { id: labelId }),
       ...(!!inputRef && { inputRef }),
     },
@@ -202,8 +204,6 @@ export const useDesktopPicker = <
         role="dialog"
         placement="bottom-start"
         anchorEl={containerRef.current}
-        {...actions}
-        open={open}
         slots={slots}
         slotProps={slotProps}
         shouldRestoreFocus={shouldRestoreFocus}

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -56,8 +56,6 @@ export const useMobilePicker = <
   const isToolbarHidden = innerSlotProps?.toolbar?.hidden ?? false;
 
   const {
-    open,
-    actions,
     layoutProps,
     providerProps,
     renderCurrentView,
@@ -100,8 +98,12 @@ export const useMobilePicker = <
       name,
       ...(isToolbarHidden && { id: labelId }),
       ...(!(disabled || readOnly) && {
-        onClick: actions.onOpen,
-        onKeyDown: onSpaceOrEnter(actions.onOpen),
+        // These direct access to `providerProps` will go away in https://github.com/mui/mui-x/pull/15671
+        onClick: (event: React.UIEvent) => {
+          event.preventDefault();
+          providerProps.contextValue.setOpen(true);
+        },
+        onKeyDown: onSpaceOrEnter(() => providerProps.contextValue.setOpen(true)),
       }),
       ...(!!inputRef && { inputRef }),
     },
@@ -151,7 +153,7 @@ export const useMobilePicker = <
         slotProps={slotProps}
         unstableFieldRef={handleFieldRef}
       />
-      <PickersModalDialog {...actions} open={open} slots={slots} slotProps={slotProps}>
+      <PickersModalDialog slots={slots} slotProps={slotProps}>
         <Layout {...layoutProps} {...slotProps?.layout} slots={slots} slotProps={slotProps}>
           {renderCurrentView()}
         </Layout>

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.ts
@@ -64,8 +64,6 @@ export const usePicker = <
 
   return {
     // Picker value
-    open: pickerValueResponse.open,
-    actions: pickerValueResponse.actions,
     fieldProps: pickerValueResponse.fieldProps,
 
     // Picker views

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
@@ -62,7 +62,7 @@ export interface UsePickerResponse<
   TValue extends PickerValidValue,
   TView extends DateOrTimeViewWithMeridiem,
   TError,
-> extends Pick<UsePickerValueResponse<TValue, TError>, 'open' | 'actions' | 'fieldProps'>,
+> extends Pick<UsePickerValueResponse<TValue, TError>, 'fieldProps'>,
     Pick<UsePickerViewsResponse<TView>, 'shouldRestoreFocus' | 'renderCurrentView'> {
   ownerState: PickerOwnerState;
   providerProps: UsePickerProviderReturnValue;

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerProvider.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerProvider.ts
@@ -113,13 +113,14 @@ export function usePickerProvider<
   );
 
   const privateContextValue = React.useMemo<PickerPrivateContextValue>(
-    () => ({ ownerState }),
-    [ownerState],
+    () => ({ ...paramsFromUsePickerValue.privateContextValue, ownerState }),
+    [paramsFromUsePickerValue, ownerState],
   );
 
   return {
     localeText,
     contextValue,
+    actionsContextValue: paramsFromUsePickerValue.actionsContextValue,
     privateContextValue,
   };
 }

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
@@ -352,7 +352,8 @@ export interface UsePickerValueActionsContextValue {
   setValueToToday: () => void;
   /**
    * Accept the current value of the picker.
-   * Will call `onAccept` if defined, and if the picker is closed, this value will be retained.
+   * Will call `onAccept` if defined.
+   * If the picker is re-opened, this value will be the one used to initialize the views.
    */
   acceptValueChanges: () => void;
   /**

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
@@ -275,16 +275,6 @@ export interface UsePickerValueParams<
   validator: Validator<TValue, InferError<TExternalProps>, TExternalProps>;
 }
 
-export interface UsePickerValueActions {
-  onAccept: () => void;
-  onClear: () => void;
-  onDismiss: () => void;
-  onCancel: () => void;
-  onSetToday: () => void;
-  onOpen: (event: React.UIEvent) => void;
-  onClose: (event?: React.UIEvent) => void;
-}
-
 export type UsePickerValueFieldResponse<TValue extends PickerValidValue, TError> = Required<
   Pick<UseFieldInternalProps<TValue, any, TError>, 'value' | 'onChange'>
 >;
@@ -296,14 +286,13 @@ export interface UsePickerValueViewsResponse<TValue extends PickerValidValue> {
   value: TValue;
   onChange: (value: TValue, selectionState?: PickerSelectionState) => void;
   open: boolean;
-  onClose: (event?: React.MouseEvent) => void;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 /**
  * Props passed to `usePickerLayoutProps`.
  */
-export interface UsePickerValueLayoutResponse<TValue extends PickerValidValue>
-  extends UsePickerValueActions {
+export interface UsePickerValueLayoutResponse<TValue extends PickerValidValue> {
   value: TValue;
   onChange: (newValue: TValue) => void;
   onSelectShortcut: (
@@ -320,20 +309,27 @@ export interface UsePickerValueLayoutResponse<TValue extends PickerValidValue>
 export interface UsePickerValueProviderParams<TValue extends PickerValidValue> {
   value: TValue;
   contextValue: UsePickerValueContextValue;
+  actionsContextValue: UsePickerValueActionsContextValue;
+  privateContextValue: UsePickerValuePrivateContextValue;
 }
 
 export interface UsePickerValueResponse<TValue extends PickerValidValue, TError> {
-  open: boolean;
-  actions: UsePickerValueActions;
   viewProps: UsePickerValueViewsResponse<TValue>;
   fieldProps: UsePickerValueFieldResponse<TValue, TError>;
   layoutProps: UsePickerValueLayoutResponse<TValue>;
   provider: UsePickerValueProviderParams<TValue>;
 }
 
-export interface UsePickerValueContextValue {
+export interface UsePickerValueContextValue extends UsePickerValueActionsContextValue {
   /**
-   * Sets the current open state of the Picker.
+   * `true` if the picker is open, `false` otherwise.
+   */
+  open: boolean;
+}
+
+export interface UsePickerValueActionsContextValue {
+  /**
+   * Set the current open state of the Picker.
    * ```ts
    * setOpen(true); // Opens the picker.
    * setOpen(false); // Closes the picker.
@@ -344,7 +340,31 @@ export interface UsePickerValueContextValue {
    */
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   /**
-   * `true` if the picker is open, `false` otherwise.
+   * Set the current value of the picker to be empty.
+   * The value will be `null` on single pickers and `[null, null]` on range pickers.
    */
-  open: boolean;
+  clearValue: () => void;
+  /**
+   * Set the current value of the picker to be the current date.
+   * The value will be `today` on single pickers and `[today, today]` on range pickers.
+   * With `today` being the current date, with its time set to `00:00:00` on Date Pickers and its time set to the current time on Time and Date Pickers.
+   */
+  setValueToToday: () => void;
+  /**
+   * Accept the current value of the picker.
+   * Will call `onAccept` if defined, and if the picker is closed, this value will be retained.
+   */
+  acceptValueChanges: () => void;
+  /**
+   * Cancel the changes made to the current value of the picker.
+   * The value will be reset to the last accepted value.
+   */
+  cancelValueChanges: () => void;
+}
+
+export interface UsePickerValuePrivateContextValue {
+  /**
+   * Closes the picker and accepts the current value if it is not equal to the last accepted value.
+   */
+  dismissViews: () => void;
 }

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerViews.ts
@@ -24,7 +24,7 @@ export type PickerViewsRendererProps<
   TAdditionalProps extends {},
 > = Omit<TExternalProps, 'className' | 'sx'> &
   TAdditionalProps &
-  UsePickerValueViewsResponse<TValue> & {
+  Pick<UsePickerValueViewsResponse<TValue>, 'value' | 'onChange'> & {
     view: TView;
     views: readonly TView[];
     focusedView: TView | null;
@@ -159,7 +159,7 @@ export const usePickerViews = <
   TExternalProps,
   TAdditionalProps
 >): UsePickerViewsResponse<TView> => {
-  const { onChange, open, onClose } = propsFromPickerValue;
+  const { onChange, value, open, setOpen } = propsFromPickerValue;
   const { view: inView, views, openTo, onViewChange, viewRenderers, timezone } = props;
   const { className, sx, ...propsToForwardToView } = props;
 
@@ -220,7 +220,7 @@ export const usePickerViews = <
   useEnhancedEffect(() => {
     // Handle case of `DateTimePicker` without time renderers
     if (currentViewMode === 'field' && open) {
-      onClose();
+      setOpen(false);
       setTimeout(() => {
         fieldRef?.current?.setSelectedSections(view);
         // focusing the input before the range selection is done
@@ -290,9 +290,9 @@ export const usePickerViews = <
       > = {
         ...propsToForwardToView,
         ...additionalViewProps,
-        ...propsFromPickerValue,
         views,
         timezone,
+        value,
         onChange: setValueAndGoToNextView,
         view: popperView,
         onViewChange: setView,

--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -68,13 +68,13 @@ export { useFieldOwnerState } from './hooks/useFieldOwnerState';
 export type { MobileOnlyPickerProps } from './hooks/useMobilePicker';
 export { usePicker } from './hooks/usePicker';
 export type {
-  UsePickerResponse,
   UsePickerParams,
   UsePickerProps,
   UsePickerValueFieldResponse,
   PickerViewsRendererProps,
 } from './hooks/usePicker';
 export type {
+  UsePickerValueContextValue,
   UsePickerValueNonStaticProps,
   PickerValueManager,
   PickerSelectionState,

--- a/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
@@ -376,7 +376,7 @@ createTheme({
     },
     MuiPickersPopper: {
       defaultProps: {
-        open: true,
+        placement: 'bottom',
         // @ts-expect-error invalid MuiPickersPopper prop
         someRandomProp: true,
       },

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -423,6 +423,7 @@
   { "name": "UseMultiInputTimeRangeFieldComponentProps", "kind": "TypeAlias" },
   { "name": "UseMultiInputTimeRangeFieldProps", "kind": "Interface" },
   { "name": "useParsedFormat", "kind": "Variable" },
+  { "name": "usePickerActionsContext", "kind": "Variable" },
   { "name": "usePickerContext", "kind": "Variable" },
   { "name": "usePickerLayout", "kind": "ExportAssignment" },
   { "name": "usePickerTranslations", "kind": "Variable" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -308,6 +308,7 @@
   { "name": "UseDateFieldProps", "kind": "Interface" },
   { "name": "UseDateTimeFieldProps", "kind": "Interface" },
   { "name": "useParsedFormat", "kind": "Variable" },
+  { "name": "usePickerActionsContext", "kind": "Variable" },
   { "name": "usePickerContext", "kind": "Variable" },
   { "name": "usePickerLayout", "kind": "ExportAssignment" },
   { "name": "usePickerTranslations", "kind": "Variable" },


### PR DESCRIPTION
Part of #15495

## What?

- [x] Use `setView` instead of `onOpen` and `onClose` on all the internal components
- [x] Create a new `usePickerActionsContext()` to get the actions from the slots
- [x] Use `usePickerActionsContext()` in all the slots (and remove the props)

## Why?

- Prepare for composition