### PR TITLE
[charts] Remove `colors` prop from `SparkLineChart`.

### DIFF
--- a/docs/data/charts/sparkline/CustomYAxis.js
+++ b/docs/data/charts/sparkline/CustomYAxis.js
@@ -19,7 +19,7 @@ export default function CustomYAxis() {
       <Typography>Without fixed y-range</Typography>
       <Stack sx={{ width: '100%', mb: 2 }} direction="row" spacing={2}>
         <Box sx={{ flexGrow: 1 }}>
-          <SparkLineChart data={smallValues} colors={['red']} {...settings} />
+          <SparkLineChart data={smallValues} color="red" {...settings} />
         </Box>
         <Box sx={{ flexGrow: 1 }}>
           <SparkLineChart data={largeValues} {...settings} />
@@ -34,7 +34,7 @@ export default function CustomYAxis() {
               min: 0,
               max: 100,
             }}
-            colors={['red']}
+            color="red"
             {...settings}
           />
         </Box>

--- a/docs/data/charts/sparkline/CustomYAxis.tsx
+++ b/docs/data/charts/sparkline/CustomYAxis.tsx
@@ -19,7 +19,7 @@ export default function CustomYAxis() {
       <Typography>Without fixed y-range</Typography>
       <Stack sx={{ width: '100%', mb: 2 }} direction="row" spacing={2}>
         <Box sx={{ flexGrow: 1 }}>
-          <SparkLineChart data={smallValues} colors={['red']} {...settings} />
+          <SparkLineChart data={smallValues} color="red" {...settings} />
         </Box>
         <Box sx={{ flexGrow: 1 }}>
           <SparkLineChart data={largeValues} {...settings} />
@@ -34,7 +34,7 @@ export default function CustomYAxis() {
               min: 0,
               max: 100,
             }}
-            colors={['red']}
+            color="red"
             {...settings}
           />
         </Box>

--- a/docs/data/migration/migration-charts-v7/migration-charts-v7.md
+++ b/docs/data/migration/migration-charts-v7/migration-charts-v7.md
@@ -265,3 +265,14 @@ The `useSeries` hook family has been stabilized and renamed accordingly.
 +   useHeatmapSeries,
   } from '@mui/x-charts-pro/hooks';
 ```
+
+## Rename `colors` prop in `SparkLineChart`
+
+The `colors` prop in `SparkLineChart` has been renamed to `color`. It now accepts a single color or a function that returns a color.
+
+```diff
+  <SparkLineChart
+-   colors={['#000', '#fff']}
++   color="#000"
+  />
+```

--- a/docs/data/migration/migration-charts-v7/migration-charts-v7.md
+++ b/docs/data/migration/migration-charts-v7/migration-charts-v7.md
@@ -276,3 +276,11 @@ The `colors` prop in `SparkLineChart` has been renamed to `color`. It now accept
 +   color="#000"
   />
 ```
+
+We provide a codemod to fix simple cases of this change, which you can run as follows:
+
+```bash
+npx @mui/x-codemod@latest v8.0.0/charts/rename-sparkline-colors-to-color <path>
+```
+
+For more complex cases, you may need to adjust the code manually. To aid you in finding these cases, the codemod adds a comment prefixed by `mui-x-codemod`, which you can search for in your codebase.

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -9,12 +9,6 @@
       "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" },
       "default": "rainbowSurgePalette[0]"
     },
-    "colors": {
-      "type": { "name": "union", "description": "Array&lt;string&gt;<br>&#124;&nbsp;func" },
-      "default": "rainbowSurgePalette",
-      "deprecated": true,
-      "deprecationInfo": "use the <code>color</code> prop instead"
-    },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
     "height": { "type": { "name": "number" } },

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -5,7 +5,6 @@
       "description": "Set to <code>true</code> to fill spark line area. Has no effect if plotType=&#39;bar&#39;."
     },
     "color": { "description": "Color used to colorize the sparkline." },
