### PR TITLE
[pickers] Add `TValidationProps` generic to the `PickerManager` interface

### DIFF
--- a/packages/x-date-pickers-pro/src/managers/useDateRangeManager.ts
+++ b/packages/x-date-pickers-pro/src/managers/useDateRangeManager.ts
@@ -54,8 +54,8 @@ export type UseDateRangeManagerReturnValue<TEnableAccessibleFieldDOMStructure ex
     PickerRangeValue,
     TEnableAccessibleFieldDOMStructure,
     DateRangeValidationError,
-    DateRangeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>,
-    DateRangeManagerFieldInternalPropsWithDefaults<TEnableAccessibleFieldDOMStructure>
+    ValidateDateRangeProps,
+    DateRangeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>
   >;
 
 export interface DateRangeManagerFieldInternalProps<
@@ -70,13 +70,3 @@ export interface DateRangeManagerFieldInternalProps<
     >,
     RangeFieldSeparatorProps,
     ExportedValidateDateRangeProps {}
-
-interface DateRangeManagerFieldInternalPropsWithDefaults<
-  TEnableAccessibleFieldDOMStructure extends boolean,
-> extends UseFieldInternalProps<
-      PickerRangeValue,
-      TEnableAccessibleFieldDOMStructure,
-      DateRangeValidationError
-    >,
-    ValidateDateRangeProps,
-    RangeFieldSeparatorProps {}

--- a/packages/x-date-pickers-pro/src/managers/useDateTimeRangeManager.ts
+++ b/packages/x-date-pickers-pro/src/managers/useDateTimeRangeManager.ts
@@ -56,8 +56,8 @@ export type UseDateTimeRangeManagerReturnValue<TEnableAccessibleFieldDOMStructur
     PickerRangeValue,
     TEnableAccessibleFieldDOMStructure,
     DateTimeRangeValidationError,
-    DateTimeRangeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>,
-    DateTimeRangeManagerFieldInternalPropsWithDefaults<TEnableAccessibleFieldDOMStructure>
+    ValidateDateTimeRangeProps,
+    DateTimeRangeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>
   >;
 
 export interface DateTimeRangeManagerFieldInternalProps<
@@ -72,14 +72,4 @@ export interface DateTimeRangeManagerFieldInternalProps<
     >,
     ExportedValidateDateTimeRangeProps,
     AmPmProps,
-    RangeFieldSeparatorProps {}
-
-interface DateTimeRangeManagerFieldInternalPropsWithDefaults<
-  TEnableAccessibleFieldDOMStructure extends boolean,
-> extends UseFieldInternalProps<
-      PickerRangeValue,
-      TEnableAccessibleFieldDOMStructure,
-      DateTimeRangeValidationError
-    >,
-    ValidateDateTimeRangeProps,
     RangeFieldSeparatorProps {}

--- a/packages/x-date-pickers-pro/src/managers/useTimeRangeManager.ts
+++ b/packages/x-date-pickers-pro/src/managers/useTimeRangeManager.ts
@@ -59,8 +59,8 @@ export type UseTimeRangeManagerReturnValue<TEnableAccessibleFieldDOMStructure ex
     PickerRangeValue,
     TEnableAccessibleFieldDOMStructure,
     TimeRangeValidationError,
-    TimeRangeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>,
-    TimeRangeManagerFieldInternalPropsWithDefaults<TEnableAccessibleFieldDOMStructure>
+    ValidateTimeRangeProps,
+    TimeRangeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>
   >;
 
 export interface TimeRangeManagerFieldInternalProps<
@@ -76,12 +76,3 @@ export interface TimeRangeManagerFieldInternalProps<
     ExportedValidateTimeRangeProps,
     AmPmProps,
     RangeFieldSeparatorProps {}
-
-interface TimeRangeManagerFieldInternalPropsWithDefaults<
-  TEnableAccessibleFieldDOMStructure extends boolean,
-> extends UseFieldInternalProps<
-      PickerRangeValue,
-      TEnableAccessibleFieldDOMStructure,
-      TimeRangeValidationError
-    >,
-    ValidateTimeRangeProps {}

--- a/packages/x-date-pickers/src/internals/models/manager.ts
+++ b/packages/x-date-pickers/src/internals/models/manager.ts
@@ -1,4 +1,5 @@
 import type { PickerManager } from '../../models';
+import type { UseFieldInternalProps } from '../hooks/useField';
 
 export type PickerAnyManager = PickerManager<any, any, any, any, any>;
 
@@ -7,15 +8,15 @@ type PickerManagerProperties<TManager extends PickerAnyManager> =
     infer TValue,
     infer TEnableAccessibleFieldDOMStructure,
     infer TError,
-    infer TFieldInternalProps,
-    infer TFieldInternalPropsWithDefaults
+    infer TValidationProps,
+    infer TFieldInternalProps
   >
     ? {
         value: TValue;
         enableAccessibleFieldDOMStructure: TEnableAccessibleFieldDOMStructure;
         error: TError;
+        validationProps: TValidationProps;
         fieldInternalProps: TFieldInternalProps;
-        fieldInternalPropsWithDefaults: TFieldInternalPropsWithDefaults;
       }
     : never;
 
