### PR TITLE
[docs] Fix outdated link to handbook

### DIFF
--- a/docs/data/data-grid/export/export.md
+++ b/docs/data/data-grid/export/export.md
@@ -326,7 +326,7 @@ In the following demo, both methods are used to set a custom header and a custom
 
 :::warning
 This feature only works with `@mui/styled-engine` v5.11.8 or newer.
-Make sure that the MUI Core version you are using is also installing the correct version for this dependency.
+Make sure that the Material UI version you are using is also installing the correct version for this dependency.
 :::
 
 Instead of generating the Excel file in the main thread, you can delegate the task to a web worker.

--- a/docs/data/data-grid/getting-started/getting-started.md
+++ b/docs/data/data-grid/getting-started/getting-started.md
@@ -158,7 +158,7 @@ const theme = createTheme({
 
 ## Licenses
 
-While MUI Core is entirely licensed under MIT, MUI X serves a part of its components under a commercial license.
+While our Core libraries are entirely licensed under MIT, MUI X serves a part of its components under a commercial license.
 Please pay attention to the license.
 
 ### Plans

--- a/docs/data/introduction/overview/overview.md
+++ b/docs/data/introduction/overview/overview.md
@@ -15,7 +15,7 @@ MUI X is a collection of advanced UI components, including:
 - [Charts](/x/react-charts/)
 - [Tree View](/x/react-tree-view/)
 
-These components are significantly more complex than the ones found in the MUI Core libraries.
+These components are significantly more complex than the ones found in our Core libraries.
 They feature advanced functionality for data-rich applications and a wide range of other use cases.
 
 :::info
@@ -28,23 +28,23 @@ Throughout the documentation, Pro- and Premium-only features are denoted with th
 ## Advantages of MUI X
 
 - **Ship faster:** Our team has invested thousands of hours into these components so you don't have to. Get up and running in a fraction of the time it would take to build from scratch.
-- **Expand on the power of MUI Core**: MUI X components work seamlessly with MUI Core libraries like Material UI, delivering more advanced functionality, but can also be used standalone.
+- **Expand on the power of Core**: MUI X components work seamlessly with Core libraries like Material UI, delivering more advanced functionality, but can also be used standalone.
 - **Grow with us:** You can start for free with the MIT-licensed packages, and upgrade to Pro or Premium when you need more advanced features or technical support.
 - **Dedicated maintenance:** MUI X is maintained by a full-time staff of engineers, so you can rest assured that any issues will be addressed in a timely manner.
 - **Technical support:** Pro and Premium users get access to technical support from our team as well as priority for bug fixes and feature requests.
 
-## MUI X vs. MUI Core
+## MUI X vs. Core
 
 MUI X is a collection of advanced UI components for complex use cases.
 Most of MUI X's components are available for free, but more advanced features require a Pro or Premium commercial license.
 
-MUI Core focuses on empowering the creation of great design systems with React.
+Core focuses on empowering the creation of great design systems with React.
 It comes with two themes (Material Design and an in-house one).
 It's about solving design problems.
 It contains foundational UI component libraries like Material UI and Base UI.
 These libraries are open source, MIT-licensed, and free forever.
 
-MUI X components are fully compatible with MUI Core.
+MUI X components are fully compatible with Core.
 MUI X can extend the functionality of UIs built with Material UI or Base UI, but its components can also stand on their own, they can be used with third-parties React component libraries that implement different designs.
 
-You can find [more details](https://mui-org.notion.site/MUI-s-products-a-brief-overview-9c5e8e11eb1247c3a124b446be7451cb) about the difference in our handbook.
+You can find [more details](https://mui-org.notion.site/X-FAQ-c33e9a7eabba4da1ad7f8c04f99044cc#11751b16538c489ba23c5133db1e67b8) about the difference in our handbook.

--- a/packages/x-charts-pro/README.md
+++ b/packages/x-charts-pro/README.md
@@ -1,7 +1,7 @@
 # MUI X Pro
 
 This package is the Pro plan edition of the chart components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-charts/README.md
+++ b/packages/x-charts/README.md
@@ -1,7 +1,7 @@
 # MUI X Charts
 
 This package is the community edition of the chart components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-data-grid-premium/README.md
+++ b/packages/x-data-grid-premium/README.md
@@ -1,7 +1,7 @@
 # MUI X Data Grid Premium
 
 This package is the Premium plan edition of the Data Grid components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-data-grid-pro/README.md
+++ b/packages/x-data-grid-pro/README.md
@@ -1,7 +1,7 @@
 # MUI X Data Grid Pro
 
 This package is the Pro plan edition of the Data Grid component.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-data-grid/README.md
+++ b/packages/x-data-grid/README.md
@@ -1,7 +1,7 @@
 # MUI X Data Grid
 
 This package is the Community plan edition of the Data Grid components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -1,7 +1,7 @@
 # MUI X Date Pickers Pro
 
 This package is the Pro plan edition of the Date and Time Picker Components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -1,7 +1,7 @@
 # MUI X Date Pickers
 
 This package is the Community plan edition of the Date and Time Picker components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-tree-view-pro/README.md
+++ b/packages/x-tree-view-pro/README.md
@@ -1,7 +1,7 @@
 # MUI X Tree View
 
 This package is the Pro plan edition of the Tree View components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/packages/x-tree-view/README.md
+++ b/packages/x-tree-view/README.md
@@ -1,7 +1,7 @@
 # MUI X Tree View
 
 This package is the Community plan edition of the Tree View components.
-It's part of [MUI X](https://mui.com/x/), an open-core extension of MUI Core, with advanced components.
+It's part of [MUI X](https://mui.com/x/), an open-core extension of our Core libraries, with advanced components.
 
 ## Installation
 

--- a/renovate.json
+++ b/renovate.json
@@ -82,7 +82,7 @@
       "enabled": false
     },
     {
-      "groupName": "MUI Core",
+      "groupName": "Material UI",
       "matchPackageNames": [
         "@mui/icons-material",
         "@mui/joy",

--- a/scripts/l10n.ts
+++ b/scripts/l10n.ts
@@ -144,7 +144,7 @@ function extractTranslations(translationsPath: string): [TranslationsByGroup, Tr
           (property.key as babelTypes.Identifier).name ||
           `'${(property.key as babelTypes.StringLiteral).value}'`;
 
-        // Ignore translations for MUI Core components, for example MuiTablePagination
+        // Ignore translations for Core components, for example MuiTablePagination
         if (key.startsWith('Mui')) {
           return;
         }


### PR DESCRIPTION
The problem https://next.mui.com/x/introduction/#mui-x-vs-mui-core
<img width="569" alt="SCR-20241212-bbzs" src="https://github.com/user-attachments/assets/ea6147f2-f1d3-4940-8509-cc4953ced33b" />

https://mui-org.slack.com/archives/C04U3R2V9UK/p1733879862542189

At the same time, this is taking more steps to completely get ride of the notion of "MUI Core".