### PR TITLE
[pickers] Fix time picker scrollbar width

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -68,6 +68,7 @@ const MultiSectionDigitalClockSectionRoot = styled(MenuList, {
   width: 56,
   padding: 0,
   overflow: 'hidden',
+  scrollbarWidth: 'thin',
   '@media (prefers-reduced-motion: no-preference)': {
     scrollBehavior: 'auto',
   },


### PR DESCRIPTION
This one feels like a quick win, so going after it. 

You can compare the scrollbar width with:

<img width="291" alt="SCR-20250301-qsdv" src="https://github.com/user-attachments/assets/6003385f-e41b-427d-a682-7f01146c4ff1" />
<img width="275" alt="SCR-20250301-qonl" src="https://github.com/user-attachments/assets/63ce44dd-e151-4689-bf64-3237a6b3c8bd" />

Help with #9311

On the solution space, Ant Design uses a similar solution, but it's different:

<img width="358" alt="SCR-20250301-qwpk" src="https://github.com/user-attachments/assets/eeb88811-fdf9-4ffe-817c-7e8822515482" />
<img width="358" alt="SCR-20250301-qxcu" src="https://github.com/user-attachments/assets/ce75009e-0d81-49d8-ad57-c7eccda6fb7e" />

they also use `scrollbar-width: thin` but also:

1. leave more width. It feels great because when we look at https://github.com/mui/mui-x/issues/9311#issuecomment-1709169359, it looks like someone who added a large zoom. So It feels like fixing #9311 should also involve a change in this direction. One could argue that to full fix this, we need to have a custom scrollbar handling logic, like one we have on Base UI scroll area component or Material UI tabs component, but I don't know, this feel overkill, the pragmatic approach feels like to try those quick wins, and see if it's good enough. Adding more JS logic will slow the component, so could be a net worse overall. 

2. change the background color to white. Because of point 1 of https://github.com/mui/base-ui/issues/1283 it makes using the scrollbar harder, but it creates more contrast, it's easier to see the scroll position.
One could argue that, now, the scrollbar is too small, but honestly, it feels like that scrollbar is not meant to be used: it's more about indicating where the scroll is. If I'm a power user, I don't care, I use my mouse scroll wheel or my trackpad. If I'm a web user noob, I use the keyboard, input field, arrow. So what Ant Design did here isn't stupid, I would default to be lazy, not do changes, unless we feel it's a clear net win.

Preview: https://deploy-preview-16774--material-ui-x.netlify.app/x/react-date-pickers/time-picker/