### PR TITLE
[DataGrid] Adds click propagation and prevents default on toggleMenu click

### DIFF
--- a/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -120,7 +120,9 @@ function GridActionsCell(props: GridActionsCellProps) {
   const hideMenu = () => {
     setOpen(false);
   };
-  const toggleMenu = () => {
+  const toggleMenu = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
     if (open) {
       hideMenu();
     } else {


### PR DESCRIPTION
Fixes #16804 

Very simple fix for stopping the click propagation from the `GridActionsCell` menu to the row.