### PR TITLE
[charts-pro] Readonly array inputs

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -69,7 +69,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
         zoom: {
           ...prevState.zoom,
           isInteracting: true,
-          zoomData: paramsZoomData,
+          zoomData: [...paramsZoomData],
         },
       };
     });
@@ -104,7 +104,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
       store.update((prevState) => {
         const newZoomData =
           typeof zoomData === 'function' ? zoomData(prevState.zoom.zoomData) : zoomData;
-        onZoomChange?.(newZoomData);
+        onZoomChange?.([...newZoomData]);
 
         if (prevState.zoom.isControlled) {
           return prevState;
@@ -114,7 +114,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
           ...prevState,
           zoom: {
             ...prevState.zoom,
-            zoomData: newZoomData,
+            zoomData: [...newZoomData],
           },
         };
       });
@@ -136,7 +136,11 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
   );
 
   const isDraggingRef = React.useRef(false);
-  const touchStartRef = React.useRef<{ x: number; y: number; zoomData: ZoomData[] } | null>(null);
+  const touchStartRef = React.useRef<{
+    x: number;
+    y: number;
+    zoomData: readonly ZoomData[];
+  } | null>(null);
   React.useEffect(() => {
     const element = svgRef.current;
     if (element === null || !isPanEnabled) {
@@ -441,13 +445,14 @@ useChartProZoom.getInitialState = (params) => {
   };
   return {
     zoom: {
-      zoomData:
+      zoomData: [
         // eslint-disable-next-line no-nested-ternary
-        zoomData !== undefined
+        ...(zoomData !== undefined
           ? zoomData
           : initialZoom !== undefined
             ? initialZoom
-            : initializeZoomData(optionsLookup),
+            : initializeZoomData(optionsLookup)),
+      ],
       isInteracting: false,
       isControlled: zoomData !== undefined,
     },

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
@@ -11,7 +11,7 @@ export interface UseChartProZoomParameters {
    * The list of zoom data related to each axis.
    * Used to initialize the zoom in a specific configuration without controlling it.
    */
-  initialZoom?: ZoomData[];
+  initialZoom?: readonly ZoomData[];
   /**
    * Callback fired when the zoom has changed.
    *
@@ -21,7 +21,7 @@ export interface UseChartProZoomParameters {
   /**
    * The list of zoom data related to each axis.
    */
-  zoomData?: ZoomData[];
+  zoomData?: readonly ZoomData[];
 }
 
 export type UseChartProZoomDefaultizedParameters = UseChartProZoomParameters &

--- a/packages/x-charts-pro/src/models/seriesType/heatmap.ts
+++ b/packages/x-charts-pro/src/models/seriesType/heatmap.ts
@@ -14,7 +14,7 @@ export interface HeatmapSeriesType
   /**
    * Data associated to each bar.
    */
-  data?: HeatmapValueType[];
+  data?: readonly HeatmapValueType[];
   /**
    * The key used to retrieve data from the dataset.
    */

--- a/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
@@ -14,7 +14,7 @@ const config = {
   margin: { top: 0, left: 0, bottom: 0, right: 0 },
   width: 400,
   height: 400,
-};
+} as const;
 
 // Plot as follow to simplify click position
 //

--- a/packages/x-charts/src/ChartsTooltip/contentDisplayed.test.tsx
+++ b/packages/x-charts/src/ChartsTooltip/contentDisplayed.test.tsx
@@ -13,7 +13,7 @@ const config: Partial<BarChartProps> = {
   hideLegend: true,
   width: 400,
   height: 400,
-};
+} as const;
 
 // Plot as follow to simplify click position
 //

--- a/packages/x-charts/src/LineChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/LineChart/checkClickEvent.test.tsx
@@ -16,7 +16,7 @@ const config = {
   margin: { top: 0, left: 0, bottom: 0, right: 0 },
   width: 400,
   height: 400,
-};
+} as const;
 
 describe('LineChart - click event', () => {
   const { render } = createRenderer();

--- a/packages/x-charts/src/LineChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/extremums.ts
@@ -15,7 +15,7 @@ type GetValues = (d: [number, number]) => [number, number];
 
 function getSeriesExtremums(
   getValues: GetValues,
-  data: (number | null)[],
+  data: readonly (number | null)[],
   stackedData: [number, number][],
   filter?: CartesianExtremumFilter,
 ): [number, number] {

--- a/packages/x-charts/src/PieChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/PieChart/checkClickEvent.test.tsx
@@ -7,7 +7,7 @@ import { PieChart } from '@mui/x-charts/PieChart';
 const config = {
   width: 400,
   height: 400,
-};
+} as const;
 
 describe('PieChart - click event', () => {
   const { render } = createRenderer();

--- a/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
@@ -53,7 +53,7 @@ describe('<ScatterChart />', () => {
     margin: { top: 0, left: 0, bottom: 0, right: 0 },
     width: 100,
     height: 100,
-  };
+  } as const;
 
   // svg.createSVGPoint not supported by JSDom https://github.com/jsdom/jsdom/issues/300
   testSkipIf(isJSDOM)('should show the tooltip without errors in default config', () => {

--- a/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
@@ -16,7 +16,7 @@ const config = {
   margin: { top: 0, left: 0, bottom: 0, right: 0 },
   width: 100,
   height: 100,
-};
+} as const;
 
 // Plot on series as a dice 5
 //

--- a/packages/x-charts/src/context/PolarProvider/Polar.types.ts
+++ b/packages/x-charts/src/context/PolarProvider/Polar.types.ts
@@ -24,7 +24,7 @@ export type PolarProviderProps = {
   /**
    * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
-  dataset?: DatasetType;
+  dataset?: Readonly<DatasetType>;
   children: React.ReactNode;
 };
 

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/processSeries.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/processSeries.ts
@@ -21,10 +21,10 @@ export const preprocessSeries = <TSeriesType extends ChartSeriesType>({
   seriesConfig,
   dataset,
 }: {
-  series: AllSeriesType<TSeriesType>[];
+  series: readonly AllSeriesType<TSeriesType>[];
   colors: string[];
   seriesConfig: ChartSeriesConfig<TSeriesType>;
-  dataset?: DatasetType;
+  dataset?: Readonly<DatasetType>;
 }) => {
   // Group series by type
   const seriesGroups: { [type in ChartSeriesType]?: SeriesProcessorParams<type> } = {};

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.ts
@@ -49,8 +49,8 @@ useChartSeries.params = {
 const EMPTY_ARRAY: any[] = [];
 
 useChartSeries.getDefaultizedParams = ({ params }) => ({
-  series: EMPTY_ARRAY,
   ...params,
+  series: params.series?.length ? [...params.series] : EMPTY_ARRAY,
   colors: params.colors ?? rainbowSurgePalette,
   theme: params.theme ?? 'light',
 });

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.types.ts
@@ -8,13 +8,13 @@ export interface UseChartSeriesParameters<T extends ChartSeriesType = ChartSerie
   /**
    * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
-  dataset?: DatasetType;
+  dataset?: Readonly<DatasetType>;
   /**
    * The array of series to display.
    * Each type of series has its own specificity.
    * Please refer to the appropriate docs page to learn more about it.
    */
-  series?: AllSeriesType<T>[];
+  series?: readonly AllSeriesType<T>[];
   /**
    * Color palette used to colorize multiple series.
    * @default rainbowSurgePalette

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -33,7 +33,7 @@ function getRange(
   return axis.reverse ? [range[1], range[0]] : range;
 }
 
-const isDateData = (data?: any[]): data is Date[] => data?.[0] instanceof Date;
+const isDateData = (data?: readonly any[]): data is Date[] => data?.[0] instanceof Date;
 
 function createDateFormatter(
   axis: AxisConfig<'band' | 'point', any, ChartsAxisProps>,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -6,7 +6,7 @@ import { DatasetType } from '../../../../models/seriesType/config';
 
 export function defaultizeAxis(
   inAxis: readonly MakeOptional<AxisConfig<ScaleName, any, ChartsAxisProps>, 'id'>[] | undefined,
-  dataset: DatasetType | undefined,
+  dataset: Readonly<DatasetType> | undefined,
   axisName: 'x' | 'y',
 ) {
   const DEFAULT_AXIS_KEY = axisName === 'x' ? DEFAULT_X_AXIS_KEY : DEFAULT_Y_AXIS_KEY;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -5,7 +5,7 @@ import { ChartsAxisProps } from '../../../../models/axis';
 import { DatasetType } from '../../../../models/seriesType/config';
 
 export function defaultizeAxis(
-  inAxis: MakeOptional<AxisConfig<ScaleName, any, ChartsAxisProps>, 'id'>[] | undefined,
+  inAxis: readonly MakeOptional<AxisConfig<ScaleName, any, ChartsAxisProps>, 'id'>[] | undefined,
   dataset: DatasetType | undefined,
   axisName: 'x' | 'y',
 ) {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.selectors.ts
@@ -12,7 +12,7 @@ import { createAxisFilterMapper, createGetAxisFilters } from './createAxisFilter
 import { ZoomAxisFilters, ZoomData } from './zoom.types';
 import { createZoomLookup } from './createZoomLookup';
 
-export const createZoomMap = (zoom: ZoomData[]) => {
+export const createZoomMap = (zoom: readonly ZoomData[]) => {
   const zoomItemMap = new Map<AxisId, ZoomData>();
   zoom.forEach((zoomItem) => {
     zoomItemMap.set(zoomItem.axisId, zoomItem);

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.types.ts
@@ -43,17 +43,17 @@ export interface UseChartCartesianAxisParameters {
    * If not provided, a default axis config is used.
    * An array of [[AxisConfig]] objects.
    */
-  xAxis?: MakeOptional<AxisConfig<ScaleName, any, ChartsXAxisProps>, 'id'>[];
+  xAxis?: readonly MakeOptional<AxisConfig<ScaleName, any, ChartsXAxisProps>, 'id'>[];
   /**
    * The configuration of the y-axes.
    * If not provided, a default axis config is used.
    * An array of [[AxisConfig]] objects.
    */
-  yAxis?: MakeOptional<AxisConfig<ScaleName, any, ChartsYAxisProps>, 'id'>[];
+  yAxis?: readonly MakeOptional<AxisConfig<ScaleName, any, ChartsYAxisProps>, 'id'>[];
   /**
    * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
-  dataset?: DatasetType;
+  dataset?: Readonly<DatasetType>;
   /**
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartZAxis/useChartZAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartZAxis/useChartZAxis.ts
@@ -35,7 +35,10 @@ function processColorMap(axisConfig: ZAxisConfig) {
   };
 }
 
-function getZAxisState(zAxis?: MakeOptional<ZAxisConfig, 'id'>[], dataset?: DatasetType) {
+function getZAxisState(
+  zAxis?: readonly MakeOptional<ZAxisConfig, 'id'>[],
+  dataset?: Readonly<DatasetType>,
+) {
   if (!zAxis || zAxis.length === 0) {
     return { axis: {}, axisIds: [] };
   }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartZAxis/useChartZAxis.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartZAxis/useChartZAxis.types.ts
@@ -12,11 +12,11 @@ export interface UseChartZAxisParameters {
   /**
    * The configuration of the z-axes.
    */
-  zAxis?: MakeOptional<ZAxisConfig, 'id'>[];
+  zAxis?: readonly MakeOptional<ZAxisConfig, 'id'>[];
   /**
    * An array of objects that can be used to populate series and axes data using their `dataKey` property.
    */
-  dataset?: DatasetType;
+  dataset?: Readonly<DatasetType>;
 }
 
 export type UseChartZAxisDefaultizedParameters = UseChartZAxisParameters;

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/seriesProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/seriesProcessor.types.ts
@@ -23,5 +23,5 @@ export type SeriesProcessorResult<TSeriesType extends ChartSeriesType> = {
 
 export type SeriesProcessor<TSeriesType extends ChartSeriesType> = (
   params: SeriesProcessorParams<TSeriesType>,
-  dataset?: DatasetType,
+  dataset?: Readonly<DatasetType>,
 ) => SeriesProcessorResult<TSeriesType>;

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -315,7 +315,7 @@ export type AxisConfig<
   /**
    * The data used by `'band'` and `'point'` scales.
    */
-  data?: V[];
+  data?: readonly V[];
   /**
    * The key used to retrieve `data` from the `dataset` prop.
    */

--- a/packages/x-charts/src/models/colorMapping.ts
+++ b/packages/x-charts/src/models/colorMapping.ts
@@ -35,7 +35,7 @@ export interface OrdinalColorConfig<Value = number | Date | string> {
    * The value to map.
    * If undefined, it will be integers from 0 to the number of colors.
    */
-  values?: Value[];
+  values?: readonly Value[];
   /**
    * The color palette.
    * Items equal to `values[k]` will get the color of `colors[k]`.

--- a/packages/x-charts/src/models/seriesType/bar.ts
+++ b/packages/x-charts/src/models/seriesType/bar.ts
@@ -15,7 +15,7 @@ export interface BarSeriesType
   /**
    * Data associated to each bar.
    */
-  data?: (number | null)[];
+  data?: readonly (number | null)[];
   /**
    * The key used to retrieve data from the dataset.
    */

--- a/packages/x-charts/src/models/seriesType/config.ts
+++ b/packages/x-charts/src/models/seriesType/config.ts
@@ -94,6 +94,6 @@ export type ChartItemIdentifier<T extends ChartSeriesType> =
   ChartsSeriesConfig[T]['itemIdentifier'];
 
 export type DatasetElementType<T> = {
-  [key: string]: T;
+  [key: string]: Readonly<T>;
 };
 export type DatasetType<T = number | string | Date | null | undefined> = DatasetElementType<T>[];

--- a/packages/x-charts/src/models/seriesType/line.ts
+++ b/packages/x-charts/src/models/seriesType/line.ts
@@ -40,7 +40,7 @@ export interface LineSeriesType
   /**
    * Data associated to the line.
    */
-  data?: (number | null)[];
+  data?: readonly (number | null)[];
   /**
    * The key used to retrieve data from the dataset.
    */

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -15,7 +15,7 @@ export interface ScatterSeriesType
   extends CommonSeriesType<ScatterValueType | null>,
     CartesianSeriesType {
   type: 'scatter';
-  data?: ScatterValueType[];
+  data?: readonly ScatterValueType[];
   markerSize?: number;
   /**
    * The label to display on the tooltip or the legend. It can be a string or a function.

--- a/packages/x-charts/src/models/z-axis.ts
+++ b/packages/x-charts/src/models/z-axis.ts
@@ -3,7 +3,7 @@ import { ContinuousColorConfig, OrdinalColorConfig, PiecewiseColorConfig } from 
 
 export interface ZAxisConfig<V = any> {
   id: string;
-  data?: V[];
+  data?: readonly V[];
   /**
    * The key used to retrieve `data` from the `dataset` prop.
    */


### PR DESCRIPTION
This might be a bit overarching, but currently sometimes when we use `[] as const` it can't be used as the input for our chart components because readonly arrays can't be downgraded to mutable arrays.

This PR tries to fix that by making all the array inputs `readonly`