-    "colors": { "description": "Color palette used to colorize multiple series." },
     "data": { "description": "Data to plot." },
     "dataset": {
       "description": "An array of objects that can be used to populate series and axes data using their <code>dataKey</code> property."

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -35,7 +35,10 @@ export interface SparkLineChartSlotProps
     ChartsTooltipSlotProps {}
 
 export interface SparkLineChartProps
-  extends Omit<ChartContainerProps, 'series' | 'xAxis' | 'yAxis' | 'zAxis' | 'margin' | 'plugins'> {
+  extends Omit<
+    ChartContainerProps,
+    'series' | 'xAxis' | 'yAxis' | 'zAxis' | 'margin' | 'plugins' | 'colors'
+  > {
   /**
    * The xAxis configuration.
    * Notice it is a single [[AxisConfig]] object, not an array of configuration.
@@ -109,13 +112,6 @@ export interface SparkLineChartProps
   slotProps?: SparkLineChartSlotProps;
 
   /**
-   * Color palette used to colorize multiple series.
-   * @default rainbowSurgePalette
-   * @deprecated use the `color` prop instead
-   */
-  colors?: ChartContainerProps['colors'];
-
-  /**
    * Color used to colorize the sparkline.
    * @default rainbowSurgePalette[0]
    */
@@ -149,7 +145,6 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
     height,
     margin = SPARKLINE_DEFAULT_MARGIN,
     color,
-    colors: deprecatedColors,
     sx,
     showTooltip,
     showHighlight,
@@ -214,7 +209,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
           ...yAxis,
         },
       ]}
-      colors={colors ?? deprecatedColors}
+      colors={colors}
       sx={sx}
       disableAxisListener={
         (!showTooltip || slotProps?.tooltip?.trigger !== 'axis') &&
@@ -265,12 +260,6 @@ SparkLineChart.propTypes = {
    * @default rainbowSurgePalette[0]
    */
   color: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /**
-   * Color palette used to colorize multiple series.
-   * @default rainbowSurgePalette
-   * @deprecated use the `color` prop instead
-   */
-  colors: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   /**
    * @default 'linear'
    */

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -302,11 +302,11 @@ If `colors` is a function, it will be wrapped in another function that returns i
 If there are cases that the codemod cannot handle, you should see a comment with a `mui-x-codemod` prefix in the code.
 
 ```diff
-<SparkLineChart
-- colors={(mode) => (mode === 'light' ? ['black'] : ['white'])}
-+ /* mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. */
-+ color={(mode) => (mode === 'light' ? ['black'] : ['white'])}
-/>
+ <SparkLineChart
+-  colors={(mode) => (mode === 'light' ? ['black'] : ['white'])}
++  /* mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. */
++  color={(mode) => (mode === 'light' ? ['black'] : ['white'])}
+ />
 ```
 
 ### Data Grid codemods

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -279,6 +279,26 @@ Remove `unstable_` prefix from `useSeries` and `use*Series` hooks, as they have 
   } from '@mui/x-charts-pro/hooks';
 ```
 
+#### `rename-sparkline-colors-to-color`
+
+Renames the `colors` prop of a `SparkLineChart` to `color` and accesses its first element.
+
+```diff
+ <SparkLineChart
+-  colors={['red']}
++  color={['red'][0]}
+ />
+```
+
+If `colors` is a function, it will be wrapped in another function that returns its first element.
+
+```diff
+ <SparkLineChart
+-  colors={fn}
++  color={typeof fn === 'function' ? mode => fn(mode)[0] : fn[0]}
+ />
+```
+
 ### Data Grid codemods
 
 #### `preset-safe` for Data Grid v8.0.0

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -286,7 +286,7 @@ Renames the `colors` prop of a `SparkLineChart` to `color` and accesses its firs
 ```diff
  <SparkLineChart
 -  colors={['red']}
-+  color={['red'][0]}
++  color={'red'}
  />
 ```
 
@@ -297,6 +297,16 @@ If `colors` is a function, it will be wrapped in another function that returns i
 -  colors={fn}
 +  color={typeof fn === 'function' ? mode => fn(mode)[0] : fn[0]}
  />
+```
+
+If there are cases that the codemod cannot handle, you should see a comment with a `mui-x-codemod` prefix in the code.
+
+```diff
+<SparkLineChart
+- colors={(mode) => (mode === 'light' ? ['black'] : ['white'])}
++ /* mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. */
++ color={(mode) => (mode === 'light' ? ['black'] : ['white'])}
+/>
 ```
 
 ### Data Grid codemods

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-imports, @typescript-eslint/no-shadow */
+/* eslint-disable no-restricted-imports */
 import * as React from 'react';
 import { SparkLineChart } from '@mui/x-charts';
 

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-imports */
+/* eslint-disable no-restricted-imports, @typescript-eslint/no-shadow */
 import * as React from 'react';
 import { SparkLineChart } from '@mui/x-charts';
 
@@ -13,7 +13,6 @@ function Chart() {
       <SparkLineChart data={data} colors={['red']} />
       <SparkLineChart data={data} colors={fn} />
       <SparkLineChart data={data} colors={(mode) => (mode === 'light' ? ['black'] : ['white'])} />
-      <SparkLineChart data={data} colors="red" />
     </React.Fragment>
   );
 }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
