### PR TITLE
v7.23.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _Dec 27, 2024_
 
 Here are some highlights ✨:
 
-- 🐞 Fix version mismatch issue in codesandbox/stackblitz demos
+- 🐞 Fix version mismatch issue in Data Grid codesandbox/stackblitz demos
 
 <!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 _Dec 27, 2024_
 
-We'd like to offer a big thanks to the 0 contributors who made this release possible. Here are some highlights ✨:
+Here are some highlights ✨:
 
 - 🐞 Fix version mismatch issue in codesandbox/stackblitz demos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 7.23.5
+
+_Dec 27, 2024_
+
+We'd like to offer a big thanks to the 0 contributors who made this release possible. Here are some highlights ✨:
+
+- 🐞 Fix version mismatch issue in codesandbox/stackblitz demos
+
+<!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->
+
+### Data Grid
+
+#### `@mui/x-data-grid@7.23.5`
+
+No changes since `@mui/x-data-grid@v7.23.4`.
+
+#### `@mui/x-data-grid-pro@7.23.5` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@7.23.5`.
+
+#### `@mui/x-data-grid-premium@7.23.5` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@7.23.5`.
+
 ## v7.23.4
 
 _Dec 27, 2024_

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.23.4",
+  "version": "7.23.5",
   "private": true,
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-generator",
-  "version": "7.23.4",
+  "version": "7.23.5",
   "description": "Generate fake data for demo purposes only.",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-premium",
-  "version": "7.23.4",
+  "version": "7.23.5",
   "description": "The Premium plan edition of the Data Grid Components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid-pro",
-  "version": "7.23.4",
+  "version": "7.23.5",
   "description": "The Pro plan edition of the Data Grid components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-data-grid",
-  "version": "7.23.4",
+  "version": "7.23.5",
   "description": "The Community plan edition of the Data Grid components (MUI X).",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-internals",
-  "version": "7.23.1",
+  "version": "7.23.5",
   "description": "Utility functions for the MUI X packages (internal use only).",
   "author": "MUI Team",
   "license": "MIT",

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-internals",
-  "version": "7.23.0",
+  "version": "7.23.5",
   "description": "Utility functions for the MUI X packages (internal use only).",
   "author": "MUI Team",
   "license": "MIT",

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-internals",
-  "version": "7.23.5",
+  "version": "7.23.1",
   "description": "Utility functions for the MUI X packages (internal use only).",
   "author": "MUI Team",
   "license": "MIT",

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license",
-  "version": "7.23.5",
+  "version": "7.23.3",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license",
-  "version": "7.23.2",
+  "version": "7.23.5",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/x-license",
-  "version": "7.23.3",
+  "version": "7.23.5",
   "description": "MUI X License verification",
   "author": "MUI Team",
   "main": "src/index.ts",


### PR DESCRIPTION
Fix #16007 

Skipping publishing of `@mui/x-internals` caused [these](https://github.com/mui/mui-x/pull/15984) changes mess up the codesandbox/stackblitz demos.