### PR TITLE
[charts] fix x-axis tick label overflow

### DIFF
--- a/docs/data/charts/areas-demo/AreaChartConnectNulls.js
+++ b/docs/data/charts/areas-demo/AreaChartConnectNulls.js
@@ -4,6 +4,7 @@ import { LineChart } from '@mui/x-charts/LineChart';
 
 const data = [4000, 3000, 2000, null, 1890, 2390, 3490];
 const xData = ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'];
+const margin = { right: 24 };
 
 export default function AreaChartConnectNulls() {
   return (
@@ -12,11 +13,13 @@ export default function AreaChartConnectNulls() {
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data, showMark: false, area: true }]}
         height={200}
+        margin={margin}
       />
       <LineChart
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data, showMark: false, area: true, connectNulls: true }]}
         height={200}
+        margin={margin}
       />
     </Stack>
   );

--- a/docs/data/charts/areas-demo/AreaChartConnectNulls.tsx
+++ b/docs/data/charts/areas-demo/AreaChartConnectNulls.tsx
@@ -4,6 +4,7 @@ import { LineChart } from '@mui/x-charts/LineChart';
 
 const data = [4000, 3000, 2000, null, 1890, 2390, 3490];
 const xData = ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'];
+const margin = { right: 24 };
 
 export default function AreaChartConnectNulls() {
   return (
@@ -12,11 +13,13 @@ export default function AreaChartConnectNulls() {
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data, showMark: false, area: true }]}
         height={200}
+        margin={margin}
       />
       <LineChart
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data, showMark: false, area: true, connectNulls: true }]}
         height={200}
+        margin={margin}
       />
     </Stack>
   );

--- a/docs/data/charts/areas-demo/AreaChartConnectNulls.tsx.preview
+++ b/docs/data/charts/areas-demo/AreaChartConnectNulls.tsx.preview
@@ -2,9 +2,11 @@
   xAxis={[{ data: xData, scaleType: 'point' }]}
   series={[{ data, showMark: false, area: true }]}
   height={200}
+  margin={margin}
 />
 <LineChart
   xAxis={[{ data: xData, scaleType: 'point' }]}
   series={[{ data, showMark: false, area: true, connectNulls: true }]}
   height={200}
+  margin={margin}
 />

--- a/docs/data/charts/areas-demo/AreaChartFillByValue.js
+++ b/docs/data/charts/areas-demo/AreaChartFillByValue.js
@@ -5,6 +5,7 @@ import Stack from '@mui/material/Stack';
 import { useYScale, useDrawingArea } from '@mui/x-charts/hooks';
 import { LineChart, areaElementClasses } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24, bottom: 0 };
 const data = [4000, 3000, -1000, 500, -2100, -250, 3490];
 const xData = ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'];
 
@@ -41,7 +42,7 @@ export default function AreaChartFillByValue() {
         yAxis={[{ min: -3000, max: 4000, width: 40 }]}
         series={[{ data, showMark: false, area: true }]}
         height={200}
-        margin={{ bottom: 0 }}
+        margin={margin}
         sx={{
           [`& .${areaElementClasses.root}`]: {
             fill: 'url(#switch-color-id-1)',
@@ -63,7 +64,7 @@ export default function AreaChartFillByValue() {
         yAxis={[{ min: -3000, max: 4000, width: 40 }]}
         series={[{ data, showMark: false, area: true }]}
         height={200}
-        margin={{ bottom: 0 }}
+        margin={margin}
         sx={{
           [`& .${areaElementClasses.root}`]: {
             fill: 'url(#switch-color-id-2)',

--- a/docs/data/charts/areas-demo/AreaChartFillByValue.tsx
+++ b/docs/data/charts/areas-demo/AreaChartFillByValue.tsx
@@ -5,6 +5,7 @@ import Stack from '@mui/material/Stack';
 import { useYScale, useDrawingArea } from '@mui/x-charts/hooks';
 import { LineChart, areaElementClasses } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24, bottom: 0 };
 const data = [4000, 3000, -1000, 500, -2100, -250, 3490];
 const xData = ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'];
 
@@ -48,7 +49,7 @@ export default function AreaChartFillByValue() {
         yAxis={[{ min: -3000, max: 4000, width: 40 }]}
         series={[{ data, showMark: false, area: true }]}
         height={200}
-        margin={{ bottom: 0 }}
+        margin={margin}
         sx={{
           [`& .${areaElementClasses.root}`]: {
             fill: 'url(#switch-color-id-1)',
@@ -70,7 +71,7 @@ export default function AreaChartFillByValue() {
         yAxis={[{ min: -3000, max: 4000, width: 40 }]}
         series={[{ data, showMark: false, area: true }]}
         height={200}
-        margin={{ bottom: 0 }}
+        margin={margin}
         sx={{
           [`& .${areaElementClasses.root}`]: {
             fill: 'url(#switch-color-id-2)',

--- a/docs/data/charts/areas-demo/SimpleAreaChart.js
+++ b/docs/data/charts/areas-demo/SimpleAreaChart.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart, lineElementClasses } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const xLabels = [
   'Page A',
@@ -23,6 +24,7 @@ export default function SimpleAreaChart() {
           display: 'none',
         },
       }}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/areas-demo/SimpleAreaChart.tsx
+++ b/docs/data/charts/areas-demo/SimpleAreaChart.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart, lineElementClasses } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const xLabels = [
   'Page A',
@@ -23,6 +24,7 @@ export default function SimpleAreaChart() {
           display: 'none',
         },
       }}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/areas-demo/SimpleAreaChart.tsx.preview
+++ b/docs/data/charts/areas-demo/SimpleAreaChart.tsx.preview
@@ -7,4 +7,5 @@
       display: 'none',
     },
   }}
+  margin={margin}
 />

--- a/docs/data/charts/areas-demo/StackedAreaChart.js
+++ b/docs/data/charts/areas-demo/StackedAreaChart.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart, lineElementClasses } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const amtData = [2400, 2210, 0, 2000, 2181, 2500, 2100];
@@ -35,6 +36,7 @@ export default function StackedAreaChart() {
           display: 'none',
         },
       }}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/areas-demo/StackedAreaChart.tsx
+++ b/docs/data/charts/areas-demo/StackedAreaChart.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart, lineElementClasses } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const amtData = [2400, 2210, 0, 2000, 2181, 2500, 2100];
@@ -35,6 +36,7 @@ export default function StackedAreaChart() {
           display: 'none',
         },
       }}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/axis/FormatterDemo.js
+++ b/docs/data/charts/axis/FormatterDemo.js
@@ -108,6 +108,7 @@ export default function FormatterDemo() {
             context.location === 'tick'
               ? `${month.slice(0, 3)} \n2023`
               : `${month} 2023`,
+          height: 40,
         },
       ]}
       series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.js
+++ b/docs/data/charts/axis/FormatterDemo.js
@@ -108,7 +108,7 @@ export default function FormatterDemo() {
             context.location === 'tick'
               ? `${month.slice(0, 3)} \n2023`
               : `${month} 2023`,
-          height: 80,
+          height: 40,
         },
       ]}
       series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.js
+++ b/docs/data/charts/axis/FormatterDemo.js
@@ -108,7 +108,7 @@ export default function FormatterDemo() {
             context.location === 'tick'
               ? `${month.slice(0, 3)} \n2023`
               : `${month} 2023`,
-          height: 40,
+          height: 80,
         },
       ]}
       series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.tsx
+++ b/docs/data/charts/axis/FormatterDemo.tsx
@@ -108,6 +108,7 @@ export default function FormatterDemo() {
             context.location === 'tick'
               ? `${month.slice(0, 3)} \n2023`
               : `${month} 2023`,
+          height: 40,
         },
       ]}
       series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.tsx
+++ b/docs/data/charts/axis/FormatterDemo.tsx
@@ -108,7 +108,7 @@ export default function FormatterDemo() {
             context.location === 'tick'
               ? `${month.slice(0, 3)} \n2023`
               : `${month} 2023`,
-          height: 80,
+          height: 40,
         },
       ]}
       series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.tsx
+++ b/docs/data/charts/axis/FormatterDemo.tsx
@@ -108,7 +108,7 @@ export default function FormatterDemo() {
             context.location === 'tick'
               ? `${month.slice(0, 3)} \n2023`
               : `${month} 2023`,
-          height: 40,
+          height: 80,
         },
       ]}
       series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.tsx.preview
+++ b/docs/data/charts/axis/FormatterDemo.tsx.preview
@@ -8,6 +8,7 @@
         context.location === 'tick'
           ? `${month.slice(0, 3)} \n2023`
           : `${month} 2023`,
+      height: 40,
     },
   ]}
   series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.tsx.preview
+++ b/docs/data/charts/axis/FormatterDemo.tsx.preview
@@ -8,7 +8,7 @@
         context.location === 'tick'
           ? `${month.slice(0, 3)} \n2023`
           : `${month} 2023`,
-      height: 40,
+      height: 80,
     },
   ]}
   series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/FormatterDemo.tsx.preview
+++ b/docs/data/charts/axis/FormatterDemo.tsx.preview
@@ -8,7 +8,7 @@
         context.location === 'tick'
           ? `${month.slice(0, 3)} \n2023`
           : `${month} 2023`,
-      height: 80,
+      height: 40,
     },
   ]}
   series={[{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }]}

--- a/docs/data/charts/axis/MarginAndLabelPosition.js
+++ b/docs/data/charts/axis/MarginAndLabelPosition.js
@@ -31,7 +31,8 @@ export default function MarginAndLabelPosition() {
                 ? value.split('').join('\n')
                 : usAirportPassengers.find((item) => item.code === value).fullName,
             label: 'airports',
-            height: fixMargin ? 85 : undefined,
+            // height: fixMargin ? 75 : undefined,
+            ...(fixMargin ? { height: 75 } : {}),
           },
         ]}
         // Other props
@@ -49,7 +50,8 @@ export default function MarginAndLabelPosition() {
           {
             valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
             label: 'passengers',
-            width: fixMargin ? 85 : undefined,
+            ...(fixMargin ? { width: 85 } : {}),
+            // width: fixMargin ? 85 : undefined,
           },
         ]}
       />

--- a/docs/data/charts/axis/MarginAndLabelPosition.js
+++ b/docs/data/charts/axis/MarginAndLabelPosition.js
@@ -31,8 +31,7 @@ export default function MarginAndLabelPosition() {
                 ? value.split('').join('\n')
                 : usAirportPassengers.find((item) => item.code === value).fullName,
             label: 'airports',
-            // height: fixMargin ? 75 : undefined,
-            ...(fixMargin ? { height: 75 } : {}),
+            height: fixMargin ? 75 : undefined,
           },
         ]}
         // Other props
@@ -50,8 +49,7 @@ export default function MarginAndLabelPosition() {
           {
             valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
             label: 'passengers',
-            ...(fixMargin ? { width: 85 } : {}),
-            // width: fixMargin ? 85 : undefined,
+            width: fixMargin ? 85 : undefined,
           },
         ]}
       />

--- a/docs/data/charts/axis/MarginAndLabelPosition.tsx
+++ b/docs/data/charts/axis/MarginAndLabelPosition.tsx
@@ -31,7 +31,8 @@ export default function MarginAndLabelPosition() {
                 ? value.split('').join('\n')
                 : usAirportPassengers.find((item) => item.code === value)!.fullName,
             label: 'airports',
-            height: fixMargin ? 85 : undefined,
+            // height: fixMargin ? 75 : undefined,
+            ...(fixMargin ? { height: 75 } : {}),
           },
         ]}
         // Other props
@@ -49,7 +50,8 @@ export default function MarginAndLabelPosition() {
           {
             valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
             label: 'passengers',
-            width: fixMargin ? 85 : undefined,
+            ...(fixMargin ? { width: 85 } : {}),
+            // width: fixMargin ? 85 : undefined,
           },
         ]}
       />