@@ -13,6 +13,7 @@ function Chart() {
       <SparkLineChart data={data} colors={['red']} />
       <SparkLineChart data={data} colors={fn} />
       <SparkLineChart data={data} colors={(mode) => (mode === 'light' ? ['black'] : ['white'])} />
+      <SparkLineChart data={data} colors="red" />
     </React.Fragment>
   );
 }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable no-restricted-imports */
+import * as React from 'react';
+import { SparkLineChart } from '@mui/x-charts';
+
+const data = [1, 2];
+
+function Chart() {
+  const fn = (mode) => (mode === 'light' ? ['black'] : ['white']);
+
+  // prettier-ignore
+  return (
+    <React.Fragment>
+      <SparkLineChart data={data} colors={['red']} />
+      <SparkLineChart data={data} colors={fn} />
+      <SparkLineChart data={data} colors={(mode) => (mode === 'light' ? ['black'] : ['white'])} />
+    </React.Fragment>
+  );
+}

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/actual.spec.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable no-restricted-imports */
 import * as React from 'react';
 import { SparkLineChart } from '@mui/x-charts';

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-imports */
+/* eslint-disable no-restricted-imports, @typescript-eslint/no-shadow */
 import * as React from 'react';
 import { SparkLineChart } from '@mui/x-charts';
 
@@ -13,7 +13,6 @@ function Chart() {
       <SparkLineChart data={data} color={['red']?.[0]} />
       <SparkLineChart data={data} color={typeof fn === "function" ? mode => fn(mode)?.[0] : fn} />
       <SparkLineChart data={data} color={mode => (mode => (mode === 'light' ? ['black'] : ['white']))(mode)?.[0]} />
-      <SparkLineChart data={data} colors="red" />
     </React.Fragment>)
   );
 }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -13,6 +13,7 @@ function Chart() {
       <SparkLineChart data={data} color={['red'][0]} />
       <SparkLineChart data={data} color={typeof fn === "function" ? mode => fn(mode)?.[0] : fn} />
       <SparkLineChart data={data} color={mode => (mode => (mode === 'light' ? ['black'] : ['white']))(mode)?.[0]} />
+      <SparkLineChart data={data} colors="red" />
     </React.Fragment>)
   );
 }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -10,7 +10,7 @@ function Chart() {
   // prettier-ignore
   return (
     (<React.Fragment>
-      <SparkLineChart data={data} color={['red']?.[0]} />
+      <SparkLineChart data={data} color={'red'} />
       <SparkLineChart data={data} color={typeof fn === "function" ? mode => fn(mode)?.[0] : fn} />
       <SparkLineChart
         data={data}

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-imports, @typescript-eslint/no-shadow */
+/* eslint-disable no-restricted-imports */
 import * as React from 'react';
 import { SparkLineChart } from '@mui/x-charts';
 
@@ -19,7 +19,7 @@ function Chart() {
       <SparkLineChart
         data={data}
         /* mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. */
-        colors="red" />
+        color="red" />
     </React.Fragment>)
   );
 }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable no-restricted-imports */
+import * as React from 'react';
+import { SparkLineChart } from '@mui/x-charts';
+
+const data = [1, 2];
+
+function Chart() {
+  const fn = (mode) => (mode === 'light' ? ['black'] : ['white']);
+
+  // prettier-ignore
+  return (
+    (<React.Fragment>
+      <SparkLineChart data={data} color={['red'][0]} />
+      <SparkLineChart data={data} color={typeof fn === "function" ? mode => fn(mode)?.[0] : fn} />
+      <SparkLineChart data={data} color={mode => (mode => (mode === 'light' ? ['black'] : ['white']))(mode)?.[0]} />
+    </React.Fragment>)
+  );
+}

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable no-restricted-imports */
 import * as React from 'react';
 import { SparkLineChart } from '@mui/x-charts';

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -12,7 +12,14 @@ function Chart() {
     (<React.Fragment>
       <SparkLineChart data={data} color={['red']?.[0]} />
       <SparkLineChart data={data} color={typeof fn === "function" ? mode => fn(mode)?.[0] : fn} />
-      <SparkLineChart data={data} color={mode => (mode => (mode === 'light' ? ['black'] : ['white']))(mode)?.[0]} />
+      <SparkLineChart
+        data={data}
+        /* mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. */
+        color={(mode) => (mode === 'light' ? ['black'] : ['white'])} />
+      <SparkLineChart
+        data={data}
+        /* mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. */
+        colors="red" />
     </React.Fragment>)
   );
 }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/expected.spec.tsx
