### PR TITLE
[infra] Improve cherry-pick action target list

### DIFF
--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -1,11 +1,8 @@
 name: Create cherry-pick PR
 on:
   pull_request_target:
-    branches:
-      - 'next'
-      - 'v*.x'
-      - 'master'
-    types: ['closed']
+    branches: [master, next, 'v[0-9]+.x']
+    types: [closed]
 
 permissions: {}
 


### PR DESCRIPTION
This is to improve the filtering for targets. For some reason the filtering with the wildcard character was not working for version branches.

I discovered while working on this that those workflows don't use the current master branch as reference for workflow files, so each workflow needs to be present on the branch it is used. For now this only applies to the cherry-pick PR action on version branches, so a cherry-pick is needed for this PR to apply the changes to them as well.