### PR TITLE
[fields] Fix Fields aria relationship with `helperText`

### DIFF
--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
@@ -191,6 +191,8 @@ const PickersTextField = React.forwardRef(function PickersTextField(
           name={name}
           role="group"
           aria-labelledby={inputLabelId}
+          aria-describedby={helperTextId}
+          aria-live={helperTextId ? 'polite' : undefined}
           {...InputProps}
         />
         {helperText && (


### PR DESCRIPTION
Fixes #16637.

We missed adding the relationship of `helperText` with some specific element.

This PR adds `aria-describedby` to the root `spinbutton` `group` element and also adds `aria-live="polite"` to signal that this element changes need to be read by the screen reader.
On the "v6" (input) approach, it is not needed because the `aria-describedby` is added on the `input` element, which is focused and receiving changes.

P.S. This is technically a small regression due to it working fine on the old "INPUT" approach. 🙈 