### PR TITLE
[charts] Add test:performance:browser script

### DIFF
--- a/test/performance-charts/package.json
+++ b/test/performance-charts/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test:performance": "vitest bench"
+    "test:performance": "vitest bench",
+    "test:performance:browser": "vitest bench --browser"
   },
   "devDependencies": {
     "@codspeed/vitest-plugin": "^4.0.0",

--- a/test/performance-charts/vitest.config.ts
+++ b/test/performance-charts/vitest.config.ts
@@ -2,19 +2,18 @@ import { defineConfig } from 'vitest/config';
 import codspeedPlugin from '@codspeed/vitest-plugin';
 import react from '@vitejs/plugin-react';
 
+const isCI = process.env.CI === 'true';
+
 export default defineConfig({
-  plugins: [codspeedPlugin(), react()],
+  plugins: [...(isCI ? [codspeedPlugin()] : []), react()],
   test: {
     setupFiles: ['./setup.ts'],
     environment: 'jsdom',
-    // browser: {
-    //   enabled: true,
-    //   headless: true,
-    //   name: 'chromium',
-    //   provider: 'playwright',
-    //   providerOptions: {
-    //     timeout: 60000,
-    //   },
-    // },
+    browser: {
+      enabled: false,
+      headless: true,
+      instances: [{ browser: 'chromium', testTimeout: 60_000 }],
+      provider: 'playwright',
+    },
   },
 });


### PR DESCRIPTION
Add `test:performance:browser` script to `performance-charts`. I'd like to benchmark locally using a real browser because some of the changes I'm doing rely on `getBBox`, which JSDOM doesn't implement. 

Ideally we'd run the benchmarks in CI using a real browser as well, but it seems Codspeed doesn't allow running vitest in browser mode. I'll keep investigating. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
