### PR TITLE
[DataGrid] Fix `showColumnVerticalBorder` prop

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -142,7 +142,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         pinnedPosition,
         indexInSection,
         sectionLength,
-        rootProps.showCellVerticalBorder,
+        rootProps.showColumnVerticalBorder,
         gridHasFiller,
       );
 

--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -259,7 +259,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
         pinnedPosition,
         indexInSection,
         sectionLength,
-        rootProps.showCellVerticalBorder,
+        rootProps.showColumnVerticalBorder,
         gridHasFiller,
       );
 
@@ -443,7 +443,7 @@ export const useGridColumnHeaders = (props: UseGridColumnHeadersProps) => {
             pinnedPosition,
             indexInSection,
             visibleColumnGroupHeader.length,
-            rootProps.showCellVerticalBorder,
+            rootProps.showColumnVerticalBorder,
             gridHasFiller,
           )}
         />

--- a/test/regressions/data-grid/DataGridBorderedCells.js
+++ b/test/regressions/data-grid/DataGridBorderedCells.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+import { randomTraderName, randomEmail } from '@mui/x-data-grid-generator';
+
+const columns = [
+  { field: 'name', headerName: 'Name', width: 160 },
+  { field: 'email', headerName: 'Email', width: 200 },
+  { field: 'age', headerName: 'Age', type: 'number' },
+];
+
+const rows = [
+  {
+    id: 1,
+    name: randomTraderName(),
+    email: randomEmail(),
+    age: 25,
+  },
+];
+
+export default function DataGridBordered() {
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGridPro rows={rows} columns={columns} showCellVerticalBorder />
+    </div>
+  );
+}

--- a/test/regressions/data-grid/DataGridBorderedColumns.js
+++ b/test/regressions/data-grid/DataGridBorderedColumns.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+import { randomTraderName, randomEmail } from '@mui/x-data-grid-generator';
+
+const columns = [
+  { field: 'name', headerName: 'Name', width: 160 },
+  { field: 'email', headerName: 'Email', width: 200 },
+  { field: 'age', headerName: 'Age', type: 'number' },
+];
+
+const rows = [
+  {
+    id: 1,
+    name: randomTraderName(),
+    email: randomEmail(),
+    age: 25,
+  },
+];
+
+export default function DataGridBordered() {
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGridPro rows={rows} columns={columns} showColumnVerticalBorder />
+    </div>
+  );
+}


### PR DESCRIPTION
The column headers were using `showCellVerticalBorder` to determine whether the border should be enabled between items instead of `showColumnVerticalBorder`.