### PR TITLE
[data grid] Break datasource tests

### DIFF
--- a/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/dataSourceAggregation.DataGridPremium.test.tsx
@@ -146,12 +146,13 @@ describe('<DataGridPremium /> - Data source aggregation', () => {
   });
 
   it('should derive the aggregation values using `dataSource.getAggregatedValue`', async () => {
+    const getAggregatedValue = () => 'Agg value';
     render(
       <TestDataSourceAggregation
         initialState={{
           aggregation: { model: { id: 'size' } },
         }}
-        getAggregatedValue={() => 'Agg value'}
+        getAggregatedValue={getAggregatedValue}
       />,
     );
     await waitFor(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This has been giving me so much grief – datasource tests seem invalid due to `useMockServer` returning a `fetchRows` function that is unstable under some circumstances, which makes the `unstable_dataSource` prop change, which in turn triggers a new fetch in the middle of a test. And `useMemo` calls `fetchRowsSpy.resetHistory();` every time this happens, so the `fetchRowsSpy.callCount` is inaccurate, which hides the underlying issue.

Just highlighting the issue here, if anyone wants to fix the tests – please go ahead.

Suggestion from me – memoize the `datasource` prop by default, since it's an object, it's easy to provide an unstable reference, while the use cases where this needs to change are slim to none, if I'm not mistaken?