### PR TITLE
[CHANGELOG] Add missing entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,6 +453,7 @@ Following are all team members who have contributed to this release:
 - [DataGrid] Change test dom check from `/jsdom/` to `/jsdom|HappyDOM/`. (#15634) @jedesroches
 - [DataGrid] Clear timers on unmount (#15620) @cherniavskii
 - [DataGrid] Fix order of spread props on toolbar items (#15556) @KenanYusuf
+- [DataGrid] Fix scroll error (#15521) @cherniavskii
 - [DataGrid] Improve resize performance (#15549) @lauri865
 - [DataGrid] Make estimation label more accurate (#15632) @arminmeh
 - [DataGrid] Remove `<GridOverlays />` export (#15573) @k-rajat19
@@ -461,7 +462,6 @@ Following are all team members who have contributed to this release:
 - [DataGrid] Remove unused `resize` method (#15599) @cherniavskii
 - [DataGrid] Support column virtualization with dynamic row height (#15541) @cherniavskii
 - [DataGrid] Update the default value for `rowSelectionPropagation` (#15523) @MBilalShafi
-- [DataGrid] Fix scroll error (#15521) @cherniavskii
 - [l10n] Improve Chinese (zh-CN) locale (#15570) @headironc
 - [l10n] Improve Portuguese (pt-PT) locale (#15561) @mathzdev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1165,14 +1165,15 @@ Following are all team members who have contributed to this release:
 
 #### `@mui/x-data-grid@v7.23.0`
 
-- [DataGrid] React 19 support (#15557) @arminmeh
 - [DataGrid] Change test dom check from `/jsdom/` to `/jsdom|HappyDOM/`. (#15642) @jedesroches
 - [DataGrid] Fix last separator not being hidden when grid is scrollable (#15551) @KenanYusuf
 - [DataGrid] Fix order of spread props on toolbar items (#15556) @KenanYusuf
 - [DataGrid] Fix row-spanning in combination with column-pinning (#15460) @lhilgert9
-- [DataGrid] Improve resize performance (#15592) @lauri865
-- [DataGrid] Support column virtualization with dynamic row height (#15567) @cherniavskii
+- [DataGrid] Fix scroll error #15657 @cherniavskii
 - [DataGrid] Improve `GridCell` performance (#15621) @lauri865
+- [DataGrid] Improve resize performance (#15592) @lauri865
+- [DataGrid] React 19 support (#15557) @arminmeh
+- [DataGrid] Support column virtualization with dynamic row height (#15567) @cherniavskii
 - [l10n] Improve Chinese (zh-CN) locale (#15570) @headironc
 - [l10n] Improve Portuguese (pt-PT) locale (#15561) @mathzdev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 8.0.0-alpha.6
+## v8.0.0-alpha.6
 
 _Dec 26, 2024_
 
@@ -84,7 +84,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.6`.
 - [docs] Remove production profiler from docs build (#15959) @lauri865
 - [code-infra] Add new `next-env.d.ts` changes (#15947) @JCQuintas
 
-## 8.0.0-alpha.5
+## v8.0.0-alpha.5
 
 _Dec 19, 2024_
 
@@ -186,7 +186,7 @@ Same changes as in `@mui/x-tree-view@8.0.0-alpha.5`.
 
 - [code-infra] Remove `@mui/material-nextjs` dependency (#15925) @LukasTy
 
-## 8.0.0-alpha.4
+## v8.0.0-alpha.4
 
 _Dec 13, 2024_
 
@@ -314,7 +314,7 @@ Releasing to benefit from license package fix (#15814).
 - [code-infra] Remove redundant `@type/react-test-renderer` dep (#15766) @LukasTy
 - [license] Use `console.log` for the error message on Codesandbox to avoid rendering error (#15814) @arminmeh
 
-## 8.0.0-alpha.3
+## v8.0.0-alpha.3
 
 _Dec 5, 2024_
 
@@ -690,7 +690,7 @@ Same changes as in `@mui/x-charts@v8.0.0-alpha.1`.
 - [docs-infra] Transpile `.ts` demo files (#15345) @KenanYusuf
 - [infra] Remove cherry-pick issue write permission (#15456) @oliviertassinari
 
-## 8.0.0-alpha.0
+## v8.0.0-alpha.0
 
 <img width="100%" alt="MUI X v8 Alpha is live" src="https://github.com/user-attachments/assets/114cf615-b617-435f-8499-76ac3c26c57b">
 
@@ -881,7 +881,117 @@ Same changes as in `@mui/x-charts@8.0.0-alpha.0`.
 - [release] v8 preparation (#15054) @michelengelen
 - [test] Fix advanced list view regression test snapshot (#15260) @KenanYusuf
 
-## 7.23.2
+## v7.23.5
+
+_Dec 27, 2024_
+
+Here are some highlights ✨:
+
+- 🐞 Fix version mismatch issue in Data Grid codesandbox/stackblitz demos
+
+<!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->
+
+### Data Grid
+
+#### `@mui/x-data-grid@7.23.5`
+
+No changes since `@mui/x-data-grid@v7.23.4`.
+
+#### `@mui/x-data-grid-pro@7.23.5` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@7.23.5`.
+
+#### `@mui/x-data-grid-premium@7.23.5` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@7.23.5`.
+
+## v7.23.4
+
+_Dec 27, 2024_
+
+We'd like to offer a big thanks to the 4 contributors who made this release possible. Here are some highlights ✨:
+
+- 🌍 Improve Dutch (nl-NL) locale on the Data Grid
+- 🐞 Bugfixes
+
+Special thanks go out to the community contributor who has helped make this release possible:
+@JoepVerkoelen.
+Following are all team members who have contributed to this release:
+@arminmeh, @oliviertassinari.
+
+<!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->
+
+### Data Grid
+
+#### `@mui/x-data-grid@7.23.4`
+
+- [DataGrid] Fix header filters showing clear button while empty (#15990) @k-rajat19
+- [DataGrid] Replace `forwardRef` with a shim for forward compatibility (#15984) @lauri865
+- [l10n] Improve Dutch (nl-NL) locale (#15920) @JoepVerkoelen
+
+#### `@mui/x-data-grid-pro@7.23.4` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@7.23.4`.
+
+#### `@mui/x-data-grid-premium@7.23.4` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@7.23.4`, plus:
+
+- [DataGridPremium] Fix column pinning with checkbox selection and row grouping (#15949) @k-rajat19
+
+### Docs
+
+- [docs] Fix outdated link to handbook (#15855) @oliviertassinari
+
+## v7.23.3
+
+_Dec 19, 2024_
+
+We'd like to offer a big thanks to the 6 contributors who made this release possible. Here are some highlights ✨:
+
+- 🌍 Improve Korean (ko-KR) locale on the Data Grid
+- 🐞 Bugfixes
+
+Special thanks go out to the community contributors who have helped make this release possible:
+@k-rajat19, @good-jinu.
+Following are all team members who have contributed to this release:
+@KenanYusuf, @MBilalShafi, @arminmeh, @flaviendelangle.
+
+<!--/ HIGHLIGHT_ABOVE_SEPARATOR /-->
+
+### Data Grid
+
+#### `@mui/x-data-grid@7.23.3`
+
+- [DataGrid] Allow passing custom props to `.main` element (#15919) @MBilalShafi
+- [DataGrid] Consider `columnGroupHeaderHeight` prop in `getTotalHeaderHeight` method (#15927) @k-rajat19
+- [DataGrid] Deprecate `indeterminateCheckboxAction` prop (#15862) @MBilalShafi
+- [DataGrid] Fix `aria-label` value for group checkboxes (#15861) @MBilalShafi
+- [DataGrid] Fix autosizing with virtualized columns (#15929) @k-rajat19
+- [DataGrid] Round dimensions to avoid subpixel rendering error (#15873) @KenanYusuf
+- [DataGrid] Toggle menu on click in `<GridActionsCell />` (#15871) @k-rajat19
+- [DataGrid] Trigger row spanning computation on rows update (#15872) @MBilalShafi
+- [l10n] Improve Korean (ko-KR) locale (#15906) @good-jinu
+
+#### `@mui/x-data-grid-pro@7.23.3` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-data-grid@7.23.3`.
+
+#### `@mui/x-data-grid-premium@7.23.3` [![premium](https://mui.com/r/x-premium-svg)](https://mui.com/r/x-premium-svg-link 'Premium plan')
+
+Same changes as in `@mui/x-data-grid-pro@7.23.3`.
+
+### Date and Time Pickers
+
+#### `@mui/x-date-pickers@7.23.3`
+
+- [pickers] Add verification to disable skipped hours in spring forward DST (#15918) @flaviendelangle
+
+#### `@mui/x-date-pickers-pro@7.23.3` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
+
+Same changes as in `@mui/x-date-pickers@7.23.3`.
+
+## v7.23.2
 
 _Dec 12, 2024_
 
@@ -962,7 +1072,7 @@ Releasing to benefit from license package fix (#15818).
 - [core] Add `@mui/x-tree-view-pro` to `releaseChangelog` (#15747) @flaviendelangle
 - [license] Use `console.log` for the error message on Codesandbox to avoid rendering error (#15818) @arminmeh
 
-## 7.23.1
+## v7.23.1
 
 _Dec 5, 2024_
 
@@ -1028,7 +1138,7 @@ Same changes as in `@mui/x-charts@7.23.1`.
 
 - [core] Add `@mui/x-tree-view-pro` to `releaseChangelog` (#15747) @flaviendelangle
 
-## 7.23.0
+## v7.23.0
 
 _Nov 29, 2024_
 
@@ -1198,7 +1308,7 @@ No changes since `@mui/x-charts@7.22.2`.
 - [docs-infra] Transpile `.ts` demo files (#15421) @KenanYusuf
 - [core] Clarify release version bump strategy (#15536) @cherniavskii
 
-## 7.22.2
+## v7.22.2
 
 _Nov 8, 2024_
 
@@ -1262,7 +1372,7 @@ Same changes as in `@mui/x-date-pickers@7.22.2`.
 
 Same changes as in `@mui/x-charts@7.22.2`.
 
-## 7.22.1
+## v7.22.1
 
 _Nov 1, 2024_
 
@@ -1324,7 +1434,7 @@ Same changes as in `@mui/x-tree-view@7.22.1`.
 
 - [docs] Add section explaining how to keep the selection while filtering in Data grid docs (#15199) @arminmeh
 
-## 7.22.0
+## v7.22.0
 
 _Oct 25, 2024_
 
@@ -1404,7 +1514,7 @@ Same changes as in `@mui/x-charts@7.22.0`.
 - [core] Update some `default-branch-switch` instances for `v7.x` (#15085) @MBilalShafi
 - [test] Revert to using `fireEvent` instead of `userEvent` (#14927) @LukasTy
 
-## 7.21.0
+## v7.21.0
 
 _Oct 17, 2024_
 
@@ -1493,7 +1603,7 @@ Same changes as in `@mui/x-charts@7.21.0`.
 - [test] Fix `AdapterDayjs` coverage calculation (#14957) @LukasTy
 - [test] Fix split infinitive API convention use @oliviertassinari
 
-## 7.20.0
+## v7.20.0
 
 _Oct 11, 2024_
 
@@ -1583,7 +1693,7 @@ Same changes as in `@mui/x-charts@7.20.0`.
 - [test] Replace `waitFor()` with `act()` (#14851) @oliviertassinari
 - [test] Restore "pnpm tc" CLI (#14852) @oliviertassinari
 
-## 7.19.0
+## v7.19.0
 
 _Oct 4, 2024_
 
@@ -1693,7 +1803,7 @@ Same changes as in `@mui/x-charts@7.19.0`.
 - [infra] Fix line break in Stack Overflow message @oliviertassinari
 - [test] Fix `Escape` event firing event (#14797) @oliviertassinari
 
-## 7.18.0
+## v7.18.0
 
 _Sep 20, 2024_
 
@@ -1786,7 +1896,7 @@ Same changes as in `@mui/x-charts@7.18.0`.
 - [docs-infra] Strengthen CSP (#14581) @oliviertassinari
 - [license] Finish renaming of LicensingModel (#14615) @oliviertassinari
 
-## 7.17.0
+## v7.17.0
 
 _Sep 13, 2024_
 
@@ -1873,7 +1983,7 @@ Same changes as in `@mui/x-charts@7.17.0`.
 - [license] Clean-up terminology to match codebase (#14531) @oliviertassinari
 - [test] Remove dead `act()` logic (#14529) @oliviertassinari
 
-## 7.16.0
+## v7.16.0
 
 _Sep 5, 2024_
 
@@ -1970,7 +2080,7 @@ Same changes as in `@mui/x-charts@7.16.0`, plus:
 - [infra] Switch "add closing message" to reusable workflow (#14499) @michelengelen
 - [infra] Switch "issue triage workflow" to reusable workflows (#14390) @michelengelen
 
-## 7.15.0
+## v7.15.0
 
 _Aug 29, 2024_
 
@@ -2039,7 +2149,7 @@ Same changes as in `@mui/x-charts@7.15.0`, plus:
 - [infra] Fix Issue cleanup action @oliviertassinari
 - [license] Prepare renaming of argument names @oliviertassinari
 
-## 7.14.0
+## v7.14.0
 
 _Aug 23, 2024_
 
@@ -2119,7 +2229,7 @@ Same changes as in `@mui/x-charts@7.14.0`, plus:
 - [code-infra] Set up `eslint-plugin-testing-library` (#14232) @LukasTy
 - [infra] Updated mui-x roadmap links with new project URL (#14271) @michelengelen
 
-## 7.13.0
+## v7.13.0
 
 _Aug 16, 2024_
 
@@ -2200,7 +2310,7 @@ Same changes as in `@mui/x-charts@7.13.0`.
 - [code-infra] Refactor Netlify `cache-docs` plugin setup (#14105) @LukasTy
 - [internals] Move utils needed for Tree View virtualization to shared package (#14202) @flaviendelangle
 
-## 7.12.1
+## v7.12.1
 
 _Aug 8, 2024_
 
@@ -2269,7 +2379,7 @@ No changes since `@mui/x-tree-view@7.12.0`.
 - [code-infra] Use concurrency 1 in CircleCI (#14110) @JCQuintas
 - [infra] Re-added the removal of `Latest Version` section (#14132) @michelengelen
 
-## 7.12.0
+## v7.12.0
 
 _Aug 1, 2024_
 
@@ -2375,7 +2485,7 @@ Same changes as in `@mui/x-date-pickers@7.12.0`.
 - [test] Fix adapters code coverage (#13969) @alexfauquette
 - [test] Fix mocha config to run charts tests (#14041) @alexfauquette
 
-## 7.11.1
+## v7.11.1
 
 _Jul 25, 2024_
 
@@ -2459,7 +2569,7 @@ Same changes as in `@mui/x-date-pickers@7.11.1`.
 - [infra] Fix regex in order id validation (#13976) @michelengelen
 - [infra] Issue template improvement (#13954) @michelengelen
 
-## 7.11.0
+## v7.11.0
 
 _Jul 18, 2024_
 
@@ -2544,7 +2654,7 @@ Same changes as in `@mui/x-date-pickers@7.11.0`, plus:
 - [code-infra] Use specific version for `@mui/docs` dependency (#13760) @LukasTy
 - [internals] Move `EventManager` to `@mui/x-internals` package (#13815) @flaviendelangle
 
-## 7.10.0
+## v7.10.0
 
 _Jul 11, 2024_
 
@@ -2618,7 +2728,7 @@ Same changes as in `@mui/x-date-pickers@7.10.0`, plus:
 - [core] Sort `DATA_GRID_PROPS_DEFAULT_VALUES` alphabetically (#13783) @oliviertassinari
 - [test] Fix split infinitive use in tests @oliviertassinari
 
-## 7.9.0
+## v7.9.0
 
 _Jul 5, 2024_
 
@@ -2684,7 +2794,7 @@ Same changes as in `@mui/x-date-pickers@7.9.0`.
 - [core] Remove `jscodeshift-add-imports` package (#13720) @LukasTy
 - [code-infra] Cleanup monorepo and `@mui/docs` usage (#13713) @LukasTy
 
-## 7.8.0
+## v7.8.0
 
 _Jun 28, 2024_
 
@@ -2783,7 +2893,7 @@ Same changes as in `@mui/x-date-pickers@7.8.0`.
 - [docs-infra] Sync `\_app` folder with monorepo (#13582) @Janpot
 - [license] Allow usage of Charts and Tree View Pro package for old premium licenses (#13619) @flaviendelangle
 
-## 7.7.1
+## v7.7.1
 
 _Jun 21, 2024_
 
@@ -2865,7 +2975,7 @@ Same changes as in `@mui/x-date-pickers@7.7.1`, plus:
 - [core] Fix failing CI test (#13574) @alexfauquette
 - [infra] Remove explicit `@testing-library/react` dependency (#13478) @LukasTy
 
-## 7.7.0
+## v7.7.0
 
 _Jun 13, 2024_
 
@@ -2946,7 +3056,7 @@ Same changes as in `@mui/x-date-pickers@7.7.0`.
 - [infra] Adjust CI setup (#13448) @LukasTy
 - [test] Add tests for the custom slots of `<TreeItem2 />` (#13314) @flaviendelangle
 
-## 7.6.2
+## v7.6.2
 
 _Jun 6, 2024_
 
@@ -3012,7 +3122,7 @@ Same changes as in `@mui/x-date-pickers@7.6.2`.
 - [core] Remove unused `@types/prettier` dependency (#13389) @LukasTy
 - [core] Add `docs/.env.local` to `.gitignore` (#13377) @KenanYusuf
 
-## 7.6.1
+## v7.6.1
 
 _May 31, 2024_
 
@@ -3037,7 +3147,7 @@ Same changes as in `@mui/x-data-grid@7.6.1`.
 
 Same changes as in `@mui/x-data-grid-pro@7.6.1`.
 
-## 7.6.0
+## v7.6.0
 
 _May 30, 2024_
 
@@ -3123,7 +3233,7 @@ Same changes as in `@mui/x-date-pickers@7.6.0`.
 - [test] Use test-utils from npm (#12880) @michaldudak
 - [typescript] Remove duplicate `DateRangePosition` type in favor of `RangePosition` (#13288) @LukasTy
 
-## 7.5.1
+## v7.5.1
 
 _May 23, 2024_
 
@@ -3183,7 +3293,7 @@ Same changes as in `@mui/x-date-pickers@7.5.1`.
 - [code-infra] Run corepack enable on all CI jobs (#13205) @Janpot
 - [code-infra] Use `nx` for lerna tasks (#13166) @LukasTy
 
-## 7.5.0
+## v7.5.0
 
 _May 17, 2024_
 
@@ -3254,7 +3364,7 @@ Same changes as in `@mui/x-date-pickers@7.5.0`.
 - [core] Shift aliasing from babel to webpack (#13051) @Janpot
 - [core] Reuse the `SectionTitle` component in the doc (#13139) @alexfauquette
 
-## 7.4.0
+## v7.4.0
 
 _May 10, 2024_
 
@@ -3321,7 +3431,7 @@ Same changes as in `@mui/x-date-pickers@7.4.0`.
 - [docs-infra] Fix Netlify PR preview path (#12993) @oliviertassinari
 - [infra] Automation: Add release PR reviewers (#12982) @michelengelen
 
-## 7.3.2
+## v7.3.2
 
 _May 2, 2024_
 
@@ -3390,7 +3500,7 @@ Same changes as in `@mui/x-date-pickers@7.3.2`.
 - [docs-infra] Use the `@mui/docs/HighlightedCode` (#12848) @alexfauquette
 - [test] Restore `t` command (#12948) @LukasTy
 
-## 7.3.1
+## v7.3.1
 
 _Apr 26, 2024_
 
@@ -3467,7 +3577,7 @@ Same changes as in `@mui/x-date-pickers@7.3.1`.
 - [code-infra] Closer sync with eslint config of codebase (#12864) @oliviertassinari
 - [support-infra] Add release announcement to GitHub workflows (#11867) (#12843) @michelengelen
 
-## 7.3.0
+## v7.3.0
 
 _Apr 18, 2024_
 
@@ -3542,7 +3652,7 @@ A typo fix:
 
 - [docs-infra] Prepare infra to document charts interfaces (#12653) @alexfauquette
 
-## 7.2.0
+## v7.2.0
 
 _Apr 12, 2024_
 
@@ -3628,7 +3738,7 @@ Same changes as in `@mui/x-date-pickers@7.2.0`, plus:
 - [core] Use `describeTreeView` for icons tests (#12672) @flaviendelangle
 - [core] Use `describeTreeView` in existing tests for `useTreeViewItems` (#12732) @flaviendelangle
 
-## 7.1.1
+## v7.1.1
 
 _Apr 5, 2024_
 
@@ -3729,7 +3839,7 @@ Same changes as in `@mui/x-date-pickers@7.1.1`, plus:
 - [support-infra] Fix user permission check (#12669) @michelengelen
 - [test] Fix Tree View test import (#12668) @LukasTy
 
-## 7.1.0
+## v7.1.0
 
 _Mar 28, 2024_
 
@@ -3800,7 +3910,7 @@ Same changes as in `@mui/x-date-pickers@7.1.0`, plus:
 - [core] Include `DateTimeRangePicker` tag in `releaseChangelog` (#12526) @LukasTy
 - [core] Upgrade monorepo (#12536) @cherniavskii
 
-## 7.0.0
+## v7.0.0
 
 _Mar 22, 2024_
 
@@ -3983,7 +4093,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0`, plus:
 - [core] Use Circle CI context @oliviertassinari
 - [license] Fix grammar on expired license error message (#12460) @joserodolfofreitas
 
-## 7.0.0-beta.7
+## v7.0.0-beta.7
 
 _Mar 14, 2024_
 
@@ -4079,7 +4189,7 @@ The `onNodeFocus` callback has been renamed to `onItemFocus` for consistency:
 - [core] Fix CI (#12414) @flaviendelangle
 - [core] Fix PR deploy link for Tree View doc pages (#12411) @flaviendelangle
 
-## 7.0.0-beta.6
+## v7.0.0-beta.6
 
 _Mar 8, 2024_
 
@@ -4165,7 +4275,7 @@ Same changes as in `@mui/x-data-grid-pro@7.0.0-beta.6`.
 
 - [test] Add `Charts` test (#11551) @alexfauquette
 
-## 7.0.0-beta.5
+## v7.0.0-beta.5
 
 _Mar 1, 2024_
 
@@ -4248,7 +4358,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.5`.
 - [infra] Update `no-response` workflow (#12193) @MBilalShafi
 - [infra] Fix missing permission reset @oliviertassinari
 
-## 7.0.0-beta.4
+## v7.0.0-beta.4
 
 _Feb 23, 2024_
 
@@ -4399,7 +4509,7 @@ These components are no longer exported from `@mui/x-charts`:
 - [docs-infra] Remove randomized API page layout (#11876) @alexfauquette
 - [test] Create local wrapper over `describeConformance` (#12130) @michaldudak
 
-## 7.0.0-beta.3
+## v7.0.0-beta.3
 
 _Feb 16, 2024_
 
@@ -4463,7 +4573,7 @@ Same changes as in `@mui/x-data-grid-pro@7.0.0-beta.3`.
 - [core] Sort prop asc (#12033) @oliviertassinari
 - [core] Bump monorepo (#12055) @alexfauquette
 
-## 7.0.0-beta.2
+## v7.0.0-beta.2
 
 _Feb 9, 2024_
 
@@ -4565,7 +4675,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.2`.
 - [core] Fix npm reference @oliviertassinari
 - [core] Normalize issue template @oliviertassinari
 
-## 7.0.0-beta.1
+## v7.0.0-beta.1
 
 _Feb 1, 2024_
 
@@ -4728,7 +4838,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.1`.
 - [core] Rely on immutable ref when possible (#11847) @oliviertassinari
 - [core] Bump monorepo (#11897) @alexfauquette
 
-## 7.0.0-beta.0
+## v7.0.0-beta.0
 
 _Jan 26, 2024_
 
@@ -4828,7 +4938,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-beta.0`, plus:
 - [core] Polish issue templates @oliviertassinari
 - [code-infra] Update prettier and pretty-quick (#11735) @Janpot
 
-## 7.0.0-alpha.9
+## v7.0.0-alpha.9
 
 _Jan 19, 2024_
 
@@ -5166,7 +5276,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.9`.
 - [docs-infra] Enforce brand name rules (#11651) @oliviertassinari
 - [test] Fix flaky Data Grid test (#11725) @cherniavskii
 
-## 7.0.0-alpha.8
+## v7.0.0-alpha.8
 
 _Jan 11, 2024_
 
@@ -5250,7 +5360,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.8`.
 - [core] Sync playwright cache between MUI X and Material UI (#11607) @oliviertassinari
 - [core] Use MUI X official name in errors (#11645) @oliviertassinari
 
-## 7.0.0-alpha.7
+## v7.0.0-alpha.7
 
 _Jan 5, 2024_
 
@@ -5390,7 +5500,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.7`.
 - [core] Sync the release instructions with MUI Core @oliviertassinari
 - [core] Yaml format match most common convention @oliviertassinari
 
-## 7.0.0-alpha.6
+## v7.0.0-alpha.6
 
 _Dec 22, 2023_
 
@@ -5481,7 +5591,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.6`.
 - [core] Fix security regressions in cherry-pick-next-to-master.yml (#11482) @MBilalShafi
 - [test] Reload the page if its blank and there are no links to the remaining tests (#11466) @cherniavskii
 
-## 7.0.0-alpha.5
+## v7.0.0-alpha.5
 
 _Dec 14, 2023_
 
@@ -5642,7 +5752,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.5`, plus:
 - [infra] Update `no-response` workflow (#11369) @MBilalShafi
 - [test] Fix flaky screenshots (#11388) @cherniavskii
 
-## 7.0.0-alpha.4
+## v7.0.0-alpha.4
 
 _Dec 8, 2023_
 
@@ -5725,7 +5835,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.4`.
 - [docs] Improve `DemoContainer` styling coverage (#11315) @LukasTy
 - [docs] General revision of the Charts docs (#11249) @danilo-leal
 
-## 7.0.0-alpha.3
+## v7.0.0-alpha.3
 
 _Dec 4, 2023_
 
@@ -5907,7 +6017,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.3`.
 - [core] Remove outdated `ENABLE_AD` env variable (#11181) @oliviertassinari
 - [github] Do not add `plan: Pro` and `plan: Premium` labels on Pro / Premium issue templates (#10183) @flaviendelangle
 
-## 7.0.0-alpha.2
+## v7.0.0-alpha.2
 
 _Nov 23, 2023_
 
@@ -6032,7 +6142,7 @@ Same changes as in `@mui/x-date-pickers@7.0.0-alpha.2`.
 - [renovate] Monthly schedule for lockfile maintenance (#10336) @Janpot
 - [test] Skip flaky e2e test in webkit (#11110) @cherniavskii
 
-## 7.0.0-alpha.1
+## v7.0.0-alpha.1
 
 _Nov 17, 2023_
 
@@ -6449,7 +6559,7 @@ And if you need the exact same output you can apply the following transformation
 - [core] Fix script to release with `next` tag (#10996) @LukasTy
 - [test] Wait for images to load (#11004) @cherniavskii
 
-## 7.0.0-alpha.0
+## v7.0.0-alpha.0
 
 _Nov 10, 2023_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,6 +461,7 @@ Following are all team members who have contributed to this release:
 - [DataGrid] Remove unused `resize` method (#15599) @cherniavskii
 - [DataGrid] Support column virtualization with dynamic row height (#15541) @cherniavskii
 - [DataGrid] Update the default value for `rowSelectionPropagation` (#15523) @MBilalShafi
+- [DataGrid] Fix scroll error (#15521) @cherniavskii
 - [l10n] Improve Chinese (zh-CN) locale (#15570) @headironc
 - [l10n] Improve Portuguese (pt-PT) locale (#15561) @mathzdev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,7 @@ Following are all team members who have contributed to this release:
 - [DataGrid] Support column virtualization with dynamic row height (#15541) @cherniavskii
 - [DataGrid] Update the default value for `rowSelectionPropagation` (#15523) @MBilalShafi
 - [l10n] Improve Chinese (zh-CN) locale (#15570) @headironc
+- [l10n] Improve German (de-DE) locale (#15610) @lhilgert9
 - [l10n] Improve Portuguese (pt-PT) locale (#15561) @mathzdev
 
 #### `@mui/x-data-grid-pro@v8.0.0-alpha.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
@@ -490,8 +491,9 @@ Same changes as in `@mui/x-data-grid-pro@v8.0.0-alpha.2`.
 - [l10n] Improve Dutch (nl-NL) locale (#15564) @nphmuller
 - [pickers] Fix DST issue with `America/Asuncion` timezone and `AdapterMoment` (#15552) @flaviendelangle
 - [pickers] Improve validation internals (#15419) @flaviendelangle
-- [pickers] Remove `TSection` and strictly type `TValue` (#15434) @flaviendelangle
 - [pickers] Remove `orientation`, `isLandscape`, `isRtl`, `wrapperVariant` and `disabled` props from `PickersLayout` (#15494) @flaviendelangle
+- [pickers] Remove `TSection` and strictly type `TValue` (#15434) @flaviendelangle
+- [pickers] Use new ownerState object in `<DateTimePickerTabs />` and `<DateTimeRangePickerTabs />` (#15498) @flaviendelangle
 - [pickers] Use the new `ownerState` in `<PickersCalendarHeader />`, `<PickersArrowSwitcher />` and `<DayCalendarSkeleton />` (#15499) @flaviendelangle
 - [pickers] Use the new `ownerState` object in all the field components (#15510) @flaviendelangle
 
@@ -508,10 +510,11 @@ Same changes as in `@mui/x-date-pickers@v8.0.0-alpha.2`.
 #### `@mui/x-charts@v8.0.0-alpha.2`
 
 - [charts] Allow the creation of custom HTML components using charts data (#15511) @JCQuintas
+- [charts] Fix custom Tooltip demos (#15631) @alexfauquette
 - [charts] Flatten imports from `@mui/utils` and `@mui/system` (#15603) @alexfauquette
 - [charts] Introduce the plugin system (#15513) @alexfauquette
 - [charts] Prevent invalid `releasePointerCapture` (#15602) @alexfauquette
-- [charts] Fix custom Tooltip demos (#15631) @alexfauquette
+- [charts] Remove labelFontSize and tickFontSize props (#15633) @JCQuintas
 
 #### `@mui/x-charts-pro@v8.0.0-alpha.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
@@ -529,14 +532,15 @@ Same changes as in `@mui/x-tree-view@v8.0.0-alpha.2`.
 
 ### Docs
 
+- [docs] Add documentation for the list view feature (#15344) @KenanYusuf
+- [docs] Fix `anchorEl` API page for charts (#15625) @oliviertassinari
 - [docs] Fix 404 links (#15575) @oliviertassinari
 - [docs] Fix bash comments (#15571) @oliviertassinari
+- [docs] Fix layout shift image on Tree View docs (#15626) @oliviertassinari
 - [docs] Fix Pickers theme augmentation example (#15672) @LukasTy
+- [docs] Improve migration guide (#15673) @arminmeh
 - [docs] Replace use of "e.g." with "for example" (#15572) @oliviertassinari
 - [docs] Update stale `new` and `preview` tags in v8 docs (#15547) @JCQuintas
-- [docs] Fix layout shift image on Tree View docs (#15626) @oliviertassinari
-- [docs] Fix `anchorEl` API page for charts (#15625) @oliviertassinari
-- [docs] Add documentation for the list view feature (#15344) @KenanYusuf
 
 ### Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,7 +464,9 @@ Following are all team members who have contributed to this release:
 - [DataGrid] Update the default value for `rowSelectionPropagation` (#15523) @MBilalShafi
 - [l10n] Improve Chinese (zh-CN) locale (#15570) @headironc
 - [l10n] Improve German (de-DE) locale (#15610) @lhilgert9
+- [l10n] Improve Portuguese (Brazil) (pt-BR) locale (#15562) @mathzdev
 - [l10n] Improve Portuguese (pt-PT) locale (#15561) @mathzdev
+- [l10n] Improve Spanish (es-ES) locale (#15559) @dloeda
 
 #### `@mui/x-data-grid-pro@v8.0.0-alpha.2` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
@@ -539,6 +541,7 @@ Same changes as in `@mui/x-tree-view@v8.0.0-alpha.2`.
 - [docs] Fix layout shift image on Tree View docs (#15626) @oliviertassinari
 - [docs] Fix Pickers theme augmentation example (#15672) @LukasTy
 - [docs] Improve migration guide (#15673) @arminmeh
+- [docs] Remove selectors section from list view docs (#15637) @KenanYusuf
 - [docs] Replace use of "e.g." with "for example" (#15572) @oliviertassinari
 - [docs] Update stale `new` and `preview` tags in v8 docs (#15547) @JCQuintas
 
@@ -1165,17 +1168,20 @@ Following are all team members who have contributed to this release:
 
 #### `@mui/x-data-grid@v7.23.0`
 
-- [DataGrid] Change test dom check from `/jsdom/` to `/jsdom|HappyDOM/`. (#15642) @jedesroches
+- [DataGrid] Change test dom check from `/jsdom/` to `/jsdom|HappyDOM/` (#15642) @jedesroches
+- [DataGrid] Clear timers on unmount (#15624) @cherniavskii
 - [DataGrid] Fix last separator not being hidden when grid is scrollable (#15551) @KenanYusuf
-- [DataGrid] Fix order of spread props on toolbar items (#15556) @KenanYusuf
+- [DataGrid] Fix order of spread props on toolbar items (#15595) @KenanYusuf
 - [DataGrid] Fix row-spanning in combination with column-pinning (#15460) @lhilgert9
 - [DataGrid] Fix scroll error #15657 @cherniavskii
-- [DataGrid] Improve `GridCell` performance (#15621) @lauri865
 - [DataGrid] Improve resize performance (#15592) @lauri865
 - [DataGrid] React 19 support (#15557) @arminmeh
+- [DataGrid] Remove try/catch from `<GridCell />` due to performance issues (#15621) @lauri865
 - [DataGrid] Support column virtualization with dynamic row height (#15567) @cherniavskii
 - [l10n] Improve Chinese (zh-CN) locale (#15570) @headironc
+- [l10n] Improve Portuguese (Brazil) (pt-BR) locale (#15562) @mathzdev
 - [l10n] Improve Portuguese (pt-PT) locale (#15561) @mathzdev
+- [l10n] Improve Spanish (es-ES) locale (#15559) @dloeda
 
 #### `@mui/x-data-grid-pro@v7.23.0` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')
 
@@ -1227,11 +1233,12 @@ Same changes as in `@mui/x-tree-view@7.23.0`.
 
 - [docs] Add data caching to lazy loaded detail panel demo (#15555) @cherniavskii
 - [docs] Remove selectors section from list view docs (#15639) @KenanYusuf
-- [docs] Add documentation for the list view feature (#15344) @KenanYusuf
+- [docs] Add documentation for the list view feature (#15635) @KenanYusuf
 
 ### Core
 
 - [core] Update @mui/monorepo (#15574) @oliviertassinari
+- [infra] Remove outdated cherry-pick Actions (#15665)
 
 ## v7.22.3
 

--- a/changelogOld/CHANGELOG.v4.md
+++ b/changelogOld/CHANGELOG.v4.md
@@ -1,6 +1,6 @@
 # Changelog for v4 releases
 
-## 4.0.0
+## v4.0.0
 
 _Aug 27, 2021_
 
@@ -91,7 +91,7 @@ A big thanks to the 6 contributors who made this release possible. Here are some
 - [core] Upgrade dependency with the monorepo (#2377) @oliviertassinari
 - [test] Use `.not.to.equal` in favor of `.to.not.equal` (#2340) @oliviertassinari
 
-## 4.0.0-alpha.37
+## v4.0.0-alpha.37
 
 _Aug 12, 2021_
 
@@ -151,7 +151,7 @@ This is the last alpha release. We are moving to beta in the next release, next 
 - [core] Use type inference in selectors (#2244) @flaviendelangle
 - [core] Improve type coverage of `colDef` (#2188) @flaviendelangle
 
-## 4.0.0-alpha.36
+## v4.0.0-alpha.36
 
 _August 5, 2021_
 
@@ -234,7 +234,7 @@ Big thanks to the 6 contributors who made this release possible. Here are some h
 - [core] Fix `rebaseWhen=auto` not working (#2271) @oliviertassinari
 - [core] Batch small changes (#2249) @oliviertassinari
 
-## 4.0.0-alpha.35
+## v4.0.0-alpha.35
 
 _July 31, 2021_
 

--- a/changelogOld/CHANGELOG.v5.md
+++ b/changelogOld/CHANGELOG.v5.md
@@ -1,6 +1,6 @@
 # Changelog for v5 releases
 
-## 5.17.25
+## v5.17.25
 
 _Feb 23, 2023_
 
@@ -20,7 +20,7 @@ We'd like to offer a big thanks to the 2 contributors who made this release poss
 
 - [DateTimePicker] Ensure toolbar `viewType` is correctly updated (#7942) @LukasTy
 
-## 5.17.24
+## v5.17.24
 
 _Feb 16, 2023_
 
@@ -44,7 +44,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [l10n] Add Hungarian (hu-HU) locale (#7796) @noherczeg
 
-## 5.17.23
+## v5.17.23
 
 _Feb 9, 2023_
 
@@ -78,7 +78,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 - [core] Upgrade monorepo (#7849) @cherniavskii
 
-## 5.17.22
+## v5.17.22
 
 _Feb 2, 2023_
 
@@ -104,7 +104,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 - [TimePicker] Add missing `themeAugmentation` entry (#7732) @LukasTy
 - [l10n] Improve Italian (it-IT) locale (#7761) @simonecervini
 
-## 5.17.21
+## v5.17.21
 
 _Jan 27, 2023_
 
@@ -142,7 +142,7 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 
 - [docs] Add info callout about available component `slots` (#7723) @Vivek-Prajapatii
 
-## 5.17.20
+## v5.17.20
 
 _Jan 19, 2023_
 
@@ -166,7 +166,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 - [pickers] Ensure `key` is passed without object spreading (#7584) @alexfauquette
 - [l10n] Improve Italian (it-IT) locale (#7547) @marikadeveloper
 
-## 5.17.19
+## v5.17.19
 
 _Jan 16, 2023_
 We'd like to offer a big thanks to the 4 contributors who made this release possible. Here are some highlights ✨:
@@ -190,7 +190,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 - [pickers] Add Belarusian (be-BY) locale (#7450) @volhalink
 - [pickers] Add Urdu (ur-PK) locale (#7449) @MBilalShafi
 
-## 5.17.18
+## v5.17.18
 
 _Jan 5, 2023_
 
@@ -222,7 +222,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 - [core] Fix the product license reference name (#7367) @oliviertassinari
 - [core] Upgrade monorepo (#7344) @cherniavskii
 
-## 5.17.17
+## v5.17.17
 
 _Dec 24, 2022_
 
@@ -245,7 +245,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 
 - [pickers] Improve Korean (ko-KR) locale (#7283) @hanbin9775
 
-## 5.17.16
+## v5.17.16
 
 _Dec 16, 2022_
 
@@ -271,7 +271,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 
 - [docs] Document aggregation selectors (#7151) @cherniavskii
 
-## 5.17.15
+## v5.17.15
 
 _Dec 8, 2022_
 
@@ -299,7 +299,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 - [docs] Keep track of the localization completion (#7099) @alexfauquette
 - [docs] Update localization doc to use existing locale (#7104) @LukasTy
 
-## 5.17.14
+## v5.17.14
 
 _Dec 1, 2022_
 
@@ -316,7 +316,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 - [DataGridPremium] Update cache before hydrating columns (#7043) @m4theushw
 - [l10n] Improve Ukrainian (uk-UA) locale (#7035) @rettoua
 
-## 5.17.13
+## v5.17.13
 
 _Nov 24, 2022_
 
@@ -353,7 +353,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [core] Upgrade monorepo (#6906) @cherniavskii
 - [core] Upgrade node to v14.21 (#6939) @piwysocki
 
-## 5.17.12
+## v5.17.12
 
 _Nov 17, 2022_
 
@@ -380,7 +380,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 - [core] Upgrade monorepo (#6864) @m4theushw
 - [license] Polish error messages (#6881) @oliviertassinari
 
-## 5.17.11
+## v5.17.11
 
 _Nov 10, 2022_
 
@@ -409,7 +409,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [license] Add new license status 'Out of scope' (#6774) @oliviertassinari
 
-## 5.17.10
+## v5.17.10
 
 _Nov 4, 2022_
 
@@ -434,7 +434,7 @@ We'd like to offer a big thanks to the 4 contributors who made this release poss
 
 - [docs] Mark Data Grid column group available (#6659) @alexfauquette
 
-## 5.17.9
+## v5.17.9
 
 _Oct 28, 2022_
 
@@ -471,7 +471,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 - [core] Upgrade monorepo (#6570) @cherniavskii
 
-## 5.17.8
+## v5.17.8
 
 _Oct 20, 2022_
 
@@ -501,7 +501,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [docs] Fix 301 link to the sx prop page @oliviertassinari
 
-## 5.17.7
+## v5.17.7
 
 _Oct 13, 2022_
 
@@ -516,7 +516,7 @@ We'd like to offer a big thanks to the 2 contributors who made this release poss
 - [DataGrid] Fix error when using column grouping with all columns hidden (#6425) @alexfauquette
 - [DataGrid] Fix start edit mode with printable character in React 18 (#6478) @m4theushw
 
-## 5.17.6
+## v5.17.6
 
 _Oct 6, 2022_
 
@@ -546,7 +546,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 
 - [docs] Fix customized day rendering demo style (#6342) @Ambrish-git
 
-## 5.17.5
+## v5.17.5
 
 _Sep 29, 2022_
 
@@ -576,7 +576,7 @@ We'd like to offer a big thanks to the 2 contributors who made this release poss
 
 - [core] Reduce the amount of updated screenshots reported by Argos (#6310) @cherniavskii
 
-## 5.17.4
+## v5.17.4
 
 _Sep 22, 2022_
 
@@ -610,7 +610,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 
 - [core] Use the official repository for `@mui/monorepo` instead of a fork (#6189) @oliviertassinari
 
-## 5.17.3
+## v5.17.3
 
 _Sep 16, 2022_
 
@@ -644,7 +644,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [core] Update to TypeScript 4.8.3 (#6136) @flaviendelangle
 - [core] Update RFC template (#6100) @bytasv
 
-## 5.17.2
+## v5.17.2
 
 _Sep 9, 2022_
 
@@ -688,7 +688,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [core] Add `yarn release:tag` script (#5169) @DanailH
 - [core] Upgrade monorepo (#6072) @m4theushw
 
-## 5.17.1
+## v5.17.1
 
 _Sep 5, 2022_
 
@@ -704,7 +704,7 @@ We'd like to offer a big thanks to the 3 contributors who made this release poss
 - [DataGrid] Fix focused cell if column is spanned and new editing API is used (#5962) @m4theushw
 - [DataGridPro] Fix import in lazy-loading causing a bundling error (#6031) @flaviendelangle
 
-## 5.17.0
+## v5.17.0
 
 _Sep 2, 2022_
 
@@ -781,7 +781,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [test] Fix time zone sensitive test (#5955) @LukasTy
 - [test] Use `userEvent.mousePress` instead of `fireClickEvent` (#5920) @cherniavskii
 
-## 5.16.0
+## v5.16.0
 
 _Aug 25, 2022_
 
@@ -837,7 +837,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [core] Remove Firefox from the BrowserStack list (#5874) @DanailH
 - [core] Small changes to the release script (#5840) @m4theushw
 
-## 5.15.3
+## v5.15.3
 
 _Aug 18, 2022_
 
@@ -879,7 +879,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [license] Only log an error type once (#5730) @oliviertassinari
 - [test] Increase timeout to take print screenshot (#5799) @m4theushw
 
-## 5.15.2
+## v5.15.2
 
 _Aug 11, 2022_
 
@@ -923,7 +923,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [core] Update tooling to run with React 18 (#4155) @m4theushw
 - [test] Fix failing dynamic row height tests on Edge (#5707) @m4theushw
 
-## 5.15.1
+## v5.15.1
 
 _Aug 4, 2022_
 
@@ -964,7 +964,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [core] Isolate asset loading under /x/ (#5594) @oliviertassinari
 - [core] Upgrade node to v14 (#4999) @cherniavskii
 
-## 5.15.0
+## v5.15.0
 
 _Jul 29, 2022_
 
@@ -1021,7 +1021,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 - [core] Upgrade monorepo (#5560) @m4theushw
 
-## 5.14.0
+## v5.14.0
 
 _Jul 21, 2022_
 
@@ -1064,7 +1064,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [core] Polish on the bug issue template (#5525) @oliviertassinari
 - [test] Add more tests related to `isPrintableKey` (#5458) @mnajdova
 
-## 5.13.1
+## v5.13.1
 
 _Jul 15, 2022_
 
@@ -1114,7 +1114,7 @@ We'd like to offer a big thanks to the 13 contributors who made this release pos
 - [core] Sort keys like in material-ui @oliviertassinari
 - [test] Wait for flags to load on regression tests (#5473) @m4theushw
 
-## 5.13.0
+## v5.13.0
 
 _Jul 7, 2022_
 
@@ -1747,7 +1747,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [core] Unify tests (#4368) @flaviendelangle
 - [core] Enforce `noImplicitAny` in `docs` folder (#4412) @cherniavskii
 
-## 5.8.0
+## v5.8.0
 
 _Apr 4, 2022_
 
@@ -1823,7 +1823,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [core] Reuse previous state when updating the columns prop (#4229) @m4theushw
 - [core] Fix Argos flakiness for pickers tests (#4312) @flaviendelangle
 
-## 5.7.0
+## v5.7.0
 
 _Mar 24, 2022_
 
@@ -1893,7 +1893,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [test] Mock `getComputedStyle` to speed up unit tests (#4142) @m4theushw
 - [test] Upgrade CircleCI convenience image (#4143) @m4theushw
 
-## 5.6.1
+## v5.6.1
 
 _Mar 10, 2022_
 
@@ -1936,7 +1936,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [test] Make focus state out-of-sync warning opt-in (#4129) @m4theushw
 - [test] Only test custom input keyboard event in edit mode (#4075) @alexfauquette
 
-## 5.6.0
+## v5.6.0
 
 _Mar 4, 2022_
 
@@ -2052,7 +2052,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [test] Reduce memory usage to run unit tests (#4031) @m4theushw
 - [test] Skip test on Firefox (#3926) @m4theushw
 
-## 5.5.1
+## v5.5.1
 
 _Feb 10, 2022_
 
@@ -2101,7 +2101,7 @@ A big thanks to the 6 contributors who made this release possible. Here are some
 - [core] Move the git repository to a new location (#3872) @oliviertassinari
 - [test] Add `codecov` (#3873) @oliviertassinari
 
-## 5.5.0
+## v5.5.0
 
 _Feb 3, 2022_
 
@@ -2153,7 +2153,7 @@ A big thanks to the 10 contributors who made this release possible. Here are som
 - [code] Fix `docs:api` silent crash (#3808) @cherniavskii
 - [test] Increase timeout for Firefox (#3813) @m4theushw
 
-## 5.4.0
+## v5.4.0
 
 _Jan 28, 2022_
 
@@ -2219,7 +2219,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [test] Wait for flags to load before creating snapshots (#3726) @m4theushw
 - [test] Warn when focusing cells without syncing the state (#3486) @m4theushw
 
-## 5.3.0
+## v5.3.0
 
 _Jan 21, 2022_
 
@@ -2361,7 +2361,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [test] Split cell/row editing tests (#3618) @m4theushw
 - [test] Skip tests on Safari (#3679) @m4theushw
 
-## 5.2.2
+## v5.2.2
 
 _Jan 6, 2022_
 
@@ -2411,7 +2411,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [core] Update dependency on the core (#3526) @oliviertassinari
 - [core] Update tweet example in release readme (#3481) @DanailH
 
-## 5.2.1
+## v5.2.1
 
 _Dec 17, 2021_
 
@@ -2452,7 +2452,7 @@ A big thanks to the 8 contributors who made this release possible. Here are some
 - [core] Remove 'x-data-grid' folder from DataGridPro bundle (#3394) @m4theushw
 - [core] Add link to OpenCollective (#3392) @oliviertassinari
 
-## 5.2.0
+## v5.2.0
 
 _Dec 9, 2021_
 
@@ -2532,7 +2532,7 @@ A big thanks to the 5 contributors who made this release possible. Here are some
 - [core] Use pre-processors for sorting and filtering (#3318) @flaviendelangle
 - [test] Replace `useFakeTimers` (#3323) @m4theushw
 
-## 5.1.0
+## v5.1.0
 
 _Dec 2, 2021_
 
@@ -2623,7 +2623,7 @@ A big thanks to the 11 contributors who made this release possible. Here are som
 - [docs] Add demos using cell/row editing with server-side persistence (#3124) @flaviendelangle
 - [docs] Use relative links (#3299) @oliviertassinari
 
-## 5.0.1
+## v5.0.1
 
 _Nov 23, 2021_
 
@@ -2679,7 +2679,7 @@ A big thanks to the 3 contributors who made this release possible. Here are some
 - [core] Remove the `index.ts` of the export hooks (#3165) @flaviendelangle
 - [core] Set the correct release date for v5.0.0 in the CHANGELOG.md (#3192) @flaviendelangle
 
-## 5.0.0
+## v5.0.0
 
 _Nov 23, 2021_
 
@@ -2761,7 +2761,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [docs] Improve `rowCount` CSS class description (#3072) @ZeeshanTamboli
 - [docs] Use core repo constants for doc internationalization (#3143) @flaviendelangle
 
-## 5.0.0-beta.7
+## v5.0.0-beta.7
 
 _Nov 4, 2021_
 
@@ -2834,7 +2834,7 @@ _Nov 4, 2021_
 - [docs] Fix the outdated demo of the docs (#3058) @oliviertassinari
 - [docs] Fix inline previews #3081) @DanailH
 
-## 5.0.0-beta.6
+## v5.0.0-beta.6
 
 _Oct 29, 2021_
 
@@ -2943,7 +2943,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [core] Add additional test for `checkboxSelection` toggling (#2979) @flaviendelangle
 - [test] Fix flaky visual regression test (#2981) @m4theushw
 
-## 5.0.0-beta.5
+## v5.0.0-beta.5
 
 _Oct 22, 2021_
 
@@ -3079,7 +3079,7 @@ A big thanks to the 5 contributors who made this release possible. Here are some
 - [core] Update monorepo version (#2927) @m4theushw
 - [test] Take screenshot of the print export (#2881) @m4theushw
 
-## 5.0.0-beta.4
+## v5.0.0-beta.4
 
 _Oct 14, 2021_
 
@@ -3251,7 +3251,7 @@ A big thanks to the 7 contributors who made this release possible. Here are some
 - [core] Update hooks to initialize their state synchronously (#2782) @flaviendelangle
 - [core] Fix rollup external warnings (#2736) @eps1lon
 
-## 5.0.0-beta.3
+## v5.0.0-beta.3
 
 _Oct 7, 2021_
 
@@ -3323,7 +3323,7 @@ A big thanks to the 9 contributors who made this release possible. Here are some
 - [core] Set up `eps1lon/actions-label-merge-conflict` action (#2751) @m4theushw
 - [core] Stop using selectors for Pro features on React components (#2716) @flaviendelangle
 
-## 5.0.0-beta.2
+## v5.0.0-beta.2
 
 _Sep 24, 2021_
 
@@ -3378,7 +3378,7 @@ A big thanks to the 5 contributors who made this release possible. Here are some
 
 - [core] Upgrade JSS plugins to 10.8.0 (#2667) @m4theushw
 
-## 5.0.0-beta.1
+## v5.0.0-beta.1
 
 _Sep 17, 2021_
 
@@ -3399,7 +3399,7 @@ This is a hotfix to fix an important regression with `v5.0.0-beta.0`.
 - [core] Copy bin folder when building the libraries (#2627) @flaviendelangle
 - [core] Remove prop-types during build (#2586) @m4theushw
 
-## 5.0.0-beta.0
+## v5.0.0-beta.0
 
 _Sep 17, 2021_
 

--- a/changelogOld/CHANGELOG.v6.md
+++ b/changelogOld/CHANGELOG.v6.md
@@ -1,6 +1,6 @@
 # Changelog for v6 releases
 
-## 6.19.12
+## v6.19.12
 
 _May 17, 2024_
 
@@ -22,7 +22,7 @@ Same changes as in `@mui/x-date-pickers@6.19.12`.
 
 - [docs] Use MUI X v6 in CodeSandbox and StackBlitz demos (#12838) @cherniavskii
 
-## 6.19.11
+## v6.19.11
 
 _Apr 18, 2024_
 
@@ -44,7 +44,7 @@ Same changes as in `@mui/x-data-grid@6.19.11`.
 
 Same changes as in `@mui/x-data-grid-pro@6.19.11`.
 
-## 6.19.10
+## v6.19.10
 
 _Apr 12, 2024_
 
@@ -72,7 +72,7 @@ Same changes as in `@mui/x-data-grid-pro@6.19.10`.
 
 - [core] Update the docs release source branch (#12685) @LukasTy
 
-## 6.19.9
+## v6.19.9
 
 _Apr 5, 2024_
 
@@ -114,7 +114,7 @@ No changes.
 
 - [core] Use Circle CI context (#12607) @cherniavskii
 
-## 6.19.8
+## v6.19.8
 
 _Mar 20, 2024_
 
@@ -142,7 +142,7 @@ Same changes as in `@mui/x-data-grid-pro@6.19.8`, plus:
 
 - [docs] Update links to v7 (#12495) @cherniavskii
 
-## 6.19.7
+## v6.19.7
 
 _Mar 14, 2024_
 
@@ -162,7 +162,7 @@ Same changes as in `@mui/x-date-pickers@6.19.7`.
 
 - [docs] Add Pickers custom start of week section (#12425) @LukasTy
 
-## 6.19.6
+## v6.19.6
 
 _Mar 1, 2024_
 
@@ -203,7 +203,7 @@ Same changes as in `@mui/x-date-pickers@6.19.6`.
 
 - [docs] Update lazy loading demo to show skeleton rows during initial rows fetch (#12062) @cherniavskii
 
-## 6.19.5
+## v6.19.5
 
 _Feb 23, 2024_
 
@@ -264,7 +264,7 @@ Same changes as in `@mui/x-date-pickers@6.19.5`.
 - [core] Fix CI @oliviertassinari
 - [core] Fix docs link check (#12137) @LukasTy
 
-## 6.19.4
+## v6.19.4
 
 _Feb 9, 2024_
 
@@ -320,7 +320,7 @@ Same changes as in `@mui/x-date-pickers@6.19.4`.
 - [docs] Refactor `Localization` documentation sections (#11997) @LukasTy
 - [code] Simplify bug reproduction (#11932) @alexfauquette
 
-## 6.19.3
+## v6.19.3
 
 _Feb 1, 2024_
 
@@ -369,7 +369,7 @@ Same changes as in `@mui/x-date-pickers@6.19.3`.
 - [docs] These API don't exist in MUI X v6 @oliviertassinari
 - [docs] Update whats new page with v7 Beta blogpost content (#11886) @joserodolfofreitas
 
-## 6.19.2
+## v6.19.2
 
 _Jan 25, 2024_
 
@@ -404,7 +404,7 @@ Same changes as in `@mui/x-data-grid@6.19.2`.
 
 Same changes as in `@mui/x-data-grid-pro@6.19.2`.
 
-## 6.19.1
+## v6.19.1
 
 _Jan 19, 2024_
 
@@ -433,7 +433,7 @@ Same changes as in `@mui/x-data-grid-pro@6.19.1`.
 - [charts] Do not propagate `innerRadius` and `outerRadius` to the DOM (#11719) @alexfauquette
 - [charts] Fix default `stackOffset` for `LineChart` (#11703) @alexfauquette
 
-## 6.19.0
+## v6.19.0
 
 _Jan 11, 2024_
 
@@ -475,7 +475,7 @@ Same changes as in `@mui/x-date-pickers@6.19.0`.
 - [docs] Improve landing page (#11570) @oliviertassinari
 - [docs] Give a general revision to the docs (#11249) @danilo-leal
 
-## 6.18.7
+## v6.18.7
 
 _Jan 5, 2024_
 
@@ -517,7 +517,7 @@ Same changes as in `@mui/x-date-pickers@6.18.7`.
 
 - [docs] Clarify Pickers usage with Luxon (#11566) @LukasTy
 
-## 6.18.6
+## v6.18.6
 
 _Dec 22, 2023_
 
@@ -566,7 +566,7 @@ Same changes as in `@mui/x-date-pickers@6.18.6`.
 - [docs] Limit `date-fns` package to v2 in codesandbox (#11478) @LukasTy
 - [test] Reload the page if its blank and there are no links to the remaining tests (#11471) @cherniavskii
 
-## 6.18.5
+## v6.18.5
 
 _Dec 14, 2023_
 
@@ -608,7 +608,7 @@ Same changes as in `@mui/x-date-pickers@6.18.5`, plus:
 - [docs] Respect GoT books (#11294) @janoma
 - [test] Fix flaky screenshots (#11391) @cherniavskii
 
-## 6.18.4
+## v6.18.4
 
 _Dec 8, 2023_
 
@@ -648,7 +648,7 @@ Same changes as in `@mui/x-date-pickers@6.18.4`.
 - [docs] Fix typo (#11323) @cadam11
 - [docs] Add FAQ page (#11347) @noraleonte
 
-## 6.18.3
+## v6.18.3
 
 _Dec 4, 2023_
 
@@ -707,7 +707,7 @@ Same changes as in `@mui/x-date-pickers@6.18.3`.
 - [docs] Improve Data Grid togglable columns example (#11241) @MBilalShafi
 - [docs] Split charts overview and getting started in distinct pages (#10910) @alexfauquette
 
-## 6.18.2
+## v6.18.2
 
 _Nov 23, 2023_
 
@@ -760,7 +760,7 @@ Same changes as in `@mui/x-date-pickers@6.18.2`.
 - [test] Skip flaky e2e test in webkit (#11115) @cherniavskii
 - [test] Wait for images to load (#11109) @cherniavskii
 
-## 6.18.1
+## v6.18.1
 
 _Nov 9, 2023_
 
@@ -818,7 +818,7 @@ Same changes as in `@mui/x-date-pickers@6.18.1`.
 - [core] Adds new alpha version to version select on the docs (#10944) @michelengelen
 - [core] Fix GitHub title tag consistency @oliviertassinari
 
-## 6.18.0
+## v6.18.0
 
 _Nov 3, 2023_
 
@@ -879,7 +879,7 @@ Same changes as in `@mui/x-date-pickers@6.18.0`.
 
 - [core] Generate `slot` API descriptions based on `slots` or `components` (#10879) @LukasTy
 
-## 6.17.0
+## v6.17.0
 
 _Oct 27, 2023_
 
@@ -945,7 +945,7 @@ No change
 
 - [test] Add missing type on `cleanText` utility function (#10780) @flaviendelangle
 
-## 6.16.3
+## v6.16.3
 
 _Oct 20, 2023_
 
@@ -1010,7 +1010,7 @@ Same changes as in `@mui/x-date-pickers@6.16.3`, plus:
 - [core] Update React renovate group with `@types` (#10723) @LukasTy
 - [core] Update `styled-components` (#10733) @LukasTy
 
-## 6.16.2
+## v6.16.2
 
 _Oct 12, 2023_
 
@@ -1115,7 +1115,7 @@ This comes with some breaking changes.
 - [test] Fix dev mode warning (#10610) @oliviertassinari
 - [test] Set UUID chance seed in visual tests (#10609) @oliviertassinari
 
-## 6.16.1
+## v6.16.1
 
 _Oct 6, 2023_
 
@@ -1175,7 +1175,7 @@ Same changes as in `@mui/x-date-pickers@6.16.1`, plus:
 - [core] Revert the link in the priority support ticket description (#10517) @michelengelen
 - [changelog] Polish image @oliviertassinari
 
-## 6.16.0
+## v6.16.0
 
 _Sep 29, 2023_
 
@@ -1259,7 +1259,7 @@ Same changes as in `@mui/x-date-pickers@6.16.0`.
 - [core] Update issue actions & templates (#10375) @romgrk
 - [core] Update release guide (#10468) @DanailH
 
-## 6.15.0
+## v6.15.0
 
 _Sep 22, 2023_
 
@@ -1342,7 +1342,7 @@ Same changes as in `@mui/x-date-pickers@6.15.0`.
 - [test] Do not use deprecated adapter methods (#10416) @flaviendelangle
 - [test] Name test suites according to sentence case (#10429) @alexfauquette
 
-## 6.14.0
+## v6.14.0
 
 _Sep 14, 2023_
 
@@ -1419,7 +1419,7 @@ Same changes as in `@mui/x-date-pickers@6.14.0`.
 - [core] Set logo height to fix layout shift in GitHub @oliviertassinari
 - [core] TrapFocus was renamed to FocusTrap @oliviertassinari
 
-## 6.13.0
+## v6.13.0
 
 _Sep 8, 2023_
 
@@ -1499,7 +1499,7 @@ Same changes as in `@mui/x-date-pickers@6.13.0`, plus:
 - [core] Prevent `e.g.` typo (#10193) @oliviertassinari
 - [core] Remove unused `babel-plugin-tester` package (#10243) @LukasTy
 
-## 6.12.1
+## v6.12.1
 
 _Aug 31, 2023_
 
@@ -1557,7 +1557,7 @@ Same changes as in `@mui/x-date-pickers@6.12.1`.
 - [core] Update babel configs (#9713) @romgrk
 - [test] Disable false positive e2e test on webkit (#10187) @LukasTy
 
-## 6.12.0
+## v6.12.0
 
 _Aug 25, 2023_
 
@@ -1624,7 +1624,7 @@ Same changes as in `@mui/x-date-pickers@6.12.0`.
 - [core] Remove outdated link (#10125) @oliviertassinari
 - [core] Update `no-response` workflow (#10102) @DanailH
 
-## 6.11.2
+## v6.11.2
 
 _Aug 17, 2023_
 
@@ -1680,7 +1680,7 @@ Same changes as in `@mui/x-date-pickers@6.11.2`.
 - [core] Set GitHub Action top level permission @oliviertassinari
 - [core] Split the pickers test utils (#9976) @flaviendelangle
 
-## 6.11.1
+## v6.11.1
 
 _Aug 11, 2023_
 
@@ -1742,7 +1742,7 @@ Same changes as in `@mui/x-date-pickers@6.11.1`.
 - [core] Port GitHub workflow for ensuring triage label is present (#9924) @DanailH
 - [docs-infra] Fix the import samples in Api pages (#9898) @alexfauquette
 
-## 6.11.0
+## v6.11.0
 
 _Aug 4, 2023_
 
@@ -1834,7 +1834,7 @@ Same changes as in `@mui/x-date-pickers@6.11.0`.
 - [test] Add pickers e2e tests (#9747) @LukasTy
 - [test] Data Grid e2e tests follow-up (#9822) @cherniavskii
 
-## 6.10.2
+## v6.10.2
 
 _Jul 27, 2023_
 
@@ -1898,7 +1898,7 @@ Same changes as in `@mui/x-date-pickers@6.10.2`.
 - [license] Only throw in dev mode (#9803) @oliviertassinari
 - [test] Fail the CI when new unexpected files are created (#9728) @oliviertassinari
 
-## 6.10.1
+## v6.10.1
 
 _Jul 20, 2023_
 
@@ -1967,7 +1967,7 @@ Same changes as in `@mui/x-date-pickers@6.10.1`.
 - [core] Add `validate` command (#9714) @romgrk
 - [changelog] Update generator to new format @oliviertassinari
 
-## 6.10.0
+## v6.10.0
 
 _Jul 13, 2023_
 
@@ -2026,7 +2026,7 @@ Same changes as in `@mui/x-date-pickers@6.10.0`.
 - [changelog] Clarify each plan (#9446) @oliviertassinari
 - [license] Fix error terminology (#9614) @oliviertassinari
 
-## 6.9.2
+## v6.9.2
 
 _Jul 6, 2023_
 
@@ -2099,7 +2099,7 @@ Same changes as in `@mui/x-date-pickers@6.9.2`.
 - [core] Fix typo in priority support @oliviertassinari
 - [core] Remove mention of Crowdin @oliviertassinari
 
-## 6.9.1
+## v6.9.1
 
 _Jun 30, 2023_
 
@@ -2176,7 +2176,7 @@ Same changes as in `@mui/x-date-pickers@6.9.1`.
 - [changelog] Remove height img attribute @oliviertassinari
 - [test] Skip flaky row pinning tests in JSDOM (#9511) @cherniavskii
 
-## 6.9.0
+## v6.9.0
 
 _Jun 22, 2023_
 
@@ -2257,7 +2257,7 @@ Same changes as in `@mui/x-date-pickers@6.9.0`.
 - [core] Move old release notes in `CHANGELOG.old.md` (#9269) @flaviendelangle
 - [core] Add priority support issue template (#8928) @DanailH
 
-## 6.8.0
+## v6.8.0
 
 _Jun 16, 2023_
 
@@ -2331,7 +2331,7 @@ Same changes as in `@mui/x-date-pickers@6.8.0`.
 - [charts] Prefix subcomponents with `Charts` (#9314) @alexfauquette
 - [license] Improve annual license expiration message (#9135) @oliviertassinari
 
-## 6.7.0
+## v6.7.0
 
 _Jun 9, 2023_
 
@@ -2418,7 +2418,7 @@ Same changes as in `@mui/x-date-pickers@6.7.0`, plus:
 - [charts] Improve axis label and ticks label alignements (#9190) @alexfauquette
 - [charts] Simplify the switch between responsive and fix dimensions (#9151) @alexfauquette
 
-## 6.6.0
+## v6.6.0
 
 _Jun 1, 2023_
 
@@ -2494,7 +2494,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [charts] Manage series stacking (#8888) @alexfauquette
 - [license] List side effects in the license package (#9092) @cherniavskii
 
-## 6.5.0
+## v6.5.0
 
 _May 19, 2023_
 
@@ -2550,7 +2550,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [DataGrid] Memoize root props for better performance (#8942) @romgrk
 - [test] Skip flaky unit tests in JSDOM (#8994) @cherniavskii
 
-## 6.4.0
+## v6.4.0
 
 _May 12, 2023_
 
@@ -2607,7 +2607,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [test] Cover row grouping regression with a unit test (#8870) @cherniavskii
 - [test] Fix flaky regression tests (#8954) @cherniavskii
 
-## 6.3.1
+## v6.3.1
 
 _May 5, 2023_
 
@@ -2653,7 +2653,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [charts] Improvement and docs on axis (#8654) @alexfauquette
 - [charts] Defaultize attributes (#8788) @alexfauquette
 
-## 6.3.0
+## v6.3.0
 
 _Apr 28, 2023_
 
@@ -2722,7 +2722,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [charts] Adapt line and scatter plot to the "band" scale type (#8701) @alexfauquette
 - [charts] Link the Gantt Charts issue in the docs (#8739) @flaviendelangle
 
-## 6.2.1
+## v6.2.1
 
 _Apr 20, 2023_
 
@@ -2770,7 +2770,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [core] Upgrade monorepo (#8668) @MBilalShafi
 - [charts] Support Tooltip (#8356) @alexfauquette
 
-## 6.2.0
+## v6.2.0
 
 _Apr 14, 2023_
 
@@ -2822,7 +2822,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [core] Upgrade monorepo (#8578) @cherniavskii
 - [core] Update last release date (#8569) @DanailH
 
-## 6.1.0
+## v6.1.0
 
 _Apr 10, 2023_
 
@@ -2880,7 +2880,7 @@ We'd like to offer a big thanks to the 15 contributors who made this release pos
 - [core] Remove legacy token (#8457) @oliviertassinari
 - [charts] Add a styling system (#8445) @alexfauquette
 
-## 6.0.4
+## v6.0.4
 
 _Mar 30, 2023_
 
@@ -2941,7 +2941,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 
 - [charts] Work on typing (#8421) @flaviendelangle
 
-## 6.0.3
+## v6.0.3
 
 _Mar 23, 2023_
 
@@ -2995,7 +2995,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [charts] Project setup (#8308) @alexfauquette
 - [test] Track visual regressions of column menu and filter/column panels (#8095) @cherniavskii
 
-## 6.0.2
+## v6.0.2
 
 _Mar 16, 2023_
 
@@ -3048,7 +3048,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [core] Regen api docs (#8220) @flaviendelangle
 - [core] Remove duplicated `/` (#8223) @alexfauquette
 
-## 6.0.1
+## v6.0.1
 
 _Mar 9, 2023_
 
@@ -3086,7 +3086,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 - [core] Upgrade monorepo (#8162) @m4theushw
 
-## 6.0.0
+## v6.0.0
 
 _Mar 3, 2023_
 
@@ -3186,7 +3186,7 @@ It can be overridden by specifying `ampmInClock` prop.
 - [core] Mention the use of Support key as an alternative to the OrderID (#6968) @joserodolfofreitas
 - [test] Fix flaky tests (#8097) @cherniavskii
 
-## 6.0.0-beta.5
+## v6.0.0-beta.5
 
 _Feb 23, 2023_
 
@@ -3240,7 +3240,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 - [core] Fix `moment` locale on adapter tests (#8020) @flaviendelangle
 - [test] Support all adapters on the field tests about the formats (#7996) @flaviendelangle
 
-## 6.0.0-beta.4
+## v6.0.0-beta.4
 
 _Feb 16, 2023_
 
@@ -3287,7 +3287,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 
 - [core] Run editing field tests on all major adapters (#7868) @flaviendelangle
 
-## 6.0.0-beta.3
+## v6.0.0-beta.3
 
 _Feb 9, 2023_
 
@@ -3346,7 +3346,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [core] Remove `tslint` package leftovers (#7841) @LukasTy
 - [test] Use `createDescribes` for `describeValue` and `describeValidation` (#7866) @flaviendelangle
 
-## 6.0.0-beta.2
+## v6.0.0-beta.2
 
 We'd like to offer a big thanks to the 11 contributors who made this release possible. Here are some highlights ✨:
 
@@ -3398,7 +3398,7 @@ We'd like to offer a big thanks to the 11 contributors who made this release pos
 - [core] Fix Next.js warning (#7754) @oliviertassinari
 - [core] Remove unused demos (#7758) @flaviendelangle
 
-## 6.0.0-beta.1
+## v6.0.0-beta.1
 
 _Jan 27, 2023_
 
@@ -3464,7 +3464,7 @@ We'd like to offer a big thanks to the 17 contributors who made this release pos
 - [core] Fix `innerslotProps` typo (#7697) @LukasTy
 - [core] Upgrade monorepo (#7676) @cherniavskii
 
-## 6.0.0-beta.0
+## v6.0.0-beta.0
 
 _Jan 19, 2023_
 
@@ -3679,7 +3679,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [core] Fix typo in `CHANGELOG` (#7611) @flaviendelangle
 - [test] Fix date range picker tests to work with western time zones (#7581) @m4theushw
 
-## 6.0.0-alpha.15
+## v6.0.0-alpha.15
 
 _Jan 13, 2023_
 
@@ -3836,7 +3836,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [core] Update package used to import LicenseInfo (#7442) @oliviertassinari
 - [test] Add a few inheritComponent (#7352) @oliviertassinari
 
-## 6.0.0-alpha.14
+## v6.0.0-alpha.14
 
 _Jan 5, 2023_
 
@@ -3915,7 +3915,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [core] Sync monorepo, fix layout scrollbar @oliviertassinari
 - [core] Upgrade monorepo (#7307) @LukasTy
 
-## 6.0.0-alpha.13
+## v6.0.0-alpha.13
 
 _Dec 24, 2022_
 
@@ -4047,7 +4047,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 
 - [core] Fix API demos callout spacing @oliviertassinari
 
-## 6.0.0-alpha.12
+## v6.0.0-alpha.12
 
 _Dec 16, 2022_
 
@@ -4119,7 +4119,7 @@ We'd like to offer a big thanks to the 6 contributors who made this release poss
 
 - [core] Fix broken test (#7179) @flaviendelangle
 
-## 6.0.0-alpha.11
+## v6.0.0-alpha.11
 
 _Dec 8, 2022_
 
@@ -4232,7 +4232,7 @@ We'd like to offer a big thanks to the 7 contributors who made this release poss
 - [core] Sync `ApiPage.js` with monorepo (#7073) @oliviertassinari
 - [test] Fix karma-mocha assertion error messages (#7054) @cherniavskii
 
-## 6.0.0-alpha.10
+## v6.0.0-alpha.10
 
 _Dec 1, 2022_
 
@@ -4324,7 +4324,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [core] Remove useless type casting in field hooks (#7045) @flaviendelangle
 - [test] Sync `test:unit` with monorepo (#6907) @oliviertassinari
 
-## 6.0.0-alpha.9
+## v6.0.0-alpha.9
 
 _Nov 24, 2022_
 
@@ -4400,7 +4400,7 @@ We'd like to offer a big thanks to the 14 contributors who made this release pos
 - [core] Upgrade ESLint (#6738) @Janpot
 - [test] Test validation on date range view (#6941) @alexfauquette
 
-## 6.0.0-alpha.8
+## v6.0.0-alpha.8
 
 _Nov 17, 2022_
 
@@ -4470,7 +4470,7 @@ We'd like to offer a big thanks to the 12 contributors who made this release pos
 - [license] Polish error messages (#6881) @oliviertassinari
 - [test] Verify `onError` call on the pickers (#6771) @alexfauquette
 
-## 6.0.0-alpha.7
+## v6.0.0-alpha.7
 
 _Nov 10, 2022_
 
@@ -4512,7 +4512,7 @@ We'd like to offer a big thanks to the 5 contributors who made this release poss
 - [core] Remove default access to GitHub action scopes @oliviertassinari
 - [test] Fix test case name: Pro-> Premium @oliviertassinari
 
-## 6.0.0-alpha.6
+## v6.0.0-alpha.6
 
 _Nov 4, 2022_
 
@@ -4564,7 +4564,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [core] Fixes for upcoming eslint upgrade (#6667) @Janpot
 - [core] Pin GitHub Action to digests (#6683) @oliviertassinari
 
-## 6.0.0-alpha.5
+## v6.0.0-alpha.5
 
 _Oct 31, 2022_
 
@@ -4683,7 +4683,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [license] Improve the license content (#6459) @oliviertassinari
 - [test] Test Arrow up/down on every token (#6563) @alexfauquette
 
-## 6.0.0-alpha.4
+## v6.0.0-alpha.4
 
 _Oct 20, 2022_
 
@@ -4813,7 +4813,7 @@ We'd like to offer a big thanks to the 9 contributors who made this release poss
 - [test] Add validation test on range pickers (#6504) @alexfauquette
 - [test] Remove BrowserStack (#6263) @DanailH
 
-## 6.0.0-alpha.3
+## v6.0.0-alpha.3
 
 _Oct 13, 2022_
 
@@ -5022,7 +5022,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [core] Test validation on textfield and date views (#6265) @alexfauquette
 - [test] Sync comment with monorepo @oliviertassinari
 
-## 6.0.0-alpha.2
+## v6.0.0-alpha.2
 
 _Oct 7, 2022_
 
@@ -5098,7 +5098,7 @@ We'd like to offer a big thanks to the 10 contributors who made this release pos
 - [test] Remove redundant test clean-ups (#6377) @oliviertassinari
 - [test] Replace `React.render` with `React.createRoot` in e2e tests (#6393) @m4theushw
 
-## 6.0.0-alpha.1
+## v6.0.0-alpha.1
 
 _Sep 29, 2022_
 
@@ -5230,7 +5230,7 @@ We'd like to offer a big thanks to the 8 contributors who made this release poss
 - [core] Simplify testing architecture (#6043) @flaviendelangle
 - [test] Skip test in Chrome non-headless and Edge (#6318) @m4theushw
 
-## 6.0.0-alpha.0
+## v6.0.0-alpha.0
 
 _Sep 22, 2022_
 

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -339,7 +339,7 @@ async function main(argv) {
   };
 
   const changelog = `
-## __VERSION__
+## v__VERSION__
 <!-- generated comparing ${lastRelease}..${release} -->
 _${nowFormatted}_
 
@@ -396,7 +396,7 @@ Same changes as in \`@mui/x-charts@__VERSION__\`${chartsProCommits.length > 0 ? 
 ${logChangelogSection(chartsProCommits)}${chartsProCommits.length > 0 ? '\n' : ''}
 ### Tree View
 ${logChangelogMessages('TreeView')}
-#### \`@mui/x-tree-view@__VERSION__\` 
+#### \`@mui/x-tree-view@__VERSION__\`
 ${logChangelogSection(treeViewProCommits) || `No changes since \`@mui/x-tree-view-pro@${lastRelease}\`.`}
 
 #### \`@mui/x-tree-view-pro@__VERSION__\` [![pro](https://mui.com/r/x-pro-svg)](https://mui.com/r/x-pro-svg-link 'Pro plan')


### PR DESCRIPTION
I was working on #16031 and need to know in which version #15521 was released to recreate a reproduction. I found no match for `#15521` in the codebase, from there I knew something was broken.

As it turned out, this was released in v8.0.0-alpha.2. Proof: nor https://github.com/mui/mui-x/releases/tag/v8.0.0-alpha.2 or #15656 has it.

As for why it happened, I guess it's because of this, see the timeline:

<img width="505" alt="SCR-20241229-oesz" src="https://github.com/user-attachments/assets/a15b63ee-a87b-488b-8149-b985a57423e7" />
<img width="657" alt="SCR-20241229-oeuk" src="https://github.com/user-attachments/assets/e714ec6a-0b81-448c-aa1f-6932bb35018c" />

---

**Edit**: Ah actually, looking at why it happened made me wonder if we didn't miss other entries in the changelog. And yes, bingo https://github.com/mui/mui-x/compare/v8.0.0-alpha.1...v8.0.0-alpha.2 PR updated.

I use the CHANGELOG.md very often to pinpoint where regressions started, I would imagine developers use the CHANGELOG.md to figure out in which version changes were released. So I think we need this to be accurate.

We could solve this at the root with: https://github.com/mui/mui-public/issues/259.

---

**Edit**: Ah the h2 version header is wrong, inconsistent with Material UI and Base UI. I have fixed it and updated the existing ones for the past, and the changelog generation script for the future.

---

**Edit**: While I was at it, I brought the least changelog from the v7.x branch.

---

**Edit**: Ah #15655 as the same issue with missing entries https://github.com/mui/mui-x/compare/v7.22.3...v7.23.0, I have brought them back here.