### PR TITLE
[pickers] Strengthen default `desktopModelMediaQuery` prop value to avoid false positives

### DIFF
--- a/docs/pages/x/api/date-pickers/date-picker.json
+++ b/docs/pages/x/api/date-pickers/date-picker.json
@@ -17,7 +17,7 @@
     "defaultValue": { "type": { "name": "object" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },
-      "default": "'@media (pointer: fine)'"
+      "default": "'@media (hover: hover) and (pointer: fine)'"
     },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "disableFuture": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -29,7 +29,7 @@
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },
-      "default": "'@media (pointer: fine)'"
+      "default": "'@media (hover: hover) and (pointer: fine)'"
     },
     "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
     "disabled": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/date-time-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-picker.json
@@ -19,7 +19,7 @@
     "defaultValue": { "type": { "name": "object" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },
-      "default": "'@media (pointer: fine)'"
+      "default": "'@media (hover: hover) and (pointer: fine)'"
     },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "disableFuture": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-range-picker.json
@@ -30,7 +30,7 @@
     "defaultValue": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },
-      "default": "'@media (pointer: fine)'"
+      "default": "'@media (hover: hover) and (pointer: fine)'"
     },
     "disableAutoMonthSwitching": { "type": { "name": "bool" }, "default": "false" },
     "disabled": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/time-picker.json
+++ b/docs/pages/x/api/date-pickers/time-picker.json
@@ -10,7 +10,7 @@
     "defaultValue": { "type": { "name": "object" } },
     "desktopModeMediaQuery": {
       "type": { "name": "string" },
-      "default": "'@media (pointer: fine)'"
+      "default": "'@media (hover: hover) and (pointer: fine)'"
     },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "disableFuture": { "type": { "name": "bool" }, "default": "false" },

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useThemeProps } from '@mui/material/styles';
 import { refType } from '@mui/utils';
