### PR TITLE
[code-infra] Ignore renovate updates for `react-docgen` package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,11 @@
       "allowedVersions": "< 2.0.0"
     },
     {
+      "groupName": "react-docgen",
+      "matchPackageNames": ["react-docgen"],
+      "allowedVersions": "< 6.0.0"
+    },
+    {
       "groupName": "React",
       "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom"]
     },


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/pull/14438.

To avoid having stale PR and keep getting updates for newer releases until we update our docs API generation.