### PR TITLE
[docs] Remove `showQuickFilter: true` toolbar prop from demos

### DIFF
--- a/docs/data/data-grid/features/FullFeaturedDemo.js
+++ b/docs/data/data-grid/features/FullFeaturedDemo.js
@@ -305,9 +305,6 @@ export default function FullFeaturedDemo() {
       <DataGridComponent
         {...data}
         showToolbar
-        slotProps={{
-          toolbar: { showQuickFilter: true },
-        }}
         loading={loading}
         checkboxSelection
         disableRowSelectionOnClick

--- a/docs/data/data-grid/features/FullFeaturedDemo.tsx
+++ b/docs/data/data-grid/features/FullFeaturedDemo.tsx
@@ -345,9 +345,6 @@ export default function FullFeaturedDemo() {
       <DataGridComponent
         {...data}
         showToolbar
-        slotProps={{
-          toolbar: { showQuickFilter: true },
-        }}
         loading={loading}
         checkboxSelection
         disableRowSelectionOnClick

--- a/docs/data/data-grid/features/PopularFeaturesDemo.js
+++ b/docs/data/data-grid/features/PopularFeaturesDemo.js
@@ -492,9 +492,6 @@ export default function PopularFeaturesDemo() {
           detailPanelCollapseIcon: ArrowUp,
         }}
         showToolbar
-        slotProps={{
-          toolbar: { showQuickFilter: true },
-        }}
         getDetailPanelContent={getDetailPanelContent}
         getDetailPanelHeight={getDetailPanelHeight}
         getRowHeight={getRowHeight}

--- a/docs/data/data-grid/features/PopularFeaturesDemo.tsx
+++ b/docs/data/data-grid/features/PopularFeaturesDemo.tsx
@@ -513,9 +513,6 @@ export default function PopularFeaturesDemo() {
           detailPanelCollapseIcon: ArrowUp,
         }}
         showToolbar
-        slotProps={{
-          toolbar: { showQuickFilter: true },
-        }}
         getDetailPanelContent={getDetailPanelContent}
         getDetailPanelHeight={getDetailPanelHeight}
         getRowHeight={getRowHeight}

