### PR TITLE
[data grid] Fix "no rows" overlay not showing with active aggregation

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/gridAggregationUtils.ts
@@ -196,7 +196,10 @@ export const addFooterRows = ({
   };
 
   const updateRootGroupFooter = (groupNode: GridGroupNode) => {
-    const shouldHaveFooter = hasAggregationRule && getAggregationPosition(groupNode) === 'footer';
+    const shouldHaveFooter =
+      hasAggregationRule &&
+      getAggregationPosition(groupNode) === 'footer' &&
+      groupNode.children.length > 0;
 
     if (shouldHaveFooter) {
       const rowId = getAggregationFooterRowIdFromGroupId(null);

--- a/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -882,4 +882,23 @@ describe('<DataGridPremium /> - Aggregation', () => {
       });
     });
   });
+
+  describe('"no rows" overlay', () => {
+    it('should display "no rows" overlay and not show aggregation footer when there are no rows', () => {
+      render(
+        <Test
+          rows={[]}
+          initialState={{
+            aggregation: { model: { id: 'sum' } },
+          }}
+        />,
+      );
+
+      // Check for "no rows" overlay
+      expect(screen.queryByText('No rows')).not.to.equal(null);
+
+      // Ensure aggregation footer is not present
+      expect(getColumnValues(0)).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
Hides the pinned aggregation row if there aren't any values to aggregate.

**Before**

[CodeSandbox](https://codesandbox.io/p/devbox/16466-aggregation-no-rows-overaly-after-forked-7h5rgz)

<img width="1085" alt="Screenshot 2025-02-05 at 10 31 46" src="https://github.com/user-attachments/assets/63793dad-9f12-4325-a0b7-e8abe947c991" />

**After**

[CodeSandbox](https://codesandbox.io/p/sandbox/16466-after-tnvcfy)

<img width="1086" alt="Screenshot 2025-02-05 at 10 32 20" src="https://github.com/user-attachments/assets/3d865355-9eaa-48b8-b3e9-e1e8c624dec8" />

Fixes #16453