### PR TITLE
[charts] Fix React 18 tests failing due to missing `forwardRef`

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/FunnelSection.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelSection.tsx
@@ -26,7 +26,10 @@ const FunnelSection = consumeSlots(
   {
     classesResolver: useUtilityClasses,
   },
-  function FunnelSection(props: FunnelSectionProps, ref: React.Ref<SVGPathElement>) {
+  React.forwardRef(function FunnelSection(
+    props: FunnelSectionProps,
+    ref: React.Ref<SVGPathElement>,
+  ) {
     const { seriesId, dataIndex, classes, color, onClick, className, ...other } = props;
     const getInteractionItemProps = useInteractionItemProps();
     const { isFaded, isHighlighted } = useItemHighlighted({
@@ -53,7 +56,7 @@ const FunnelSection = consumeSlots(
         ref={ref}
       />
     );
-  },
+  }),
 );
 
 export { FunnelSection };

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -86,7 +86,10 @@ const ChartsLegend = consumeSlots(
     omitProps: ['position'],
     classesResolver: useUtilityClasses,
   },
-  function ChartsLegend(props: ChartsLegendProps, ref: React.Ref<HTMLUListElement>) {
+  React.forwardRef(function ChartsLegend(
+    props: ChartsLegendProps,
+    ref: React.Ref<HTMLUListElement>,
+  ) {
     const data = useLegend();
     const { direction, onItemClick, className, classes, ...other } = props;
 
@@ -129,7 +132,7 @@ const ChartsLegend = consumeSlots(
         })}
       </RootElement>
     );
-  },
+  }),
 );
 
 ChartsLegend.propTypes = {

--- a/packages/x-charts/src/internals/consumeSlots.test.tsx
+++ b/packages/x-charts/src/internals/consumeSlots.test.tsx
@@ -23,7 +23,7 @@ const SlotsWrapper = consumeSlots(
       root: ['wrapper-root', props.data, props.shouldOmit ? 'shouldOmit' : ''].join(' '),
     }),
   },
-  function SlotsWrapper(props: WrapperProps, ref: React.Ref<HTMLDivElement>) {
+  React.forwardRef(function SlotsWrapper(props: WrapperProps, ref: React.Ref<HTMLDivElement>) {
     return (
       <div ref={ref}>
         <div className="data">{props.data}</div>
@@ -31,7 +31,7 @@ const SlotsWrapper = consumeSlots(
         <div className="classes">{props.classes?.root}</div>
       </div>
     );
-  },
+  }),
 );
 
 describe('consumeSlots', () => {
@@ -91,9 +91,9 @@ describe('consumeSlots', () => {
     render(
       <SlotsWrapper
         slots={{
-          wrapper: (_, ref: React.Ref<HTMLDivElement>) => (
+          wrapper: React.forwardRef((_, ref: React.Ref<HTMLDivElement>) => (
             <div ref={ref}>props and ref arguments</div>
-          ),
+          )),
         }}
       />,
     );


### PR DESCRIPTION
Fix [React 18 tests failing](https://app.circleci.com/pipelines/github/mui/mui-x/84116/workflows/4f11b85a-b719-4dee-988c-d545bbc849d3/jobs/480151) due to missing `forwardRef`.

Issue introduced in [this PR](https://github.com/mui/mui-x/pull/16640). [I had identified](https://github.com/mui/mui-x/pull/16640#discussion_r1973955807) that we needed to add `forwardRef`, but forgot to add it in the PR. It wasn't caught in CI because it isn't needed in React 19, but it is in React 18.