### PR TITLE
[core] Allow MUI Core v7 in dependencies

### DIFF
--- a/packages/x-charts-pro/README.md
+++ b/packages/x-charts-pro/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-charts-pro/package.json
+++ b/packages/x-charts-pro/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-charts": "workspace:*",
     "@mui/x-charts-vendor": "workspace:*",
     "@mui/x-internals": "workspace:*",
@@ -53,8 +53,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-charts/README.md
+++ b/packages/x-charts/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-charts-vendor": "workspace:*",
     "@mui/x-internals": "workspace:*",
     "@react-spring/rafz": "^9.7.5",
@@ -51,8 +51,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -50,8 +50,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/icons-material": "^5.4.1 || ^6.0.0",
-    "@mui/material": "^5.15.14 || ^6.0.0",
+    "@mui/icons-material": "^5.4.1 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/x-data-grid-premium/README.md
+++ b/packages/x-data-grid-premium/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-data-grid": "workspace:*",
     "@mui/x-data-grid-pro": "workspace:*",
     "@mui/x-internals": "workspace:*",
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-data-grid-pro/README.md
+++ b/packages/x-data-grid-pro/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-data-grid": "workspace:*",
     "@mui/x-internals": "workspace:*",
     "@mui/x-license": "workspace:*",
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-data-grid/README.md
+++ b/packages/x-data-grid/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-internals": "workspace:*",
     "clsx": "^2.1.1",
     "prop-types": "^15.8.1",
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-date-pickers-pro/README.md
+++ b/packages/x-date-pickers-pro/README.md
@@ -34,7 +34,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-date-pickers": "workspace:*",
     "@mui/x-internals": "workspace:*",
     "@mui/x-license": "workspace:*",
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
     "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
     "dayjs": "^1.10.7",

--- a/packages/x-date-pickers/README.md
+++ b/packages/x-date-pickers/README.md
@@ -34,7 +34,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-internals": "workspace:*",
     "@types/react-transition-group": "^4.4.11",
     "clsx": "^2.1.1",
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
     "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
     "dayjs": "^1.10.7",

--- a/packages/x-internals/package.json
+++ b/packages/x-internals/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0"
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-internals": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/x-tree-view-pro/README.md
+++ b/packages/x-tree-view-pro/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-internals": "workspace:*",
     "@mui/x-license": "workspace:*",
     "@mui/x-tree-view": "workspace:*",
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/packages/x-tree-view/README.md
+++ b/packages/x-tree-view/README.md
@@ -15,7 +15,7 @@ This component has the following peer dependencies that you will need to install
 
 ```json
 "peerDependencies": {
-  "@mui/material": "^5.15.14 || ^6.0.0",
+  "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
   "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
   "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 },

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.25.7",
-    "@mui/utils": "^5.16.6 || ^6.0.0",
+    "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "@mui/x-internals": "workspace:*",
     "@types/react-transition-group": "^4.4.11",
     "clsx": "^2.1.1",
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.15.14 || ^6.0.0",
-    "@mui/system": "^5.15.14 || ^6.0.0",
+    "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+    "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,7 +737,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-charts-vendor':
         specifier: workspace:*
@@ -802,7 +802,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-charts':
         specifier: workspace:*
@@ -987,7 +987,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1093,7 +1093,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-data-grid':
         specifier: workspace:*
@@ -1161,7 +1161,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-data-grid':
         specifier: workspace:*
@@ -1220,7 +1220,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1306,7 +1306,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-date-pickers':
         specifier: workspace:*
@@ -1380,7 +1380,7 @@ importers:
         specifier: ^7.25.7
         version: 7.26.0
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
     devDependencies:
       '@mui/internal-test-utils':
@@ -1403,7 +1403,7 @@ importers:
         specifier: ^7.25.7
         version: 7.26.0
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1435,7 +1435,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-internals':
         specifier: workspace:*
@@ -1488,7 +1488,7 @@ importers:
         specifier: ^11.8.1
         version: 11.13.0(@emotion/react@11.14.0(@types/react@19.0.2)(react@19.0.0))(@types/react@19.0.2)(react@19.0.0)
       '@mui/utils':
-        specifier: ^5.16.6 || ^6.0.0
+        specifier: ^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta
         version: 5.16.13(@types/react@19.0.2)(react@19.0.0)
       '@mui/x-internals':
         specifier: workspace:*


### PR DESCRIPTION
Add support for MUI Core libraries v7 versions to peer dependencies to support migration from v5 to v7 of Core packages before upgrading MUI X to v8.

> [!NOTE]
> Tested on a minimal project locally all X v7 with Core v7 libraries, and they seem to work fine. 👌 