### PR TITLE
[charts] Fix zoom panning

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/creatZoomLookup.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/creatZoomLookup.ts
@@ -2,14 +2,14 @@ import { AxisId, DefaultizedZoomOptions } from '@mui/x-charts/internals';
 import { AxisConfig, ChartsXAxisProps, ChartsYAxisProps, ScaleName } from '@mui/x-charts/models';
 import { defaultizeZoom } from './defaultizeZoom';
 
-export const creatZoomLookup = (
-  axes: AxisConfig<ScaleName, any, ChartsXAxisProps | ChartsYAxisProps>[],
-) =>
-  axes.reduce<Record<AxisId, DefaultizedZoomOptions>>((acc, v) => {
-    const { zoom, id: axisId } = v;
-    const defaultizedZoom = defaultizeZoom(zoom, axisId, 'x');
-    if (defaultizedZoom) {
-      acc[axisId] = defaultizedZoom;
-    }
-    return acc;
-  }, {});
+export const creatZoomLookup =
+  (axisDirection: 'x' | 'y') =>
+  (axes: AxisConfig<ScaleName, any, ChartsXAxisProps | ChartsYAxisProps>[]) =>
+    axes.reduce<Record<AxisId, DefaultizedZoomOptions>>((acc, v) => {
+      const { zoom, id: axisId } = v;
+      const defaultizedZoom = defaultizeZoom(zoom, axisId, axisDirection);
+      if (defaultizedZoom) {
+        acc[axisId] = defaultizedZoom;
+      }
+      return acc;
+    }, {});

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.selectors.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.selectors.ts
@@ -10,9 +10,9 @@ import { creatZoomLookup } from './creatZoomLookup';
 export const selectorChartZoomState: ChartRootSelector<UseChartProZoomSignature> = (state) =>
   state.zoom;
 
-const selectorChartXZoomOptionsLookup = createSelector(selectorChartRawXAxis, creatZoomLookup);
+const selectorChartXZoomOptionsLookup = createSelector(selectorChartRawXAxis, creatZoomLookup('x'));
 
-const selectorChartYZoomOptionsLookup = createSelector(selectorChartRawYAxis, creatZoomLookup);
+const selectorChartYZoomOptionsLookup = createSelector(selectorChartRawYAxis, creatZoomLookup('y'));
 
 export const selectorChartZoomOptionsLookup = createSelector(
   [selectorChartXZoomOptionsLookup, selectorChartYZoomOptionsLookup],

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -373,8 +373,8 @@ useChartProZoom.params = {
 
 useChartProZoom.getDefaultizedParams = ({ params }) => {
   const optionsLookup = {
-    ...creatZoomLookup(params.defaultizedXAxis),
-    ...creatZoomLookup(params.defaultizedYAxis),
+    ...creatZoomLookup('x')(params.defaultizedXAxis),
+    ...creatZoomLookup('y')(params.defaultizedYAxis),
   };
 
   return {


### PR DESCRIPTION
Panning along x/y was buggy because all zoom option was associated to the x direction 🙈