### PR TITLE
[DataGridPro] Fix header select checkbox state with `checkboxSelectionVisibleOnly` and `paginationMode="server"`

### DIFF
--- a/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -77,7 +77,9 @@ const GridHeaderCheckbox = forwardRef<HTMLButtonElement, GridColumnHeaderParams>
     // All the rows that could be selected / unselected by toggling this checkbox
     const selectionCandidates = React.useMemo(() => {
       const rowIds =
-        !rootProps.pagination || !rootProps.checkboxSelectionVisibleOnly
+        !rootProps.pagination ||
+        !rootProps.checkboxSelectionVisibleOnly ||
+        rootProps.paginationMode === 'server'
           ? visibleRowIds
           : paginatedVisibleRowIds;
 

--- a/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -95,6 +95,7 @@ const GridHeaderCheckbox = forwardRef<HTMLButtonElement, GridColumnHeaderParams>
     }, [
       apiRef,
       rootProps.pagination,
+      rootProps.paginationMode,
       rootProps.checkboxSelectionVisibleOnly,
       paginatedVisibleRowIds,
       visibleRowIds,


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17005

Maybe an example with a bit more context would help (https://github.com/mui/mui-x/issues/17005#issuecomment-2733744567)

I don't see a benefit of using `checkboxSelectionVisibleOnly` and `paginationMode="server"` because you are seeing all rows anyway.

But, we can fix the issue regardless.