### PR TITLE
[DataGrid] Fix: base Select menuprops onClose

### DIFF
--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -11,6 +11,7 @@ import MUIFocusTrap from '@mui/material/Unstable_TrapFocus';
 import MUILinearProgress from '@mui/material/LinearProgress';
 import MUIListItemIcon from '@mui/material/ListItemIcon';
 import MUIListItemText from '@mui/material/ListItemText';
+import { MenuProps as MUIMenuProps } from '@mui/material/Menu';
 import MUIMenuList from '@mui/material/MenuList';
 import MUIMenuItem from '@mui/material/MenuItem';
 import MUITextField from '@mui/material/TextField';
@@ -84,6 +85,14 @@ const BaseSelect = forwardRef<any, GridSlotProps['baseSelect']>(function BaseSel
     fullWidth,
     ...rest
   } = props;
+  const menuProps = {
+    PaperProps: {
+      onKeyDown,
+    },
+  } as Partial<MUIMenuProps>;
+  if (onClose) {
+    menuProps.onClose = onClose;
+  }
   return (
     <MUIFormControl
       size={size}
@@ -113,12 +122,7 @@ const BaseSelect = forwardRef<any, GridSlotProps['baseSelect']>(function BaseSel
         notched
         inputProps={slotProps?.htmlInput}
         onOpen={onOpen}
-        MenuProps={{
-          onClose,
-          PaperProps: {
-            onKeyDown,
-          },
-        }}
+        MenuProps={menuProps}
         size={size}
       />
     </MUIFormControl>


### PR DESCRIPTION
Fixes Select components not closing on click-away.

Having `onClose: undefined` in `MenuProps` removes the default close handler.