### PR TITLE
[test] Avoid test warning when running on React 18

### DIFF
--- a/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/cellSelection.DataGridPremium.test.tsx
@@ -73,7 +73,7 @@ describe('<DataGridPremium /> - Cell selection', () => {
   it('should work with the paginated grid', () => {
     render(
       <TestDataGridSelection
-        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 3 } } }}
+        initialState={{ pagination: { paginationModel: { page: 0, pageSize: 3 }, rowCount: 4 } }}
         rowLength={30}
         pagination
         pageSizeOptions={[3]}


### PR DESCRIPTION
Avoid test failures due to a warning when running on React 18.
- https://app.circleci.com/pipelines/github/mui/mui-x/80660/workflows/2960b68a-efaa-44ad-bed2-2ac18642fbc8/jobs/459233
- https://app.circleci.com/pipelines/github/mui/mui-x/80660/workflows/2960b68a-efaa-44ad-bed2-2ac18642fbc8/jobs/459236