### PR TITLE
[docs] Revise planned feature callouts and descriptions

### DIFF
--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -87,7 +87,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With this feature, end users would be able to expand and collapse grouped columns to toggle their visibility.
+With this feature, users would be able to expand and collapse grouped columns to toggle their visibility.
 
 ## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
@@ -96,7 +96,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With this feature, end users would be able to drag and drop grouped headers to move all grouped children at once (which is [already possible for normal columns](/x/react-data-grid/column-ordering/)).
+With this feature, users would be able to drag and drop grouped headers to move all grouped children at once (which is [already possible for normal columns](/x/react-data-grid/column-ordering/)).
 
 ## API
 

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -82,21 +82,21 @@ The demo below uses [`renderHeaderGroup`](/x/react-data-grid/column-groups/#cust
 
 ## Manage group visibility 🚧
 
-The column group should allow to switch between an extended/collapsed view which hide/show some columns.
-
 :::warning
 This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/6651) to help us prioritize it.
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
+With this feature, end users would be able to expand and collapse grouped columns to toggle their visibility.
 
-Users could drag and drop group header to move all the group children at once, [like they can already do it with normal columns](/x/react-data-grid/column-ordering/).
+## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
 :::warning
 This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/9448) to help us prioritize it.
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
+
+With this feature, end users would be able to drag and drop grouped headers to move all grouped children at once (which is [already possible for normal columns](/x/react-data-grid/column-ordering/)).
 
 ## API
 

--- a/docs/data/data-grid/column-groups/column-groups.md
+++ b/docs/data/data-grid/column-groups/column-groups.md
@@ -85,11 +85,8 @@ The demo below uses [`renderHeaderGroup`](/x/react-data-grid/column-groups/#cust
 The column group should allow to switch between an extended/collapsed view which hide/show some columns.
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #6651](https://github.com/mui/mui-x/issues/6651) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/6651) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
 ## Column group ordering [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
@@ -97,11 +94,8 @@ Don't hesitate to leave a comment on the same issue to influence what gets built
 Users could drag and drop group header to move all the group children at once, [like they can already do it with normal columns](/x/react-data-grid/column-ordering/).
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #9448](https://github.com/mui/mui-x/issues/9448) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/9448) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
 ## API

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -11,7 +11,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-Pivoting turns a column into a row, transforming its values into new columns.
+Pivoting would make it possible for users to turn a column into a row, transforming the column's values into new columns.
 
 ## API
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -4,17 +4,14 @@ title: Data Grid - Pivoting
 
 # Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🚧
 
-<p class="description">Turn a column values into columns.</p>
+<p class="description">Rearrange columns and values to view data from multiple perspectives.</p>
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #214](https://github.com/mui/mui-x/issues/214) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/214) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-Pivoting will allow you to take a columns values and turn them into columns.
+Pivoting turns a column into a row, transforming its values into new columns.
 
 ## API
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -11,7 +11,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-Pivoting would make it possible for users to turn a column into a row, transforming the column's values into new columns.
+The pivoting feature would make it possible for users to turn a column into a row, transforming the column's values into new columns.
 
 ## API
 

--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -11,7 +11,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-The pivoting feature would make it possible for users to turn a column into a row, transforming the column's values into new columns.
+With the pivoting feature, users would be able to turn a column into a row, transforming the column's values into new columns.
 
 ## API
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -391,7 +391,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With the row group panel, end users would be able to control which columns are used for grouping by dragging them inside the panel.
+With the row group panel, users would be able to control which columns are used for grouping by dragging them inside the panel.
 
 ## Full example
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -387,14 +387,11 @@ The `apiRef.current.getRowGroupChildren` method is not compatible with the [serv
 ## Row group panel 🚧
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #5235](https://github.com/mui/mui-x/issues/5235) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/5235) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With this panel, your users will be able to control which columns are used for grouping just by dragging them inside the panel.
+With the row group panel, end users will be able to control which columns are used for grouping by dragging them inside the panel.
 
 ## Full example
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -391,7 +391,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With the row group panel, end users will be able to control which columns are used for grouping by dragging them inside the panel.
+With the row group panel, end users would be able to control which columns are used for grouping by dragging them inside the panel.
 
 ## Full example
 

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -84,7 +84,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With this feature, end users would be able to reorder rows in use cases that also involve tree data and/or row grouping.
+With this feature, users would be able to reorder rows in use cases that also involve tree data and/or row grouping.
 
 ## API
 

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -77,7 +77,7 @@ This approach can also be used to change the location of the toggle column.
 For now, row reordering is disabled if sorting is applied to the Data Grid.
 :::
 
-## Reordering rows 🚧
+## Reordering with tree data and grouping 🚧
 
 :::warning
 This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/4821) to help us prioritize it.

--- a/docs/data/data-grid/row-ordering/row-ordering.md
+++ b/docs/data/data-grid/row-ordering/row-ordering.md
@@ -77,25 +77,14 @@ This approach can also be used to change the location of the toggle column.
 For now, row reordering is disabled if sorting is applied to the Data Grid.
 :::
 
-## Reordering rows with row grouping 🚧
+## Reordering rows 🚧
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #4821](https://github.com/mui/mui-x/issues/4821) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/4821) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-## Reordering rows with tree data 🚧
-
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #4821](https://github.com/mui/mui-x/issues/4821) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
-:::
+With this feature, end users would be able to reorder rows in use cases that also involve tree data and/or row grouping.
 
 ## API
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -98,7 +98,7 @@ This feature isn't available yet, but it is planned—you can 👍 upvote [this 
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-With this feature, you would able to use the `unstable_lazyLoading` flag in use cases that also involve tree data and/or row grouping.
+With this feature, you would be able to use the `unstable_lazyLoading` flag in use cases that also involve tree data and/or row grouping.
 
 ## Error handling
 

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -94,14 +94,11 @@ The demo below serves as a showcase of the behavior described above, and is not 
 ## Nested lazy loading 🚧
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #14527](https://github.com/mui/mui-x/issues/14527) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the issue to help influence what gets built—especially if you already have a use case for this feature, or if you're facing a specific pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/14527) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 
-When completed, it will be possible to use the `unstable_lazyLoading` flag in combination with [tree data](/x/react-data-grid/server-side-data/tree-data/) and [row grouping](/x/react-data-grid/server-side-data/row-grouping/).
+With this feature, you would able to use the `unstable_lazyLoading` flag in use cases that also involve tree data and/or row grouping.
 
 ## Error handling
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -114,12 +114,9 @@ See the [Validation](/x/react-date-pickers/validation/) documentation page for m
 
 ## Month Range Picker 🚧
 
-The Month Range Picker allows setting a range of months.
-
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #4995](https://github.com/mui/mui-x/issues/4995) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/4995) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
+
+The Month Range Picker would let users select a range of months.

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -115,7 +115,7 @@ See the [Validation](/x/react-date-pickers/validation/) documentation page for m
 ## Month Range Picker 🚧
 
 :::warning
-This feature isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/4995) to help us prioritize it.
+This component isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/4995) to help us prioritize it.
 Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
 

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -8,12 +8,11 @@ materialDesign: https://m2.material.io/components/date-pickers
 
 # Time Range Picker [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
