### PR TITLE
[infra] Update label in priority-support issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -1,7 +1,7 @@
 name: 'Priority Support: SLA ⏰'
 description: I'm an MUI X Premium user and we have purchased the Priority Support add-on. I can't find a solution to my problem with MUI X.
 title: '[question] '
-labels: ['status: waiting for maintainer', 'support: commercial', 'support: unknown']
+labels: ['status: waiting for maintainer', 'support: priority']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Replaced 'support: unknown' with 'support: priority' to better reflect the intended categorization of issues for MUI X Premium users with the Priority Support add-on. This ensures more accurate labeling for streamlined issue management.