### PR TITLE
[DataGrid] Bug: Avoid Breakage When Deleting Rows In An "Edit" State

### DIFF
--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -518,7 +518,13 @@ export const useGridRowEditing = (
 
       const editingState = gridEditRowsStateSelector(apiRef);
       const row = prevRowValuesLookup.current[id];
-
+      
+      // If the row no longer exists (e.g., it has been removed from the grid), we cannot proceed with any row update.
+      if (!row) {
+        finishRowEditMode();
+        return;
+      }
+      
       const isSomeFieldProcessingProps = Object.values(editingState[id]).some(
         (fieldProps) => fieldProps.isProcessingProps,
       );


### PR DESCRIPTION
Hi,

**Problem:**
When editing a row, if the row is deleted (or the grid data is cleared) while it’s still in edit mode, the code attempts to update a row that no longer exists, leading to errors. This happens because the row object fetched via `apiRef.current.getRow(id)` is null when the row is deleted.
The absence of the row in this case would result in the code failing during the row update process.

**Solution:**
To prevent this, a check was added to ensure that the row exists before attempting to perform any update operations. If the row no longer exists (i.e., it is null), the function exits early and cleans up the row's edit state without attempting to perform any further updates.
This ensures that if a row is deleted or the grid is cleared during editing, the row edit state is properly finalized without causing errors or undefined behavior.

**Changes Made:**
Added a check to verify if the row exists before processing any updates. If the row is null (meaning it no longer exists), the function immediately calls `finishRowEditMode()` to safely exit edit mode without trying to update a non-existent row.

**Results:**
This change prevents errors when a row is deleted or the data grid is cleared during an active row edit session.
It ensures that the editing process is cleaned up properly when a row is no longer available, allowing the grid to continue functioning without issues.

Thanks,
Blake