### PR TITLE
[DataGrid] Fix bug with adding and removing columns in active edit state

### DIFF
--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -712,12 +712,10 @@ export const useGridRowEditing = (
 
       Object.entries(editingState[id]).forEach(([field, fieldProps]) => {
         const column = apiRef.current.getColumn(field);
-        if(column){
-          if (column.valueSetter) {
-            rowUpdate = column.valueSetter(fieldProps.value, rowUpdate, column, apiRef);
-          } else {
-            rowUpdate[field] = fieldProps.value;
-          }
+        if (column && column.valueSetter) { //Ensure that column has a value before trying to access the value setter.
+          rowUpdate = column.valueSetter(fieldProps.value, rowUpdate, column, apiRef);
+        } else {
+          rowUpdate[field] = fieldProps.value;
         }
       });
 

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -712,10 +712,12 @@ export const useGridRowEditing = (
 
       Object.entries(editingState[id]).forEach(([field, fieldProps]) => {
         const column = apiRef.current.getColumn(field);
-        if (column.valueSetter) {
-          rowUpdate = column.valueSetter(fieldProps.value, rowUpdate, column, apiRef);
-        } else {
-          rowUpdate[field] = fieldProps.value;
+        if(column){
+          if (column.valueSetter) {
+            rowUpdate = column.valueSetter(fieldProps.value, rowUpdate, column, apiRef);
+          } else {
+            rowUpdate[field] = fieldProps.value;
+          }
         }
       });
 

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -712,7 +712,9 @@ export const useGridRowEditing = (
 
       Object.entries(editingState[id]).forEach(([field, fieldProps]) => {
         const column = apiRef.current.getColumn(field);
-        if (column && column.valueSetter) { //Ensure that column has a value before trying to access the value setter.
+        // Column might have been removed
+        // see https://github.com/mui/mui-x/pull/16888
+        if (column?.valueSetter) {
           rowUpdate = column.valueSetter(fieldProps.value, rowUpdate, column, apiRef);
         } else {
           rowUpdate[field] = fieldProps.value;


### PR DESCRIPTION
Hi there,


**Problem:**
When adding or removing columns in a grid with an active edit state, the column change fires, causing the field to no longer appear. This happens because the editing state fetched via const editingState = gridEditRowsStateSelector(apiRef.current.state) still holds the old list of columns and their editing states, which includes the old field.

As a result, the call to const column = apiRef.current.getColumn(field) returns undefined because the current column state doesn’t reflect the most up-to-date column state, leading to an outdated state. This causes the following check to fail:
`if (column.valueSetter)`

**Solution:**
To address this issue, I’ve added a check to ensure that the column is defined before accessing column.valueSetter. This prevents errors caused by accessing properties on undefined columns. Additionally, this approach ensures the code behaves the same as before, or at least improves error messaging when a column is missing

**Changes Made:**
Modified useGridRowEditing.js to include a check for undefined columns before attempting to access valueSetter.

**Result:**
This fix ensures that columns that are removed or added dynamically during an edit session don’t result in undefined columns, thereby avoiding the error and allowing proper editing functionality to continue.

Thanks,
Blake