### PR TITLE
[charts] Animate charts using CSS

### DIFF
--- a/packages/x-charts/src/BarChart/AnimatedBarElement.tsx
+++ b/packages/x-charts/src/BarChart/AnimatedBarElement.tsx
@@ -1,73 +1,22 @@
 'use client';
 import * as React from 'react';
-import { AnimatedProps, animated } from '@react-spring/web';
-import { isWidthDown } from '@mui/material/Hidden/withWidth';
 import type { BarElementOwnerState } from './BarElement';
 
-export interface BarProps
-  extends Omit<
-      React.SVGProps<SVGRectElement>,
-      'id' | 'color' | 'ref' | 'x' | 'y' | 'height' | 'width'
-    >,
-    AnimatedProps<{
-      x?: string | number | undefined;
-      y?: string | number | undefined;
-      height?: string | number | undefined;
-      width?: string | number | undefined;
-    }> {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  ownerState: BarElementOwnerState;
+export interface BarProps extends Omit<React.SVGProps<SVGRectElement>, 'id' | 'color' | 'ref'> {
+  ownerState?: BarElementOwnerState;
 }
 
 /**
  * @ignore - internal component.
  */
 export function AnimatedBarElement(props: BarProps) {
-  const { ownerState, x, y, width, height, ...other } = props;
-
-  return (
-    <animated.rect
-      {...other}
-      // @ts-expect-error
-      filter={ownerState.isHighlighted ? 'brightness(120%)' : undefined}
-      opacity={ownerState.isFaded ? 0.3 : 1}
-    />
-  );
-}
-
-export function AnimatedBarElementV2(props: BarProps) {
-  const { ownerState, x, y, width, height, ...other } = props;
+  const { ownerState, ...other } = props;
 
   return (
     <rect
       {...other}
-      x={x}
-      y={y}
-      width={width}
-      height={height}
-      // @ts-expect-error
-      filter={ownerState.isHighlighted ? 'brightness(120%)' : undefined}
-      opacity={ownerState.isFaded ? 0.3 : 1}
-    >
-      <animate
-        attributeName="y"
-        from={y + height}
-        to={y}
-        dur="0.2s"
-        calcMode="spline"
-        keySplines="0.4 0 0.2 1; 0.4 0 0.2 1"
-      />
-      <animate
-        attributeName="height"
-        from="0"
-        to={height}
-        dur="0.2s"
-        calcMode="spline"
-        keySplines="0.4 0 0.2 1; 0.4 0 0.2 1"
-      />
-    </rect>
+      filter={ownerState?.isHighlighted ? 'brightness(120%)' : undefined}
+      opacity={ownerState?.isFaded ? 0.3 : 1}
+    />
   );
 }

--- a/packages/x-charts/src/BarChart/AnimatedBarElement.tsx
+++ b/packages/x-charts/src/BarChart/AnimatedBarElement.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { AnimatedProps, animated } from '@react-spring/web';
+import { isWidthDown } from '@mui/material/Hidden/withWidth';
 import type { BarElementOwnerState } from './BarElement';
 
 export interface BarProps
@@ -14,6 +15,10 @@ export interface BarProps
       height?: string | number | undefined;
       width?: string | number | undefined;
     }> {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
   ownerState: BarElementOwnerState;
 }
 
