### PR TITLE
[pickers] Do not close the picker when doing keyboard editing

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldInternalPropsWithDefaults.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldInternalPropsWithDefaults.ts
@@ -38,6 +38,7 @@ export function useFieldInternalPropsWithDefaults<TManager extends PickerAnyMana
     (newValue, ctx) => {
       return setValue?.(newValue, {
         validationError: ctx.validationError,
+        shouldClose: false,
       });
     },
     [setValue],

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.ts
@@ -145,6 +145,7 @@ export const usePickerValue = <
       skipPublicationIfPristine = false,
       validationError,
       shortcut,
+      shouldClose = changeImportance === 'accept',
     } = options ?? {};
 
     let shouldPublish: boolean;
@@ -193,7 +194,7 @@ export const usePickerValue = <
       onAccept(newValue, getContext());
     }
 
-    if (changeImportance === 'accept') {
+    if (shouldClose) {
       setOpen(false);
     }
   });

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePickerValue.types.ts
@@ -359,4 +359,9 @@ export interface SetValueActionOptions<TError = string | null> {
    * @default false
    */
   skipPublicationIfPristine?: boolean;
+  /**
+   * Whether the picker should close.
+   * @default changeImportance === "accept"
+   */
+  shouldClose?: boolean;
 }


### PR DESCRIPTION
Noticed this regression while working on #16175
In range picker, you can edit the field when the view is opened, and it would automatically close the view when doing it.
