### PR TITLE
[charts] Accept component in `labelMarkType`

### DIFF
--- a/docs/data/charts/legend/LegendCustomLabelMark.js
+++ b/docs/data/charts/legend/LegendCustomLabelMark.js
@@ -1,0 +1,29 @@
+import { BarChart } from '@mui/x-charts/BarChart';
+import * as React from 'react';
+
+function HTMLCircle({ color, ...props }) {
+  return <div {...props} style={{ borderRadius: '100%', background: color }} />;
+}
+
+function SVGDiamond({ color, ...props }) {
+  return (
+    <svg viewBox="-7.423 -7.423 14.846 14.846">
+      <path {...props} d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z" fill={color} />
+    </svg>
+  );
+}
+
+export default function LegendCustomLabelMark() {
+  return (
+    <BarChart
+      series={[
+        { id: 0, data: [10], label: 'Series A', labelMarkType: HTMLCircle },
+        { id: 1, data: [15], label: 'Series B', labelMarkType: 'line' },
+        { id: 2, data: [20], label: 'Series C' },
+        { id: 3, data: [10], label: 'Series D', labelMarkType: SVGDiamond },
+      ]}
+      xAxis={[{ scaleType: 'band', data: ['Category'] }]}
+      height={200}
+    />
+  );
+}

