### PR TITLE
Update koKR.ts

### DIFF
--- a/packages/x-data-grid/src/locales/koKR.ts
+++ b/packages/x-data-grid/src/locales/koKR.ts
@@ -185,7 +185,7 @@ const koKRGrid: Partial<GridLocaleText> = {
   rowReorderingHeaderName: '행 재배치',
 
   // Aggregation
-  aggregationMenuItemHeader: '총계',
+  aggregationMenuItemHeader: '집계',
   aggregationFunctionLabelSum: '합',
   aggregationFunctionLabelAvg: '평균',
   aggregationFunctionLabelMin: '최소값',


### PR DESCRIPTION
as for the Aggregation, "집계" is the correct translation rather than "총계" which means 'total sum'

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
