### PR TITLE
[DataGrid] remove the quick filtering on a given column

### DIFF
--- a/docs/data/data-grid/filtering/QuickFilteringCustomLogic.js
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomLogic.js
@@ -53,7 +53,7 @@ export default function QuickFilteringCustomLogic() {
           if (column.field === 'name') {
             return {
               ...column,
-              getApplyQuickFilterFn: undefined,
+              getApplyQuickFilterFn: () => null,
             };
           }
           return column;

--- a/docs/data/data-grid/filtering/QuickFilteringCustomLogic.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringCustomLogic.tsx
@@ -59,7 +59,7 @@ export default function QuickFilteringCustomLogic() {
           if (column.field === 'name') {
             return {
               ...column,
-              getApplyQuickFilterFn: undefined,
+              getApplyQuickFilterFn: () => null,
             };
           }
           return column;

--- a/docs/data/data-grid/filtering/quick-filter.md
+++ b/docs/data/data-grid/filtering/quick-filter.md
@@ -94,7 +94,7 @@ const getApplyQuickFilterFn: GetApplyQuickFilterFn<any, unknown> = (value) => {
 };
 ```
 
-To remove the quick filtering on a given column set `getApplyQuickFilterFn: undefined`.
+To remove the quick filtering on a given column set `getApplyQuickFilterFn: () => null`.
 
 In the demo below, the column "Name" is not searchable with the quick filter, and 4 digits figures will be compared to the year of column "Created on."
 

--- a/packages/x-data-grid/src/colDef/gridActionsColDef.tsx
+++ b/packages/x-data-grid/src/colDef/gridActionsColDef.tsx
@@ -18,5 +18,5 @@ export const GRID_ACTIONS_COL_DEF: GridColTypeDef = {
   disableColumnMenu: true,
   disableExport: true,
   renderCell: renderActionsCell,
-  getApplyQuickFilterFn: undefined,
+  getApplyQuickFilterFn: () => null,
 };

--- a/packages/x-data-grid/src/colDef/gridBooleanColDef.tsx
+++ b/packages/x-data-grid/src/colDef/gridBooleanColDef.tsx
@@ -41,7 +41,7 @@ export const GRID_BOOLEAN_COL_DEF: GridColTypeDef<boolean | null, any> = {
   sortComparator: gridNumberComparator,
   valueFormatter: gridBooleanFormatter,
   filterOperators: getGridBooleanOperators(),
-  getApplyQuickFilterFn: undefined,
+  getApplyQuickFilterFn: () => null,
   // @ts-ignore
   aggregable: false,
   // @ts-ignore

--- a/packages/x-data-grid/src/colDef/gridCheckboxSelectionColDef.tsx
+++ b/packages/x-data-grid/src/colDef/gridCheckboxSelectionColDef.tsx
@@ -20,7 +20,7 @@ export const GRID_CHECKBOX_SELECTION_COL_DEF: GridColDef = {
   disableColumnMenu: true,
   disableReorder: true,
   disableExport: true,
-  getApplyQuickFilterFn: undefined,
+  getApplyQuickFilterFn: () => null,
   display: 'flex',
   valueGetter: (value, row, column, apiRef) => {
     const rowId = gridRowIdSelector(apiRef, row);


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16733

from https://github.com/mui/mui-x/blob/master/packages/x-data-grid/src/models/colDef/gridColDef.ts#L264-L265
   * The callback that generates a filtering function for a given quick filter value.
   * This function can return `null` to skip filtering for this value and column.
