### PR TITLE
[pickers] Fix `edge` property setting in different button position cases

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -158,9 +158,8 @@ export function PickerFieldUI(props: PickerFieldUIProps) {
       onClick: handleClickOpeningButton,
       'aria-label': openPickerAriaLabel,
       edge:
-        clearButtonPosition === 'start' && openPickerButtonPosition === 'start'
-          ? undefined
-          : openPickerButtonPosition,
+        // open button is always rendered at the edge
+        textFieldProps.variant !== 'standard' ? openPickerButtonPosition : false,
     },
     ownerState,
   });
@@ -187,9 +186,10 @@ export function PickerFieldUI(props: PickerFieldUIProps) {
       onClick: onClear,
       disabled: fieldResponse.disabled || fieldResponse.readOnly,
       edge:
-        clearButtonPosition === 'end' && openPickerButtonPosition === 'end'
-          ? undefined
-          : clearButtonPosition,
+        // clear button can only be at the edge if it's position differs from the open button
+        textFieldProps.variant !== 'standard' && clearButtonPosition !== openPickerButtonPosition
+          ? clearButtonPosition
+          : false,
     },
     ownerState,
   });


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/12825.

Looks like the main problem is with us setting `edge` when `variant` is `standard`, which is not ok according to https://v5.mui.com/material-ui/react-text-field/#input-adornments.

In regards to the vertical scrollbar, it seems to be coming from the `DemoContainer` component usage. 🙈 