### PR TITLE
[charts] Divide the logic for `useXxxSeries` into `useXxxSeriesContext`

### DIFF
--- a/docs/data/charts/components/SeriesDemo.tsx
+++ b/docs/data/charts/components/SeriesDemo.tsx
@@ -18,8 +18,8 @@ function ExtremaLabels() {
 
   return (
     <React.Fragment>
-      {lineSeries.seriesOrder.map((seriesId) => (
-        <SingleSeriesExtremaLabels series={lineSeries.series[seriesId]} />
+      {lineSeries.map((series) => (
+        <SingleSeriesExtremaLabels series={series} />
       ))}
     </React.Fragment>
   );

--- a/docs/data/charts/scatter/CustomScatter.tsx
+++ b/docs/data/charts/scatter/CustomScatter.tsx
@@ -23,14 +23,14 @@ const series = [
 ];
 
 function LinkPoints({ seriesId, close }: { seriesId: string; close?: boolean }) {
-  const scatter = useScatterSeries();
+  const scatter = useScatterSeries(seriesId);
   const xScale = useXScale();
   const yScale = useYScale();
 
-  if (!scatter || !scatter.series[seriesId]) {
+  if (!scatter) {
     return null;
   }
-  const { color, data } = scatter.series[seriesId];
+  const { color, data } = scatter;
 
   if (!data) {
     return null;

--- a/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapPlot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useXScale, useYScale, useZColorScale } from '@mui/x-charts/hooks';
-import { useHeatmapSeries } from '../hooks/useHeatmapSeries';
+import { useHeatmapSeriesContext } from '../hooks/useHeatmapSeries';
 import { HeatmapItem, HeatmapItemProps } from './HeatmapItem';
 
 export interface HeatmapPlotProps extends Pick<HeatmapItemProps, 'slots' | 'slotProps'> {}
@@ -11,7 +11,7 @@ function HeatmapPlot(props: HeatmapPlotProps) {
   const xScale = useXScale<'band'>();
   const yScale = useYScale<'band'>();
   const colorScale = useZColorScale()!;
-  const series = useHeatmapSeries();
+  const series = useHeatmapSeriesContext();
 
   const xDomain = xScale.domain();
   const yDomain = yScale.domain();

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/x-charts/ChartsTooltip';
 import { useXAxis, useYAxis } from '@mui/x-charts/hooks';
 import { getLabel, ChartsLabelMark } from '@mui/x-charts/internals';
-import { useHeatmapSeries } from '../hooks/useHeatmapSeries';
+import { useHeatmapSeriesContext } from '../hooks/useHeatmapSeries';
 
 export interface HeatmapTooltipProps
   extends Omit<ChartsTooltipContainerProps, 'trigger' | 'children'> {}
@@ -44,7 +44,7 @@ function DefaultHeatmapTooltipContent(props: Pick<HeatmapTooltipProps, 'classes'
 
   const xAxis = useXAxis();
   const yAxis = useYAxis();
-  const heatmapSeries = useHeatmapSeries();
+  const heatmapSeries = useHeatmapSeriesContext();
 
   const tooltipData = useItemTooltip<'heatmap'>();
 

--- a/packages/x-charts-pro/src/hooks/useHeatmapSeries.test.tsx
+++ b/packages/x-charts-pro/src/hooks/useHeatmapSeries.test.tsx
@@ -67,6 +67,6 @@ describe('useHeatmapSeries', () => {
 
   it('should return undefined series when invalid seriesIds are provided', () => {
     const { result } = renderHook(() => useHeatmapSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, undefined]);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts-pro/src/hooks/useHeatmapSeries.test.tsx
+++ b/packages/x-charts-pro/src/hooks/useHeatmapSeries.test.tsx
@@ -1,55 +1,63 @@
 import { renderHook } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
-import { useHeatmapSeries } from './useHeatmapSeries';
+import { useHeatmapSeries, useHeatmapSeriesContext } from './useHeatmapSeries';
 import { Heatmap } from '../Heatmap';
 import { HeatmapSeriesType } from '../models';
 
-describe('useHeatmapSeries', () => {
-  const mockSeries: HeatmapSeriesType[] = [
-    {
-      type: 'heatmap',
-      id: '1',
-      data: [
-        [0, 0, 10],
-        [0, 1, 20],
-        [0, 2, 40],
-      ],
-    },
-    {
-      type: 'heatmap',
-      id: '2',
-      data: [
-        [3, 2, 20],
-        [3, 3, 70],
-        [3, 4, 90],
-      ],
-    },
-  ];
+const mockSeries: HeatmapSeriesType[] = [
+  {
+    type: 'heatmap',
+    id: '1',
+    data: [
+      [0, 0, 10],
+      [0, 1, 20],
+      [0, 2, 40],
+    ],
+  },
+  {
+    type: 'heatmap',
+    id: '2',
+    data: [
+      [3, 2, 20],
+      [3, 3, 70],
+      [3, 4, 90],
+    ],
+  },
+];
 
-  const defaultProps = {
-    series: mockSeries,
-    height: 400,
-    width: 400,
-    xAxis: [{ data: [1, 2, 3, 4] }],
-    yAxis: [{ data: ['A', 'B', 'C', 'D', 'E'] }],
-  };
+const defaultProps = {
+  series: mockSeries,
+  height: 400,
+  width: 400,
+  xAxis: [{ data: [1, 2, 3, 4] }],
+  yAxis: [{ data: ['A', 'B', 'C', 'D', 'E'] }],
+};
 
-  const options: any = {
-    wrapper: ({ children }: { children: React.ReactElement }) => {
-      return <Heatmap {...defaultProps}>{children}</Heatmap>;
-    },
-  };
+const options: any = {
+  wrapper: ({ children }: { children: React.ReactElement }) => {
+    return <Heatmap {...defaultProps}>{children}</Heatmap>;
+  },
+};
 
+describe('useHeatmapSeriesContext', () => {
   it('should return all heatmap series when no seriesIds are provided', () => {
-    const { result } = renderHook(() => useHeatmapSeries(), options);
+    const { result } = renderHook(() => useHeatmapSeriesContext(), options);
     expect(result.current?.seriesOrder).to.deep.equal(['1', '2']);
     expect(Object.keys(result.current?.series ?? {})).to.deep.equal(['1', '2']);
   });
+});
 
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('useHeatmapSeries', () => {
   it('should return the specific heatmap series when a single seriesId is provided', () => {
     const { result } = renderHook(() => useHeatmapSeries('1'), options);
     expect(result.current?.id).to.deep.equal(mockSeries[0].id);
+  });
+
+  it('should return all heatmap series when no seriesId is provided', () => {
+    const { result } = renderHook(() => useHeatmapSeries(), options);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, mockSeries[1].id]);
   });
 
   it('should return the specific heatmap series when multiple seriesIds are provided', () => {

--- a/packages/x-charts-pro/src/hooks/useHeatmapSeries.ts
+++ b/packages/x-charts-pro/src/hooks/useHeatmapSeries.ts
@@ -10,7 +10,7 @@ import {
 const selectorSeries = createSeriesSelectorsOfType('heatmap');
 const selectorSeriesContext = createAllSeriesSelectorOfType('heatmap');
 
-export type UseHeatmapSeriesReturnValue = ChartSeriesDefaultized<'heatmap'> | undefined;
+export type UseHeatmapSeriesReturnValue = ChartSeriesDefaultized<'heatmap'>;
 export type UseHeatmapSeriesContextReturnValue = ProcessedSeries['heatmap'];
 
 /**
@@ -19,7 +19,7 @@ export type UseHeatmapSeriesContextReturnValue = ProcessedSeries['heatmap'];
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseHeatmapSeriesReturnValue} the heatmap series
  */
-export function useHeatmapSeries(seriesId: SeriesId): UseHeatmapSeriesReturnValue;
+export function useHeatmapSeries(seriesId: SeriesId): UseHeatmapSeriesReturnValue | undefined;
 /**
  * Get access to the internal state of heatmap series.
  *

--- a/packages/x-charts-pro/src/hooks/useHeatmapSeries.ts
+++ b/packages/x-charts-pro/src/hooks/useHeatmapSeries.ts
@@ -1,5 +1,6 @@
 'use client';
 import {
+  createAllSeriesSelectorOfType,
   createSeriesSelectorsOfType,
   ProcessedSeries,
   SeriesId,
@@ -7,31 +8,44 @@ import {
 } from '@mui/x-charts/internals';
 
 const selectorSeries = createSeriesSelectorsOfType('heatmap');
+const selectorSeriesContext = createAllSeriesSelectorOfType('heatmap');
+
+export type UseHeatmapSeriesReturnValue = ChartSeriesDefaultized<'heatmap'> | undefined;
+export type UseHeatmapSeriesContextReturnValue = ProcessedSeries['heatmap'];
+
+/**
+ * Get access to the internal state of heatmap series.
+ *
+ * @param {SeriesId} seriesId The id of the series to get.
+ * @returns {UseHeatmapSeriesReturnValue} the heatmap series
+ */
+export function useHeatmapSeries(seriesId: SeriesId): UseHeatmapSeriesReturnValue;
+/**
+ * Get access to the internal state of heatmap series.
+ *
+ * When called without arguments, it returns all heatmap series.
+ *
+ * @returns {UseHeatmapSeriesReturnValue[]} the heatmap series
+ */
+export function useHeatmapSeries(): UseHeatmapSeriesReturnValue[];
+/**
+ * Get access to the internal state of heatmap series.
+ *
+ * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
+ * @returns {UseHeatmapSeriesReturnValue[]} the heatmap series
+ */
+export function useHeatmapSeries(seriesIds: SeriesId[]): UseHeatmapSeriesReturnValue[];
+export function useHeatmapSeries(seriesIds?: SeriesId | SeriesId[]) {
+  return selectorSeries(seriesIds);
+}
 
 /**
  * Get access to the internal state of heatmap series.
  * The returned object contains:
  * - series: a mapping from ids to series attributes.
  * - seriesOrder: the array of series ids.
- * @returns {{ series: Record<SeriesId, DefaultizedHeatmapSeriesType>; seriesOrder: SeriesId[]; } | undefined} heatmapSeries
+ * @returns the heatmap series
  */
-export function useHeatmapSeries(): ProcessedSeries['heatmap'];
-/**
- * Get access to the internal state of heatmap series.
- *
- * @param {SeriesId} seriesId The id of the series to get.
- * @returns {ChartSeriesDefaultized<'heatmap'> | undefined}  heatmapSeries
- */
-export function useHeatmapSeries(seriesId: SeriesId): ChartSeriesDefaultized<'heatmap'> | undefined;
-/**
- * Get access to the internal state of heatmap series.
- *
- * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
- * @returns {ChartSeriesDefaultized<'heatmap'>[] | undefined}  heatmapSeries
- */
-export function useHeatmapSeries(
-  seriesIds: SeriesId[],
-): (ChartSeriesDefaultized<'heatmap'> | undefined)[];
-export function useHeatmapSeries(seriesIds?: SeriesId | SeriesId[]) {
-  return selectorSeries(seriesIds);
+export function useHeatmapSeriesContext(): UseHeatmapSeriesContextReturnValue {
+  return selectorSeriesContext();
 }

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -13,7 +13,7 @@ import { BarClipPath } from './BarClipPath';
 import { BarLabelItemProps, BarLabelSlotProps, BarLabelSlots } from './BarLabel/BarLabelItem';
 import { BarLabelPlot } from './BarLabel/BarLabelPlot';
 import { checkScaleErrors } from './checkScaleErrors';
-import { useBarSeries } from '../hooks/useBarSeries';
+import { useBarSeriesContext } from '../hooks/useBarSeries';
 import { useSkipAnimation } from '../context/AnimationProvider';
 import { SeriesProcessorResult } from '../internals/plugins/models/seriesConfig/seriesProcessor.types';
 
@@ -89,7 +89,7 @@ const useAggregatedData = (): {
   masksData: MaskData[];
 } => {
   const seriesData =
-    useBarSeries() ??
+    useBarSeriesContext() ??
     ({ series: {}, stackingGroups: [], seriesOrder: [] } as SeriesProcessorResult<'bar'>);
 
   const drawingArea = useDrawingArea();

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -15,7 +15,7 @@ import { getCurveFactory } from '../internals/getCurve';
 import { isBandScale } from '../internals/isBandScale';
 import { DEFAULT_X_AXIS_KEY } from '../constants';
 import { LineItemIdentifier } from '../models/seriesType/line';
-import { useLineSeries } from '../hooks/useLineSeries';
+import { useLineSeriesContext } from '../hooks/useLineSeries';
 import { useSkipAnimation } from '../context/AnimationProvider';
 import { useChartGradientIdBuilder } from '../hooks/useChartGradientId';
 import { useXAxes, useYAxes } from '../hooks/useAxis';
@@ -49,7 +49,7 @@ const AreaPlotRoot = styled('g', {
 });
 
 const useAggregatedData = () => {
-  const seriesData = useLineSeries();
+  const seriesData = useLineSeriesContext();
   const { xAxis, xAxisIds } = useXAxes();
   const { yAxis, yAxisIds } = useYAxes();
   const getGradientId = useChartGradientIdBuilder();

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -7,7 +7,7 @@ import { useSelector } from '../internals/store/useSelector';
 import { LineHighlightElement, LineHighlightElementProps } from './LineHighlightElement';
 import { getValueToPositionMapper } from '../hooks/useScale';
 import { DEFAULT_X_AXIS_KEY } from '../constants';
-import { useLineSeries } from '../hooks/useLineSeries';
+import { useLineSeriesContext } from '../hooks/useLineSeries';
 import getColor from './seriesConfig/getColor';
 import { useChartContext } from '../context/ChartProvider';
 import { selectorChartsInteractionXAxis } from '../internals/plugins/featurePlugins/useChartInteraction';
@@ -47,7 +47,7 @@ export interface LineHighlightPlotProps extends React.SVGAttributes<SVGSVGElemen
 function LineHighlightPlot(props: LineHighlightPlotProps) {
   const { slots, slotProps, ...other } = props;
 
-  const seriesData = useLineSeries();
+  const seriesData = useLineSeriesContext();
   const { xAxis, xAxisIds } = useXAxes();
   const { yAxis, yAxisIds } = useYAxes();
 

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -15,7 +15,7 @@ import { getCurveFactory } from '../internals/getCurve';
 import { isBandScale } from '../internals/isBandScale';
 import { DEFAULT_X_AXIS_KEY } from '../constants';
 import { LineItemIdentifier } from '../models/seriesType/line';
-import { useLineSeries } from '../hooks/useLineSeries';
+import { useLineSeriesContext } from '../hooks/useLineSeries';
 import { useSkipAnimation } from '../context/AnimationProvider';
 import { useChartGradientIdBuilder } from '../hooks/useChartGradientId';
 import { useXAxes, useYAxes } from '../hooks';
@@ -49,7 +49,7 @@ const LinePlotRoot = styled('g', {
 });
 
 const useAggregatedData = () => {
-  const seriesData = useLineSeries();
+  const seriesData = useLineSeriesContext();
 
   const { xAxis, xAxisIds } = useXAxes();
   const { yAxis, yAxisIds } = useYAxes();

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_X_AXIS_KEY } from '../constants';
 import { useSkipAnimation } from '../context/AnimationProvider';
 import { useChartId } from '../hooks/useChartId';
 import { getValueToPositionMapper } from '../hooks/useScale';
-import { useLineSeries } from '../hooks/useLineSeries';
+import { useLineSeriesContext } from '../hooks/useLineSeries';
 import { cleanId } from '../internals/cleanId';
 import { LineItemIdentifier } from '../models/seriesType/line';
 import { CircleMarkElement } from './CircleMarkElement';
@@ -60,7 +60,7 @@ function MarkPlot(props: MarkPlotProps) {
   const { slots, slotProps, skipAnimation: inSkipAnimation, onItemClick, ...other } = props;
   const skipAnimation = useSkipAnimation(inSkipAnimation);
 
-  const seriesData = useLineSeries();
+  const seriesData = useLineSeriesContext();
   const { xAxis, xAxisIds } = useXAxes();
   const { yAxis, yAxisIds } = useYAxes();
 

--- a/packages/x-charts/src/PieChart/PiePlot.tsx
+++ b/packages/x-charts/src/PieChart/PiePlot.tsx
@@ -5,7 +5,7 @@ import { PieArcPlot, PieArcPlotProps, PieArcPlotSlotProps, PieArcPlotSlots } fro
 import { PieArcLabelPlotSlots, PieArcLabelPlotSlotProps, PieArcLabelPlot } from './PieArcLabelPlot';
 import { getPercentageValue } from '../internals/getPercentageValue';
 import { getPieCoordinates } from './getPieCoordinates';
-import { usePieSeries } from '../hooks/usePieSeries';
+import { usePieSeriesContext } from '../hooks/usePieSeries';
 import { useSkipAnimation } from '../context/AnimationProvider';
 import { useDrawingArea } from '../hooks';
 
@@ -38,7 +38,7 @@ export interface PiePlotProps extends Pick<PieArcPlotProps, 'skipAnimation' | 'o
  */
 function PiePlot(props: PiePlotProps) {
   const { skipAnimation: inSkipAnimation, slots, slotProps, onItemClick } = props;
-  const seriesData = usePieSeries();
+  const seriesData = usePieSeriesContext();
   const { left, top, width, height } = useDrawingArea();
   const skipAnimation = useSkipAnimation(inSkipAnimation);
 

--- a/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Scatter, ScatterProps } from './Scatter';
-import { useScatterSeries } from '../hooks/useScatterSeries';
+import { useScatterSeriesContext } from '../hooks/useScatterSeries';
 import getColor from './seriesConfig/getColor';
 import { useXAxes, useYAxes } from '../hooks';
 import { useZAxes } from '../hooks/useZAxis';
@@ -40,7 +40,7 @@ export interface ScatterPlotProps extends Pick<ScatterProps, 'onItemClick'> {
  */
 function ScatterPlot(props: ScatterPlotProps) {
   const { slots, slotProps, onItemClick } = props;
-  const seriesData = useScatterSeries();
+  const seriesData = useScatterSeriesContext();
   const { xAxis, xAxisIds } = useXAxes();
   const { yAxis, yAxisIds } = useYAxes();
   const { zAxis, zAxisIds } = useZAxes();

--- a/packages/x-charts/src/hooks/useBarSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useBarSeries.test.tsx
@@ -1,45 +1,53 @@
 import { renderHook } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
-import { useBarSeries } from './useBarSeries';
+import { useBarSeries, useBarSeriesContext } from './useBarSeries';
 import { BarSeriesType } from '../models';
 import { BarChart } from '../BarChart';
 
-describe('useBarSeries', () => {
-  const mockSeries: BarSeriesType[] = [
-    {
-      type: 'bar',
-      id: '1',
-      data: [1, 2, 3],
-    },
-    {
-      type: 'bar',
-      id: '2',
-      data: [4, 5, 6],
-    },
-  ];
+const mockSeries: BarSeriesType[] = [
+  {
+    type: 'bar',
+    id: '1',
+    data: [1, 2, 3],
+  },
+  {
+    type: 'bar',
+    id: '2',
+    data: [4, 5, 6],
+  },
+];
 
-  const defaultProps = {
-    series: mockSeries,
-    height: 400,
-    width: 400,
-  };
+const defaultProps = {
+  series: mockSeries,
+  height: 400,
+  width: 400,
+};
 
-  const options: any = {
-    wrapper: ({ children }: { children: React.ReactElement }) => {
-      return <BarChart {...defaultProps}>{children}</BarChart>;
-    },
-  };
+const options: any = {
+  wrapper: ({ children }: { children: React.ReactElement }) => {
+    return <BarChart {...defaultProps}>{children}</BarChart>;
+  },
+};
 
+describe('useBarSeriesContext', () => {
   it('should return all bar series when no seriesIds are provided', () => {
-    const { result } = renderHook(() => useBarSeries(), options);
+    const { result } = renderHook(() => useBarSeriesContext(), options);
     expect(result.current?.seriesOrder).to.deep.equal(['1', '2']);
     expect(Object.keys(result.current?.series ?? {})).to.deep.equal(['1', '2']);
   });
+});
 
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('useBarSeries', () => {
   it('should return the specific bar series when a single seriesId is provided', () => {
     const { result } = renderHook(() => useBarSeries('1'), options);
     expect(result.current?.id).to.deep.equal(mockSeries[0].id);
+  });
+
+  it('should return all bar series when no seriesId is provided', () => {
+    const { result } = renderHook(() => useBarSeries(), options);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, mockSeries[1].id]);
   });
 
   it('should return the specific bar series when multiple seriesIds are provided', () => {

--- a/packages/x-charts/src/hooks/useBarSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useBarSeries.test.tsx
@@ -57,6 +57,6 @@ describe('useBarSeries', () => {
 
   it('should return undefined series when invalid seriesIds are provided', () => {
     const { result } = renderHook(() => useBarSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, undefined]);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/useBarSeries.ts
+++ b/packages/x-charts/src/hooks/useBarSeries.ts
@@ -2,32 +2,50 @@
 import { ProcessedSeries } from '../internals/plugins/corePlugins/useChartSeries/useChartSeries.types';
 import { SeriesId } from '../models/seriesType/common';
 import { ChartSeriesDefaultized } from '../models/seriesType/config';
-import { createSeriesSelectorsOfType } from '../internals/createSeriesSelectorOfType';
+import {
+  createSeriesSelectorsOfType,
+  createAllSeriesSelectorOfType,
+} from '../internals/createSeriesSelectorOfType';
 
 const selectorSeries = createSeriesSelectorsOfType('bar');
+const selectorSeriesContext = createAllSeriesSelectorOfType('bar');
+
+export type UseBarSeriesReturnValue = ChartSeriesDefaultized<'bar'> | undefined;
+export type UseBarSeriesContextReturnValue = ProcessedSeries['bar'];
+
+/**
+ * Get access to the internal state of bar series.
+ *
+ * @param {SeriesId} seriesId The id of the series to get.
+ * @returns {UseBarSeriesReturnValue} the bar series
+ */
+export function useBarSeries(seriesId: SeriesId): UseBarSeriesReturnValue;
+/**
+ * Get access to the internal state of bar series.
+ *
+ * When called without arguments, it returns all bar series.
+ *
+ * @returns {UseBarSeriesReturnValue[]} the bar series
+ */
+export function useBarSeries(): UseBarSeriesReturnValue[];
+/**
+ * Get access to the internal state of bar series.
+ *
+ * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
+ * @returns {UseBarSeriesReturnValue[]} the bar series
+ */
+export function useBarSeries(seriesIds: SeriesId[]): UseBarSeriesReturnValue[];
+export function useBarSeries(seriesIds?: SeriesId | SeriesId[]) {
+  return selectorSeries(seriesIds);
+}
 
 /**
  * Get access to the internal state of bar series.
  * The returned object contains:
  * - series: a mapping from ids to series attributes.
  * - seriesOrder: the array of series ids.
- * @returns {{ series: Record<SeriesId, DefaultizedBarSeriesType>; seriesOrder: SeriesId[]; } | undefined}  barSeries
+ * @returns the bar series
  */
-export function useBarSeries(): ProcessedSeries['bar'];
-/**
- * Get access to the internal state of bar series.
- *
- * @param {SeriesId} seriesId The id of the series to get.
- * @returns {ChartSeriesDefaultized<'bar'> | undefined}  barSeries
- */
-export function useBarSeries(seriesId: SeriesId): ChartSeriesDefaultized<'bar'> | undefined;
-/**
- * Get access to the internal state of bar series.
- *
- * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
- * @returns {ChartSeriesDefaultized<'bar'>[] | undefined}  barSeries
- */
-export function useBarSeries(seriesIds: SeriesId[]): (ChartSeriesDefaultized<'bar'> | undefined)[];
-export function useBarSeries(seriesIds?: SeriesId | SeriesId[]) {
-  return selectorSeries(seriesIds);
+export function useBarSeriesContext(): UseBarSeriesContextReturnValue {
+  return selectorSeriesContext();
 }

--- a/packages/x-charts/src/hooks/useBarSeries.ts
+++ b/packages/x-charts/src/hooks/useBarSeries.ts
@@ -10,7 +10,7 @@ import {
 const selectorSeries = createSeriesSelectorsOfType('bar');
 const selectorSeriesContext = createAllSeriesSelectorOfType('bar');
 
-export type UseBarSeriesReturnValue = ChartSeriesDefaultized<'bar'> | undefined;
+export type UseBarSeriesReturnValue = ChartSeriesDefaultized<'bar'>;
 export type UseBarSeriesContextReturnValue = ProcessedSeries['bar'];
 
 /**
@@ -19,7 +19,7 @@ export type UseBarSeriesContextReturnValue = ProcessedSeries['bar'];
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseBarSeriesReturnValue} the bar series
  */
-export function useBarSeries(seriesId: SeriesId): UseBarSeriesReturnValue;
+export function useBarSeries(seriesId: SeriesId): UseBarSeriesReturnValue | undefined;
 /**
  * Get access to the internal state of bar series.
  *

--- a/packages/x-charts/src/hooks/useLineSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useLineSeries.test.tsx
@@ -1,45 +1,53 @@
 import { renderHook } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
-import { useLineSeries } from './useLineSeries';
+import { useLineSeries, useLineSeriesContext } from './useLineSeries';
 import { LineSeriesType } from '../models';
 import { LineChart } from '../LineChart';
 
-describe('useLineSeries', () => {
-  const mockSeries: LineSeriesType[] = [
-    {
-      type: 'line',
-      id: '1',
-      data: [1, 2, 3],
-    },
-    {
-      type: 'line',
-      id: '2',
-      data: [4, 5, 6],
-    },
-  ];
+const mockSeries: LineSeriesType[] = [
+  {
+    type: 'line',
+    id: '1',
+    data: [1, 2, 3],
+  },
+  {
+    type: 'line',
+    id: '2',
+    data: [4, 5, 6],
+  },
+];
 
-  const defaultProps = {
-    series: mockSeries,
-    height: 400,
-    width: 400,
-  };
+const defaultProps = {
+  series: mockSeries,
+  height: 400,
+  width: 400,
+};
 
-  const options: any = {
-    wrapper: ({ children }: { children: React.ReactElement }) => {
-      return <LineChart {...defaultProps}>{children}</LineChart>;
-    },
-  };
+const options: any = {
+  wrapper: ({ children }: { children: React.ReactElement }) => {
+    return <LineChart {...defaultProps}>{children}</LineChart>;
+  },
+};
 
+describe('useLineSeriesContext', () => {
   it('should return all line series when no seriesIds are provided', () => {
-    const { result } = renderHook(() => useLineSeries(), options);
+    const { result } = renderHook(() => useLineSeriesContext(), options);
     expect(result.current?.seriesOrder).to.deep.equal(['1', '2']);
     expect(Object.keys(result.current?.series ?? {})).to.deep.equal(['1', '2']);
   });
+});
 
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('useLineSeries', () => {
   it('should return the specific line series when a single seriesId is provided', () => {
     const { result } = renderHook(() => useLineSeries('1'), options);
     expect(result.current?.id).to.deep.equal(mockSeries[0].id);
+  });
+
+  it('should return all line series when no seriesId is provided', () => {
+    const { result } = renderHook(() => useLineSeries(), options);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, mockSeries[1].id]);
   });
 
   it('should return the specific line series when multiple seriesIds are provided', () => {

--- a/packages/x-charts/src/hooks/useLineSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useLineSeries.test.tsx
@@ -57,6 +57,6 @@ describe('useLineSeries', () => {
 
   it('should return undefined series when invalid seriesIds are provided', () => {
     const { result } = renderHook(() => useLineSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, undefined]);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/useLineSeries.ts
+++ b/packages/x-charts/src/hooks/useLineSeries.ts
@@ -10,7 +10,7 @@ import {
 const selectorSeries = createSeriesSelectorsOfType('line');
 const selectorSeriesContext = createAllSeriesSelectorOfType('line');
 
-export type UseLineSeriesReturnValue = ChartSeriesDefaultized<'line'> | undefined;
+export type UseLineSeriesReturnValue = ChartSeriesDefaultized<'line'>;
 export type UseLineSeriesContextReturnValue = ProcessedSeries['line'];
 
 /**
@@ -19,7 +19,7 @@ export type UseLineSeriesContextReturnValue = ProcessedSeries['line'];
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseLineSeriesReturnValue} the line series
  */
-export function useLineSeries(seriesId: SeriesId): UseLineSeriesReturnValue;
+export function useLineSeries(seriesId: SeriesId): UseLineSeriesReturnValue | undefined;
 /**
  * Get access to the internal state of line series.
  *

--- a/packages/x-charts/src/hooks/useLineSeries.ts
+++ b/packages/x-charts/src/hooks/useLineSeries.ts
@@ -2,34 +2,50 @@
 import { ProcessedSeries } from '../internals/plugins/corePlugins/useChartSeries/useChartSeries.types';
 import { SeriesId } from '../models/seriesType/common';
 import { ChartSeriesDefaultized } from '../models/seriesType/config';
-import { createSeriesSelectorsOfType } from '../internals/createSeriesSelectorOfType';
+import {
+  createSeriesSelectorsOfType,
+  createAllSeriesSelectorOfType,
+} from '../internals/createSeriesSelectorOfType';
 
 const selectorSeries = createSeriesSelectorsOfType('line');
+const selectorSeriesContext = createAllSeriesSelectorOfType('line');
+
+export type UseLineSeriesReturnValue = ChartSeriesDefaultized<'line'> | undefined;
+export type UseLineSeriesContextReturnValue = ProcessedSeries['line'];
+
+/**
+ * Get access to the internal state of line series.
+ *
+ * @param {SeriesId} seriesId The id of the series to get.
+ * @returns {UseLineSeriesReturnValue} the line series
+ */
+export function useLineSeries(seriesId: SeriesId): UseLineSeriesReturnValue;
+/**
+ * Get access to the internal state of line series.
+ *
+ * When called without arguments, it returns all line series.
+ *
+ * @returns {UseLineSeriesReturnValue[]} the line series
+ */
+export function useLineSeries(): UseLineSeriesReturnValue[];
+/**
+ * Get access to the internal state of line series.
+ *
+ * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
+ * @returns {UseLineSeriesReturnValue[]} the line series
+ */
+export function useLineSeries(seriesIds: SeriesId[]): UseLineSeriesReturnValue[];
+export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
+  return selectorSeries(seriesIds);
+}
 
 /**
  * Get access to the internal state of line series.
  * The returned object contains:
  * - series: a mapping from ids to series attributes.
  * - seriesOrder: the array of series ids.
- * @returns {{ series: Record<SeriesId, DefaultizedLineSeriesType>; seriesOrder: SeriesId[]; } | undefined}  lineSeries
+ * @returns the line series
  */
-export function useLineSeries(): ProcessedSeries['line'];
-/**
- * Get access to the internal state of line series.
- *
- * @param {SeriesId} seriesId The id of the series to get.
- * @returns {ChartSeriesDefaultized<'line'> | undefined}  lineSeries
- */
-export function useLineSeries(seriesId: SeriesId): ChartSeriesDefaultized<'line'> | undefined;
-/**
- * Get access to the internal state of line series.
- *
- * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
- * @returns {ChartSeriesDefaultized<'line'>[] | undefined}  lineSeries
- */
-export function useLineSeries(
-  seriesIds: SeriesId[],
-): (ChartSeriesDefaultized<'line'> | undefined)[];
-export function useLineSeries(seriesIds?: SeriesId | SeriesId[]) {
-  return selectorSeries(seriesIds);
+export function useLineSeriesContext(): UseLineSeriesContextReturnValue {
+  return selectorSeriesContext();
 }

--- a/packages/x-charts/src/hooks/usePieSeries.test.tsx
+++ b/packages/x-charts/src/hooks/usePieSeries.test.tsx
@@ -57,6 +57,6 @@ describe('usePieSeries', () => {
 
   it('should return undefined series when invalid seriesIds are provided', () => {
     const { result } = renderHook(() => usePieSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, undefined]);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/usePieSeries.test.tsx
+++ b/packages/x-charts/src/hooks/usePieSeries.test.tsx
@@ -1,45 +1,53 @@
 import { renderHook } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
-import { usePieSeries } from './usePieSeries';
+import { usePieSeries, usePieSeriesContext } from './usePieSeries';
 import { PieSeriesType } from '../models';
 import { PieChart } from '../PieChart';
 
-describe('usePieSeries', () => {
-  const mockSeries: PieSeriesType[] = [
-    {
-      type: 'pie',
-      id: '1',
-      data: [{ value: 1 }],
-    },
-    {
-      type: 'pie',
-      id: '2',
-      data: [{ value: 1 }],
-    },
-  ];
+const mockSeries: PieSeriesType[] = [
+  {
+    type: 'pie',
+    id: '1',
+    data: [{ value: 1 }],
+  },
+  {
+    type: 'pie',
+    id: '2',
+    data: [{ value: 1 }],
+  },
+];
 
-  const defaultProps = {
-    series: mockSeries,
-    height: 400,
-    width: 400,
-  };
+const defaultProps = {
+  series: mockSeries,
+  height: 400,
+  width: 400,
+};
 
-  const options: any = {
-    wrapper: ({ children }: { children: React.ReactElement }) => {
-      return <PieChart {...defaultProps}>{children}</PieChart>;
-    },
-  };
+const options: any = {
+  wrapper: ({ children }: { children: React.ReactElement }) => {
+    return <PieChart {...defaultProps}>{children}</PieChart>;
+  },
+};
 
+describe('usePieSeriesContext', () => {
   it('should return all pie series when no seriesIds are provided', () => {
-    const { result } = renderHook(() => usePieSeries(), options);
+    const { result } = renderHook(() => usePieSeriesContext(), options);
     expect(result.current?.seriesOrder).to.deep.equal(['1', '2']);
     expect(Object.keys(result.current?.series ?? {})).to.deep.equal(['1', '2']);
   });
+});
 
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('usePieSeries', () => {
   it('should return the specific pie series when a single seriesId is provided', () => {
     const { result } = renderHook(() => usePieSeries('1'), options);
     expect(result.current?.id).to.deep.equal(mockSeries[0].id);
+  });
+
+  it('should return all pie series when no seriesId is provided', () => {
+    const { result } = renderHook(() => usePieSeries(), options);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, mockSeries[1].id]);
   });
 
   it('should return the specific pie series when multiple seriesIds are provided', () => {

--- a/packages/x-charts/src/hooks/usePieSeries.ts
+++ b/packages/x-charts/src/hooks/usePieSeries.ts
@@ -10,7 +10,7 @@ import {
 const selectorSeries = createSeriesSelectorsOfType('pie');
 const selectorSeriesContext = createAllSeriesSelectorOfType('pie');
 
-export type UsePieSeriesReturnValue = ChartSeriesDefaultized<'pie'> | undefined;
+export type UsePieSeriesReturnValue = ChartSeriesDefaultized<'pie'>;
 export type UsePieSeriesContextReturnValue = ProcessedSeries['pie'];
 
 /**
@@ -19,7 +19,7 @@ export type UsePieSeriesContextReturnValue = ProcessedSeries['pie'];
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UsePieSeriesReturnValue} the pie series
  */
-export function usePieSeries(seriesId: SeriesId): UsePieSeriesReturnValue;
+export function usePieSeries(seriesId: SeriesId): UsePieSeriesReturnValue | undefined;
 /**
  * Get access to the internal state of pie series.
  *

--- a/packages/x-charts/src/hooks/usePieSeries.ts
+++ b/packages/x-charts/src/hooks/usePieSeries.ts
@@ -2,32 +2,50 @@
 import { ProcessedSeries } from '../internals/plugins/corePlugins/useChartSeries/useChartSeries.types';
 import { SeriesId } from '../models/seriesType/common';
 import { ChartSeriesDefaultized } from '../models/seriesType/config';
-import { createSeriesSelectorsOfType } from '../internals/createSeriesSelectorOfType';
+import {
+  createSeriesSelectorsOfType,
+  createAllSeriesSelectorOfType,
+} from '../internals/createSeriesSelectorOfType';
 
 const selectorSeries = createSeriesSelectorsOfType('pie');
+const selectorSeriesContext = createAllSeriesSelectorOfType('pie');
+
+export type UsePieSeriesReturnValue = ChartSeriesDefaultized<'pie'> | undefined;
+export type UsePieSeriesContextReturnValue = ProcessedSeries['pie'];
+
+/**
+ * Get access to the internal state of pie series.
+ *
+ * @param {SeriesId} seriesId The id of the series to get.
+ * @returns {UsePieSeriesReturnValue} the pie series
+ */
+export function usePieSeries(seriesId: SeriesId): UsePieSeriesReturnValue;
+/**
+ * Get access to the internal state of pie series.
+ *
+ * When called without arguments, it returns all pie series.
+ *
+ * @returns {UsePieSeriesReturnValue[]} the pie series
+ */
+export function usePieSeries(): UsePieSeriesReturnValue[];
+/**
+ * Get access to the internal state of pie series.
+ *
+ * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
+ * @returns {UsePieSeriesReturnValue[]} the pie series
+ */
+export function usePieSeries(seriesIds: SeriesId[]): UsePieSeriesReturnValue[];
+export function usePieSeries(seriesIds?: SeriesId | SeriesId[]) {
+  return selectorSeries(seriesIds);
+}
 
 /**
  * Get access to the internal state of pie series.
  * The returned object contains:
  * - series: a mapping from ids to series attributes.
  * - seriesOrder: the array of series ids.
- * @returns {{ series: Record<SeriesId, DefaultizedPieSeriesType>; seriesOrder: SeriesId[]; } | undefined}  pieSeries
+ * @returns the pie series
  */
-export function usePieSeries(): ProcessedSeries['pie'];
-/**
- * Get access to the internal state of pie series.
- *
- * @param {SeriesId} seriesId The id of the series to get.
- * @returns {ChartSeriesDefaultized<'pie'> | undefined}  pieSeries
- */
-export function usePieSeries(seriesId: SeriesId): ChartSeriesDefaultized<'pie'> | undefined;
-/**
- * Get access to the internal state of pie series.
- *
- * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
- * @returns {ChartSeriesDefaultized<'pie'>[] | undefined}  pieSeries
- */
-export function usePieSeries(seriesIds: SeriesId[]): (ChartSeriesDefaultized<'pie'> | undefined)[];
-export function usePieSeries(seriesIds?: SeriesId | SeriesId[]) {
-  return selectorSeries(seriesIds);
+export function usePieSeriesContext(): UsePieSeriesContextReturnValue {
+  return selectorSeriesContext();
 }

--- a/packages/x-charts/src/hooks/useScatterSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useScatterSeries.test.tsx
@@ -1,51 +1,59 @@
 import { renderHook } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
-import { useScatterSeries } from './useScatterSeries';
+import { useScatterSeries, useScatterSeriesContext } from './useScatterSeries';
 import { ScatterSeriesType } from '../models';
 import { ScatterChart } from '../ScatterChart';
 
-describe('useScatterSeries', () => {
-  const mockSeries: ScatterSeriesType[] = [
-    {
-      type: 'scatter',
-      id: '1',
-      data: [
-        { id: 1, x: 1, y: 1 },
-        { id: 2, x: 2, y: 2 },
-      ],
-    },
-    {
-      type: 'scatter',
-      id: '2',
-      data: [
-        { id: 3, x: 3, y: 3 },
-        { id: 4, x: 4, y: 4 },
-      ],
-    },
-  ];
+const mockSeries: ScatterSeriesType[] = [
+  {
+    type: 'scatter',
+    id: '1',
+    data: [
+      { id: 1, x: 1, y: 1 },
+      { id: 2, x: 2, y: 2 },
+    ],
+  },
+  {
+    type: 'scatter',
+    id: '2',
+    data: [
+      { id: 3, x: 3, y: 3 },
+      { id: 4, x: 4, y: 4 },
+    ],
+  },
+];
 
-  const defaultProps = {
-    series: mockSeries,
-    height: 400,
-    width: 400,
-  };
+const defaultProps = {
+  series: mockSeries,
+  height: 400,
+  width: 400,
+};
 
-  const options: any = {
-    wrapper: ({ children }: { children: React.ReactElement }) => {
-      return <ScatterChart {...defaultProps}>{children}</ScatterChart>;
-    },
-  };
+const options: any = {
+  wrapper: ({ children }: { children: React.ReactElement }) => {
+    return <ScatterChart {...defaultProps}>{children}</ScatterChart>;
+  },
+};
 
+describe('useScatterSeriesContext', () => {
   it('should return all scatter series when no seriesIds are provided', () => {
-    const { result } = renderHook(() => useScatterSeries(), options);
+    const { result } = renderHook(() => useScatterSeriesContext(), options);
     expect(result.current?.seriesOrder).to.deep.equal(['1', '2']);
     expect(Object.keys(result.current?.series ?? {})).to.deep.equal(['1', '2']);
   });
+});
 
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('useScatterSeries', () => {
   it('should return the specific scatter series when a single seriesId is provided', () => {
     const { result } = renderHook(() => useScatterSeries('1'), options);
     expect(result.current?.id).to.deep.equal(mockSeries[0].id);
+  });
+
+  it('should return all scatter series when no seriesId is provided', () => {
+    const { result } = renderHook(() => useScatterSeries(), options);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, mockSeries[1].id]);
   });
 
   it('should return the specific scatter series when multiple seriesIds are provided', () => {

--- a/packages/x-charts/src/hooks/useScatterSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useScatterSeries.test.tsx
@@ -63,6 +63,6 @@ describe('useScatterSeries', () => {
 
   it('should return undefined series when invalid seriesIds are provided', () => {
     const { result } = renderHook(() => useScatterSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id, undefined]);
+    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/useScatterSeries.ts
+++ b/packages/x-charts/src/hooks/useScatterSeries.ts
@@ -2,34 +2,50 @@
 import { ProcessedSeries } from '../internals/plugins/corePlugins/useChartSeries/useChartSeries.types';
 import { SeriesId } from '../models/seriesType/common';
 import { ChartSeriesDefaultized } from '../models/seriesType/config';
-import { createSeriesSelectorsOfType } from '../internals/createSeriesSelectorOfType';
+import {
+  createSeriesSelectorsOfType,
+  createAllSeriesSelectorOfType,
+} from '../internals/createSeriesSelectorOfType';
 
 const selectorSeries = createSeriesSelectorsOfType('scatter');
+const selectorSeriesContext = createAllSeriesSelectorOfType('scatter');
+
+export type UseScatterSeriesReturnValue = ChartSeriesDefaultized<'scatter'> | undefined;
+export type UseScatterSeriesContextReturnValue = ProcessedSeries['scatter'];
+
+/**
+ * Get access to the internal state of scatter series.
+ *
+ * @param {SeriesId} seriesId The id of the series to get.
+ * @returns {UseScatterSeriesReturnValue} the scatter series
+ */
+export function useScatterSeries(seriesId: SeriesId): UseScatterSeriesReturnValue;
+/**
+ * Get access to the internal state of scatter series.
+ *
+ * When called without arguments, it returns all scatter series.
+ *
+ * @returns {UseScatterSeriesReturnValue[]} the scatter series
+ */
+export function useScatterSeries(): UseScatterSeriesReturnValue[];
+/**
+ * Get access to the internal state of scatter series.
+ *
+ * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
+ * @returns {UseScatterSeriesReturnValue[]} the scatter series
+ */
+export function useScatterSeries(seriesIds: SeriesId[]): UseScatterSeriesReturnValue[];
+export function useScatterSeries(seriesIds?: SeriesId | SeriesId[]) {
+  return selectorSeries(seriesIds);
+}
 
 /**
  * Get access to the internal state of scatter series.
  * The returned object contains:
  * - series: a mapping from ids to series attributes.
  * - seriesOrder: the array of series ids.
- * @returns {{ series: Record<SeriesId, DefaultizedScatterSeriesType>; seriesOrder: SeriesId[]; } | undefined}  scatterSeries
+ * @returns the scatter series
  */
-export function useScatterSeries(): ProcessedSeries['scatter'];
-/**
- * Get access to the internal state of scatter series.
- *
- * @param {SeriesId} seriesId The id of the series to get.
- * @returns {ChartSeriesDefaultized<'scatter'> | undefined}  scatterSeries
- */
-export function useScatterSeries(seriesId: SeriesId): ChartSeriesDefaultized<'scatter'> | undefined;
-/**
- * Get access to the internal state of scatter series.
- *
- * @param {SeriesId[]} seriesIds The ids of the series to get. Order is preserved.
- * @returns {ChartSeriesDefaultized<'scatter'>[] | undefined}  scatterSeries
- */
-export function useScatterSeries(
-  seriesIds: SeriesId[],
-): (ChartSeriesDefaultized<'scatter'> | undefined)[];
-export function useScatterSeries(seriesIds?: SeriesId | SeriesId[]) {
-  return selectorSeries(seriesIds);
+export function useScatterSeriesContext(): UseScatterSeriesContextReturnValue {
+  return selectorSeriesContext();
 }

--- a/packages/x-charts/src/hooks/useScatterSeries.ts
+++ b/packages/x-charts/src/hooks/useScatterSeries.ts
@@ -10,7 +10,7 @@ import {
 const selectorSeries = createSeriesSelectorsOfType('scatter');
 const selectorSeriesContext = createAllSeriesSelectorOfType('scatter');
 
-export type UseScatterSeriesReturnValue = ChartSeriesDefaultized<'scatter'> | undefined;
+export type UseScatterSeriesReturnValue = ChartSeriesDefaultized<'scatter'>;
 export type UseScatterSeriesContextReturnValue = ProcessedSeries['scatter'];
 
 /**
@@ -19,7 +19,7 @@ export type UseScatterSeriesContextReturnValue = ProcessedSeries['scatter'];
  * @param {SeriesId} seriesId The id of the series to get.
  * @returns {UseScatterSeriesReturnValue} the scatter series
  */
-export function useScatterSeries(seriesId: SeriesId): UseScatterSeriesReturnValue;
+export function useScatterSeries(seriesId: SeriesId): UseScatterSeriesReturnValue | undefined;
 /**
  * Get access to the internal state of scatter series.
  *

--- a/packages/x-charts/src/internals/createSeriesSelectorOfType.ts
+++ b/packages/x-charts/src/internals/createSeriesSelectorOfType.ts
@@ -1,4 +1,5 @@
-import { ChartsSeriesConfig } from '../models/seriesType/config';
+import { fastArrayCompare } from '@mui/x-internals/fastArrayCompare';
+import { ChartSeriesDefaultized, ChartsSeriesConfig } from '../models/seriesType/config';
 import { SeriesId } from '../models/seriesType/common';
 import { createSelector } from './plugins/utils/selectors';
 import { selectorChartSeriesProcessed } from './plugins/corePlugins/useChartSeries/useChartSeries.selectors';
@@ -10,21 +11,28 @@ export function createSeriesSelectorsOfType<T extends keyof ChartsSeriesConfig>(
     [selectorChartSeriesProcessed, (_, ids?: SeriesId | SeriesId[]) => ids],
     (processedSeries, ids) => {
       if (!ids || (Array.isArray(ids) && ids.length === 0)) {
-        return Object.values(processedSeries[seriesType]?.series ?? []);
+        return Object.values(processedSeries[seriesType]?.series ?? {});
       }
 
       if (!Array.isArray(ids)) {
         return processedSeries[seriesType]?.series?.[ids];
       }
 
-      return ids.map((id) => processedSeries[seriesType]?.series?.[id]);
+      const result: ChartSeriesDefaultized<T>[] = [];
+      for (const id of ids) {
+        const series = processedSeries[seriesType]?.series?.[id];
+        if (series) {
+          result.push(series);
+        }
+      }
+      return result;
     },
   );
 
   return (ids?: SeriesId | SeriesId[]) => {
     const store = useStore();
 
-    return useSelector(store, selectorSeriesWithIds, ids);
+    return useSelector(store, selectorSeriesWithIds, ids, fastArrayCompare);
   };
 }
 

--- a/packages/x-charts/src/internals/createSeriesSelectorOfType.ts
+++ b/packages/x-charts/src/internals/createSeriesSelectorOfType.ts
@@ -10,7 +10,7 @@ export function createSeriesSelectorsOfType<T extends keyof ChartsSeriesConfig>(
     [selectorChartSeriesProcessed, (_, ids?: SeriesId | SeriesId[]) => ids],
     (processedSeries, ids) => {
       if (!ids || (Array.isArray(ids) && ids.length === 0)) {
-        return processedSeries[seriesType];
+        return Object.values(processedSeries[seriesType]?.series ?? []);
       }
 
       if (!Array.isArray(ids)) {
@@ -25,5 +25,18 @@ export function createSeriesSelectorsOfType<T extends keyof ChartsSeriesConfig>(
     const store = useStore();
 
     return useSelector(store, selectorSeriesWithIds, ids);
+  };
+}
+
+export function createAllSeriesSelectorOfType<T extends keyof ChartsSeriesConfig>(seriesType: T) {
+  const selectorSeries = createSelector(
+    selectorChartSeriesProcessed,
+    (processedSeries) => processedSeries[seriesType],
+  );
+
+  return () => {
+    const store = useStore();
+
+    return useSelector(store, selectorSeries);
   };
 }

--- a/packages/x-internals/src/fastArrayCompare/fastArrayCompare.test.ts
+++ b/packages/x-internals/src/fastArrayCompare/fastArrayCompare.test.ts
@@ -20,7 +20,6 @@ describe('fastArrayCompare', () => {
   });
 
   it('should return false if both arguments are not an array', () => {
-    // @ts-expect-error
     expect(fastArrayCompare(1, 2)).to.equal(false);
   });
 

--- a/packages/x-internals/src/fastArrayCompare/fastArrayCompare.ts
+++ b/packages/x-internals/src/fastArrayCompare/fastArrayCompare.ts
@@ -5,9 +5,11 @@
  *
  * It is faster than `fastObjectShallowCompare` for arrays.
  *
+ * Returns true for instance equality, even if inputs are not arrays.
+ *
  * @returns true if arrays contain the same elements in the same order, false otherwise.
  */
-export function fastArrayCompare<T extends any[]>(a: T, b: T): boolean {
+export function fastArrayCompare<T extends any>(a: T, b: T): boolean {
   if (a === b) {
     return true;
   }


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16537

- Divides `useXxxSeries` into `useXxxSeries(seriesId?: SeriesId | SeriesId[])` and `useXxxSeriesContext`
- `useXxxSeries()` now returns all the series of type `Xxx`
- Fix some typings
- Update demos