### PR TITLE
[test] Fix console warning in browser test on React 18

### DIFF
--- a/packages/x-data-grid-pro/src/tests/dataSource.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSource.DataGridPro.test.tsx
@@ -67,10 +67,10 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source', () => {
       [fetchRows],
     );
 
-    const baselineProps = {
+    const baselineProps: DataGridProProps = {
       unstable_dataSource: dataSource,
       columns: mockServer.columns,
-      initialState: { pagination: { paginationModel: { page: 0, pageSize: 10 } } },
+      initialState: { pagination: { paginationModel: { page: 0, pageSize: 10 }, rowCount: 0 } },
       disableVirtualization: true,
       pagination: true,
       pageSizeOptions: [10],


### PR DESCRIPTION
Follow-up on https://github.com/mui/mui-x/pull/16266.
Setting the `rowCount` on the expected object solves the issue.