### PR TITLE
[charts] Allow `tickLabelPlacement='middle'` in continuous scales

### DIFF
--- a/docs/data/charts/axis/OverlappingAxes.js
+++ b/docs/data/charts/axis/OverlappingAxes.js
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { LineChart } from '@mui/x-charts/LineChart';
+
+export default function OverlappingAxes() {
+  return (
+    <LineChart
+      xAxis={[
+        {
+          scaleType: 'time',
+          data: time,
+          valueFormatter: formatShortMonth,
+          height: 0,
+          tickLabelPlacement: 'middle',
+        },
+        {
+          scaleType: 'time',
+          data: time,
+          tickInterval: time.filter((_, index) => index % 3 === 0),
+          valueFormatter: formatQuarterYear,
+          position: 'bottom',
+          tickSize: 25,
+          tickLabelPlacement: 'middle',
+          height: 35,
+        },
+      ]}
+      {...chartConfig}
+    />
+  );
+}
+
+const formatQuarterYear = (date, context) => {
+  if (context.location === 'tick') {
+    const quarter = Math.floor(date.getMonth() / 3) + 1;
+    const year = date.getFullYear().toString().slice(-2);
+    return `Q${quarter} '${year}`;
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const formatShortMonth = (date, context) => {
+  if (context.location === 'tick') {
+    return date.toLocaleDateString('en-US', { month: 'short' });
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const time = [
+  new Date(2015, 0, 1),
+  new Date(2015, 1, 1),
+  new Date(2015, 2, 1),
+  new Date(2015, 3, 1),
+  new Date(2015, 4, 1),
+  new Date(2015, 5, 1),
+  new Date(2015, 6, 1),
+  new Date(2015, 7, 1),
+  new Date(2015, 8, 1),
+  new Date(2015, 9, 1),
+  new Date(2015, 10, 1),
+  new Date(2015, 11, 1),
+  new Date(2016, 0, 1),
+];
+
+const a = [
+  4000, 3000, 2000, 2780, 1890, 2390, 3490, 2400, 1398, 9800, 3908, 4800, 2400,
+];
+
+const b = [
+  2400, 1398, 9800, 3908, 4800, 3800, 4300, 2181, 2500, 2100, 3000, 2000, 3908,
+];
+
+const getPercents = (array) =>
+  array.map((v, index) => (100 * v) / (a[index] + b[index]));
+
+const chartConfig = {
+  height: 300,
+  series: [
+    {
+      data: getPercents(a),
+      type: 'line',
+      label: 'a',
+      area: true,
+      stack: 'total',
+      showMark: false,
+    },
+    {
+      data: getPercents(b),
+      type: 'line',
+      label: 'b',
+      area: true,
+      stack: 'total',
+      showMark: false,
+    },
+  ],
+};

--- a/docs/data/charts/axis/OverlappingAxes.js
+++ b/docs/data/charts/axis/OverlappingAxes.js
@@ -1,19 +1,19 @@
 import * as React from 'react';
-import { LineChart } from '@mui/x-charts/LineChart';
+import { BarChart } from '@mui/x-charts/BarChart';
 
 export default function OverlappingAxes() {
   return (
-    <LineChart
+    <BarChart
       xAxis={[
         {
-          scaleType: 'time',
+          scaleType: 'band',
           data: time,
           valueFormatter: formatShortMonth,
           height: 0,
           tickLabelPlacement: 'middle',
         },
         {
-          scaleType: 'time',
+          scaleType: 'band',
           data: time,
           tickInterval: time.filter((_, index) => index % 3 === 0),
           valueFormatter: formatQuarterYear,
@@ -57,7 +57,6 @@ const time = [
   new Date(2015, 9, 1),
   new Date(2015, 10, 1),
   new Date(2015, 11, 1),
-  new Date(2016, 0, 1),
 ];
 
 const a = [
@@ -76,19 +75,18 @@ const chartConfig = {
   series: [
     {
       data: getPercents(a),
-      type: 'line',
-      label: 'a',
-      area: true,
-      stack: 'total',
-      showMark: false,
+      label: 'Income',
+      valueFormatter: (value) => `${(value ?? 0).toFixed(0)}%`,
     },
     {
       data: getPercents(b),
-      type: 'line',
-      label: 'b',
-      area: true,
-      stack: 'total',
-      showMark: false,
+      label: 'Expenses',
+      valueFormatter: (value) => `${(value ?? 0).toFixed(0)}%`,
+    },
+  ],
+  yAxis: [
+    {
+      valueFormatter: (value) => `${(value ?? 0).toFixed(0)}%`,
     },
   ],
 };

--- a/docs/data/charts/axis/OverlappingAxes.tsx
+++ b/docs/data/charts/axis/OverlappingAxes.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
-import { LineChart } from '@mui/x-charts/LineChart';
+import { BarChart } from '@mui/x-charts/BarChart';
 import { AxisValueFormatterContext } from '@mui/x-charts/models';
 
 export default function OverlappingAxes() {
   return (
-    <LineChart
+    <BarChart
       xAxis={[
         {
-          scaleType: 'time',
+          scaleType: 'band',
           data: time,
           valueFormatter: formatShortMonth,
           height: 0,
           tickLabelPlacement: 'middle',
         },
         {
-          scaleType: 'time',
+          scaleType: 'band',
           data: time,
           tickInterval: time.filter((_, index) => index % 3 === 0),
           valueFormatter: formatQuarterYear,
@@ -58,7 +58,6 @@ const time = [
   new Date(2015, 9, 1),
   new Date(2015, 10, 1),
   new Date(2015, 11, 1),
-  new Date(2016, 0, 1),
 ];
 const a = [
   4000, 3000, 2000, 2780, 1890, 2390, 3490, 2400, 1398, 9800, 3908, 4800, 2400,
@@ -75,19 +74,18 @@ const chartConfig = {
   series: [
     {
       data: getPercents(a),
-      type: 'line',
-      label: 'a',
-      area: true,
-      stack: 'total',
-      showMark: false,
+      label: 'Income',
+      valueFormatter: (value: number | null) => `${(value ?? 0).toFixed(0)}%`,
     },
     {
       data: getPercents(b),
-      type: 'line',
-      label: 'b',
-      area: true,
-      stack: 'total',
-      showMark: false,
+      label: 'Expenses',
+      valueFormatter: (value: number | null) => `${(value ?? 0).toFixed(0)}%`,
+    },
+  ],
+  yAxis: [
+    {
+      valueFormatter: (value: number | null) => `${(value ?? 0).toFixed(0)}%`,
     },
   ],
 } as const;

--- a/docs/data/charts/axis/OverlappingAxes.tsx
+++ b/docs/data/charts/axis/OverlappingAxes.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { AxisValueFormatterContext } from '@mui/x-charts/models';
+
+export default function OverlappingAxes() {
+  return (
+    <LineChart
+      xAxis={[
+        {
+          scaleType: 'time',
+          data: time,
+          valueFormatter: formatShortMonth,
+          height: 0,
+          tickLabelPlacement: 'middle',
+        },
+        {
+          scaleType: 'time',
+          data: time,
+          tickInterval: time.filter((_, index) => index % 3 === 0),
+          valueFormatter: formatQuarterYear,
+          position: 'bottom',
+          tickSize: 25,
+          tickLabelPlacement: 'middle',
+          height: 35,
+        },
+      ]}
+      {...chartConfig}
+    />
+  );
+}
+
+const formatQuarterYear = (date: Date, context: AxisValueFormatterContext) => {
+  if (context.location === 'tick') {
+    const quarter = Math.floor(date.getMonth() / 3) + 1;
+    const year = date.getFullYear().toString().slice(-2);
+    return `Q${quarter} '${year}`;
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const formatShortMonth = (date: Date, context: AxisValueFormatterContext) => {
+  if (context.location === 'tick') {
+    return date.toLocaleDateString('en-US', { month: 'short' });
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const time = [
+  new Date(2015, 0, 1),
+  new Date(2015, 1, 1),
+  new Date(2015, 2, 1),
+  new Date(2015, 3, 1),
+  new Date(2015, 4, 1),
+  new Date(2015, 5, 1),
+  new Date(2015, 6, 1),
+  new Date(2015, 7, 1),
+  new Date(2015, 8, 1),
+  new Date(2015, 9, 1),
+  new Date(2015, 10, 1),
+  new Date(2015, 11, 1),
+  new Date(2016, 0, 1),
+];
+const a = [
+  4000, 3000, 2000, 2780, 1890, 2390, 3490, 2400, 1398, 9800, 3908, 4800, 2400,
+];
+const b = [
+  2400, 1398, 9800, 3908, 4800, 3800, 4300, 2181, 2500, 2100, 3000, 2000, 3908,
+];
+
+const getPercents = (array: number[]) =>
+  array.map((v, index) => (100 * v) / (a[index] + b[index]));
+
+const chartConfig = {
+  height: 300,
+  series: [
+    {
+      data: getPercents(a),
+      type: 'line',
+      label: 'a',
+      area: true,
+      stack: 'total',
+      showMark: false,
+    },
+    {
+      data: getPercents(b),
+      type: 'line',
+      label: 'b',
+      area: true,
+      stack: 'total',
+      showMark: false,
+    },
+  ],
+} as const;

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -218,6 +218,15 @@ To avoid overlapping, you can use the `height` prop for `xAxis` and `width` for 
 
 {{"demo": "MultipleAxes.js"}}
 
+### Overlapping axes
+
+In order to overlap axes, the axis size can be set to `0`.
+
+In the following example, we show a quarterly axis on the bottom and a monthly axis on top of it.
+By playing with the `tickSize` and `tickLabelPlacement` it is possible to make the labels of the two axes not overlap.
+
+{{"demo": "OverlappingAxes.js"}}
+
 ## Axis customization
 
 You can further customize the axis rendering besides the axis definition.

--- a/docs/translations/api-docs/charts/axis-config.json
+++ b/docs/translations/api-docs/charts/axis-config.json
@@ -45,7 +45,7 @@
       "description": "Defines which ticks get its label displayed. Its value can be:<br />- &#39;auto&#39; In such case, labels are displayed if they do not overlap with the previous one.<br />- a filtering function of the form (value, index) =&gt; boolean. Warning: the index is tick index, not data ones."
     },
     "tickLabelPlacement": {
-      "description": "The placement of ticks label. Can be the middle of the band, or the tick position.<br />Only used if scale is &#39;band&#39;."
+      "description": "The placement of ticks label. Can be the middle of the band, or the tick position."
     },
     "tickLabelStyle": { "description": "The style applied to ticks text." },
     "tickMaxStep": {

--- a/docs/translations/api-docs/charts/charts-x-axis/charts-x-axis.json
+++ b/docs/translations/api-docs/charts/charts-x-axis/charts-x-axis.json
@@ -23,7 +23,7 @@
       "description": "The minimum gap in pixels between two tick labels. If two tick labels are closer than this minimum gap, one of them will be hidden."
     },
     "tickLabelPlacement": {
-      "description": "The placement of ticks label. Can be the middle of the band, or the tick position. Only used if scale is &#39;band&#39;."
+      "description": "The placement of ticks label. Can be the middle of the band, or the tick position."
     },
     "tickLabelStyle": { "description": "The style applied to ticks text." },
     "tickMaxStep": {

--- a/docs/translations/api-docs/charts/charts-y-axis/charts-y-axis.json
+++ b/docs/translations/api-docs/charts/charts-y-axis/charts-y-axis.json
@@ -20,7 +20,7 @@
       "description": "Defines which ticks get its label displayed. Its value can be: - &#39;auto&#39; In such case, labels are displayed if they do not overlap with the previous one. - a filtering function of the form (value, index) =&gt; boolean. Warning: the index is tick index, not data ones."
     },
     "tickLabelPlacement": {
-      "description": "The placement of ticks label. Can be the middle of the band, or the tick position. Only used if scale is &#39;band&#39;."
+      "description": "The placement of ticks label. Can be the middle of the band, or the tick position."
     },
     "tickLabelStyle": { "description": "The style applied to ticks text." },
     "tickMaxStep": {

--- a/packages/x-charts/src/ChartsGrid/ChartsHorizontalGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsHorizontalGrid.tsx
@@ -17,9 +17,9 @@ interface ChartsGridHorizontalProps {
 export function ChartsGridHorizontal(props: ChartsGridHorizontalProps) {
   const { axis, start, end, classes } = props;
 
-  const { scale, tickNumber, tickInterval } = axis;
+  const { scale, scaleType, tickNumber, tickInterval } = axis;
 
-  const yTicks = useTicks({ scale, tickNumber, tickInterval });
+  const yTicks = useTicks({ scale, scaleType, tickNumber, tickInterval });
 
   return (
     <React.Fragment>

--- a/packages/x-charts/src/ChartsGrid/ChartsVerticalGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsVerticalGrid.tsx
@@ -17,9 +17,9 @@ interface ChartsGridVerticalProps {
 export function ChartsGridVertical(props: ChartsGridVerticalProps) {
   const { axis, start, end, classes } = props;
 
-  const { scale, tickNumber, tickInterval } = axis;
+  const { scale, scaleType, tickNumber, tickInterval } = axis;
 
-  const xTicks = useTicks({ scale, tickNumber, tickInterval });
+  const xTicks = useTicks({ scale, scaleType, tickNumber, tickInterval });
 
   return (
     <React.Fragment>

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -196,6 +196,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
 
   const xTicks = useTicks({
     scale: xScale,
+    scaleType: settings.scaleType,
     tickNumber,
     valueFormatter,
     tickInterval,

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -386,7 +386,6 @@ ChartsXAxis.propTypes = {
   tickLabelMinGap: PropTypes.number,
   /**
    * The placement of ticks label. Can be the middle of the band, or the tick position.
-   * Only used if scale is 'band'.
    * @default 'middle'
    */
   tickLabelPlacement: PropTypes.oneOf(['middle', 'tick']),

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -310,7 +310,6 @@ ChartsYAxis.propTypes = {
   tickLabelInterval: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.func]),
   /**
    * The placement of ticks label. Can be the middle of the band, or the tick position.
-   * Only used if scale is 'band'.
    * @default 'middle'
    */
   tickLabelPlacement: PropTypes.oneOf(['middle', 'tick']),

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -95,6 +95,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
 
   const yTicks = useTicks({
     scale: yScale,
+    scaleType: settings.scaleType,
     tickNumber,
     valueFormatter,
     tickPlacement,

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -121,7 +121,10 @@ export function useTicks(
             labelOffset:
               tickLabelPlacement === 'tick'
                 ? 0
-                : scale.step() * (offsetRatio[tickLabelPlacement] - offsetRatio[tickPlacement]),
+                : scale.step() *
+                  (offsetRatio[tickLabelPlacement] - offsetRatio[tickPlacement]) *
+                  // Only really works if ticks are evenly spaced
+                  (domain.length !== filteredDomain.length ? filteredDomain.length - 1 : 1),
           })),
 
           ...(tickPlacement === 'extremities'

--- a/packages/x-charts/src/models/index.ts
+++ b/packages/x-charts/src/models/index.ts
@@ -7,6 +7,7 @@ export type {
   ScaleName,
   ContinuousScaleName,
   ChartsAxisData,
+  AxisValueFormatterContext,
 } from './axis';
 
 // Utils shared across the X packages

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -19,6 +19,7 @@
   { "name": "AXIS_LABEL_DEFAULT_HEIGHT", "kind": "Variable" },
   { "name": "axisClasses", "kind": "Variable" },
   { "name": "AxisConfig", "kind": "TypeAlias" },
+  { "name": "AxisValueFormatterContext", "kind": "TypeAlias" },
   { "name": "BarChart", "kind": "Variable" },
   { "name": "BarChartPro", "kind": "Variable" },
   { "name": "BarChartProProps", "kind": "Interface" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -19,6 +19,7 @@
   { "name": "AXIS_LABEL_DEFAULT_HEIGHT", "kind": "Variable" },
   { "name": "axisClasses", "kind": "Variable" },
   { "name": "AxisConfig", "kind": "TypeAlias" },
+  { "name": "AxisValueFormatterContext", "kind": "TypeAlias" },
   { "name": "BarChart", "kind": "Variable" },
   { "name": "BarChartProps", "kind": "Interface" },
   { "name": "BarChartSlotProps", "kind": "Interface" },


### PR DESCRIPTION
👻 

- Allow `tickLabelPlacement='middle'` in continuous scales
- Add example of overlapping axis
- Exported `AxisValueFormatterContext` which wasn't previously exported

![Screenshot 2025-03-03 at 18 05 52](https://github.com/user-attachments/assets/770907a3-3f50-4822-8d53-5b923dc7a2ef)

## Changelog

- Charts axes now accept `tickLabelPlacement='middle'` on continuous scales as well as 'band' scale.