### PR TITLE
[DataGrid] Only try to mount filter button if there are filters present

### DIFF
--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderFilterIconButton.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderFilterIconButton.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses, unstable_useId as useId } from '@mui/utils';
 import { useGridSelector } from '../../hooks';
-import { gridPreferencePanelStateSelector } from '../../hooks/features/preferencesPanel/gridPreferencePanelSelector';
+import {
+  gridPreferencePanelSelectorWithLabel,
+  gridPreferencePanelStateSelector,
+} from '../../hooks/features/preferencesPanel/gridPreferencePanelSelector';
 import { GridPreferencePanelsValue } from '../../hooks/features/preferencesPanel/gridPreferencePanelsValue';
 import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
@@ -31,14 +34,31 @@ const useUtilityClasses = (ownerState: OwnerState) => {
   return composeClasses(slots, getDataGridUtilityClass, classes);
 };
 
+function GridColumnHeaderFilterIconButtonWrapped(props: ColumnHeaderFilterIconButtonProps) {
+  if (!props.counter) {
+    return null;
+  }
+  return <GridColumnHeaderFilterIconButton {...props} />;
+}
+
+GridColumnHeaderFilterIconButtonWrapped.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // | To update them edit the TypeScript types and run "pnpm proptypes"  |
+  // ----------------------------------------------------------------------
+  counter: PropTypes.number,
+  field: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+} as any;
+
 function GridColumnHeaderFilterIconButton(props: ColumnHeaderFilterIconButtonProps) {
   const { counter, field, onClick } = props;
   const apiRef = useGridApiContext();
   const rootProps = useGridRootProps();
   const ownerState = { ...props, classes: rootProps.classes };
   const classes = useUtilityClasses(ownerState);
-  const preferencePanel = useGridSelector(apiRef, gridPreferencePanelStateSelector);
   const labelId = useId();
+  const isOpen = useGridSelector(apiRef, gridPreferencePanelSelectorWithLabel, labelId);
   const panelId = useId();
 
   const toggleFilter = React.useCallback(
@@ -65,8 +85,6 @@ function GridColumnHeaderFilterIconButton(props: ColumnHeaderFilterIconButtonPro
     return null;
   }
 
-  const open = preferencePanel.open && preferencePanel.labelId === labelId;
-
   const iconButton = (
     <rootProps.slots.baseIconButton
       id={labelId}
@@ -75,8 +93,8 @@ function GridColumnHeaderFilterIconButton(props: ColumnHeaderFilterIconButtonPro
       size="small"
       tabIndex={-1}
       aria-haspopup="menu"
-      aria-expanded={open}
-      aria-controls={open ? panelId : undefined}
+      aria-expanded={isOpen}
+      aria-controls={isOpen ? panelId : undefined}
       {...rootProps.slotProps?.baseIconButton}
     >
       <rootProps.slots.columnFilteredIcon className={classes.icon} fontSize="small" />
@@ -116,4 +134,4 @@ GridColumnHeaderFilterIconButton.propTypes = {
   onClick: PropTypes.func,
 } as any;
 
-export { GridColumnHeaderFilterIconButton };
+export { GridColumnHeaderFilterIconButtonWrapped as GridColumnHeaderFilterIconButton };

--- a/packages/x-data-grid/src/hooks/features/preferencesPanel/gridPreferencePanelSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/preferencesPanel/gridPreferencePanelSelector.ts
@@ -1,6 +1,5 @@
 import { GridStateCommunity } from '../../../models/gridStateCommunity';
 import { createSelector } from '../../../utils/createSelector';
-import { GridPreferencePanelsValue } from './gridPreferencePanelsValue';
 
 export const gridPreferencePanelStateSelector = (state: GridStateCommunity) =>
   state.preferencePanel;

--- a/packages/x-data-grid/src/hooks/features/preferencesPanel/gridPreferencePanelSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/preferencesPanel/gridPreferencePanelSelector.ts
@@ -1,4 +1,17 @@
 import { GridStateCommunity } from '../../../models/gridStateCommunity';
+import { createSelector } from '../../../utils/createSelector';
+import { GridPreferencePanelsValue } from './gridPreferencePanelsValue';
 
 export const gridPreferencePanelStateSelector = (state: GridStateCommunity) =>
   state.preferencePanel;
+
+export const gridPreferencePanelSelectorWithLabel = createSelector(
+  gridPreferencePanelStateSelector,
+  (panel, labelId: string) => {
+    if (panel.open && panel.labelId === labelId) {
+      return true;
+    }
+
+    return false;
+  },
+);

--- a/packages/x-data-grid/src/hooks/features/preferencesPanel/index.ts
+++ b/packages/x-data-grid/src/hooks/features/preferencesPanel/index.ts
@@ -1,3 +1,3 @@
-export * from './gridPreferencePanelSelector';
+export { gridPreferencePanelStateSelector } from './gridPreferencePanelSelector';
 export * from './gridPreferencePanelState';
 export * from './gridPreferencePanelsValue';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As a side-note to #16257, I saw that filter buttons are unnecessarily mounted to all columns, resulting in `n = # of rendered columns` state subscriptions and re-renders whenever `preferencePanel` state is changed. Added a simple wrapper for the default implementation as well as a state selector with params. A wrapper is necessary to still allow users to mount it to every column if they wish to do so.