@@ -10,7 +10,7 @@ function Chart() {
   // prettier-ignore
   return (
     (<React.Fragment>
-      <SparkLineChart data={data} color={['red'][0]} />
+      <SparkLineChart data={data} color={['red']?.[0]} />
       <SparkLineChart data={data} color={typeof fn === "function" ? mode => fn(mode)?.[0] : fn} />
       <SparkLineChart data={data} color={mode => (mode => (mode === 'light' ? ['black'] : ['white']))(mode)?.[0]} />
       <SparkLineChart data={data} colors="red" />

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
@@ -39,9 +39,7 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
       let colorAttributeExpression;
 
       if (colorsAttributeExpression?.type === 'ArrayExpression') {
-        colorAttributeExpression = j.chainExpression(
-          j.optionalMemberExpression(colorsAttributeExpression, j.literal(0)),
-        );
+        colorAttributeExpression = colorsAttributeExpression.elements[0];
       } else if (colorsAttributeExpression?.type === 'Identifier') {
         colorAttributeExpression = j.conditionalExpression(
           j.binaryExpression(

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
@@ -26,36 +26,38 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
         return;
       }
 
-      const colorsExpression = attribute.node.value.expression;
+      const colorsAttributeExpression = attribute.node.value.expression;
 
-      let colorExpression;
+      let colorAttributeExpression;
 
-      if (colorsExpression.type === 'ArrayExpression') {
-        colorExpression = j.memberExpression(colorsExpression, j.literal(0));
-      } else if (colorsExpression.type === 'Identifier') {
-        colorExpression = j.conditionalExpression(
+      if (colorsAttributeExpression.type === 'ArrayExpression') {
+        colorAttributeExpression = j.chainExpression(
+          j.optionalMemberExpression(colorsAttributeExpression, j.literal(0)),
+        );
+      } else if (colorsAttributeExpression.type === 'Identifier') {
+        colorAttributeExpression = j.conditionalExpression(
           j.binaryExpression(
             '===',
-            j.unaryExpression('typeof', colorsExpression),
+            j.unaryExpression('typeof', colorsAttributeExpression),
             j.literal('function'),
           ),
           j.arrowFunctionExpression(
             [j.identifier('mode')],
             j.chainExpression(
               j.optionalMemberExpression(
-                j.callExpression(colorsExpression, [j.identifier('mode')]),
+                j.callExpression(colorsAttributeExpression, [j.identifier('mode')]),
                 j.literal(0),
               ),
             ),
           ),
-          colorsExpression,
+          colorsAttributeExpression,
         );
-      } else if (colorsExpression.type === 'ArrowFunctionExpression') {
-        colorExpression = j.arrowFunctionExpression(
+      } else if (colorsAttributeExpression.type === 'ArrowFunctionExpression') {
+        colorAttributeExpression = j.arrowFunctionExpression(
           [j.identifier('mode')],
           j.chainExpression(
             j.optionalMemberExpression(
-              j.callExpression(colorsExpression, [j.identifier('mode')]),
+              j.callExpression(colorsAttributeExpression, [j.identifier('mode')]),
               j.literal(0),
             ),
           ),
@@ -65,11 +67,11 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
       }
 
       // Only apply transformation if we know how to handle it
-      if (colorExpression) {
+      if (colorAttributeExpression) {
         j(attribute).replaceWith(
           j.jsxAttribute(
             j.jsxIdentifier(props[attribute.node.name.name as string]),
-            j.jsxExpressionContainer(colorExpression),
+            j.jsxExpressionContainer(colorAttributeExpression),
           ),
         );
       }

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
@@ -23,7 +23,7 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
   return colorAttributes
     .forEach((attribute) => {
       const colorsAttributeExpression =
-        attribute.node.value.type === 'JSXExpressionContainer'
+        attribute.node.value?.type === 'JSXExpressionContainer'
           ? attribute.node.value.expression
           : null;
 

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
@@ -22,15 +22,6 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
 
   return colorAttributes
     .forEach((attribute) => {
-      if (attribute.node.value?.type !== 'JSXExpressionContainer') {
-        j(attribute).insertBefore(
-          j.commentBlock(
-            " mui-x-codemod: We renamed the `colors` prop to `color`, but didn't change the value. Please ensure sure this prop receives a string or a function that returns a string. ",
-          ),
-        );
-        return;
-      }
-
       const colorsAttributeExpression =
         attribute.node.value.type === 'JSXExpressionContainer'
           ? attribute.node.value.expression

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/index.ts
@@ -1,0 +1,78 @@
+import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
+/**
+ * @param {import('jscodeshift').FileInfo} file
+ * @param {import('jscodeshift').API} api
+ */
+export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
+  const j = api.jscodeshift;
+
+  const printOptions = options.printOptions;
+
+  const root = j(file.source);
+  const componentNames = ['SparkLineChart'];
+  const props = { colors: 'color' };
+
+  const colorAttributes = root
+    .find(j.JSXElement)
+    .filter((path) => {
+      return componentNames.includes((path.value.openingElement.name as any).name);
+    })
+    .find(j.JSXAttribute)
+    .filter((attribute) => Object.keys(props).includes(attribute.node.name.name as string));
+
+  return colorAttributes
+    .forEach((attribute) => {
+      if (attribute.node.value?.type !== 'JSXExpressionContainer') {
+        return;
+      }
+
+      const colorsExpression = attribute.node.value.expression;
+
+      let colorExpression;
+
+      if (colorsExpression.type === 'ArrayExpression') {
+        colorExpression = j.memberExpression(colorsExpression, j.literal(0));
+      } else if (colorsExpression.type === 'Identifier') {
+        colorExpression = j.conditionalExpression(
+          j.binaryExpression(
+            '===',
+            j.unaryExpression('typeof', colorsExpression),
+            j.literal('function'),
+          ),
+          j.arrowFunctionExpression(
+            [j.identifier('mode')],
+            j.chainExpression(
+              j.optionalMemberExpression(
+                j.callExpression(colorsExpression, [j.identifier('mode')]),
+                j.literal(0),
+              ),
+            ),
+          ),
+          colorsExpression,
+        );
+      } else if (colorsExpression.type === 'ArrowFunctionExpression') {
+        colorExpression = j.arrowFunctionExpression(
+          [j.identifier('mode')],
+          j.chainExpression(
+            j.optionalMemberExpression(
+              j.callExpression(colorsExpression, [j.identifier('mode')]),
+              j.literal(0),
+            ),
+          ),
+        );
+      } else {
+        // Don't know how to handle this case
+      }
+
+      // Only apply transformation if we know how to handle it
+      if (colorExpression) {
+        j(attribute).replaceWith(
+          j.jsxAttribute(
+            j.jsxIdentifier(props[attribute.node.name.name as string]),
+            j.jsxExpressionContainer(colorExpression),
+          ),
+        );
+      }
+    })
+    .toSource(printOptions);
+}

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/rename-sparkline-colors-to-color.test.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/rename-sparkline-colors-to-color.test.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from '.';
+import readFile from '../../../util/readFile';
+
+function read(fileName) {
+  return readFile(path.join(__dirname, fileName));
+}
+
+describe('v8.0.0/charts', () => {
+  describe('rename-sparkline-colors-to-color', () => {
+    it('transforms code as needed', () => {
+      const actual = transform(
+        {
+          source: read('./actual.spec.tsx'),
+          path: require.resolve('./actual.spec.tsx'),
+        },
+        { jscodeshift: jscodeshift.withParser('tsx') },
+        {},
+      );
+
+      const expected = read('./expected.spec.tsx');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
+    it('should be idempotent for expression', () => {
+      const actual = transform(
+        {
+          source: read('./expected.spec.tsx'),
+          path: require.resolve('./expected.spec.tsx'),
+        },
+        { jscodeshift: jscodeshift.withParser('tsx') },
+        {},
+      );
+
+      const expected = read('./expected.spec.tsx');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+  });
+});

--- a/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/rename-sparkline-colors-to-color.test.ts
+++ b/packages/x-codemod/src/v8.0.0/charts/rename-sparkline-colors-to-color/rename-sparkline-colors-to-color.test.ts
@@ -23,19 +23,5 @@ describe('v8.0.0/charts', () => {
       const expected = read('./expected.spec.tsx');
       expect(actual).to.equal(expected, 'The transformed version should be correct');
     });
-
-    it('should be idempotent for expression', () => {
-      const actual = transform(
-        {
-          source: read('./expected.spec.tsx'),
-          path: require.resolve('./expected.spec.tsx'),
-        },
-        { jscodeshift: jscodeshift.withParser('tsx') },
-        {},
-      );
-
-      const expected = read('./expected.spec.tsx');
-      expect(actual).to.equal(expected, 'The transformed version should be correct');
-    });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Remove `colors` prop from `SparkLineChart`. 

In https://github.com/mui/mui-x/pull/16477, I deprecated the `colors` prop, but we can still do breaking changes for v8. This will reduce the maintenance burden slightly. 

Also added codemod to migrate from the old `colors` prop to the new `color` prop.



<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
