### PR TITLE
[charts] Fix scatter the chart value type if `null`

### DIFF
--- a/docs/data/charts/scatter-demo/MultipleYAxesScatterChart.js
+++ b/docs/data/charts/scatter-demo/MultipleYAxesScatterChart.js
@@ -35,12 +35,12 @@ export default function MultipleYAxesScatterChart() {
         {
           data: data1,
           yAxisId: 'leftAxis',
-          valueFormatter: ({ x, y }) => `${x}cm, ${y}kg`,
+          valueFormatter: (value) => value && `${value.x}cm, ${value.y}kg`,
         },
         {
           data: data2,
           yAxisId: 'rightAxis',
-          valueFormatter: ({ x, y }) => `${x}cm, ${y}kg`,
+          valueFormatter: (value) => value && `${value.x}cm, ${value.y}kg`,
         },
       ]}
       xAxis={[{ min: 0 }]}

--- a/docs/data/charts/scatter-demo/MultipleYAxesScatterChart.tsx
+++ b/docs/data/charts/scatter-demo/MultipleYAxesScatterChart.tsx
@@ -34,14 +34,12 @@ export default function MultipleYAxesScatterChart() {
         {
           data: data1,
           yAxisId: 'leftAxis',
-
-          valueFormatter: ({ x, y }) => `${x}cm, ${y}kg`,
+          valueFormatter: (value) => value && `${value.x}cm, ${value.y}kg`,
         },
         {
           data: data2,
           yAxisId: 'rightAxis',
-
-          valueFormatter: ({ x, y }) => `${x}cm, ${y}kg`,
+          valueFormatter: (value) => value && `${value.x}cm, ${value.y}kg`,
         },
       ]}
       xAxis={[{ min: 0 }]}

--- a/docs/data/charts/scatter/ColorScale.js
+++ b/docs/data/charts/scatter/ColorScale.js
@@ -247,7 +247,7 @@ const series = [
   },
 ].map((s) => ({
   ...s,
-  valueFormatter: (v) => `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
+  valueFormatter: (v) => v && `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
 }));
 
 function getGaussianSeriesData(mean, stdev = [0.5, 0.5], N = 50) {

--- a/docs/data/charts/scatter/ColorScale.tsx
+++ b/docs/data/charts/scatter/ColorScale.tsx
@@ -264,7 +264,8 @@ const series = [
   },
 ].map((s) => ({
   ...s,
-  valueFormatter: (v: ScatterValueType) => `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
+  valueFormatter: (v: ScatterValueType | null) =>
+    v && `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
 }));
 
 function getGaussianSeriesData(

--- a/docs/data/charts/styling/ColorTemplate.js
+++ b/docs/data/charts/styling/ColorTemplate.js
@@ -58,7 +58,7 @@ const series = [
   { label: 'Series 13', data: getGaussianSeriesData([7, 0]) },
 ].map((s) => ({
   ...s,
-  valueFormatter: (v) => `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
+  valueFormatter: (v) => v && `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
 }));
 
 const categories = {

--- a/docs/data/charts/styling/ColorTemplate.tsx
+++ b/docs/data/charts/styling/ColorTemplate.tsx
@@ -62,7 +62,8 @@ const series = [
   { label: 'Series 13', data: getGaussianSeriesData([7, 0]) },
 ].map((s) => ({
   ...s,
-  valueFormatter: (v: ScatterValueType) => `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
+  valueFormatter: (v: ScatterValueType | null) =>
+    v && `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
 }));
 
 const categories: { [key: string]: string[] } = {

--- a/docs/data/charts/styling/MuiColorTemplate.js
+++ b/docs/data/charts/styling/MuiColorTemplate.js
@@ -68,7 +68,7 @@ const series = [
   { label: 'Series 13', data: getGaussianSeriesData([7, 0]) },
 ].map((s) => ({
   ...s,
-  valueFormatter: (v) => `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
+  valueFormatter: (v) => v && `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
 }));
 
 const categories = {

--- a/docs/data/charts/styling/MuiColorTemplate.tsx
+++ b/docs/data/charts/styling/MuiColorTemplate.tsx
@@ -72,7 +72,8 @@ const series = [
   { label: 'Series 13', data: getGaussianSeriesData([7, 0]) },
 ].map((s) => ({
   ...s,
-  valueFormatter: (v: ScatterValueType) => `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
+  valueFormatter: (v: ScatterValueType | null) =>
+    v && `(${v.x.toFixed(1)}, ${v.y.toFixed(1)})`,
 }));
 
 const categories = {

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -62,7 +62,7 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
         <ChartsOverlay {...overlayProps} />
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsAxisHighlight {...axisHighlightProps} />
-        {!props.loading && <Tooltip {...props?.slotProps?.tooltip} />}
+        {!props.loading && <Tooltip {...props?.slotProps?.tooltip} trigger="item" />}
         <ZoomSetup />
         {children}
       </ZAxisContextProvider>

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -35,7 +35,7 @@ const formatter: SeriesFormatter<'scatter'> = ({ series, seriesOrder }, dataset)
         {
           ...seriesData,
           data,
-          valueFormatter: seriesData.valueFormatter ?? ((v) => `(${v.x}, ${v.y})`),
+          valueFormatter: seriesData.valueFormatter ?? ((v) => v && `(${v.x}, ${v.y})`),
         },
       ];
     }),

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -11,7 +11,9 @@ export type ScatterValueType = {
   id: string | number;
 };
 
-export interface ScatterSeriesType extends CommonSeriesType<ScatterValueType>, CartesianSeriesType {
+export interface ScatterSeriesType
+  extends CommonSeriesType<ScatterValueType | null>,
+    CartesianSeriesType {
   type: 'scatter';
   data?: ScatterValueType[];
   markerSize?: number;


### PR DESCRIPTION
We recently introduced the possibility that some scatter chart item can be `null` if the x or y key is missing