### PR TITLE
[DataGrid] Use readonly array for GridSortModel

### DIFF
--- a/packages/x-data-grid/src/hooks/features/sorting/useGridSorting.ts
+++ b/packages/x-data-grid/src/hooks/features/sorting/useGridSorting.ts
@@ -188,7 +188,7 @@ export const useGridSorting = (
     (field, direction, allowMultipleSorting) => {
       const column = apiRef.current.getColumn(field);
       const sortItem = createSortItem(column, direction);
-      let sortModel: GridSortItem[];
+      let sortModel: GridSortModel;
       if (!allowMultipleSorting || props.disableMultipleColumnsSorting) {
         sortModel = sortItem?.sort == null ? [] : [sortItem];
       } else {

--- a/packages/x-data-grid/src/models/gridSortModel.ts
+++ b/packages/x-data-grid/src/models/gridSortModel.ts
@@ -37,4 +37,4 @@ export interface GridSortItem {
 /**
  * The model used for sorting the grid.
  */
-export type GridSortModel = GridSortItem[];
+export type GridSortModel = readonly GridSortItem[];

--- a/packages/x-data-grid/src/tests/DataGrid.spec.tsx
+++ b/packages/x-data-grid/src/tests/DataGrid.spec.tsx
@@ -277,3 +277,10 @@ function ApiRefProMethods() {
 
   return null;
 }
+
+function ImmutableProps() {
+  const rows = [] as const;
+  const columns = [] as const;
+  const initialState = { sorting: { sortModel: [{ field: 'id', sort: 'asc' }] } } as const;
+  return <DataGrid rows={rows} columns={columns} initialState={initialState} />;
+}


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Changelog

Fix the type of the GridSortModel to allow readonly arrays.
