### PR TITLE
[infra] changed event trigger from `pull_request` to `pull_request_target`

### DIFF
--- a/.github/workflows/check-if-pr-has-type-label.yml
+++ b/.github/workflows/check-if-pr-has-type-label.yml
@@ -1,7 +1,7 @@
 name: Check PR type label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, labeled, unlabeled]
 
 permissions: {}


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file. The change modifies the event type that triggers the workflow from `pull_request` to `pull_request_target`.

Before it was failing tdue to the Ressuource not being available to the integration (meaning the permissions were insufficient).

* [`.github/workflows/check-if-pr-has-type-label.yml`](diffhunk://#diff-e8fcf79eea3fa306c8271129d4ffddbd9d678d355e91d79beebc29417d0a49a4L4-R4): Changed the event type from `pull_request` to `pull_request_target` to ensure the workflow runs with the correct permissions.