### PR TITLE
[DataGrid] Make `GridSortItem` internal

### DIFF
--- a/docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md
+++ b/docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md
@@ -199,6 +199,7 @@ You have to import it from `@mui/x-license` instead:
   - Return early if `apiRef` is `null`
   - Throw an error if `apiRef` is `null`
 
+- `GridSortItem` interface is not exported anymore.
 - `createUseGridApiEventHandler()` is not exported anymore.
 - The `showToolbar` prop is now required to display the toolbar.
 
@@ -337,7 +338,3 @@ You have to import it from `@mui/x-license` instead:
 <!-- ### Editing
 
 TBD
-
-### Changes to slots
-
-TBD -->

--- a/packages/x-data-grid/src/models/api/gridSortApi.ts
+++ b/packages/x-data-grid/src/models/api/gridSortApi.ts
@@ -24,7 +24,7 @@ export interface GridSortApi {
    * Sorts a column.
    * @param {GridColDef['field']} field The field identifier of the column to be sorted.
    * @param {GridSortDirection} direction The direction to be sorted. By default, the next in the `sortingOrder` prop.
-   * @param {boolean} allowMultipleSorting Whether to keep the existing [[GridSortItem]]. Default is `false`.
+   * @param {boolean} allowMultipleSorting Whether to keep the existing [GridSortModel]. Default is `false`.
    */
   sortColumn: (
     field: GridColDef['field'],

--- a/packages/x-data-grid/src/models/index.ts
+++ b/packages/x-data-grid/src/models/index.ts
@@ -23,7 +23,8 @@ export * from './gridDensity';
 export * from './logger';
 export * from './muiEvent';
 export * from './events';
-export * from './gridSortModel';
+export type { GridSortDirection, GridComparatorFn, GridSortModel } from './gridSortModel';
+export { GridSortCellParams } from './gridSortModel';
 export * from './gridColumnGrouping';
 export type { GridDataSourceCache } from './gridDataSource';
 // Do not export GridExportFormat and GridExportExtension which are override in pro package

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -596,7 +596,6 @@
   { "name": "gridSortedRowIdsSelector", "kind": "Variable" },
   { "name": "GridSortingInitialState", "kind": "Interface" },
   { "name": "GridSortingState", "kind": "Interface" },
-  { "name": "GridSortItem", "kind": "Interface" },
   { "name": "GridSortModel", "kind": "TypeAlias" },
   { "name": "gridSortModelSelector", "kind": "Variable" },
   { "name": "GridState", "kind": "TypeAlias" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -546,7 +546,6 @@
   { "name": "gridSortedRowIdsSelector", "kind": "Variable" },
   { "name": "GridSortingInitialState", "kind": "Interface" },
   { "name": "GridSortingState", "kind": "Interface" },
-  { "name": "GridSortItem", "kind": "Interface" },
   { "name": "GridSortModel", "kind": "TypeAlias" },
   { "name": "gridSortModelSelector", "kind": "Variable" },
   { "name": "GridState", "kind": "TypeAlias" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -504,7 +504,6 @@
   { "name": "gridSortedRowIdsSelector", "kind": "Variable" },
   { "name": "GridSortingInitialState", "kind": "Interface" },
   { "name": "GridSortingState", "kind": "Interface" },
-  { "name": "GridSortItem", "kind": "Interface" },
   { "name": "GridSortModel", "kind": "TypeAlias" },
   { "name": "gridSortModelSelector", "kind": "Variable" },
   { "name": "GridState", "kind": "TypeAlias" },


### PR DESCRIPTION
## Changelog

- `GridSortItem` interface is not exported anymore.
