### PR TITLE
[docs] Improve Pickers migration page

### DIFF
--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -68,6 +68,36 @@ After running the codemods, make sure to test your application and that you don'
 Feel free to [open an issue](https://github.com/mui/mui-x/issues/new/choose) for support if you need help to proceed with your migration.
 :::
 
+## ✅ Rename `date-fns` adapter imports
+
+:::warning
+This codemod is not idempotent. Running it multiple times will rename the imports back and forth.
+
+In example: usage of `AdapterDateFnsV3` would be replaced by `AdapterDateFns` and a subsequent run would rename it to `AdapterDateFnsV2`.
+:::
+
+- The `AdapterDateFns` and `AdapterDateFnsJalali` adapters have been renamed to `AdapterDateFnsV2` and `AdapterDateFnsJalaliV2` respectively.
+  If you were using the old imports, you need to update them:
+
+  ```diff
+  -import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+  -import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
+  +import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV2';
+  +import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalaliV2';
+  ```
+
+  Or consider updating the `date-fns` or `date-fns-jalali` package to the latest version and use the updated adapters.
+
+- The `AdapterDateFnsV3` and `AdapterDateFnsJalaliV3` adapters have been renamed to `AdapterDateFns` and `AdapterDateFnsJalali` respectively.
+  If you were using the old imports, you need to update them:
+
+  ```diff
+  -import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
+  -import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalaliV3';
+  +import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+  +import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
+  ```
+
 ## Components breaking changes
 
 ### New DOM structure for the field
@@ -1692,36 +1722,6 @@ const theme = createTheme({
   },
 });
 ```
-
-## ✅ Rename `date-fns` adapter imports
-
-:::warning
-This codemod is not idempotent. Running it multiple times will rename the imports back and forth.
-
-In example: usage of `AdapterDateFnsV3` would be replaced by `AdapterDateFns` and a subsequent run would rename it to `AdapterDateFnsV2`.
-:::
-
-- The `AdapterDateFns` and `AdapterDateFnsJalali` adapters have been renamed to `AdapterDateFnsV2` and `AdapterDateFnsJalaliV2` respectively.
-  If you were using the old imports, you need to update them:
-
-  ```diff
-  -import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-  -import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
-  +import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV2';
-  +import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalaliV2';
-  ```
-
-  Or consider updating the `date-fns` or `date-fns-jalali` package to the latest version and use the updated adapters.
-
-- The `AdapterDateFnsV3` and `AdapterDateFnsJalaliV3` adapters have been renamed to `AdapterDateFns` and `AdapterDateFnsJalali` respectively.
-  If you were using the old imports, you need to update them:
-
-  ```diff
-  -import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
-  -import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalaliV3';
-  +import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-  +import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
-  ```
 
 ## Stop using `LicenseInfo` from `@mui/x-date-pickers-pro`
 

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -28,6 +28,13 @@ Since `v8` is a major release, it contains changes that affect the public API.
 These changes were done for consistency, improved stability and to make room for new features.
 Described below are the steps needed to migrate from v7 to v8.
 
+:::success
+The amount of breaking changes is relatively large, but most of them might impact only a small portion of users, who are using advanced customization.
+
+Changes that might impact such users are marked with a ⏩ emoji.
+You can skip them and come back to them later if you experience any issues after the migration.
+:::
+
 ## Run codemods
 
 The `preset-safe` codemod will automatically adjust the bulk of your code to account for breaking changes in v8. You can run `v8.0.0/pickers/preset-safe` targeting only Date and Time Pickers or `v8.0.0/preset-safe` to target the other packages as well.
@@ -292,7 +299,7 @@ const theme = createTheme({
 });
 ```
 
-### Field editing on mobile Pickers
+### ⏩ Field editing on mobile Pickers
 
 The field is now editable if rendered inside a mobile Picker.
 Before v8, if rendered inside a mobile Picker, the field was read-only, and clicking anywhere on it would open the Picker.
