### PR TITLE
[test] Fix Apple M3 failing to execute unit test cases

### DIFF
--- a/packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx
+++ b/packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx
@@ -8,7 +8,7 @@ import { gridPinnedRowsCountSelector } from '../rows/gridRowsSelector';
 import { GridLoadingOverlayVariant } from '../../../components/GridLoadingOverlay';
 import { GridOverlayWrapper } from '../../../components/base/GridOverlays';
 import type { GridOverlayType } from '../../../components/base/GridOverlays';
-import { gridVisibleColumnDefinitionsSelector } from '..';
+import { gridVisibleColumnDefinitionsSelector } from '../columns';
 
 /**
  * Uses the grid state to determine which overlay to display.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Apple M3 is unable to execute unit test cases. On the other hand, the Apple Intel processor has no problem running them.
The `selector` is undefined.

```bash
➜  mui-x git:(master) npx cross-env NODE_OPTIONS=--max-old-space-size=4096 NODE_ENV=test TZ=UTC mocha  packages/x-data-grid/src/tests/columnGrouping.DataGrid.test.tsx
including inaccessible elements by default
[
  '3gp',  'aac',  'doc',
  'docx', 'm4a',  'ppt',
  'pptx', 'txt',  'webp',
  'xls',  'xlsx'
]


  !!!!!!!!!!!,,,,

  0 passing (83ms)
  4 pending
  11 failing

  1) <DataGrid /> - Column grouping
       Header grouping columns
         should add one header row when columns have a group:
     TypeError: selector is not a function
      at useGridSelector (packages/x-data-grid/src/hooks/utils/useGridSelector.ts:72:23)
      at useGridOverlays (packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx:24:41)
      at GridVirtualScroller (packages/x-data-grid/src/components/virtualization/GridVirtualScroller.tsx:88:56)
      at Object.react-stack-bottom-frame (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:22428:20)
      at renderWithHooks (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:5757:22)
      at updateFunctionComponent (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:8018:19)
      at beginWork (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:9683:18)
      at runWithFiberInDEV (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:543:16)
      at performUnitOfWork (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:15044:22)
      at workLoopSync (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:14870:41)
      at renderRootSync (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:14850:11)
      at performWorkOnRoot (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:14384:44)
      at performWorkOnRootViaSchedulerTask (node_modules/.pnpm/react-dom@19.0.0_react@19.0.0/node_modules/react-dom/cjs/react-dom-client.development.js:15931:7)
      at flushActQueue (node_modules/.pnpm/react@19.0.0/node_modules/react/cjs/react.development.js:862:34)
      at process.env.NODE_ENV.exports.act (node_modules/.pnpm/react@19.0.0/node_modules/react/cjs/react.development.js:1151:10)
      at /Users/steve/work/test/mui-x/node_modules/.pnpm/@testing-library+react@16.2.0_@testing-library+dom@10.4.0_@types+react-dom@19.0.4_@types+reac_4qqh6yguqwrorusxxqzlwjc5ha/node_modules/@testing-library/react/dist/act-compat.js:47:25
      at renderRoot (node_modules/.pnpm/@testing-library+react@16.2.0_@testing-library+dom@10.4.0_@types+react-dom@19.0.4_@types+reac_4qqh6yguqwrorusxxqzlwjc5ha/node_modules/@testing-library/react/dist/pure.js:188:26)
      at render (node_modules/.pnpm/@testing-library+react@16.2.0_@testing-library+dom@10.4.0_@types+react-dom@19.0.4_@types+reac_4qqh6yguqwrorusxxqzlwjc5ha/node_modules/@testing-library/react/dist/pure.js:287:10)
      at /Users/steve/work/test/mui-x/node_modules/.pnpm/@mui+internal-test-utils@2.0.3_@babel+core@7.26.10_@types+react-dom@19.0.4_@types+react@19.0._5wroap62emktc3t3ollqlaogxm/node_modules/@mui/internal-test-utils/src/createRenderer.tsx:262:25
      at noTrace (node_modules/.pnpm/@mui+internal-test-utils@2.0.3_@babel+core@7.26.10_@types+react-dom@19.0.4_@types+react@19.0._5wroap62emktc3t3ollqlaogxm/node_modules/@mui/internal-test-utils/src/createRenderer.tsx:32:10)
      at render (node_modules/.pnpm/@mui+internal-test-utils@2.0.3_@babel+core@7.26.10_@types+react-dom@19.0.4_@types+react@19.0._5wroap62emktc3t3ollqlaogxm/node_modules/@mui/internal-test-utils/src/createRenderer.tsx:261:38)
      at render (node_modules/.pnpm/@mui+internal-test-utils@2.0.3_@babel+core@7.26.10_@types+react-dom@19.0.4_@types+react@19.0._5wroap62emktc3t3ollqlaogxm/node_modules/@mui/internal-test-utils/src/createRenderer.tsx:664:14)
      at Context.<anonymous> (packages/x-data-grid/src/tests/columnGrouping.DataGrid.test.tsx:43:7)
      at processImmediate (node:internal/timers:483:21)
```

You can fix this problem by changing `useGridOverlays.tsx` like this:

```bash
➜  mui-x git:(master) ✗ echo "$(git diff HEAD)"
diff --git a/packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx b/packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx
index 3327b8bf5..8f7a7ad67 100644
--- a/packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx
+++ b/packages/x-data-grid/src/hooks/features/overlays/useGridOverlays.tsx
@@ -8,7 +8,7 @@ import { gridPinnedRowsCountSelector } from '../rows/gridRowsSelector';
 import { GridLoadingOverlayVariant } from '../../../components/GridLoadingOverlay';
 import { GridOverlayWrapper } from '../../../components/base/GridOverlays';
 import type { GridOverlayType } from '../../../components/base/GridOverlays';
-import { gridVisibleColumnDefinitionsSelector } from '..';
+import { gridVisibleColumnDefinitionsSelector } from '../columns';

 /**
  * Uses the grid state to determine which overlay to display.
➜  mui-x git:(master) ✗ npx cross-env NODE_OPTIONS=--max-old-space-size=4096 NODE_ENV=test TZ=UTC mocha  packages/x-data-grid/src/tests/columnGrouping.DataGrid.test.tsx
including inaccessible elements by default


  ...........,,,,

  11 passing (457ms)
  4 pending

```

**npx @mui/envinfo**

```bash
  System:
    OS: macOS 15.3.1
  Binaries:
    Node: 20.18.3 - ~/.nvm/versions/node/v20.18.3/bin/node
    npm: 10.8.2 - ~/.nvm/versions/node/v20.18.3/bin/npm
    pnpm: 9.15.4 - ~/.nvm/versions/node/v20.18.3/bin/pnpm
  Browsers:
    Chrome: 134.0.6998.89
    Edge: 134.0.3124.62
    Safari: 18.3
  npmPackages:
    @emotion/react: ^11.14.0 => 11.14.0
    @emotion/styled: ^11.14.0 => 11.14.0
    @mui/icons-material: ^5.16.14 => 5.16.14
    @mui/internal-babel-plugin-resolve-imports: 1.0.20 => 1.0.20
    @mui/internal-markdown: ^2.0.1 => 2.0.1
    @mui/internal-test-utils: ^2.0.3 => 2.0.3
    @mui/material: ^5.16.14 => 5.16.14
    @mui/monorepo: github:mui/material-ui#87194996f65fdce52dea3466aeb04a2195457521 => 7.0.0-alpha.1
    @mui/utils: ^5.16.14 => 5.16.14
    @types/react: ^19.0.10 => 19.0.10
    react: ^19.0.0 => 19.0.0
    react-dom: ^19.0.0 => 19.0.0
    typescript: ^5.8.2 => 5.8.2
```
