### PR TITLE
[charts] Remove redundant default axis

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
@@ -29,4 +29,35 @@ describe('<Heatmap /> - License', () => {
 
     expect(screen.getByText('No data to display')).toBeVisible();
   });
+
+  describe('axis defaults', () => {
+    const series = [
+      {
+        data: [
+          [-1, 3, 7],
+          [1, 5, 8],
+        ],
+      },
+    ] as const;
+
+    it('should render default axes when axes are empty arrays and series contain data', () => {
+      render(<Heatmap series={series} width={100} height={100} xAxis={[]} yAxis={[]} />);
+
+      const xAxisTickLabels = screen.getAllByTestId('ChartsXAxisTickLabel');
+      expect(xAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['-1', '1']);
+
+      const yAxisTickLabels = screen.getAllByTestId('ChartsYAxisTickLabel');
+      expect(yAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['3', '5']);
+    });
+
+    it('should render default axes when axes are an array of an empty object and series contain data', () => {
+      render(<Heatmap series={series} width={100} height={100} xAxis={[{}]} yAxis={[{}]} />);
+
+      const xAxisTickLabels = screen.getAllByTestId('ChartsXAxisTickLabel');
+      expect(xAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['-1', '1']);
+
+      const yAxisTickLabels = screen.getAllByTestId('ChartsYAxisTickLabel');
+      expect(yAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['3', '5']);
+    });
+  });
 });

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
@@ -34,7 +34,7 @@ describe('<Heatmap /> - License', () => {
     const series = [
       {
         data: [
-          [-1, 3, 7],
+          [0, 3, 7],
           [1, 5, 8],
         ],
       },

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
@@ -23,4 +23,10 @@ describe('<Heatmap /> - License', () => {
 
     expect(await screen.findAllByText('MUI X Missing license key')).not.to.equal(null);
   });
+
+  it('should render "No data to display" when axes are empty arrays', () => {
+    render(<Heatmap series={[]} width={100} height={100} xAxis={[]} yAxis={[]} />);
+
+    expect(screen.getByText('No data to display')).toBeVisible();
+  });
 });

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
@@ -44,20 +44,34 @@ describe('<Heatmap /> - License', () => {
       render(<Heatmap series={series} width={100} height={100} xAxis={[]} yAxis={[]} />);
 
       const xAxisTickLabels = screen.getAllByTestId('ChartsXAxisTickLabel');
-      expect(xAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['-1', '1']);
+      expect(xAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['0', '1']);
 
       const yAxisTickLabels = screen.getAllByTestId('ChartsYAxisTickLabel');
-      expect(yAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['3', '5']);
+      expect(yAxisTickLabels.map((t) => t.textContent)).to.deep.equal([
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+      ]);
     });
 
     it('should render default axes when axes are an array of an empty object and series contain data', () => {
       render(<Heatmap series={series} width={100} height={100} xAxis={[{}]} yAxis={[{}]} />);
 
       const xAxisTickLabels = screen.getAllByTestId('ChartsXAxisTickLabel');
-      expect(xAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['-1', '1']);
+      expect(xAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['0', '1']);
 
       const yAxisTickLabels = screen.getAllByTestId('ChartsYAxisTickLabel');
-      expect(yAxisTickLabels.map((t) => t.textContent)).to.deep.equal(['3', '5']);
+      expect(yAxisTickLabels.map((t) => t.textContent)).to.deep.equal([
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+      ]);
     });
   });
 });

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -135,15 +135,33 @@ const Heatmap = React.forwardRef(function Heatmap(
         id: DEFAULT_X_AXIS_KEY,
         scaleType: 'band' as const,
         categoryGapRatio: 0,
-        data: [],
+        data:
+          series?.[0]?.data && series[0].data.length > 0
+            ? Array.from(
+                { length: Math.max(...series[0].data.map(([xIndex]) => xIndex)) },
+                (_, index) => index + 1,
+              )
+            : [],
         ...axis,
       })),
