### PR TITLE
[DataGrid] Consider `columnGroupHeaderHeight`  prop in `getTotalHeaderHeight` method

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -442,7 +442,7 @@ export function getTotalHeaderHeight(
   apiRef: React.MutableRefObject<GridApiCommunity>,
   props: Pick<
     DataGridProcessedProps,
-    'columnHeaderHeight' | 'headerFilterHeight' | 'unstable_listView'
+    'columnHeaderHeight' | 'headerFilterHeight' | 'unstable_listView' | 'columnGroupHeaderHeight'
   >,
 ) {
   if (props.unstable_listView) {
@@ -454,9 +454,12 @@ export function getTotalHeaderHeight(
   const isHeaderFilteringEnabled = gridHeaderFilteringEnabledSelector(apiRef);
 
   const columnHeadersHeight = Math.floor(props.columnHeaderHeight * densityFactor);
+  const columnGroupHeadersHeight = Math.floor(
+    (props.columnGroupHeaderHeight ?? props.columnHeaderHeight) * densityFactor,
+  );
   const filterHeadersHeight = isHeaderFilteringEnabled
     ? Math.floor((props.headerFilterHeight ?? props.columnHeaderHeight) * densityFactor)
     : 0;
 
-  return columnHeadersHeight * (1 + (maxDepth ?? 0)) + filterHeadersHeight;
+  return columnHeadersHeight + columnGroupHeadersHeight * maxDepth + filterHeadersHeight;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/mui-x/issues/15874

https://deploy-preview-15915--material-ui-x.netlify.app/x/react-data-grid/column-groups/#group-header-height