### PR TITLE
[data grid] Reduce the use of `useGridSelector` in root-level hooks

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
@@ -25,7 +25,6 @@ import {
   gridFocusCellSelector,
   GridCellParams,
   GRID_REORDER_COL_DEF,
-  useGridSelector,
   gridSortedRowIdsSelector,
   gridDimensionsSelector,
 } from '@mui/x-data-grid-pro';
@@ -68,8 +67,6 @@ export const useGridCellSelection = (
   const lastMouseDownCell = React.useRef<GridCellCoordinates | null>();
   const mousePosition = React.useRef<{ x: number; y: number } | null>(null);
   const autoScrollRAF = React.useRef<number | null>();
-  const sortedRowIds = useGridSelector(apiRef, gridSortedRowIdsSelector);
-  const dimensions = useGridSelector(apiRef, gridDimensionsSelector);
   const totalHeaderHeight = getTotalHeaderHeight(apiRef, props);
 
   const ignoreValueFormatterProp = props.ignoreValueFormatterDuringExport;
@@ -291,6 +288,7 @@ export const useGridCellSelection = (
         return;
       }
 
+      const dimensions = gridDimensionsSelector(apiRef.current.state);
       const { x: mouseX, y: mouseY } = mousePosition.current;
       const { width, height: viewportOuterHeight } = dimensions.viewportOuterSize;
       const height = viewportOuterHeight - totalHeaderHeight;
@@ -330,7 +328,7 @@ export const useGridCellSelection = (
     }
 
     autoScroll();
-  }, [apiRef, dimensions, totalHeaderHeight]);
+  }, [apiRef, totalHeaderHeight]);
 
   const handleCellMouseOver = React.useCallback<GridEventListener<'cellMouseOver'>>(
     (params, event) => {
@@ -353,6 +351,7 @@ export const useGridCellSelection = (
         return;
       }
 
+      const dimensions = gridDimensionsSelector(apiRef.current.state);
       const { x, y } = virtualScrollerRect;
       const { width, height: viewportOuterHeight } = dimensions.viewportOuterSize;
       const height = viewportOuterHeight - totalHeaderHeight;
@@ -377,7 +376,7 @@ export const useGridCellSelection = (
         stopAutoScroll();
       }
     },
-    [apiRef, startAutoScroll, stopAutoScroll, totalHeaderHeight, dimensions],
+    [apiRef, startAutoScroll, stopAutoScroll, totalHeaderHeight],
   );
 
   const handleCellClick = useEventCallback<
@@ -565,6 +564,7 @@ export const useGridCellSelection = (
       if (apiRef.current.getSelectedCellsAsArray().length <= 1) {
         return value;
       }
+      const sortedRowIds = gridSortedRowIdsSelector(apiRef);
       const cellSelectionModel = apiRef.current.getCellSelectionModel();
       const unsortedSelectedRowIds = Object.keys(cellSelectionModel);
       const sortedSelectedRowIds = sortedRowIds.filter((id) =>
@@ -593,7 +593,7 @@ export const useGridCellSelection = (
       }, '');
       return copyData;
     },
-    [apiRef, ignoreValueFormatter, clipboardCopyCellDelimiter, sortedRowIds],
+    [apiRef, ignoreValueFormatter, clipboardCopyCellDelimiter],
   );
 
   useGridRegisterPipeProcessor(apiRef, 'isCellSelected', checkIfCellIsSelected);

--- a/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  useGridSelector,
   gridVisibleColumnDefinitionsSelector,
   gridColumnsTotalWidthSelector,
   gridColumnPositionsSelector,
