### PR TITLE
[DataGridPremium] Namespace Excel export worker

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/export/serializer/setupExcelExportWebWorker.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/export/serializer/setupExcelExportWebWorker.ts
@@ -14,6 +14,7 @@ export function setupExcelExportWebWorker(
   // eslint-disable-next-line no-restricted-globals
   addEventListener('message', async (event: MessageEvent<ExcelExportInitEvent>) => {
     const {
+      namespace,
       serializedColumns,
       serializedRows,
       options,
@@ -22,6 +23,11 @@ export function setupExcelExportWebWorker(
       columnGroupDetails,
       columnGroupPaths,
     } = event.data;
+
+    // workers share the pub-sub channel namespace. Use this property to filter out messages.
+    if (namespace !== 'mui-x-data-grid-export') {
+      return;
+    }
 
     const { exceljsPostProcess, exceljsPreProcess } = workerOptions;
 

--- a/packages/x-data-grid-premium/src/hooks/features/export/serializer/utils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/export/serializer/utils.ts
@@ -122,6 +122,7 @@ export async function createValueOptionsSheetIfNeeded(
 }
 
 export interface ExcelExportInitEvent {
+  namespace?: string;
   serializedColumns: SerializedColumns;
   serializedRows: SerializedRow[];
   valueOptionsSheetName: string;

--- a/packages/x-data-grid-premium/src/hooks/features/export/useGridExcelExport.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/export/useGridExcelExport.tsx
@@ -156,6 +156,8 @@ export const useGridExcelExport = (
       }, {});
 
       const message: ExcelExportInitEvent = {
+        // workers share the pub-sub channel namespace. Use this property to filter out messages.
+        namespace: 'mui-x-data-grid-export',
         serializedColumns,
         serializedRows,
         valueOptionsData,


### PR DESCRIPTION
The current logic looks wrong. Workers share the same pub-sub channel namespace. I believe it's why, e.g. https://revealjs.com/postmessage/ has a `namespace` property. You can reproduce a conflict by running

```bash
pnpm test:regressions:dev
```

and opening the page:

<img width="810" alt="SCR-20241228-tvwf" src="https://github.com/user-attachments/assets/2ccceca0-e5d3-4e72-a418-977e51cdc777" />

I don't know how to write a test for this effectively, so I skipped it. I initially noticed this improving slightly the visual regression flow in Material UI, saw an error in the console, which shouldn't be there.

Preview: https://deploy-preview-16020--material-ui-x.netlify.app/x/react-data-grid/export/#using-a-web-worker