### PR TITLE
[pickers] Fix time related aria labels to depend on `ampm` flag value

### DIFF
--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -397,12 +397,7 @@ export function Clock(inProps: ClockProps) {
           aria-activedescendant={selectedId}
           aria-label={translations.clockLabelText(
             type,
-            value == null
-              ? null
-              : utils.format(
-                  value,
-                  utils.is12HourCycleInCurrentLocale() ? 'fullTime12h' : 'fullTime24h',
-                ),
+            value == null ? null : utils.format(value, ampm ? 'fullTime12h' : 'fullTime24h'),
           )}
           ref={listboxRef}
           role="listbox"

--- a/packages/x-date-pickers/src/managers/useTimeManager.ts
+++ b/packages/x-date-pickers/src/managers/useTimeManager.ts
@@ -20,7 +20,7 @@ import { PickerValue } from '../internals/models';
 export function useTimeManager<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   parameters: UseTimeManagerParameters<TEnableAccessibleFieldDOMStructure> = {},
 ): UseTimeManagerReturnValue<TEnableAccessibleFieldDOMStructure> {
-  const { enableAccessibleFieldDOMStructure = true as TEnableAccessibleFieldDOMStructure } =
+  const { enableAccessibleFieldDOMStructure = true as TEnableAccessibleFieldDOMStructure, ampm } =
     parameters;
 
   return React.useMemo(
@@ -36,15 +36,12 @@ export function useTimeManager<TEnableAccessibleFieldDOMStructure extends boolea
       }),
       internal_getOpenPickerButtonAriaLabel: ({ value, utils, localeText }) => {
         const formattedValue = utils.isValid(value)
-          ? utils.format(
-              value,
-              utils.is12HourCycleInCurrentLocale() ? 'fullTime12h' : 'fullTime24h',
-            )
+          ? utils.format(value, ampm ? 'fullTime12h' : 'fullTime24h')
           : null;
         return localeText.openTimePickerDialogue(formattedValue);
       },
     }),
-    [enableAccessibleFieldDOMStructure],
+    [ampm, enableAccessibleFieldDOMStructure],
   );
 }
 
@@ -66,7 +63,8 @@ export function getTimeFieldInternalPropsDefaults(
   };
 }
 
-export interface UseTimeManagerParameters<TEnableAccessibleFieldDOMStructure extends boolean> {
+export interface UseTimeManagerParameters<TEnableAccessibleFieldDOMStructure extends boolean>
+  extends AmPmProps {
   enableAccessibleFieldDOMStructure?: TEnableAccessibleFieldDOMStructure;
 }
 


### PR DESCRIPTION
Follow up on https://github.com/mui/mui-x/pull/16522#discussion_r1954094585.

Do you think it warrants an entry in the migration guide? 🤔 

## Changelog

- The `aria-label` on the `<Clock />` component and Time Picker opening button has been fixed to rely on the set `ampm` property instead of defaulting to the user's locale.