### PR TITLE
[charts] Improve tooltip placement in mobile

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import HTMLElementType from '@mui/utils/HTMLElementType';
 import useLazyRef from '@mui/utils/useLazyRef';
 import { styled, useThemeProps } from '@mui/material/styles';
-import Popper, { PopperProps } from '@mui/material/Popper';
+import Popper, { PopperPlacementType, PopperProps } from '@mui/material/Popper';
 import NoSsr from '@mui/material/NoSsr';
 import { useSvgRef } from '../hooks/useSvgRef';
 import { AxisDefaultized } from '../models/axis';
@@ -131,7 +131,15 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
             {
               name: 'offset',
               options: {
-                offset: [0, pointerType?.pointerType === 'touch' ? 40 - pointerType.height : 0],
+                offset: ({ placement }: { placement: PopperPlacementType }) => {
+                  if (pointerType?.pointerType !== 'touch') {
+                    return [0, 0];
+                  }
+
+                  const isBottom = placement.startsWith('bottom');
+                  const placementOffset = isBottom ? 32 : 8;
+                  return [0, pointerType.height + placementOffset];
+                },
               },
             },
           ]}


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/15736.

The tooltip offset on mobile now depends on its placement plus some offset to reduce the odds of it being displayed under the user's finger. 

Pardon my amateur video 😛:

https://github.com/user-attachments/assets/74905614-32c2-4cc8-913f-d79c513ea9ae

Tested on Safari iOS. It would be nice if someone could test it on an Android device as I don't have access to one.
I also don't have access to other touch formats (e.g., stylus/pen). It would be nice if we could test that.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