--- a/docs/data/charts/axis/MarginAndLabelPosition.tsx
+++ b/docs/data/charts/axis/MarginAndLabelPosition.tsx
@@ -31,8 +31,7 @@ export default function MarginAndLabelPosition() {
                 ? value.split('').join('\n')
                 : usAirportPassengers.find((item) => item.code === value)!.fullName,
             label: 'airports',
-            // height: fixMargin ? 75 : undefined,
-            ...(fixMargin ? { height: 75 } : {}),
+            height: fixMargin ? 75 : undefined,
           },
         ]}
         // Other props
@@ -50,8 +49,7 @@ export default function MarginAndLabelPosition() {
           {
             valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
             label: 'passengers',
-            ...(fixMargin ? { width: 85 } : {}),
-            // width: fixMargin ? 85 : undefined,
+            width: fixMargin ? 85 : undefined,
           },
         ]}
       />

--- a/docs/data/charts/axis/ModifyAxisPosition.js
+++ b/docs/data/charts/axis/ModifyAxisPosition.js
@@ -13,7 +13,7 @@ const data = Array.from({ length: 200 }, () => ({
 const params = {
   series: [{ data }],
   height: 300,
-  margin: 10,
+  margin: 12,
 };
 export default function ModifyAxisPosition() {
   return (

--- a/docs/data/charts/axis/ModifyAxisPosition.tsx
+++ b/docs/data/charts/axis/ModifyAxisPosition.tsx
@@ -13,7 +13,7 @@ const data = Array.from({ length: 200 }, () => ({
 const params = {
   series: [{ data }],
   height: 300,
-  margin: 10,
+  margin: 12,
 };
 export default function ModifyAxisPosition() {
   return (

--- a/docs/data/charts/axis/XAxisTickLabelOverflow.js
+++ b/docs/data/charts/axis/XAxisTickLabelOverflow.js
@@ -1,0 +1,262 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+const defaultXAxis = {
+  id: 'angle0',
+  scaleType: 'band',
+  dataKey: 'code',
+  position: 'bottom',
+  height: 80,
+  valueFormatter: (value) =>
+    usAirportPassengers.find((item) => item.code === value).fullName,
+  label: '0deg Axis Title',
+};
+
+export default function XAxisTickLabelOverflow() {
+  return (
+    <BarChart
+      xAxis={[
+        {
+          ...defaultXAxis,
+          id: 'angle-90',
+          label: '-90deg Axis Title',
+          tickLabelStyle: {
+            angle: -90,
+            textAnchor: 'end',
+            dominantBaseline: 'central',
+          },
+        },
+        {
+          ...defaultXAxis,
+          id: 'angle-45',
+          label: '-45deg Axis Title',
+          tickLabelStyle: {
+            angle: -45,
+            textAnchor: 'end',
+            dominantBaseline: 'central',
+          },
+        },
+        defaultXAxis,
+        {
+          ...defaultXAxis,
+          id: 'angle45',
+          label: '45deg Axis Title',
+          tickLabelStyle: {
+            angle: 45,
+            textAnchor: 'start',
+          },
+        },
+        {
+          ...defaultXAxis,
+          id: 'angle90',
+          label: '90deg Axis Title',
+          tickLabelStyle: {
+            angle: 90,
+            textAnchor: 'start',
+            dominantBaseline: 'central',
+          },
+        },
+      ]}
+      // Other props
+      height={600}
+      dataset={usAirportPassengers}
+      series={[
+        { dataKey: '2018', label: '2018' },
+        { dataKey: '2019', label: '2019' },
+        { dataKey: '2020', label: '2020' },
+        { dataKey: '2021', label: '2021' },
+        { dataKey: '2022', label: '2022' },
+      ]}
+      hideLegend
+      yAxis={[
+        {
+          valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
+          width: 40,
+        },
+      ]}
+    />
+  );
+}
+
+const usAirportPassengers = [
+  {
+    fullName: 'Hartsfield–Jackson Atlanta International Airport',
+    code: 'ATL',
+    2022: 45396001,
+    2021: 36676010,
+    2020: 20559866,
+    2019: 53505795,
+    2018: 51865797,
+  },
+  {
+    fullName: 'Dallas/Fort Worth International Airport',
+    code: 'DFW',
+    2022: 35345138,
+    2021: 30005266,
+    2020: 18593421,
+    2019: 35778573,
+    2018: 32821799,
+  },
+  {
+    fullName: 'Denver International Airport',
+    code: 'DEN',
+    2022: 33773832,
+    2021: 28645527,
+    2020: 16243216,
+    2019: 33592945,
+    2018: 31362941,
+  },
+  {
+    fullName: "O'Hare International Airport",
+    code: 'ORD',
+    2022: 33120474,
+    2021: 26350976,
+    2020: 14606034,
+    2019: 40871223,
+    2018: 39873927,
+  },
+  {
+    fullName: 'Los Angeles International Airport',
+    code: 'LAX',
+    2022: 32326616,
+    2021: 23663410,
+    2020: 14055777,
+    2019: 42939104,
+    2018: 42624050,
+  },
+  {
+    fullName: 'John F. Kennedy International Airport',
+    code: 'JFK',
+    2022: 26919982,
+    2021: 15273342,
+    2020: 8269819,
+    2019: 31036655,
+    2018: 30620769,
+  },
+  {
+    fullName: 'Harry Reid International Airport',
+    code: 'LAS',
+    2022: 25480500,
+    2021: 19160342,
+    2020: 10584059,
+    2019: 24728361,
+    2018: 23795012,
+  },
+  {
+    fullName: 'Orlando International Airport',
+    code: 'MCO',
+    2022: 24469733,
+    2021: 19618838,
+    2020: 10467728,
+    2019: 24562271,
+    2018: 23202480,
+  },
+  {
+    fullName: 'Miami International Airport',
+    code: 'MIA',
+    2022: 23949892,
+    2021: 17500096,
+    2020: 8786007,
+    2019: 21421031,
+    2018: 21021640,
+  },
+  {
+    fullName: 'Charlotte Douglas International Airport',
+    code: 'CLT',
+    2022: 23100300,
+    2021: 20900875,
+    2020: 12952869,
+    2019: 24199688,
+    2018: 22281949,
+  },
+  {
+    fullName: 'Seattle–Tacoma International Airport',
+    code: 'SEA',
+    2022: 22157862,
+    2021: 17430195,
+    2020: 9462411,
+    2019: 25001762,
+    2018: 24024908,
+  },
+  {
+    fullName: 'Phoenix Sky Harbor International Airport',
+    code: 'PHX',
+    2022: 21852586,
+    2021: 18940287,
+    2020: 10531436,
+    2019: 22433552,
+    2018: 21622580,
+  },
+  {
+    fullName: 'Newark Liberty International Airport',
+    code: 'EWR',
+    2022: 21572147,
+    2021: 14514049,
+    2020: 7985474,
+    2019: 23160763,
+    2018: 22797602,
+  },
+  {
+    fullName: 'San Francisco International Airport',
+    code: 'SFO',
+    2022: 20411420,
+    2021: 11725347,
+    2020: 7745057,
+    2019: 27779230,
+    2018: 27790717,
+  },
+  {
+    fullName: 'George Bush Intercontinental Airport',
+    code: 'IAH',
+    2022: 19814052,
+    2021: 16242821,
+    2020: 8682558,
+    2019: 21905309,
+    2018: 21157398,
+  },
+  {
+    fullName: 'Logan International Airport',
+    code: 'BOS',
+    2022: 17443775,
+    2021: 10909817,
+    2020: 6035452,
+    2019: 20699377,
+    2018: 20006521,
+  },
+  {
+    fullName: 'Fort Lauderdale–Hollywood International Airport',
+    code: 'FLL',
+    2022: 15370165,
+    2021: 13598994,
+    2020: 8015744,
+    2019: 17950989,
+    2018: 17612331,
+  },
+  {
+    fullName: 'Minneapolis–Saint Paul International Airport',
+    code: 'MSP',
+    2022: 15242089,
+    2021: 12211409,
+    2020: 7069720,
+    2019: 19192917,
+    2018: 18361942,
+  },
+  {
+    fullName: 'LaGuardia Airport',
+    code: 'LGA',
+    2022: 14367463,
+    2021: 7827307,
+    2020: 4147116,
+    2019: 15393601,
+    2018: 15058501,
+  },
+  {
+    fullName: 'Detroit Metropolitan Airport',
+    code: 'DTW',
+    2022: 13751197,
+    2021: 11517696,
+    2020: 6822324,
+    2019: 18143040,
+    2018: 17436837,
+  },
+];

--- a/docs/data/charts/axis/XAxisTickLabelOverflow.js
+++ b/docs/data/charts/axis/XAxisTickLabelOverflow.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { BarChart } from '@mui/x-charts/BarChart';
+import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 
 const defaultXAxis = {
   id: 'angle0',
   scaleType: 'band',
   dataKey: 'code',
   position: 'bottom',
+  zoom: true,
   height: 80,
   valueFormatter: (value) =>
     usAirportPassengers.find((item) => item.code === value).fullName,
@@ -14,7 +15,7 @@ const defaultXAxis = {
 
 export default function XAxisTickLabelOverflow() {
   return (
-    <BarChart
+    <BarChartPro
       xAxis={[
         {
           ...defaultXAxis,

--- a/docs/data/charts/axis/XAxisTickLabelOverflow.tsx
+++ b/docs/data/charts/axis/XAxisTickLabelOverflow.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { BarChart } from '@mui/x-charts/BarChart';
+import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 
 const defaultXAxis = {
   id: 'angle0',
   scaleType: 'band',
   dataKey: 'code',
   position: 'bottom',
+  zoom: true,
   height: 80,
   valueFormatter: (value: any) =>
     usAirportPassengers.find((item) => item.code === value)!.fullName,
@@ -14,7 +15,7 @@ const defaultXAxis = {
 
 export default function XAxisTickLabelOverflow() {
   return (
-    <BarChart
+    <BarChartPro
       xAxis={[
         {
           ...defaultXAxis,

--- a/docs/data/charts/axis/XAxisTickLabelOverflow.tsx
+++ b/docs/data/charts/axis/XAxisTickLabelOverflow.tsx
@@ -1,0 +1,263 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+const defaultXAxis = {
+  id: 'angle0',
+  scaleType: 'band',
+  dataKey: 'code',
+  position: 'bottom',
+  height: 80,
+  valueFormatter: (value: any) =>
+    usAirportPassengers.find((item) => item.code === value)!.fullName,
+  label: '0deg Axis Title',
+} as const;
+
+export default function XAxisTickLabelOverflow() {
+  return (
+    <BarChart
+      xAxis={[
+        {
+          ...defaultXAxis,
+          id: 'angle-90',
+          label: '-90deg Axis Title',
+          tickLabelStyle: {
+            angle: -90,
+            textAnchor: 'end',
+            dominantBaseline: 'central',
+          },
+        },
+
+        {
+          ...defaultXAxis,
+          id: 'angle-45',
+          label: '-45deg Axis Title',
+          tickLabelStyle: {
+            angle: -45,
+            textAnchor: 'end',
+            dominantBaseline: 'central',
+          },
+        },
+        defaultXAxis,
+        {
+          ...defaultXAxis,
+          id: 'angle45',
+          label: '45deg Axis Title',
+          tickLabelStyle: {
+            angle: 45,
+            textAnchor: 'start',
+          },
+        },
+        {
+          ...defaultXAxis,
+          id: 'angle90',
+          label: '90deg Axis Title',
+          tickLabelStyle: {
+            angle: 90,
+            textAnchor: 'start',
+            dominantBaseline: 'central',
+          },
+        },
+      ]}
+      // Other props
+      height={600}
+      dataset={usAirportPassengers}
+      series={[
+        { dataKey: '2018', label: '2018' },
+        { dataKey: '2019', label: '2019' },
+        { dataKey: '2020', label: '2020' },
+        { dataKey: '2021', label: '2021' },
+        { dataKey: '2022', label: '2022' },
+      ]}
+      hideLegend
+      yAxis={[
+        {
+          valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
+          width: 40,
+        },
+      ]}
+    />
+  );
+}
+
+const usAirportPassengers = [
+  {
+    fullName: 'Hartsfield–Jackson Atlanta International Airport',
+    code: 'ATL',
+    2022: 45396001,
+    2021: 36676010,
+    2020: 20559866,
+    2019: 53505795,
+    2018: 51865797,
+  },
+  {
+    fullName: 'Dallas/Fort Worth International Airport',
+    code: 'DFW',
+    2022: 35345138,
+    2021: 30005266,
+    2020: 18593421,
+    2019: 35778573,
+    2018: 32821799,
+  },
+  {
+    fullName: 'Denver International Airport',
+    code: 'DEN',
+    2022: 33773832,
+    2021: 28645527,
+    2020: 16243216,
+    2019: 33592945,
+    2018: 31362941,
+  },
+  {
+    fullName: "O'Hare International Airport",
+    code: 'ORD',
+    2022: 33120474,
+    2021: 26350976,
+    2020: 14606034,
+    2019: 40871223,
+    2018: 39873927,
+  },
+  {
+    fullName: 'Los Angeles International Airport',
+    code: 'LAX',
+    2022: 32326616,
+    2021: 23663410,
+    2020: 14055777,
+    2019: 42939104,
+    2018: 42624050,
+  },
+  {
+    fullName: 'John F. Kennedy International Airport',
+    code: 'JFK',
+    2022: 26919982,
+    2021: 15273342,
+    2020: 8269819,
+    2019: 31036655,
+    2018: 30620769,
+  },
+  {
+    fullName: 'Harry Reid International Airport',
+    code: 'LAS',
+    2022: 25480500,
+    2021: 19160342,
+    2020: 10584059,
+    2019: 24728361,
+    2018: 23795012,
+  },
+  {
+    fullName: 'Orlando International Airport',
+    code: 'MCO',
+    2022: 24469733,
+    2021: 19618838,
+    2020: 10467728,
+    2019: 24562271,
+    2018: 23202480,
+  },
+  {
+    fullName: 'Miami International Airport',
+    code: 'MIA',
+    2022: 23949892,
+    2021: 17500096,
+    2020: 8786007,
+    2019: 21421031,
+    2018: 21021640,
+  },
+  {
+    fullName: 'Charlotte Douglas International Airport',
+    code: 'CLT',
+    2022: 23100300,
+    2021: 20900875,
+    2020: 12952869,
+    2019: 24199688,
+    2018: 22281949,
+  },
+  {
+    fullName: 'Seattle–Tacoma International Airport',
+    code: 'SEA',
+    2022: 22157862,
+    2021: 17430195,
+    2020: 9462411,
+    2019: 25001762,
+    2018: 24024908,
+  },
+  {
+    fullName: 'Phoenix Sky Harbor International Airport',
+    code: 'PHX',
+    2022: 21852586,
+    2021: 18940287,
+    2020: 10531436,
+    2019: 22433552,
+    2018: 21622580,
+  },
+  {
+    fullName: 'Newark Liberty International Airport',
+    code: 'EWR',
+    2022: 21572147,
+    2021: 14514049,
+    2020: 7985474,
+    2019: 23160763,
+    2018: 22797602,
+  },
+  {
+    fullName: 'San Francisco International Airport',
+    code: 'SFO',
+    2022: 20411420,
+    2021: 11725347,
+    2020: 7745057,
+    2019: 27779230,
+    2018: 27790717,
+  },
+  {
+    fullName: 'George Bush Intercontinental Airport',
+    code: 'IAH',
+    2022: 19814052,
+    2021: 16242821,
+    2020: 8682558,
+    2019: 21905309,
+    2018: 21157398,
+  },
+  {
+    fullName: 'Logan International Airport',
+    code: 'BOS',
+    2022: 17443775,
+    2021: 10909817,
+    2020: 6035452,
+    2019: 20699377,
+    2018: 20006521,
+  },
+  {
+    fullName: 'Fort Lauderdale–Hollywood International Airport',
+    code: 'FLL',
+    2022: 15370165,
+    2021: 13598994,
+    2020: 8015744,
+    2019: 17950989,
+    2018: 17612331,
+  },
+  {
+    fullName: 'Minneapolis–Saint Paul International Airport',
+    code: 'MSP',
+    2022: 15242089,
+    2021: 12211409,
+    2020: 7069720,
+    2019: 19192917,
+    2018: 18361942,
+  },
+  {
+    fullName: 'LaGuardia Airport',
+    code: 'LGA',
+    2022: 14367463,
+    2021: 7827307,
+    2020: 4147116,
+    2019: 15393601,
+    2018: 15058501,
+  },
+  {
+    fullName: 'Detroit Metropolitan Airport',
+    code: 'DTW',
+    2022: 13751197,
+    2021: 11517696,
+    2020: 6822324,
+    2019: 18143040,
+    2018: 17436837,
+  },
+];

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -229,10 +229,10 @@ If you would like to reduce clipping due to overflow, you can [apply an angle to
 
 In the following demo, the size of the x- and y-axes is modified to increase the space available for tick labels.
 
-{{"demo": "MarginAndLabelPosition.js"}}
-
 The first and last tick labels may bleed into the margin. If that margin is not enough to display the label, it might be clipped.
 To avoid this, you can use the `margin` property to increase the space between the chart and the edge of the container.
+
+{{"demo": "MarginAndLabelPosition.js"}}
 
 ### Rendering
 

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -222,16 +222,14 @@ To avoid overlapping, you can use the `height` prop for `xAxis` and `width` for 
 
 You can further customize the axis rendering besides the axis definition.
 
-### Fixing overflow issues
+### Fixing tick label overflow issues
 
-If your tick labels are too long, they can either overflow the SVG or overlap with the axis label.
-You can resolve this by [increasing the size of the overflowing axis](/x/react-charts/styling/#placement).
+When your tick labels are too long, they are clipped to avoid overflowing.
+If you would like to reduce clipping due to overflow, you can [apply an angle to the tick labels](/x/react-charts/axis/#text-customization) or [increase the axis size](/x/react-charts/styling/#placement) to accommodate them.
 
 In the following demo, the size of the x- and y-axes is modified to increase the space available for tick labels.
 
 {{"demo": "MarginAndLabelPosition.js"}}
-
-{{"demo": "XAxisTickLabelOverflow.js"}}
 
 ### Rendering
 

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -231,6 +231,9 @@ In the following demo, the size of the x- and y-axes is modified to increase the
 
 {{"demo": "MarginAndLabelPosition.js"}}
 
+The first and last tick labels may bleed into the margin. If that margin is not enough to display the label, it might be clipped.
+To avoid this, you can use the `margin` property to increase the space between the chart and the edge of the container.
+
 ### Rendering
 
 Axes rendering can be further customized. Below is an interactive demonstration of the axis props.

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -231,6 +231,8 @@ In the following demo, the size of the x- and y-axes is modified to increase the
 
 {{"demo": "MarginAndLabelPosition.js"}}
 
+{{"demo": "XAxisTickLabelOverflow.js"}}
+
 ### Rendering
 
 Axes rendering can be further customized. Below is an interactive demonstration of the axis props.

--- a/docs/data/charts/line-demo/CustomLineMarks.js
+++ b/docs/data/charts/line-demo/CustomLineMarks.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -32,6 +33,7 @@ export default function CustomLineMarks() {
         },
       ]}
       xAxis={[{ scaleType: 'point', data: xLabels }]}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/line-demo/CustomLineMarks.tsx
+++ b/docs/data/charts/line-demo/CustomLineMarks.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -32,6 +33,7 @@ export default function CustomLineMarks() {
         },
       ]}
       xAxis={[{ scaleType: 'point', data: xLabels }]}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/line-demo/DashedLineChart.js
+++ b/docs/data/charts/line-demo/DashedLineChart.js
@@ -5,6 +5,7 @@ import {
   markElementClasses,
 } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -43,6 +44,7 @@ export default function DashedLineChart() {
           stroke: 'none',
         },
       }}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/line-demo/DashedLineChart.tsx
+++ b/docs/data/charts/line-demo/DashedLineChart.tsx
@@ -5,6 +5,7 @@ import {
   markElementClasses,
 } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -43,6 +44,7 @@ export default function DashedLineChart() {
           stroke: 'none',
         },
       }}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/line-demo/LineChartConnectNulls.js
+++ b/docs/data/charts/line-demo/LineChartConnectNulls.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import { LineChart } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const data = [4000, 3000, 2000, null, 1890, 2390, 3490];
 const xData = ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'];
 export default function LineChartConnectNulls() {
@@ -11,11 +12,13 @@ export default function LineChartConnectNulls() {
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data }]}
         height={200}
+        margin={margin}
       />
       <LineChart
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data, connectNulls: true }]}
         height={200}
+        margin={margin}
       />
     </Stack>
   );

--- a/docs/data/charts/line-demo/LineChartConnectNulls.tsx
+++ b/docs/data/charts/line-demo/LineChartConnectNulls.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import { LineChart } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const data = [4000, 3000, 2000, null, 1890, 2390, 3490];
 const xData = ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F', 'Page G'];
 export default function LineChartConnectNulls() {
@@ -11,11 +12,13 @@ export default function LineChartConnectNulls() {
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data }]}
         height={200}
+        margin={margin}
       />
       <LineChart
         xAxis={[{ data: xData, scaleType: 'point' }]}
         series={[{ data, connectNulls: true }]}
         height={200}
+        margin={margin}
       />
     </Stack>
   );

--- a/docs/data/charts/line-demo/LineChartConnectNulls.tsx.preview
+++ b/docs/data/charts/line-demo/LineChartConnectNulls.tsx.preview
@@ -2,9 +2,11 @@
   xAxis={[{ data: xData, scaleType: 'point' }]}
   series={[{ data }]}
   height={200}
+  margin={margin}
 />
 <LineChart
   xAxis={[{ data: xData, scaleType: 'point' }]}
   series={[{ data, connectNulls: true }]}
   height={200}
+  margin={margin}
 />

--- a/docs/data/charts/line-demo/LineChartWithReferenceLines.js
+++ b/docs/data/charts/line-demo/LineChartWithReferenceLines.js
@@ -5,6 +5,7 @@ import { LinePlot, MarkPlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -27,6 +28,7 @@ export default function LineChartWithReferenceLines() {
         { data: uData, label: 'uv', type: 'line' },
       ]}
       xAxis={[{ scaleType: 'point', data: xLabels }]}
+      margin={margin}
     >
       <LinePlot />
       <MarkPlot />

--- a/docs/data/charts/line-demo/LineChartWithReferenceLines.tsx
+++ b/docs/data/charts/line-demo/LineChartWithReferenceLines.tsx
@@ -5,6 +5,7 @@ import { LinePlot, MarkPlot } from '@mui/x-charts/LineChart';
 import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
 import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -27,6 +28,7 @@ export default function LineChartWithReferenceLines() {
         { data: uData, label: 'uv', type: 'line' },
       ]}
       xAxis={[{ scaleType: 'point', data: xLabels }]}
+      margin={margin}
     >
       <LinePlot />
       <MarkPlot />

--- a/docs/data/charts/line-demo/SimpleLineChart.js
+++ b/docs/data/charts/line-demo/SimpleLineChart.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -22,6 +23,7 @@ export default function SimpleLineChart() {
         { data: uData, label: 'uv' },
       ]}
       xAxis={[{ scaleType: 'point', data: xLabels }]}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/line-demo/SimpleLineChart.tsx
+++ b/docs/data/charts/line-demo/SimpleLineChart.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LineChart } from '@mui/x-charts/LineChart';
 
+const margin = { right: 24 };
 const uData = [4000, 3000, 2000, 2780, 1890, 2390, 3490];
 const pData = [2400, 1398, 9800, 3908, 4800, 3800, 4300];
 const xLabels = [
@@ -22,6 +23,7 @@ export default function SimpleLineChart() {
         { data: uData, label: 'uv' },
       ]}
       xAxis={[{ scaleType: 'point', data: xLabels }]}
+      margin={margin}
     />
   );
 }

--- a/docs/data/charts/line-demo/SimpleLineChart.tsx.preview
+++ b/docs/data/charts/line-demo/SimpleLineChart.tsx.preview
@@ -5,4 +5,5 @@
     { data: uData, label: 'uv' },
   ]}
   xAxis={[{ scaleType: 'point', data: xLabels }]}
+  margin={margin}
 />

--- a/docs/data/charts/stacking/StackOrderDemo.js
+++ b/docs/data/charts/stacking/StackOrderDemo.js
@@ -115,7 +115,7 @@ export default function StackOrderDemo() {
                 dominantBaseline: 'hanging',
                 textAnchor: 'start',
               },
-              height: 60,
+              height: 65,
             },
           ]}
           yAxis={[{ min: 0, max: 100 }]}

--- a/docs/data/charts/stacking/StackOrderDemo.tsx
+++ b/docs/data/charts/stacking/StackOrderDemo.tsx
@@ -111,7 +111,7 @@ export default function StackOrderDemo() {
                 dominantBaseline: 'hanging',
                 textAnchor: 'start',
               },
-              height: 60,
+              height: 65,
             },
           ]}
           yAxis={[{ min: 0, max: 100 }]}