-<p class="description">The Time Range Picker lets the user select a range of time.</p>
+<p class="description">The Time Range Picker lets users select a range of time values.</p>
 
 :::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #4460](https://github.com/mui/mui-x/issues/4460) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+This component isn't available yet, but it is planned—you can 👍 upvote [this GitHub issue](https://github.com/mui/mui-x/issues/4460) to help us prioritize it.
+Please don't hesitate to leave a comment there to describe your needs, especially if you have a use case we should address or you're facing specific pain points with your current solution.
 :::
+
+The Time Range Picker would let users select a range of time values.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,22 +712,6 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
 
-  packages/rsc-builder:
-    dependencies:
-      fs-extra:
-        specifier: ^11.3.0
-        version: 11.3.0
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
-    devDependencies:
-      '@types/mocha':
-        specifier: ^10.0.10
-        version: 10.0.10
-      '@types/node':
-        specifier: ^20.17.14
-        version: 20.17.14
-
   packages/x-charts:
     dependencies:
       '@babel/runtime':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,7 +712,7 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
 
-packages/rsc-builder:
+  packages/rsc-builder:
     dependencies:
       fs-extra:
         specifier: ^11.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,6 +712,22 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
 
+packages/rsc-builder:
+    dependencies:
+      fs-extra:
+        specifier: ^11.3.0
+        version: 11.3.0
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: ^20.17.14
+        version: 20.17.14
+
   packages/x-charts:
     dependencies:
       '@babel/runtime':


### PR DESCRIPTION
This PR cleans up the copy for planned feature callouts and standardizes the style and format for describing planned features: 

- callout comes first, then feature description
- "With this feature, users would be able to..."