--- a/docs/data/data-grid/filtering/QuickFilteringDiacritics.js
+++ b/docs/data/data-grid/filtering/QuickFilteringDiacritics.js
@@ -54,7 +54,6 @@ export default function QuickFilteringDiacritics() {
           disableDensitySelector
           hideFooter
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
           ignoreDiacritics={ignoreDiacritics}
         />
       </div>

--- a/docs/data/data-grid/filtering/QuickFilteringDiacritics.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringDiacritics.tsx
@@ -55,7 +55,6 @@ export default function QuickFilteringDiacritics() {
           disableDensitySelector
           hideFooter
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
           ignoreDiacritics={ignoreDiacritics}
         />
       </div>

--- a/docs/data/data-grid/filtering/QuickFilteringExcludeHiddenColumns.js
+++ b/docs/data/data-grid/filtering/QuickFilteringExcludeHiddenColumns.js
@@ -76,11 +76,6 @@ export default function QuickFilteringExcludeHiddenColumns() {
           disableColumnSelector
           disableDensitySelector
           showToolbar
-          slotProps={{
-            toolbar: {
-              showQuickFilter: true,
-            },
-          }}
           filterModel={filterModel}
           onFilterModelChange={handleFilterModelChange}
           columnVisibilityModel={columnVisibilityModel}

--- a/docs/data/data-grid/filtering/QuickFilteringExcludeHiddenColumns.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringExcludeHiddenColumns.tsx
@@ -80,11 +80,6 @@ export default function QuickFilteringExcludeHiddenColumns() {
           disableColumnSelector
           disableDensitySelector
           showToolbar
-          slotProps={{
-            toolbar: {
-              showQuickFilter: true,
-            },
-          }}
           filterModel={filterModel}
           onFilterModelChange={handleFilterModelChange}
           columnVisibilityModel={columnVisibilityModel}

--- a/docs/data/data-grid/filtering/QuickFilteringGrid.js
+++ b/docs/data/data-grid/filtering/QuickFilteringGrid.js
@@ -23,11 +23,6 @@ export default function QuickFilteringGrid() {
         disableDensitySelector
         columns={columns}
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringGrid.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringGrid.tsx
@@ -23,11 +23,6 @@ export default function QuickFilteringGrid() {
         disableDensitySelector
         columns={columns}
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringGrid.tsx.preview
+++ b/docs/data/data-grid/filtering/QuickFilteringGrid.tsx.preview
@@ -5,9 +5,4 @@
   disableDensitySelector
   columns={columns}
   showToolbar
-  slotProps={{
-    toolbar: {
-      showQuickFilter: true,
-    },
-  }}
 />

--- a/docs/data/data-grid/filtering/QuickFilteringInitialize.js
+++ b/docs/data/data-grid/filtering/QuickFilteringInitialize.js
@@ -31,11 +31,6 @@ export default function QuickFilteringInitialize() {
         disableDensitySelector
         columns={columns}
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringInitialize.tsx
+++ b/docs/data/data-grid/filtering/QuickFilteringInitialize.tsx
@@ -31,11 +31,6 @@ export default function QuickFilteringInitialize() {
         disableDensitySelector
         columns={columns}
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/filtering/QuickFilteringInitialize.tsx.preview
+++ b/docs/data/data-grid/filtering/QuickFilteringInitialize.tsx.preview
@@ -1,0 +1,16 @@
+<DataGrid
+  {...data}
+  initialState={{
+    filter: {
+      filterModel: {
+        items: [],
+        quickFilterValues: ['Disney', 'Star'],
+      },
+    },
+  }}
+  disableColumnFilter
+  disableColumnSelector
+  disableDensitySelector
+  columns={columns}
+  showToolbar
+/>

--- a/docs/data/data-grid/overlays/NoResultsOverlay.js
+++ b/docs/data/data-grid/overlays/NoResultsOverlay.js
@@ -24,11 +24,6 @@ export default function NoResultsOverlay() {
           },
         }}
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overlays/NoResultsOverlay.tsx
+++ b/docs/data/data-grid/overlays/NoResultsOverlay.tsx
@@ -24,11 +24,6 @@ export default function NoResultsOverlay() {
           },
         }}
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </Box>
   );

--- a/docs/data/data-grid/overlays/NoResultsOverlay.tsx.preview
+++ b/docs/data/data-grid/overlays/NoResultsOverlay.tsx.preview
@@ -1,0 +1,13 @@
+<DataGrid
+  {...data}
+  initialState={{
+    ...data.initialState,
+    filter: {
+      filterModel: {
+        items: [],
+        quickFilterValues: ['abc'],
+      },
+    },
+  }}
+  showToolbar
+/>

--- a/docs/data/data-grid/overlays/NoResultsOverlayCustom.js
+++ b/docs/data/data-grid/overlays/NoResultsOverlayCustom.js
@@ -80,11 +80,6 @@ export default function NoResultsOverlayCustom() {
             },
           },
         }}
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/overlays/NoResultsOverlayCustom.tsx
+++ b/docs/data/data-grid/overlays/NoResultsOverlayCustom.tsx
@@ -80,11 +80,6 @@ export default function NoResultsOverlayCustom() {
             },
           },
         }}
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/overlays/NoResultsOverlayCustom.tsx.preview
+++ b/docs/data/data-grid/overlays/NoResultsOverlayCustom.tsx.preview
@@ -1,0 +1,16 @@
+<DataGrid
+  {...data}
+  showToolbar
+  slots={{
+    noResultsOverlay: CustomNoResultsOverlay,
+  }}
+  initialState={{
+    ...data.initialState,
+    filter: {
+      filterModel: {
+        items: [],
+        quickFilterValues: ['abc'],
+      },
+    },
+  }}
+/>

