### PR TITLE
[charts] Improve performance of rendering ticks in x-axis

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -32,7 +32,7 @@ const useUtilityClasses = (ownerState: AxisConfig<any, any, ChartsXAxisProps>) =
   return composeClasses(slots, getAxisUtilityClass, classes);
 };
 
-type LabelExtraData = { width: number; height: number; skipLabel?: boolean };
+type LabelExtraData = { skipLabel?: boolean };
 
 function addLabelDimension(
   xTicks: TickItemType[],
@@ -84,12 +84,15 @@ function addLabelDimension(
     const { offset, labelOffset } = item;
     const textPosition = offset + labelOffset;
 
-    if (labelIndex > 0 && direction * textPosition  < direction * (previousTextLimit + tickLabelMinGap)) {
-      return { ...item, width: 0, height: 0, skipLabel: true };
+    if (
+      labelIndex > 0 &&
+      direction * textPosition < direction * (previousTextLimit + tickLabelMinGap)
+    ) {
+      return { ...item, skipLabel: true };
     }
 
     if (!isPointInside(textPosition)) {
-      return { ...item, width: 0, height: 0, skipLabel: true };
+      return { ...item, skipLabel: true };
     }
 
     const { width, height } = getTickLabelSize(item);
@@ -97,14 +100,17 @@ function addLabelDimension(
     const distance = getMinXTranslation(width, height, style?.angle);
 
     const currentTextLimit = textPosition - (direction * distance) / 2;
-    if (labelIndex > 0 && direction * currentTextLimit < direction * (previousTextLimit + tickLabelMinGap)) {
+    if (
+      labelIndex > 0 &&
+      direction * currentTextLimit < direction * (previousTextLimit + tickLabelMinGap)
+    ) {
       // Except for the first label, we skip all label that overlap with the last accepted.
       // Notice that the early return prevents `previousTextLimit` from being updated.
-      return { ...item, width, height, skipLabel: true };
+      return { ...item, skipLabel: true };
     }
 
     previousTextLimit = textPosition + (direction * distance) / 2;
-    return { ...item, width, height };
+    return item;
   });
 }
 

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -42,10 +42,12 @@ function addLabelDimension(
     tickLabelMinGap,
     reverse,
     isMounted,
+    isPointInside,
   }: Pick<ChartsXAxisProps, 'tickLabelInterval' | 'tickLabelStyle'> &
     Pick<AxisDefaultized<ScaleName, any, ChartsXAxisProps>, 'reverse'> & {
       isMounted: boolean;
       tickLabelMinGap: NonNullable<ChartsXAxisProps['tickLabelMinGap']>;
+      isPointInside: (position: number) => boolean;
     },
 ): (TickItemType & LabelExtraData)[] {
   const getTickSize = (tick: TickItemType) => {
@@ -81,6 +83,10 @@ function addLabelDimension(
       return { ...item, width: 0, height: 0, skipLabel: true };
     }
 
+    if (!isPointInside(textPosition)) {
+      return { ...item, width: 0, height: 0, skipLabel: true };
+    }
+
     const { width, height } = getTickSize(item);
 
     const distance = getMinXTranslation(width, height, style?.angle);
@@ -91,6 +97,7 @@ function addLabelDimension(
       // Notice that the early return prevents `previousTextLimit` from being updated.
       return { ...item, width, height, skipLabel: true };
     }
+
     previousTextLimit = textPosition + (direction * distance) / 2;
     return { ...item, width, height };
   });
@@ -196,6 +203,8 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     tickLabelMinGap,
     reverse,
     isMounted,
+    isPointInside: (offset: number) =>
+      instance.isPointInside({ x: offset, y: -1 }, { direction: 'x' }),
   });
 
   const labelRefPoint = {

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -207,8 +207,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     tickLabelMinGap,
     reverse,
     isMounted,
-    isPointInside: (offset: number) =>
-      instance.isPointInside({ x: offset, y: -1 }, { direction: 'x' }),
+    isPointInside: (x: number) => instance.isPointInside({ x, y: -1 }, { direction: 'x' }),
   });
 
   const labelRefPoint = {
@@ -248,45 +247,39 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         <Line x1={left} x2={left + width} className={classes.line} {...slotProps?.axisLine} />
       )}
 
