### PR TITLE
[pickers] Memoize `<PickersActionBar />`

### DIFF
--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -36,7 +36,7 @@ const PickersActionBarRoot = styled(DialogActions, {
  *
  * - [PickersActionBar API](https://mui.com/x/api/date-pickers/pickers-action-bar/)
  */
-function PickersActionBar(props: PickersActionBarProps) {
+function PickersActionBarComponent(props: PickersActionBarProps) {
   const { actions, ...other } = props;
 
   const translations = usePickerTranslations();
@@ -85,7 +85,7 @@ function PickersActionBar(props: PickersActionBarProps) {
   return <PickersActionBarRoot {...other}>{buttons}</PickersActionBarRoot>;
 }
 
-PickersActionBar.propTypes = {
+PickersActionBarComponent.propTypes = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
@@ -112,5 +112,7 @@ PickersActionBar.propTypes = {
     PropTypes.object,
   ]),
 } as any;
+
+const PickersActionBar = React.memo(PickersActionBarComponent);
 
 export { PickersActionBar };

--- a/packages/x-date-pickers/src/PickersLayout/usePickerLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/usePickerLayout.tsx
@@ -55,7 +55,11 @@ const usePickerLayout = <TValue extends PickerValidValue>(
 
   // Action bar
   const ActionBar = slots?.actionBar ?? PickersActionBar;
-  const actionBarProps = useSlotProps({
+  const {
+    // PickersActionBar does not use it and providing it breaks memoization
+    ownerState: destructuredOwnerState,
+    ...actionBarProps
+  } = useSlotProps({
     elementType: ActionBar,
     externalSlotProps: slotProps?.actionBar,
     additionalProps: {

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -252,7 +252,7 @@
   { "name": "PickerManager", "kind": "Interface" },
   { "name": "PickerOwnerState", "kind": "Interface" },
   { "name": "PickerRangeFieldSlotProps", "kind": "TypeAlias" },
-  { "name": "PickersActionBar", "kind": "Function" },
+  { "name": "PickersActionBar", "kind": "Variable" },
   { "name": "PickersActionBarAction", "kind": "TypeAlias" },
   { "name": "PickersActionBarProps", "kind": "Interface" },
   { "name": "PickersCalendarHeader", "kind": "Variable" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -167,7 +167,7 @@
   { "name": "PickerLayoutOwnerState", "kind": "Interface" },
   { "name": "PickerManager", "kind": "Interface" },
   { "name": "PickerOwnerState", "kind": "Interface" },
-  { "name": "PickersActionBar", "kind": "Function" },
+  { "name": "PickersActionBar", "kind": "Variable" },
   { "name": "PickersActionBarAction", "kind": "TypeAlias" },
   { "name": "PickersActionBarProps", "kind": "Interface" },
   { "name": "PickersCalendarHeader", "kind": "Variable" },


### PR DESCRIPTION
Follow up on https://github.com/mui/mui-x/pull/15944#discussion_r1900791135.

- Memoize `PickersActionBar`
- Stop passing `ownerState` to the slot component to avoid breaking memoization
- Add tests to ensure the optimization does not get lost among changes