### PR TITLE
[docs] Fix `domainLimit` definition

### DIFF
--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -93,7 +93,7 @@ It can take 3 different values:
 
 - `"nice"` Rounds the domain at human friendly values. It's the default behavior.
 - `"strict"` Sets the domain to the min/max value to display.
-- `([minValue, maxValue]) => [min, max]` Receives the calculated extremums as parameters, and should return the axis domain.
+- `(minValue, maxValue) => { min, max }` Receives the calculated extremums as parameters, and should return the axis domain.
 
 The demo below shows different ways to set the y-axis range.
 They always display the same data, going from -15 to 92, but with different `domainLimit` settings.


### PR DESCRIPTION
Found while answering a zendesk ticket.

We update the DevEx but not the docs