### PR TITLE
[docs] Fix padding package install on mobile

### DIFF
--- a/docs/src/modules/components/InstallationInstructions.tsx
+++ b/docs/src/modules/components/InstallationInstructions.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import HighlightedCodeWithTabs from '@mui/docs/HighlightedCodeWithTabs';
-import Stack from '@mui/material/Stack';
 import Box from '@mui/material/Box';
 import ToggleOptions from './ToggleOptions';
 
@@ -45,7 +44,7 @@ export default function InstallationInstructions(props: {
   });
 
   return (
-    <Stack sx={{ width: '100%' }} px={{ xs: 3, sm: 0 }}>
+    <React.Fragment>
       <Box sx={{ display: 'flex', gap: 3, width: 'max-content', py: 1, pb: 1.5 }}>
         <ToggleOptions
           value={licenceType}
@@ -63,8 +62,7 @@ export default function InstallationInstructions(props: {
           />
         )}
       </Box>
-
       <HighlightedCodeWithTabs tabs={tabs} storageKey="codeblock-package-manager" />
-    </Stack>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
## Before

<img width="214" alt="SCR-20250302-rrcd" src="https://github.com/user-attachments/assets/9002515f-7187-4abf-b725-7a717779d12a" />

## After

<img width="223" alt="SCR-20250302-rrle" src="https://github.com/user-attachments/assets/d5e95bd9-5516-426e-ba95-4c8e94ed0fc5" />

Preview: https://deploy-preview-16794--material-ui-x.netlify.app/x/react-date-pickers/quickstart/

Noticed this with #16554