### PR TITLE
[charts] run benchmarks using production build

### DIFF
--- a/test/performance-charts/vitest.config.ts
+++ b/test/performance-charts/vitest.config.ts
@@ -5,6 +5,10 @@ import react from '@vitejs/plugin-react';
 const isCI = process.env.CI === 'true';
 
 export default defineConfig({
+  mode: 'build',
+  build: {
+    minify: false,
+  },
   plugins: [...(isCI ? [codspeedPlugin()] : []), react()],
   test: {
     setupFiles: ['./setup.ts'],


### PR DESCRIPTION
Run benchmarks using production build to provide more accurate results. 

