### PR TITLE
[charts] Add unit test for pie chart with empty series

### DIFF
--- a/packages/x-charts/src/PieChart/PieChart.test.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer } from '@mui/internal-test-utils/createRenderer';
+import { createRenderer, screen } from '@mui/internal-test-utils/createRenderer';
 import { describeConformance } from 'test/utils/describeConformance';
 import { PieChart } from '@mui/x-charts/PieChart';
+import { expect } from 'chai';
 
 describe('<PieChart />', () => {
   const { render } = createRenderer();
@@ -38,4 +39,11 @@ describe('<PieChart />', () => {
       ],
     }),
   );
+
+  it('should render "No Data" overlay when series prop is an empty array', () => {
+    render(<PieChart height={100} width={100} series={[]} />);
+
+    const noDataOverlay = screen.getByText('No data to display');
+    expect(noDataOverlay).toBeVisible();
+  });
 });


### PR DESCRIPTION
Add unit test for pie chart with empty series.

Cherry-picked from https://github.com/mui/mui-x/pull/16657. 



<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

