### PR TITLE
[test] Fix console warning in the test

### DIFF
--- a/packages/x-data-grid-pro/src/tests/dataSource.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSource.DataGridPro.test.tsx
@@ -69,7 +69,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source', () => {
     const baselineProps = {
       unstable_dataSource: dataSource,
       columns: mockServer.columns,
-      initialState: { pagination: { paginationModel: { page: 0, pageSize: 10 } } },
+      initialState: { pagination: { paginationModel: { page: 0, pageSize: 10 } }, rowCount: 0 },
       disableVirtualization: true,
       pagination: true,
       pageSizeOptions: [10],


### PR DESCRIPTION
Missing `rowCount` in the initial state might be throwing warnings and breaking tests with React 18.
The [exact same test](https://github.com/mui/mui-x/blob/v8.0.0-alpha.8/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx#L85) with the `treeData` and `rowCount` in the [initial state](https://github.com/mui/mui-x/blob/v8.0.0-alpha.8/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx#L74) works just fine.