### PR TITLE
[DataGridPremium] Improve aggregation performance for multiple columns

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/createAggregationLookup.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/createAggregationLookup.ts
@@ -104,11 +104,11 @@ export const createAggregationLookup = ({
   aggregationRowsScope: DataGridPremiumProcessedProps['aggregationRowsScope'];
   getAggregationPosition: DataGridPremiumProcessedProps['getAggregationPosition'];
 }): GridAggregationLookup => {
-  const aggregationRules = getAggregationRules({
-    columnsLookup: gridColumnLookupSelector(apiRef),
-    aggregationModel: gridAggregationModelSelector(apiRef),
+  const aggregationRules = getAggregationRules(
+    gridColumnLookupSelector(apiRef),
+    gridAggregationModelSelector(apiRef),
     aggregationFunctions,
-  });
+  );
 
   const aggregatedFields = Object.keys(aggregationRules);
   if (aggregatedFields.length === 0) {

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/createAggregationLookup.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/createAggregationLookup.ts
@@ -19,21 +19,14 @@ import {
 import { getAggregationRules } from './gridAggregationUtils';
 import { gridAggregationModelSelector } from './gridAggregationSelectors';
 
-const getGroupAggregatedValue = ({
-  groupId,
-  apiRef,
-  aggregationRowsScope,
-  aggregatedFields,
-  aggregationRules,
-  position,
-}: {
-  groupId: GridRowId;
-  apiRef: React.MutableRefObject<GridApiPremium>;
-  aggregationRowsScope: DataGridPremiumProcessedProps['aggregationRowsScope'];
-  aggregatedFields: string[];
-  aggregationRules: GridAggregationRules;
-  position: GridAggregationPosition;
-}) => {
+const getGroupAggregatedValue = (
+  groupId: GridRowId,
+  apiRef: React.MutableRefObject<GridApiPremium>,
+  aggregationRowsScope: DataGridPremiumProcessedProps['aggregationRowsScope'],
+  aggregatedFields: string[],
+  aggregationRules: GridAggregationRules,
+  position: GridAggregationPosition,
+) => {
   const groupAggregationLookup: GridAggregationLookup[GridRowId] = {};
   const aggregatedValues: { aggregatedField: string; values: any[] }[] = [];
 
@@ -139,14 +132,14 @@ export const createAggregationLookup = ({
     if (hasAggregableChildren) {
       const position = getAggregationPosition(groupNode);
       if (position != null) {
-        aggregationLookup[groupNode.id] = getGroupAggregatedValue({
-          groupId: groupNode.id,
+        aggregationLookup[groupNode.id] = getGroupAggregatedValue(
+          groupNode.id,
           apiRef,
-          aggregatedFields,
           aggregationRowsScope,
+          aggregatedFields,
           aggregationRules,
           position,
-        });
+        );
       }
     }
   };

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/createAggregationLookup.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/createAggregationLookup.ts
@@ -19,23 +19,27 @@ import {
 import { getAggregationRules } from './gridAggregationUtils';
 import { gridAggregationModelSelector } from './gridAggregationSelectors';
 
-const getAggregationCellValue = ({
-  apiRef,
+const getGroupAggregatedValue = ({
   groupId,
-  field,
-  aggregationFunction,
+  apiRef,
   aggregationRowsScope,
+  aggregatedFields,
+  aggregationRules,
+  position,
 }: {
-  apiRef: React.MutableRefObject<GridApiPremium>;
   groupId: GridRowId;
-  field: string;
-  aggregationFunction: GridAggregationFunction;
+  apiRef: React.MutableRefObject<GridApiPremium>;
   aggregationRowsScope: DataGridPremiumProcessedProps['aggregationRowsScope'];
+  aggregatedFields: string[];
+  aggregationRules: GridAggregationRules;
+  position: GridAggregationPosition;
 }) => {
-  const filteredRowsLookup = gridFilteredRowsLookupSelector(apiRef);
-  const rowIds: GridRowId[] = apiRef.current.getRowGroupChildren({ groupId });
+  const groupAggregationLookup: GridAggregationLookup[GridRowId] = {};
+  const aggregatedValues: { aggregatedField: string; values: any[] }[] = [];
 
-  const values: any[] = [];
+  const rowIds = apiRef.current.getRowGroupChildren({ groupId });
+  const filteredRowsLookup = gridFilteredRowsLookupSelector(apiRef);
+
   rowIds.forEach((rowId) => {
     if (aggregationRowsScope === 'filtered' && filteredRowsLookup[rowId] === false) {
       return;
@@ -53,51 +57,43 @@ const getAggregationCellValue = ({
       return;
     }
 
-    if (typeof aggregationFunction.getCellValue === 'function') {
-      const row = apiRef.current.getRow(rowId);
-      values.push(aggregationFunction.getCellValue({ row }));
-    } else {
-      values.push(apiRef.current.getCellValue(rowId, field));
+    const row = apiRef.current.getRow(rowId);
+
+    for (let j = 0; j < aggregatedFields.length; j += 1) {
+      const aggregatedField = aggregatedFields[j];
+      const columnAggregationRules = aggregationRules[aggregatedField];
+
+      const aggregationFunction = columnAggregationRules.aggregationFunction;
+      const field = aggregatedField;
+
+      if (aggregatedValues[j] === undefined) {
+        aggregatedValues[j] = {
+          aggregatedField,
+          values: [],
+        };
+      }
+
+      if (typeof aggregationFunction.getCellValue === 'function') {
+        aggregatedValues[j].values.push(aggregationFunction.getCellValue({ row }));
+      } else {
+        const colDef = apiRef.current.getColumn(field);
+        aggregatedValues[j].values.push(apiRef.current.getRowValue(row, colDef));
+      }
     }
   });
 
-  return aggregationFunction.apply({
-    values,
-    groupId,
-    field, // Added per user request in https://github.com/mui/mui-x/issues/6995#issuecomment-1327423455
-  });
-};
-
-const getGroupAggregatedValue = ({
-  groupId,
-  apiRef,
-  aggregationRowsScope,
-  aggregatedFields,
-  aggregationRules,
-  position,
-}: {
-  groupId: GridRowId;
-  apiRef: React.MutableRefObject<GridApiPremium>;
-  aggregationRowsScope: DataGridPremiumProcessedProps['aggregationRowsScope'];
-  aggregatedFields: string[];
-  aggregationRules: GridAggregationRules;
-  position: GridAggregationPosition;
-}) => {
-  const groupAggregationLookup: GridAggregationLookup[GridRowId] = {};
-
-  for (let j = 0; j < aggregatedFields.length; j += 1) {
-    const aggregatedField = aggregatedFields[j];
-    const columnAggregationRules = aggregationRules[aggregatedField];
+  for (let i = 0; i < aggregatedValues.length; i += 1) {
+    const { aggregatedField, values } = aggregatedValues[i];
+    const aggregationFunction = aggregationRules[aggregatedField].aggregationFunction;
+    const value = aggregationFunction.apply({
+      values,
+      groupId,
+      field: aggregatedField, // Added per user request in https://github.com/mui/mui-x/issues/6995#issuecomment-1327423455
+    });
 
     groupAggregationLookup[aggregatedField] = {
       position,
-      value: getAggregationCellValue({
-        apiRef,
-        groupId,
-        field: aggregatedField,
-        aggregationFunction: columnAggregationRules.aggregationFunction,
-        aggregationRowsScope,
-      }),
+      value,
     };
   }
 

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
@@ -86,15 +86,11 @@ export const mergeStateWithAggregationModel =
     aggregation: { ...state.aggregation, model: aggregationModel },
   });
 
-export const getAggregationRules = ({
-  columnsLookup,
-  aggregationModel,
-  aggregationFunctions,
-}: {
-  columnsLookup: GridColumnRawLookup;
-  aggregationModel: GridAggregationModel;
-  aggregationFunctions: Record<string, GridAggregationFunction>;
-}) => {
+export const getAggregationRules = (
+  columnsLookup: GridColumnRawLookup,
+  aggregationModel: GridAggregationModel,
+  aggregationFunctions: Record<string, GridAggregationFunction>,
+) => {
   const aggregationRules: GridAggregationRules = {};
 
   // eslint-disable-next-line guard-for-in

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
@@ -94,8 +94,8 @@ export const getAggregationRules = (
   const aggregationRules: GridAggregationRules = {};
 
   // eslint-disable-next-line guard-for-in
-  for (const item in aggregationModel) {
-    const [field, columnItem] = item;
+  for (const field in aggregationModel) {
+    const columnItem = aggregationModel[field];
     if (
       columnsLookup[field] &&
       canColumnHaveAggregationFunction({

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
@@ -97,7 +97,9 @@ export const getAggregationRules = ({
 }) => {
   const aggregationRules: GridAggregationRules = {};
 
-  Object.entries(aggregationModel).forEach(([field, columnItem]) => {
+  // eslint-disable-next-line guard-for-in
+  for (const item in aggregationModel) {
+    const [field, columnItem] = item;
     if (
       columnsLookup[field] &&
       canColumnHaveAggregationFunction({
@@ -111,7 +113,7 @@ export const getAggregationRules = ({
         aggregationFunction: aggregationFunctions[columnItem],
       };
     }
-  });
+  }
 
   return aggregationRules;
 };

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts
@@ -103,11 +103,11 @@ export const useGridAggregation = (
 
     const aggregationRules = props.disableAggregation
       ? {}
-      : getAggregationRules({
-          columnsLookup: gridColumnLookupSelector(apiRef),
-          aggregationModel: gridAggregationModelSelector(apiRef),
-          aggregationFunctions: props.aggregationFunctions,
-        });
+      : getAggregationRules(
+          gridColumnLookupSelector(apiRef),
+          gridAggregationModelSelector(apiRef),
+          props.aggregationFunctions,
+        );
 
     // Re-apply the row hydration to add / remove the aggregation footers
     if (!areAggregationRulesEqual(rulesOnLastRowHydration, aggregationRules)) {

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregationPreProcessors.tsx
@@ -36,11 +36,11 @@ export const useGridAggregationPreProcessors = (
     (columnsState) => {
       const aggregationRules = props.disableAggregation
         ? {}
-        : getAggregationRules({
-            columnsLookup: columnsState.lookup,
-            aggregationModel: gridAggregationModelSelector(apiRef),
-            aggregationFunctions: props.aggregationFunctions,
-          });
+        : getAggregationRules(
+            columnsState.lookup,
+            gridAggregationModelSelector(apiRef),
+            props.aggregationFunctions,
+          );
 
       columnsState.orderedFields.forEach((field) => {
         const shouldHaveAggregationValue = !!aggregationRules[field];
@@ -76,11 +76,11 @@ export const useGridAggregationPreProcessors = (
     (value) => {
       const aggregationRules = props.disableAggregation
         ? {}
-        : getAggregationRules({
-            columnsLookup: gridColumnLookupSelector(apiRef),
-            aggregationModel: gridAggregationModelSelector(apiRef),
-            aggregationFunctions: props.aggregationFunctions,
-          });
+        : getAggregationRules(
+            gridColumnLookupSelector(apiRef),
+            gridAggregationModelSelector(apiRef),
+            props.aggregationFunctions,
+          );
 
       const hasAggregationRule = Object.keys(aggregationRules).length > 0;
 


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-x/pull/9877

## Why

Aggregation is one of the core features for pivoting. It often involves aggregating dozens of columns.
This PR improves aggregation calculation performance with row grouping and multiple aggregation rules.

## How

I've changed the way we calculate aggregation value for each row group.

**Before**

1. **Loop**: Iterate over aggregation rules (`getGroupAggregatedValue`). For each aggregation field:
	2. Get the child `rowIds` for the row group (`getRowGroupChildren`). Requires traversing the group tree.
	3. **Loop**: Iterate over child `rowIds` and calculate the aggregated value

Optimizations:
- Point 2 can be moved up to do `1 x row_group`, as opposed to `1 x row_group x aggregation_rule`.
- In the inner loop (point 3) we return early for some rows, so the outer loop iterations are unnecessary for some rows.

**After**

1. Get the child `rowIds` for the row group (`getRowGroupChildren`). Requires traversing the group tree.
2. **Loop**: Iterate over child `rowIds`. For each row:
	3. **Loop**: Iterate over aggregation rules and store row values.
4. **Loop**: Iterate over the aggregation rules and calculate the aggregated value.

## Results

| Setup | Before (median) | After (median) | Difference (%) |
| ----- | --------------- | -------------- | -------------- |
| rows: 10_000 (Commodities)<br/>row grouping: by commodity<br/>aggregation rules: 1 | 121ms | 121ms | 0% |
| rows: 10_000 (Commodities)<br/>row grouping: none<br/>aggregation rules: 1 | 91ms | 91ms | 0% |
| rows: 10_000 (Commodities)<br/>row grouping: by commodity<br/>aggregation rules: 6 | 193ms | 162ms | -16% |
| rows: 10_000 (Commodities)<br/>row grouping: by commodity<br/>aggregation rules: 10 | 300ms | 190ms | -36% |
| rows: 10_000 (Commodities)<br/>row grouping: by commodity<br/>aggregation rules: 17 | 363ms | 261ms | -28% |
| rows: 10_000 ([Column virtualization demo](https://mui.com/x/react-data-grid/virtualization/#column-virtualization))<br/>row grouping: by price1M<br/>aggregation rules: 50 | 1017ms | 548ms | -46% |

<details>
<summary>Detailed results</summary>

```yaml
rows: 10_000 (Commodities)
row grouping: by commodity
aggregation:
  {
      quantity: 'sum',
    }
scripting time:
  before:
    measurements: 120ms, 121ms, 128ms, 119ms, 122ms
    median: 121ms
  after:
    measurements: 121ms, 121ms, 123ms, 120ms, 120ms
    median: 121ms
  difference: 0%

rows: 10_000 (Commodities)
row grouping: None
aggregation:
  {
    quantity: 'sum',
  }
scripting time:
  before:
    measurements: 98ms, 86ms, 92ms, 88ms, 90ms, 93ms
    median: 91ms
  after:
    measurements: 84ms, 94ms, 92ms, 89ms, 90ms, 95ms
    median: 91ms
  difference: 0%

rows: 10_000 (Commodities)
row grouping: by commodity
aggregation:
  {
    quantity: 'sum',
    filledQuantity: 'size',
    isFilled: 'size',
    status: 'size',
    unitPrice: 'sum',
    subTotal: 'sum',
  }
scripting time:
  before:
    measurements: 193ms, 193ms, 194ms, 192ms, 194ms
    median: 193ms
  after:
    measurements: 162ms, 162ms, 162ms, 166ms, 164ms
    median: 162ms
  difference: -16%

rows: 10_000 (Commodities)
row grouping: by commodity
aggregation:
  {
    quantity: 'sum',
    filledQuantity: 'size',
    isFilled: 'size',
    status: 'size',
    unitPrice: 'sum',
    subTotal: 'sum',
    unitPriceCurrency: 'size',
    feeRate: 'sum',
    feeAmount: 'sum',
    incoTerm: 'size',
  }
scripting time:
  before:
    measurements: 363ms, 250ms, 266ms, 251ms, 346ms, 327ms, 300ms
    median: 300ms
  after:
    measurements: 186ms, 194ms, 184ms, 248ms, 213ms, 188ms, 190ms
    median: 190ms
  difference: -36%

rows: 10_000 (Commodities)
row grouping: by commodity
aggregation:
  {
    quantity: 'sum',
    filledQuantity: 'size',
    isFilled: 'size',
    status: 'size',
    unitPrice: 'sum',
    subTotal: 'sum',
    unitPriceCurrency: 'size',
    feeRate: 'sum',
    feeAmount: 'sum',
    incoTerm: 'size',
    desk: 'size',
    traderName: 'size',
    traderEmail: 'size',
    totalPrice: 'sum',
    pnl: 'sum',
    maturityDate: 'size',
    tradeDate: 'size',
  }
scripting time:
  before:
    measurements: 361ms, 365ms, 363ms, 399ms, 399ms, 331ms, 329ms
    median: 363ms
  after:
    measurements: 303ms, 236ms, 211ms, 223ms, 297ms, 261ms, 262ms
    median: 261ms
  difference: -28%

rows: 10_000 (Column virtualization demo (mui.com/x/react-data-grid/virtualization/#column-virtualization))
row grouping: by price1M
aggregation: 50 columns
  {
    price1M: 'size',
    price2M: 'size',
    price3M: 'size',
    price4M: 'size',
    price5M: 'size',
    price6M: 'size',
    price7M: 'size',
    price8M: 'size',
    price9M: 'size',
    price10M: 'size',
    price11M: 'size',
    price12M: 'size',
    price13M: 'size',
    price14M: 'size',
    price15M: 'size',
    price16M: 'size',
    price17M: 'size',
    price18M: 'size',
    price19M: 'size',
    price20M: 'size',
    price21M: 'size',
    price22M: 'size',
    price23M: 'size',
    price24M: 'size',
    price25M: 'size',
    price26M: 'size',
    price27M: 'size',
    price28M: 'size',
    price29M: 'size',
    price30M: 'size',
    price31M: 'size',
    price32M: 'size',
    price33M: 'size',
    price34M: 'size',
    price35M: 'size',
    price36M: 'size',
    price37M: 'size',
    price38M: 'size',
    price39M: 'size',
    price40M: 'size',
    price41M: 'size',
    price42M: 'size',
    price43M: 'size',
    price44M: 'size',
    price45M: 'size',
    price46M: 'size',
    price47M: 'size',
    price48M: 'size',
    price49M: 'size',
    price50M: 'size',
  }
scripting time:
  before:
    measurements: 1062ms, 1007ms, 1062ms, 1012ms, 1018ms, 994ms, 1071ms, 1037ms, 1017ms, 1010ms
    median: 1017ms
  after:
    measurements: 548ms, 548ms, 613ms, 556ms, 543ms, 536ms, 596ms, 536ms, 548ms, 573ms
    median: 548ms
  difference: -46%
```

</details>

## Demos

**Before**: https://codesandbox.io/p/sandbox/wispy-leaf-r2kpzm
**After**: https://codesandbox.io/p/sandbox/wispy-architecture-8xpsg8