### PR TITLE
[DataGrid] Fix order of `onClick` prop on toolbar buttons

### DIFF
--- a/packages/x-data-grid/src/components/toolbar/GridToolbarColumnsButton.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarColumnsButton.tsx
@@ -69,14 +69,15 @@ const GridToolbarColumnsButton = forwardRef<HTMLButtonElement, GridToolbarColumn
           aria-expanded={isOpen}
           aria-controls={isOpen ? columnPanelId : undefined}
           startIcon={<rootProps.slots.columnSelectorIcon />}
-          onClick={showColumns}
+          {...rootProps.slotProps?.baseButton}
+          {...buttonProps}
           onPointerUp={(event) => {
             if (preferencePanel.open) {
               event.stopPropagation();
             }
+            buttonProps.onPointerUp?.(event);
           }}
-          {...rootProps.slotProps?.baseButton}
-          {...buttonProps}
+          onClick={showColumns}
           ref={ref}
         >
           {apiRef.current.getLocaleText('toolbarColumns')}

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
@@ -119,9 +119,9 @@ const GridToolbarDensitySelector = forwardRef<HTMLButtonElement, GridToolbarDens
             aria-expanded={open}
             aria-controls={open ? densityMenuId : undefined}
             id={densityButtonId}
-            onClick={handleDensitySelectorOpen}
             {...rootProps.slotProps?.baseButton}
             {...buttonProps}
+            onClick={handleDensitySelectorOpen}
             ref={handleRef}
           >
             {apiRef.current.getLocaleText('toolbarDensity')}

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -71,9 +71,9 @@ const GridToolbarExportContainer = forwardRef<
           aria-haspopup="menu"
           aria-controls={open ? exportMenuId : undefined}
           id={exportButtonId}
-          onClick={handleMenuOpen}
           {...rootProps.slotProps?.baseButton}
           {...buttonProps}
+          onClick={handleMenuOpen}
           ref={handleRef}
         >
           {apiRef.current.getLocaleText('toolbarExport')}

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
@@ -159,14 +159,15 @@ const GridToolbarFilterButton = forwardRef<HTMLButtonElement, GridToolbarFilterB
               <rootProps.slots.openFilterButtonIcon />
             </rootProps.slots.baseBadge>
           }
+          {...rootProps.slotProps?.baseButton}
+          {...buttonProps}
           onClick={toggleFilter}
           onPointerUp={(event) => {
             if (preferencePanel.open) {
               event.stopPropagation();
             }
+            buttonProps.onPointerUp?.(event);
           }}
-          {...rootProps.slotProps?.baseButton}
-          {...buttonProps}
           ref={ref}
         >
           {apiRef.current.getLocaleText('toolbarFilters')}


### PR DESCRIPTION
Fixes #16355 

`onClick` needs to come after `{...buttonProps}` to ensure the button behavior works as expected when an `onClick` prop is passed to the toolbar button.