@@ -28,8 +29,16 @@ export type PickerManagerError<TManager extends PickerAnyManager> =
 export type PickerManagerFieldInternalProps<TManager extends PickerAnyManager> =
   PickerManagerProperties<TManager>['fieldInternalProps'];
 
+export type PickerManagerValidationProps<TManager extends PickerAnyManager> =
+  PickerManagerProperties<TManager>['validationProps'];
+
 export type PickerManagerFieldInternalPropsWithDefaults<TManager extends PickerAnyManager> =
-  PickerManagerProperties<TManager>['fieldInternalPropsWithDefaults'];
+  UseFieldInternalProps<
+    PickerManagerValue<TManager>,
+    PickerManagerEnableAccessibleFieldDOMStructure<TManager>,
+    PickerManagerError<TManager>
+  > &
+    PickerManagerValidationProps<TManager>;
 
 export type PickerManagerEnableAccessibleFieldDOMStructure<TManager extends PickerAnyManager> =
   PickerManagerProperties<TManager>['enableAccessibleFieldDOMStructure'];

--- a/packages/x-date-pickers/src/managers/useDateManager.ts
+++ b/packages/x-date-pickers/src/managers/useDateManager.ts
@@ -15,7 +15,7 @@ import {
   ValidateDatePropsToDefault,
   ValidateDateProps,
 } from '../validation/validateDate';
-import { PickerValue } from '../internals/models';
+import { PickerManagerFieldInternalPropsWithDefaults, PickerValue } from '../internals/models';
 
 export function useDateManager<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   parameters: UseDateManagerParameters<TEnableAccessibleFieldDOMStructure> = {},
@@ -70,8 +70,8 @@ export type UseDateManagerReturnValue<TEnableAccessibleFieldDOMStructure extends
     PickerValue,
     TEnableAccessibleFieldDOMStructure,
     DateValidationError,
-    DateManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>,
-    DateManagerFieldInternalPropsWithDefaults<TEnableAccessibleFieldDOMStructure>
+    ValidateDateProps,
+    DateManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>
   >;
 
 export interface DateManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure extends boolean>
@@ -81,15 +81,6 @@ export interface DateManagerFieldInternalProps<TEnableAccessibleFieldDOMStructur
     >,
     ExportedValidateDateProps {}
 
-interface DateManagerFieldInternalPropsWithDefaults<
-  TEnableAccessibleFieldDOMStructure extends boolean,
-> extends UseFieldInternalProps<
-      PickerValue,
-      TEnableAccessibleFieldDOMStructure,
-      DateValidationError
-    >,
-    ValidateDateProps {}
-
 type DateManagerFieldPropsToDefault = 'format' | ValidateDatePropsToDefault;
 
 interface GetDateFieldInternalPropsDefaultsParameters
@@ -98,4 +89,7 @@ interface GetDateFieldInternalPropsDefaultsParameters
 }
 
 interface GetDateFieldInternalPropsDefaultsReturnValue
-  extends Pick<DateManagerFieldInternalPropsWithDefaults<true>, DateManagerFieldPropsToDefault> {}
+  extends Pick<
+    PickerManagerFieldInternalPropsWithDefaults<UseDateManagerReturnValue<true>>,
+    DateManagerFieldPropsToDefault
+  > {}

--- a/packages/x-date-pickers/src/managers/useDateTimeManager.ts
+++ b/packages/x-date-pickers/src/managers/useDateTimeManager.ts
@@ -16,7 +16,7 @@ import {
   ValidateDateTimeProps,
   ValidateDateTimePropsToDefault,
 } from '../validation/validateDateTime';
-import { PickerValue } from '../internals/models';
+import { PickerManagerFieldInternalPropsWithDefaults, PickerValue } from '../internals/models';
 
 export function useDateTimeManager<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   parameters: UseDateTimeManagerParameters<TEnableAccessibleFieldDOMStructure> = {},
@@ -88,8 +88,8 @@ export type UseDateTimeManagerReturnValue<TEnableAccessibleFieldDOMStructure ext
     PickerValue,
     TEnableAccessibleFieldDOMStructure,
     DateTimeValidationError,
-    DateTimeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>,
-    DateTimeManagerFieldInternalPropsWithDefaults<TEnableAccessibleFieldDOMStructure>
+    ValidateDateTimeProps,
+    DateTimeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>
   >;
 
 export interface DateTimeManagerFieldInternalProps<
@@ -104,15 +104,6 @@ export interface DateTimeManagerFieldInternalProps<
     >,
     ExportedValidateDateTimeProps,
     AmPmProps {}
