### PR TITLE
[docs] Fix inconsistent multi input range field separators

### DIFF
--- a/docs/data/date-pickers/custom-field/BrowserV7MultiInputRangeField.js
+++ b/docs/data/date-pickers/custom-field/BrowserV7MultiInputRangeField.js
@@ -140,7 +140,7 @@ const BrowserMultiInputDateRangeField = React.forwardRef((props, ref) => {
       className={className}
     >
       <BrowserTextField {...fieldResponse.startDate} />
-      <span> — </span>
+      <span> – </span>
       <BrowserTextField {...fieldResponse.endDate} />
     </Stack>
   );

--- a/docs/data/date-pickers/custom-field/BrowserV7MultiInputRangeField.tsx
+++ b/docs/data/date-pickers/custom-field/BrowserV7MultiInputRangeField.tsx
@@ -179,7 +179,7 @@ const BrowserMultiInputDateRangeField = React.forwardRef(
         className={className}
       >
         <BrowserTextField {...fieldResponse.startDate} />
-        <span> — </span>
+        <span> – </span>
         <BrowserTextField {...fieldResponse.endDate} />
       </Stack>
     );

--- a/docs/data/date-pickers/custom-field/JoyV6MultiInputRangeField.js
+++ b/docs/data/date-pickers/custom-field/JoyV6MultiInputRangeField.js
@@ -91,7 +91,7 @@ const MultiInputJoyDateRangeFieldSeparator = styled(
     <FormControl>
       {/* Ensure that the separator is correctly aligned */}
       <span />
-      <Typography {...props}>{props.children ?? ' — '}</Typography>
+      <Typography {...props}>{props.children ?? ' – '}</Typography>
     </FormControl>
   ),
   {

--- a/docs/data/date-pickers/custom-field/JoyV6MultiInputRangeField.tsx
+++ b/docs/data/date-pickers/custom-field/JoyV6MultiInputRangeField.tsx
@@ -117,7 +117,7 @@ const MultiInputJoyDateRangeFieldSeparator = styled(
     <FormControl>
       {/* Ensure that the separator is correctly aligned */}
       <span />
-      <Typography {...props}>{props.children ?? ' — '}</Typography>
+      <Typography {...props}>{props.children ?? ' – '}</Typography>
     </FormControl>
   ),
   {


### PR DESCRIPTION
I noticed in #15505 that those two demos are not using the same separator as the built-in one.
I'm extracting this change to avoid Argos diffs on the main PR.