-    [xAxis],
+    [series, xAxis],
   );
 
   const defaultizedYAxis = React.useMemo(
-    () => yAxis.map((axis) => ({ scaleType: 'band' as const, categoryGapRatio: 0, ...axis })),
-    [yAxis],
+    () =>
+      (yAxis && yAxis.length > 0 ? yAxis : [{}]).map((axis) => ({
+        scaleType: 'band' as const,
+        categoryGapRatio: 0,
+        data:
+          series?.[0]?.data && series[0].data.length > 0
+            ? Array.from(
+                { length: Math.max(...series[0].data.map(([_, yIndex]) => yIndex)) },
+                (_, index) => index + 1,
+              )
+            : [],
+        ...axis,
+      })),
+    [series, yAxis],
   );
 
   const defaultizedZAxis = React.useMemo(

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -22,6 +22,7 @@ import {
   ChartsOverlaySlotProps,
   ChartsOverlaySlots,
 } from '@mui/x-charts/ChartsOverlay';
+import { DEFAULT_X_AXIS_KEY } from '@mui/x-charts/constants';
 import { ChartContainerPro, ChartContainerProProps } from '../ChartContainerPro';
 import { HeatmapSeriesType } from '../models/seriesType/heatmap';
 import { HeatmapPlot } from './HeatmapPlot';
@@ -129,7 +130,14 @@ const Heatmap = React.forwardRef(function Heatmap(
   const clipPathId = `${id}-clip-path`;
 
   const defaultizedXAxis = React.useMemo(
-    () => xAxis.map((axis) => ({ scaleType: 'band' as const, categoryGapRatio: 0, ...axis })),
+    () =>
+      (xAxis && xAxis.length > 0 ? xAxis : [{}]).map((axis) => ({
+        id: DEFAULT_X_AXIS_KEY,
+        scaleType: 'band' as const,
+        categoryGapRatio: 0,
+        data: [],
+        ...axis,
+      })),
     [xAxis],
   );
 

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -101,6 +101,20 @@ const defaultColorMap = interpolateRgbBasis([
 
 const seriesConfig: ChartSeriesConfig<'heatmap'> = { heatmap: heatmapSeriesConfig };
 
+function getDefaultDataForAxis(series: HeatmapProps['series'], dimension: number) {
+  if (series?.[0]?.data === undefined || series[0].data.length === 0) {
+    return [];
+  }
+
+  const uniqueValues = new Set();
+
+  series[0].data.forEach((dataPoint) => uniqueValues.add(dataPoint[dimension]));
+
+  return Array.from(uniqueValues.values());
+}
+const getDefaultDataForXAxis = (series: HeatmapProps['series']) => getDefaultDataForAxis(series, 0);
+const getDefaultDataForYAxis = (series: HeatmapProps['series']) => getDefaultDataForAxis(series, 1);
+
 const Heatmap = React.forwardRef(function Heatmap(
   inProps: HeatmapProps,
   ref: React.Ref<SVGSVGElement>,
@@ -135,13 +149,7 @@ const Heatmap = React.forwardRef(function Heatmap(
         id: DEFAULT_X_AXIS_KEY,
         scaleType: 'band' as const,
         categoryGapRatio: 0,
-        data:
-          series?.[0]?.data && series[0].data.length > 0
-            ? Array.from(
-                { length: Math.max(...series[0].data.map(([xIndex]) => xIndex)) },
-                (_, index) => index + 1,
-              )
-            : [],
+        data: axis.data ? undefined : getDefaultDataForXAxis(series),
         ...axis,
       })),
     [series, xAxis],
@@ -152,13 +160,7 @@ const Heatmap = React.forwardRef(function Heatmap(
       (yAxis && yAxis.length > 0 ? yAxis : [{}]).map((axis) => ({
         scaleType: 'band' as const,
         categoryGapRatio: 0,
-        data:
-          series?.[0]?.data && series[0].data.length > 0
-            ? Array.from(
-                { length: Math.max(...series[0].data.map(([_, yIndex]) => yIndex)) },
-                (_, index) => index + 1,
-              )
-            : [],
+        data: axis.data ? undefined : getDefaultDataForYAxis(series),
         ...axis,
       })),
     [series, yAxis],

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -22,7 +22,7 @@ import {
   ChartsOverlaySlotProps,
   ChartsOverlaySlots,
 } from '@mui/x-charts/ChartsOverlay';
-import { DEFAULT_X_AXIS_KEY } from '@mui/x-charts/constants';
+import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '@mui/x-charts/constants';
 import { ChartContainerPro, ChartContainerProProps } from '../ChartContainerPro';
 import { HeatmapSeriesType } from '../models/seriesType/heatmap';
 import { HeatmapPlot } from './HeatmapPlot';
@@ -106,11 +106,10 @@ function getDefaultDataForAxis(series: HeatmapProps['series'], dimension: number
     return [];
   }
 
-  const uniqueValues = new Set();
-
-  series[0].data.forEach((dataPoint) => uniqueValues.add(dataPoint[dimension]));
-
-  return Array.from(uniqueValues.values());
+  return Array.from(
+    { length: Math.max(...series[0].data.map((dataPoint) => dataPoint[dimension])) + 1 },
+    (_, index) => index,
+  );
 }
 const getDefaultDataForXAxis = (series: HeatmapProps['series']) => getDefaultDataForAxis(series, 0);
 const getDefaultDataForYAxis = (series: HeatmapProps['series']) => getDefaultDataForAxis(series, 1);
@@ -145,23 +144,22 @@ const Heatmap = React.forwardRef(function Heatmap(
 
   const defaultizedXAxis = React.useMemo(
     () =>
-      (xAxis && xAxis.length > 0 ? xAxis : [{}]).map((axis) => ({
-        id: DEFAULT_X_AXIS_KEY,
+      (xAxis && xAxis.length > 0 ? xAxis : [{ id: DEFAULT_X_AXIS_KEY }]).map((axis) => ({
         scaleType: 'band' as const,
         categoryGapRatio: 0,
-        data: axis.data ? undefined : getDefaultDataForXAxis(series),
         ...axis,
+        data: axis.data ?? getDefaultDataForXAxis(series),
       })),
     [series, xAxis],
   );
 
   const defaultizedYAxis = React.useMemo(
     () =>
-      (yAxis && yAxis.length > 0 ? yAxis : [{}]).map((axis) => ({
+      (yAxis && yAxis.length > 0 ? yAxis : [{ id: DEFAULT_Y_AXIS_KEY }]).map((axis) => ({
         scaleType: 'band' as const,
         categoryGapRatio: 0,
-        data: axis.data ? undefined : getDefaultDataForYAxis(series),
         ...axis,
+        data: axis.data ?? getDefaultDataForYAxis(series),
       })),
     [series, yAxis],
   );

--- a/packages/x-charts/src/BarChart/BarChart.test.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils/createRenderer';
 import { describeConformance } from 'test/utils/describeConformance';
 import { BarChart } from '@mui/x-charts/BarChart';
+import { expect } from 'chai';
+import { screen } from '@mui/internal-test-utils';
 
 describe('<BarChart />', () => {
   const { render } = createRenderer();
@@ -28,4 +30,10 @@ describe('<BarChart />', () => {
       ],
     }),
   );
+
+  it('should render "No data to display" when axes are empty arrays', () => {
+    render(<BarChart series={[]} width={100} height={100} xAxis={[]} yAxis={[]} />);
+
+    expect(screen.getByText('No data to display')).toBeVisible();
+  });
 });

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -278,6 +278,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
               <TickLabel
                 x={xTickLabel}
                 y={yTickLabel}
+                data-testid="ChartsXAxisTickLabel"
                 {...axisTickLabelProps}
                 text={formattedValue.toString()}
               />

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -208,6 +208,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
               <TickLabel
                 x={xTickLabel}
                 y={yTickLabel}
+                data-testid="ChartsYAxisTickLabel"
                 text={formattedValue.toString()}
                 {...axisTickLabelProps}
               />

--- a/packages/x-charts/src/LineChart/LineChart.test.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils/createRenderer';
 import { describeConformance } from 'test/utils/describeConformance';
 import { LineChart } from '@mui/x-charts/LineChart';
+import { expect } from 'chai';
+import { screen } from '@mui/internal-test-utils';
 
 describe('<LineChart />', () => {
   const { render } = createRenderer();
@@ -27,4 +29,10 @@ describe('<LineChart />', () => {
       ],
     }),
   );
+
+  it('should render "No data to display" when axes are empty arrays', () => {
+    render(<LineChart series={[]} width={100} height={100} xAxis={[]} yAxis={[]} />);
+
+    expect(screen.getByText('No data to display')).toBeVisible();
+  });
 });

--- a/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
@@ -159,4 +159,10 @@ describe('<ScatterChart />', () => {
     const labelY = await screen.findByText('600');
     expect(labelY).toBeVisible();
   });
+
+  it('should render "No data to display" when axes are empty arrays', () => {
+    render(<ScatterChart series={[]} width={100} height={100} xAxis={[]} yAxis={[]} />);
+
+    expect(screen.getByText('No data to display')).toBeVisible();
+  });
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -34,49 +34,50 @@ export function defaultizeAxis(
     none: 0,
   };
 
-  const parsedAxes = (inAxis || [{ id: DEFAULT_AXIS_KEY, scaleType: 'linear' as const }]).map(
-    (axisConfig, index) => {
-      const dataKey = axisConfig.dataKey;
-      const defaultPosition = axisName === 'x' ? ('bottom' as const) : ('left' as const);
+  const inputAxes =
+    inAxis && inAxis.length > 0 ? inAxis : [{ id: DEFAULT_AXIS_KEY, scaleType: 'linear' as const }];
 
-      const position = axisConfig.position ?? 'none';
-      const dimension = axisName === 'x' ? 'height' : 'width';
+  const parsedAxes = inputAxes.map((axisConfig, index) => {
+    const dataKey = axisConfig.dataKey;
+    const defaultPosition = axisName === 'x' ? ('bottom' as const) : ('left' as const);
 
-      const height = axisName === 'x' ? DEFAULT_AXIS_SIZE_HEIGHT : 0;
-      const width = axisName === 'y' ? DEFAULT_AXIS_SIZE_WIDTH : 0;
+    const position = axisConfig.position ?? 'none';
+    const dimension = axisName === 'x' ? 'height' : 'width';
 
-      const sharedConfig = {
-        id: `defaultized-${axisName}-axis-${index}`,
-        // The fist axis is defaultized to the bottom/left
-        ...(index === 0 ? { position: defaultPosition } : {}),
-        height,
-        width,
-        offset: offsets[position],
-        ...axisConfig,
-      };
+    const height = axisName === 'x' ? DEFAULT_AXIS_SIZE_HEIGHT : 0;
+    const width = axisName === 'y' ? DEFAULT_AXIS_SIZE_WIDTH : 0;
 
-      // Increment the offset for the next axis
-      if (position !== 'none') {
-        offsets[position] +=
-          (axisConfig as any)[dimension] ?? (dimension === 'height' ? height : width);
-      }
+    const sharedConfig = {
+      id: `defaultized-${axisName}-axis-${index}`,
+      // The fist axis is defaultized to the bottom/left
+      ...(index === 0 ? { position: defaultPosition } : {}),
+      height,
+      width,
+      offset: offsets[position],
+      ...axisConfig,
+    };
 
-      // If `dataKey` is NOT provided
-      if (dataKey === undefined || axisConfig.data !== undefined) {
-        return sharedConfig;
-      }
+    // Increment the offset for the next axis
+    if (position !== 'none') {
+      offsets[position] +=
+        (axisConfig as any)[dimension] ?? (dimension === 'height' ? height : width);
+    }
 
-      if (dataset === undefined) {
-        throw new Error(`MUI X: ${axisName}-axis uses \`dataKey\` but no \`dataset\` is provided.`);
-      }
+    // If `dataKey` is NOT provided
+    if (dataKey === undefined || axisConfig.data !== undefined) {
+      return sharedConfig;
+    }
 
-      // If `dataKey` is provided
-      return {
-        ...sharedConfig,
-        data: dataset.map((d) => d[dataKey]),
-      };
-    },
-  );
+    if (dataset === undefined) {
+      throw new Error(`MUI X: ${axisName}-axis uses \`dataKey\` but no \`dataset\` is provided.`);
+    }
+
+    // If `dataKey` is provided
+    return {
+      ...sharedConfig,
+      data: dataset.map((d) => d[dataKey]),
+    };
+  });
 
   return parsedAxes;
 }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -26,9 +26,6 @@ export function defaultizeAxis(
 ): AxisConfig[] {
   const DEFAULT_AXIS_KEY = axisName === 'x' ? DEFAULT_X_AXIS_KEY : DEFAULT_Y_AXIS_KEY;
 
-  const hasNoDefaultAxis =
-    inAxis === undefined || inAxis.findIndex(({ id }) => id === DEFAULT_AXIS_KEY) === -1;
-
   const offsets = {
     top: 0,
     right: 0,
@@ -37,50 +34,49 @@ export function defaultizeAxis(
     none: 0,
   };
 
-  const parsedAxes = [
-    ...(inAxis ?? []),
-    ...(hasNoDefaultAxis ? [{ id: DEFAULT_AXIS_KEY, scaleType: 'linear' as const }] : []),
-  ].map((axisConfig, index) => {
-    const dataKey = axisConfig.dataKey;
-    const defaultPosition = axisName === 'x' ? ('bottom' as const) : ('left' as const);
+  const parsedAxes = (inAxis || [{ id: DEFAULT_AXIS_KEY, scaleType: 'linear' as const }]).map(
+    (axisConfig, index) => {
+      const dataKey = axisConfig.dataKey;
+      const defaultPosition = axisName === 'x' ? ('bottom' as const) : ('left' as const);
 
-    const position = axisConfig.position ?? 'none';
-    const dimension = axisName === 'x' ? 'height' : 'width';
+      const position = axisConfig.position ?? 'none';
+      const dimension = axisName === 'x' ? 'height' : 'width';
 
-    const height = axisName === 'x' ? DEFAULT_AXIS_SIZE_HEIGHT : 0;
-    const width = axisName === 'y' ? DEFAULT_AXIS_SIZE_WIDTH : 0;
+      const height = axisName === 'x' ? DEFAULT_AXIS_SIZE_HEIGHT : 0;
+      const width = axisName === 'y' ? DEFAULT_AXIS_SIZE_WIDTH : 0;
 
-    const sharedConfig = {
-      id: `defaultized-${axisName}-axis-${index}`,
-      // The fist axis is defaultized to the bottom/left
-      ...(index === 0 ? { position: defaultPosition } : {}),
-      height,
-      width,
-      offset: offsets[position],
-      ...axisConfig,
-    };
+      const sharedConfig = {
+        id: `defaultized-${axisName}-axis-${index}`,
+        // The fist axis is defaultized to the bottom/left
+        ...(index === 0 ? { position: defaultPosition } : {}),
+        height,
+        width,
+        offset: offsets[position],
+        ...axisConfig,
+      };
 
-    // Increment the offset for the next axis
-    if (position !== 'none') {
-      offsets[position] +=
-        (axisConfig as any)[dimension] ?? (dimension === 'height' ? height : width);
-    }
+      // Increment the offset for the next axis
+      if (position !== 'none') {
+        offsets[position] +=
+          (axisConfig as any)[dimension] ?? (dimension === 'height' ? height : width);
+      }
 
-    // If `dataKey` is NOT provided
-    if (dataKey === undefined || axisConfig.data !== undefined) {
-      return sharedConfig;
-    }
+      // If `dataKey` is NOT provided
+      if (dataKey === undefined || axisConfig.data !== undefined) {
+        return sharedConfig;
+      }
 
-    if (dataset === undefined) {
-      throw new Error(`MUI X: ${axisName}-axis uses \`dataKey\` but no \`dataset\` is provided.`);
-    }
+      if (dataset === undefined) {
+        throw new Error(`MUI X: ${axisName}-axis uses \`dataKey\` but no \`dataset\` is provided.`);
+      }
 
-    // If `dataKey` is provided
-    return {
-      ...sharedConfig,
-      data: dataset.map((d) => d[dataKey]),
-    };
-  });
+      // If `dataKey` is provided
+      return {
+        ...sharedConfig,
+        data: dataset.map((d) => d[dataKey]),
+      };
+    },
+  );
 
   return parsedAxes;
 }


### PR DESCRIPTION
Remove redundant default axis when processing user-provided axes. 

Also fixes a crash with the Heatmap when the `xAxis` prop was an empty array. 

Added unit tests for every chart that accepts an array for either the `xAxis` or the `yAxis` prop.

Before:

https://github.com/user-attachments/assets/af4e3546-fa2a-48b5-b929-10c109468b31

After:

https://github.com/user-attachments/assets/22938fba-0d8b-4120-93b2-c555958f38cc