-
-interface DateTimeManagerFieldInternalPropsWithDefaults<
-  TEnableAccessibleFieldDOMStructure extends boolean,
-> extends UseFieldInternalProps<
-      PickerValue,
-      TEnableAccessibleFieldDOMStructure,
-      DateTimeValidationError
-    >,
-    ValidateDateTimeProps {}
 
 type DateTimeManagerFieldPropsToDefault =
   | 'format'
@@ -131,6 +122,6 @@ interface GetDateTimeFieldInternalPropsDefaultsParameters
 
 interface GetDateTimeFieldInternalPropsDefaultsReturnValue
   extends Pick<
-    DateTimeManagerFieldInternalPropsWithDefaults<true>,
+    PickerManagerFieldInternalPropsWithDefaults<UseDateTimeManagerReturnValue<true>>,
     DateTimeManagerFieldPropsToDefault | 'disableIgnoringDatePartForTimeValidation'
   > {}

--- a/packages/x-date-pickers/src/managers/useTimeManager.ts
+++ b/packages/x-date-pickers/src/managers/useTimeManager.ts
@@ -15,7 +15,7 @@ import {
   ValidateTimeProps,
   ValidateTimePropsToDefault,
 } from '../validation/validateTime';
-import { PickerValue } from '../internals/models';
+import { PickerManagerFieldInternalPropsWithDefaults, PickerValue } from '../internals/models';
 
 export function useTimeManager<TEnableAccessibleFieldDOMStructure extends boolean = true>(
   parameters: UseTimeManagerParameters<TEnableAccessibleFieldDOMStructure> = {},
@@ -73,8 +73,8 @@ export type UseTimeManagerReturnValue<TEnableAccessibleFieldDOMStructure extends
     PickerValue,
     TEnableAccessibleFieldDOMStructure,
     TimeValidationError,
-    TimeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>,
-    TimeManagerFieldInternalPropsWithDefaults<TEnableAccessibleFieldDOMStructure>
+    ValidateTimeProps,
+    TimeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure>
   >;
 
 export interface TimeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructure extends boolean>
@@ -85,15 +85,6 @@ export interface TimeManagerFieldInternalProps<TEnableAccessibleFieldDOMStructur
     ExportedValidateTimeProps,
     AmPmProps {}
 
-interface TimeManagerFieldInternalPropsWithDefaults<
-  TEnableAccessibleFieldDOMStructure extends boolean,
-> extends UseFieldInternalProps<
-      PickerValue,
-      TEnableAccessibleFieldDOMStructure,
-      TimeValidationError
-    >,
-    ValidateTimeProps {}
-
 type TimeManagerFieldPropsToDefault = 'format' | ValidateTimePropsToDefault;
 
 interface GetTimeFieldInternalPropsDefaultsParameters
@@ -102,4 +93,7 @@ interface GetTimeFieldInternalPropsDefaultsParameters
 }
 
 interface GetTimeFieldInternalPropsDefaultsReturnValue
-  extends Pick<TimeManagerFieldInternalPropsWithDefaults<true>, TimeManagerFieldPropsToDefault> {}
+  extends Pick<
+    PickerManagerFieldInternalPropsWithDefaults<UseTimeManagerReturnValue<true>>,
+    TimeManagerFieldPropsToDefault
+  > {}

--- a/packages/x-date-pickers/src/models/manager.ts
+++ b/packages/x-date-pickers/src/models/manager.ts
@@ -27,12 +27,8 @@ export interface PickerManager<
   TValue extends PickerValidValue,
   TEnableAccessibleFieldDOMStructure extends boolean,
   TError,
+  TValidationProps extends {},
   TFieldInternalProps extends {},
-  TFieldInternalPropsWithDefaults extends UseFieldInternalProps<
-    TValue,
-    TEnableAccessibleFieldDOMStructure,
-    TError
-  >,
 > {
   /**
    * The type of the value (e.g. 'date', 'date-time', 'time').
@@ -55,7 +51,7 @@ export interface PickerManager<
    * });
    * ```
    */
-  validator: Validator<TValue, TError, TFieldInternalPropsWithDefaults>;
+  validator: Validator<TValue, TError, TValidationProps>;
   /**
    * Object containing basic methods to interact with the value of the picker or field.
    * This property is not part of the public API and should not be used directly.
@@ -83,7 +79,7 @@ export interface PickerManager<
    */
   internal_applyDefaultsToFieldInternalProps: (
     parameters: ApplyDefaultsToFieldInternalPropsParameters<TFieldInternalProps>,
-  ) => TFieldInternalPropsWithDefaults;
+  ) => UseFieldInternalProps<TValue, TEnableAccessibleFieldDOMStructure, TError> & TValidationProps;
   /**
    * Returns the aria-label to apply on the button that opens the picker.
    * @param {GetOpenPickerButtonAriaLabelParameters<TValue>} params The parameters to get the aria-label.


### PR DESCRIPTION
Allow to pass only the props relevant for validation to `useValidation` without having TS complain in #16069
It also simplifies some of the typing