--- a/docs/data/charts/legend/LegendCustomLabelMark.js
+++ b/docs/data/charts/legend/LegendCustomLabelMark.js
@@ -17,12 +17,12 @@ export default function LegendCustomLabelMark() {
   return (
     <BarChart
       series={[
-        { id: 0, data: [10], label: 'Series A', labelMarkType: HTMLCircle },
-        { id: 1, data: [15], label: 'Series B', labelMarkType: 'line' },
-        { id: 2, data: [20], label: 'Series C' },
-        { id: 3, data: [10], label: 'Series D', labelMarkType: SVGDiamond },
+        { id: 0, data: [10, 15], label: 'Series A', labelMarkType: HTMLCircle },
+        { id: 1, data: [15, 20], label: 'Series B', labelMarkType: 'line' },
+        { id: 2, data: [20, 25], label: 'Series C' },
+        { id: 3, data: [10, 15], label: 'Series D', labelMarkType: SVGDiamond },
       ]}
-      xAxis={[{ scaleType: 'band', data: ['Category'] }]}
+      xAxis={[{ scaleType: 'band', data: ['Category 1', 'Category 2'] }]}
       height={200}
     />
   );

--- a/docs/data/charts/legend/LegendCustomLabelMark.tsx
+++ b/docs/data/charts/legend/LegendCustomLabelMark.tsx
@@ -1,0 +1,30 @@
+import { BarChart } from '@mui/x-charts/BarChart';
+import * as React from 'react';
+import { ChartsLabelCustomMarkProps } from '@mui/x-charts/ChartsLabel';
+
+function HTMLCircle({ color, ...props }: ChartsLabelCustomMarkProps) {
+  return <div {...props} style={{ borderRadius: '100%', background: color }} />;
+}
+
+function SVGDiamond({ color, ...props }: ChartsLabelCustomMarkProps) {
+  return (
+    <svg viewBox="-7.423 -7.423 14.846 14.846">
+      <path {...props} d="M0,-7.423L4.285,0L0,7.423L-4.285,0Z" fill={color} />
+    </svg>
+  );
+}
+
+export default function LegendCustomLabelMark() {
+  return (
+    <BarChart
+      series={[
+        { id: 0, data: [10], label: 'Series A', labelMarkType: HTMLCircle },
+        { id: 1, data: [15], label: 'Series B', labelMarkType: 'line' },
+        { id: 2, data: [20], label: 'Series C' },
+        { id: 3, data: [10], label: 'Series D', labelMarkType: SVGDiamond },
+      ]}
+      xAxis={[{ scaleType: 'band', data: ['Category'] }]}
+      height={200}
+    />
+  );
+}

--- a/docs/data/charts/legend/LegendCustomLabelMark.tsx
+++ b/docs/data/charts/legend/LegendCustomLabelMark.tsx
@@ -18,12 +18,12 @@ export default function LegendCustomLabelMark() {
   return (
     <BarChart
       series={[
-        { id: 0, data: [10], label: 'Series A', labelMarkType: HTMLCircle },
-        { id: 1, data: [15], label: 'Series B', labelMarkType: 'line' },
-        { id: 2, data: [20], label: 'Series C' },
-        { id: 3, data: [10], label: 'Series D', labelMarkType: SVGDiamond },
+        { id: 0, data: [10, 15], label: 'Series A', labelMarkType: HTMLCircle },
+        { id: 1, data: [15, 20], label: 'Series B', labelMarkType: 'line' },
+        { id: 2, data: [20, 25], label: 'Series C' },
+        { id: 3, data: [10, 15], label: 'Series D', labelMarkType: SVGDiamond },
       ]}
-      xAxis={[{ scaleType: 'band', data: ['Category'] }]}
+      xAxis={[{ scaleType: 'band', data: ['Category 1', 'Category 2'] }]}
       height={200}
     />
   );

--- a/docs/data/charts/legend/LegendCustomLabelMark.tsx.preview
+++ b/docs/data/charts/legend/LegendCustomLabelMark.tsx.preview
@@ -1,0 +1,10 @@
+<BarChart
+  series={[
+    { id: 0, data: [10], label: 'Series A', labelMarkType: HTMLCircle },
+    { id: 1, data: [15], label: 'Series B', labelMarkType: 'line' },
+    { id: 2, data: [20], label: 'Series C' },
+    { id: 3, data: [10], label: 'Series D', labelMarkType: SVGDiamond },
+  ]}
+  xAxis={[{ scaleType: 'band', data: ['Category'] }]}
+  height={200}
+/>

--- a/docs/data/charts/legend/LegendCustomLabelMark.tsx.preview
+++ b/docs/data/charts/legend/LegendCustomLabelMark.tsx.preview
@@ -1,10 +1,10 @@
 <BarChart
   series={[
-    { id: 0, data: [10], label: 'Series A', labelMarkType: HTMLCircle },
-    { id: 1, data: [15], label: 'Series B', labelMarkType: 'line' },
-    { id: 2, data: [20], label: 'Series C' },
-    { id: 3, data: [10], label: 'Series D', labelMarkType: SVGDiamond },
+    { id: 0, data: [10, 15], label: 'Series A', labelMarkType: HTMLCircle },
+    { id: 1, data: [15, 20], label: 'Series B', labelMarkType: 'line' },
+    { id: 2, data: [20, 25], label: 'Series C' },
+    { id: 3, data: [10, 15], label: 'Series D', labelMarkType: SVGDiamond },
   ]}
-  xAxis={[{ scaleType: 'band', data: ['Category'] }]}
+  xAxis={[{ scaleType: 'band', data: ['Category 1', 'Category 2'] }]}
   height={200}
 />

--- a/docs/data/charts/legend/legend.md
+++ b/docs/data/charts/legend/legend.md
@@ -81,7 +81,7 @@ Passing a component to `labelMarkType` affects not only the legend but other pla
 
 Customizing the mark shape of a pie chart depending on the series is slightly different. You can find how to do it in [this example](/x/react-charts/pie-demo/#pie-chart-with-custom-mark-in-legend-and-tooltip).
 
-Please note that using HTML elements for `labelMarkType` may make the legend incompatible with [gradients and patterns](/x/react-charts/styling/#gradients-and-patterns).
+To ensure compatibility with [gradients and patterns](/x/react-charts/styling/#gradients-and-patterns), consider using SVG instead of HTML in the `labelMarkType`.
 
 ### Scrollable legend
 

--- a/docs/data/charts/legend/legend.md
+++ b/docs/data/charts/legend/legend.md
@@ -81,6 +81,8 @@ Passing a component to `labelMarkType` affects not only the legend but other pla
 
 Customizing the mark shape of a pie chart depending on the series is slightly different. You can find how to do it in [this example](/x/react-charts/pie-demo/#pie-chart-with-custom-mark-in-legend-and-tooltip).
 
+Please note that using HTML elements for `labelMarkType` may make the legend incompatible with [gradients and patterns](/x/react-charts/styling/#gradients-and-patterns).
+
 ### Scrollable legend
 
 The legend can be made scrollable by setting the `overflowY` for vertical legends or `overflowX` for horizontal legends.

--- a/docs/data/charts/legend/legend.md
+++ b/docs/data/charts/legend/legend.md
@@ -71,6 +71,16 @@ For the `pie` series, the `labelMarkType` property is available for each of the 
 
 {{"demo": "LegendMarkType.js", "hideToolbar": true, "bg": "playground"}}
 
+#### Custom shapes
+
+For more advanced use cases, you can also provide a component to the `labelMarkType` property of each series to fully customize the mark.
+
+{{"demo": "LegendCustomLabelMark.js" }}
+
+Passing a component to `labelMarkType` affects not only the legend but other places where the label mark is shown, such as tooltips.
+
+Customizing the mark shape of a pie chart depending on the series is slightly different. You can find how to do it in [this example](/x/react-charts/pie-demo/#pie-chart-with-custom-mark-in-legend-and-tooltip).
+
 ### Scrollable legend
 
 The legend can be made scrollable by setting the `overflowY` for vertical legends or `overflowX` for horizontal legends.

--- a/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.js
+++ b/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.js
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { PieChart } from '@mui/x-charts/PieChart';
+
+function HTMLDiamond({ color, ...props }) {
+  return (
+    <div
+      {...props}
+      style={{ transform: 'scale(0.6, 0.75) rotate(45deg)', background: color }}
+    />
+  );
+}
+
+function SVGStar({ color, ...props }) {
+  return (
+    <svg viewBox="-7.423 -7.423 14.846 14.846">
+      <path
+        {...props}
+        d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+export default function PieChartWithCustomLegendTooltip() {
+  return (
+    <PieChart
+      series={[
+        {
+          data: [
+            { value: 10, label: 'Circle', labelMarkType: 'circle' },
+            {
+              value: 15,
+              label: 'Diamond',
+              labelMarkType: HTMLDiamond,
+            },
+            { value: 20, label: 'Star', labelMarkType: SVGStar },
+          ],
+        },
+      ]}
+      width={200}
+      height={200}
+    />
+  );
+}

--- a/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.js
+++ b/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.js
@@ -22,7 +22,7 @@ function SVGStar({ color, ...props }) {
   );
 }
 
-export default function PieChartWithCustomLegendTooltip() {
+export default function PieChartWithCustomLegendAndTooltip() {
   return (
     <PieChart
       series={[

--- a/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.tsx
+++ b/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { PieChart } from '@mui/x-charts/PieChart';
+import { ChartsLabelCustomMarkProps } from '@mui/x-charts/ChartsLabel';
+
+function HTMLDiamond({ color, ...props }: ChartsLabelCustomMarkProps) {
+  return (
+    <div
+      {...props}
+      style={{ transform: 'scale(0.6, 0.75) rotate(45deg)', background: color }}
+    />
+  );
+}
+
+function SVGStar({ color, ...props }: ChartsLabelCustomMarkProps) {
+  return (
+    <svg viewBox="-7.423 -7.423 14.846 14.846">
+      <path
+        {...props}
+        d="M0,-7.528L1.69,-2.326L7.16,-2.326L2.735,0.889L4.425,6.09L0,2.875L-4.425,6.09L-2.735,0.889L-7.16,-2.326L-1.69,-2.326Z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+export default function PieChartWithCustomLegendTooltip() {
+  return (
+    <PieChart
+      series={[
+        {
+          data: [
+            { value: 10, label: 'Circle', labelMarkType: 'circle' },
+            {
+              value: 15,
+              label: 'Diamond',
+              labelMarkType: HTMLDiamond,
+            },
+            { value: 20, label: 'Star', labelMarkType: SVGStar },
+          ],
+        },
+      ]}
+      width={200}
+      height={200}
+    />
+  );
+}

--- a/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.tsx
+++ b/docs/data/charts/pie-demo/PieChartWithCustomLegendAndTooltip.tsx
@@ -23,7 +23,7 @@ function SVGStar({ color, ...props }: ChartsLabelCustomMarkProps) {
   );
 }
 
-export default function PieChartWithCustomLegendTooltip() {
+export default function PieChartWithCustomLegendAndTooltip() {
   return (
     <PieChart
       series={[

--- a/docs/data/charts/pie-demo/pie-demo.md
+++ b/docs/data/charts/pie-demo/pie-demo.md
@@ -31,3 +31,7 @@ components: PieArc, PieArcLabel, PieArcLabelPlot, PieArcPlot, PieChart, PiePlot
 ## PieChartWithCenterLabel
 
 {{"demo": "PieChartWithCenterLabel.js"}}
+
+## Pie chart with custom mark in legend and tooltip
+
+{{"demo": "PieChartWithCustomLegendAndTooltip.js"}}

--- a/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
@@ -6,12 +6,18 @@ import clsx from 'clsx';
 import { ChartsLabelMarkClasses, labelMarkClasses, useUtilityClasses } from './labelMarkClasses';
 import { consumeThemeProps } from '../internals/consumeThemeProps';
 
+export interface ChartsLabelCustomMarkProps {
+  className?: string;
+  /** Color of the series this mark refers to. */
+  color?: string;
+}
+
 export interface ChartsLabelMarkProps {
   /**
    * The type of the mark.
    * @default 'square'
    */
-  type?: 'square' | 'circle' | 'line';
+  type?: 'square' | 'circle' | 'line' | React.ComponentType<ChartsLabelCustomMarkProps>;
   /**
    * The color of the mark.
    */
@@ -34,6 +40,8 @@ const Root = styled('div', {
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+    width: 14,
+    height: 14,
     [`&.${labelMarkClasses.line}`]: {
       width: 16,
       display: 'flex',
@@ -59,6 +67,12 @@ const Root = styled('div', {
     },
     svg: {
       display: 'block',
+    },
+    [`& .${labelMarkClasses.mask} > *`]: {
+      height: '100%',
+      width: '100%',
+    },
+    [`& .${labelMarkClasses.mask}`]: {
       height: '100%',
       width: '100%',
     },
@@ -77,6 +91,7 @@ const ChartsLabelMark = consumeThemeProps(
   },
   function ChartsLabelMark(props: ChartsLabelMarkProps, ref: React.Ref<HTMLDivElement>) {
     const { type, color, className, classes, ...other } = props;
+    const Component = type;
 
     return (
       <Root
@@ -87,9 +102,13 @@ const ChartsLabelMark = consumeThemeProps(
         {...other}
       >
         <div className={classes?.mask}>
-          <svg viewBox="0 0 24 24" preserveAspectRatio={type === 'line' ? 'none' : undefined}>
-            <rect className={classes?.fill} width="24" height="24" fill={color} />
-          </svg>
+          {typeof Component === 'function' ? (
+            <Component className={classes?.fill} color={color} />
+          ) : (
+            <svg viewBox="0 0 24 24" preserveAspectRatio={type === 'line' ? 'none' : undefined}>
+              <rect className={classes?.fill} width="24" height="24" fill={color} />
+            </svg>
+          )}
         </div>
       </Root>
     );

--- a/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
@@ -44,6 +44,7 @@ const Root = styled('div', {
     height: 14,
     [`&.${labelMarkClasses.line}`]: {
       width: 16,
+      height: 'unset',
       display: 'flex',
       alignItems: 'center',
       [`.${labelMarkClasses.mask}`]: {

--- a/packages/x-charts/src/ChartsLabel/index.ts
+++ b/packages/x-charts/src/ChartsLabel/index.ts
@@ -1,6 +1,4 @@
-// export * from './ChartsLabel';
-export type { ChartsLabelMarkProps } from './ChartsLabelMark';
-// export * from './ChartsLabelGradient';
+export type { ChartsLabelMarkProps, ChartsLabelCustomMarkProps } from './ChartsLabelMark';
 export { labelClasses } from './labelClasses';
 export type { ChartsLabelClasses } from './labelClasses';
 export { labelMarkClasses } from './labelMarkClasses';

--- a/packages/x-charts/src/ChartsLabel/labelMarkClasses.ts
+++ b/packages/x-charts/src/ChartsLabel/labelMarkClasses.ts
@@ -30,7 +30,7 @@ export const labelMarkClasses: ChartsLabelMarkClasses = generateUtilityClasses(
 export const useUtilityClasses = (props: ChartsLabelMarkProps) => {
   const { type } = props;
   const slots = {
-    root: ['root', type],
+    root: typeof type === 'function' ? ['root'] : ['root', type],
     mask: ['mask'],
     fill: ['fill'],
   };

--- a/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabelPlot.tsx
@@ -206,7 +206,10 @@ PieArcLabelPlot.propTypes = {
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       index: PropTypes.number.isRequired,
       label: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-      labelMarkType: PropTypes.oneOf(['circle', 'line', 'square']),
+      labelMarkType: PropTypes.oneOfType([
+        PropTypes.oneOf(['circle', 'line', 'square']),
+        PropTypes.func,
+      ]),
       padAngle: PropTypes.number.isRequired,
       startAngle: PropTypes.number.isRequired,
       value: PropTypes.number.isRequired,

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -168,7 +168,10 @@ PieArcPlot.propTypes = {
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       index: PropTypes.number.isRequired,
       label: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-      labelMarkType: PropTypes.oneOf(['circle', 'line', 'square']),
+      labelMarkType: PropTypes.oneOfType([
+        PropTypes.oneOf(['circle', 'line', 'square']),
+        PropTypes.func,
+      ]),
       padAngle: PropTypes.number.isRequired,
       startAngle: PropTypes.number.isRequired,
       value: PropTypes.number.isRequired,

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -87,6 +87,7 @@
   { "name": "ChartsItemTooltipContent", "kind": "Function" },
   { "name": "ChartsItemTooltipContentProps", "kind": "Interface" },
   { "name": "ChartsLabelClasses", "kind": "Interface" },
+  { "name": "ChartsLabelCustomMarkProps", "kind": "Interface" },
   { "name": "ChartsLabelGradientClasses", "kind": "Interface" },
   { "name": "ChartsLabelMarkClasses", "kind": "Interface" },
   { "name": "ChartsLabelMarkProps", "kind": "Interface" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -83,6 +83,7 @@
   { "name": "ChartsItemTooltipContent", "kind": "Function" },
   { "name": "ChartsItemTooltipContentProps", "kind": "Interface" },
   { "name": "ChartsLabelClasses", "kind": "Interface" },
+  { "name": "ChartsLabelCustomMarkProps", "kind": "Interface" },
   { "name": "ChartsLabelGradientClasses", "kind": "Interface" },
   { "name": "ChartsLabelMarkClasses", "kind": "Interface" },
   { "name": "ChartsLabelMarkProps", "kind": "Interface" },


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/16640. Implementation of option B as defined [here](https://github.com/mui/mui-x/pull/16654#issuecomment-2677967216). 

Accept component in `labelMarkType` to customize the mark in legends and tooltips. 

A consequence of this API is that when customizing the shape of a scatter chart, a user will need to define the `labelMarkType` and scatter shape in different places. 

https://github.com/user-attachments/assets/e5769e3b-bf20-40b1-b0c3-6d6a45cabce2

