### PR TITLE
[DataGrid] Fix `aria-hidden` console error when scrollbar is dragged

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
@@ -173,6 +173,11 @@ const GridVirtualScrollbar = forwardRef<HTMLDivElement, GridVirtualScrollbarProp
         }
         tabIndex={-1}
         aria-hidden="true"
+        // tabIndex does not prevent focus with a mouse click, throwing a console error
+        // https://github.com/mui/mui-x/issues/16706
+        onFocus={(event) => {
+          event.target.blur();
+        }}
       >
         <div ref={contentRef} className={classes.content} />
       </Container>

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -716,12 +716,10 @@ export const useGridVirtualScroller = () => {
     getRenderZoneProps: () => ({ role: 'rowgroup' }),
     getScrollbarVerticalProps: () => ({
       ref: scrollbarVerticalRef,
-      role: 'presentation',
       scrollPosition,
     }),
     getScrollbarHorizontalProps: () => ({
       ref: scrollbarHorizontalRef,
-      role: 'presentation',
       scrollPosition,
     }),
     getScrollAreaProps: () => ({


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16706

`aria-hidden` cannot be removed because of https://github.com/mui/mui-x/issues/16706#issuecomment-2698060646
`tabIndex` cannot be removed because we don't want focus on the scrollbar