### PR TITLE
[DataGridPro] Fix the return type of `useGridApiRef` for Pro and Premium packages on React < 19

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
@@ -2,6 +2,5 @@ import { RefObject } from '@mui/x-internals/types';
 import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPremium } from '../../models/gridApiPremium';
 
-export const useGridApiRef = useCommunityGridApiRef as <
-  Api extends GridApiCommon = GridApiPremium,
->() => RefObject<Api>;
+export const useGridApiRef: <Api extends GridApiCommon = GridApiPremium>() => RefObject<Api> =
+  useCommunityGridApiRef;

--- a/packages/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
@@ -1,4 +1,7 @@
-import { useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
+import { RefObject } from '@mui/x-internals/types';
+import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPremium } from '../../models/gridApiPremium';
 
-export const useGridApiRef = useCommunityGridApiRef<GridApiPremium>;
+export const useGridApiRef = useCommunityGridApiRef as <
+  Api extends GridApiCommon = GridApiPremium,
+>() => RefObject<Api>;

--- a/packages/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
@@ -2,6 +2,5 @@ import { RefObject } from '@mui/x-internals/types';
 import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPro } from '../../models/gridApiPro';
 
-export const useGridApiRef = useCommunityGridApiRef as <
-  Api extends GridApiCommon = GridApiPro,
->() => RefObject<Api>;
+export const useGridApiRef: <Api extends GridApiCommon = GridApiPro>() => RefObject<Api> =
+  useCommunityGridApiRef;

--- a/packages/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
@@ -1,4 +1,7 @@
-import { useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
+import { RefObject } from '@mui/x-internals/types';
+import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPro } from '../../models/gridApiPro';
 
-export const useGridApiRef = useCommunityGridApiRef<GridApiPro>;
+export const useGridApiRef = useCommunityGridApiRef as <
+  Api extends GridApiCommon = GridApiPro,
+>() => RefObject<Api>;


### PR DESCRIPTION
Re-exported hook needs to be explicitly typed again to prevent type evaluation during build time to `React.RefObject`

Content of `useGridApiRef.d.ts` for the Pro package

before changes:
```typescript
import { GridApiPro } from '../../models/gridApiPro';
export declare const useGridApiRef: () => import("react").RefObject<GridApiPro>;
```

after changes:
```typescript
import { RefObject } from '@mui/x-internals/types';
import { GridApiCommon } from '@mui/x-data-grid';
import { GridApiPro } from '../../models/gridApiPro';
export declare const useGridApiRef: <Api extends GridApiCommon = GridApiPro>() => RefObject<Api>;
```
