### PR TITLE
[DataGrid] fix: popper focus trap

### DIFF
--- a/packages/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.tsx
@@ -110,7 +110,6 @@ const GridPanel = forwardRef<HTMLElement, GridPanelProps>((props, ref) => {
       clickAwayMouseEvent="onPointerUp"
       clickAwayTouchEvent={false}
       focusTrap
-      focusTrapEnabled
       {...other}
       {...rootProps.slotProps?.basePopper}
       ref={ref}

--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -499,8 +499,10 @@ function focusTrapWrapper(props: PopperProps, content: any) {
     return content;
   }
   return (
-    <MUIFocusTrap open disableEnforceFocus isEnabled={() => props.focusTrapEnabled ?? true}>
-      {content}
+    <MUIFocusTrap open disableEnforceFocus>
+      <div tabIndex={-1}>
+        {content}
+      </div>
     </MUIFocusTrap>
   );
 }

--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -500,9 +500,7 @@ function focusTrapWrapper(props: PopperProps, content: any) {
   }
   return (
     <MUIFocusTrap open disableEnforceFocus>
-      <div tabIndex={-1}>
-        {content}
-      </div>
+      <div tabIndex={-1}>{content}</div>
     </MUIFocusTrap>
   );
 }

--- a/packages/x-data-grid/src/models/gridBaseSlots.ts
+++ b/packages/x-data-grid/src/models/gridBaseSlots.ts
@@ -187,7 +187,6 @@ export type PopperProps = {
   clickAwayMouseEvent?: false | ClickAwayMouseEventHandler;
   flip?: boolean;
   focusTrap?: boolean;
-  focusTrapEnabled?: boolean;
   onExited?: (node: HTMLElement | null) => void;
   onClickAway?: (event: MouseEvent | TouchEvent) => void;
   onDidShow?: () => void;


### PR DESCRIPTION
Fixes https://mui-org.slack.com/archives/C05SBSU8NPR/p1740497242687319

Focus trap was not working.

Both `MUIClickAwayListener` and `MUIFocusTrap` require a ref'able child, but none of them forward the ref, so they can't be used on top of another.