### PR TITLE
[test] Fix flaky browser tests

### DIFF
--- a/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
@@ -99,13 +99,17 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
   it('should show aggregation option in the column menu', async () => {
     const { user } = render(<TestDataSourceAggregation />);
     await user.click(within(getColumnHeaderCell(0)).getByLabelText('Menu'));
-    expect(screen.queryByLabelText('Aggregation')).not.to.equal(null);
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Aggregation')).not.to.equal(null);
+    });
   });
 
   it('should not show aggregation option in the column menu when no aggregation function is defined', async () => {
     const { user } = render(<TestDataSourceAggregation aggregationFunctions={{}} />);
     await user.click(within(getColumnHeaderCell(0)).getByLabelText('Menu'));
-    expect(screen.queryByLabelText('Aggregation')).to.equal(null);
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Aggregation')).to.equal(null);
+    });
   });
 
   it('should provide the `aggregationModel` in the `getRows` params', async () => {

--- a/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
@@ -100,7 +100,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     const { user } = render(<TestDataSourceAggregation />);
     await user.click(within(getColumnHeaderCell(0)).getByLabelText('Menu'));
     await waitFor(() => {
-      expect(screen.queryByLabelText('Aggregation')).not.to.equal(null);
+      expect(screen.getByLabelText('Aggregation')).not.to.equal(null);
     });
   });
 
@@ -108,7 +108,7 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
     const { user } = render(<TestDataSourceAggregation aggregationFunctions={{}} />);
     await user.click(within(getColumnHeaderCell(0)).getByLabelText('Menu'));
     await waitFor(() => {
-      expect(screen.queryByLabelText('Aggregation')).to.equal(null);
+      expect(screen.getByLabelText('Aggregation')).to.equal(null);
     });
   });
 


### PR DESCRIPTION
Trying to fix flaky test: [\<DataGridPremium /> - Data source aggregation should show aggregation option in the column menu](https://app.circleci.com/pipelines/github/mui/mui-x/78146/workflows/aeccf30b-80fc-466f-9edf-28a8db21928d/jobs/444925?invite=true#step-106-6191_143)