### PR TITLE
[pickers] Remove `NonEmptyDateRange` type

### DIFF
--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -789,6 +789,25 @@ The `TSection` generic of the `FieldRef` type has been replaced with the `TValue
 The following types are no longer exported by `@mui/x-date-pickers` and/or `@mui/x-date-pickers-pro`.
 If you were using them, you need to replace them with the following code:
 
+- `NonEmptyDateRange`
+
+  ```ts
+  // When using AdapterDayjs
+  import { Dayjs } from 'dayjs';
+  type NonEmptyDateRange = [Dayjs, Dayjs];
+
+  // When using AdapterLuxon
+  import { DateTime } from 'luxon';
+  type NonEmptyDateRange = [DateTime, DateTime];
+
+  // When using AdapterMoment, AdapterMomentJalaali or AdapterMomentHijri
+  import { Moment } from 'moment';
+  type NonEmptyDateRange = [Moment, Moment];
+
+  // When using AdapterDateFns, AdapterDateFnsV3, AdapterDateFnsJalali or AdapterDateFnsJalaliV3
+  type NonEmptyDateRange = [Date, Date];
+  ```
+
 - `UseDateFieldComponentProps`
 
   ```ts

--- a/packages/x-date-pickers-pro/src/models/range.ts
+++ b/packages/x-date-pickers-pro/src/models/range.ts
@@ -2,6 +2,3 @@ import { PickerValidDate } from '@mui/x-date-pickers/models';
 
 // Should not be used in our packages, instead use `PickerRangeValue` from the community package.
 export type DateRange<TDate extends PickerValidDate> = [TDate | null, TDate | null];
-
-// TODO v8: Remove
-export type NonEmptyDateRange = [PickerValidDate, PickerValidDate];

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.utils.ts
@@ -736,7 +736,7 @@ export const mergeDateIntoReferenceDate = (
 
 export const isAndroid = () => navigator.userAgent.toLowerCase().includes('android');
 
-// TODO v8: Remove if we drop the v6 TextField approach.
+// TODO v9: Remove
 export const getSectionOrder = (
   sections: FieldSection[],
   shouldApplyRTL: boolean,

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -243,7 +243,6 @@
   { "name": "MultiSectionDigitalClockSectionClassKey", "kind": "TypeAlias" },
   { "name": "MultiSectionDigitalClockSlotProps", "kind": "Interface" },
   { "name": "MultiSectionDigitalClockSlots", "kind": "Interface" },
-  { "name": "NonEmptyDateRange", "kind": "TypeAlias" },
   { "name": "OnErrorProps", "kind": "Interface" },
   { "name": "PickerChangeHandlerContext", "kind": "Interface" },
   { "name": "PickerChangeImportance", "kind": "TypeAlias" },


### PR DESCRIPTION
I noticed the comment asking to remove it 