--- a/docs/data/visual-regression-tests/XAxisAnchorBaselineDefaults.js
+++ b/docs/data/visual-regression-tests/XAxisAnchorBaselineDefaults.js
@@ -2,108 +2,33 @@ import * as React from 'react';
 import { BarChart } from '@mui/x-charts/BarChart';
 
 const defaultXAxis = {
-  id: 'angle0',
   scaleType: 'band',
   dataKey: 'code',
-  position: 'bottom',
   height: 45,
 };
+
+const degrees = [-180, -135, -90, -45, 0, 45, 90, 135, 180];
+
+const xAxes = degrees
+  .map((angle) => ({
+    ...defaultXAxis,
+    position: 'bottom',
+    id: `angle${angle}`,
+    tickLabelStyle: { angle },
+  }))
+  .concat(
+    degrees.map((angle) => ({
+      ...defaultXAxis,
+      id: `top-angle${angle}`,
+      position: 'top',
+      tickLabelStyle: { angle },
+    })),
+  );
 
 export default function XAxisAnchorBaselineDefaults() {
   return (
     <BarChart
-      xAxis={[
-        {
-          ...defaultXAxis,
-          id: 'angle-180',
-          tickLabelStyle: { angle: -180 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-135',
-          tickLabelStyle: { angle: -135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-90',
-          tickLabelStyle: { angle: -90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-45',
-          tickLabelStyle: { angle: -45 },
-        },
-        defaultXAxis,
-        {
-          ...defaultXAxis,
-          id: 'angle45',
-          tickLabelStyle: { angle: 45 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle90',
-          tickLabelStyle: { angle: 90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle135',
-          tickLabelStyle: { angle: 135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle180',
-          tickLabelStyle: { angle: 180 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-180',
-          position: 'top',
-          tickLabelStyle: { angle: -180 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-135',
-          position: 'top',
-          tickLabelStyle: { angle: -135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-90',
-          position: 'top',
-          tickLabelStyle: { angle: -90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-45',
-          position: 'top',
-          tickLabelStyle: { angle: -45 },
-        },
-        { ...defaultXAxis, id: 'top-angle0', position: 'top' },
-        {
-          ...defaultXAxis,
-          id: 'top-angle45',
-          position: 'top',
-          tickLabelStyle: { angle: 45 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle90',
-          position: 'top',
-          tickLabelStyle: { angle: 90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle135',
-          position: 'top',
-          tickLabelStyle: { angle: 135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle180',
-          position: 'top',
-          tickLabelStyle: { angle: 180 },
-        },
-      ]}
+      xAxis={xAxes}
       // Other props
       width={600}
       height={900}

--- a/docs/data/visual-regression-tests/XAxisAnchorBaselineDefaults.tsx
+++ b/docs/data/visual-regression-tests/XAxisAnchorBaselineDefaults.tsx
@@ -1,110 +1,36 @@
 import * as React from 'react';
-import { BarChart } from '@mui/x-charts/BarChart';
+import { BarChart, BarChartProps } from '@mui/x-charts/BarChart';
 
 const defaultXAxis = {
-  id: 'angle0',
   scaleType: 'band',
   dataKey: 'code',
-  position: 'bottom',
   height: 45,
 } as const;
+
+const degrees = [-180, -135, -90, -45, 0, 45, 90, 135, 180];
+
+type AxisPosition = NonNullable<BarChartProps['xAxis']>[number]['position'];
+
+const xAxes = degrees
+  .map((angle) => ({
+    ...defaultXAxis,
+    position: 'bottom' as AxisPosition,
+    id: `angle${angle}`,
+    tickLabelStyle: { angle },
+  }))
+  .concat(
+    degrees.map((angle) => ({
+      ...defaultXAxis,
+      id: `top-angle${angle}`,
+      position: 'top',
+      tickLabelStyle: { angle },
+    })),
+  ) satisfies BarChartProps['xAxis'];
 
 export default function XAxisAnchorBaselineDefaults() {
   return (
     <BarChart
-      xAxis={[
-        {
-          ...defaultXAxis,
-          id: 'angle-180',
-          tickLabelStyle: { angle: -180 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-135',
-          tickLabelStyle: { angle: -135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-90',
-          tickLabelStyle: { angle: -90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-45',
-          tickLabelStyle: { angle: -45 },
-        },
-        defaultXAxis,
-        {
-          ...defaultXAxis,
-          id: 'angle45',
-          tickLabelStyle: { angle: 45 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle90',
-          tickLabelStyle: { angle: 90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle135',
-          tickLabelStyle: { angle: 135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle180',
-          tickLabelStyle: { angle: 180 },
-        },
-
-        {
-          ...defaultXAxis,
-          id: 'top-angle-180',
-          position: 'top',
-          tickLabelStyle: { angle: -180 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-135',
-          position: 'top',
-          tickLabelStyle: { angle: -135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-90',
-          position: 'top',
-          tickLabelStyle: { angle: -90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle-45',
-          position: 'top',
-          tickLabelStyle: { angle: -45 },
-        },
-        { ...defaultXAxis, id: 'top-angle0', position: 'top' },
-        {
-          ...defaultXAxis,
-          id: 'top-angle45',
-          position: 'top',
-          tickLabelStyle: { angle: 45 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle90',
-          position: 'top',
-          tickLabelStyle: { angle: 90 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle135',
-          position: 'top',
-          tickLabelStyle: { angle: 135 },
-        },
-        {
-          ...defaultXAxis,
-          id: 'top-angle180',
-          position: 'top',
-          tickLabelStyle: { angle: 180 },
-        },
-      ]}
+      xAxis={xAxes}
       // Other props
       width={600}
       height={900}

--- a/docs/data/visual-regression-tests/XAxisAnchorBaselineDefaults.tsx.preview
+++ b/docs/data/visual-regression-tests/XAxisAnchorBaselineDefaults.tsx.preview
@@ -1,0 +1,15 @@
+<BarChart
+  xAxis={xAxes}
+  // Other props
+  width={600}
+  height={900}
+  dataset={usAirportPassengers}
+  series={[{ dataKey: '2022', label: '2022' }]}
+  hideLegend
+  yAxis={[
+    {
+      valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
+      width: 40,
+    },
+  ]}
+/>

--- a/docs/data/visual-regression-tests/XAxisTickLabelOverflow.js
+++ b/docs/data/visual-regression-tests/XAxisTickLabelOverflow.js
@@ -2,64 +2,40 @@ import * as React from 'react';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 
 const defaultXAxis = {
-  id: 'angle0',
   scaleType: 'band',
   dataKey: 'code',
-  position: 'bottom',
-  zoom: true,
   height: 80,
   valueFormatter: (value) =>
     usAirportPassengers.find((item) => item.code === value).fullName,
   label: '0deg Axis Title',
 };
 
+const degrees = [-180, -135, -90, -45, 0, 45, 90, 135, 180];
+
+const xAxes = degrees
+  .map((angle) => ({
+    ...defaultXAxis,
+    position: 'bottom',
+    id: `angle${angle}`,
+    label: `${angle}deg Axis Title`,
+    tickLabelStyle: { angle },
+  }))
+  .concat(
+    degrees.map((angle) => ({
+      ...defaultXAxis,
+      id: `top-angle${angle}`,
+      label: `${angle}deg Axis Title`,
+      position: 'top',
+      tickLabelStyle: { angle },
+    })),
+  );
+
 export default function XAxisTickLabelOverflow() {
   return (
     <BarChartPro
-      xAxis={[
-        {
-          ...defaultXAxis,
-          id: 'angle-90',
-          label: '-90deg Axis Title',
-          tickLabelStyle: {
-            angle: -90,
-            textAnchor: 'end',
-            dominantBaseline: 'central',
-          },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle-45',
-          label: '-45deg Axis Title',
-          tickLabelStyle: {
-            angle: -45,
-            textAnchor: 'end',
-            dominantBaseline: 'central',
-          },
-        },
-        defaultXAxis,
-        {
-          ...defaultXAxis,
-          id: 'angle45',
-          label: '45deg Axis Title',
-          tickLabelStyle: {
-            angle: 45,
-            textAnchor: 'start',
-          },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle90',
-          label: '90deg Axis Title',
-          tickLabelStyle: {
-            angle: 90,
-            textAnchor: 'start',
-            dominantBaseline: 'central',
-          },
-        },
-      ]}
+      xAxis={xAxes}
       // Other props
-      height={600}
+      height={1600}
       dataset={usAirportPassengers}
       series={[
         { dataKey: '2018', label: '2018' },

--- a/docs/data/visual-regression-tests/XAxisTickLabelOverflow.tsx
+++ b/docs/data/visual-regression-tests/XAxisTickLabelOverflow.tsx
@@ -1,66 +1,44 @@
 import * as React from 'react';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
+import { BarChartProps } from '@mui/x-charts/BarChart';
 
 const defaultXAxis = {
-  id: 'angle0',
   scaleType: 'band',
   dataKey: 'code',
-  position: 'bottom',
-  zoom: true,
   height: 80,
   valueFormatter: (value: any) =>
     usAirportPassengers.find((item) => item.code === value)!.fullName,
   label: '0deg Axis Title',
 } as const;
 
+const degrees = [-180, -135, -90, -45, 0, 45, 90, 135, 180];
+
+type AxisPosition = NonNullable<BarChartProps['xAxis']>[number]['position'];
+
+const xAxes = degrees
+  .map((angle) => ({
+    ...defaultXAxis,
+    position: 'bottom' as AxisPosition,
+    id: `angle${angle}`,
+    label: `${angle}deg Axis Title`,
+    tickLabelStyle: { angle },
+  }))
+  .concat(
+    degrees.map((angle) => ({
+      ...defaultXAxis,
+      id: `top-angle${angle}`,
+      label: `${angle}deg Axis Title`,
+      position: 'top',
+      tickLabelStyle: { angle },
+    })),
+  ) satisfies BarChartProps['xAxis'];
+
 export default function XAxisTickLabelOverflow() {
   return (
     <BarChartPro
-      xAxis={[
-        {
-          ...defaultXAxis,
-          id: 'angle-90',
-          label: '-90deg Axis Title',
-          tickLabelStyle: {
-            angle: -90,
-            textAnchor: 'end',
-            dominantBaseline: 'central',
-          },
-        },
-
-        {
-          ...defaultXAxis,
-          id: 'angle-45',
-          label: '-45deg Axis Title',
-          tickLabelStyle: {
-            angle: -45,
-            textAnchor: 'end',
-            dominantBaseline: 'central',
-          },
-        },
-        defaultXAxis,
-        {
-          ...defaultXAxis,
-          id: 'angle45',
-          label: '45deg Axis Title',
-          tickLabelStyle: {
-            angle: 45,
-            textAnchor: 'start',
-          },
-        },
-        {
-          ...defaultXAxis,
-          id: 'angle90',
-          label: '90deg Axis Title',
-          tickLabelStyle: {
-            angle: 90,
-            textAnchor: 'start',
-            dominantBaseline: 'central',
-          },
-        },
-      ]}
+      xAxis={xAxes}
       // Other props
-      height={600}
+      height={1600}
       dataset={usAirportPassengers}
       series={[
         { dataKey: '2018', label: '2018' },

--- a/packages/x-charts/src/ChartsText/ChartsText.tsx
+++ b/packages/x-charts/src/ChartsText/ChartsText.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { GetWordsByLinesParams, getWordsByLines } from '../internals/getWordsByLines';
+import { useIsClient } from '../hooks/useIsClient';
 
 export interface ChartsTextProps
   extends Omit<
@@ -24,14 +25,17 @@ function ChartsText(props: ChartsTextProps) {
 
   const { angle, textAnchor, dominantBaseline, ...style } = styleProps ?? {};
 
+  const isClient = useIsClient();
+
   const wordsByLines = React.useMemo(
-    () => getWordsByLines({ style, needsComputation: text.includes('\n'), text }),
-    [style, text],
+    () => getWordsByLines({ style, needsComputation: isClient && text.includes('\n'), text }),
+    [style, text, isClient],
   );
 
   let startDy: number;
   switch (dominantBaseline) {
     case 'hanging':
+    case 'text-before-edge':
       startDy = 0;
       break;
     case 'central':

--- a/packages/x-charts/src/ChartsText/ChartsText.tsx
+++ b/packages/x-charts/src/ChartsText/ChartsText.tsx
@@ -42,19 +42,10 @@ function ChartsText(props: ChartsTextProps) {
       break;
   }
 
-  const transforms: string[] = [];
-  // if (scaleToFit) {
-  //   const lineWidth = wordsByLines[0].width;
-  //   transforms.push(`scale(${(isNumber(width as number) ? (width as number) / lineWidth : 1) / lineWidth})`);
-  // }
-  if (angle) {
-    transforms.push(`rotate(${angle}, ${x}, ${y})`);
-  }
-
   return (
     <text
       {...textProps}
-      transform={transforms.length > 0 ? transforms.join(' ') : undefined}
+      transform={angle ? `rotate(${angle}, ${x}, ${y})` : undefined}
       x={x}
       y={y}
       textAnchor={textAnchor}

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -224,6 +224,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
       style: {
         ...theme.typography.caption,
         fontSize: 12,
+        lineHeight: 1.25,
         textAnchor: isRtl ? invertTextAnchor(defaultTextAnchor) : defaultTextAnchor,
         dominantBaseline: defaultDominantBaseline,
         ...tickLabelStyle,

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -7,7 +7,7 @@ import { useThemeProps, useTheme, styled } from '@mui/material/styles';
 import { useRtl } from '@mui/system/RtlProvider';
 import { clampAngle } from '../internals/clampAngle';
 import { useIsClient } from '../hooks/useIsClient';
-import { ellipsize } from '../internals/ellipsize';
+import { doesTextFitInRect, ellipsize } from '../internals/ellipsize';
 import { getStringSize } from '../internals/domUtils';
 import { useTicks, TickItemType } from '../hooks/useTicks';
 import { AxisConfig, AxisDefaultized, ChartsXAxisProps, ScaleName } from '../models/axis';
@@ -159,15 +159,15 @@ function shortenLabels(
           rightBoundModifier,
       );
 
-      shortenedLabels.set(
-        item,
-        ellipsize(item.formattedValue.toString(), {
+      const doesTextFit = (text: string) =>
+        doesTextFitInRect(text, {
           width,
           height: maxHeight,
           angle,
-          measureText: (text) => getStringSize(text, tickLabelStyle),
-        }),
-      );
+          measureText: (string: string) => getStringSize(string, tickLabelStyle),
+        });
+
+      shortenedLabels.set(item, ellipsize(item.formattedValue.toString(), doesTextFit));
     }
   }
 

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -302,7 +302,6 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         textAnchor: 'middle',
         dominantBaseline: position === 'bottom' ? 'hanging' : 'auto',
         ...labelStyle,
-        transform: `${labelStyle?.transform ?? ''} translateY(${position === 'bottom' ? '-1' : 1}lh)`,
       },
     } as Partial<ChartsTextProps>,
     ownerState: {},
@@ -322,15 +321,16 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     return null;
   }
 
-  const labelRefPoint = { x: left + width / 2, y: positionSign * axisHeight };
+  const labelHeight = label ? getStringSize(label, axisLabelProps.style).height : 0;
+  const labelRefPoint = {
+    x: left + width / 2,
+    y: positionSign * (axisHeight - labelHeight),
+  };
 
   /* If there's an axis title, the tick labels have less space to render  */
   const tickLabelsMaxHeight = Math.max(
     0,
-    axisHeight -
-      (label ? getStringSize(label, axisLabelProps.style).height + AXIS_LABEL_TICK_LABEL_GAP : 0) -
-      tickSize -
-      TICK_LABEL_GAP,
+    axisHeight - (label ? labelHeight + AXIS_LABEL_TICK_LABEL_GAP : 0) - tickSize - TICK_LABEL_GAP,
   );
 
   const tickLabels = isClient

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -38,6 +38,11 @@ const useUtilityClasses = (ownerState: AxisConfig<any, any, ChartsXAxisProps>) =
   return composeClasses(slots, getAxisUtilityClass, classes);
 };
 
+/* Gap between a tick and its label. */
+const TICK_LABEL_GAP = 3;
+/* Gap between the axis label and tick labels. */
+const AXIS_LABEL_TICK_LABEL_GAP = 4;
+
 /* Returns a set of indices of the tick labels that should be visible.  */
 function getVisibleLabels(
   xTicks: TickItemType[],
@@ -126,8 +131,10 @@ function shortenLabels(
       shortenedLabels.set(
         item,
         ellipsize(item.formattedValue.toString(), {
+          // FIXME: Remove this hard-coded value
           width: axisWidth - item.offset + 100,
           height: maxHeight,
+          // FIXME: Do we need to mod by 180?
           angle: (tickLabelStyle?.angle ?? 0) % 180,
           measureText: (text) => getStringSize(text, tickLabelStyle),
         }),
@@ -257,7 +264,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     additionalProps: {
       style: {
         ...theme.typography.body1,
-        lineHeight: 1.2,
+        lineHeight: 1,
         fontSize: 14,
         textAnchor: 'middle',
         dominantBaseline: position === 'bottom' ? 'hanging' : 'auto',
@@ -288,7 +295,10 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   };
 
   /* If there's an axis title, the tick labels have less space to render  */
-  const tickLabelsMaxHeight = axisHeight - labelHeight - tickSize;
+  const tickLabelsMaxHeight = Math.max(
+    0,
+    axisHeight - labelHeight - tickSize - TICK_LABEL_GAP - AXIS_LABEL_TICK_LABEL_GAP,
+  );
 
   const shortenedLabels = shortenLabels(visibleLabels, width, tickLabelsMaxHeight, {
     tickLabelStyle: axisTickLabelProps.style,
@@ -307,7 +317,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
       {xTicks.map((item, index) => {
         const { offset: tickOffset, labelOffset } = item;
         const xTickLabel = labelOffset ?? 0;
-        const yTickLabel = positionSign * (tickSize + 3);
+        const yTickLabel = positionSign * (tickSize + TICK_LABEL_GAP);
 
         const showTick = instance.isPointInside({ x: tickOffset, y: -1 }, { direction: 'x' });
         const formattedValue = shortenedLabels.get(item);

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -144,8 +144,12 @@ function shortenLabels(
 
       // That maximum width of the tick depends on its proximity to the axis bounds.
       const width = Math.min(
-        item.offset * leftBoundModifier,
-        (drawingArea.left + drawingArea.width + drawingArea.right - item.offset) *
+        (item.offset + item.labelOffset) * leftBoundModifier,
+        (drawingArea.left +
+          drawingArea.width +
+          drawingArea.right -
+          item.offset -
+          item.labelOffset) *
           rightBoundModifier,
       );
 

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -129,7 +129,7 @@ function shortenLabels(
         ellipsize(item.formattedValue.toString(), {
           width: axisWidth - item.offset + 100,
           height: maxHeight,
-          angle: tickLabelStyle?.angle ?? 0,
+          angle: (tickLabelStyle?.angle ?? 0) % 180,
           measureText: (text) => getStringSize(text, tickLabelStyle),
         }),
       );
@@ -258,7 +258,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     additionalProps: {
       style: {
         ...theme.typography.body1,
-        lineHeight: 1,
+        lineHeight: 1.2,
         fontSize: 14,
         textAnchor: 'middle',
         dominantBaseline: position === 'bottom' ? 'hanging' : 'auto',

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -128,35 +128,37 @@ function shortenLabels(
   const shortenedLabels = new Map<TickItemType, string>();
   const angle = clampAngle(tickLabelStyle?.angle ?? 0);
 
-  let leftBoundModifier = 1;
-  let rightBoundModifier = 1;
+  // Multiplying the space available to the left of the text position by leftBoundFactor returns the max width of the text.
+  // Same for rightBoundFactor
+  let leftBoundFactor = 1;
+  let rightBoundFactor = 1;
 
   if (tickLabelStyle?.textAnchor === 'start') {
-    leftBoundModifier = Infinity;
-    rightBoundModifier = 1;
+    leftBoundFactor = Infinity;
+    rightBoundFactor = 1;
   } else if (tickLabelStyle?.textAnchor === 'end') {
-    leftBoundModifier = 1;
-    rightBoundModifier = Infinity;
+    leftBoundFactor = 1;
+    rightBoundFactor = Infinity;
   } else {
-    leftBoundModifier = 2;
-    rightBoundModifier = 2;
+    leftBoundFactor = 2;
+    rightBoundFactor = 2;
   }
 
   if (angle > 90 && angle < 270) {
-    [leftBoundModifier, rightBoundModifier] = [rightBoundModifier, leftBoundModifier];
+    [leftBoundFactor, rightBoundFactor] = [rightBoundFactor, leftBoundFactor];
   }
 
   for (const item of visibleLabels) {
     if (item.formattedValue) {
       // That maximum width of the tick depends on its proximity to the axis bounds.
       const width = Math.min(
-        (item.offset + item.labelOffset) * leftBoundModifier,
+        (item.offset + item.labelOffset) * leftBoundFactor,
         (drawingArea.left +
           drawingArea.width +
           drawingArea.right -
           item.offset -
           item.labelOffset) *
-          rightBoundModifier,
+          rightBoundFactor,
       );
 
       const doesTextFit = (text: string) =>

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -251,10 +251,6 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     isPointInside: (x: number) => instance.isPointInside({ x, y: -1 }, { direction: 'x' }),
   });
 
-    const shortenedLabels = shortenLabels(visibleLabels, width, axisHeight, {
-        tickLabelStyle,
-    });
-
   const axisLabelProps = useSlotProps({
     elementType: Label,
     externalSlotProps: slotProps?.axisLabel,
@@ -290,6 +286,14 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     x: left + width / 2,
     y: positionSign * (axisHeight - labelHeight),
   };
+
+  /* If there's an axis title, the tick labels have less space to render  */
+  const tickLabelsMaxHeight = (label ? labelRefPoint.y : axisHeight) - tickSize;
+  console.log({ tickLabelsMaxHeight });
+
+  const shortenedLabels = shortenLabels(visibleLabels, width, tickLabelsMaxHeight, {
+    tickLabelStyle: axisTickLabelProps.style,
+  });
 
   return (
     <XAxisRoot

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -300,7 +300,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         lineHeight: 1,
         fontSize: 14,
         textAnchor: 'middle',
-        dominantBaseline: position === 'bottom' ? 'hanging' : 'auto',
+        dominantBaseline: position === 'bottom' ? 'text-after-edge' : 'text-before-edge',
         ...labelStyle,
       },
     } as Partial<ChartsTextProps>,
@@ -324,7 +324,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   const labelHeight = label ? getStringSize(label, axisLabelProps.style).height : 0;
   const labelRefPoint = {
     x: left + width / 2,
-    y: positionSign * (axisHeight - labelHeight),
+    y: positionSign * axisHeight,
   };
 
   /* If there's an axis title, the tick labels have less space to render  */

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -302,6 +302,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         textAnchor: 'middle',
         dominantBaseline: position === 'bottom' ? 'hanging' : 'auto',
         ...labelStyle,
+        transform: `${labelStyle?.transform ?? ''} translateY(${position === 'bottom' ? '-1' : 1}lh)`,
       },
     } as Partial<ChartsTextProps>,
     ownerState: {},
@@ -321,16 +322,15 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     return null;
   }
 
-  const labelHeight = label ? getStringSize(label, axisLabelProps.style).height : 0;
-  const labelRefPoint = {
-    x: left + width / 2,
-    y: positionSign * (axisHeight - labelHeight),
-  };
+  const labelRefPoint = { x: left + width / 2, y: positionSign * axisHeight };
 
   /* If there's an axis title, the tick labels have less space to render  */
   const tickLabelsMaxHeight = Math.max(
     0,
-    axisHeight - (label ? labelHeight + AXIS_LABEL_TICK_LABEL_GAP : 0) - tickSize - TICK_LABEL_GAP,
+    axisHeight -
+      (label ? getStringSize(label, axisLabelProps.style).height + AXIS_LABEL_TICK_LABEL_GAP : 0) -
+      tickSize -
+      TICK_LABEL_GAP,
   );
 
   const tickLabels = isClient

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -123,7 +123,6 @@ function shortenLabels(
 
   for (const item of visibleLabels) {
     if (item.formattedValue) {
-      console.log({ item, maxHeight, width: axisWidth - item.offset });
       shortenedLabels.set(
         item,
         ellipsize(item.formattedValue.toString(), {
@@ -290,7 +289,6 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
 
   /* If there's an axis title, the tick labels have less space to render  */
   const tickLabelsMaxHeight = axisHeight - labelHeight - tickSize;
-  console.log({ tickLabelsMaxHeight });
 
   const shortenedLabels = shortenLabels(visibleLabels, width, tickLabelsMaxHeight, {
     tickLabelStyle: axisTickLabelProps.style,

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -335,7 +335,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
 
   const tickLabels = isClient
     ? shortenLabels(visibleLabels, drawingArea, tickLabelsMaxHeight, axisTickLabelProps.style)
-    : new Map();
+    : new Map(Array.from(visibleLabels).map((item) => [item, item.formattedValue]));
 
   return (
     <XAxisRoot
@@ -383,7 +383,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         );
       })}
 
-      {label && isClient && (
+      {label && (
         <g className={classes.label}>
           <Label {...labelRefPoint} {...axisLabelProps} text={label} />
         </g>

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -126,23 +126,28 @@ function shortenLabels(
   { tickLabelStyle }: Pick<ChartsXAxisProps, 'tickLabelStyle'>,
 ) {
   const shortenedLabels = new Map<TickItemType, string>();
+  const angle = clampAngle(tickLabelStyle?.angle ?? 0);
+
+  let leftBoundModifier = 1;
+  let rightBoundModifier = 1;
+
+  if (tickLabelStyle?.textAnchor === 'start') {
+    leftBoundModifier = Infinity;
+    rightBoundModifier = 1;
+  } else if (tickLabelStyle?.textAnchor === 'end') {
+    leftBoundModifier = 1;
+    rightBoundModifier = Infinity;
+  } else {
+    leftBoundModifier = 2;
+    rightBoundModifier = 2;
+  }
+
+  if (angle > 90 && angle < 270) {
+    [leftBoundModifier, rightBoundModifier] = [rightBoundModifier, leftBoundModifier];
+  }
 
   for (const item of visibleLabels) {
     if (item.formattedValue) {
-      let leftBoundModifier = 1;
-      let rightBoundModifier = 1;
-
-      if (tickLabelStyle?.textAnchor === 'start') {
-        leftBoundModifier = Infinity;
-        rightBoundModifier = 1;
-      } else if (tickLabelStyle?.textAnchor === 'end') {
-        leftBoundModifier = 1;
-        rightBoundModifier = Infinity;
-      } else {
-        leftBoundModifier = 2;
-        rightBoundModifier = 2;
-      }
-
       // That maximum width of the tick depends on its proximity to the axis bounds.
       const width = Math.min(
         (item.offset + item.labelOffset) * leftBoundModifier,
@@ -159,8 +164,7 @@ function shortenLabels(
         ellipsize(item.formattedValue.toString(), {
           width,
           height: maxHeight,
-          // FIXME: Do we need to mod by 180?
-          angle: (tickLabelStyle?.angle ?? 0) % 180,
+          angle,
           measureText: (text) => getStringSize(text, tickLabelStyle),
         }),
       );

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -289,7 +289,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   };
 
   /* If there's an axis title, the tick labels have less space to render  */
-  const tickLabelsMaxHeight = (label ? labelRefPoint.y : axisHeight) - tickSize;
+  const tickLabelsMaxHeight = axisHeight - labelHeight - tickSize;
   console.log({ tickLabelsMaxHeight });
 
   const shortenedLabels = shortenLabels(visibleLabels, width, tickLabelsMaxHeight, {

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -123,7 +123,7 @@ function shortenLabels(
   visibleLabels: Set<TickItemType>,
   drawingArea: Pick<ChartDrawingArea, 'left' | 'width' | 'right'>,
   maxHeight: number,
-  { tickLabelStyle }: Pick<ChartsXAxisProps, 'tickLabelStyle'>,
+  tickLabelStyle: ChartsXAxisProps['tickLabelStyle'],
 ) {
   const shortenedLabels = new Map<TickItemType, string>();
   const angle = clampAngle(tickLabelStyle?.angle ?? 0);
@@ -332,9 +332,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   );
 
   const tickLabels = isClient
-    ? shortenLabels(visibleLabels, drawingArea, tickLabelsMaxHeight, {
-        tickLabelStyle: axisTickLabelProps.style,
-      })
+    ? shortenLabels(visibleLabels, drawingArea, tickLabelsMaxHeight, axisTickLabelProps.style)
     : new Map();
 
   return (

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -328,7 +328,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
   /* If there's an axis title, the tick labels have less space to render  */
   const tickLabelsMaxHeight = Math.max(
     0,
-    axisHeight - labelHeight - tickSize - TICK_LABEL_GAP - AXIS_LABEL_TICK_LABEL_GAP,
+    axisHeight - (label ? labelHeight + AXIS_LABEL_TICK_LABEL_GAP : 0) - tickSize - TICK_LABEL_GAP,
   );
 
   const tickLabels = isClient

--- a/packages/x-charts/src/hooks/useIsClient.ts
+++ b/packages/x-charts/src/hooks/useIsClient.ts
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+
+export function useIsClient() {
+  const [isClient, setIsClient] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  return isClient;
+}

--- a/packages/x-charts/src/hooks/useIsClient.ts
+++ b/packages/x-charts/src/hooks/useIsClient.ts
@@ -1,6 +1,9 @@
 'use client';
-import React from 'react';
+import * as React from 'react';
 
+/** Returns true after this hook runs the client.
+ *
+ * Basically a implementation of Option 2 of this gist: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#option-2-lazily-show-component-with-uselayouteffect. */
 export function useIsClient() {
   const [isClient, setIsClient] = React.useState(false);
 

--- a/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
+++ b/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
@@ -10,6 +10,7 @@ export const AxisRoot = styled('g', {
     /* The tick label is measured using only its style prop, so applying properties that change its size will cause the
      * measurements to be off. As such, it is recommended to apply those properties through the `tickLabelStyle` prop. */
     ...theme.typography.caption,
+    lineHeight: 1.25,
     fill: (theme.vars || theme).palette.text.primary,
   },
   [`& .${axisClasses.label}`]: {

--- a/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
+++ b/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
@@ -10,7 +10,6 @@ export const AxisRoot = styled('g', {
     /* The tick label is measured using only its style prop, so applying properties that change its size will cause the
      * measurements to be off. As such, it is recommended to apply those properties through the `tickLabelStyle` prop. */
     ...theme.typography.caption,
-    lineHeight: 1.25,
     fill: (theme.vars || theme).palette.text.primary,
   },
   [`& .${axisClasses.label}`]: {

--- a/packages/x-charts/src/internals/degToRad.ts
+++ b/packages/x-charts/src/internals/degToRad.ts
@@ -1,0 +1,4 @@
+/** Converts degrees to radians. */
+export function degToRad(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}

--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -6,7 +6,7 @@ function isSsr(): boolean {
 }
 
 interface StringCache {
-  widthCache: Record<string, any>;
+  widthCache: Record<string, { width: number; height: number }>;
   cacheCount: number;
 }
 

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import { degToRad, ellipsize, shortenText } from './ellipsize';
+
+describe('ellipsizeText', () => {
+  it('does nothing if text fits', () => {
+    expect(
+      ellipsize('Hello World', {
+        width: 110,
+        height: 20,
+        angle: 0,
+        measureText: (text) => ({ width: text.length * 10, height: 20 }),
+      }),
+    ).to.be.equal('Hello World');
+
+    expect(
+      ellipsize('Hello World', {
+        width: 110 * Math.cos(degToRad(45)) + 20 * Math.sin(degToRad(45)),
+        height: 110 * Math.sin(degToRad(45)) + 20 * Math.cos(degToRad(45)),
+        angle: 45,
+        measureText: (text) => ({ width: text.length * 10, height: 20 }),
+      }),
+    ).to.be.equal('Hello World');
+  });
+
+  it("shortens text and adds ellipsis if it doesn't fit", () => {
+    expect(
+      ellipsize('Hello World', {
+        width: 60,
+        height: 20,
+        angle: 0,
+        measureText: (text) => ({ width: text.length * 10, height: 20 }),
+      }),
+    ).to.be.equal('Hello…');
+
+    expect(
+      ellipsize('Hello World', {
+        width: 60 * Math.cos(degToRad(45)) + 20 * Math.sin(degToRad(45)),
+        height: 60 * Math.sin(degToRad(45)) + 20 * Math.cos(degToRad(45)),
+        angle: 45,
+        measureText: (text) => ({ width: text.length * 10, height: 20 }),
+      }),
+    ).to.be.equal('Hello…');
+  });
+
+  it("returns an empty string if text doesn't fit at all", () => {
+    expect(
+      ellipsize('Hello World', {
+        width: 1,
+        height: 20,
+        angle: 0,
+        measureText: (text) => ({ width: text.length * 10, height: 20 }),
+      }),
+    ).to.be.equal('');
+
+    expect(
+      ellipsize('Hello World', {
+        width: 11,
+        height: 20,
+        angle: 0,
+        measureText: (text) => ({ width: text.length * 10, height: 20 }),
+      }),
+    ).to.be.equal('');
+  });
+});
+
+describe('shortenText', () => {
+  it('shortens one line text properly', () => {
+    const cases = [
+      // [input, expected]
+      ['Hello  World', 'Hello'],
+      ['Hello World  again', 'Hello World'],
+      ['Huge_string_without_spaces_to_test_overflow', 'Huge_string_without_s'],
+      ['', ''],
+      ['a', ''],
+    ];
+
+    const inputs = cases.map(([input]) => shortenText(input));
+    const expected = cases.map(([_, result]) => result);
+
+    expect(inputs).to.be.deep.equal(expected);
+  });
+
+  it.skip('splits unicode characters properly', () => {
+    // 5 latin characters + 7 emoji => 12 graphemes.
+    // Result should have 6 graphemes.
+    expect(shortenText('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️')).to.be.equal('emoji👱🏽‍♀️');
+  });
+
+  it('shortens multi line text properly', () => {});
+});

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -80,7 +80,7 @@ describe('shortenText', () => {
     expect(inputs).to.be.deep.equal(expected);
   });
 
-  it.skip('splits unicode characters properly', () => {
+  it('splits unicode characters properly', () => {
     // 5 latin characters + 7 emoji => 12 graphemes.
     // Result should have 6 graphemes.
     expect(shortenText('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️')).to.be.equal('emoji👱🏽‍♀️');

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { degToRad, ellipsize, shortenText } from './ellipsize';
+import { degToRad, ellipsize, segmentAt, shortenText } from './ellipsize';
 
 describe('ellipsizeText', () => {
   it('does nothing if text fits', () => {
@@ -87,4 +87,20 @@ describe('shortenText', () => {
   });
 
   it('shortens multi line text properly', () => {});
+});
+
+describe('segmentAt', () => {
+  it('segments ASCII properly', () => {
+    expect(segmentAt('Hello World', 5)).to.equal('Hello');
+    expect(segmentAt('Hello World', 6)).to.equal('Hello ');
+    expect(segmentAt('Hello World', 7)).to.equal('Hello W');
+    expect(segmentAt('Hello World', 9)).to.equal('Hello Wor');
+  });
+
+  it('segments unicode characters properly', () => {
+    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 5)).to.equal('emoji');
+    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 6)).to.equal('emoji');
+    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 11)).to.equal('emoji');
+    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 12)).to.equal('emoji👱🏽‍♀️');
+  });
 });

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { degToRad, ellipsize, segmentAt, shortenText } from './ellipsize';
+import { degToRad, ellipsize } from './ellipsize';
 
 describe('ellipsizeText', () => {
   it('does nothing if text fits', () => {
@@ -60,47 +60,5 @@ describe('ellipsizeText', () => {
         measureText: (text) => ({ width: text.length * 10, height: 20 }),
       }),
     ).to.be.equal('');
-  });
-});
-
-describe('shortenText', () => {
-  it('shortens one line text properly', () => {
-    const cases = [
-      // [input, expected]
-      ['Hello  World', 'Hello'],
-      ['Hello World  again', 'Hello World'],
-      ['Huge_string_without_spaces_to_test_overflow', 'Huge_string_without_s'],
-      ['', ''],
-      ['a', ''],
-    ];
-
-    const inputs = cases.map(([input]) => shortenText(input));
-    const expected = cases.map(([_, result]) => result);
-
-    expect(inputs).to.be.deep.equal(expected);
-  });
-
-  it('splits unicode characters properly', () => {
-    // 5 latin characters + 7 emoji => 12 graphemes.
-    // Result should have 6 graphemes.
-    expect(shortenText('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️')).to.be.equal('emoji👱🏽‍♀️');
-  });
-
-  it('shortens multi line text properly', () => {});
-});
-
-describe('segmentAt', () => {
-  it('segments ASCII properly', () => {
-    expect(segmentAt('Hello World', 5)).to.equal('Hello');
-    expect(segmentAt('Hello World', 6)).to.equal('Hello ');
-    expect(segmentAt('Hello World', 7)).to.equal('Hello W');
-    expect(segmentAt('Hello World', 9)).to.equal('Hello Wor');
-  });
-
-  it('segments unicode characters properly', () => {
-    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 5)).to.equal('emoji');
-    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 6)).to.equal('emoji');
-    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 11)).to.equal('emoji');
-    expect(segmentAt('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 12)).to.equal('emoji👱🏽‍♀️');
   });
 });

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -1,65 +1,76 @@
 import { expect } from 'chai';
 import { ellipsize } from './ellipsize';
-import { degToRad } from './degToRad';
 
 describe('ellipsizeText', () => {
-  it('does nothing if text fits', () => {
-    expect(
-      ellipsize('Hello World', {
-        width: 110,
-        height: 20,
-        angle: 0,
-        measureText: (text) => ({ width: text.length * 10, height: 20 }),
-      }),
-    ).to.be.equal('Hello World');
-
-    expect(
-      ellipsize('Hello World', {
-        width: 110 * Math.cos(degToRad(45)) + 20 * Math.sin(degToRad(45)),
-        height: 110 * Math.sin(degToRad(45)) + 20 * Math.cos(degToRad(45)),
-        angle: 45,
-        measureText: (text) => ({ width: text.length * 10, height: 20 }),
-      }),
-    ).to.be.equal('Hello World');
+  it('returns the original text if it fits', () => {
+    const doesTextFit = () => true;
+    expect(ellipsize('Hello World', doesTextFit)).to.be.equal('Hello World');
   });
 
   it("shortens text and adds ellipsis if it doesn't fit", () => {
-    expect(
-      ellipsize('Hello World', {
-        width: 60,
-        height: 20,
-        angle: 0,
-        measureText: (text) => ({ width: text.length * 10, height: 20 }),
-      }),
-    ).to.be.equal('Hello…');
-
-    expect(
-      ellipsize('Hello World', {
-        width: 60 * Math.cos(degToRad(45)) + 20 * Math.sin(degToRad(45)),
-        height: 60 * Math.sin(degToRad(45)) + 20 * Math.cos(degToRad(45)),
-        angle: 45,
-        measureText: (text) => ({ width: text.length * 10, height: 20 }),
-      }),
-    ).to.be.equal('Hello…');
+    const doesTextFit = (text: string) => text.length <= 6;
+    expect(ellipsize('Hello World', doesTextFit)).to.be.equal('Hello…');
   });
 
-  it("returns an empty string if text doesn't fit at all", () => {
-    expect(
-      ellipsize('Hello World', {
-        width: 1,
-        height: 20,
-        angle: 0,
-        measureText: (text) => ({ width: text.length * 10, height: 20 }),
-      }),
-    ).to.be.equal('');
+  it('returns an empty string if text never fits', () => {
+    const doesTextFit = () => false;
+    expect(ellipsize('Hello World', doesTextFit)).to.be.equal('');
+  });
 
-    expect(
-      ellipsize('Hello World', {
-        width: 11,
-        height: 20,
-        angle: 0,
-        measureText: (text) => ({ width: text.length * 10, height: 20 }),
-      }),
-    ).to.be.equal('');
+  it('returns an empty string if only ellipsis fits', () => {
+    const doesTextFit = (text: string) => text.length <= 1;
+    expect(ellipsize('Hello World', doesTextFit)).to.be.equal('');
+  });
+
+  describe('performance', () => {
+    /* I'm assuming that checking if the text fits is expensive, so we should reduce the number of calls. */
+
+    it('calls `doesTextFit` the minimum amount of times when the text does not fit', () => {
+      let doesTextFitCalled = 0;
+      const doesTextFit = () => {
+        doesTextFitCalled += 1;
+        return false;
+      };
+      expect(ellipsize('A_string_with_22_chars', doesTextFit)).to.be.equal('');
+
+      // Starting with 22 chars, we should reduce to 11, then to 5, then to 2, then to 1, totaling 5 calls.
+      expect(doesTextFitCalled).to.equal(5);
+    });
+
+    it('calls `doesTextFit` the minimum amount of times when the text fits', () => {
+      let doesTextFitCalled = 0;
+      const doesTextFit = (text: string) => {
+        doesTextFitCalled += 1;
+        return text.length <= 29;
+      };
+      expect(ellipsize('A_string_with_30_characters!!!', doesTextFit)).to.be.equal(
+        'A_string_with_30_characters!…',
+      );
+
+      /* Starting with 30 chars, we should:
+       *   1. reduce to 15
+       *   2. increase to 22
+       *   3. increase to 26
+       *   4. increase to 28
+       *   5. increase to 29
+       *
+       * Return 28, but we shouldn't measure it again, totaling 6 calls.
+       */
+      expect(doesTextFitCalled).to.equal(6);
+    });
+
+    it('calls `doesTextFit` the minimum amount of times when unicode text does not fit', () => {
+      let doesTextFitCalled = 0;
+      const doesTextFit = () => {
+        doesTextFitCalled += 1;
+        return false;
+      };
+
+      /* `'🧑‍🧑‍🧒‍🧒'.length` is 11.  */
+      expect(ellipsize('🧑‍🧑‍🧒‍🧒🧑‍🧑‍🧒‍🧒🧑‍🧑‍🧒‍🧒🧑‍🧑‍🧒‍🧒🧑‍🧑‍🧒‍🧒', doesTextFit)).to.be.equal('');
+
+      /* Starting with 5 graphemes, we should reduce to 2, then 1, totaling 3 calls. */
+      expect(doesTextFitCalled).to.equal(3);
+    });
   });
 });

--- a/packages/x-charts/src/internals/ellipsize.test.ts
+++ b/packages/x-charts/src/internals/ellipsize.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { degToRad, ellipsize } from './ellipsize';
+import { ellipsize } from './ellipsize';
+import { degToRad } from './degToRad';
 
 describe('ellipsizeText', () => {
   it('does nothing if text fits', () => {

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -32,23 +32,28 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
   let by = 1 / 2;
   let newLength = text.length;
   let lastLength = text.length;
+  let longestFittingText: string | null = null;
 
   do {
     lastLength = newLength;
     newLength = Math.floor(text.length * by);
 
+    // FIXME: This breaks for unicode characters. Check if we can use Intl.Segmenter.
     ellipsizedText = text.slice(0, newLength).trim();
     const fits = doesTextFitInRect(ellipsizedText + ELLIPSIS, config);
     step += 1;
 
     if (fits) {
+      longestFittingText = ellipsizedText;
       by += 1 / 2 ** step;
     } else {
       by -= 1 / 2 ** step;
     }
   } while (newLength !== lastLength);
 
-  return ellipsizedText.length === 0 ? '' : ellipsizedText + ELLIPSIS;
+  console.log({ text, largestFit: longestFittingText, config });
+
+  return longestFittingText ? longestFittingText + ELLIPSIS : '';
 }
 
 export function shortenText(text: string, by: number) {

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -1,3 +1,5 @@
+import { sliceUntil } from './sliceUntil';
+
 const ELLIPSIS = '…';
 
 interface EllipsizeConfig {
@@ -38,8 +40,7 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
     lastLength = newLength;
     newLength = Math.floor(text.length * by);
 
-    // FIXME: This breaks for unicode characters. Check if we can use Intl.Segmenter.
-    ellipsizedText = text.slice(0, newLength).trim();
+    ellipsizedText = sliceUntil(text, newLength).trim();
     const fits = doesTextFitInRect(ellipsizedText + ELLIPSIS, config);
     step += 1;
 
@@ -52,50 +53,6 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
   } while (newLength !== lastLength);
 
   return longestFittingText ? longestFittingText + ELLIPSIS : '';
-}
-
-const segmenter =
-  'Intl' in window && 'Segmenter' in Intl
-    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
-    : null;
-export function segmentAt(text: string, index: number) {
-  if (!segmenter) {
-    return text.slice(0, index);
-  }
-
-  const segments = segmenter.segment(text);
-
-  const { index: indexLimit } = segments.containing(index);
-
-  let newText = '';
-
-  for (const segment of segments) {
-    if (segment.index >= indexLimit) {
-      break;
-    }
-
-    newText += segment.segment;
-  }
-
-  return newText;
-}
-
-export function shortenText(text: string, by: number) {
-  // If text has less than two characters, we can't shorten it, so just return an empty string.
-  if (text.length <= 1) {
-    return '';
-  }
-
-  const isMultiline = text.includes('\n');
-
-  if (isMultiline) {
-    return text.split('\n').slice(0, -1).join('\n');
-  }
-
-  const newLength = Math.floor(text.length * by);
-
-  // FIXME: This breaks for unicode characters. Check if we can use Intl.Segmenter.
-  return text.slice(0, newLength).trim();
 }
 
 /** Converts degrees to radians. */

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -1,3 +1,4 @@
+import { degToRad } from './degToRad';
 import { sliceUntil } from './sliceUntil';
 
 const ELLIPSIS = '…';
@@ -53,9 +54,4 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
   } while (newLength !== lastLength);
 
   return longestFittingText ? longestFittingText + ELLIPSIS : '';
-}
-
-/** Converts degrees to radians. */
-export function degToRad(degrees: number): number {
-  return degrees * (Math.PI / 180);
 }

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -13,17 +13,17 @@ export function doesTextFitInRect(text: string, config: EllipsizeConfig) {
   const angle = degToRad(config.angle);
   const textSize = measureText(text);
 
-  console.log({ text, textSize, config });
-
   const angledWidth = textSize.width * Math.cos(angle) + textSize.height * Math.sin(angle);
   const angledHeight = textSize.width * Math.sin(angle) + textSize.height * Math.cos(angle);
+
+  console.log({ text, textSize, config, angledWidth, angledHeight });
 
   return angledWidth <= width && angledHeight <= height;
 }
 
 export function ellipsize(text: string, config: EllipsizeConfig) {
   if (doesTextFitInRect(text, config)) {
-    console.log({ text, config, result: text });
+    console.log('fit', { text, config, result: text });
     return text;
   }
 
@@ -41,7 +41,7 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
   return '';
 }
 
-const WHITE_SPACE = /\s/g;
+const WHITE_SPACE = /\s/;
 
 export function shortenText(text: string) {
   // If text has less than two characters, we can't shorten it, so just return an empty string.

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -1,0 +1,73 @@
+const ELLIPSIS = '…';
+
+interface EllipsizeConfig {
+  width: number;
+  height: number;
+  /** Angle, in degrees, in which the text should be displayed */
+  angle: number;
+  measureText: (text: string) => { width: number; height: number };
+}
+
+export function doesTextFitInRect(text: string, config: EllipsizeConfig) {
+  const { width, height, measureText } = config;
+  const angle = degToRad(config.angle);
+  const textSize = measureText(text);
+
+  console.log({ text, textSize, config });
+
+  const angledWidth = textSize.width * Math.cos(angle) + textSize.height * Math.sin(angle);
+  const angledHeight = textSize.width * Math.sin(angle) + textSize.height * Math.cos(angle);
+
+  return angledWidth <= width && angledHeight <= height;
+}
+
+export function ellipsize(text: string, config: EllipsizeConfig) {
+  if (doesTextFitInRect(text, config)) {
+    console.log({ text, config, result: text });
+    return text;
+  }
+
+  let ellipsizedText = text;
+  while (ellipsizedText.length > 1) {
+    ellipsizedText = shortenText(ellipsizedText);
+
+    if (doesTextFitInRect(ellipsizedText + ELLIPSIS, config)) {
+      console.log({ text, config, result: ellipsizedText + ELLIPSIS });
+      return ellipsizedText + ELLIPSIS;
+    }
+  }
+
+  console.log({ text, config, result: '' });
+  return '';
+}
+
+const WHITE_SPACE = /\s/g;
+
+export function shortenText(text: string) {
+  // If text has less than two characters, we can't shorten it, so just return an empty string.
+  if (text.length <= 1) {
+    return '';
+  }
+
+  const isMultiline = text.includes('\n');
+
+  if (isMultiline) {
+    return text.split('\n').slice(0, -1).join('\n');
+  }
+
+  const halfLength = Math.floor(text.length / 2);
+
+  const firstWhiteSpaceAfterMidpoint = WHITE_SPACE.exec(text.slice(halfLength))?.index;
+
+  if (firstWhiteSpaceAfterMidpoint !== undefined) {
+    return text.slice(0, halfLength + firstWhiteSpaceAfterMidpoint).trim();
+  }
+
+  // FIXME: This breaks for unicode characters. Check if we can use Intl.Segmenter.
+  return text.slice(0, halfLength).trim();
+}
+
+/** Converts degrees to radians. */
+export function degToRad(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -55,7 +55,9 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
 }
 
 const segmenter =
-  'Segmenter' in Intl ? new Intl.Segmenter(undefined, { granularity: 'grapheme' }) : null;
+  'Intl' in window && 'Segmenter' in Intl
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
 export function segmentAt(text: string, index: number) {
   if (!segmenter) {
     return text.slice(0, index);
@@ -69,11 +71,13 @@ export function segmentAt(text: string, index: number) {
 
   for (const segment of segments) {
     if (segment.index >= indexLimit) {
-      return newText;
+      break;
     }
 
     newText += segment.segment;
   }
+
+  return newText;
 }
 
 export function shortenText(text: string, by: number) {

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -13,8 +13,10 @@ export function doesTextFitInRect(text: string, config: EllipsizeConfig) {
   const angle = degToRad(config.angle);
   const textSize = measureText(text);
 
-  const angledWidth = textSize.width * Math.cos(angle) + textSize.height * Math.sin(angle);
-  const angledHeight = textSize.width * Math.sin(angle) + textSize.height * Math.cos(angle);
+  const angledWidth =
+    Math.abs(textSize.width * Math.cos(angle)) + Math.abs(textSize.height * Math.sin(angle));
+  const angledHeight =
+    Math.abs(textSize.width * Math.sin(angle)) + Math.abs(textSize.height * Math.cos(angle));
 
   return angledWidth <= width && angledHeight <= height;
 }

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -54,6 +54,28 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
   return longestFittingText ? longestFittingText + ELLIPSIS : '';
 }
 
+const segmenter =
+  'Segmenter' in Intl ? new Intl.Segmenter(undefined, { granularity: 'grapheme' }) : null;
+export function segmentAt(text: string, index: number) {
+  if (!segmenter) {
+    return text.slice(0, index);
+  }
+
+  const segments = segmenter.segment(text);
+
+  const { index: indexLimit } = segments.containing(index);
+
+  let newText = '';
+
+  for (const segment of segments) {
+    if (segment.index >= indexLimit) {
+      return newText;
+    }
+
+    newText += segment.segment;
+  }
+}
+
 export function shortenText(text: string, by: number) {
   // If text has less than two characters, we can't shorten it, so just return an empty string.
   if (text.length <= 1) {

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -26,11 +26,11 @@ export function doesTextFitInRect(text: string, config: EllipsizeConfig) {
 }
 
 /** This function finds the best place to clip the text to add an ellipsis.
- * This function assumes that the {@link doesTextFit} never return true for longer text after returning false for
- * shorter text.
+ *  This function assumes that the {@link doesTextFit} never returns true for longer text after returning false for
+ *  shorter text.
  *
- * @param text Text to ellipsize if needed
- * @param doesTextFit a function that returns whether a string fits inside a container.
+ *  @param text Text to ellipsize if needed
+ *  @param doesTextFit a function that returns whether a string fits inside a container.
  */
 export function ellipsize(text: string, doesTextFit: (text: string) => boolean) {
   if (doesTextFit(text)) {

--- a/packages/x-charts/src/internals/ellipsize.ts
+++ b/packages/x-charts/src/internals/ellipsize.ts
@@ -51,8 +51,6 @@ export function ellipsize(text: string, config: EllipsizeConfig) {
     }
   } while (newLength !== lastLength);
 
-  console.log({ text, largestFit: longestFittingText, config });
-
   return longestFittingText ? longestFittingText + ELLIPSIS : '';
 }
 

--- a/packages/x-charts/src/internals/getGraphemeCount.ts
+++ b/packages/x-charts/src/internals/getGraphemeCount.ts
@@ -1,0 +1,24 @@
+const segmenter =
+  typeof window !== 'undefined' && 'Intl' in window && 'Segmenter' in Intl
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+function getGraphemeCountFallback(text: string) {
+  return text.length;
+}
+
+function getGraphemeCountModern(text: string) {
+  const segments = segmenter!.segment(text);
+
+  let count = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for (const unused of segments) {
+    count += 1;
+  }
+
+  return count;
+}
+
+/** Returns the number of graphemes (basically characters) present in {@link text}. */
+export const getGraphemeCount = segmenter ? getGraphemeCountModern : getGraphemeCountFallback;

--- a/packages/x-charts/src/internals/getGraphemeCount.ts
+++ b/packages/x-charts/src/internals/getGraphemeCount.ts
@@ -12,8 +12,8 @@ function getGraphemeCountModern(text: string) {
 
   let count = 0;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  for (const unused of segments) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/naming-convention,no-underscore-dangle
+  for (const _unused of segments) {
     count += 1;
   }
 

--- a/packages/x-charts/src/internals/getWordsByLines.ts
+++ b/packages/x-charts/src/internals/getWordsByLines.ts
@@ -1,6 +1,11 @@
 import { getStringSize } from './domUtils';
 
-export type ChartsTextBaseline = 'hanging' | 'central' | 'auto';
+export type ChartsTextBaseline =
+  | 'hanging'
+  | 'central'
+  | 'auto'
+  | 'text-after-edge'
+  | 'text-before-edge';
 
 export interface ChartsTextStyle extends React.CSSProperties {
   angle?: number;

--- a/packages/x-charts/src/internals/sliceUntil.test.ts
+++ b/packages/x-charts/src/internals/sliceUntil.test.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { sliceUntil } from './sliceUntil';
+
+describe('sliceUntil', () => {
+  it('slices ASCII properly', () => {
+    expect(sliceUntil('Hello World', 5)).to.equal('Hello');
+    expect(sliceUntil('Hello World', 6)).to.equal('Hello ');
+    expect(sliceUntil('Hello World', 7)).to.equal('Hello W');
+    expect(sliceUntil('Hello World', 9)).to.equal('Hello Wor');
+  });
+
+  it('slices unicode characters properly', () => {
+    expect(sliceUntil('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 5)).to.equal('emoji');
+    expect(sliceUntil('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 6)).to.equal('emoji👱🏽‍♀️');
+    expect(sliceUntil('emoji👱🏽‍♀️👱🏽‍♀️👱🏽‍♀️', 7)).to.equal('emoji👱🏽‍♀️👱🏽‍♀️');
+  });
+});

--- a/packages/x-charts/src/internals/sliceUntil.ts
+++ b/packages/x-charts/src/internals/sliceUntil.ts
@@ -1,5 +1,5 @@
 const segmenter =
-  'Intl' in window && 'Segmenter' in Intl
+  typeof window !== 'undefined' && 'Intl' in window && 'Segmenter' in Intl
     ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
     : null;
 

--- a/packages/x-charts/src/internals/sliceUntil.ts
+++ b/packages/x-charts/src/internals/sliceUntil.ts
@@ -1,0 +1,29 @@
+const segmenter =
+  'Intl' in window && 'Segmenter' in Intl
+    ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+    : null;
+
+function sliceUntilFallback(text: string, endIndex: number) {
+  return text.slice(0, endIndex);
+}
+
+function sliceUntilModern(text: string, endIndex: number) {
+  const segments = segmenter!.segment(text);
+
+  let newText = '';
+  let i = 0;
+
+  for (const segment of segments) {
+    newText += segment.segment;
+    i += 1;
+
+    if (i >= endIndex) {
+      break;
+    }
+  }
+
+  return newText;
+}
+
+/** Creates a slice of {@link text} from the start until the {@link endIndex}th grapheme (basically character). */
+export const sliceUntil = segmenter ? sliceUntilModern : sliceUntilFallback;


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/10928.

Fix x-axis tick label overflow by applying an ellipsis for overflowing labels.


This PR does not change the algorithm for tick label visibility, so that logic should remain the same. The only difference is if those label would cause an overflow, they no longer will. This is especially noticeable for angles !== 0 and for tick labels at the extremities of charts.

### Before

![image](https://github.com/user-attachments/assets/2406bf85-e30b-4549-ad28-0a7c55a067a9)


### After

![image](https://github.com/user-attachments/assets/1cf39ba7-f6dc-42b0-bd27-eca9328c0aa3)


## Checklist
- [x] Test multi-line labels
  ![image](https://github.com/user-attachments/assets/e56356ff-d7a3-44d9-acbe-00ce780bd0bd)
- [x] Test multiple anchors/baselines
  
  ![localhost_3001_playground_long-x-axis-ticks_ (2)](https://github.com/user-attachments/assets/09e3dd60-993a-4eeb-a536-39467854d9fd)

- [x] Test with zoom

  https://github.com/user-attachments/assets/9e6e24bc-918a-4319-9598-40fb979e5bec
- [x] Test ellipsis with unicode characters
  ![image](https://github.com/user-attachments/assets/55cd176a-96a2-47c7-a029-e4f473d88194)


## Changelog

Tick labels in the x-axis of cartesian charts will now have an ellipsis applied to prevent overflow. 
If your tick labels are being clipped sooner than you would like, you can increase the x-axis size by increasing its `height` property. 
The default line-height has also been changed to 1.25, so if you aren't customizing the line height for x-axis tick labels, make sure to double check if the result is desirable. 
