### PR TITLE
[charts] Fix type imports v7

### DIFF
--- a/packages/x-charts-pro/src/ResponsiveChartContainerPro/ResponsiveChartContainerPro.tsx
+++ b/packages/x-charts-pro/src/ResponsiveChartContainerPro/ResponsiveChartContainerPro.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import '../typeOverloads/modules';
 import PropTypes from 'prop-types';
 import { Watermark } from '@mui/x-license/Watermark';
 import { ResponsiveChartContainerProps } from '@mui/x-charts/ResponsiveChartContainer';

--- a/packages/x-charts-pro/src/index.ts
+++ b/packages/x-charts-pro/src/index.ts
@@ -1,4 +1,4 @@
-import {} from './typeOverloads/modules';
+import './typeOverloads/modules';
 
 // exports from MIT package
 export * from '@mui/x-charts/constants';


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16573

Empty imports get optimized out of the build by typescript. To overcome that we can replace `import {} from ''` with `import ''`