### PR TITLE
[DataGridPro] Fix the return type of `useGridApiContext()` for Pro and Premium packages on React < 19

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/utils/useGridApiContext.ts
+++ b/packages/x-data-grid-premium/src/hooks/utils/useGridApiContext.ts
@@ -1,4 +1,6 @@
-import { useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
+import { RefObject } from '@mui/x-internals/types';
+import { GridApiCommon, useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
 import { GridApiPremium } from '../../models/gridApiPremium';
 
-export const useGridApiContext = useCommunityGridApiContext<GridApiPremium>;
+export const useGridApiContext: <Api extends GridApiCommon = GridApiPremium>() => RefObject<Api> =
+  useCommunityGridApiContext;

--- a/packages/x-data-grid-pro/src/hooks/utils/useGridApiContext.ts
+++ b/packages/x-data-grid-pro/src/hooks/utils/useGridApiContext.ts
@@ -1,4 +1,6 @@
-import { useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
+import { RefObject } from '@mui/x-internals/types';
+import { GridApiCommon, useGridApiContext as useCommunityGridApiContext } from '@mui/x-data-grid';
 import { GridApiPro } from '../../models/gridApiPro';
 
-export const useGridApiContext = useCommunityGridApiContext<GridApiPro>;
+export const useGridApiContext: <Api extends GridApiCommon = GridApiPro>() => RefObject<Api> =
+  useCommunityGridApiContext;


### PR DESCRIPTION
Same fix that has been applied to `useGridApiRef()` in https://github.com/mui/mui-x/pull/16328