### PR TITLE
[docs] Fix demo rendering issue on Codesandbox

### DIFF
--- a/docs/data/data-grid/api-object/UseGridApiRef.js
+++ b/docs/data/data-grid/api-object/UseGridApiRef.js
@@ -32,6 +32,7 @@ export default function UseGridApiRef() {
           pagination
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}
+          pageSizeOptions={[10, 25, 50, 100]}
         />
       </Box>
     </Stack>

--- a/docs/data/data-grid/api-object/UseGridApiRef.tsx
+++ b/docs/data/data-grid/api-object/UseGridApiRef.tsx
@@ -32,6 +32,7 @@ export default function UseGridApiRef() {
           pagination
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}
+          pageSizeOptions={[10, 25, 50, 100]}
         />
       </Box>
     </Stack>

--- a/docs/data/data-grid/api-object/UseGridApiRef.tsx.preview
+++ b/docs/data/data-grid/api-object/UseGridApiRef.tsx.preview
@@ -7,5 +7,6 @@
     pagination
     paginationModel={paginationModel}
     onPaginationModelChange={setPaginationModel}
+    pageSizeOptions={[10, 25, 50, 100]}
   />
 </Box>


### PR DESCRIPTION
https://mui.com/x/react-data-grid/api-object/#outside-the-data-grid does not render on Codesanbox.

Found out that the reason is missing `pageSize` in `pageSizeOptions`.

`pageSizeOptions` default is `[25, 50, 100]`. I have searched in other demos for the `paginationModel, setPaginationModel` state getter/setter and found that all other demos either have `pageSize: 25` or they add their `pageSizeOptions` values.

I have extended the default with the `pageSize` that was in the code.