### PR TITLE
[charts] Remove the polar axis plugin from the default plugins of the ChartContainer

### DIFF
--- a/packages/x-charts-pro/src/ChartContainerPro/useChartContainerProProps.ts
+++ b/packages/x-charts-pro/src/ChartContainerPro/useChartContainerProProps.ts
@@ -8,7 +8,7 @@ import {
 import * as React from 'react';
 import { ChartDataProviderProps } from '@mui/x-charts/ChartDataProvider';
 import type { ChartContainerProProps } from './ChartContainerPro';
-import { ALL_PLUGINS, AllPluginSignatures } from '../internals/plugins/allPlugins';
+import { DEFAULT_PLUGINS, AllPluginSignatures } from '../internals/plugins/allPlugins';
 
 export type UseChartContainerProPropsReturnValue<
   TSeries extends ChartSeriesType,
@@ -41,7 +41,7 @@ export const useChartContainerProProps = <
     zoomData,
     onZoomChange,
     apiRef,
-    plugins: plugins ?? ALL_PLUGINS,
+    plugins: plugins ?? DEFAULT_PLUGINS,
   } as unknown as ChartDataProviderProps<TSeries, TSignatures>;
 
   return {

--- a/packages/x-charts-pro/src/internals/plugins/allPlugins.ts
+++ b/packages/x-charts-pro/src/internals/plugins/allPlugins.ts
@@ -36,3 +36,23 @@ export const ALL_PLUGINS = [
   useChartHighlight,
   useChartProZoom,
 ];
+
+export type DefaultPluginSignatures<TSeries extends ChartSeriesType = ChartSeriesType> = [
+  UseChartZAxisSignature,
+  UseChartCartesianAxisSignature<TSeries>,
+  UseChartPolarAxisSignature<TSeries>,
+  UseChartInteractionSignature,
+  UseChartHighlightSignature,
+  UseChartProZoomSignature,
+];
+
+export type DefaultPluginsType<TSeries extends ChartSeriesType = ChartSeriesType> =
+  ConvertSignaturesIntoPlugins<DefaultPluginSignatures<TSeries>>;
+
+export const DEFAULT_PLUGINS = [
+  useChartZAxis,
+  useChartCartesianAxis,
+  useChartInteraction,
+  useChartHighlight,
+  useChartProZoom,
+];

--- a/packages/x-charts/src/ChartContainer/useChartContainerProps.ts
+++ b/packages/x-charts/src/ChartContainer/useChartContainerProps.ts
@@ -4,7 +4,7 @@ import { ChartsSurfaceProps } from '../ChartsSurface';
 import { ChartDataProviderProps } from '../ChartDataProvider';
 import type { ChartContainerProps } from './ChartContainer';
 import { ChartSeriesType } from '../models/seriesType/config';
-import { ALL_PLUGINS, AllPluginSignatures } from '../internals/plugins/allPlugins';
+import { DEFAULT_PLUGINS, AllPluginSignatures } from '../internals/plugins/allPlugins';
 import { ChartAnyPluginSignature } from '../internals/plugins/models/plugin';
 
 export type UseChartContainerPropsReturnValue<
@@ -81,7 +81,7 @@ export const useChartContainerProps = <
     width,
     height,
     seriesConfig,
-    plugins: plugins ?? ALL_PLUGINS,
+    plugins: plugins ?? DEFAULT_PLUGINS,
   } as unknown as Omit<ChartDataProviderProps<TSeries, TSignatures>, 'children'>;
 
   return {

--- a/packages/x-charts/src/internals/plugins/allPlugins.ts
+++ b/packages/x-charts/src/internals/plugins/allPlugins.ts
@@ -34,3 +34,23 @@ export const ALL_PLUGINS = [
   useChartHighlight,
   useChartVoronoi,
 ];
+
+export type DefaultPluginSignatures<TSeries extends ChartSeriesType = ChartSeriesType> = [
+  UseChartZAxisSignature,
+  UseChartCartesianAxisSignature<TSeries>,
+  UseChartPolarAxisSignature,
+  UseChartInteractionSignature,
+  UseChartHighlightSignature,
+  UseChartVoronoiSignature,
+];
+
+export type DefaultPluginsType<TSeries extends ChartSeriesType = ChartSeriesType> =
+  ConvertSignaturesIntoPlugins<DefaultPluginSignatures<TSeries>>;
+
+export const DEFAULT_PLUGINS = [
+  useChartZAxis,
+  useChartCartesianAxis,
+  useChartInteraction,
+  useChartHighlight,
+  useChartVoronoi,
+];


### PR DESCRIPTION
The polar event handler was triggered even if no polar axis are provided. So I removed the plugin.

Latter we could remove this `ChartContainer` by `CartesianChartContainer` and let all the other chart get `RadarChartContainer`, `PieChartContainer`, ...