@@ -21,7 +26,7 @@ export interface BarProps
  * @ignore - internal component.
  */
 export function AnimatedBarElement(props: BarProps) {
-  const { ownerState, ...other } = props;
+  const { ownerState, x, y, width, height, ...other } = props;
 
   return (
     <animated.rect
@@ -30,5 +35,39 @@ export function AnimatedBarElement(props: BarProps) {
       filter={ownerState.isHighlighted ? 'brightness(120%)' : undefined}
       opacity={ownerState.isFaded ? 0.3 : 1}
     />
+  );
+}
+
+export function AnimatedBarElementV2(props: BarProps) {
+  const { ownerState, x, y, width, height, ...other } = props;
+
+  return (
+    <rect
+      {...other}
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      // @ts-expect-error
+      filter={ownerState.isHighlighted ? 'brightness(120%)' : undefined}
+      opacity={ownerState.isFaded ? 0.3 : 1}
+    >
+      <animate
+        attributeName="y"
+        from={y + height}
+        to={y}
+        dur="0.2s"
+        calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0.4 0 0.2 1"
+      />
+      <animate
+        attributeName="height"
+        from="0"
+        to={height}
+        dur="0.2s"
+        calcMode="spline"
+        keySplines="0.4 0 0.2 1; 0.4 0 0.2 1"
+      />
+    </rect>
   );
 }

--- a/packages/x-charts/src/BarChart/BarClipPath.tsx
+++ b/packages/x-charts/src/BarChart/BarClipPath.tsx
@@ -9,6 +9,7 @@ export interface BarClipPathProps {
   hasNegative: boolean;
   hasPositive: boolean;
   layout?: 'vertical' | 'horizontal';
+  style?: React.CSSProperties;
 
   x: number;
   y: number;
@@ -35,7 +36,7 @@ export const barClipPathClasses: BarClipPathClasses = generateUtilityClasses('Mu
  * @ignore - internal component.
  */
 function BarClipPath(props: BarClipPathProps) {
-  const { className, maskId, x, y, width, height, ...radiusData } = props;
+  const { className, maskId, x, y, width, height, style, ...radiusData } = props;
 
   if (!props.borderRadius || props.borderRadius <= 0) {
     return null;
@@ -50,6 +51,7 @@ function BarClipPath(props: BarClipPathProps) {
         width={width}
         height={height}
         style={{
+          ...style,
           clipPath: `inset(0px round ${getRadius('top-left', radiusData)}px ${getRadius('top-right', radiusData)}px ${getRadius('bottom-right', radiusData)}px ${getRadius('bottom-left', radiusData)}px)`,
         }}
       />

--- a/packages/x-charts/src/BarChart/BarClipPath.tsx
+++ b/packages/x-charts/src/BarChart/BarClipPath.tsx
@@ -1,53 +1,41 @@
 import * as React from 'react';
-import { SpringValue, animated } from '@react-spring/web';
+import generateUtilityClasses from '@mui/utils/generateUtilityClasses';
 import { getRadius } from './getRadius';
 
-const buildInset = (corners: {
-  topLeft: number;
-  topRight: number;
-  bottomRight: number;
-  bottomLeft: number;
-}) =>
-  `inset(0px round ${corners.topLeft}px ${corners.topRight}px ${corners.bottomRight}px ${corners.bottomLeft}px)`;
-
-function BarClipRect(props: Record<string, any>) {
-  const radiusData = props.ownerState;
-
-  return (
-    <animated.rect
-      style={{
-        ...props.style,
-        clipPath: (
-          (props.ownerState.layout === 'vertical'
-            ? props.style?.height
-            : props.style?.width) as SpringValue<number>
-        ).to((value) =>
-          buildInset({
-            topLeft: Math.min(value, getRadius('top-left', radiusData)),
-            topRight: Math.min(value, getRadius('top-right', radiusData)),
-            bottomRight: Math.min(value, getRadius('bottom-right', radiusData)),
-            bottomLeft: Math.min(value, getRadius('bottom-left', radiusData)),
-          }),
-        ),
-      }}
-    />
-  );
-}
-
 export interface BarClipPathProps {
+  className?: string;
   maskId: string;
   borderRadius?: number;
   hasNegative: boolean;
   hasPositive: boolean;
   layout?: 'vertical' | 'horizontal';
-  style: {};
+
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
+
+export interface BarClipPathClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if it is horizontal. */
+  horizontal: string;
+  /** Styles applied to the root element if it is vertical. */
+  vertical: string;
+}
+
+export const barClipPathClasses: BarClipPathClasses = generateUtilityClasses('MuiBarClipPath', [
+  'root',
+  'horizontal',
+  'vertical',
+]);
 
 /**
  * @ignore - internal component.
  */
 function BarClipPath(props: BarClipPathProps) {
-  const { style, maskId, ...rest } = props;
+  const { className, maskId, x, y, width, height, ...radiusData } = props;
 
   if (!props.borderRadius || props.borderRadius <= 0) {
     return null;
@@ -55,7 +43,16 @@ function BarClipPath(props: BarClipPathProps) {
 
   return (
     <clipPath id={maskId}>
-      <BarClipRect ownerState={rest} style={style} />
+      <rect
+        className={className}
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        style={{
+          clipPath: `inset(0px round ${getRadius('top-left', radiusData)}px ${getRadius('top-right', radiusData)}px ${getRadius('bottom-left', radiusData)}px ${getRadius('bottom-right', radiusData)}px)`,
+        }}
+      />
     </clipPath>
   );
 }

--- a/packages/x-charts/src/BarChart/BarClipPath.tsx
+++ b/packages/x-charts/src/BarChart/BarClipPath.tsx
@@ -50,7 +50,7 @@ function BarClipPath(props: BarClipPathProps) {
         width={width}
         height={height}
         style={{
-          clipPath: `inset(0px round ${getRadius('top-left', radiusData)}px ${getRadius('top-right', radiusData)}px ${getRadius('bottom-left', radiusData)}px ${getRadius('bottom-right', radiusData)}px)`,
+          clipPath: `inset(0px round ${getRadius('top-left', radiusData)}px ${getRadius('top-right', radiusData)}px ${getRadius('bottom-right', radiusData)}px ${getRadius('bottom-left', radiusData)}px)`,
         }}
       />
     </clipPath>

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -112,13 +112,7 @@ function BarElement(props: BarElementProps) {
     externalForwardedProps: other,
     additionalProps: {
       ...getInteractionItemProps({ type: 'bar', seriesId: id, dataIndex }),
-      style: {
-        ...style,
-        '--x': `${other.x}px`,
-        '--y': `${other.y}px`,
-        '--width': `${other.width}px`,
-        '--height': `${other.height}px`,
-      },
+      style,
       onClick,
       cursor: onClick ? 'pointer' : 'unset',
       stroke: 'none',

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -9,7 +9,7 @@ import { SlotComponentPropsFromProps } from '@mui/x-internals/types';
 import { useInteractionItemProps } from '../hooks/useInteractionItemProps';
 import { SeriesId } from '../models/seriesType/common';
 import { useItemHighlighted } from '../hooks/useItemHighlighted';
-import { AnimatedBarElement, BarProps } from './AnimatedBarElement';
+import { AnimatedBarElement, AnimatedBarElementV2, BarProps } from './AnimatedBarElement';
 
 export interface BarElementClasses {
   /** Styles applied to the root element. */

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -9,7 +9,7 @@ import { SlotComponentPropsFromProps } from '@mui/x-internals/types';
 import { useInteractionItemProps } from '../hooks/useInteractionItemProps';
 import { SeriesId } from '../models/seriesType/common';
 import { useItemHighlighted } from '../hooks/useItemHighlighted';
-import { AnimatedBarElement, AnimatedBarElementV2, BarProps } from './AnimatedBarElement';
+import { AnimatedBarElement, BarProps } from './AnimatedBarElement';
 
 export interface BarElementClasses {
   /** Styles applied to the root element. */
@@ -112,7 +112,13 @@ function BarElement(props: BarElementProps) {
     externalForwardedProps: other,
     additionalProps: {
       ...getInteractionItemProps({ type: 'bar', seriesId: id, dataIndex }),
-      style,
+      style: {
+        ...style,
+        '--x': `${other.x}px`,
+        '--y': `${other.y}px`,
+        '--width': `${other.width}px`,
+        '--height': `${other.height}px`,
+      },
       onClick,
       cursor: onClick ? 'pointer' : 'unset',
       stroke: 'none',

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -18,6 +18,10 @@ export interface BarElementClasses {
   highlighted: string;
   /** Styles applied to the root element if it is faded. */
   faded: string;
+  /** Styles applied to the root element if it is horizontal. */
+  horizontal: string;
+  /** Styles applied to the root element if it is vertical. */
+  vertical: string;
 }
 
 export type BarElementClassKey = keyof BarElementClasses;
@@ -28,6 +32,7 @@ export interface BarElementOwnerState {
   color: string;
   isFaded: boolean;
   isHighlighted: boolean;
+  layout: 'horizontal' | 'vertical';
   classes?: Partial<BarElementClasses>;
 }
 
@@ -39,12 +44,20 @@ export const barElementClasses: BarElementClasses = generateUtilityClasses('MuiB
   'root',
   'highlighted',
   'faded',
+  'horizontal',
+  'vertical',
 ]);
 
 const useUtilityClasses = (ownerState: BarElementOwnerState) => {
-  const { classes, id, isHighlighted, isFaded } = ownerState;
+  const { classes, id, isHighlighted, isFaded, layout } = ownerState;
   const slots = {
-    root: ['root', `series-${id}`, isHighlighted && 'highlighted', isFaded && 'faded'],
+    root: [
+      'root',
+      `series-${id}`,
+      isHighlighted && 'highlighted',
+      isFaded && 'faded',
+      layout === 'vertical' ? 'vertical' : 'horizontal',
+    ],
   };
 
   return composeClasses(slots, getBarElementUtilityClass, classes);
@@ -85,6 +98,7 @@ function BarElement(props: BarElementProps) {
     slotProps,
     style,
     onClick,
+    layout,
     ...other
   } = props;
   const getInteractionItemProps = useInteractionItemProps();
@@ -100,6 +114,7 @@ function BarElement(props: BarElementProps) {
     color,
     isFaded,
     isHighlighted,
+    layout,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -1,15 +1,15 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useTransition } from '@react-spring/web';
 import { styled } from '@mui/material/styles';
+import clsx from 'clsx';
 import { BarElement, barElementClasses, BarElementSlotProps, BarElementSlots } from './BarElement';
 import { AxisDefaultized } from '../models/axis';
 import { BarItemIdentifier } from '../models';
 import getColor from './seriesConfig/getColor';
 import { useChartId, useDrawingArea, useXAxes, useYAxes } from '../hooks';
-import { AnimationData, CompletedBarData, MaskData } from './types';
-import { BarClipPath } from './BarClipPath';
+import { CompletedBarData, MaskData } from './types';
+import { BarClipPath, barClipPathClasses } from './BarClipPath';
 import { BarLabelItemProps, BarLabelSlotProps, BarLabelSlots } from './BarLabel/BarLabelItem';
 import { BarLabelPlot } from './BarLabel/BarLabelPlot';
 import { checkScaleErrors } from './checkScaleErrors';
@@ -209,58 +209,37 @@ const useAggregatedData = (): {
   };
 };
 
-const leaveStyle = ({ layout, yOrigin, x, width, y, xOrigin, height }: AnimationData) => ({
-  ...(layout === 'vertical'
-    ? {
-        y: yOrigin,
-        x,
-        height: 0,
-        width,
-      }
-    : {
-        y,
-        x: xOrigin,
-        height,
-        width: 0,
-      }),
-});
-
-const enterStyle = ({ x, width, y, height }: AnimationData) => ({
-  y,
-  x,
-  height,
-  width,
-});
+const ANIMATION_DURATION = '0.5s';
 
 const BarPlotRoot = styled('g', {
   name: 'MuiBarPlot',
   slot: 'Root',
   overridesResolver: (_, styles) => styles.root,
 })({
-  [`& .${barElementClasses.root}`]: {
-    [`&.${barElementClasses.vertical}`]: {
-      transition: 'opacity 0.2s ease-in, fill 0.2s ease-in, height 0.5s ease-in, y 0.5s ease-in',
+  [`& .${barElementClasses.root}.${barElementClasses.vertical}, & .${barClipPathClasses.root}.${barClipPathClasses.vertical}`]:
+    {
+      transition: `opacity 0.2s ease-in, fill 0.2s ease-in, height ${ANIMATION_DURATION} ease-in, y ${ANIMATION_DURATION} ease-in`,
 
       '@keyframes growHeight': {
         from: { transform: 'scaleY(0%)' },
         to: { transform: 'scaleY(100%)' },
       },
 
-      transformOrigin: '0% 100%',
-      animation: 'growHeight 0.5s ease',
+      transformOrigin: 'bottom',
+      animation: `growHeight ${ANIMATION_DURATION} ease`,
     },
 
-    [`&.${barElementClasses.horizontal}`]: {
-      transition: 'opacity 0.2s ease-in, fill 0.2s ease-in, width 0.5s ease-in, x 0.5s ease-in',
+  [`& .${barElementClasses.root}.${barElementClasses.horizontal}, & .${barClipPathClasses.root}.${barClipPathClasses.horizontal}`]:
+    {
+      transition: `opacity 0.2s ease-in, fill 0.2s ease-in, width ${ANIMATION_DURATION} ease-in, x ${ANIMATION_DURATION} ease-in`,
 
       '@keyframes growWidth': {
         from: { transform: 'scaleX(0%)' },
         to: { transform: 'scaleX(100%)' },
       },
 
-      animation: 'growWidth 0.5s ease',
+      animation: `growWidth ${ANIMATION_DURATION} ease`,
     },
-  },
 });
 
 /**
@@ -281,30 +260,26 @@ function BarPlot(props: BarPlotProps) {
 
   const withoutBorderRadius = !borderRadius || borderRadius <= 0;
 
-  const maskTransition = useTransition(withoutBorderRadius ? [] : masksData, {
-    keys: (v) => v.id,
-    from: skipAnimation ? undefined : leaveStyle,
-    leave: leaveStyle,
-    enter: enterStyle,
-    update: enterStyle,
-    immediate: skipAnimation,
-  });
-
   return (
     <BarPlotRoot>
       {!withoutBorderRadius &&
-        maskTransition((style, { id, hasPositive, hasNegative, layout }) => {
-          return (
-            <BarClipPath
-              maskId={id}
-              borderRadius={borderRadius}
-              hasNegative={hasNegative}
-              hasPositive={hasPositive}
-              layout={layout}
-              style={style}
-            />
-          );
-        })}
+        masksData.map(({ id, hasPositive, hasNegative, layout, x, y, width, height }) => (
+          <BarClipPath
+            className={clsx(
+              barClipPathClasses.root,
+              layout === 'horizontal' ? barClipPathClasses.horizontal : barClipPathClasses.vertical,
+            )}
+            maskId={id}
+            borderRadius={borderRadius}
+            hasNegative={hasNegative}
+            hasPositive={hasPositive}
+            layout={layout}
+            x={x}
+            y={y}
+            width={width}
+            height={height}
+          />
+        ))}
       {completedData.map(({ x, y, width, height, dataIndex, color, seriesId, maskId, layout }) => {
         const barElement = (
           <BarElement
@@ -316,7 +291,7 @@ function BarPlot(props: BarPlotProps) {
             y={y}
             width={width}
             height={height}
-            layout={layout}
+            layout={layout ?? 'vertical'}
             {...other}
             onClick={
               onItemClick &&

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -220,7 +220,7 @@ const BarPlotRoot = styled('g', {
     transition: `opacity 0.2s ease-in, fill 0.2s ease-in, height ${ANIMATION_DURATION} ease-in, y ${ANIMATION_DURATION} ease-in`,
 
     '@keyframes growHeight': {
-      from: { height: 0 },
+      from: { height: 0, y: 'calc(var(--y) + var(--height))' },
       to: {},
     },
 
@@ -230,7 +230,7 @@ const BarPlotRoot = styled('g', {
     transition: `height ${ANIMATION_DURATION} ease-in, y ${ANIMATION_DURATION} ease-in`,
 
     '@keyframes growClipPathHeight': {
-      from: { height: 0 },
+      from: { height: 0, y: 'calc(var(--y) + var(--height))' },
       to: {},
     },
 
@@ -295,6 +295,7 @@ function BarPlot(props: BarPlotProps) {
             y={y}
             width={width}
             height={height}
+            style={{ '--y': `${y}px`, '--height': `${height}px` }}
           />
         ))}
       {completedData.map(({ x, y, width, height, dataIndex, color, seriesId, maskId, layout }) => {
@@ -309,6 +310,7 @@ function BarPlot(props: BarPlotProps) {
             width={width}
             height={height}
             layout={layout ?? 'vertical'}
+            style={{ '--y': `${y}px`, '--height': `${height}px` }}
             {...other}
             onClick={
               onItemClick &&

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -239,6 +239,18 @@ const BarPlotRoot = styled('g', {
 })({
   [`& .${barElementClasses.root}`]: {
     transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',
+
+    '@keyframes growHeight': {
+      from: {
+        height: 0,
+        y: 'calc(var(--y) + var(--height))',
+      },
+      to: {
+        height: 'var(--height)',
+        y: 'var(--y)',
+      },
+    },
+    animation: 'growHeight 0.5s ease',
   },
 });
 
@@ -259,18 +271,6 @@ function BarPlot(props: BarPlotProps) {
   const skipAnimation = useSkipAnimation(inSkipAnimation);
 
   const withoutBorderRadius = !borderRadius || borderRadius <= 0;
-
-  const transition = useTransition(completedData, {
-    keys: (bar) => `${bar.seriesId}-${bar.dataIndex}`,
-    from: skipAnimation ? undefined : leaveStyle,
-    leave: leaveStyle,
-    enter: enterStyle,
-    update: enterStyle,
-    immediate: skipAnimation,
-    config: {
-      // duration: 5_000,
-    },
-  });
 
   const maskTransition = useTransition(withoutBorderRadius ? [] : masksData, {
     keys: (v) => v.id,
@@ -296,25 +296,24 @@ function BarPlot(props: BarPlotProps) {
             />
           );
         })}
-      {transition((style, { seriesId, dataIndex, color, maskId }) => {
-        console.log(style);
+      {completedData.map(({ x, y, width, height, dataIndex, color, seriesId, maskId }) => {
         const barElement = (
           <BarElement
+            key={`${seriesId}-${dataIndex}`}
             id={seriesId}
             dataIndex={dataIndex}
             color={color}
+            x={x}
+            y={y}
+            width={width}
+            height={height}
             {...other}
-            x={style.x.goal}
-            y={style.y.goal}
-            width={style.width.goal}
-            height={style.height.goal}
             onClick={
               onItemClick &&
               ((event) => {
                 onItemClick(event, { type: 'bar', seriesId, dataIndex });
               })
             }
-            style={style}
           />
         );
 

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -216,30 +216,46 @@ const BarPlotRoot = styled('g', {
   slot: 'Root',
   overridesResolver: (_, styles) => styles.root,
 })({
-  [`& .${barElementClasses.root}.${barElementClasses.vertical}, & .${barClipPathClasses.root}.${barClipPathClasses.vertical}`]:
-    {
-      transition: `opacity 0.2s ease-in, fill 0.2s ease-in, height ${ANIMATION_DURATION} ease-in, y ${ANIMATION_DURATION} ease-in`,
+  [`& .${barElementClasses.root}.${barElementClasses.vertical}`]: {
+    transition: `opacity 0.2s ease-in, fill 0.2s ease-in, height ${ANIMATION_DURATION} ease-in, y ${ANIMATION_DURATION} ease-in`,
 
-      '@keyframes growHeight': {
-        from: { transform: 'scaleY(0%)' },
-        to: { transform: 'scaleY(100%)' },
-      },
-
-      transformOrigin: 'bottom',
-      animation: `growHeight ${ANIMATION_DURATION} ease`,
+    '@keyframes growHeight': {
+      from: { height: 0 },
+      to: {},
     },
 
-  [`& .${barElementClasses.root}.${barElementClasses.horizontal}, & .${barClipPathClasses.root}.${barClipPathClasses.horizontal}`]:
-    {
-      transition: `opacity 0.2s ease-in, fill 0.2s ease-in, width ${ANIMATION_DURATION} ease-in, x ${ANIMATION_DURATION} ease-in`,
+    animation: `growHeight ${ANIMATION_DURATION} ease`,
+  },
+  [`& .${barClipPathClasses.root}.${barClipPathClasses.vertical}`]: {
+    transition: `height ${ANIMATION_DURATION} ease-in, y ${ANIMATION_DURATION} ease-in`,
 
-      '@keyframes growWidth': {
-        from: { transform: 'scaleX(0%)' },
-        to: { transform: 'scaleX(100%)' },
-      },
-
-      animation: `growWidth ${ANIMATION_DURATION} ease`,
+    '@keyframes growClipPathHeight': {
+      from: { height: 0 },
+      to: {},
     },
+
+    animation: `growClipPathHeight ${ANIMATION_DURATION} ease`,
+  },
+  [`& .${barElementClasses.root}.${barElementClasses.horizontal}`]: {
+    transition: `opacity 0.2s ease-in, fill 0.2s ease-in, width ${ANIMATION_DURATION} ease-in`,
+
+    '@keyframes growWidth': {
+      from: { width: 0 },
+      to: {},
+    },
+
+    animation: `growWidth ${ANIMATION_DURATION} ease`,
+  },
+  [`& .${barClipPathClasses.root}.${barClipPathClasses.horizontal}`]: {
+    transition: `width ${ANIMATION_DURATION} ease-in`,
+
+    '@keyframes growClipPathWidth': {
+      from: { width: 0 },
+      to: {},
+    },
+
+    animation: `growClipPathWidth ${ANIMATION_DURATION} ease`,
+  },
 });
 
 /**
@@ -265,6 +281,7 @@ function BarPlot(props: BarPlotProps) {
       {!withoutBorderRadius &&
         masksData.map(({ id, hasPositive, hasNegative, layout, x, y, width, height }) => (
           <BarClipPath
+            key={id}
             className={clsx(
               barClipPathClasses.root,
               layout === 'horizontal' ? barClipPathClasses.horizontal : barClipPathClasses.vertical,

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -238,19 +238,14 @@ const BarPlotRoot = styled('g', {
   overridesResolver: (_, styles) => styles.root,
 })({
   [`& .${barElementClasses.root}`]: {
-    transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',
+    transition: 'opacity 0.2s ease-in, fill 0.2s ease-in, height 0.5s ease-in, y 0.5s ease-in',
 
     '@keyframes growHeight': {
-      from: {
-        height: 0,
-        y: 'calc(var(--y) + var(--height))',
-      },
-      to: {
-        height: 'var(--height)',
-        y: 'var(--y)',
-      },
+      from: { transform: 'scaleY(0%)' },
+      to: { transform: 'scaleY(100%)' },
     },
     animation: 'growHeight 0.5s ease',
+    transformOrigin: '0% 100%',
   },
 });
 

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -238,14 +238,28 @@ const BarPlotRoot = styled('g', {
   overridesResolver: (_, styles) => styles.root,
 })({
   [`& .${barElementClasses.root}`]: {
-    transition: 'opacity 0.2s ease-in, fill 0.2s ease-in, height 0.5s ease-in, y 0.5s ease-in',
+    [`&.${barElementClasses.vertical}`]: {
+      transition: 'opacity 0.2s ease-in, fill 0.2s ease-in, height 0.5s ease-in, y 0.5s ease-in',
 
-    '@keyframes growHeight': {
-      from: { transform: 'scaleY(0%)' },
-      to: { transform: 'scaleY(100%)' },
+      '@keyframes growHeight': {
+        from: { transform: 'scaleY(0%)' },
+        to: { transform: 'scaleY(100%)' },
+      },
+
+      transformOrigin: '0% 100%',
+      animation: 'growHeight 0.5s ease',
     },
-    animation: 'growHeight 0.5s ease',
-    transformOrigin: '0% 100%',
+
+    [`&.${barElementClasses.horizontal}`]: {
+      transition: 'opacity 0.2s ease-in, fill 0.2s ease-in, width 0.5s ease-in, x 0.5s ease-in',
+
+      '@keyframes growWidth': {
+        from: { transform: 'scaleX(0%)' },
+        to: { transform: 'scaleX(100%)' },
+      },
+
+      animation: 'growWidth 0.5s ease',
+    },
   },
 });
 
@@ -291,7 +305,7 @@ function BarPlot(props: BarPlotProps) {
             />
           );
         })}
-      {completedData.map(({ x, y, width, height, dataIndex, color, seriesId, maskId }) => {
+      {completedData.map(({ x, y, width, height, dataIndex, color, seriesId, maskId, layout }) => {
         const barElement = (
           <BarElement
             key={`${seriesId}-${dataIndex}`}
@@ -302,6 +316,7 @@ function BarPlot(props: BarPlotProps) {
             y={y}
             width={width}
             height={height}
+            layout={layout}
             {...other}
             onClick={
               onItemClick &&

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -267,6 +267,9 @@ function BarPlot(props: BarPlotProps) {
     enter: enterStyle,
     update: enterStyle,
     immediate: skipAnimation,
+    config: {
+      // duration: 5_000,
+    },
   });
 
   const maskTransition = useTransition(withoutBorderRadius ? [] : masksData, {
@@ -294,12 +297,17 @@ function BarPlot(props: BarPlotProps) {
           );
         })}
       {transition((style, { seriesId, dataIndex, color, maskId }) => {
+        console.log(style);
         const barElement = (
           <BarElement
             id={seriesId}
             dataIndex={dataIndex}
             color={color}
             {...other}
+            x={style.x.goal}
+            y={style.y.goal}
+            width={style.width.goal}
+            height={style.height.goal}
             onClick={
               onItemClick &&
               ((event) => {

--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -55,7 +55,7 @@ const useUtilityClasses = (ownerState: PieArcOwnerState) => {
   return composeClasses(slots, getPieArcUtilityClass, classes);
 };
 
-const PieArcRoot = styled(animated.path, {
+const PieArcRoot = styled('path', {
   name: 'MuiPieArc',
   slot: 'Root',
   overridesResolver: (_, styles) => styles.arc,
@@ -73,7 +73,7 @@ const PieArcRoot = styled(animated.path, {
     },
   },
 
-  animation: 'animation 0.2s ease-in',
+  // animation: 'animation 0.2s ease-in',
 }));
 
 const PieArcClipPath = styled('path')({});
@@ -127,29 +127,58 @@ function PieArc(props: PieArcProps) {
     outerRadius,
   })!;
 
+  const [lastD, setLastD] = React.useState(
+    () =>
+      d3Arc().cornerRadius(cornerRadius)({
+        padAngle: paddingAngle,
+        startAngle: (endAngle + startAngle) / 2,
+        endAngle: (endAngle + startAngle) / 2 + 0.00001,
+        innerRadius,
+        outerRadius,
+      })!,
+  );
+  const [newD, setNewD] = React.useState(d);
+  console.log({ startAngle, endAngle, d, lastD });
+
+  // React.useEffect(() => {
+  //  if (d !== newD) {
+  //    setLastD(newD);
+  //    setNewD(d);
+  //  }
+  // }, [d, newD]);
+
   return (
     <React.Fragment>
+      {/*
       <clipPath id={`pie-${id}-arc-clip-path-${dataIndex}`}>
         <PieArcClipPath d={d} />
       </clipPath>
-      <g clipPath={`url(#pie-${id}-arc-clip-path-${dataIndex})`}>
-        <PieArcRoot
-          d={d}
-          visibility={startAngle === endAngle ? 'hidden' : 'visible'}
-          onClick={onClick}
-          cursor={onClick ? 'pointer' : 'unset'}
-          ownerState={ownerState}
-          className={classes.root}
-          fill={ownerState.color}
-          opacity={ownerState.isFaded ? 0.3 : 1}
-          filter={ownerState.isHighlighted ? 'brightness(120%)' : 'none'}
-          strokeWidth={1}
-          strokeLinejoin="round"
-          style={{ '--angle': `-${endAngle - startAngle}rad` }}
-          {...other}
-          {...getInteractionItemProps({ type: 'pie', seriesId: id, dataIndex })}
+*/}
+      {/* <g clipPath={`url(#pie-${id}-arc-clip-path-${dataIndex})`}> */}
+      <PieArcRoot
+        d={lastD}
+        visibility={startAngle === endAngle ? 'hidden' : 'visible'}
+        onClick={onClick}
+        cursor={onClick ? 'pointer' : 'unset'}
+        ownerState={ownerState}
+        className={classes.root}
+        fill={ownerState.color}
+        opacity={ownerState.isFaded ? 0.3 : 1}
+        filter={ownerState.isHighlighted ? 'brightness(120%)' : 'none'}
+        strokeWidth={1}
+        strokeLinejoin="round"
+        {...other}
+        {...getInteractionItemProps({ type: 'pie', seriesId: id, dataIndex })}
+      >
+        <animate
+          attributeName="d"
+          dur="0.2s"
+          keyTimes="0;1"
+          values={`${lastD};${newD}`}
+          fill="freeze"
         />
-      </g>
+      </PieArcRoot>
+      {/* </g> */}
     </React.Fragment>
   );
 }

--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -145,7 +145,7 @@ function PieArc(props: PieArcProps) {
           filter={ownerState.isHighlighted ? 'brightness(120%)' : 'none'}
           strokeWidth={1}
           strokeLinejoin="round"
-          style={{ '--angle': `${endAngle - startAngle}rad` }}
+          style={{ '--angle': `-${endAngle - startAngle}rad` }}
           {...other}
           {...getInteractionItemProps({ type: 'pie', seriesId: id, dataIndex })}
         />

--- a/packages/x-charts/src/PieChart/PieArcPlot.tsx
+++ b/packages/x-charts/src/PieChart/PieArcPlot.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useTransition } from '@react-spring/web';
 import { PieArc, PieArcProps } from './PieArc';
 import {
   ComputedPieRadius,
@@ -9,12 +8,7 @@ import {
   DefaultizedPieValueType,
   PieItemIdentifier,
 } from '../models/seriesType/pie';
-import { getDefaultTransitionConfig } from './dataTransform/transition';
-import {
-  AnimatedObject,
-  ValueWithHighlight,
-  useTransformData,
-} from './dataTransform/useTransformData';
+import { useTransformData } from './dataTransform/useTransformData';
 
 export interface PieArcPlotSlots {
   pieArc?: React.JSXElementConstructor<PieArcProps>;
@@ -90,10 +84,6 @@ function PieArcPlot(props: PieArcPlotProps) {
     faded,
     data,
   });
-  const transition = useTransition<ValueWithHighlight, AnimatedObject>(transformedData, {
-    ...getDefaultTransitionConfig(skipAnimation),
-    immediate: skipAnimation,
-  });
 
   if (data.length === 0) {
     return null;
@@ -103,44 +93,29 @@ function PieArcPlot(props: PieArcPlotProps) {
 
   return (
     <g {...other}>
-      {transition(
-        (
-          {
-            startAngle,
-            endAngle,
-            paddingAngle: pA,
-            innerRadius: iR,
-            outerRadius: oR,
-            cornerRadius: cR,
-          },
-          item,
-          _,
-          index,
-        ) => {
-          return (
-            <Arc
-              startAngle={startAngle}
-              endAngle={endAngle}
-              paddingAngle={pA}
-              innerRadius={iR}
-              outerRadius={oR}
-              cornerRadius={cR}
-              id={id}
-              color={item.color}
-              dataIndex={index}
-              isFaded={item.isFaded}
-              isHighlighted={item.isHighlighted}
-              onClick={
-                onItemClick &&
-                ((event) => {
-                  onItemClick(event, { type: 'pie', seriesId: id, dataIndex: index }, item);
-                })
-              }
-              {...slotProps?.pieArc}
-            />
-          );
-        },
-      )}
+      {transformedData.map((item, index) => (
+        <Arc
+          key={index}
+          startAngle={item.startAngle}
+          endAngle={item.endAngle}
+          paddingAngle={item.paddingAngle}
+          innerRadius={item.innerRadius}
+          outerRadius={item.outerRadius}
+          cornerRadius={item.cornerRadius}
+          id={id}
+          color={item.color}
+          dataIndex={index}
+          isFaded={item.isFaded}
+          isHighlighted={item.isHighlighted}
+          onClick={
+            onItemClick &&
+            ((event) => {
+              onItemClick(event, { type: 'pie', seriesId: id, dataIndex: index }, item);
+            })
+          }
+          {...slotProps?.pieArc}
+        />
+      ))}
     </g>
   );
 }

--- a/packages/x-charts/src/PieChart/dataTransform/transition.ts
+++ b/packages/x-charts/src/PieChart/dataTransform/transition.ts
@@ -1,69 +1,6 @@
 import { UseTransitionProps } from '@react-spring/web';
 import { ValueWithHighlight } from './useTransformData';
 
-export const getDefaultTransitionConfig = (
-  skipAnimation?: boolean,
-): UseTransitionProps<ValueWithHighlight> => ({
-  keys: (item) => item.id ?? item.dataIndex,
-  from: skipAnimation
-    ? undefined
-    : ({
-        innerRadius,
-        outerRadius,
-        cornerRadius,
-        startAngle,
-        endAngle,
-        paddingAngle,
-        color,
-        isFaded,
-      }) => ({
-        innerRadius,
-        outerRadius: (innerRadius + outerRadius) / 2,
-        cornerRadius,
-        startAngle: (startAngle + endAngle) / 2,
-        endAngle: (startAngle + endAngle) / 2,
-        paddingAngle,
-        fill: color,
-        opacity: isFaded ? 0.3 : 1,
-      }),
-  leave: ({ innerRadius, startAngle, endAngle }) => ({
-    innerRadius,
-    outerRadius: innerRadius,
-    startAngle: (startAngle + endAngle) / 2,
-    endAngle: (startAngle + endAngle) / 2,
-  }),
-  enter: ({ innerRadius, outerRadius, startAngle, endAngle }) => ({
-    innerRadius,
-    outerRadius,
-    startAngle,
-    endAngle,
-  }),
-  update: ({
-    innerRadius,
-    outerRadius,
-    cornerRadius,
-    startAngle,
-    endAngle,
-    paddingAngle,
-    color,
-    isFaded,
-  }) => ({
-    innerRadius,
-    outerRadius,
-    cornerRadius,
-    startAngle,
-    endAngle,
-    paddingAngle,
-    fill: color,
-    opacity: isFaded ? 0.3 : 1,
-  }),
-  config: {
-    tension: 120,
-    friction: 14,
-    clamp: true,
-  },
-});
-
 export const getDefaultLabelTransitionConfig = (
   skipAnimation?: boolean,
 ): UseTransitionProps<ValueWithHighlight> => ({


### PR DESCRIPTION
TODO: 
- [ ] Implement `skipAnimation`

Unfortunately, Safari doesn't allow animating `path`'s `d` attribute using CSS ([source](https://caniuse.com/mdn-svg_elements_path_d_path)).