### PR TITLE
[docs] Adjust Picker field lifecycle explanation

### DIFF
--- a/docs/data/date-pickers/lifecycle/lifecycle.md
+++ b/docs/data/date-pickers/lifecycle/lifecycle.md
@@ -20,10 +20,9 @@ The field components have an internal state controlling the visible value.
 
 It will only call the `onChange` callback when:
 
-- the user fills one section of an empty field. The value equals `Invalid date`.
 - the user completes all sections of a field. The value reflects the field.
-- the user cleans one section of a completed field. The value equals `Invalid date`.
-- the user cleans all sections of a field. The value equals `null`.
+  - the value could be `Invalid Date` in case of an unparsable date (i.e., if the [year is less than "100"](https://github.com/iamkun/dayjs/issues/1237) in case of `dayjs`).
+- the user cleans at least one or all sections of a completed field. The value equals `null`.
 
 The example below shows the last value received by `onChange`.
 

--- a/docs/data/date-pickers/lifecycle/lifecycle.md
+++ b/docs/data/date-pickers/lifecycle/lifecycle.md
@@ -21,7 +21,7 @@ The field components have an internal state controlling the visible value.
 It will only call the `onChange` callback when:
 
 - the user completes all sections of a field. The value reflects the field.
-  - the value could be `Invalid Date` in case of an unparsable date (i.e., if the [year is less than "100"](https://github.com/iamkun/dayjs/issues/1237) in case of `dayjs`).
+  - the value will be `Invalid Date` in case of an unparsable date (for example, if the [year is less than "100"](https://github.com/iamkun/dayjs/issues/1237) in case of `dayjs`).
 - the user cleans at least one or all sections of a completed field. The value equals `null`.
 
 The example below shows the last value received by `onChange`.

--- a/docs/data/date-pickers/lifecycle/lifecycle.md
+++ b/docs/data/date-pickers/lifecycle/lifecycle.md
@@ -21,7 +21,7 @@ The field components have an internal state controlling the visible value.
 It will only call the `onChange` callback when:
 
 - the user completes all sections of a field. The value reflects the field.
-  - the value will be `Invalid Date` in case of an unparsable date (for example, if the [year is less than "100"](https://github.com/iamkun/dayjs/issues/1237) in case of `dayjs`).
+  - when the date is not parseable, the `onChange` prop receives an `Invalid Date` (for example, if the [year is less than "100"](https://github.com/iamkun/dayjs/issues/1237) in case of `dayjs`).
 - the user cleans at least one or all sections of a completed field. The value equals `null`.
 
 The example below shows the last value received by `onChange`.


### PR DESCRIPTION
Clarify the field lifecycle section explaining when `onChange` is called and with what values.

The current explanation is no longer valid after https://github.com/mui/mui-x/pull/15875.