### PR TITLE
[charts] Performance tests auto cleanup and production mode

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -33,6 +33,8 @@ jobs:
           (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'component: charts') ||
           (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'component: charts'))
       }}
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install --frozen-lockfile
       # Ensure we are running on the prod version of our libs
-      - run: pnpm --filter "@mui/x-charts-pro..." build\
+      - run: pnpm --filter "@mui/x-charts-pro..." build
         env:
           NODE_ENV: production
       - name: Run benchmarks

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -33,8 +33,6 @@ jobs:
           (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'component: charts') ||
           (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'component: charts'))
       }}
-    env:
-      NODE_ENV: production
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -47,9 +45,13 @@ jobs:
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install --frozen-lockfile
       # Ensure we are running on the prod version of our libs
-      - run: pnpm --filter "@mui/x-charts-pro..." build
+      - run: pnpm --filter "@mui/x-charts-pro..." build\
+        env:
+          NODE_ENV: production
       - name: Run benchmarks
         uses: CodSpeedHQ/action@63ae6025a0ffee97d7736a37c9192dbd6ed4e75f
+        env:
+          NODE_ENV: production
         with:
           run: pnpm --filter @mui-x-internal/performance-charts test:performance
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { options } from '../utils/options';
@@ -37,8 +37,6 @@ describe('BarChart', () => {
       );
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('BarChart', () => {
   const dataLength = 150;

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('BarChart', () => {
   const dataLength = 150;

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { BarChart } from '@mui/x-charts/BarChart';
+
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('BarChart', () => {
   const dataLength = 150;
@@ -18,7 +18,7 @@ describe('BarChart', () => {
   bench(
     'BarChart with big data amount',
     async () => {
-      const { findByText } = render(
+      const { unmount, findByText } = directRender(
         <BarChart
           xAxis={[
             {
@@ -38,7 +38,7 @@ describe('BarChart', () => {
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { options } from '../utils/options';
@@ -37,6 +37,8 @@ describe('BarChart', () => {
       );
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { options } from '../utils/options';
@@ -33,8 +33,6 @@ describe('BarChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('BarChartPro', () => {
   const dataLength = 400;
@@ -18,7 +17,7 @@ describe('BarChartPro', () => {
   bench(
     'BarChartPro with big data amount',
     async () => {
-      const { findByText } = render(
+      const { unmount, findByText } = directRender(
         <BarChartPro
           xAxis={[{ id: 'x', scaleType: 'band', data: xData, zoom: { filterMode: 'discard' } }]}
           initialZoom={[{ axisId: 'x', start: 25, end: 75 }]}
@@ -34,7 +33,7 @@ describe('BarChartPro', () => {
 
       await findByText('60', { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('BarChartPro', () => {
   const dataLength = 400;

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('BarChartPro', () => {
   const dataLength = 400;

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { options } from '../utils/options';
@@ -33,6 +33,8 @@ describe('BarChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/FunnelChart.bench.tsx
+++ b/test/performance-charts/tests/FunnelChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { Unstable_FunnelChart as FunnelChart } from '@mui/x-charts-pro/FunnelChart';
 import { options } from '../utils/options';
@@ -19,8 +19,6 @@ describe('FunnelChart', () => {
       const { findByText } = render(<FunnelChart series={series} width={500} height={300} />);
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/FunnelChart.bench.tsx
+++ b/test/performance-charts/tests/FunnelChart.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { Unstable_FunnelChart as FunnelChart } from '@mui/x-charts-pro/FunnelChart';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('FunnelChart', () => {
   const dataLength = 10;

--- a/test/performance-charts/tests/FunnelChart.bench.tsx
+++ b/test/performance-charts/tests/FunnelChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { Unstable_FunnelChart as FunnelChart } from '@mui/x-charts-pro/FunnelChart';
 import { options } from '../utils/options';
@@ -19,6 +19,8 @@ describe('FunnelChart', () => {
       const { findByText } = render(<FunnelChart series={series} width={500} height={300} />);
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/FunnelChart.bench.tsx
+++ b/test/performance-charts/tests/FunnelChart.bench.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { Unstable_FunnelChart as FunnelChart } from '@mui/x-charts-pro/FunnelChart';
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('FunnelChart', () => {
   const dataLength = 10;
@@ -16,11 +15,13 @@ describe('FunnelChart', () => {
   bench(
     'FunnelChart with big data amount',
     async () => {
-      const { findByText } = render(<FunnelChart series={series} width={500} height={300} />);
+      const { unmount, findByText } = directRender(
+        <FunnelChart series={series} width={500} height={300} />,
+      );
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/FunnelChart.bench.tsx
+++ b/test/performance-charts/tests/FunnelChart.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { Unstable_FunnelChart as FunnelChart } from '@mui/x-charts-pro/FunnelChart';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('FunnelChart', () => {
   const dataLength = 10;

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('LineChart', () => {
   const dataLength = 200;
@@ -18,7 +17,7 @@ describe('LineChart', () => {
   bench(
     'LineChart with big data amount',
     async () => {
-      const { findByText } = render(
+      const { unmount, findByText } = directRender(
         <LineChart
           xAxis={[{ data: xData }]}
           series={[
@@ -33,7 +32,7 @@ describe('LineChart', () => {
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('LineChart', () => {
   const dataLength = 200;

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { options } from '../utils/options';
@@ -32,8 +32,6 @@ describe('LineChart', () => {
       );
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { options } from '../utils/options';
@@ -32,6 +32,8 @@ describe('LineChart', () => {
       );
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('LineChart', () => {
   const dataLength = 200;

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { LineChartPro } from '@mui/x-charts-pro/LineChartPro';
 import { options } from '../utils/options';
@@ -33,8 +33,6 @@ describe('LineChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { LineChartPro } from '@mui/x-charts-pro/LineChartPro';
 import { options } from '../utils/options';
@@ -33,6 +33,8 @@ describe('LineChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { LineChartPro } from '@mui/x-charts-pro/LineChartPro';
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('LineChartPro', () => {
   const dataLength = 200;
@@ -18,7 +17,7 @@ describe('LineChartPro', () => {
   bench(
     'LineChartPro with big data amount',
     async () => {
-      const { findByText } = render(
+      const { unmount, findByText } = directRender(
         <LineChartPro
           xAxis={[{ id: 'x', data: xData, zoom: { filterMode: 'discard' } }]}
           initialZoom={[{ axisId: 'x', start: 50, end: 75 }]}
@@ -34,7 +33,7 @@ describe('LineChartPro', () => {
 
       await findByText('60', { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { LineChartPro } from '@mui/x-charts-pro/LineChartPro';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('LineChartPro', () => {
   const dataLength = 200;

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { LineChartPro } from '@mui/x-charts-pro/LineChartPro';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('LineChartPro', () => {
   const dataLength = 200;

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { options } from '../utils/options';
@@ -31,6 +31,8 @@ describe('ScatterChart', () => {
       );
 
       await findByText(dataLength.toLocaleString('en-US'), { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('ScatterChart', () => {
   const dataLength = 800;

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('ScatterChart', () => {
   const dataLength = 800;

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { options } from '../utils/options';
@@ -31,8 +31,6 @@ describe('ScatterChart', () => {
       );
 
       await findByText(dataLength.toLocaleString('en-US'), { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('ScatterChart', () => {
   const dataLength = 800;
@@ -17,7 +16,7 @@ describe('ScatterChart', () => {
   bench(
     'ScatterChart with big data amount',
     async () => {
-      const { findByText } = render(
+      const { unmount, findByText } = directRender(
         <ScatterChart
           xAxis={[{ data: xData, valueFormatter: (v) => v.toLocaleString('en-US') }]}
           series={[
@@ -32,7 +31,7 @@ describe('ScatterChart', () => {
 
       await findByText(dataLength.toLocaleString('en-US'), { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, vi } from 'vitest';
+import { bench, describe } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
-
-vi.spyOn(React, 'act').mockImplementation(async (cb) => {
-  await cb();
-});
 
 describe('ScatterChartPro', () => {
   const dataLength = 50;

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, vi } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
+
+vi.spyOn(React, 'act').mockImplementation(async (cb) => {
+  await cb();
+});
 
 describe('ScatterChartPro', () => {
   const dataLength = 50;

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
+import { directRender } from '../utils/directRender';
 
 describe('ScatterChartPro', () => {
   const dataLength = 50;
@@ -17,7 +16,7 @@ describe('ScatterChartPro', () => {
   bench(
     'ScatterChartPro with big data amount',
     async () => {
-      const { findByText } = render(
+      const { unmount, findByText } = directRender(
         <ScatterChartPro
           xAxis={[
             {
@@ -40,7 +39,7 @@ describe('ScatterChartPro', () => {
 
       await findByText('60', { ignore: 'span' });
 
-      cleanup();
+      unmount();
     },
     options,
   );

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render, cleanup } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
@@ -39,8 +39,6 @@ describe('ScatterChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
-
-      cleanup();
     },
     options,
   );

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import { bench, describe } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
@@ -39,6 +39,8 @@ describe('ScatterChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
+
+      cleanup();
     },
     options,
   );

--- a/test/performance-charts/utils/directRender.ts
+++ b/test/performance-charts/utils/directRender.ts
@@ -1,0 +1,33 @@
+import * as ReactDOM from 'react-dom/client';
+import * as React from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { screen } from '@testing-library/react';
+
+export const directRender = (fn: React.JSX.Element) => {
+  const root = document.createElement('div');
+  root.id = 'root';
+  document.body.appendChild(root);
+  const reactRoot = ReactDOM.createRoot(document.querySelector('#root')!);
+
+  reactRoot.render(fn);
+
+  return {
+    unmount: () => reactRoot.unmount(),
+    ...screen,
+    // findByText: async (text: string) => {
+    //   const el = document.querySelector(
+    //     `#root *:not(script):not(style):not(link):not(meta):not(title):not(base):not(template):not(noscript):not(head):not(html):not(body):not(#root)`,
+    //   );
+    //   if (!el) {
+    //     throw new Error('Element not found');
+    //   }
+    //   if (!el.textContent) {
+    //     throw new Error('Element has no text content');
+    //   }
+    //   if (!el.textContent.includes(text)) {
+    //     throw new Error('Text not found');
+    //   }
+    //   return el;
+    // },
+  };
+};

--- a/test/performance-charts/utils/directRender.ts
+++ b/test/performance-charts/utils/directRender.ts
@@ -14,20 +14,5 @@ export const directRender = (fn: React.JSX.Element) => {
   return {
     unmount: () => reactRoot.unmount(),
     ...screen,
-    // findByText: async (text: string) => {
-    //   const el = document.querySelector(
-    //     `#root *:not(script):not(style):not(link):not(meta):not(title):not(base):not(template):not(noscript):not(head):not(html):not(body):not(#root)`,
-    //   );
-    //   if (!el) {
-    //     throw new Error('Element not found');
-    //   }
-    //   if (!el.textContent) {
-    //     throw new Error('Element has no text content');
-    //   }
-    //   if (!el.textContent.includes(text)) {
-    //     throw new Error('Text not found');
-    //   }
-    //   return el;
-    // },
   };
 };

--- a/test/performance-charts/utils/options.ts
+++ b/test/performance-charts/utils/options.ts
@@ -1,5 +1,4 @@
 import { BenchOptions } from 'vitest';
-import { cleanup } from '@testing-library/react';
 
 const iterations = globalThis.process?.env?.BENCHMARK_ITERATIONS
   ? parseInt(globalThis.process.env.BENCHMARK_ITERATIONS, 10)
@@ -7,7 +6,4 @@ const iterations = globalThis.process?.env?.BENCHMARK_ITERATIONS
 
 export const options: BenchOptions = {
   iterations,
-  teardown: () => {
-    cleanup();
-  },
 };

--- a/test/performance-charts/utils/options.ts
+++ b/test/performance-charts/utils/options.ts
@@ -1,4 +1,5 @@
 import { BenchOptions } from 'vitest';
+import { cleanup } from '@testing-library/react';
 
 const iterations = globalThis.process?.env?.BENCHMARK_ITERATIONS
   ? parseInt(globalThis.process.env.BENCHMARK_ITERATIONS, 10)
@@ -6,4 +7,7 @@ const iterations = globalThis.process?.env?.BENCHMARK_ITERATIONS
 
 export const options: BenchOptions = {
   iterations,
+  teardown: () => {
+    cleanup();
+  },
 };

--- a/test/performance-charts/vitest.config.ts
+++ b/test/performance-charts/vitest.config.ts
@@ -6,7 +6,6 @@ const isCI = process.env.CI === 'true';
 
 export default defineConfig({
   plugins: [...(isCI ? [codspeedPlugin()] : []), react()],
-  mode: 'production',
   test: {
     setupFiles: ['./setup.ts'],
     environment: 'jsdom',

--- a/test/performance-charts/vitest.config.ts
+++ b/test/performance-charts/vitest.config.ts
@@ -6,6 +6,7 @@ const isCI = process.env.CI === 'true';
 
 export default defineConfig({
   plugins: [...(isCI ? [codspeedPlugin()] : []), react()],
+  mode: 'production',
   test: {
     setupFiles: ['./setup.ts'],
     environment: 'jsdom',


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16750

@bernardobelchior running on production slices ~10-15% off individual tests, though it could be because of the custom renderer.

Do I know if there is any side-effect related to the custom render? No, but I wanted to try it out, since RTL doesn't work well with `NODE_ENV=production`.

Not sure if the hassle is worth the 10-15% cut, since it is relative anyways, and the actual chart render comprises of a very small part of the code 😓

All the react setup seems to happen inside the calculated time as well

https://codspeed.io/mui/mui-x/branches/JCQuintas%3Aautocleanup-and-production-mode