-      {xTicks.map(
-        (item, index) => {
-          const { formattedValue, offset: tickOffset, labelOffset } = item;
-          const xTickLabel = labelOffset ?? 0;
-          const yTickLabel = positionSign * (tickSize + 3);
+      {xTicks.map((item, index) => {
+        const { formattedValue, offset: tickOffset, labelOffset } = item;
+        const xTickLabel = labelOffset ?? 0;
+        const yTickLabel = positionSign * (tickSize + 3);
 
-          const showTick = instance.isPointInside({ x: tickOffset, y: -1 }, { direction: 'x' });
-          const showTickLabel = instance.isPointInside(
-            { x: tickOffset + xTickLabel, y: -1 },
-            { direction: 'x' },
-          );
-          const skipLabel = !visibleLabels.has(item);
+        const showTick = instance.isPointInside({ x: tickOffset, y: -1 }, { direction: 'x' });
+        const showTickLabel = visibleLabels.has(item);
 
-          return (
-            <g
-              key={index}
-              transform={`translate(${tickOffset}, 0)`}
-              className={classes.tickContainer}
-            >
-              {!disableTicks && showTick && (
-                <Tick
-                  y2={positionSign * tickSize}
-                  className={classes.tick}
-                  {...slotProps?.axisTick}
-                />
-              )}
+        return (
+          <g
+            key={index}
+            transform={`translate(${tickOffset}, 0)`}
+            className={classes.tickContainer}
+          >
+            {!disableTicks && showTick && (
+              <Tick
+                y2={positionSign * tickSize}
+                className={classes.tick}
+                {...slotProps?.axisTick}
+              />
+            )}
 
-              {formattedValue !== undefined && !skipLabel && showTickLabel && (
-                <TickLabel
-                  x={xTickLabel}
-                  y={yTickLabel}
-                  {...axisTickLabelProps}
-                  text={formattedValue.toString()}
-                />
-              )}
-            </g>
-          );
-        },
-      )}
+            {formattedValue !== undefined && showTickLabel && (
+              <TickLabel
+                x={xTickLabel}
+                y={yTickLabel}
+                {...axisTickLabelProps}
+                text={formattedValue.toString()}
+              />
+            )}
+          </g>
+        );
+      })}
 
       {label && (
         <g className={classes.label}>

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -50,7 +50,7 @@ function addLabelDimension(
       isPointInside: (position: number) => boolean;
     },
 ): (TickItemType & LabelExtraData)[] {
-  const getTickSize = (tick: TickItemType) => {
+  const getTickLabelSize = (tick: TickItemType) => {
     if (!isMounted || tick.formattedValue === undefined) {
       return { width: 0, height: 0 };
     }
@@ -63,13 +63,18 @@ function addLabelDimension(
     };
   };
 
-  // FIXME: Add this back
-  // if (typeof tickLabelInterval === 'function') {
-  //  return withDimension.map((item, index) => ({
-  //    ...item,
-  //    skipLabel: !tickLabelInterval(item.value, index),
-  //  }));
-  // }
+  if (typeof tickLabelInterval === 'function') {
+    return xTicks.map((item, index) => {
+      const skipLabel = !tickLabelInterval(item.value, index);
+      const size = skipLabel ? { width: 0, height: 0 } : getTickLabelSize(item);
+
+      return {
+        ...item,
+        ...size,
+        skipLabel,
+      };
+    });
+  }
 
   // Filter label to avoid overlap
   let previousTextLimit = 0;
@@ -87,7 +92,7 @@ function addLabelDimension(
       return { ...item, width: 0, height: 0, skipLabel: true };
     }
 
-    const { width, height } = getTickSize(item);
+    const { width, height } = getTickLabelSize(item);
 
     const distance = getMinXTranslation(width, height, style?.angle);
 

--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -98,10 +98,6 @@ export const getStyleString = (style: React.CSSProperties) =>
     );
 
 let domCleanTimeout: NodeJS.Timeout | undefined;
-const domResults = { count: 0, time: 0 };
-if (typeof window !== 'undefined') {
-  window.domResults = domResults;
-}
 
 /**
  *
@@ -121,9 +117,6 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
   if (stringCache.widthCache[cacheKey]) {
     return stringCache.widthCache[cacheKey];
   }
-
-  domResults.count++;
-  const startTime = performance.now();
 
   try {
     let measurementSpan = document.getElementById(MEASUREMENT_SPAN_ID);
@@ -166,8 +159,6 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
     return result;
   } catch {
     return { width: 0, height: 0 };
-  } finally {
-    domResults.time += performance.now() - startTime;
   }
 };
 

--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -98,6 +98,11 @@ export const getStyleString = (style: React.CSSProperties) =>
     );
 
 let domCleanTimeout: NodeJS.Timeout | undefined;
+const domResults = { count: 0, time: 0 };
+if (typeof window !== 'undefined') {
+  window.domResults = domResults;
+}
+
 /**
  *
  * @param text The string to estimate
@@ -116,6 +121,9 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
   if (stringCache.widthCache[cacheKey]) {
     return stringCache.widthCache[cacheKey];
   }
+
+  domResults.count++;
+  const startTime = performance.now();
 
   try {
     let measurementSpan = document.getElementById(MEASUREMENT_SPAN_ID);
@@ -158,6 +166,8 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
     return result;
   } catch {
     return { width: 0, height: 0 };
+  } finally {
+    domResults.time += performance.now() - startTime;
   }
 };
 


### PR DESCRIPTION
Depends on https://github.com/mui/mui-x/pull/16548.

Part of https://github.com/mui/mui-x/issues/10928.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Measuring the size of text using `getBoundingClientRect` is expensive, especially when appending elements one by one to the DOM, which is what we're doing at the moment. 

Knowing that, this PR focuses on reducing the number of times we actually measure text. In the case of tick labels in the x-axis, this is done by:
1. Checking whether the center of label would overlap with a previous label (or the minimum gap between labels);
2. Checking whether the center of the label would be outside the visible area.

Only if these two checks are true do we actually measure the text. This helps us reduce the number of measurements, improving performance for when rendering many labels. 

Bear in mind that we cache the measurements, so the impact on performance will be less if we're measuring the same strings repeatedly. 


## Results

Rendering the following bar chart (from the "BarChartPro" benchmark) in a Vite application using production builds:

![image](https://github.com/user-attachments/assets/8def6d5d-a4da-4b7b-a6df-e4d325bf1eb8)

### Before

401 cache misses, around 20ms spent measuring text.

### After

99 cache misses, around 7ms spent measuring text.

For this example, this means a 75% reduction of measurements taken and around 65% reduction in time spent measuring. 