### PR TITLE
[RangePicker] Make text separator correctly aligned vertically

### DIFF
--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
@@ -44,7 +44,7 @@ const useUtilityClasses = (classes: Partial<MultiInputRangeFieldClasses> | undef
 
 const MultiInputDateRangeFieldRoot = styled(
   React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement>) => (
-    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+    <Stack ref={ref} spacing={2} direction="row" alignItems="start" {...props} />
   )),
   {
     name: 'MuiMultiInputDateRangeField',
@@ -59,6 +59,7 @@ const MultiInputDateRangeFieldSeparator = styled(Typography, {
   overridesResolver: (props, styles) => styles.separator,
 })({
   lineHeight: '1.4375em', // 23px
+  padding: '16.5px 0',
 });
 
 type MultiInputDateRangeFieldComponent = (<

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
@@ -42,7 +42,7 @@ const useUtilityClasses = (classes: Partial<MultiInputRangeFieldClasses> | undef
 
 const MultiInputDateTimeRangeFieldRoot = styled(
   React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement>) => (
-    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+    <Stack ref={ref} spacing={2} direction="row" alignItems="start" {...props} />
   )),
   {
     name: 'MuiMultiInputDateTimeRangeField',
@@ -57,6 +57,7 @@ const MultiInputDateTimeRangeFieldSeparator = styled(Typography, {
   overridesResolver: (props, styles) => styles.separator,
 })({
   lineHeight: '1.4375em', // 23px
+  padding: '16.5px 0',
 });
 
 type MultiInputDateTimeRangeFieldComponent = (<

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx
@@ -44,7 +44,7 @@ const useUtilityClasses = (classes: Partial<MultiInputRangeFieldClasses> | undef
 
 const MultiInputTimeRangeFieldRoot = styled(
   React.forwardRef((props: StackProps, ref: React.Ref<HTMLDivElement>) => (
-    <Stack ref={ref} spacing={2} direction="row" alignItems="center" {...props} />
+    <Stack ref={ref} spacing={2} direction="row" alignItems="start" {...props} />
   )),
   {
     name: 'MuiMultiInputTimeRangeField',
@@ -59,6 +59,7 @@ const MultiInputTimeRangeFieldSeparator = styled(Typography, {
   overridesResolver: (props, styles) => styles.separator,
 })({
   lineHeight: '1.4375em', // 23px
+  padding: '16.5px 0',
 });
 
 type MultiInputTimeRangeFieldComponent = (<


### PR DESCRIPTION
- Update style of MultiInput...RangeField Root and Seperator

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #15847 

## Root cause

The root cause of this issue is the misalignment of the three elements. They are currently centered based on the height of the TextField element, which includes the helper text. This is causing the elements to appear misaligned when the helper text is present or has varying lengths.

![11](https://github.com/user-attachments/assets/9859d94a-d85c-469c-9cbc-32ee939bbf39)


## What is changed

- 3 `MultiInput...RangeField` Files
  - `MultiInputDateRangeField`
  - `MultiInputDateTimeRangeField`
  - `MultiInputTimeRangeField` : This feature isn't implemented yet. But it needed to be modified as the same issue occurs
- Set three elements aligned to top
- Set seperator padding value as same as picker TextField Component.

*To minimize additional bugs and PR, I chose the simplest method.*

### Before

[codesandbox](https://codesandbox.io/p/sandbox/muddy-morning-5wjrc3)

![33](https://github.com/user-attachments/assets/32abbd91-717c-428f-9050-fae217f56fef)


### After

[codesandbox](https://codesandbox.io/p/sandbox/beautiful-diffie-7cd8cs)

![22](https://github.com/user-attachments/assets/8db7be61-4f5b-4f38-8fe4-e9bedffa21c9)