@@ -306,7 +313,7 @@ If you prefer the old behavior, you can create a custom field that renders a rea
 See [Custom field—Using a read-only Text Field on mobile](/x/react-date-pickers/custom-field/#using-a-read-only-text-field-on-mobile) to learn more.
 :::
 
-### New default fields for the range pickers
+### ⏩ New default fields for the range pickers
 
 The range pickers now use single input fields by default:
 
@@ -336,7 +343,7 @@ If you were already using a single input field, you no longer need to manually p
  />
 ```
 
-### Month Calendar
+### ⏩ Month Calendar
 
 To simplify the theme and class structure, the `<PickersMonth />` component has been moved inside the Month Calendar component.
 This change causes a few breaking changes:
@@ -377,7 +384,7 @@ This change causes a few breaking changes:
 
 - The button to render a single month is no longer wrapped in a `<div />`, the spacing are instead defined inside the `root` slot of the Month Calendar.
 
-### Year Calendar
+### ⏩ Year Calendar
 
 To simplify the theme and class structure, the `<PickersYear />` component has been moved inside the Year Calendar component.
 This change causes a few breaking changes:
@@ -418,7 +425,7 @@ This change causes a few breaking changes:
 
 - The button to render a single year is no longer wrapped in a `<div />`, the spacing are instead defined inside the `root` slot of the Year Calendar.
 
-### Update default `closeOnSelect` and Action Bar `actions` values
+### ⏩ Update default `closeOnSelect` and Action Bar `actions` values
 
 The default value of the `closeOnSelect` prop has been updated to `false` for all Picker components, except `<DesktopDatePicker />` and `<DesktopDateRangePicker />`, which still have `closeOnSelect` set to `true`.
 
@@ -624,7 +631,7 @@ If the updated values do not fit your use case, you can [override them](/x/react
    />
   ```
 
-### Slot: `layout`
+### ⏩ Slot: `layout`
 
 - The `<PickersLayoutRoot />` and `<PickersLayoutContentWrapper />` components must now receive the `ownerState` returned by `usePickerLayout` instead of their props:
 
@@ -796,7 +803,7 @@ If the updated values do not fit your use case, you can [override them](/x/react
   +setRangePosition('start');
   ```
 
-### Slot: `toolbar`
+### ⏩ Slot: `toolbar`
 
 - The component passed to the `toolbar` slot no longer receives the `value` prop.
   You can use the `usePickerContext` hook instead:
@@ -885,7 +892,7 @@ If the updated values do not fit your use case, you can [override them](/x/react
   +setRangePosition('start');
   ```
 
-### Slot: `tabs`
+### ⏩ Slot: `tabs`
 
 - The component passed to the `tabs` slot no longer receives the `view`, `views` and `onViewChange` props.
   You can use the `usePickerContext` hook instead:
@@ -917,7 +924,7 @@ If the updated values do not fit your use case, you can [override them](/x/react
   +setRangePosition('start');
   ```
 
-### Slot: `actionBar`
+### ⏩ Slot: `actionBar`
 
 - The component passed to the `actionBar` slot no longer receives the `onClear`, `onSetToday`, `onAccept` and `onCancel` props.
   You can use the `usePickerActionsContext` or the `usePickerContext` hooks instead:
@@ -943,7 +950,7 @@ If the updated values do not fit your use case, you can [override them](/x/react
   The only difference is that `usePickerActionsContext` only contains variables with stable references that won't cause a re-render of your component.
   :::
 
-### Slot: `shortcuts`
+### ⏩ Slot: `shortcuts`
 
 - The component passed to the `shortcuts` slot no longer receives the `isLandscape` prop.
   You can use the `usePickerContext` hook instead:
@@ -983,7 +990,7 @@ If the updated values do not fit your use case, you can [override them](/x/react
   +const isTodayValid = isValidValue(dayjs());
   ```
 
-## Renamed variables and types
+## ⏩ Renamed variables and types
 
 The following variables and types have been renamed to have a coherent `Picker` / `Pickers` prefix:
 
@@ -1049,9 +1056,9 @@ The following variables and types have been renamed to have a coherent `Picker` 
   +import { PickerChangeImportance } from '@mui/x-date-pickers';
   ```
 
-## Hooks breaking changes
+## ⏩ Hooks breaking changes
 
-### `useMultiInputDateRangeField`
+### ⏩ `useMultiInputDateRangeField`
 
 This hook has been removed in favor of the new `useMultiInputRangeField` hook with an improved DX:
 
@@ -1102,7 +1109,7 @@ This hook has been removed in favor of the new `useMultiInputRangeField` hook wi
 The associated types have also been removed. [Learn how to migrate them](/x/migration/migration-pickers-v7/#removed-types).
 :::
 
-### `useMultiInputTimeRangeField`
+### ⏩ `useMultiInputTimeRangeField`
 
 This hook has been removed in favor of the new `useMultiInputRangeField` hook with an improved DX:
 
@@ -1154,7 +1161,7 @@ This hook has been removed in favor of the new `useMultiInputRangeField` hook wi
 The associated types have also been removed. [Learn how to migrate them](/x/migration/migration-pickers-v7/#removed-types).
 :::
 
-### `useMultiInputDateTimeRangeField`
+### ⏩ `useMultiInputDateTimeRangeField`
 
 This hook has been removed in favor of the new `useMultiInputRangeField` hook with an improved DX:
 
@@ -1206,7 +1213,7 @@ This hook has been removed in favor of the new `useMultiInputRangeField` hook wi
 The associated types have also been removed. [Learn how to migrate them](/x/migration/migration-pickers-v7/#removed-types).
 :::
 
-### `usePickerContext`
+### ⏩ `usePickerContext`
 
 - The `onOpen` and `onClose` methods have been replaced with a single `setOpen` method.
   This method no longer takes an event, which was used to prevent the browser default behavior:
@@ -1275,7 +1282,7 @@ The `TSection` generic of the `FieldRef` type has been replaced with the `TValue
 +const fieldRef = React.useRef<DateRange<Dayjs>>(null);
 ```
 
-### Removed types
+### ⏩ Removed types
 
 The following types are no longer exported by `@mui/x-date-pickers` and/or `@mui/x-date-pickers-pro`.
 If you were using them, you need to replace them with the following code:
@@ -1692,7 +1699,7 @@ If you were using them, you need to replace them with the following code:
 
 ## Theme breaking change
 
-### `MuiPickersPopper`
+### ⏩ `MuiPickersPopper`
 
 The theme entry have been renamed to have a coherent `Picker` / `Pickers` prefix:
 
@@ -1723,7 +1730,7 @@ const theme = createTheme({
 });
 ```
 
-## Stop using `LicenseInfo` from `@mui/x-date-pickers-pro`
+## ⏩ Stop using `LicenseInfo` from `@mui/x-date-pickers-pro`
 
 The `LicenseInfo` object is no longer exported from the `@mui/x-date-pickers-pro` package.
 You can import it from `@mui/x-license` instead:
@@ -1735,7 +1742,7 @@ You can import it from `@mui/x-license` instead:
  LicenseInfo.setLicenseKey('YOUR_LICENSE_KEY');
 ```
 
-## Stop passing `utils` and the date object to some translation keys
+## ⏩ Stop passing `utils` and the date object to some translation keys
 
 Some translation keys no longer require `utils` and the date object as parameters, but only the formatted value as a string. The keys affected by this changes are: `clockLabelText`, `openDatePickerDialogue` and `openTimePickerDialogue`.
 If you have customized those translation keys, you have to update them following the examples below:
@@ -1833,7 +1840,7 @@ If you have customized those translation keys, you have to update them following
 +);
 ```
 
-## Remove unused adapter formats
+## ⏩ Remove unused adapter formats
 
 The following unused formats have been removed from the adapters and can no longer be overridden via the `dateFormats` prop on the `<LocalizationProvider />` component:
 


### PR DESCRIPTION
Improve the Pickers migration guide docs:
- Move the `date-fns` adapters rename section to the top of the page
- Mark low impacts BCs with ⏩ and add a callout explaining this marking