### PR TITLE
[DataGridPro] Fix infinite loading not reacting on scrolling to the end

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
@@ -67,10 +67,7 @@ export const useGridInfiniteLoader = (
 
   React.useEffect(() => {
     const virtualScroller = apiRef.current.virtualScrollerRef.current;
-    if (!isEnabled) {
-      return;
-    }
-    if (!virtualScroller) {
+    if (!isEnabled || !isReady || !virtualScroller) {
       return;
     }
     observer.current?.disconnect();

--- a/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
@@ -5,6 +5,7 @@ import {
   useGridApiOptionHandler,
   gridVisibleColumnDefinitionsSelector,
   useGridApiMethod,
+  gridDimensionsSelector,
 } from '@mui/x-data-grid';
 import {
   useGridVisibleRows,
@@ -37,6 +38,7 @@ export const useGridInfiniteLoader = (
     'onRowsScrollEnd' | 'pagination' | 'paginationMode' | 'rowsLoadingMode' | 'scrollEndThreshold'
   >,
 ): void => {
+  const isReady = useGridSelector(apiRef, gridDimensionsSelector).isReady;
   const visibleColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
   const currentPage = useGridVisibleRows(apiRef, props);
   const observer = React.useRef<IntersectionObserver>(null);
@@ -63,9 +65,8 @@ export const useGridInfiniteLoader = (
     }
   });
 
-  const virtualScroller = apiRef.current.virtualScrollerRef.current;
-
   React.useEffect(() => {
+    const virtualScroller = apiRef.current.virtualScrollerRef.current;
     if (!isEnabled) {
       return;
     }
@@ -85,7 +86,7 @@ export const useGridInfiniteLoader = (
     if (triggerElement.current) {
       observer.current.observe(triggerElement.current);
     }
-  }, [apiRef, virtualScroller, handleLoadMoreRows, isEnabled, props.scrollEndThreshold]);
+  }, [apiRef, isReady, handleLoadMoreRows, isEnabled, props.scrollEndThreshold]);
 
   const updateTarget = (node: HTMLElement | null) => {
     if (triggerElement.current !== node) {

--- a/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
@@ -63,8 +63,9 @@ export const useGridInfiniteLoader = (
     }
   });
 
+  const virtualScroller = apiRef.current.virtualScrollerRef.current;
+
   React.useEffect(() => {
-    const virtualScroller = apiRef.current.virtualScrollerRef.current;
     if (!isEnabled) {
       return;
     }
@@ -84,7 +85,7 @@ export const useGridInfiniteLoader = (
     if (triggerElement.current) {
       observer.current.observe(triggerElement.current);
     }
-  }, [apiRef, handleLoadMoreRows, isEnabled, props.scrollEndThreshold]);
+  }, [apiRef, virtualScroller, handleLoadMoreRows, isEnabled, props.scrollEndThreshold]);
 
   const updateTarget = (node: HTMLElement | null) => {
     if (triggerElement.current !== node) {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16906

~~Reverts the change made to the infinite loading in https://github.com/mui/mui-x/pull/16488~~

Had to take a different approach. In tests, virtual scroll reference is never updated so the observer is not attached.
Waiting until dimensions are ready does the trick.

@cherniavskii since you did the changes in https://github.com/mui/mui-x/pull/16488 do you see any issues with the update?

Before: https://mui.com/x/react-data-grid/row-updates/#infinite-loading
After: https://deploy-preview-16926--material-ui-x.netlify.app/x/react-data-grid/row-updates/#infinite-loading
