### PR TITLE
[charts] Fix undefined behaving differently from missing value for axis size

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -28,16 +28,17 @@ export function defaultizeXAxis(
   const parsedAxes = inputAxes.map((axisConfig, index) => {
     const dataKey = axisConfig.dataKey;
 
-    const position = axisConfig.position ?? 'none';
+    // The first x-axis is defaultized to the bottom
+    const defaultPosition = index === 0 ? 'bottom' : 'none';
+    const position = axisConfig.position ?? defaultPosition;
     const defaultHeight =
       DEFAULT_AXIS_SIZE_HEIGHT + (axisConfig.label ? AXIS_LABEL_DEFAULT_HEIGHT : 0);
 
     const sharedConfig = {
       id: `defaultized-x-axis-${index}`,
-      // The fist axis is defaultized to the bottom/left
-      ...(index === 0 ? ({ position: 'bottom' } as const) : {}),
       offset: offsets[position],
       ...axisConfig,
+      position,
       height: axisConfig.height ?? defaultHeight,
     };
 
@@ -79,16 +80,17 @@ export function defaultizeYAxis(
   const parsedAxes = inputAxes.map((axisConfig, index) => {
     const dataKey = axisConfig.dataKey;
 
-    const position = axisConfig.position ?? 'none';
+    // The first y-axis is defaultized to the left
+    const defaultPosition = index === 0 ? 'left' : 'none';
+    const position = axisConfig.position ?? defaultPosition;
     const defaultWidth =
       DEFAULT_AXIS_SIZE_WIDTH + (axisConfig.label ? AXIS_LABEL_DEFAULT_HEIGHT : 0);
 
     const sharedConfig = {
       id: `defaultized-y-axis-${index}`,
-      // The first axis is defaultized to the left
-      ...(index === 0 ? ({ position: 'left' } as const) : {}),
       offset: offsets[position],
       ...axisConfig,
+      position,
       width: axisConfig.width ?? defaultWidth,
     };
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -36,14 +36,14 @@ export function defaultizeXAxis(
       id: `defaultized-x-axis-${index}`,
       // The fist axis is defaultized to the bottom/left
       ...(index === 0 ? ({ position: 'bottom' } as const) : {}),
-      height: defaultHeight,
       offset: offsets[position],
       ...axisConfig,
+      height: axisConfig.height ?? defaultHeight,
     };
 
     // Increment the offset for the next axis
     if (position !== 'none') {
-      offsets[position] += axisConfig.height ?? defaultHeight;
+      offsets[position] += sharedConfig.height;
     }
 
     // If `dataKey` is NOT provided
@@ -87,14 +87,14 @@ export function defaultizeYAxis(
       id: `defaultized-y-axis-${index}`,
       // The first axis is defaultized to the left
       ...(index === 0 ? ({ position: 'left' } as const) : {}),
-      width: defaultWidth,
       offset: offsets[position],
       ...axisConfig,
+      width: axisConfig.width ?? defaultWidth,
     };
 
     // Increment the offset for the next axis
     if (position !== 'none') {
-      offsets[position] += axisConfig.width ?? defaultWidth;
+      offsets[position] += sharedConfig.width;
     }
 
     // If `dataKey` is NOT provided


### PR DESCRIPTION
Fix `undefined` behaving differently from missing value for axis size. Also fixed the same issue for the `position` property.

Example:

```tsx
<BarChart xAxis={[{ height: undefined }]} />
```

had a different behavior than:

```tsx
<BarChart xAxis={[{}]} />
```

### Before

`height`:

https://github.com/user-attachments/assets/7a041ac6-6e2a-4d92-939d-d03c634f2f2f


`position`:


https://github.com/user-attachments/assets/86163be5-e3e6-4c17-a17b-dcae9deb2ed4



### After

`height`:


https://github.com/user-attachments/assets/1f751111-cb77-4925-b0da-c4cf44eb4219



`position`:

https://github.com/user-attachments/assets/6c081c2e-6024-4bb1-9049-497ff00b6814

