### PR TITLE
[DataGrid] Remove outdated warning

### DIFF
--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -5,16 +5,12 @@ import { forwardRef } from '@mui/x-internals/forwardRef';
 import { GridRoot } from '../components';
 import { useGridAriaAttributes } from '../hooks/utils/useGridAriaAttributes';
 import { useGridRowAriaAttributes } from '../hooks/features/rows/useGridRowAriaAttributes';
-import { DataGridProcessedProps, DataGridProps } from '../models/props/DataGridProps';
+import { DataGridProps } from '../models/props/DataGridProps';
 import { GridContextProvider } from '../context/GridContextProvider';
 import { useDataGridComponent } from './useDataGridComponent';
 import { useDataGridProps } from './useDataGridProps';
 import { GridValidRowModel } from '../models/gridRows';
-import {
-  PropValidator,
-  propValidatorsDataGrid,
-  validateProps,
-} from '../internals/utils/propValidation';
+import { propValidatorsDataGrid, validateProps } from '../internals/utils/propValidation';
 
 export type { GridSlotsComponent as GridSlots } from '../models';
 
@@ -24,11 +20,6 @@ const configuration = {
     useGridRowAriaAttributes,
   },
 };
-let propValidators: PropValidator<DataGridProcessedProps>[];
-
-if (process.env.NODE_ENV !== 'production') {
-  propValidators = propValidatorsDataGrid;
-}
 
 const DataGridRaw = forwardRef(function DataGrid<R extends GridValidRowModel>(
   inProps: DataGridProps<R>,
@@ -38,7 +29,7 @@ const DataGridRaw = forwardRef(function DataGrid<R extends GridValidRowModel>(
   const privateApiRef = useDataGridComponent(props.apiRef, props);
 
   if (process.env.NODE_ENV !== 'production') {
-    validateProps(props, propValidators);
+    validateProps(props, propValidatorsDataGrid);
   }
   return (
     <GridContextProvider privateApiRef={privateApiRef} configuration={configuration} props={props}>

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -27,20 +27,7 @@ const configuration = {
 let propValidators: PropValidator<DataGridProcessedProps>[];
 
 if (process.env.NODE_ENV !== 'production') {
-  propValidators = [
-    ...propValidatorsDataGrid,
-    // Only validate in MIT version
-    (props) =>
-      (props.columns &&
-        props.columns.some((column) => column.resizable) &&
-        [
-          `MUI X: \`column.resizable = true\` is not a valid prop.`,
-          'Column resizing is not available in the MIT version.',
-          '',
-          'You need to upgrade to DataGridPro or DataGridPremium component to unlock this feature.',
-        ].join('\n')) ||
-      undefined,
-  ];
+  propValidators = propValidatorsDataGrid;
 }
 
 const DataGridRaw = forwardRef(function DataGrid<R extends GridValidRowModel>(


### PR DESCRIPTION
The resizing feature was made available to community users in https://github.com/mui/mui-x/pull/12420, however, this outdated warning remains.
Noticed in https://app.circleci.com/pipelines/github/mui/mui-x/79506/workflows/aefe7b46-c0ae-4730-8f29-426877e0a865/jobs/452817