### PR TITLE
[charts] Fix x-axis text anchor default when language is RTL

### DIFF
--- a/packages/x-charts/src/internals/invertTextAnchor.ts
+++ b/packages/x-charts/src/internals/invertTextAnchor.ts
@@ -1,0 +1,14 @@
+import { ChartsTextStyle } from '../ChartsText';
+
+export function invertTextAnchor(
+  textAnchor: ChartsTextStyle['textAnchor'],
+): ChartsTextStyle['textAnchor'] {
+  switch (textAnchor) {
+    case 'start':
+      return 'end';
+    case 'end':
+      return 'start';
+    default:
+      return textAnchor;
+  }
+}


### PR DESCRIPTION
Fix x-axis text anchor default when language is RTL.

### Before

![localhost_3001_playground_long-x-axis-ticks_ (4)](https://github.com/user-attachments/assets/78717542-60cc-4c1a-9e44-094bdb1a3622)


### After

![localhost_3001_playground_long-x-axis-ticks_ (3)](https://github.com/user-attachments/assets/374596c9-8c05-4623-bbfd-7a1b97090e89)


<details>
<summary>Comparison code</summary>

```tsx
import * as React from 'react';
import { BarChart } from '@mui/x-charts/BarChart';
import { BarChartProps } from '@mui/x-charts';
import RtlProvider from '@mui/system/RtlProvider';

const rtl = true;

const defaultXAxis = {
  scaleType: 'band',
  dataKey: 'code',
  height: 80,
  valueFormatter: (value: any) => {
    const item = usAirportPassengers.find((item) => item.code === value)!;
    return (rtl ? item.fullNameAr.slice(0, 5) : item.fullName.slice(0, 5)) + '…';
  },
} as const;

const degrees = [-180, -135, -90, -45, 0, 45, 90, 135, 180];

const xAxes: BarChartProps['xAxis'] = degrees
  .map((angle) => ({
    ...defaultXAxis,
    position: 'bottom',
    id: `angle${angle}`,
    tickLabelStyle: { angle },
  }))
  .concat(
    degrees.map((angle) => ({
      ...defaultXAxis,
      id: `top-angle${angle}`,
      position: 'top',
      tickLabelStyle: { angle },
    })),
  );

export default function XAxisTickLabelOverflow() {
  return (
    <RtlProvider value={rtl}>
      <div style={{ direction: rtl ? 'rtl' : 'ltr' }}>
        <BarChart
          xAxis={xAxes}
          // Other props
          width={600}
          height={1600}
          dataset={usAirportPassengers}
          series={[
            { dataKey: '2018', label: '2018' },
            { dataKey: '2019', label: '2019' },
            { dataKey: '2020', label: '2020' },
            { dataKey: '2021', label: '2021' },
            { dataKey: '2022', label: '2022' },
          ]}
          hideLegend
          yAxis={[
            {
              valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
              width: 40,
            },
          ]}
        />
      </div>
    </RtlProvider>
  );
}

const usAirportPassengers = [
  {
    fullName: 'Hartsfield–Jackson Atlanta International Airport',
    fullNameAr: 'مطار هارتسفيلد جاكسون أتلانتا الدولي',
    code: 'ATL',
    2022: 45396001,
    2021: 36676010,
    2020: 20559866,
    2019: 53505795,
    2018: 51865797,
  },
  {
    fullName: 'Dallas/Fort Worth International Airport',
    fullNameAr: 'مطار دالاس فورت وورث الدولي',
    code: 'DFW',
    2022: 35345138,
    2021: 30005266,
    2020: 18593421,
    2019: 35778573,
    2018: 32821799,
  },
  {
    fullName: 'Denver International Airport',
    fullNameAr: 'مطار دنفر الدولي',
    code: 'DEN',
    2022: 33773832,
    2021: 28645527,
    2020: 16243216,
    2019: 33592945,
    2018: 31362941,
  },
  {
    fullName: "O'Hare International Airport",
    fullNameAr: 'مطار أوهير الدولي',
    code: 'ORD',
    2022: 33120474,
    2021: 26350976,
    2020: 14606034,
    2019: 40871223,
    2018: 39873927,
  },
  {
    fullName: 'Los Angeles International Airport',
    fullNameAr: 'مطار لوس أنجلوس الدولي',
    code: 'LAX',
    2022: 32326616,
    2021: 23663410,
    2020: 14055777,
    2019: 42939104,
    2018: 42624050,
  },
  {
    fullName: 'John F. Kennedy International Airport',
    fullNameAr: 'مطار جون إف كينيدي الدولي',
    code: 'JFK',
    2022: 26919982,
    2021: 15273342,
    2020: 8269819,
    2019: 31036655,
    2018: 30620769,
  },
  {
    fullName: 'Harry Reid International Airport',
    fullNameAr: 'مطار هاري ريد الدولي',
    code: 'LAS',
    2022: 25480500,
    2021: 19160342,
    2020: 10584059,
    2019: 24728361,
    2018: 23795012,
  },
  {
    fullName: 'Orlando International Airport',
    fullNameAr: 'مطار أورلاندو الدولي',
    code: 'MCO',
    2022: 24469733,
    2021: 19618838,
    2020: 10467728,
    2019: 24562271,
    2018: 23202480,
  },
  {
    fullName: 'Miami International Airport',
    fullNameAr: 'مطار ميامي الدولي',
    code: 'MIA',
    2022: 23949892,
    2021: 17500096,
    2020: 8786007,
    2019: 21421031,
    2018: 21021640,
  },
  {
    fullName: 'Charlotte Douglas International Airport',
    fullNameAr: 'مطار شارلوت دوغلاس الدولي',
    code: 'CLT',
    2022: 23100300,
    2021: 20900875,
    2020: 12952869,
    2019: 24199688,
    2018: 22281949,
  },
  {
    fullName: 'Seattle–Tacoma International Airport',
    fullNameAr: 'مطار سياتل تاكوما الدولي',
    code: 'SEA',
    2022: 22157862,
    2021: 17430195,
    2020: 9462411,
    2019: 25001762,
    2018: 24024908,
  },
  {
    fullName: 'Phoenix Sky Harbor International Airport',
    fullNameAr: 'مطار فينيكس سكاي هاربور الدولي',
    code: 'PHX',
    2022: 21852586,
    2021: 18940287,
    2020: 10531436,
    2019: 22433552,
    2018: 21622580,
  },
  {
    fullName: 'Newark Liberty International Airport',
    fullNameAr: 'مطار نيوارك ليبرتي الدولي',
    code: 'EWR',
    2022: 21572147,
    2021: 14514049,
    2020: 7985474,
    2019: 23160763,
    2018: 22797602,
  },
  {
    fullName: 'San Francisco International Airport',
    fullNameAr: 'مطار سان فرانسيسكو الدولي',
    code: 'SFO',
    2022: 20411420,
    2021: 11725347,
    2020: 7745057,
    2019: 27779230,
    2018: 27790717,
  },
  {
    fullName: 'George Bush Intercontinental Airport',
    fullNameAr: 'مطار جورج بوش القاري',
    code: 'IAH',
    2022: 19814052,
    2021: 16242821,
    2020: 8682558,
    2019: 21905309,
    2018: 21157398,
  },
  {
    fullName: 'Logan International Airport',
    fullNameAr: 'مطار لوغان الدولي',
    code: 'BOS',
    2022: 17443775,
    2021: 10909817,
    2020: 6035452,
    2019: 20699377,
    2018: 20006521,
  },
  {
    fullName: 'Fort Lauderdale–Hollywood International Airport',
    fullNameAr: 'مطار فورت لودرديل هوليوود الدولي',
    code: 'FLL',
    2022: 15370165,
    2021: 13598994,
    2020: 8015744,
    2019: 17950989,
    2018: 17612331,
  },
  {
    fullName: 'Minneapolis–Saint Paul International Airport',
    fullNameAr: 'مطار مينيابوليس سانت بول الدولي',
    code: 'MSP',
    2022: 15242089,
    2021: 12211409,
    2020: 7069720,
    2019: 19192917,
    2018: 18361942,
  },
  {
    fullName: 'LaGuardia Airport',
    fullNameAr: 'مطار لا غوارديا',
    code: 'LGA',
    2022: 14367463,
    2021: 7827307,
    2020: 4147116,
    2019: 15393601,
    2018: 15058501,
  },
  {
    fullName: 'Detroit Metropolitan Airport',
    fullNameAr: 'مطار ديترويت المترو',
    code: 'DTW',
    2022: 13751197,
    2021: 11517696,
    2020: 6822324,
    2019: 18143040,
    2018: 17436837,
  },
];
```

</details>