### PR TITLE
Sometimes root in extractColumnWidths is null

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -190,7 +190,7 @@ function extractColumnWidths(
   const widthByField = {} as Record<string, number>;
 
   const root = apiRef.current.rootElementRef!.current!;
-  root.classList.add(gridClasses.autosizing);
+  root?.classList.add(gridClasses.autosizing);
 
   columns.forEach((column) => {
     const cells = findGridCells(apiRef.current, column.field);


### PR DESCRIPTION
![Screenshot 2025-03-05 at 5 15 11 PM](https://github.com/user-attachments/assets/5f883cd5-f760-419f-b874-6fa63572d498)
