### PR TITLE
[DataGrid] Refactor: create base MenuList props

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -235,7 +235,6 @@ function GridActionsCell(props: GridActionsCellProps) {
             className={gridClasses.menuList}
             onKeyDown={handleListKeyDown}
             aria-labelledby={buttonId}
-            variant="menu"
             autoFocusItem
           >
             {menuButtons.map((button, index) =>

--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -97,7 +97,7 @@ const baseSlots: GridBaseSlots = {
   baseCircularProgress: MUICircularProgress,
   baseDivider: MUIDivider,
   baseLinearProgress: MUILinearProgress,
-  baseMenuList: MUIMenuList,
+  baseMenuList: BaseMenuList,
   baseMenuItem: BaseMenuItem,
   baseTextField: BaseTextField,
   baseFormControl: MUIFormControl,
@@ -119,6 +119,10 @@ const materialSlots: GridBaseSlots & GridIconSlotsComponent = {
 };
 
 export default materialSlots;
+
+function BaseMenuList(props: GridSlotProps['baseMenuList']) {
+  return <MUIMenuList {...props} />;
+}
 
 function BaseMenuItem(props: GridSlotProps['baseMenuItem']) {
   const { inert, iconStart, iconEnd, children, ...other } = props;

--- a/packages/x-data-grid/src/models/gridBaseSlots.ts
+++ b/packages/x-data-grid/src/models/gridBaseSlots.ts
@@ -36,7 +36,7 @@ export type IconButtonProps = Omit<ButtonProps, 'startIcon'> & {
 export type DividerProps = {};
 
 export type MenuListProps = {
-  ref?: Ref;
+  ref?: Ref<HTMLUListElement>;
   id?: string;
   className?: string;
   children?: React.ReactNode;

--- a/packages/x-data-grid/src/models/gridBaseSlots.ts
+++ b/packages/x-data-grid/src/models/gridBaseSlots.ts
@@ -36,6 +36,7 @@ export type IconButtonProps = Omit<ButtonProps, 'startIcon'> & {
 export type DividerProps = {};
 
 export type MenuListProps = {
+  ref?: Ref;
   id?: string;
   className?: string;
   children?: React.ReactNode;

--- a/packages/x-data-grid/src/models/gridBaseSlots.ts
+++ b/packages/x-data-grid/src/models/gridBaseSlots.ts
@@ -35,6 +35,15 @@ export type IconButtonProps = Omit<ButtonProps, 'startIcon'> & {
 
 export type DividerProps = {};
 
+export type MenuListProps = {
+  id?: string;
+  className?: string;
+  children?: React.ReactNode;
+  autoFocus?: boolean;
+  autoFocusItem?: boolean;
+  onKeyDown?: React.KeyboardEventHandler;
+};
+
 export type MenuItemProps = {
   autoFocus?: boolean;
   children?: React.ReactNode;

--- a/packages/x-data-grid/src/models/gridSlotsComponentsProps.ts
+++ b/packages/x-data-grid/src/models/gridSlotsComponentsProps.ts
@@ -4,7 +4,6 @@ import type { ButtonProps as MUIButtonProps } from '@mui/material/Button';
 import type { CheckboxProps } from '@mui/material/Checkbox';
 import type { CircularProgressProps as MUICircularProgressProps } from '@mui/material/CircularProgress';
 import type { LinearProgressProps as MUILinearProgressProps } from '@mui/material/LinearProgress';
-import type { MenuListProps } from '@mui/material/MenuList';
 import type { MenuItemProps as MUIMenuItemProps } from '@mui/material/MenuItem';
 import type { FormControlProps } from '@mui/material/FormControl';
 import type { SelectProps } from '@mui/material/Select';
@@ -41,6 +40,7 @@ import type {
   DividerProps,
   IconButtonProps,
   LinearProgressProps,
+  MenuListProps,
   MenuItemProps,
   SkeletonProps,
   TooltipProps,


### PR DESCRIPTION
Part of the design-system agnostic work.

Create base MenuList props. These are directly compatible with material props.
