### PR TITLE
[Charts] Fix GaugeValueArc Styling Reference

### DIFF
--- a/packages/x-charts/src/Gauge/GaugeValueArc.tsx
+++ b/packages/x-charts/src/Gauge/GaugeValueArc.tsx
@@ -6,8 +6,8 @@ import { useGaugeState } from './GaugeProvider';
 
 const StyledPath = styled('path', {
   name: 'MuiGauge',
-  slot: 'ReferenceArc',
-  overridesResolver: (props, styles) => styles.referenceArc,
+  slot: 'ValueArc',
+  overridesResolver: (props, styles) => styles.valueArc,
 })(({ theme }) => ({
   fill: (theme.vars || theme).palette.primary.main,
 }));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Renames both the styling and slot element on `GaugeValueArc` class which was otherwise applying the same styling as the `GaugeReferenceArc`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
