### PR TITLE
[DataGrid] Fix page scrolling when preference panel is opened

### DIFF
--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -560,7 +560,7 @@ function focusTrapWrapper(props: PopperProps, content: any) {
     return content;
   }
   return (
-    <MUIFocusTrap open disableEnforceFocus>
+    <MUIFocusTrap open disableEnforceFocus disableAutoFocus>
       <div tabIndex={-1}>{content}</div>
     </MUIFocusTrap>
   );


### PR DESCRIPTION
Adds the `disableAutoFocus` prop to the MUI `FocusTrap`, removing the automatic scrolling when the columns and filter panels open — it is not necessary since we handle focus manually.

Fixes #16867

**Before**

https://github.com/user-attachments/assets/78bfcea4-c955-41f0-a666-50b56f955e35


**After**

https://github.com/user-attachments/assets/4eab4a02-0b90-4e37-adb8-5016b7ad9291
