### PR TITLE
[data grid] Experimental touch scroll lock

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridMainContainer.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridMainContainer.tsx
@@ -20,6 +20,7 @@ const Element = styled('div', {
   overridesResolver: (props, styles) => styles.main,
 })<{ ownerState: OwnerState }>({
   flexGrow: 1,
+  flexShrink: 0,
   position: 'relative',
   overflow: 'hidden',
   display: 'flex',

--- a/packages/x-data-grid/src/components/virtualization/GridMainContainer.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridMainContainer.tsx
@@ -20,7 +20,6 @@ const Element = styled('div', {
   overridesResolver: (props, styles) => styles.main,
 })<{ ownerState: OwnerState }>({
   flexGrow: 1,
-  flexShrink: 0,
   position: 'relative',
   overflow: 'hidden',
   display: 'flex',

--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
@@ -15,7 +15,13 @@ import { DataGridProcessedProps } from '../../models/props/DataGridProps';
 
 type Position = 'vertical' | 'horizontal';
 type OwnerState = DataGridProcessedProps;
-type GridVirtualScrollbarProps = { position: Position };
+type GridVirtualScrollbarProps = {
+  position: Position;
+  scrollPosition: React.RefObject<{
+    left: number;
+    top: number;
+  }>;
+};
 
 const useUtilityClasses = (ownerState: OwnerState, position: Position) => {
   const { classes } = ownerState;
@@ -83,6 +89,7 @@ const GridVirtualScrollbar = forwardRef<HTMLDivElement, GridVirtualScrollbarProp
 
     const propertyDimension = props.position === 'vertical' ? 'height' : 'width';
     const propertyScroll = props.position === 'vertical' ? 'scrollTop' : 'scrollLeft';
+    const propertyScrollPosition = props.position === 'vertical' ? 'top' : 'left';
     const hasScroll = props.position === 'vertical' ? dimensions.hasScrollX : dimensions.hasScrollY;
 
     const contentSize =
@@ -97,17 +104,18 @@ const GridVirtualScrollbar = forwardRef<HTMLDivElement, GridVirtualScrollbarProp
       scrollbarSize * (contentSize / dimensions.viewportOuterSize[propertyDimension]);
 
     const onScrollerScroll = useEventCallback(() => {
-      const scroller = apiRef.current.virtualScrollerRef.current!;
       const scrollbar = scrollbarRef.current;
+      const scrollPosition = props.scrollPosition.current;
+
       if (!scrollbar) {
         return;
       }
 
-      if (scroller[propertyScroll] === lastPosition.current) {
+      if (scrollPosition[propertyScrollPosition] === lastPosition.current) {
         return;
       }
 
-      lastPosition.current = scroller[propertyScroll];
+      lastPosition.current = scrollPosition[propertyScrollPosition];
 
       if (isLocked.current) {
         isLocked.current = false;
@@ -115,13 +123,14 @@ const GridVirtualScrollbar = forwardRef<HTMLDivElement, GridVirtualScrollbarProp
       }
       isLocked.current = true;
 
-      const value = scroller[propertyScroll] / contentSize;
+      const value = scrollPosition[propertyScrollPosition] / contentSize;
       scrollbar[propertyScroll] = value * scrollbarInnerSize;
     });
 
     const onScrollbarScroll = useEventCallback(() => {
       const scroller = apiRef.current.virtualScrollerRef.current!;
       const scrollbar = scrollbarRef.current;
+
       if (!scrollbar) {
         return;
       }
@@ -139,12 +148,12 @@ const GridVirtualScrollbar = forwardRef<HTMLDivElement, GridVirtualScrollbarProp
     useOnMount(() => {
       const scroller = apiRef.current.virtualScrollerRef.current!;
       const scrollbar = scrollbarRef.current!;
-      const options = { capture: true, passive: true };
+      const options = { passive: true };
       scroller.addEventListener('scroll', onScrollerScroll, options);
       scrollbar.addEventListener('scroll', onScrollbarScroll, options);
       return () => {
-        scroller.removeEventListener('scroll', onScrollerScroll, options);
-        scrollbar.removeEventListener('scroll', onScrollbarScroll, options);
+        scroller.removeEventListener('scroll', onScrollerScroll, options as any);
+        scrollbar.removeEventListener('scroll', onScrollbarScroll, options as any);
       };
     });
 

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -256,10 +256,10 @@ export const useGridVirtualScroller = () => {
       return undefined;
     }
 
-    const maxScrollTop = Math.round(
+    const maxScrollTop = Math.ceil(
       dimensions.minimumSize.height - dimensions.viewportOuterSize.height,
     );
-    const maxScrollLeft = Math.round(
+    const maxScrollLeft = Math.ceil(
       dimensions.minimumSize.width - dimensions.viewportOuterSize.width,
     );
 

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -266,7 +266,9 @@ export const useGridVirtualScroller = () => {
     // Clamp the scroll position to the viewport to avoid re-calculating the render context for scroll bounce
     const newScroll = {
       top: clamp(scroller.scrollTop, 0, maxScrollTop),
-      left: clamp(scroller.scrollLeft, 0, maxScrollLeft),
+      left: isRtl
+        ? clamp(scroller.scrollLeft, -maxScrollLeft, 0)
+        : clamp(scroller.scrollLeft, 0, maxScrollLeft),
     };
 
     const dx = newScroll.left - scrollPosition.current.left;

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -260,7 +260,12 @@ export const useGridVirtualScroller = () => {
       dimensions.minimumSize.height - dimensions.viewportOuterSize.height,
     );
     const maxScrollLeft = Math.ceil(
-      dimensions.minimumSize.width - dimensions.viewportOuterSize.width,
+      dimensions.minimumSize.width -
+        // TODO: remove remove pinned columns once the below gets merged:
+        // https://github.com/mui/mui-x/pull/15627
+        (dimensions.viewportInnerSize.width +
+          dimensions.leftPinnedWidth +
+          dimensions.rightPinnedWidth),
     );
 
     // Clamp the scroll position to the viewport to avoid re-calculating the render context for scroll bounce


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hacky experiment to try to solve #11230

Best solution I've found to date (but does mean side-stepping native scroll and scroll properties altogether in favour of `transform`), but it still has many rough edges:
* Breaks when switching between input devices
* Doesn't support sticky bottom rows (easy fix)
* Probably breaks with some `apiRef` methods, such as `scrollToIndexes`, etc.
* Doesn't properly support overscroll (probably an easy fix though)

More context: https://github.com/mui/mui-x/issues/11230#issuecomment-2609853528

Preview on touch device (try scrolling diagonally, and switching directions quickly): https://deploy-preview-16313--material-ui-x.netlify.app/x/react-data-grid/#pro-version