### PR TITLE
[DataGrid] Trigger row spanning computation on rows update

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rows/useGridRowSpanning.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRowSpanning.ts
@@ -72,7 +72,7 @@ const computeRowSpanningState = (
 
     for (
       let index = rangeToProcess.firstRowIndex;
-      index <= rangeToProcess.lastRowIndex;
+      index < rangeToProcess.lastRowIndex;
       index += 1
     ) {
       const row = visibleRows[index];
@@ -188,7 +188,7 @@ export const rowSpanningStateInitializer: GridStateInitializer = (state, props, 
     }
     const rangeToProcess = {
       firstRowIndex: 0,
-      lastRowIndex: Math.min(DEFAULT_ROWS_TO_PROCESS - 1, Math.max(rowIds.length - 1, 0)),
+      lastRowIndex: Math.min(DEFAULT_ROWS_TO_PROCESS, Math.max(rowIds.length, 0)),
     };
     const rows = rowIds.map((id) => ({
       id,
@@ -233,8 +233,8 @@ export const useGridRowSpanning = (
       ? {
           firstRowIndex: 0,
           lastRowIndex: Math.min(
-            DEFAULT_ROWS_TO_PROCESS - 1,
-            Math.max(apiRef.current.state.rows.dataRowIds.length - 1, 0),
+            DEFAULT_ROWS_TO_PROCESS,
+            Math.max(apiRef.current.state.rows.dataRowIds.length, 0),
           ),
         }
       : EMPTY_RANGE;
@@ -267,7 +267,7 @@ export const useGridRowSpanning = (
       const rangeToProcess = getUnprocessedRange(
         {
           firstRowIndex: renderContext.firstRowIndex,
-          lastRowIndex: Math.min(renderContext.lastRowIndex - 1, range.lastRowIndex),
+          lastRowIndex: Math.min(renderContext.lastRowIndex, range.lastRowIndex + 1),
         },
         processedRange.current,
       );

--- a/packages/x-data-grid/src/hooks/features/rows/useGridRowSpanning.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRowSpanning.ts
@@ -5,6 +5,7 @@ import { gridVisibleColumnDefinitionsSelector } from '../columns/gridColumnsSele
 import { useGridVisibleRows } from '../../utils/useGridVisibleRows';
 import { gridRenderContextSelector } from '../virtualization/gridVirtualizationSelectors';
 import { useGridSelector } from '../../utils/useGridSelector';
+import { gridRowTreeSelector } from './gridRowsSelector';
 import type { GridColDef } from '../../../models/colDef';
 import type { GridRowId, GridValidRowModel, GridRowEntry } from '../../../models/gridRows';
 import type { DataGridProcessedProps } from '../../../models/props/DataGridProps';
@@ -226,6 +227,7 @@ export const useGridRowSpanning = (
   const { range, rows: visibleRows } = useGridVisibleRows(apiRef, props);
   const renderContext = useGridSelector(apiRef, gridRenderContextSelector);
   const colDefs = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
+  const tree = useGridSelector(apiRef, gridRowTreeSelector);
   const processedRange = useLazyRef<RowRange, void>(() => {
     return Object.keys(apiRef.current.state.rowSpanning.spannedCells).length > 0
       ? {
@@ -326,10 +328,16 @@ export const useGridRowSpanning = (
   const prevRenderContext = React.useRef(renderContext);
   const isFirstRender = React.useRef(true);
   const shouldResetState = React.useRef(false);
+  const previousTree = React.useRef(tree);
   React.useEffect(() => {
     const firstRender = isFirstRender.current;
     if (isFirstRender.current) {
       isFirstRender.current = false;
+    }
+    if (tree !== previousTree.current) {
+      previousTree.current = tree;
+      updateRowSpanningState(true);
+      return;
     }
     if (range && lastRange.current && isRowRangeUpdated(range, lastRange.current)) {
       lastRange.current = range;
@@ -344,5 +352,5 @@ export const useGridRowSpanning = (
       return;
     }
     updateRowSpanningState();
-  }, [updateRowSpanningState, renderContext, range, lastRange]);
+  }, [updateRowSpanningState, renderContext, range, lastRange, tree]);
 };

--- a/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
@@ -260,7 +260,10 @@ describe('<DataGrid /> - Row spanning', () => {
       expect(rowSpanValueGetter.callCount).to.equal(2);
 
       act(() => {
-        apiRef.current.setRows([{ id: 1, code: 'A101' }, { id: 2, code: 'A102' }]);
+        apiRef.current.setRows([
+          { id: 1, code: 'A101' },
+          { id: 2, code: 'A102' },
+        ]);
       });
 
       expect(rowSpanValueGetter.callCount).to.equal(4);

--- a/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { DataGrid, useGridApiRef, DataGridProps, GridApi } from '@mui/x-data-grid';
 import { getCell, getActiveCell } from 'test/utils/helperFn';
 
@@ -244,6 +245,25 @@ describe('<DataGrid /> - Row spanning', () => {
       const cell30 = getCell(3, 0);
       fireEvent.keyDown(cell30, { key: 'ArrowRight' });
       expect(getActiveCell()).to.equal('3-1');
+    });
+  });
+
+  describe('rows update', () => {
+    it('should update the row spanning state when the rows are updated', () => {
+      const rowSpanValueGetter = spy();
+      render(
+        <TestDataGrid
+          columns={[{ field: 'code', rowSpanValueGetter }]}
+          rows={[{ id: 1, code: 'A101' }]}
+        />,
+      );
+      expect(rowSpanValueGetter.callCount).to.equal(2);
+
+      act(() => {
+        apiRef.current.setRows([{ id: 1, code: 'A101' }, { id: 2, code: 'A102' }]);
+      });
+
+      expect(rowSpanValueGetter.callCount).to.equal(4);
     });
   });
 

--- a/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
@@ -257,13 +257,10 @@ describe('<DataGrid /> - Row spanning', () => {
           rows={[{ id: 1, code: 'A101' }]}
         />,
       );
-      expect(rowSpanValueGetter.callCount).to.equal(2);
+      expect(rowSpanValueGetter.callCount).to.equal(3);
 
       act(() => {
-        apiRef.current.setRows([
-          { id: 1, code: 'A101' },
-          { id: 2, code: 'A102' },
-        ]);
+        apiRef.current.setRows([{ id: 1, code: 'A101' }]);
       });
 
       expect(rowSpanValueGetter.callCount).to.equal(4);

--- a/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/rowSpanning.DataGrid.test.tsx
@@ -251,19 +251,31 @@ describe('<DataGrid /> - Row spanning', () => {
   describe('rows update', () => {
     it('should update the row spanning state when the rows are updated', () => {
       const rowSpanValueGetter = spy();
+      let rowSpanningStateUpdates = 0;
+      let spannedCells = {};
       render(
         <TestDataGrid
           columns={[{ field: 'code', rowSpanValueGetter }]}
           rows={[{ id: 1, code: 'A101' }]}
+          onStateChange={(newState) => {
+            const newSpannedCells = newState.rowSpanning.spannedCells;
+            if (newSpannedCells !== spannedCells) {
+              rowSpanningStateUpdates += 1;
+              spannedCells = newSpannedCells;
+            }
+          }}
         />,
       );
-      expect(rowSpanValueGetter.callCount).to.equal(3);
+
+      // First update by initializer
+      expect(rowSpanningStateUpdates).to.equal(1);
 
       act(() => {
         apiRef.current.setRows([{ id: 1, code: 'A101' }]);
       });
 
-      expect(rowSpanValueGetter.callCount).to.equal(4);
+      // Second update on row update
+      expect(rowSpanningStateUpdates).to.equal(2);
     });
   });
 


### PR DESCRIPTION
Fixes #15819 
- Before: https://grfpfs.csb.app/
- After: https://wglxzl.csb.app/

Addresses a corner case, whenever rows get updated and the (index based) `range` doesn't change, it results in skipping the necessary re-computation of row spanning state.

- [x] Add test coverage