### PR TITLE
[pickers] Fix `TimeClock` meridiem button selected styles

### DIFF
--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -158,7 +158,10 @@ const ClockPin = styled('div', {
   transform: 'translate(-50%, -50%)',
 }));
 
-const meridiemButtonCommonStyles = (theme: Theme, meridiemMode: Meridiem) => ({
+const meridiemButtonCommonStyles = (
+  theme: Theme,
+  clockMeridiemMode: ClockOwnerState['clockMeridiemMode'],
+) => ({
   zIndex: 1,
   bottom: 8,
   paddingLeft: 4,
@@ -166,7 +169,7 @@ const meridiemButtonCommonStyles = (theme: Theme, meridiemMode: Meridiem) => ({
   width: CLOCK_HOUR_WIDTH,
   variants: [
     {
-      props: { meridiemMode },
+      props: { clockMeridiemMode },
       style: {
         backgroundColor: (theme.vars || theme).palette.primary.main,
         color: (theme.vars || theme).palette.primary.contrastText,

--- a/packages/x-date-pickers/src/TimeClock/ClockPointer.tsx
+++ b/packages/x-date-pickers/src/TimeClock/ClockPointer.tsx
@@ -84,7 +84,7 @@ const ClockPointerThumb = styled('div', {
   boxSizing: 'content-box',
   variants: [
     {
-      props: { isBetweenTwoClockValues: false },
+      props: { isClockPointerBetweenTwoValues: false },
       style: {
         backgroundColor: (theme.vars || theme).palette.primary.main,
       },


### PR DESCRIPTION
It's broken only on v8/master.

| Before | After |
|--------|------|
|![Screenshot 2025-02-21 at 12 31 39](https://github.com/user-attachments/assets/5b4d5703-1bb5-4424-886a-76239e492d35)|![Screenshot 2025-02-21 at 12 48 03](https://github.com/user-attachments/assets/e672e565-44c4-4fb0-9146-f38559a1eae9)|