@@ -58,8 +57,6 @@ export const useGridColumnPinning = (
     | 'slots'
   >,
 ): void => {
-  const pinnedColumns = useGridSelector(apiRef, gridPinnedColumnsSelector);
-
   /**
    * PRE-PROCESSING
    */
@@ -201,6 +198,7 @@ export const useGridColumnPinning = (
         return;
       }
 
+      const pinnedColumns = gridPinnedColumnsSelector(apiRef.current.state);
       const otherSide =
         side === GridPinnedColumnPosition.RIGHT
           ? GridPinnedColumnPosition.LEFT
@@ -213,17 +211,18 @@ export const useGridColumnPinning = (
 
       apiRef.current.setPinnedColumns(newPinnedColumns);
     },
-    [apiRef, pinnedColumns],
+    [apiRef],
   );
 
   const unpinColumn = React.useCallback<GridColumnPinningApi['unpinColumn']>(
     (field: string) => {
+      const pinnedColumns = gridPinnedColumnsSelector(apiRef.current.state);
       apiRef.current.setPinnedColumns({
         left: (pinnedColumns.left || []).filter((column) => column !== field),
         right: (pinnedColumns.right || []).filter((column) => column !== field),
       });
     },
-    [apiRef, pinnedColumns.left, pinnedColumns.right],
+    [apiRef],
   );
 
   const getPinnedColumns = React.useCallback<GridColumnPinningApi['getPinnedColumns']>(() => {
@@ -240,6 +239,7 @@ export const useGridColumnPinning = (
 
   const isColumnPinned = React.useCallback<GridColumnPinningApi['isColumnPinned']>(
     (field) => {
+      const pinnedColumns = gridPinnedColumnsSelector(apiRef.current.state);
       const leftPinnedColumns = pinnedColumns.left || [];
       if (leftPinnedColumns.includes(field)) {
         return GridPinnedColumnPosition.LEFT;
@@ -250,7 +250,7 @@ export const useGridColumnPinning = (
       }
       return false;
     },
-    [pinnedColumns.left, pinnedColumns.right],
+    [apiRef],
   );
 
   const columnPinningApi: GridColumnPinningApi = {

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts
@@ -87,7 +87,6 @@ export const useGridDataSource = (
   const nestedDataManager = useLazyRef<NestedDataManager, void>(
     () => new NestedDataManager(apiRef),
   ).current;
-  const paginationModel = useGridSelector(apiRef, gridPaginationModelSelector);
   const groupsToAutoFetch = useGridSelector(apiRef, gridRowGroupsToFetchSelector);
   const scheduledGroups = React.useRef<number>(0);
   const lastRequestId = React.useRef<number>(0);
@@ -98,6 +97,7 @@ export const useGridDataSource = (
     const sortedPageSizeOptions = props.pageSizeOptions
       .map((option) => (typeof option === 'number' ? option : option.value))
       .sort((a, b) => a - b);
+    const paginationModel = gridPaginationModelSelector(apiRef);
     const cacheChunkSize = Math.min(paginationModel.pageSize, sortedPageSizeOptions[0]);
 
     return new CacheChunkManager(cacheChunkSize);

--- a/packages/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   GridEventListener,
   GridRowId,
-  useGridSelector,
   useGridApiEventHandler,
   useGridApiMethod,
   GridCellParams,
@@ -91,15 +90,13 @@ export const useGridDetailPanel = (
     | 'onDetailPanelExpandedRowIdsChange'
   >,
 ): void => {
-  const expandedRowIds = useGridSelector(apiRef, gridDetailPanelExpandedRowIdsSelector);
-  const contentCache = useGridSelector(apiRef, gridDetailPanelExpandedRowsContentCacheSelector);
-
   const handleCellClick = React.useCallback<GridEventListener<'cellClick'>>(
     (params: GridCellParams, event: React.MouseEvent) => {
       if (params.field !== GRID_DETAIL_PANEL_TOGGLE_FIELD || props.getDetailPanelContent == null) {
         return;
       }
 
+      const contentCache = gridDetailPanelExpandedRowsContentCacheSelector(apiRef.current.state);
       const content = contentCache[params.id];
       if (!React.isValidElement(content)) {
         return;
@@ -112,7 +109,7 @@ export const useGridDetailPanel = (
 
       apiRef.current.toggleDetailPanel(params.id);
     },
-    [apiRef, contentCache, props.getDetailPanelContent],
+    [apiRef, props.getDetailPanelContent],
   );
 
   const handleCellKeyDown = React.useCallback<GridEventListener<'cellKeyDown'>>(
@@ -145,6 +142,7 @@ export const useGridDetailPanel = (
         return;
       }
 
+      const contentCache = gridDetailPanelExpandedRowsContentCacheSelector(apiRef.current.state);
       const content = contentCache[id];
       if (!React.isValidElement(content)) {
         return;
@@ -159,7 +157,7 @@ export const useGridDetailPanel = (
       }
       apiRef.current.setExpandedDetailPanels(newIds);
     },
-    [apiRef, contentCache, props.getDetailPanelContent],
+    [apiRef, props.getDetailPanelContent],
   );
 
   const getExpandedDetailPanels = React.useCallback<GridDetailPanelApi['getExpandedDetailPanels']>(
@@ -288,6 +286,7 @@ export const useGridDetailPanel = (
 
   const addDetailHeight = React.useCallback<GridPipeProcessor<'rowHeight'>>(
     (initialValue, row) => {
+      const expandedRowIds = gridDetailPanelExpandedRowIdsSelector(apiRef.current.state);
       if (!expandedRowIds || expandedRowIds.size === 0 || !expandedRowIds.has(row.id)) {
         initialValue.detail = 0;
         return initialValue;
@@ -300,7 +299,7 @@ export const useGridDetailPanel = (
       initialValue.detail = heightCache[row.id].height ?? 0; // Fallback to zero because the cache might not be ready yet (for example page was changed)
       return initialValue;
     },
-    [apiRef, expandedRowIds, updateCachesIfNeeded],
+    [apiRef, updateCachesIfNeeded],
   );
 
   useGridRegisterPipeProcessor(apiRef, 'rowHeight', addDetailHeight);

--- a/packages/x-data-grid-pro/src/hooks/features/lazyLoader/useGridLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/lazyLoader/useGridLazyLoader.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   useGridApiEventHandler,
-  useGridSelector,
   gridSortModelSelector,
   gridFilterModelSelector,
   gridRenderContextSelector,
@@ -27,8 +26,6 @@ export const useGridLazyLoader = (
     'onFetchRows' | 'rowsLoadingMode' | 'pagination' | 'paginationMode' | 'experimentalFeatures'
   >,
 ): void => {
-  const sortModel = useGridSelector(privateApiRef, gridSortModelSelector);
-  const filterModel = useGridSelector(privateApiRef, gridFilterModelSelector);
   const renderedRowsIntervalCache = React.useRef({
     firstRowToRender: 0,
     lastRowToRender: 0,
@@ -42,6 +39,9 @@ export const useGridLazyLoader = (
       if (isDisabled) {
         return;
       }
+
+      const sortModel = gridSortModelSelector(privateApiRef);
+      const filterModel = gridFilterModelSelector(privateApiRef);
 
       const fetchRowsParams: GridFetchRowsParams = {
         firstRowToRender: params.firstRowIndex,
@@ -86,7 +86,7 @@ export const useGridLazyLoader = (
 
       privateApiRef.current.publishEvent('fetchRows', fetchRowsParams);
     },
-    [privateApiRef, isDisabled, props.pagination, props.paginationMode, sortModel, filterModel],
+    [privateApiRef, isDisabled, props.pagination, props.paginationMode],
   );
 
   const handleGridSortModelChange = React.useCallback<GridEventListener<'sortModelChange'>>(
@@ -98,6 +98,7 @@ export const useGridLazyLoader = (
       privateApiRef.current.requestPipeProcessorsApplication('hydrateRows');
 
       const renderContext = gridRenderContextSelector(privateApiRef);
+      const filterModel = gridFilterModelSelector(privateApiRef);
       const fetchRowsParams: GridFetchRowsParams = {
         firstRowToRender: renderContext.firstRowIndex,
         lastRowToRender: renderContext.lastRowIndex,
@@ -107,7 +108,7 @@ export const useGridLazyLoader = (
 
       privateApiRef.current.publishEvent('fetchRows', fetchRowsParams);
     },
-    [privateApiRef, isDisabled, filterModel],
+    [privateApiRef, isDisabled],
   );
 
   const handleGridFilterModelChange = React.useCallback<GridEventListener<'filterModelChange'>>(
@@ -119,6 +120,7 @@ export const useGridLazyLoader = (
       privateApiRef.current.requestPipeProcessorsApplication('hydrateRows');
 
       const renderContext = gridRenderContextSelector(privateApiRef);
+      const sortModel = gridSortModelSelector(privateApiRef);
       const fetchRowsParams: GridFetchRowsParams = {
         firstRowToRender: renderContext.firstRowIndex,
         lastRowToRender: renderContext.lastRowIndex,
@@ -128,7 +130,7 @@ export const useGridLazyLoader = (
 
       privateApiRef.current.publishEvent('fetchRows', fetchRowsParams);
     },
-    [privateApiRef, isDisabled, sortModel],
+    [privateApiRef, isDisabled],
   );
 
   useGridApiEventHandler(

--- a/packages/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
@@ -76,7 +76,7 @@ export const useGridRowReorder = (
     const sortModel = gridSortModelSelector(apiRef);
     const treeDepth = gridRowMaximumTreeDepthSelector(apiRef);
     return !props.rowReordering || !!sortModel.length || treeDepth !== 1;
-  }, [props.rowReordering]);
+  }, [apiRef, props.rowReordering]);
 
   const handleDragStart = React.useCallback<GridEventListener<'rowDragStart'>>(
     (params, event) => {

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -19,7 +19,7 @@ import {
   GridStrategyGroup,
   GridStrategyProcessor,
   useGridRegisterStrategyProcessor,
-  runIf
+  runIf,
 } from '@mui/x-data-grid/internals';
 import { GridPrivateApiPro } from '../../../models/gridApiPro';
 import { DataGridProProcessedProps } from '../../../models/dataGridProProps';

--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -132,9 +132,8 @@ async function isColumnVirtualizationDisabledNow(
 ) {
   if (gridVirtualizationColumnEnabledSelector(apiRef) === false) {
     return true;
-  } else {
-    throw new Error('Column virtualization was not disabled');
   }
+  throw new Error('Column virtualization was not disabled');
 }
 
 /**

--- a/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -7,7 +7,6 @@ import {
   gridColumnPositionsSelector,
   gridVisibleColumnDefinitionsSelector,
 } from '../columns/gridColumnsSelector';
-import { useGridSelector } from '../../utils/useGridSelector';
 import { DataGridProcessedProps } from '../../../models/props/DataGridProps';
 import { gridPageSelector, gridPageSizeSelector } from '../pagination/gridPaginationSelector';
 import { gridRowCountSelector } from '../rows/gridRowsSelector';
@@ -60,7 +59,6 @@ export const useGridScroll = (
   const logger = useGridLogger(apiRef, 'useGridScroll');
   const colRef = apiRef.current.columnHeadersContainerRef;
   const virtualScrollerRef = apiRef.current.virtualScrollerRef!;
-  const visibleSortedRows = useGridSelector(apiRef, gridExpandedSortedRowEntriesSelector);
 
   const scrollToIndexes = React.useCallback<GridScrollApi['scrollToIndexes']>(
     (params: Partial<GridCellIndexCoordinates>) => {
@@ -84,6 +82,7 @@ export const useGridScroll = (
         let cellWidth: number | undefined;
 
         if (typeof params.rowIndex !== 'undefined') {
+          const visibleSortedRows = gridExpandedSortedRowEntriesSelector(apiRef);
           const rowId = visibleSortedRows[params.rowIndex]?.id;
           const cellColSpanInfo = apiRef.current.unstable_getCellColSpanInfo(
             rowId,
@@ -142,14 +141,7 @@ export const useGridScroll = (
 
       return false;
     },
-    [
-      logger,
-      apiRef,
-      virtualScrollerRef,
-      props.pagination,
-      visibleSortedRows,
-      props.unstable_listView,
-    ],
+    [logger, apiRef, virtualScrollerRef, props.pagination, props.unstable_listView],
   );
 
   const scroll = React.useCallback<GridScrollApi['scroll']>(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As discussed in https://github.com/mui/mui-x/pull/15986#issuecomment-2562320887

The use of `useGridSelector` should be avoided whenever possible in root level (feature) hooks, as it sends the whole grid root and all sibling hooks to re-evaluate on every time selecto state changes. There's many instances, where `useGridSelector` values are passed to `useCallback`, which re-creates callback functions and event listeners on state changes. If the callbacks are indeed callbacks, the state they access is identical to just evaluating the selector within the callback itself.

This instance is a bit more difficult to refactor for the time being, but will be very easy once #15666 gets merged as it'll be refactored as a pure selector then:
```typescript
const initialCurrentPageRows = useGridVisibleRows(apiRef, props).rows;
```

The only instances where `useGridSelector` is valid truly valid and necessary are `useGridDimensions` and `useGridRowsMeta` as they need to perform calculations in response to many different parts of the state. If those were to be optimised further, they could be moved to a separate component, so they wouldn't affect all the other hooks any time the state they depend on changes.

Two other instances that were difficult to refactor currently:
https://github.com/mui/mui-x/blob/b061f5596a4b80b2c262b38a4d6de6d622927c5b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts#L91
https://github.com/mui/mui-x/blob/b061f5596a4b80b2c262b38a4d6de6d622927c5b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx#L135

But they are pretty minor.

However, if we could get rid of them completely, I think it would make for a good convention not to allow selector hooks in root-level feature hooks. Makes it easier to write more isolated features, and safer to introduce experimental features. Alternative is:
https://github.com/mui/mui-x/pull/15986#issuecomment-2559633158