+import { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from '@mui/x-date-pickers/internals';
 import { DesktopDateRangePicker } from '../DesktopDateRangePicker';
 import { MobileDateRangePicker } from '../MobileDateRangePicker';
 import { DateRangePickerProps } from './DateRangePicker.types';
-import { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from '@mui/x-date-pickers/internals';
 
 type DatePickerComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   props: DateRangePickerProps<TEnableAccessibleFieldDOMStructure> &

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -7,6 +7,7 @@ import { refType } from '@mui/utils';
 import { DesktopDateRangePicker } from '../DesktopDateRangePicker';
 import { MobileDateRangePicker } from '../MobileDateRangePicker';
 import { DateRangePickerProps } from './DateRangePicker.types';
+import { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from '@mui/x-date-pickers/internals';
 
 type DatePickerComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   props: DateRangePickerProps<TEnableAccessibleFieldDOMStructure> &
@@ -31,7 +32,7 @@ const DateRangePicker = React.forwardRef(function DateRangePicker<
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiDateRangePicker' });
 
-  const { desktopModeMediaQuery = '@media (pointer: fine)', ...other } = props;
+  const { desktopModeMediaQuery = DEFAULT_DESKTOP_MODE_MEDIA_QUERY, ...other } = props;
 
   // defaults to `true` in environments where `window.matchMedia` would not be available (i.e. test/jsdom)
   const isDesktop = useMediaQuery(desktopModeMediaQuery, { defaultMatches: true });

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -92,7 +92,7 @@ DateRangePicker.propTypes = {
   defaultValue: PropTypes.arrayOf(PropTypes.object),
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery: PropTypes.string,

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.types.ts
@@ -25,7 +25,7 @@ export interface DateRangePickerProps<TEnableAccessibleFieldDOMStructure extends
     MobileDateRangePickerProps<TEnableAccessibleFieldDOMStructure> {
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery?: string;

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -97,7 +97,7 @@ DateTimeRangePicker.propTypes = {
   defaultValue: PropTypes.arrayOf(PropTypes.object),
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery: PropTypes.string,

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import { refType } from '@mui/utils';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useThemeProps } from '@mui/material/styles';
+import { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from '@mui/x-date-pickers/internals';
 import { DateTimeRangePickerProps } from './DateTimeRangePicker.types';
 import { DesktopDateTimeRangePicker } from '../DesktopDateTimeRangePicker';
 import { MobileDateTimeRangePicker } from '../MobileDateTimeRangePicker';
-import { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from '@mui/x-date-pickers/internals';
 
 type DateTimeRangePickerComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   props: DateTimeRangePickerProps<TEnableAccessibleFieldDOMStructure> &

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -7,6 +7,7 @@ import { useThemeProps } from '@mui/material/styles';
 import { DateTimeRangePickerProps } from './DateTimeRangePicker.types';
 import { DesktopDateTimeRangePicker } from '../DesktopDateTimeRangePicker';
 import { MobileDateTimeRangePicker } from '../MobileDateTimeRangePicker';
+import { DEFAULT_DESKTOP_MODE_MEDIA_QUERY } from '@mui/x-date-pickers/internals';
 
 type DateTimeRangePickerComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   props: DateTimeRangePickerProps<TEnableAccessibleFieldDOMStructure> &
@@ -31,7 +32,7 @@ const DateTimeRangePicker = React.forwardRef(function DateTimeRangePicker<
 ) {
   const props = useThemeProps({ props: inProps, name: 'MuiDateTimeRangePicker' });
 
-  const { desktopModeMediaQuery = '@media (pointer: fine)', ...other } = props;
+  const { desktopModeMediaQuery = DEFAULT_DESKTOP_MODE_MEDIA_QUERY, ...other } = props;
 
   // defaults to `true` in environments where `window.matchMedia` would not be available (i.e. test/jsdom)
   const isDesktop = useMediaQuery(desktopModeMediaQuery, { defaultMatches: true });

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.types.ts
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.types.ts
@@ -25,7 +25,7 @@ export interface DateTimeRangePickerProps<TEnableAccessibleFieldDOMStructure ext
     MobileDateTimeRangePickerProps<TEnableAccessibleFieldDOMStructure> {
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery?: string;

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.tsx
@@ -72,7 +72,7 @@ DatePicker.propTypes = {
   defaultValue: PropTypes.object,
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery: PropTypes.string,

--- a/packages/x-date-pickers/src/DatePicker/DatePicker.types.ts
+++ b/packages/x-date-pickers/src/DatePicker/DatePicker.types.ts
@@ -23,7 +23,7 @@ export interface DatePickerProps<TEnableAccessibleFieldDOMStructure extends bool
     MobileDatePickerProps<TEnableAccessibleFieldDOMStructure> {
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery?: string;

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.tsx
@@ -86,7 +86,7 @@ DateTimePicker.propTypes = {
   defaultValue: PropTypes.object,
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery: PropTypes.string,

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.types.ts
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePicker.types.ts
@@ -34,7 +34,7 @@ export interface DateTimePickerProps<TEnableAccessibleFieldDOMStructure extends 
     > {
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery?: string;

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.tsx
@@ -75,7 +75,7 @@ TimePicker.propTypes = {
   defaultValue: PropTypes.object,
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery: PropTypes.string,

--- a/packages/x-date-pickers/src/TimePicker/TimePicker.types.ts
+++ b/packages/x-date-pickers/src/TimePicker/TimePicker.types.ts
@@ -25,7 +25,7 @@ export interface TimePickerProps<TEnableAccessibleFieldDOMStructure extends bool
     Omit<MobileTimePickerProps<TimeViewWithMeridiem, TEnableAccessibleFieldDOMStructure>, 'views'> {
   /**
    * CSS media query when `Mobile` mode will be changed to `Desktop`.
-   * @default '@media (pointer: fine)'
+   * @default '@media (hover: hover) and (pointer: fine)'
    * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
    */
   desktopModeMediaQuery?: string;

--- a/packages/x-date-pickers/src/internals/utils/utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/utils.ts
@@ -58,4 +58,4 @@ export const getFocusedListItemIndex = (listElement: HTMLUListElement): number =
   return children.indexOf(getActiveElement(document)!);
 };
 
-export const DEFAULT_DESKTOP_MODE_MEDIA_QUERY = '@media (pointer: fine)';
+export const DEFAULT_DESKTOP_MODE_MEDIA_QUERY = '@media (hover: hover) and @media (pointer: fine)';

--- a/packages/x-date-pickers/src/internals/utils/utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/utils.ts
@@ -58,4 +58,4 @@ export const getFocusedListItemIndex = (listElement: HTMLUListElement): number =
   return children.indexOf(getActiveElement(document)!);
 };
 
-export const DEFAULT_DESKTOP_MODE_MEDIA_QUERY = '@media (hover: hover) and @media (pointer: fine)';
+export const DEFAULT_DESKTOP_MODE_MEDIA_QUERY = '@media (hover: hover) and (pointer: fine)';

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -28,12 +28,12 @@ module.exports = function setKarmaConfig(config) {
         served: true,
         included: true,
       },
-      {
-        pattern: 'test/karma.datagrid.tests.js',
-        watched: true,
-        served: true,
-        included: true,
-      },
+      // {
+      //   pattern: 'test/karma.datagrid.tests.js',
+      //   watched: true,
+      //   served: true,
+      //   included: true,
+      // },
     ],
     plugins: (process.env.PARALLEL === 'true' ? ['karma-parallel'] : []).concat([
       'karma-mocha',
@@ -104,7 +104,7 @@ module.exports = function setKarmaConfig(config) {
           // to mimic "desktop" environment more correctly we force blink to have `pointer: fine` support
           // this allows correct pickers behavior, where their rendering depends on this condition
           // https://github.com/microsoft/playwright/issues/7769#issuecomment-1205106311
-          '--blink-settings=primaryPointerType=4,primaryHoverType=2',
+          // '--blink-settings=primaryPointerType=4,primaryHoverType=2',
           // increasing default `800x600` size to certain window sizing cases to consider browser as "mobile"
           // i.e.: date time pickers do check height > 667
           '--window-size=1000,800',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -28,12 +28,12 @@ module.exports = function setKarmaConfig(config) {
         served: true,
         included: true,
       },
-      // {
-      //   pattern: 'test/karma.datagrid.tests.js',
-      //   watched: true,
-      //   served: true,
-      //   included: true,
-      // },
+      {
+        pattern: 'test/karma.datagrid.tests.js',
+        watched: true,
+        served: true,
+        included: true,
+      },
     ],
     plugins: (process.env.PARALLEL === 'true' ? ['karma-parallel'] : []).concat([
       'karma-mocha',
@@ -104,7 +104,7 @@ module.exports = function setKarmaConfig(config) {
           // to mimic "desktop" environment more correctly we force blink to have `pointer: fine` support
           // this allows correct pickers behavior, where their rendering depends on this condition
           // https://github.com/microsoft/playwright/issues/7769#issuecomment-1205106311
-          // '--blink-settings=primaryPointerType=4,primaryHoverType=2',
+          '--blink-settings=primaryPointerType=4,primaryHoverType=2',
           // increasing default `800x600` size to certain window sizing cases to consider browser as "mobile"
           // i.e.: date time pickers do check height > 667
           '--window-size=1000,800',


### PR DESCRIPTION
Strengthen the `desktopModelMediaQuery` default value to avoid false positives when mobile devices might report as capable of a `precise` pointer, but not `hover`.

Part of https://github.com/mui/mui-x/issues/10039.

Revival of https://github.com/mui/mui-x/pull/10064.


This is the only relevant change: https://github.com/mui/mui-x/pull/15926/files#diff-ad2eb94cb4c75196d92810b38d94a7d91ea62f51d32e49a8b3321734b2627153R61