### PR TITLE
[charts] Memoize some tooltip internals

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -93,12 +93,50 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
       positionRef.current = { x: event.clientX, y: event.clientY };
       popperRef.current?.update();
     };
+
     element.addEventListener('pointermove', handleMove);
 
     return () => {
       element.removeEventListener('pointermove', handleMove);
     };
   }, [svgRef, positionRef]);
+
+  const anchorEl = React.useMemo(
+    () => ({
+      getBoundingClientRect: () => ({
+        x: positionRef.current.x,
+        y: positionRef.current.y,
+        top: positionRef.current.y,
+        left: positionRef.current.x,
+        right: positionRef.current.x,
+        bottom: positionRef.current.y,
+        width: 0,
+        height: 0,
+        toJSON: () => '',
+      }),
+    }),
+    [positionRef],
+  );
+
+  const modifiers = React.useMemo(
+    () => [
+      {
+        name: 'offset',
+        options: {
+          offset: ({ placement }: { placement: PopperPlacementType }) => {
+            if (pointerType?.pointerType !== 'touch') {
+              return [0, 0];
+            }
+
+            const isBottom = placement.startsWith('bottom');
+            const placementOffset = isBottom ? 32 : 8;
+            return [0, pointerType.height + placementOffset];
+          },
+        },
+      },
+    ],
+    [pointerType],
+  );
 
   if (trigger === 'none') {
     return null;
@@ -114,35 +152,8 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
             pointerType?.pointerType === 'mouse' ? ('right-start' as const) : ('top' as const)
           }
           popperRef={popperRef}
-          anchorEl={{
-            getBoundingClientRect: () => ({
-              x: positionRef.current.x,
-              y: positionRef.current.y,
-              top: positionRef.current.y,
-              left: positionRef.current.x,
-              right: positionRef.current.x,
-              bottom: positionRef.current.y,
-              width: 0,
-              height: 0,
-              toJSON: () => '',
-            }),
-          }}
-          modifiers={[
-            {
-              name: 'offset',
-              options: {
-                offset: ({ placement }: { placement: PopperPlacementType }) => {
-                  if (pointerType?.pointerType !== 'touch') {
-                    return [0, 0];
-                  }
-
-                  const isBottom = placement.startsWith('bottom');
-                  const placementOffset = isBottom ? 32 : 8;
-                  return [0, pointerType.height + placementOffset];
-                },
-              },
-            },
-          ]}
+          anchorEl={anchorEl}
+          modifiers={modifiers}
           {...other}
         >
           {children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: 5.16.14(@emotion/react@11.14.0(@types/react@19.0.8)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@mui/monorepo':
         specifier: github:mui/material-ui#c390c1c2d1c85f42d40f16ce405a3c4b62026ec7
-        version: https://codeload.github.com/mui/material-ui/tar.gz/c390c1c2d1c85f42d40f16ce405a3c4b62026ec7(@babel/core@7.26.7)(encoding@0.1.13)
+        version: https://codeload.github.com/mui/material-ui/tar.gz/c390c1c2d1c85f42d40f16ce405a3c4b62026ec7(@babel/core@7.26.8)(encoding@0.1.13)
       '@mui/utils':
         specifier: ^5.16.14
         version: 5.16.14(@types/react@19.0.8)(react@19.0.0)
@@ -12323,12 +12323,12 @@ snapshots:
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.0.8)(react@19.0.0))(@types/react@19.0.8)(react@19.0.0)
       '@types/react': 19.0.8
 
-  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/c390c1c2d1c85f42d40f16ce405a3c4b62026ec7(@babel/core@7.26.7)(encoding@0.1.13)':
+  '@mui/monorepo@https://codeload.github.com/mui/material-ui/tar.gz/c390c1c2d1c85f42d40f16ce405a3c4b62026ec7(@babel/core@7.26.8)(encoding@0.1.13)':
     dependencies:
       '@googleapis/sheets': 9.3.1(encoding@0.1.13)
       '@netlify/functions': 3.0.0
       '@slack/bolt': 4.2.0
-      babel-plugin-transform-import-meta: 2.3.2(@babel/core@7.26.7)
+      babel-plugin-transform-import-meta: 2.3.2(@babel/core@7.26.8)
       execa: 9.5.2
       google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
@@ -14215,10 +14215,10 @@ snapshots:
 
   babel-plugin-search-and-replace@1.1.1: {}
 
-  babel-plugin-transform-import-meta@2.3.2(@babel/core@7.26.7):
+  babel-plugin-transform-import-meta@2.3.2(@babel/core@7.26.8):
     dependencies:
-      '@babel/core': 7.26.7
-      '@babel/template': 7.25.9
+      '@babel/core': 7.26.8
+      '@babel/template': 7.26.8
       tslib: 2.8.1
 
   babel-plugin-transform-react-remove-prop-types@0.4.24: {}


### PR DESCRIPTION
Should fix #13450

My assumption is that the `anchorEl` and `modifiers`  was always triggering the creation of a new popper.js instance.

After those memorization I do not manage to reproduce the error message