### PR TITLE
[pickers] Avoid passing unexpected `focusedView` to time renderers

### DIFF
--- a/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
+++ b/packages/x-date-pickers/src/timeViewRenderers/timeViewRenderers.tsx
@@ -7,7 +7,7 @@ import {
   MultiSectionDigitalClock,
   MultiSectionDigitalClockProps,
 } from '../MultiSectionDigitalClock';
-import { isTimeView } from '../internals/utils/time-utils';
+import { isInternalTimeView, isTimeView } from '../internals/utils/time-utils';
 import { TimeViewWithMeridiem } from '../internals/models';
 import type { TimePickerProps } from '../TimePicker/TimePicker.types';
 
@@ -118,7 +118,7 @@ export const renderDigitalClockTimeView = ({
   <DigitalClock
     view={view}
     onViewChange={onViewChange}
-    focusedView={focusedView}
+    focusedView={focusedView && isTimeView(focusedView) ? focusedView : null}
     onFocusedViewChange={onFocusedViewChange}
     views={views.filter(isTimeView)}
     value={value}
@@ -180,7 +180,7 @@ export const renderMultiSectionDigitalClockTimeView = ({
   <MultiSectionDigitalClock
     view={view}
     onViewChange={onViewChange}
-    focusedView={focusedView}
+    focusedView={focusedView && isInternalTimeView(focusedView) ? focusedView : null}
     onFocusedViewChange={onFocusedViewChange}
     views={views.filter(isTimeView)}
     value={value}


### PR DESCRIPTION
Fix consistently failing tests on React 18:
- https://app.circleci.com/pipelines/github/mui/mui-x/83939/workflows/ccd79a7c-a82f-4230-a01d-bf5269f15187/jobs/479137
- https://app.circleci.com/pipelines/github/mui/mui-x/83939/workflows/ccd79a7c-a82f-4230-a01d-bf5269f15187/jobs/479136

The `renderTimeViewClock` already has this safeguard to prevent wrapper components from passing unexpected `focusedView`.