--- a/docs/data/data-grid/row-selection/KeepNonExistentRowsSelected.js
+++ b/docs/data/data-grid/row-selection/KeepNonExistentRowsSelected.js
@@ -17,11 +17,6 @@ export default function KeepNonExistentRowsSelected() {
         disableRowSelectionOnClick
         keepNonExistentRowsSelected
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/row-selection/KeepNonExistentRowsSelected.tsx
+++ b/docs/data/data-grid/row-selection/KeepNonExistentRowsSelected.tsx
@@ -17,11 +17,6 @@ export default function KeepNonExistentRowsSelected() {
         disableRowSelectionOnClick
         keepNonExistentRowsSelected
         showToolbar
-        slotProps={{
-          toolbar: {
-            showQuickFilter: true,
-          },
-        }}
       />
     </div>
   );

--- a/docs/data/data-grid/row-selection/KeepNonExistentRowsSelected.tsx.preview
+++ b/docs/data/data-grid/row-selection/KeepNonExistentRowsSelected.tsx.preview
@@ -4,9 +4,4 @@
   disableRowSelectionOnClick
   keepNonExistentRowsSelected
   showToolbar
-  slotProps={{
-    toolbar: {
-      showQuickFilter: true,
-    },
-  }}
 />

--- a/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.js
+++ b/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.js
@@ -65,11 +65,6 @@ export default function ServerSideRowGroupingFullDataGrid() {
           apiRef={apiRef}
           initialState={initialState}
           showToolbar
-          slotProps={{
-            toolbar: {
-              showQuickFilter: true,
-            },
-          }}
           groupingColDef={{
             width: 250,
           }}

--- a/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx
@@ -66,11 +66,6 @@ export default function ServerSideRowGroupingFullDataGrid() {
           apiRef={apiRef}
           initialState={initialState}
           showToolbar
-          slotProps={{
-            toolbar: {
-              showQuickFilter: true,
-            },
-          }}
           groupingColDef={{
             width: 250,
           }}

--- a/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx.preview
+++ b/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx.preview
@@ -1,0 +1,14 @@
+<Button onClick={loadNewData}>Regenerate Data</Button>
+
+<div style={{ height: 450, position: 'relative' }}>
+  <DataGridPremium
+    columns={columns}
+    dataSource={dataSource}
+    apiRef={apiRef}
+    initialState={initialState}
+    showToolbar
+    groupingColDef={{
+      width: 250,
+    }}
+  />
+</div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeData.js
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeData.js
@@ -66,7 +66,6 @@ export default function ServerSideTreeData() {
           pageSizeOptions={pageSizeOptions}
           initialState={initialStateWithPagination}
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
         />
       </div>
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeData.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeData.tsx
@@ -71,7 +71,6 @@ export default function ServerSideTreeData() {
           pageSizeOptions={pageSizeOptions}
           initialState={initialStateWithPagination}
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
         />
       </div>
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.js
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.js
@@ -97,7 +97,6 @@ export default function ServerSideTreeDataCustomCache() {
           pageSizeOptions={pageSizeOptions}
           initialState={initialState}
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
         />
       </div>
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.tsx
@@ -104,7 +104,6 @@ export default function ServerSideTreeDataCustomCache() {
           pageSizeOptions={pageSizeOptions}
           initialState={initialState}
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
         />
       </div>
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.tsx.preview
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataCustomCache.tsx.preview
@@ -10,6 +10,5 @@
     pageSizeOptions={pageSizeOptions}
     initialState={initialState}
     showToolbar
-    slotProps={{ toolbar: { showQuickFilter: true } }}
   />
 </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataGroupExpansion.js
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataGroupExpansion.js
@@ -66,7 +66,6 @@ export default function ServerSideTreeDataGroupExpansion() {
           pageSizeOptions={pageSizeOptions}
           initialState={initialStateWithPagination}
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
           defaultGroupingExpansionDepth={-1}
         />
       </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataGroupExpansion.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataGroupExpansion.tsx
@@ -73,7 +73,6 @@ export default function ServerSideTreeDataGroupExpansion() {
           pageSizeOptions={pageSizeOptions}
           initialState={initialStateWithPagination}
           showToolbar
-          slotProps={{ toolbar: { showQuickFilter: true } }}
           defaultGroupingExpansionDepth={-1}
         />
       </div>

--- a/docs/data/data-grid/server-side-data/ServerSideTreeDataGroupExpansion.tsx.preview
+++ b/docs/data/data-grid/server-side-data/ServerSideTreeDataGroupExpansion.tsx.preview
@@ -11,5 +11,6 @@
     pageSizeOptions={pageSizeOptions}
     initialState={initialStateWithPagination}
     showToolbar
+    defaultGroupingExpansionDepth={-1}
   />
 </div>


### PR DESCRIPTION
Removes the explicit setting of `slotProps={{ toolbar: { showQuickFilter: true } }}` from demos since it is now the default.

Part of https://github.com/mui/mui-x/issues/16864