### PR TITLE
[DataGrid] Refactor: remove material MenuList import

### DIFF
--- a/packages/x-data-grid/src/components/menu/columnMenu/GridColumnMenuContainer.tsx
+++ b/packages/x-data-grid/src/components/menu/columnMenu/GridColumnMenuContainer.tsx
@@ -1,21 +1,24 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import MenuList from '@mui/material/MenuList';
 import { styled } from '@mui/material/styles';
 
 import { forwardRef } from '@mui/x-internals/forwardRef';
 import { isHideMenuKey } from '../../../utils/keyboardUtils';
-import { GridColumnMenuContainerProps } from './GridColumnMenuProps';
+import { NotRendered } from '../../../utils/assert';
 import { gridClasses } from '../../../constants/gridClasses';
+import { GridSlotProps } from '../../../models/gridSlotsComponent';
+import { useGridRootProps } from '../../../hooks/utils/useGridRootProps';
+import { GridColumnMenuContainerProps } from './GridColumnMenuProps';
 
-const StyledMenuList = styled(MenuList)(() => ({
+const StyledMenuList = styled(NotRendered<GridSlotProps['baseMenuList']>)(() => ({
   minWidth: 248,
 }));
 
 const GridColumnMenuContainer = forwardRef<HTMLUListElement, GridColumnMenuContainerProps>(
   function GridColumnMenuContainer(props, ref) {
     const { hideMenu, colDef, id, labelledby, className, children, open, ...other } = props;
+    const rootProps = useGridRootProps();
 
     const handleListKeyDown = React.useCallback(
       (event: React.KeyboardEvent) => {
@@ -31,6 +34,7 @@ const GridColumnMenuContainer = forwardRef<HTMLUListElement, GridColumnMenuConta
 
     return (
       <StyledMenuList
+        as={rootProps.slots.baseMenuList}
         id={id}
         className={clsx(gridClasses.menuList, className)}
         aria-labelledby={labelledby}


### PR DESCRIPTION
Part of the design-system agnostic work.

Missed MenuList import.