### PR TITLE
[DataGrid] Add `resetPageOnSortFilter` prop that resets the page after sorting/filtering

### DIFF
--- a/docs/data/data-grid/filtering/FilteringWithPageReset.js
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.js
@@ -17,7 +17,10 @@ export default function FilteringWithPageReset() {
         {...data}
         loading={loading}
         pagination
-        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        initialState={{
+          ...data.initialState,
+          pagination: { paginationModel: { page: 0, pageSize: 10 } },
+        }}
         pageSizeOptions={[10]}
         resetPageOnSortFilter
         slots={{ toolbar: GridToolbar }}

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.js
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+export default function FilteringWithPageReset() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Employee',
+    visibleFields: VISIBLE_FIELDS,
+    rowLength: 100,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        pagination
+        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        pageSizeOptions={[10]}
+        resetPageAfterSortingOrFiltering
+        slots={{ toolbar: GridToolbar }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.js
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.js
@@ -19,7 +19,7 @@ export default function FilteringWithPageReset() {
         pagination
         initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
         pageSizeOptions={[10]}
-        resetPageAfterSortingOrFiltering
+        resetPageOnSortFilter
         slots={{ toolbar: GridToolbar }}
       />
     </div>

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
@@ -17,7 +17,7 @@ export default function FilteringWithPageReset() {
         {...data}
         loading={loading}
         pagination
-        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        initialState={{ ...data.initialState, pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
         pageSizeOptions={[10]}
         resetPageOnSortFilter
         slots={{ toolbar: GridToolbar }}

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
@@ -17,7 +17,10 @@ export default function FilteringWithPageReset() {
         {...data}
         loading={loading}
         pagination
-        initialState={{ ...data.initialState, pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        initialState={{
+          ...data.initialState,
+          pagination: { paginationModel: { page: 0, pageSize: 10 } },
+        }}
         pageSizeOptions={[10]}
         resetPageOnSortFilter
         slots={{ toolbar: GridToolbar }}

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+export default function FilteringWithPageReset() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Employee',
+    visibleFields: VISIBLE_FIELDS,
+    rowLength: 100,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        pagination
+        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        pageSizeOptions={[10]}
+        resetPageAfterSortingOrFiltering
+        slots={{ toolbar: GridToolbar }}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx
@@ -19,7 +19,7 @@ export default function FilteringWithPageReset() {
         pagination
         initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
         pageSizeOptions={[10]}
-        resetPageAfterSortingOrFiltering
+        resetPageOnSortFilter
         slots={{ toolbar: GridToolbar }}
       />
     </div>

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx.preview
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx.preview
@@ -4,6 +4,6 @@
   pagination
   initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
   pageSizeOptions={[10]}
-  resetPageAfterSortingOrFiltering
+  resetPageOnSortFilter
   slots={{ toolbar: GridToolbar }}
 />

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx.preview
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx.preview
@@ -1,0 +1,9 @@
+<DataGrid
+  {...data}
+  loading={loading}
+  pagination
+  initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+  pageSizeOptions={[10]}
+  resetPageAfterSortingOrFiltering
+  slots={{ toolbar: GridToolbar }}
+/>

--- a/docs/data/data-grid/filtering/FilteringWithPageReset.tsx.preview
+++ b/docs/data/data-grid/filtering/FilteringWithPageReset.tsx.preview
@@ -2,7 +2,10 @@
   {...data}
   loading={loading}
   pagination
-  initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+  initialState={{
+    ...data.initialState,
+    pagination: { paginationModel: { page: 0, pageSize: 10 } },
+  }}
   pageSizeOptions={[10]}
   resetPageOnSortFilter
   slots={{ toolbar: GridToolbar }}

--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -147,6 +147,12 @@ const columns = [
 
 {{"demo": "ReadOnlyFilters.js", "bg": "inline", "defaultCodeOpen": false}}
 
+## Reset pagination
+
+By default user stays on the same page after the filter is applied, unless the new row count indicates that that page does not exist anymore. In that case, page is changed to the last page for the new row count. If you want to get the user back to the first page each time new filter is applied, use `resetPageAfterSortingOrFiltering` prop.
+
+{{"demo": "FilteringWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Ignore diacritics (accents)
 
 You can ignore diacritics (accents) when filtering the rows. See [Quick filter - Ignore diacritics (accents)](/x/react-data-grid/filtering/quick-filter/#ignore-diacritics-accents).

--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -149,8 +149,8 @@ const columns = [
 
 ## Reset page on filtering
 
-By default, the user stays on the same page after a filter is applied, unless the new row count indicates that that page doesn't exist anymore. 
-In that case, the user is sent to the last page as defined by the new row count. 
+By default, the user stays on the same page after a filter is applied, unless the new row count indicates that that page doesn't exist anymore.
+In that case, the user is sent to the last page as defined by the new row count.
 To send the user back to the first page when a new filter is applied, use the `resetPageOnSortFilter` prop.
 
 {{"demo": "FilteringWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}

--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -149,7 +149,7 @@ const columns = [
 
 ## Reset pagination
 
-By default user stays on the same page after the filter is applied, unless the new row count indicates that that page does not exist anymore. In that case, page is changed to the last page for the new row count. If you want to get the user back to the first page each time new filter is applied, use `resetPageAfterSortingOrFiltering` prop.
+By default user stays on the same page after the filter is applied, unless the new row count indicates that that page does not exist anymore. In that case, page is changed to the last page for the new row count. If you want to get the user back to the first page each time new filter is applied, use `resetPageOnSortFilter` prop.
 
 {{"demo": "FilteringWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/data/data-grid/filtering/index.md
+++ b/docs/data/data-grid/filtering/index.md
@@ -147,9 +147,11 @@ const columns = [
 
 {{"demo": "ReadOnlyFilters.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Reset pagination
+## Reset page on filtering
 
-By default user stays on the same page after the filter is applied, unless the new row count indicates that that page does not exist anymore. In that case, page is changed to the last page for the new row count. If you want to get the user back to the first page each time new filter is applied, use `resetPageOnSortFilter` prop.
+By default, the user stays on the same page after a filter is applied, unless the new row count indicates that that page doesn't exist anymore. 
+In that case, the user is sent to the last page as defined by the new row count. 
+To send the user back to the first page when a new filter is applied, use the `resetPageOnSortFilter` prop.
 
 {{"demo": "FilteringWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/data/data-grid/filtering/server-side.md
+++ b/docs/data/data-grid/filtering/server-side.md
@@ -8,7 +8,7 @@ The example below demonstrates how to achieve server-side filtering.
 
 {{"demo": "ServerFilterGrid.js", "bg": "inline"}}
 
-:::info
+:::success
 Combine server-side filtering with [Server-side sorting](/x/react-data-grid/sorting/#server-side-sorting) and [Server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since you already process the data outside of the Data Grid.
 :::
 

--- a/docs/data/data-grid/filtering/server-side.md
+++ b/docs/data/data-grid/filtering/server-side.md
@@ -9,7 +9,7 @@ The example below demonstrates how to achieve server-side filtering.
 {{"demo": "ServerFilterGrid.js", "bg": "inline"}}
 
 :::success
-Combine server-side filtering with [Server-side sorting](/x/react-data-grid/sorting/#server-side-sorting) and [Server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since you already process the data outside of the Data Grid.
+You can combine server-side filtering with [server-side sorting](/x/react-data-grid/sorting/#server-side-sorting) and [server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since it's already processed outside of the Data Grid.
 :::
 
 ## API

--- a/docs/data/data-grid/filtering/server-side.md
+++ b/docs/data/data-grid/filtering/server-side.md
@@ -8,6 +8,10 @@ The example below demonstrates how to achieve server-side filtering.
 
 {{"demo": "ServerFilterGrid.js", "bg": "inline"}}
 
+:::info
+Combine server-side filtering with [Server-side sorting](/x/react-data-grid/sorting/#server-side-sorting) and [Server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since you already process the data outside of the Data Grid.
+:::
+
 ## API
 
 - [DataGrid](/x/api/data-grid/data-grid/)

--- a/docs/data/data-grid/pagination/ServerPaginationFilterSortGrid.js
+++ b/docs/data/data-grid/pagination/ServerPaginationFilterSortGrid.js
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { createFakeServer } from '@mui/x-data-grid-generator';
+
+const SERVER_OPTIONS = {
+  useCursorPagination: false,
+};
+
+const { useQuery, ...data } = createFakeServer({}, SERVER_OPTIONS);
+
+export default function ServerPaginationFilterSortGrid() {
+  const [paginationModel, setPaginationModel] = React.useState({
+    page: 0,
+    pageSize: 5,
+  });
+  const [sortModel, setSortModel] = React.useState([]);
+  const [filterModel, setFilterModel] = React.useState({
+    items: [],
+  });
+  const queryOptions = React.useMemo(
+    () => ({ ...paginationModel, sortModel, filterModel }),
+    [paginationModel, sortModel, filterModel],
+  );
+  const { isLoading, rows, pageInfo } = useQuery(queryOptions);
+
+  // Some API clients return undefined while loading
+  // Following lines are here to prevent `rowCount` from being undefined during the loading
+  const rowCountRef = React.useRef(pageInfo?.totalRowCount || 0);
+
+  const rowCount = React.useMemo(() => {
+    if (pageInfo?.totalRowCount !== undefined) {
+      rowCountRef.current = pageInfo.totalRowCount;
+    }
+    return rowCountRef.current;
+  }, [pageInfo?.totalRowCount]);
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        rows={rows}
+        {...data}
+        rowCount={rowCount}
+        loading={isLoading}
+        pageSizeOptions={[5]}
+        paginationModel={paginationModel}
+        sortModel={sortModel}
+        filterModel={filterModel}
+        paginationMode="server"
+        sortingMode="server"
+        filterMode="server"
+        onPaginationModelChange={setPaginationModel}
+        onSortModelChange={setSortModel}
+        onFilterModelChange={setFilterModel}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/pagination/ServerPaginationFilterSortGrid.tsx
+++ b/docs/data/data-grid/pagination/ServerPaginationFilterSortGrid.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { DataGrid, GridSortModel, GridFilterModel } from '@mui/x-data-grid';
+import { createFakeServer } from '@mui/x-data-grid-generator';
+
+const SERVER_OPTIONS = {
+  useCursorPagination: false,
+};
+
+const { useQuery, ...data } = createFakeServer({}, SERVER_OPTIONS);
+
+export default function ServerPaginationFilterSortGrid() {
+  const [paginationModel, setPaginationModel] = React.useState({
+    page: 0,
+    pageSize: 5,
+  });
+  const [sortModel, setSortModel] = React.useState<GridSortModel>([]);
+  const [filterModel, setFilterModel] = React.useState<GridFilterModel>({
+    items: [],
+  });
+  const queryOptions = React.useMemo(
+    () => ({ ...paginationModel, sortModel, filterModel }),
+    [paginationModel, sortModel, filterModel],
+  );
+  const { isLoading, rows, pageInfo } = useQuery(queryOptions);
+
+  // Some API clients return undefined while loading
+  // Following lines are here to prevent `rowCount` from being undefined during the loading
+  const rowCountRef = React.useRef(pageInfo?.totalRowCount || 0);
+
+  const rowCount = React.useMemo(() => {
+    if (pageInfo?.totalRowCount !== undefined) {
+      rowCountRef.current = pageInfo.totalRowCount;
+    }
+    return rowCountRef.current;
+  }, [pageInfo?.totalRowCount]);
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        rows={rows}
+        {...data}
+        rowCount={rowCount}
+        loading={isLoading}
+        pageSizeOptions={[5]}
+        paginationModel={paginationModel}
+        sortModel={sortModel}
+        filterModel={filterModel}
+        paginationMode="server"
+        sortingMode="server"
+        filterMode="server"
+        onPaginationModelChange={setPaginationModel}
+        onSortModelChange={setSortModel}
+        onFilterModelChange={setFilterModel}
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/pagination/ServerPaginationFilterSortGrid.tsx.preview
+++ b/docs/data/data-grid/pagination/ServerPaginationFilterSortGrid.tsx.preview
@@ -1,0 +1,16 @@
+<DataGrid
+  rows={rows}
+  {...data}
+  rowCount={rowCount}
+  loading={isLoading}
+  pageSizeOptions={[5]}
+  paginationModel={paginationModel}
+  sortModel={sortModel}
+  filterModel={filterModel}
+  paginationMode="server"
+  sortingMode="server"
+  filterMode="server"
+  onPaginationModelChange={setPaginationModel}
+  onSortModelChange={setSortModel}
+  onFilterModelChange={setFilterModel}
+/>

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -103,6 +103,12 @@ By default, the pagination is handled on the client.
 This means you have to give the rows of all pages to the Data Grid.
 If your dataset is too big, and you want to fetch the pages on demand, you can use server-side pagination.
 
+:::warning
+Enabling server-side pagination means that the Data Grid is provided with the partial data. In most cases you still want to sort and filter on the whole dataset which means that you need to use [Server-side filter](/x/react-data-grid/filtering/server-side/) and [Server-side sorting](/x/react-data-grid/sorting/#server-side-sorting).
+:::
+
+{{"demo": "ServerPaginationFilterSortGrid.js", "bg": "inline"}}
+
 In general, the server-side pagination could be categorized into two types:
 
 - Index-based pagination

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -104,7 +104,7 @@ This means you have to give the rows of all pages to the Data Grid.
 If your dataset is too big, and you want to fetch the pages on demand, you can use server-side pagination.
 
 :::warning
-If you enable server-side pagination with no other server-side features, then the Data Grid will only be provided with partial data for filtering and sorting. 
+If you enable server-side pagination with no other server-side features, then the Data Grid will only be provided with partial data for filtering and sorting.
 To be able to work with the entire dataset, you must also implement [server-side filtering](/x/react-data-grid/filtering/server-side/) and [server-side sorting](/x/react-data-grid/sorting/#server-side-sorting).
 :::
 

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -104,7 +104,8 @@ This means you have to give the rows of all pages to the Data Grid.
 If your dataset is too big, and you want to fetch the pages on demand, you can use server-side pagination.
 
 :::warning
-Enabling server-side pagination means that the Data Grid is provided with the partial data. In most cases you still want to sort and filter on the whole dataset which means that you need to use [Server-side filter](/x/react-data-grid/filtering/server-side/) and [Server-side sorting](/x/react-data-grid/sorting/#server-side-sorting).
+If you enable server-side pagination with no other server-side features, then the Data Grid will only be provided with partial data for filtering and sorting. 
+To be able to work with the entire dataset, you must also implement [server-side filtering](/x/react-data-grid/filtering/server-side/) and [server-side sorting](/x/react-data-grid/sorting/#server-side-sorting).
 :::
 
 {{"demo": "ServerPaginationFilterSortGrid.js", "bg": "inline"}}

--- a/docs/data/data-grid/pagination/pagination.md
+++ b/docs/data/data-grid/pagination/pagination.md
@@ -106,6 +106,7 @@ If your dataset is too big, and you want to fetch the pages on demand, you can u
 :::warning
 If you enable server-side pagination with no other server-side features, then the Data Grid will only be provided with partial data for filtering and sorting.
 To be able to work with the entire dataset, you must also implement [server-side filtering](/x/react-data-grid/filtering/server-side/) and [server-side sorting](/x/react-data-grid/sorting/#server-side-sorting).
+The demo below does exactly that.
 :::
 
 {{"demo": "ServerPaginationFilterSortGrid.js", "bg": "inline"}}

--- a/docs/data/data-grid/sorting/SortingWithPageReset.js
+++ b/docs/data/data-grid/sorting/SortingWithPageReset.js
@@ -19,7 +19,7 @@ export default function SortingWithPageReset() {
         pagination
         pageSizeOptions={[10]}
         initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
-        resetPageAfterSortingOrFiltering
+        resetPageOnSortFilter
       />
     </div>
   );

--- a/docs/data/data-grid/sorting/SortingWithPageReset.js
+++ b/docs/data/data-grid/sorting/SortingWithPageReset.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+export default function SortingWithPageReset() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Employee',
+    visibleFields: VISIBLE_FIELDS,
+    rowLength: 100,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        pagination
+        pageSizeOptions={[10]}
+        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        resetPageAfterSortingOrFiltering
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/sorting/SortingWithPageReset.tsx
+++ b/docs/data/data-grid/sorting/SortingWithPageReset.tsx
@@ -19,7 +19,7 @@ export default function SortingWithPageReset() {
         pagination
         pageSizeOptions={[10]}
         initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
-        resetPageAfterSortingOrFiltering
+        resetPageOnSortFilter
       />
     </div>
   );

--- a/docs/data/data-grid/sorting/SortingWithPageReset.tsx
+++ b/docs/data/data-grid/sorting/SortingWithPageReset.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { useDemoData } from '@mui/x-data-grid-generator';
+
+const VISIBLE_FIELDS = ['name', 'rating', 'country', 'dateCreated', 'isAdmin'];
+
+export default function SortingWithPageReset() {
+  const { data, loading } = useDemoData({
+    dataSet: 'Employee',
+    visibleFields: VISIBLE_FIELDS,
+    rowLength: 100,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        {...data}
+        loading={loading}
+        pagination
+        pageSizeOptions={[10]}
+        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+        resetPageAfterSortingOrFiltering
+      />
+    </div>
+  );
+}

--- a/docs/data/data-grid/sorting/SortingWithPageReset.tsx.preview
+++ b/docs/data/data-grid/sorting/SortingWithPageReset.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  {...data}
+  loading={loading}
+  pagination
+  pageSizeOptions={[10]}
+  initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
+  resetPageAfterSortingOrFiltering
+/>

--- a/docs/data/data-grid/sorting/SortingWithPageReset.tsx.preview
+++ b/docs/data/data-grid/sorting/SortingWithPageReset.tsx.preview
@@ -4,5 +4,5 @@
   pagination
   pageSizeOptions={[10]}
   initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 } } }}
-  resetPageAfterSortingOrFiltering
+  resetPageOnSortFilter
 />

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -171,8 +171,8 @@ Sorting can be run server-side by setting the `sortingMode` prop to `server`, an
 
 {{"demo": "ServerSortingGrid.js", "bg": "inline"}}
 
-:::info
-Combine server-side sorting with [Server-side filtering](/x/react-data-grid/filtering/server-side/) and [Server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since you already process the data outside of the Data Grid.
+:::success
+You can combine server-side sorting with [server-side filtering](/x/react-data-grid/filtering/server-side/) and [server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since it's already processed outside of the Data Grid.
 :::
 
 ## apiRef

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -93,7 +93,7 @@ In the following demo, the `firstName` column is not sortable by the default gri
 
 ## Reset page on sorting
 
-By default, sorting does not change the current page. 
+By default, sorting does not change the current page.
 To send the user back to the first page when a new sort is applied, use the `resetPageOnSortFilter` prop.
 
 {{"demo": "SortingWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -91,6 +91,12 @@ In the following demo, the `firstName` column is not sortable by the default gri
 
 {{"demo": "ReadOnlySortingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
+## Reset pagination
+
+By default sorting does not change the current page. If you want to get the user back to the first page each time new sort is applied, use `resetPageAfterSortingOrFiltering` prop.
+
+{{"demo": "SortingWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}
+
 ## Custom comparator
 
 A comparator determines how two cell values should be sorted.

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -93,7 +93,7 @@ In the following demo, the `firstName` column is not sortable by the default gri
 
 ## Reset pagination
 
-By default sorting does not change the current page. If you want to get the user back to the first page each time new sort is applied, use `resetPageAfterSortingOrFiltering` prop.
+By default sorting does not change the current page. If you want to get the user back to the first page each time new sort is applied, use `resetPageOnSortFilter` prop.
 
 {{"demo": "SortingWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}
 
@@ -169,6 +169,10 @@ const columns: GridColDef = [
 Sorting can be run server-side by setting the `sortingMode` prop to `server`, and implementing the `onSortModelChange` handler.
 
 {{"demo": "ServerSortingGrid.js", "bg": "inline"}}
+
+:::info
+Combine server-side sorting with [Server-side filtering](/x/react-data-grid/filtering/server-side/) and [Server-side pagination](/x/react-data-grid/pagination/#server-side-pagination) to avoid fetching more data than needed, since you already process the data outside of the Data Grid.
+:::
 
 ## apiRef
 

--- a/docs/data/data-grid/sorting/sorting.md
+++ b/docs/data/data-grid/sorting/sorting.md
@@ -91,9 +91,10 @@ In the following demo, the `firstName` column is not sortable by the default gri
 
 {{"demo": "ReadOnlySortingGrid.js", "bg": "inline", "defaultCodeOpen": false}}
 
-## Reset pagination
+## Reset page on sorting
 
-By default sorting does not change the current page. If you want to get the user back to the first page each time new sort is applied, use `resetPageOnSortFilter` prop.
+By default, sorting does not change the current page. 
+To send the user back to the first page when a new sort is applied, use the `resetPageOnSortFilter` prop.
 
 {{"demo": "SortingWithPageReset.js", "bg": "inline", "defaultCodeOpen": false}}
 

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -569,7 +569,7 @@
         "returned": "Promise<R> | R"
       }
     },
-    "resetPageAfterSortingOrFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "resetPageOnSortFilter": { "type": { "name": "bool" }, "default": "false" },
     "resizeThrottleMs": { "type": { "name": "number" }, "default": "60" },
     "rowBufferPx": { "type": { "name": "number" }, "default": "150" },
     "rowCount": { "type": { "name": "number" } },

--- a/docs/pages/x/api/data-grid/data-grid-premium.json
+++ b/docs/pages/x/api/data-grid/data-grid-premium.json
@@ -569,6 +569,7 @@
         "returned": "Promise<R> | R"
       }
     },
+    "resetPageAfterSortingOrFiltering": { "type": { "name": "bool" }, "default": "false" },
     "resizeThrottleMs": { "type": { "name": "number" }, "default": "60" },
     "rowBufferPx": { "type": { "name": "number" }, "default": "150" },
     "rowCount": { "type": { "name": "number" } },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -512,6 +512,7 @@
         "returned": "Promise<R> | R"
       }
     },
+    "resetPageAfterSortingOrFiltering": { "type": { "name": "bool" }, "default": "false" },
     "resizeThrottleMs": { "type": { "name": "number" }, "default": "60" },
     "rowBufferPx": { "type": { "name": "number" }, "default": "150" },
     "rowCount": { "type": { "name": "number" } },

--- a/docs/pages/x/api/data-grid/data-grid-pro.json
+++ b/docs/pages/x/api/data-grid/data-grid-pro.json
@@ -512,7 +512,7 @@
         "returned": "Promise<R> | R"
       }
     },
-    "resetPageAfterSortingOrFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "resetPageOnSortFilter": { "type": { "name": "bool" }, "default": "false" },
     "resizeThrottleMs": { "type": { "name": "number" }, "default": "60" },
     "rowBufferPx": { "type": { "name": "number" }, "default": "150" },
     "rowCount": { "type": { "name": "number" } },

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -430,6 +430,7 @@
         "returned": "Promise<R> | R"
       }
     },
+    "resetPageAfterSortingOrFiltering": { "type": { "name": "bool" }, "default": "false" },
     "resizeThrottleMs": { "type": { "name": "number" }, "default": "60" },
     "rowBufferPx": { "type": { "name": "number" }, "default": "150" },
     "rowCount": { "type": { "name": "number" } },

--- a/docs/pages/x/api/data-grid/data-grid.json
+++ b/docs/pages/x/api/data-grid/data-grid.json
@@ -430,7 +430,7 @@
         "returned": "Promise<R> | R"
       }
     },
-    "resetPageAfterSortingOrFiltering": { "type": { "name": "bool" }, "default": "false" },
+    "resetPageOnSortFilter": { "type": { "name": "bool" }, "default": "false" },
     "resizeThrottleMs": { "type": { "name": "number" }, "default": "60" },
     "rowBufferPx": { "type": { "name": "number" }, "default": "150" },
     "rowCount": { "type": { "name": "number" } },

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -599,6 +599,9 @@
         "Promise<R> | R": "The final values to update the row."
       }
     },
+    "resetPageAfterSortingOrFiltering": {
+      "description": "If <code>true</code>, the page is set to 0 after each sorting or filtering. This prop will be removed in the next major version and resetting the page will become the default behavior."
+    },
     "resizeThrottleMs": { "description": "The milliseconds throttle delay for resizing the grid." },
     "rowBufferPx": { "description": "Row region in pixels to render before/after the viewport" },
     "rowCount": {

--- a/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
+++ b/docs/translations/api-docs/data-grid/data-grid-premium/data-grid-premium.json
@@ -599,7 +599,7 @@
         "Promise<R> | R": "The final values to update the row."
       }
     },
-    "resetPageAfterSortingOrFiltering": {
+    "resetPageOnSortFilter": {
       "description": "If <code>true</code>, the page is set to 0 after each sorting or filtering. This prop will be removed in the next major version and resetting the page will become the default behavior."
     },
     "resizeThrottleMs": { "description": "The milliseconds throttle delay for resizing the grid." },

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -545,6 +545,9 @@
         "Promise<R> | R": "The final values to update the row."
       }
     },
+    "resetPageAfterSortingOrFiltering": {
+      "description": "If <code>true</code>, the page is set to 0 after each sorting or filtering. This prop will be removed in the next major version and resetting the page will become the default behavior."
+    },
     "resizeThrottleMs": { "description": "The milliseconds throttle delay for resizing the grid." },
     "rowBufferPx": { "description": "Row region in pixels to render before/after the viewport" },
     "rowCount": {

--- a/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
+++ b/docs/translations/api-docs/data-grid/data-grid-pro/data-grid-pro.json
@@ -545,7 +545,7 @@
         "Promise<R> | R": "The final values to update the row."
       }
     },
-    "resetPageAfterSortingOrFiltering": {
+    "resetPageOnSortFilter": {
       "description": "If <code>true</code>, the page is set to 0 after each sorting or filtering. This prop will be removed in the next major version and resetting the page will become the default behavior."
     },
     "resizeThrottleMs": { "description": "The milliseconds throttle delay for resizing the grid." },

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -447,7 +447,7 @@
         "Promise<R> | R": "The final values to update the row."
       }
     },
-    "resetPageAfterSortingOrFiltering": {
+    "resetPageOnSortFilter": {
       "description": "If <code>true</code>, the page is set to 0 after each sorting or filtering. This prop will be removed in the next major version and resetting the page will become the default behavior."
     },
     "resizeThrottleMs": { "description": "The milliseconds throttle delay for resizing the grid." },

--- a/docs/translations/api-docs/data-grid/data-grid/data-grid.json
+++ b/docs/translations/api-docs/data-grid/data-grid/data-grid.json
@@ -447,6 +447,9 @@
         "Promise<R> | R": "The final values to update the row."
       }
     },
+    "resetPageAfterSortingOrFiltering": {
+      "description": "If <code>true</code>, the page is set to 0 after each sorting or filtering. This prop will be removed in the next major version and resetting the page will become the default behavior."
+    },
     "resizeThrottleMs": { "description": "The milliseconds throttle delay for resizing the grid." },
     "rowBufferPx": { "description": "Row region in pixels to render before/after the viewport" },
     "rowCount": {

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -911,7 +911,7 @@ DataGridPremiumRaw.propTypes = {
    * This prop will be removed in the next major version and resetting the page will become the default behavior.
    * @default false
    */
-  resetPageAfterSortingOrFiltering: PropTypes.bool,
+  resetPageOnSortFilter: PropTypes.bool,
   /**
    * The milliseconds throttle delay for resizing the grid.
    * @default 60

--- a/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/DataGridPremium.tsx
@@ -907,6 +907,12 @@ DataGridPremiumRaw.propTypes = {
    */
   processRowUpdate: PropTypes.func,
   /**
+   * If `true`, the page is set to 0 after each sorting or filtering.
+   * This prop will be removed in the next major version and resetting the page will become the default behavior.
+   * @default false
+   */
+  resetPageAfterSortingOrFiltering: PropTypes.bool,
+  /**
    * The milliseconds throttle delay for resizing the grid.
    * @default 60
    */

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -828,7 +828,7 @@ DataGridProRaw.propTypes = {
    * This prop will be removed in the next major version and resetting the page will become the default behavior.
    * @default false
    */
-  resetPageAfterSortingOrFiltering: PropTypes.bool,
+  resetPageOnSortFilter: PropTypes.bool,
   /**
    * The milliseconds throttle delay for resizing the grid.
    * @default 60

--- a/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/DataGridPro.tsx
@@ -824,6 +824,12 @@ DataGridProRaw.propTypes = {
    */
   processRowUpdate: PropTypes.func,
   /**
+   * If `true`, the page is set to 0 after each sorting or filtering.
+   * This prop will be removed in the next major version and resetting the page will become the default behavior.
+   * @default false
+   */
+  resetPageAfterSortingOrFiltering: PropTypes.bool,
+  /**
    * The milliseconds throttle delay for resizing the grid.
    * @default 60
    */

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -675,6 +675,12 @@ DataGridRaw.propTypes = {
    */
   processRowUpdate: PropTypes.func,
   /**
+   * If `true`, the page is set to 0 after each sorting or filtering.
+   * This prop will be removed in the next major version and resetting the page will become the default behavior.
+   * @default false
+   */
+  resetPageAfterSortingOrFiltering: PropTypes.bool,
+  /**
    * The milliseconds throttle delay for resizing the grid.
    * @default 60
    */

--- a/packages/x-data-grid/src/DataGrid/DataGrid.tsx
+++ b/packages/x-data-grid/src/DataGrid/DataGrid.tsx
@@ -679,7 +679,7 @@ DataGridRaw.propTypes = {
    * This prop will be removed in the next major version and resetting the page will become the default behavior.
    * @default false
    */
-  resetPageAfterSortingOrFiltering: PropTypes.bool,
+  resetPageOnSortFilter: PropTypes.bool,
   /**
    * The milliseconds throttle delay for resizing the grid.
    * @default 60

--- a/packages/x-data-grid/src/constants/dataGridPropsDefaultValues.ts
+++ b/packages/x-data-grid/src/constants/dataGridPropsDefaultValues.ts
@@ -44,7 +44,7 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
   pageSizeOptions: [25, 50, 100],
   pagination: false,
   paginationMode: 'client',
-  resetPageAfterSortingOrFiltering: false,
+  resetPageOnSortFilter: false,
   resizeThrottleMs: 60,
   rowBufferPx: 150,
   rowHeight: 52,

--- a/packages/x-data-grid/src/constants/dataGridPropsDefaultValues.ts
+++ b/packages/x-data-grid/src/constants/dataGridPropsDefaultValues.ts
@@ -44,6 +44,7 @@ export const DATA_GRID_PROPS_DEFAULT_VALUES: DataGridPropsWithDefaultValues = {
   pageSizeOptions: [25, 50, 100],
   pagination: false,
   paginationMode: 'client',
+  resetPageAfterSortingOrFiltering: false,
   resizeThrottleMs: 60,
   rowBufferPx: 150,
   rowHeight: 52,

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
@@ -10,7 +10,6 @@ import {
   gridFilterModelSelector,
   gridFilterActiveItemsSelector,
 } from '../filter/gridFilterSelector';
-import { getDefaultGridFilterModel } from '../filter/gridFilterState';
 import { gridDensityFactorSelector } from '../density';
 import {
   useGridLogger,
@@ -79,8 +78,10 @@ export const useGridPaginationModel = (
 ) => {
   const logger = useGridLogger(apiRef, 'useGridPaginationModel');
 
-  const previousFilterModel = React.useRef<GridFilterModel>(getDefaultGridFilterModel());
+  const filterModel = useGridSelector(apiRef, gridFilterModelSelector);
   const densityFactor = useGridSelector(apiRef, gridDensityFactorSelector);
+  const previousFilterModel = React.useRef<GridFilterModel>(filterModel);
+
   const rowHeight = Math.floor(props.rowHeight * densityFactor);
   apiRef.current.registerControlState({
     stateId: 'paginationModel',
@@ -282,7 +283,7 @@ export const useGridPaginationModel = (
     }
 
     const currentActiveFilters = {
-      ...gridFilterModelSelector(apiRef),
+      ...filterModel,
       // replace items with the active items
       items: gridFilterActiveItemsSelector(apiRef),
     };
@@ -293,7 +294,7 @@ export const useGridPaginationModel = (
 
     previousFilterModel.current = currentActiveFilters;
     apiRef.current.setPage(0);
-  }, [apiRef]);
+  }, [apiRef, filterModel]);
 
   useGridApiEventHandler(apiRef, 'viewportInnerSizeChange', handleUpdateAutoPageSize);
   useGridApiEventHandler(apiRef, 'paginationModelChange', handlePaginationModelChange);

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
@@ -278,10 +278,6 @@ export const useGridPaginationModel = (
    */
   const handleFilterModelChange = React.useCallback(() => {
     const paginationModel = gridPaginationModelSelector(apiRef);
-    if (paginationModel.page === 0) {
-      return;
-    }
-
     const currentActiveFilters = {
       ...filterModel,
       // replace items with the active items
@@ -293,7 +289,10 @@ export const useGridPaginationModel = (
     }
 
     previousFilterModel.current = currentActiveFilters;
-    apiRef.current.setPage(0);
+
+    if (paginationModel.page !== 0) {
+      apiRef.current.setPage(0);
+    }
   }, [apiRef, filterModel]);
 
   useGridApiEventHandler(apiRef, 'viewportInnerSizeChange', handleUpdateAutoPageSize);

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
@@ -77,10 +77,8 @@ export const useGridPaginationModel = (
   >,
 ) => {
   const logger = useGridLogger(apiRef, 'useGridPaginationModel');
-
-  const filterModel = useGridSelector(apiRef, gridFilterModelSelector);
   const densityFactor = useGridSelector(apiRef, gridDensityFactorSelector);
-  const previousFilterModel = React.useRef<GridFilterModel>(filterModel);
+  const previousFilterModel = React.useRef<GridFilterModel>(gridFilterModelSelector(apiRef));
 
   const rowHeight = Math.floor(props.rowHeight * densityFactor);
   apiRef.current.registerControlState({
@@ -276,24 +274,27 @@ export const useGridPaginationModel = (
    * because of and update of the operator from an item that does not have the value
    * or reseting when the filter panel is just opened
    */
-  const handleFilterModelChange = React.useCallback(() => {
-    const paginationModel = gridPaginationModelSelector(apiRef);
-    const currentActiveFilters = {
-      ...filterModel,
-      // replace items with the active items
-      items: gridFilterActiveItemsSelector(apiRef),
-    };
+  const handleFilterModelChange = React.useCallback<GridEventListener<'filterModelChange'>>(
+    (filterModel) => {
+      const paginationModel = gridPaginationModelSelector(apiRef);
+      const currentActiveFilters = {
+        ...filterModel,
+        // replace items with the active items
+        items: gridFilterActiveItemsSelector(apiRef),
+      };
 
-    if (isDeepEqual(currentActiveFilters, previousFilterModel.current)) {
-      return;
-    }
+      if (isDeepEqual(currentActiveFilters, previousFilterModel.current)) {
+        return;
+      }
 
-    previousFilterModel.current = currentActiveFilters;
+      previousFilterModel.current = currentActiveFilters;
 
-    if (paginationModel.page !== 0) {
-      apiRef.current.setPage(0);
-    }
-  }, [apiRef, filterModel]);
+      if (paginationModel.page !== 0) {
+        apiRef.current.setPage(0);
+      }
+    },
+    [apiRef],
+  );
 
   useGridApiEventHandler(apiRef, 'viewportInnerSizeChange', handleUpdateAutoPageSize);
   useGridApiEventHandler(apiRef, 'paginationModelChange', handlePaginationModelChange);

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
@@ -74,7 +74,7 @@ export const useGridPaginationModel = (
     | 'pagination'
     | 'signature'
     | 'rowHeight'
-    | 'resetPageAfterSortingOrFiltering'
+    | 'resetPageOnSortFilter'
   >,
 ) => {
   const logger = useGridLogger(apiRef, 'useGridPaginationModel');
@@ -301,12 +301,12 @@ export const useGridPaginationModel = (
   useGridApiEventHandler(
     apiRef,
     'sortModelChange',
-    runIf(props.resetPageAfterSortingOrFiltering, handleSortModelChange),
+    runIf(props.resetPageOnSortFilter, handleSortModelChange),
   );
   useGridApiEventHandler(
     apiRef,
     'filterModelChange',
-    runIf(props.resetPageAfterSortingOrFiltering, handleFilterModelChange),
+    runIf(props.resetPageOnSortFilter, handleFilterModelChange),
   );
 
   /**

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -291,7 +291,7 @@ export interface DataGridPropsWithDefaultValues<R extends GridValidRowModel = an
    * This prop will be removed in the next major version and resetting the page will become the default behavior.
    * @default false
    */
-  resetPageAfterSortingOrFiltering: boolean;
+  resetPageOnSortFilter: boolean;
   /**
    * Set of rows of type [[GridRowsProp]].
    * @default []

--- a/packages/x-data-grid/src/models/props/DataGridProps.ts
+++ b/packages/x-data-grid/src/models/props/DataGridProps.ts
@@ -287,6 +287,12 @@ export interface DataGridPropsWithDefaultValues<R extends GridValidRowModel = an
    */
   paginationMode: GridFeatureMode;
   /**
+   * If `true`, the page is set to 0 after each sorting or filtering.
+   * This prop will be removed in the next major version and resetting the page will become the default behavior.
+   * @default false
+   */
+  resetPageAfterSortingOrFiltering: boolean;
+  /**
    * Set of rows of type [[GridRowsProp]].
    * @default []
    */

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -618,8 +618,8 @@ describe('<DataGrid /> - Pagination', () => {
     });
   });
 
-  describe('resetPageAfterSortingOrFiltering prop', () => {
-    it('should reset page to 0 if sort or filter is applied and `resetPageAfterSortingOrFiltering` is `true`', () => {
+  describe('resetPageOnSortFilter prop', () => {
+    it('should reset page to 0 if sort or filter is applied and `resetPageOnSortFilter` is `true`', () => {
       const { setProps } = render(
         <BaselineTestCase
           initialState={{ pagination: { paginationModel: { page: 0, pageSize: 5 }, rowCount: 0 } }}
@@ -650,7 +650,7 @@ describe('<DataGrid /> - Pagination', () => {
 
       // enable reset
       setProps({
-        resetPageAfterSortingOrFiltering: true,
+        resetPageOnSortFilter: true,
       });
 
       act(() => {

--- a/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -2,7 +2,14 @@ import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { spy, stub, SinonStub, SinonSpy } from 'sinon';
 import { expect } from 'chai';
-import { createRenderer, fireEvent, reactMajor, screen, waitFor } from '@mui/internal-test-utils';
+import {
+  createRenderer,
+  fireEvent,
+  reactMajor,
+  screen,
+  waitFor,
+  act,
+} from '@mui/internal-test-utils';
 import {
   DataGrid,
   DataGridProps,
@@ -19,15 +26,17 @@ import { isJSDOM, describeSkipIf } from 'test/utils/skipIf';
 
 describe('<DataGrid /> - Pagination', () => {
   const { render } = createRenderer();
+  let apiRef: RefObject<GridApi | null>;
 
   function BaselineTestCase(props: Omit<DataGridProps, 'rows' | 'columns'> & { height?: number }) {
     const { height = 300, ...other } = props;
 
+    apiRef = useGridApiRef();
     const basicData = useBasicDemoData(20, 2);
 
     return (
       <div style={{ width: 300, height }}>
-        <DataGrid {...basicData} autoHeight={isJSDOM} {...other} />
+        <DataGrid {...basicData} apiRef={apiRef} autoHeight={isJSDOM} {...other} />
       </div>
     );
   }
@@ -258,18 +267,12 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     it('should throw if pageSize exceeds 100', () => {
-      let apiRef: RefObject<GridApi | null>;
-      function TestCase() {
-        apiRef = useGridApiRef();
-        return (
-          <BaselineTestCase
-            apiRef={apiRef}
-            paginationModel={{ pageSize: 1, page: 0 }}
-            pageSizeOptions={[1, 2, 101]}
-          />
-        );
-      }
-      render(<TestCase />);
+      render(
+        <BaselineTestCase
+          paginationModel={{ pageSize: 1, page: 0 }}
+          pageSizeOptions={[1, 2, 101]}
+        />,
+      );
       expect(() => apiRef.current?.setPageSize(101)).to.throw(
         /`pageSize` cannot exceed 100 in the MIT version of the DataGrid./,
       );
@@ -612,6 +615,70 @@ describe('<DataGrid /> - Pagination', () => {
       setProps({ rowCount: 4 });
       expect(getColumnValues(0)).to.deep.equal(['3']);
       expect(screen.getByText('4–4 of 4')).not.to.equal(null);
+    });
+  });
+
+  describe('resetPageAfterSortingOrFiltering prop', () => {
+    it('should reset page to 0 if sort or filter is applied and `resetPageAfterSortingOrFiltering` is `true`', () => {
+      const { setProps } = render(
+        <BaselineTestCase
+          initialState={{ pagination: { paginationModel: { page: 0, pageSize: 5 }, rowCount: 0 } }}
+          pageSizeOptions={[5]}
+        />,
+      );
+
+      act(() => {
+        apiRef.current?.setPage(1);
+      });
+      expect(apiRef.current!.state.pagination.paginationModel.page).to.equal(1);
+
+      act(() => {
+        apiRef.current?.sortColumn('id', 'desc');
+        apiRef.current?.setFilterModel({
+          items: [
+            {
+              field: 'id',
+              value: '1',
+              operator: '>=',
+            },
+          ],
+        });
+      });
+
+      // page stays the same after sorting and filtering
+      expect(apiRef.current!.state.pagination.paginationModel.page).to.equal(1);
+
+      // enable reset
+      setProps({
+        resetPageAfterSortingOrFiltering: true,
+      });
+
+      act(() => {
+        apiRef.current?.sortColumn('id', 'asc');
+      });
+      // page is reset to 0 after sorting
+      expect(apiRef.current!.state.pagination.paginationModel.page).to.equal(0);
+
+      // move to the next page again
+      act(() => {
+        apiRef.current?.setPage(1);
+      });
+      expect(apiRef.current!.state.pagination.paginationModel.page).to.equal(1);
+
+      act(() => {
+        apiRef.current?.setFilterModel({
+          items: [
+            {
+              field: 'id',
+              value: '1',
+              operator: '>=',
+            },
+          ],
+        });
+      });
+
+      // page is reset to 0 after filtering
+      expect(apiRef.current!.state.pagination.paginationModel.page).to.equal(0);
     });
   });
 


### PR DESCRIPTION
Realted to https://github.com/mui/mui-x/issues/15378

It is a first PR that will be cherry-picked to v7

https://github.com/mui/mui-x/pull/16447 will remove the prop for v8 and include migration notes

Preview
https://deploy-preview-16450--material-ui-x.netlify.app/x/react-data-grid/sorting/#reset-page-on-sorting
https://deploy-preview-16450--material-ui-x.netlify.app/x/react-data-grid/filtering/#reset-page-on-filtering