### PR TITLE
[charts] Make `id` optional on `PieValueType` and `ScatterValueType`

### DIFF
--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -11,7 +11,8 @@ components: ScatterChart, ScatterChartPro, ScatterPlot, ChartsVoronoiHandler, Ch
 ## Basics
 
 Scatter chart series should contain a `data` property containing an array of objects.
-Those objects require `x`, `y`, and `id` properties.
+Those objects require the `x` and `y` properties.
+With an optional `id` property if more optimization is needed.
 
 {{"demo": "BasicScatter.js"}}
 
@@ -22,8 +23,8 @@ It accepts an array of objects such as `dataset={[{a: 1, b: 32, c: 873}, {a: 2, 
 
 You can reuse this data when defining the series.
 The scatter series work a bit differently than in other charts.
-You need to specify the `datasetKeys` properties which is an object that requires `x`, `y`, and `id` keys.
-With an optional `z` key if needed.
+You need to specify the `datasetKeys` properties which is an object that requires the `x` and `y` keys.
+With an optional `id` and `z` keys if needed.
 
 {{"demo": "ScatterDataset.js"}}
 

--- a/docs/pages/x/api/charts/scatter-series-type.json
+++ b/docs/pages/x/api/charts/scatter-series-type.json
@@ -10,7 +10,7 @@
     "data": { "type": { "description": "ScatterValueType[]" } },
     "datasetKeys": {
       "type": {
-        "description": "{<br />  /**<br />   * The key used to retrieve data from the dataset for the X axis.<br />   */<br />  x: string<br />  /**<br />   * The key used to retrieve data from the dataset for the Y axis.<br />   */<br />  y: string<br />  /**<br />   * The key used to retrieve data from the dataset for the Z axis.<br />   */<br />  z?: string<br />  /**<br />   * The key used to retrieve data from the dataset for the id.<br />   */<br />  id: string<br />}"
+        "description": "{<br />  /**<br />   * The key used to retrieve data from the dataset for the X axis.<br />   */<br />  x: string<br />  /**<br />   * The key used to retrieve data from the dataset for the Y axis.<br />   */<br />  y: string<br />  /**<br />   * The key used to retrieve data from the dataset for the Z axis.<br />   */<br />  z?: string<br />  /**<br />   * The key used to retrieve data from the dataset for the id.<br />   */<br />  id?: string<br />}"
       }
     },
     "disableHover": { "type": { "description": "boolean" }, "default": "false" },

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -203,7 +203,7 @@ PieArcLabelPlot.propTypes = {
       color: PropTypes.string.isRequired,
       endAngle: PropTypes.number.isRequired,
       formattedValue: PropTypes.string.isRequired,
-      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       index: PropTypes.number.isRequired,
       label: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
       labelMarkType: PropTypes.oneOf(['circle', 'line', 'square']),

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -165,7 +165,7 @@ PieArcPlot.propTypes = {
       color: PropTypes.string.isRequired,
       endAngle: PropTypes.number.isRequired,
       formattedValue: PropTypes.string.isRequired,
-      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       index: PropTypes.number.isRequired,
       label: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
       labelMarkType: PropTypes.oneOf(['circle', 'line', 'square']),

--- a/packages/x-charts/src/PieChart/dataTransform/transition.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/transition.ts
@@ -4,7 +4,7 @@ import { ValueWithHighlight } from './useTransformData';
 export const getDefaultTransitionConfig = (
   skipAnimation?: boolean,
 ): UseTransitionProps<ValueWithHighlight> => ({
-  keys: (item) => item.id,
+  keys: (item) => item.id ?? item.dataIndex,
   from: skipAnimation
     ? undefined
     : ({
@@ -67,7 +67,7 @@ export const getDefaultTransitionConfig = (
 export const getDefaultLabelTransitionConfig = (
   skipAnimation?: boolean,
 ): UseTransitionProps<ValueWithHighlight> => ({
-  keys: (item) => item.id,
+  keys: (item) => item.id ?? item.dataIndex,
   from: skipAnimation
     ? undefined
     : ({

--- a/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/useTransformData.ts
@@ -18,6 +18,7 @@ export interface AnimatedObject {
 }
 
 export interface ValueWithHighlight extends DefaultizedPieValueType, AnimatedObject {
+  dataIndex: number;
   isFaded: boolean;
   isHighlighted: boolean;
 }
@@ -77,6 +78,7 @@ export function useTransformData(
         return {
           ...item,
           ...attributesOverride,
+          dataIndex: itemIndex,
           isFaded,
           isHighlighted,
           paddingAngle,

--- a/packages/x-charts/src/PieChart/legend.ts
+++ b/packages/x-charts/src/PieChart/legend.ts
@@ -5,7 +5,7 @@ import { LegendGetter } from '../internals/plugins/models';
 const legendGetter: LegendGetter<'pie'> = (params) => {
   const { seriesOrder, series } = params;
   return seriesOrder.reduce((acc, seriesId) => {
-    series[seriesId].data.forEach((item) => {
+    series[seriesId].data.forEach((item, dataIndex) => {
       const formattedLabel = getLabel(item.label, 'legend');
 
       if (formattedLabel === undefined) {
@@ -14,11 +14,11 @@ const legendGetter: LegendGetter<'pie'> = (params) => {
 
       acc.push({
         markType: item.labelMarkType ?? series[seriesId].labelMarkType,
-        id: item.id,
+        id: item.id ?? dataIndex,
         seriesId,
         color: item.color,
         label: formattedLabel,
-        itemId: item.id,
+        itemId: item.id ?? dataIndex,
       });
     });
     return acc;

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -113,7 +113,7 @@ function Scatter(props: ScatterProps) {
     <g>
       {cleanData.map((dataPoint) => (
         <circle
-          key={dataPoint.id}
+          key={dataPoint.id ?? dataPoint.dataIndex}
           cx={0}
           cy={0}
           r={(dataPoint.isHighlighted ? 1.2 : 1) * markerSize}

--- a/packages/x-charts/src/ScatterChart/formatter.ts
+++ b/packages/x-charts/src/ScatterChart/formatter.ts
@@ -26,7 +26,7 @@ const formatter: SeriesProcessor<'scatter'> = ({ series, seriesOrder }, dataset)
               x: d[datasetKeys.x] ?? null,
               y: d[datasetKeys.y] ?? null,
               z: datasetKeys.z && d[datasetKeys.z],
-              id: d[datasetKeys.id],
+              id: datasetKeys.id && d[datasetKeys.id],
             } as ScatterValueType;
           }) ?? []);
 

--- a/packages/x-charts/src/models/seriesType/pie.ts
+++ b/packages/x-charts/src/models/seriesType/pie.ts
@@ -9,7 +9,7 @@ export type PieValueType = {
   /**
    * A unique identifier of the pie slice.
    */
-  id: PieItemId;
+  id?: PieItemId;
   value: number;
   /**
    * The label to display on the tooltip, arc, or the legend. It can be a string or a function.

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -8,7 +8,7 @@ export type ScatterValueType = {
   /**
    * A unique identifier for the scatter point
    */
-  id: string | number;
+  id?: string | number;
 };
 
 export interface ScatterSeriesType
@@ -53,7 +53,7 @@ export interface ScatterSeriesType
     /**
      * The key used to retrieve data from the dataset for the id.
      */
-    id: string;
+    id?: string;
   };
 }
 

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -8,7 +8,6 @@ import { options } from '../utils/options';
 describe('ScatterChart', () => {
   const dataLength = 800;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
-    id: i,
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
   }));

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -9,7 +9,6 @@ import { options } from '../utils/options';
 describe('ScatterChartPro', () => {
   const dataLength = 50;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
-    id: i,
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
   }));


### PR DESCRIPTION
## Changelog

- The `id` property is now optional on the `Pie` and `Scatter` data types.