### PR TITLE
[charts] Revert changes in `consumeSlots` that were breaking React 18 tests

### DIFF
--- a/packages/x-charts/src/internals/consumeSlots.tsx
+++ b/packages/x-charts/src/internals/consumeSlots.tsx
@@ -104,11 +104,17 @@ export const consumeSlots = <
       delete (outProps as unknown as Props)[prop];
     }
 
+    // Component can be wrapped in React.forwardRef or just a function that accepts (props, ref).
+    // If it is a plain function which accepts two arguments, we need to wrap it in React.forwardRef.
+    const OutComponent = (
+      Component.length >= 2 ? React.forwardRef(Component) : Component
+    ) as React.FunctionComponent<Props>;
+
     if (process.env.NODE_ENV !== 'production') {
-      Component.displayName = `${name}.slots.${slotPropName}`;
+      OutComponent.displayName = `${name}.slots.${slotPropName}`;
     }
 
-    return <Component {...outProps} ref={ref} />;
+    return <OutComponent {...outProps} ref={ref} />;
   }
 
   return React.forwardRef<Ref, Props>(ConsumeSlotsInternal);


### PR DESCRIPTION
Revert changes in `consumeSlots` introduced in https://github.com/mui/mui-x/pull/16640 that started breaking [React 18 tests](https://app.circleci.com/pipelines/github/mui/mui-x/84116/workflows/4f11b85a-b719-4dee-988c-d545bbc849d3/jobs/480151).

