### PR TITLE
[TreeView] Use state and instance instead of context in all plugins except `useTreeViewIcons`

### DIFF
--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.itemPlugin.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.itemPlugin.ts
@@ -15,25 +15,23 @@ import {
   UseTreeItemContentSlotPropsFromItemsReordering,
 } from './useTreeViewItemsReordering.types';
 import {
-  selectorItemsReorderingDraggedItemProperties,
-  selectorItemsReorderingIsValidTarget,
+  selectorCanItemBeReordered,
+  selectorDraggedItemProperties,
+  selectorIsItemValidReorderingTarget,
 } from './useTreeViewItemsReordering.selectors';
 
 export const isAndroid = () => navigator.userAgent.toLowerCase().includes('android');
 
 export const useTreeViewItemsReorderingItemPlugin: TreeViewItemPlugin = ({ props }) => {
-  const { instance, store, itemsReordering } =
+  const { instance, store } =
     useTreeViewContext<[UseTreeViewItemsSignature, UseTreeViewItemsReorderingSignature]>();
   const { itemId } = props;
 
   const validActionsRef = React.useRef<TreeViewItemItemReorderingValidActions | null>(null);
 
-  const draggedItemProperties = useSelector(
-    store,
-    selectorItemsReorderingDraggedItemProperties,
-    itemId,
-  );
-  const isValidTarget = useSelector(store, selectorItemsReorderingIsValidTarget, itemId);
+  const draggedItemProperties = useSelector(store, selectorDraggedItemProperties, itemId);
+  const canItemBeReordered = useSelector(store, selectorCanItemBeReordered);
+  const isValidTarget = useSelector(store, selectorIsItemValidReorderingTarget, itemId);
 
   return {
     propsEnhancers: {
@@ -42,10 +40,7 @@ export const useTreeViewItemsReorderingItemPlugin: TreeViewItemPlugin = ({ props
         contentRefObject,
         externalEventHandlers,
       }): UseTreeItemRootSlotPropsFromItemsReordering => {
-        if (
-          !itemsReordering.enabled ||
-          (itemsReordering.isItemReorderable && !itemsReordering.isItemReorderable(itemId))
-        ) {
+        if (!canItemBeReordered) {
           return {};
         }
 

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.selectors.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.selectors.ts
@@ -4,11 +4,20 @@ import { UseTreeViewItemsReorderingSignature } from './useTreeViewItemsReorderin
 /**
  * Get the items reordering state.
  * @param {TreeViewState<[UseTreeViewItemsReorderingSignature]>} state The state of the tree view.
- * @returns {TreeViewItemsReorderingState | null} The items reordering state.
+ * @returns {TreeViewItemsReorderingState} The items reordering state.
  */
-export const selectorItemsReordering = (
-  state: TreeViewState<[UseTreeViewItemsReorderingSignature]>,
-) => state.itemsReordering;
+const selectorItemsReordering = (state: TreeViewState<[UseTreeViewItemsReorderingSignature]>) =>
+  state.itemsReordering;
+
+/**
+ * Get the properties of the current reordering.
+ * @param {TreeViewState<[UseTreeViewItemsReorderingSignature]>} state The state of the tree view.
+ * @returns {TreeViewItemsReorderingState['currentReorder']} The properties of the current reordering.
+ */
+export const selectorCurrentItemReordering = createSelector(
+  [selectorItemsReordering],
+  (itemsReordering) => itemsReordering.currentReorder,
+);
 
 /**
  * Get the properties of the dragged item.
@@ -16,26 +25,26 @@ export const selectorItemsReordering = (
  * @param {string} itemId The id of the item.
  * @returns {TreeViewItemDraggedItemProperties | null} The properties of the dragged item if the current item is being dragged, `null` otherwise.
  */
-export const selectorItemsReorderingDraggedItemProperties = createSelector(
-  [selectorItemsReordering, selectorItemMetaLookup, (_, itemId: string) => itemId],
-  (itemsReordering, itemMetaLookup, itemId) => {
+export const selectorDraggedItemProperties = createSelector(
+  [selectorCurrentItemReordering, selectorItemMetaLookup, (_, itemId: string) => itemId],
+  (currentReorder, itemMetaLookup, itemId) => {
     if (
-      !itemsReordering ||
-      itemsReordering.targetItemId !== itemId ||
-      itemsReordering.action == null
+      !currentReorder ||
+      currentReorder.targetItemId !== itemId ||
+      currentReorder.action == null
     ) {
       return null;
     }
 
     const targetDepth =
-      itemsReordering.newPosition?.parentId == null
+      currentReorder.newPosition?.parentId == null
         ? 0
         : // The depth is always defined because drag&drop is only usable with Rich Tree View components.
           itemMetaLookup[itemId].depth! + 1;
 
     return {
-      newPosition: itemsReordering.newPosition,
-      action: itemsReordering.action,
+      newPosition: currentReorder.newPosition,
+      action: currentReorder.action,
       targetDepth,
     };
   },
@@ -47,7 +56,18 @@ export const selectorItemsReorderingDraggedItemProperties = createSelector(
  * @param {string} itemId The id of the item.
  * @returns {boolean} `true` if the current item is a valid target for the dragged item, `false` otherwise.
  */
-export const selectorItemsReorderingIsValidTarget = createSelector(
+export const selectorIsItemValidReorderingTarget = createSelector(
+  [selectorCurrentItemReordering, (_, itemId: string) => itemId],
+  (currentReorder, itemId) => currentReorder && currentReorder.draggedItemId !== itemId,
+);
+
+/**
+ * Check if the items can be reordered.
+ * @param {TreeViewState<[UseTreeViewItemsReorderingSignature]>} state The state of the tree view.
+ * @param {string} itemId The id of the item.
+ * @returns {boolean} `true` if the items can be reordered, `false` otherwise.
+ */
+export const selectorCanItemBeReordered = createSelector(
   [selectorItemsReordering, (_, itemId: string) => itemId],
-  (itemsReordering, itemId) => itemsReordering && itemsReordering.draggedItemId !== itemId,
+  (itemsReordering, itemId) => itemsReordering.isItemReorderable(itemId),
 );

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import {
   TreeViewPlugin,
   selectorItemIndex,
@@ -18,7 +19,7 @@ import {
   moveItemInTree,
 } from './useTreeViewItemsReordering.utils';
 import { useTreeViewItemsReorderingItemPlugin } from './useTreeViewItemsReordering.itemPlugin';
-import { selectorItemsReordering } from './useTreeViewItemsReordering.selectors';
+import { selectorCurrentItemReordering } from './useTreeViewItemsReordering.selectors';
 
 export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderingSignature> = ({
   params,
@@ -42,19 +43,19 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
 
   const getDroppingTargetValidActions = React.useCallback(
     (itemId: string) => {
-      const itemsReordering = selectorItemsReordering(store.value);
-      if (!itemsReordering) {
+      const currentReorder = selectorCurrentItemReordering(store.value);
+      if (!currentReorder) {
         throw new Error('There is no ongoing reordering.');
       }
 
-      if (itemId === itemsReordering.draggedItemId) {
+      if (itemId === currentReorder.draggedItemId) {
         return {};
       }
 
       const canMoveItemToNewPosition = params.canMoveItemToNewPosition;
       const targetItemMeta = selectorItemMeta(store.value, itemId)!;
       const targetItemIndex = selectorItemIndex(store.value, targetItemMeta.id);
-      const draggedItemMeta = selectorItemMeta(store.value, itemsReordering.draggedItemId)!;
+      const draggedItemMeta = selectorItemMeta(store.value, currentReorder.draggedItemId)!;
       const draggedItemIndex = selectorItemIndex(store.value, draggedItemMeta.id);
 
       const oldPosition: TreeViewItemReorderPosition = {
@@ -72,7 +73,7 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
           isValid = false;
         } else if (canMoveItemToNewPosition) {
           isValid = canMoveItemToNewPosition({
-            itemId: itemsReordering.draggedItemId,
+            itemId: currentReorder.draggedItemId,
             oldPosition,
             newPosition: positionAfterAction,
           });
@@ -133,10 +134,13 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
       store.update((prevState) => ({
         ...prevState,
         itemsReordering: {
-          targetItemId: itemId,
-          draggedItemId: itemId,
-          action: null,
-          newPosition: null,
+          ...prevState.itemsReordering,
+          currentReorder: {
+            targetItemId: itemId,
+            draggedItemId: itemId,
+            action: null,
+            newPosition: null,
+          },
         },
       }));
     },
@@ -145,32 +149,38 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
 
   const stopDraggingItem = React.useCallback(
     (itemId: string) => {
-      const itemsReordering = selectorItemsReordering(store.value);
-      if (itemsReordering == null || itemsReordering.draggedItemId !== itemId) {
+      const currentReorder = selectorCurrentItemReordering(store.value);
+      if (currentReorder == null || currentReorder.draggedItemId !== itemId) {
         return;
       }
 
       if (
-        itemsReordering.draggedItemId === itemsReordering.targetItemId ||
-        itemsReordering.action == null ||
-        itemsReordering.newPosition == null
+        currentReorder.draggedItemId === currentReorder.targetItemId ||
+        currentReorder.action == null ||
+        currentReorder.newPosition == null
       ) {
-        store.update((prevState) => ({ ...prevState, itemsReordering: null }));
+        store.update((prevState) => ({
+          ...prevState,
+          itemsReordering: { ...prevState.itemsReordering, currentReorder: null },
+        }));
         return;
       }
 
-      const draggedItemMeta = selectorItemMeta(store.value, itemsReordering.draggedItemId)!;
+      const draggedItemMeta = selectorItemMeta(store.value, currentReorder.draggedItemId)!;
 
       const oldPosition: TreeViewItemReorderPosition = {
         parentId: draggedItemMeta.parentId,
         index: selectorItemIndex(store.value, draggedItemMeta.id),
       };
 
-      const newPosition = itemsReordering.newPosition;
+      const newPosition = currentReorder.newPosition;
 
       store.update((prevState) => ({
         ...prevState,
-        itemsReordering: null,
+        itemsReordering: {
+          ...prevState.itemsReordering,
+          currentReorder: null,
+        },
         items: moveItemInTree({
           itemToMoveId: itemId,
           newPosition,
@@ -194,8 +204,8 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
   >(
     ({ itemId, validActions, targetHeight, cursorY, cursorX, contentElement }) => {
       store.update((prevState) => {
-        const prevSubState = prevState.itemsReordering;
-        if (prevSubState == null || isAncestor(store, itemId, prevSubState.draggedItemId)) {
+        const prevItemReorder = prevState.itemsReordering.currentReorder;
+        if (prevItemReorder == null || isAncestor(store, itemId, prevItemReorder.draggedItemId)) {
           return prevState;
         }
         const action = chooseActionToApply({
@@ -211,10 +221,10 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
         const newPosition = action == null ? null : validActions[action]!;
 
         if (
-          prevSubState.targetItemId === itemId &&
-          prevSubState.action === action &&
-          prevSubState.newPosition?.parentId === newPosition?.parentId &&
-          prevSubState.newPosition?.index === newPosition?.index
+          prevItemReorder.targetItemId === itemId &&
+          prevItemReorder.action === action &&
+          prevItemReorder.newPosition?.parentId === newPosition?.parentId &&
+          prevItemReorder.newPosition?.index === newPosition?.index
         ) {
           return prevState;
         }
@@ -222,10 +232,13 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
         return {
           ...prevState,
           itemsReordering: {
-            ...prevSubState,
-            targetItemId: itemId,
-            newPosition,
-            action,
+            ...prevState.itemsReordering,
+            currentReorder: {
+              ...prevItemReorder,
+              targetItemId: itemId,
+              newPosition,
+              action,
+            },
           },
         };
       });
@@ -233,15 +246,17 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
     [store, params.itemChildrenIndentation],
   );
 
-  const pluginContextValue = React.useMemo(
-    () => ({
+  useEnhancedEffect(() => {
+    store.update((prevState) => ({
+      ...prevState,
       itemsReordering: {
-        enabled: params.itemsReordering,
-        isItemReorderable: params.isItemReorderable,
+        ...prevState.itemsReordering,
+        isItemReorderable: params.itemsReordering
+          ? (params.isItemReorderable ?? (() => true))
+          : () => false,
       },
-    }),
-    [params.itemsReordering, params.isItemReorderable],
-  );
+    }));
+  }, [store, params.itemsReordering, params.isItemReorderable]);
 
   return {
     instance: {
@@ -251,7 +266,6 @@ export const useTreeViewItemsReordering: TreeViewPlugin<UseTreeViewItemsReorderi
       stopDraggingItem,
       setDragTargetItem,
     },
-    contextValue: pluginContextValue,
   };
 };
 
@@ -262,7 +276,14 @@ useTreeViewItemsReordering.getDefaultizedParams = ({ params }) => ({
   itemsReordering: params.itemsReordering ?? false,
 });
 
-useTreeViewItemsReordering.getInitialState = () => ({ itemsReordering: null });
+useTreeViewItemsReordering.getInitialState = (params) => ({
+  itemsReordering: {
+    currentReorder: null,
+    isItemReorderable: params.itemsReordering
+      ? (params.isItemReorderable ?? (() => true))
+      : () => false,
+  },
+});
 
 useTreeViewItemsReordering.params = {
   itemsReordering: true,

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewItemsReordering/useTreeViewItemsReordering.types.ts
@@ -108,17 +108,13 @@ export type UseTreeViewItemsReorderingDefaultizedParameters = DefaultizedProps<
 
 export interface UseTreeViewItemsReorderingState {
   itemsReordering: {
-    draggedItemId: string;
-    targetItemId: string;
-    newPosition: TreeViewItemReorderPosition | null;
-    action: TreeViewItemsReorderingAction | null;
-  } | null;
-}
-
-interface UseTreeViewItemsReorderingContextValue {
-  itemsReordering: {
-    enabled: boolean;
-    isItemReorderable: ((itemId: string) => boolean) | undefined;
+    isItemReorderable: (itemId: string) => boolean;
+    currentReorder: {
+      draggedItemId: string;
+      targetItemId: string;
+      newPosition: TreeViewItemReorderPosition | null;
+      action: TreeViewItemsReorderingAction | null;
+    } | null;
   };
 }
 
@@ -127,7 +123,6 @@ export type UseTreeViewItemsReorderingSignature = TreeViewPluginSignature<{
   defaultizedParams: UseTreeViewItemsReorderingDefaultizedParameters;
   instance: UseTreeViewItemsReorderingInstance;
   state: UseTreeViewItemsReorderingState;
-  contextValue: UseTreeViewItemsReorderingContextValue;
   dependencies: [UseTreeViewItemsSignature];
 }>;
 

--- a/packages/x-tree-view/src/hooks/useTreeItemUtils/useTreeItemUtils.tsx
+++ b/packages/x-tree-view/src/hooks/useTreeItemUtils/useTreeItemUtils.tsx
@@ -92,10 +92,7 @@ export const useTreeItemUtils = <
   itemId: string;
   children?: React.ReactNode;
 }): UseTreeItemUtilsReturnValue<TSignatures, TOptionalSignatures> => {
-  const { instance, label, store, publicAPI } = useTreeViewContext<
-    TSignatures,
-    TOptionalSignatures
-  >();
+  const { instance, store, publicAPI } = useTreeViewContext<TSignatures, TOptionalSignatures>();
 
   const isItemExpandable = useSelector(store, selectorIsItemExpandable, itemId);
   const isLazyLoadingEnabled = useSelector(store, selectorIsLazyLoadingEnabled);
@@ -112,14 +109,8 @@ export const useTreeItemUtils = <
   const isFocused = useSelector(store, selectorIsItemFocused, itemId);
   const isSelected = useSelector(store, selectorIsItemSelected, itemId);
   const isDisabled = useSelector(store, selectorIsItemDisabled, itemId);
-  const isEditing = useSelector(store, (state) =>
-    label == null ? false : selectorIsItemBeingEdited(state, itemId),
-  );
-  const isEditable = useSelector(store, (state) =>
-    label == null
-      ? false
-      : selectorIsItemEditable(state, { itemId, isItemEditable: label.isItemEditable }),
-  );
+  const isEditing = useSelector(store, selectorIsItemBeingEdited, itemId);
+  const isEditable = useSelector(store, selectorIsItemEditable, itemId);
 
   const status: UseTreeItemStatus = {
     expandable: isExpandable,

--- a/packages/x-tree-view/src/hooks/useTreeItemUtils/useTreeItemUtils.tsx
+++ b/packages/x-tree-view/src/hooks/useTreeItemUtils/useTreeItemUtils.tsx
@@ -21,7 +21,10 @@ import {
 } from '../../internals/plugins/useTreeViewExpansion/useTreeViewExpansion.selectors';
 import { selectorIsItemFocused } from '../../internals/plugins/useTreeViewFocus/useTreeViewFocus.selectors';
 import { selectorIsItemDisabled } from '../../internals/plugins/useTreeViewItems/useTreeViewItems.selectors';
-import { selectorIsItemSelected } from '../../internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors';
+import {
+  selectorIsItemSelected,
+  selectorIsMultiSelectEnabled,
+} from '../../internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors';
 import {
   selectorGetTreeItemError,
   selectorIsItemLoading,
@@ -89,16 +92,14 @@ export const useTreeItemUtils = <
   itemId: string;
   children?: React.ReactNode;
 }): UseTreeItemUtilsReturnValue<TSignatures, TOptionalSignatures> => {
-  const {
-    instance,
-    label,
-    store,
-    selection: { multiSelect },
-    publicAPI,
-  } = useTreeViewContext<TSignatures, TOptionalSignatures>();
+  const { instance, label, store, publicAPI } = useTreeViewContext<
+    TSignatures,
+    TOptionalSignatures
+  >();
 
   const isItemExpandable = useSelector(store, selectorIsItemExpandable, itemId);
   const isLazyLoadingEnabled = useSelector(store, selectorIsLazyLoadingEnabled);
+  const isMultiSelectEnabled = useSelector(store, selectorIsMultiSelectEnabled);
 
   const loading = useSelector(store, (state) =>
     isLazyLoadingEnabled ? selectorIsItemLoading(state, itemId) : false,
@@ -141,7 +142,7 @@ export const useTreeItemUtils = <
       instance.focusItem(event, itemId);
     }
 
-    const multiple = multiSelect && (event.shiftKey || event.ctrlKey || event.metaKey);
+    const multiple = isMultiSelectEnabled && (event.shiftKey || event.ctrlKey || event.metaKey);
 
     // If already expanded and trying to toggle selection don't close
     if (status.expandable && !(multiple && selectorIsItemExpanded(store.value, itemId))) {
@@ -159,7 +160,7 @@ export const useTreeItemUtils = <
       instance.focusItem(event, itemId);
     }
 
-    const multiple = multiSelect && (event.shiftKey || event.ctrlKey || event.metaKey);
+    const multiple = isMultiSelectEnabled && (event.shiftKey || event.ctrlKey || event.metaKey);
 
     if (multiple) {
       if (event.shiftKey) {
@@ -174,13 +175,13 @@ export const useTreeItemUtils = <
 
   const handleCheckboxSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
     const hasShift = (event.nativeEvent as PointerEvent).shiftKey;
-    if (multiSelect && hasShift) {
+    if (isMultiSelectEnabled && hasShift) {
       instance.expandSelectionRange(event, itemId);
     } else {
       instance.setItemSelection({
         event,
         itemId,
-        keepExistingSelection: multiSelect,
+        keepExistingSelection: isMultiSelectEnabled,
         shouldBeSelected: event.target.checked,
       });
     }

--- a/packages/x-tree-view/src/internals/models/itemPlugin.ts
+++ b/packages/x-tree-view/src/internals/models/itemPlugin.ts
@@ -6,7 +6,7 @@ import type {
   UseTreeItemLabelInputSlotOwnProps,
   UseTreeItemRootSlotOwnProps,
   UseTreeItemCheckboxSlotOwnProps,
-  UseTreeItemStatus,
+  UseTreeItemLabelSlotOwnProps,
 } from '../../useTreeItem';
 import type { UseTreeItemInteractions } from '../../hooks/useTreeItemUtils/useTreeItemUtils';
 import type { TreeItemProps } from '../../TreeItem/TreeItem.types';
@@ -16,7 +16,6 @@ export interface TreeViewItemPluginSlotPropsEnhancerParams {
   contentRefObject: React.RefObject<HTMLDivElement | null>;
   externalEventHandlers: EventHandlers;
   interactions: UseTreeItemInteractions;
-  status: UseTreeItemStatus;
 }
 
 type TreeViewItemPluginSlotPropsEnhancer<TSlotProps> = (
@@ -28,6 +27,7 @@ export interface TreeViewItemPluginSlotPropsEnhancers {
   content?: TreeViewItemPluginSlotPropsEnhancer<UseTreeItemContentSlotOwnProps>;
   dragAndDropOverlay?: TreeViewItemPluginSlotPropsEnhancer<UseTreeItemDragAndDropOverlaySlotOwnProps>;
   labelInput?: TreeViewItemPluginSlotPropsEnhancer<UseTreeItemLabelInputSlotOwnProps>;
+  label?: TreeViewItemPluginSlotPropsEnhancer<UseTreeItemLabelSlotOwnProps>;
   checkbox?: TreeViewItemPluginSlotPropsEnhancer<UseTreeItemCheckboxSlotOwnProps>;
 }
 
@@ -44,7 +44,7 @@ export interface TreeViewItemPluginResponse {
    * Callback to enhance the slot props of the Tree Item.
    *
    * Not all slots are enabled by default,
-   * if a new plugin needs to pass to an unconfigured slot,
+   * if a new plugin needs to pass to an un-configured slot,
    * it just needs to be added to `TreeViewItemPluginSlotPropsEnhancers`
    */
   propsEnhancers?: TreeViewItemPluginSlotPropsEnhancers;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.selectors.ts
@@ -58,10 +58,7 @@ export const selectorItemOrderedChildrenIds = createSelector(
  */
 export const selectorItemModel = createSelector(
   [selectorTreeViewItemsState, (_, itemId: string) => itemId],
-  (itemsState, itemId) => {
-    const a = itemsState.itemModelLookup[itemId];
-    return a;
-  },
+  (itemsState, itemId) => itemsState.itemModelLookup[itemId],
 );
 
 /**

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
@@ -350,20 +350,11 @@ export const useTreeViewItems: TreeViewPlugin<UseTreeViewItemsSignature> = ({
   ]);
 
   // Wrap `props.onItemClick` with `useEventCallback` to prevent unneeded context updates.
-  const handleItemClick = useEventCallback((event: React.MouseEvent, itemId: string) => {
+  const handleItemClick = useEventCallback((event: React.MouseEvent, itemId: TreeViewItemId) => {
     if (params.onItemClick) {
       params.onItemClick(event, itemId);
     }
   });
-
-  const pluginContextValue = React.useMemo(
-    () => ({
-      items: {
-        onItemClick: handleItemClick,
-      },
-    }),
-    [handleItemClick],
-  );
 
   return {
     getRootProps: () => ({
@@ -390,8 +381,8 @@ export const useTreeViewItems: TreeViewPlugin<UseTreeViewItemsSignature> = ({
       setTreeViewLoading,
       setTreeViewError,
       removeChildren,
+      handleItemClick,
     },
-    contextValue: pluginContextValue,
   };
 };
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.types.ts
@@ -13,6 +13,7 @@ export type AddItemsParameters<R> = {
   depth: number;
   getChildrenCount?: (item: R) => number;
 };
+
 export interface UseTreeViewItemsPublicAPI<R extends {}> {
   /**
    * Get the item with the given id.
@@ -87,6 +88,12 @@ export interface UseTreeViewItemsInstance<R extends {}>
    * @param {Error | null} error The error on the tree view.
    */
   setTreeViewError: (error: Error | null) => void;
+  /**
+   * Event handler to fire when the `content` slot of a given Tree Item is clicked.
+   * @param {React.MouseEvent} event The DOM event that triggered the change.
+   * @param {TreeViewItemId} itemId The id of the item being clicked.
+   */
+  handleItemClick: (event: React.MouseEvent, itemId: TreeViewItemId) => void;
 }
 
 export interface UseTreeViewItemsParameters<R extends { children?: R[] }> {
@@ -184,12 +191,6 @@ export interface UseTreeViewItemsState<R extends {}> {
   };
 }
 
-interface UseTreeViewItemsContextValue {
-  items: {
-    onItemClick: (event: React.MouseEvent, itemId: string) => void;
-  };
-}
-
 export type UseTreeViewItemsSignature = TreeViewPluginSignature<{
   params: UseTreeViewItemsParameters<any>;
   defaultizedParams: UseTreeViewItemsDefaultizedParameters<any>;
@@ -197,5 +198,4 @@ export type UseTreeViewItemsSignature = TreeViewPluginSignature<{
   publicAPI: UseTreeViewItemsPublicAPI<any>;
   events: UseTreeViewItemsEventLookup;
   state: UseTreeViewItemsState<TreeViewDefaultItemModelProperties>;
-  contextValue: UseTreeViewItemsContextValue;
 }>;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
@@ -26,7 +26,11 @@ import {
   selectorIsItemBeingEdited,
   selectorIsItemEditable,
 } from '../useTreeViewLabel/useTreeViewLabel.selectors';
-import { selectorIsItemSelected } from '../useTreeViewSelection/useTreeViewSelection.selectors';
+import {
+  selectorIsItemSelected,
+  selectorIsMultiSelectEnabled,
+  selectorIsSelectionEnabled,
+} from '../useTreeViewSelection/useTreeViewSelection.selectors';
 import {
   selectorIsItemExpandable,
   selectorIsItemExpanded,
@@ -94,7 +98,7 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
   };
 
   const canToggleItemSelection = (itemId: string) =>
-    !params.disableSelection && !selectorIsItemDisabled(store.value, itemId);
+    selectorIsSelectionEnabled(store.value) && !selectorIsItemDisabled(store.value, itemId);
 
   const canToggleItemExpansion = (itemId: string) => {
     return (
@@ -120,20 +124,21 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
 
     const ctrlPressed = event.ctrlKey || event.metaKey;
     const key = event.key;
+    const isMultiSelectEnabled = selectorIsMultiSelectEnabled(store.value);
 
     // eslint-disable-next-line default-case
     switch (true) {
       // Select the item when pressing "Space"
       case key === ' ' && canToggleItemSelection(itemId): {
         event.preventDefault();
-        if (params.multiSelect && event.shiftKey) {
+        if (isMultiSelectEnabled && event.shiftKey) {
           instance.expandSelectionRange(event, itemId);
         } else {
           instance.setItemSelection({
             event,
             itemId,
-            keepExistingSelection: params.multiSelect,
-            shouldBeSelected: params.multiSelect ? undefined : true,
+            keepExistingSelection: isMultiSelectEnabled,
+            shouldBeSelected: isMultiSelectEnabled ? undefined : true,
           });
         }
         break;
@@ -152,7 +157,7 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
           instance.setItemExpansion({ event, itemId });
           event.preventDefault();
         } else if (canToggleItemSelection(itemId)) {
-          if (params.multiSelect) {
+          if (isMultiSelectEnabled) {
             event.preventDefault();
             instance.setItemSelection({ event, itemId, keepExistingSelection: true });
           } else if (!selectorIsItemSelected(store.value, itemId)) {
@@ -173,7 +178,7 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
 
           // Multi select behavior when pressing Shift + ArrowDown
           // Toggles the selection state of the next item
-          if (params.multiSelect && event.shiftKey && canToggleItemSelection(nextItem)) {
+          if (isMultiSelectEnabled && event.shiftKey && canToggleItemSelection(nextItem)) {
             instance.selectItemFromArrowNavigation(event, itemId, nextItem);
           }
         }
@@ -190,7 +195,7 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
 
           // Multi select behavior when pressing Shift + ArrowUp
           // Toggles the selection state of the previous item
-          if (params.multiSelect && event.shiftKey && canToggleItemSelection(previousItem)) {
+          if (isMultiSelectEnabled && event.shiftKey && canToggleItemSelection(previousItem)) {
             instance.selectItemFromArrowNavigation(event, itemId, previousItem);
           }
         }
@@ -242,7 +247,12 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
       case key === 'Home': {
         // Multi select behavior when pressing Ctrl + Shift + Home
         // Selects the focused item and all items up to the first item.
-        if (canToggleItemSelection(itemId) && params.multiSelect && ctrlPressed && event.shiftKey) {
+        if (
+          canToggleItemSelection(itemId) &&
+          isMultiSelectEnabled &&
+          ctrlPressed &&
+          event.shiftKey
+        ) {
           instance.selectRangeFromStartToItem(event, itemId);
         } else {
           instance.focusItem(event, getFirstNavigableItem(store.value));
@@ -256,7 +266,12 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
       case key === 'End': {
         // Multi select behavior when pressing Ctrl + Shirt + End
         // Selects the focused item and all the items down to the last item.
-        if (canToggleItemSelection(itemId) && params.multiSelect && ctrlPressed && event.shiftKey) {
+        if (
+          canToggleItemSelection(itemId) &&
+          isMultiSelectEnabled &&
+          ctrlPressed &&
+          event.shiftKey
+        ) {
           instance.selectRangeFromItemToEnd(event, itemId);
         } else {
           instance.focusItem(event, getLastNavigableItem(store.value));
@@ -277,8 +292,8 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
       // Selects all the items
       case String.fromCharCode(event.keyCode) === 'A' &&
         ctrlPressed &&
-        params.multiSelect &&
-        !params.disableSelection: {
+        isMultiSelectEnabled &&
+        selectorIsSelectionEnabled(store.value): {
         instance.selectAllNavigableItems(event);
         event.preventDefault();
         break;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
@@ -149,7 +149,7 @@ export const useTreeViewKeyboardNavigation: TreeViewPlugin<
       case key === 'Enter': {
         if (
           hasPlugin(instance, useTreeViewLabel) &&
-          selectorIsItemEditable(store.value, { itemId, isItemEditable: params.isItemEditable! }) &&
+          selectorIsItemEditable(store.value, itemId) &&
           !selectorIsItemBeingEdited(store.value, itemId)
         ) {
           instance.setEditedItemId(itemId);

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.types.ts
@@ -5,8 +5,6 @@ import { UseTreeViewSelectionSignature } from '../useTreeViewSelection';
 import { UseTreeViewFocusSignature } from '../useTreeViewFocus';
 import { UseTreeViewExpansionSignature } from '../useTreeViewExpansion';
 import { TreeViewItemId, TreeViewCancellableEvent } from '../../../models';
-import { UseTreeViewLabelSignature } from '../useTreeViewLabel';
-import { UseTreeViewLazyLoadingSignature } from '../useTreeViewLazyLoading';
 
 export interface UseTreeViewKeyboardNavigationInstance {
   /**
@@ -36,7 +34,6 @@ export type UseTreeViewKeyboardNavigationSignature = TreeViewPluginSignature<{
     UseTreeViewFocusSignature,
     UseTreeViewExpansionSignature,
   ];
-  optionalDependencies: [UseTreeViewLabelSignature, UseTreeViewLazyLoadingSignature];
 }>;
 
 export type TreeViewFirstCharMap = { [itemId: string]: string };

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.itemPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.itemPlugin.ts
@@ -11,15 +11,12 @@ import { useSelector } from '../../hooks/useSelector';
 import { selectorIsItemBeingEdited, selectorIsItemEditable } from './useTreeViewLabel.selectors';
 
 export const useTreeViewLabelItemPlugin: TreeViewItemPlugin = ({ props }) => {
-  const {
-    store,
-    label: { isItemEditable },
-  } = useTreeViewContext<[UseTreeViewItemsSignature, UseTreeViewLabelSignature]>();
+  const { store } = useTreeViewContext<[UseTreeViewItemsSignature, UseTreeViewLabelSignature]>();
   const { label, itemId } = props;
 
   const [labelInputValue, setLabelInputValue] = React.useState(label as string);
 
-  const editable = useSelector(store, selectorIsItemEditable, { itemId, isItemEditable });
+  const editable = useSelector(store, selectorIsItemEditable, itemId);
   const editing = useSelector(store, selectorIsItemBeingEdited, itemId);
 
   React.useEffect(() => {

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.itemPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.itemPlugin.ts
@@ -16,22 +16,23 @@ export const useTreeViewLabelItemPlugin: TreeViewItemPlugin = ({ props }) => {
 
   const [labelInputValue, setLabelInputValue] = React.useState(label as string);
 
-  const editable = useSelector(store, selectorIsItemEditable, itemId);
-  const editing = useSelector(store, selectorIsItemBeingEdited, itemId);
+  const isItemEditable = useSelector(store, selectorIsItemEditable, itemId);
+  const isItemBeingEdited = useSelector(store, selectorIsItemBeingEdited, itemId);
 
   React.useEffect(() => {
-    if (!editing) {
+    if (!isItemBeingEdited) {
       setLabelInputValue(label as string);
     }
-  }, [editing, label]);
+  }, [isItemBeingEdited, label]);
 
   return {
     propsEnhancers: {
+      label: () => ({ editable: isItemEditable }),
       labelInput: ({
         externalEventHandlers,
         interactions,
       }): UseTreeItemLabelInputSlotPropsFromLabelEditing => {
-        if (!editable) {
+        if (!isItemEditable) {
           return {};
         }
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.selectors.ts
@@ -2,28 +2,23 @@ import { UseTreeViewLabelSignature } from './useTreeViewLabel.types';
 import { createSelector, TreeViewRootSelector } from '../../utils/selectors';
 import { selectorItemModel } from '../useTreeViewItems/useTreeViewItems.selectors';
 
-const selectorTreeViewLabelState: TreeViewRootSelector<UseTreeViewLabelSignature> = (state) =>
+const selectorTreeViewLabelState: TreeViewRootSelector<UseTreeViewLabelSignature, true> = (state) =>
   state.label;
 
 /**
  * Check if an item is editable.
  * @param {TreeViewState<[UseTreeViewItemsSignature]>} state The state of the tree view.
- * @param {object} params The parameters.
- * @param {TreeViewItemId} params.itemId The id of the item to check.
- * @param {((item: any) => boolean) | boolean} params.isItemEditable The function to determine if an item is editable.
+ * @param {TreeViewItemId} itemId The id of the item to check.
  * @returns {boolean} `true` if the item is editable, `false` otherwise.
  */
 export const selectorIsItemEditable = createSelector(
-  [
-    (_, args: { itemId: string; isItemEditable: ((item: any) => boolean) | boolean }) => args,
-    (state, args) => selectorItemModel(state, args.itemId),
-  ],
-  (args, itemModel) => {
-    if (!itemModel || !args.isItemEditable) {
+  [selectorTreeViewLabelState, (state, itemId: string) => selectorItemModel(state, itemId)],
+  (labelState, itemModel) => {
+    if (!itemModel || !labelState) {
       return false;
     }
 
-    return typeof args.isItemEditable === 'function' ? args.isItemEditable(itemModel) : true;
+    return labelState.isItemEditable(itemModel);
   },
 );
 
@@ -35,5 +30,5 @@ export const selectorIsItemEditable = createSelector(
  */
 export const selectorIsItemBeingEdited = createSelector(
   [selectorTreeViewLabelState, (_, itemId: string) => itemId],
-  (labelState, itemId) => labelState.editedItemId === itemId,
+  (labelState, itemId) => labelState?.editedItemId === itemId,
 );

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.types.ts
@@ -46,12 +46,9 @@ export type UseTreeViewLabelDefaultizedParameters<R extends {}> = DefaultizedPro
 
 export interface UseTreeViewLabelState {
   label: {
+    isItemEditable: (item: any) => boolean;
     editedItemId: string | null;
   };
-}
-
-export interface UseTreeViewLabelContextValue {
-  label: Pick<UseTreeViewLabelDefaultizedParameters<any>, 'isItemEditable'>;
 }
 
 export type UseTreeViewLabelSignature = TreeViewPluginSignature<{
@@ -60,7 +57,6 @@ export type UseTreeViewLabelSignature = TreeViewPluginSignature<{
   publicAPI: UseTreeViewLabelPublicAPI;
   instance: UseTreeViewLabelInstance;
   state: UseTreeViewLabelState;
-  contextValue: UseTreeViewLabelContextValue;
   dependencies: [UseTreeViewItemsSignature];
 }>;
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.types.ts
@@ -62,7 +62,13 @@ export type UseTreeViewLabelSignature = TreeViewPluginSignature<{
 
 export interface UseTreeItemLabelInputSlotPropsFromLabelEditing extends TreeItemLabelInputProps {}
 
+export interface UseTreeItemLabelSlotPropsFromLabelEditing {
+  editable?: boolean;
+}
+
 declare module '@mui/x-tree-view/useTreeItem' {
   interface UseTreeItemLabelInputSlotOwnProps
     extends UseTreeItemLabelInputSlotPropsFromLabelEditing {}
+
+  interface UseTreeItemLabelSlotOwnProps extends UseTreeItemLabelSlotPropsFromLabelEditing {}
 }

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLazyLoading/useTreeViewLazyLoading.selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLazyLoading/useTreeViewLazyLoading.selectors.ts
@@ -1,17 +1,9 @@
-import { TreeViewAnyPluginSignature, TreeViewState } from '../../models';
 import {
   createSelector,
   TreeViewRootSelector,
   TreeViewRootSelectorForOptionalPlugin,
 } from '../../utils/selectors';
 import { UseTreeViewLazyLoadingSignature } from './useTreeViewLazyLoading.types';
-
-export type Temp<TSignature extends TreeViewAnyPluginSignature> = <
-  TSignatures extends [],
-  TOptionalSignatures extends [TSignature],
->(
-  state: TreeViewState<TSignatures, TOptionalSignatures>,
-) => TSignature['state'][keyof TSignature['state']];
 
 const selectorLazyLoading: TreeViewRootSelector<UseTreeViewLazyLoadingSignature> = (state) =>
   state.lazyLoading;

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.itemPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.itemPlugin.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { fastObjectShallowCompare } from '@mui/x-internals/fastObjectShallowCompare';
 import { TreeViewItemId, TreeViewCancellableEvent } from '../../../models';
 import { useTreeViewContext } from '../../TreeViewProvider';
 import { TreeViewItemPlugin, TreeViewState } from '../../models';
@@ -77,7 +78,7 @@ export const useTreeViewSelectionItemPlugin: TreeViewItemPlugin = ({ props }) =>
     store,
     selectorItemCheckboxStatus,
     itemId,
-    (a, b) => a.checked === b.checked && a.indeterminate === b.indeterminate,
+    fastObjectShallowCompare,
   );
 
   return {
@@ -94,7 +95,7 @@ export const useTreeViewSelectionItemPlugin: TreeViewItemPlugin = ({ props }) =>
             return;
           }
 
-          if (selectorIsItemSelectionEnabled(store, itemId)) {
+          if (!selectorIsItemSelectionEnabled(store.value, itemId)) {
             return;
           }
 

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector, TreeViewRootSelector } from '../../utils/selectors';
+import { selectorIsItemDisabled } from '../useTreeViewItems/useTreeViewItems.selectors';
 import { UseTreeViewSelectionSignature } from './useTreeViewSelection.types';
 
 const selectorTreeViewSelectionState: TreeViewRootSelector<UseTreeViewSelectionSignature> = (
@@ -13,4 +14,55 @@ const selectorTreeViewSelectionState: TreeViewRootSelector<UseTreeViewSelectionS
 export const selectorIsItemSelected = createSelector(
   [selectorTreeViewSelectionState, (_, itemId: string) => itemId],
   (selectionState, itemId) => selectionState.selectedItemsMap.has(itemId),
+);
+
+/**
+ * Check if multi selection is enabled.
+ * @param {TreeViewState<[UseTreeViewSelectionSignature]>} state The state of the tree view.
+ * @returns {boolean} `true` if multi selection is enabled, `false` otherwise.
+ */
+export const selectorIsMultiSelectEnabled = createSelector(
+  [selectorTreeViewSelectionState],
+  (selectionState) => selectionState.isEnabled && selectionState.isMultiSelectEnabled,
+);
+
+/**
+ * Check if selection is enabled.
+ * @param {TreeViewState<[UseTreeViewSelectionSignature]>} state The state of the tree view.
+ * @returns {boolean} `true` if selection is enabled, `false` otherwise.
+ */
+export const selectorIsSelectionEnabled = createSelector(
+  [selectorTreeViewSelectionState],
+  (selectionState) => selectionState.isEnabled,
+);
+
+/**
+ * Check if checkbox selection is enabled.
+ * @param {TreeViewState<[UseTreeViewSelectionSignature]>} state The state of the tree view.
+ * @returns {boolean} `true` if checkbox selection is enabled, `false` otherwise.
+ */
+export const selectorIsCheckboxSelectionEnabled = createSelector(
+  [selectorTreeViewSelectionState],
+  (selectionState) => selectionState.isCheckboxSelectionEnabled,
+);
+
+/**
+ * Check if selection is enabled for an item (if selection is enabled and if the item is not disabled).
+ * @param {TreeViewState<[UseTreeViewSelectionSignature]>} state The state of the tree view.
+ * @param {string} itemId The id of the item to check.
+ * @returns {boolean} `true` if selection is enabled for the item, `false` otherwise.
+ */
+export const selectorIsItemSelectionEnabled = createSelector(
+  [selectorIsSelectionEnabled, selectorIsItemDisabled],
+  (isSelectionEnabled, isItemDisabled) => isSelectionEnabled && !isItemDisabled,
+);
+
+/**
+ * Get the selection propagation rules.
+ * @param {TreeViewState<[UseTreeViewSelectionSignature]>} state The state of the tree view.
+ * @returns {TreeViewSelectionPropagation} The selection propagation rules.
+ */
+export const selectorSelectionPropagationRules = createSelector(
+  [selectorTreeViewSelectionState],
+  (selectionState) => selectionState.selectionPropagation,
 );

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors.ts
@@ -53,8 +53,8 @@ export const selectorIsCheckboxSelectionEnabled = createSelector(
  * @returns {boolean} `true` if selection is enabled for the item, `false` otherwise.
  */
 export const selectorIsItemSelectionEnabled = createSelector(
-  [selectorIsSelectionEnabled, selectorIsItemDisabled],
-  (isSelectionEnabled, isItemDisabled) => isSelectionEnabled && !isItemDisabled,
+  [selectorIsItemDisabled, selectorIsSelectionEnabled],
+  (isItemDisabled, isSelectionEnabled) => isSelectionEnabled && !isItemDisabled,
 );
 
 /**

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
@@ -470,7 +470,7 @@ describeTreeView<[UseTreeViewSelectionSignature, UseTreeViewExpansionSignature]>
           expect(view.isItemSelected('1')).to.equal(false);
         });
 
-        it('should select un-selected item when clicking on an item checkbox', () => {
+        it.only('should select un-selected item when clicking on an item checkbox', () => {
           const view = render({
             items: [{ id: '1' }, { id: '2' }],
             checkboxSelection: true,

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.test.tsx
@@ -470,7 +470,7 @@ describeTreeView<[UseTreeViewSelectionSignature, UseTreeViewExpansionSignature]>
           expect(view.isItemSelected('1')).to.equal(false);
         });
 
-        it.only('should select un-selected item when clicking on an item checkbox', () => {
+        it('should select un-selected item when clicking on an item checkbox', () => {
           const view = render({
             items: [{ id: '1' }, { id: '2' }],
             checkboxSelection: true,

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.ts
@@ -225,15 +225,6 @@ export const useTreeViewSelection: TreeViewPlugin<UseTreeViewSelectionSignature>
     store.update((prevState) => ({
       ...prevState,
       selection: {
-        ...prevState.selection,
-      },
-    }));
-  }, [store, models.selectedItems.value]);
-
-  React.useEffect(() => {
-    store.update((prevState) => ({
-      ...prevState,
-      selection: {
         rawSelectedItems: models.selectedItems.value,
         // Only re-compute the map when the model changes.
         selectedItemsMap:

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.types.ts
@@ -141,15 +141,13 @@ export type UseTreeViewSelectionDefaultizedParameters<Multiple extends boolean> 
 
 export interface UseTreeViewSelectionState {
   selection: {
+    rawSelectedItems: TreeViewSelectionValue<boolean>;
     selectedItemsMap: Map<string, true>;
+    isEnabled: boolean;
+    isMultiSelectEnabled: boolean;
+    isCheckboxSelectionEnabled: boolean;
+    selectionPropagation: TreeViewSelectionPropagation;
   };
-}
-
-interface UseTreeViewSelectionContextValue {
-  selection: Pick<
-    UseTreeViewSelectionDefaultizedParameters<boolean>,
-    'multiSelect' | 'checkboxSelection' | 'disableSelection' | 'selectionPropagation'
-  >;
 }
 
 export type UseTreeViewSelectionSignature = TreeViewPluginSignature<{
@@ -157,7 +155,6 @@ export type UseTreeViewSelectionSignature = TreeViewPluginSignature<{
   defaultizedParams: UseTreeViewSelectionDefaultizedParameters<any>;
   instance: UseTreeViewSelectionInstance;
   publicAPI: UseTreeViewSelectionPublicAPI;
-  contextValue: UseTreeViewSelectionContextValue;
   modelNames: 'selectedItems';
   state: UseTreeViewSelectionState;
   dependencies: [

--- a/packages/x-tree-view/src/internals/utils/selectors.ts
+++ b/packages/x-tree-view/src/internals/utils/selectors.ts
@@ -17,11 +17,14 @@ const cache = new WeakMap<
 /**
  * Type of a selector that take the whole tree view state as input and returns a value based on a required plugin.
  */
-export type TreeViewRootSelector<TSignature extends TreeViewAnyPluginSignature> = <
-  TSignatures extends [TSignature],
->(
+export type TreeViewRootSelector<
+  TSignature extends TreeViewAnyPluginSignature,
+  IsOptional extends boolean = false,
+> = <TSignatures extends [TSignature]>(
   state: TreeViewState<TSignatures>,
-) => TSignature['state'][keyof TSignature['state']];
+) => IsOptional extends true
+  ? TSignature['state'][keyof TSignature['state']] | undefined
+  : TSignature['state'][keyof TSignature['state']];
 
 /**
  * Type of a selector that take the whole tree view state as input and returns a value based on an optional plugin.

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
@@ -85,7 +85,7 @@ export const useTreeItem = <
   const sharedPropsEnhancerParams: Omit<
     TreeViewItemPluginSlotPropsEnhancerParams,
     'externalEventHandlers'
-  > = { rootRefObject, contentRefObject, interactions, status };
+  > = { rootRefObject, contentRefObject, interactions };
 
   const createRootHandleFocus =
     (otherHandlers: EventHandlers) =>
@@ -309,11 +309,16 @@ export const useTreeItem = <
       onDoubleClick: createLabelHandleDoubleClick(externalEventHandlers),
     };
 
-    if (status.editable) {
-      props.editable = true;
-    }
+    const enhancedLabelProps =
+      propsEnhancers.label?.({
+        ...sharedPropsEnhancerParams,
+        externalEventHandlers,
+      }) ?? {};
 
-    return props;
+    return {
+      ...enhancedLabelProps,
+      ...props,
+    };
   };
 
   const getLabelInputProps = <ExternalProps extends Record<string, any> = {}>(

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
@@ -33,6 +33,10 @@ import { generateTreeItemIdAttribute } from '../internals/corePlugins/useTreeVie
 import { selectorCanItemBeFocused } from '../internals/plugins/useTreeViewItems/useTreeViewItems.selectors';
 import { selectorTreeViewId } from '../internals/corePlugins/useTreeViewId/useTreeViewId.selectors';
 import { selectorItemExpansionTrigger } from '../internals/plugins/useTreeViewExpansion/useTreeViewExpansion.selectors';
+import {
+  selectorIsCheckboxSelectionEnabled,
+  selectorIsItemSelectionEnabled,
+} from '../internals/plugins/useTreeViewSelection/useTreeViewSelection.selectors';
 
 export const useTreeItem = <
   TSignatures extends UseTreeItemMinimalPlugins = UseTreeItemMinimalPlugins,
@@ -42,8 +46,6 @@ export const useTreeItem = <
 ): UseTreeItemReturnValue<TSignatures, TOptionalSignatures> => {
   const {
     runItemPlugins,
-    items: { onItemClick },
-    selection: { disableSelection, checkboxSelection },
     label: labelContext,
     instance,
     publicAPI,
@@ -74,6 +76,8 @@ export const useTreeItem = <
   const checkboxRef = React.useRef<HTMLButtonElement>(null);
 
   const treeId = useSelector(store, selectorTreeViewId);
+  const isSelectionEnabledForItem = useSelector(store, selectorIsItemSelectionEnabled);
+  const isCheckboxSelectionEnabled = useSelector(store, selectorIsCheckboxSelectionEnabled);
   const idAttribute = generateTreeItemIdAttribute({ itemId, treeId, id });
   const shouldBeAccessibleWithTab = useSelector(
     store,
@@ -159,7 +163,7 @@ export const useTreeItem = <
   const createContentHandleClick =
     (otherHandlers: EventHandlers) => (event: React.MouseEvent & TreeViewCancellableEvent) => {
       otherHandlers.onClick?.(event);
-      onItemClick(event, itemId);
+      instance.handleItemClick(event, itemId);
 
       if (event.defaultMuiPrevented || checkboxRef.current?.contains(event.target as HTMLElement)) {
         return;
@@ -168,7 +172,7 @@ export const useTreeItem = <
         interactions.handleExpansion(event);
       }
 
-      if (!checkboxSelection) {
+      if (!isCheckboxSelectionEnabled) {
         interactions.handleSelection(event);
       }
     };
@@ -212,7 +216,7 @@ export const useTreeItem = <
     if (status.selected) {
       // - each selected node has aria-selected set to true.
       ariaSelected = true;
-    } else if (disableSelection || status.disabled) {
+    } else if (!isSelectionEnabledForItem) {
       // - if the tree contains nodes that are not selectable, aria-selected is not present on those nodes.
       ariaSelected = undefined;
     } else {

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
@@ -44,13 +44,10 @@ export const useTreeItem = <
 >(
   parameters: UseTreeItemParameters,
 ): UseTreeItemReturnValue<TSignatures, TOptionalSignatures> => {
-  const {
-    runItemPlugins,
-    label: labelContext,
-    instance,
-    publicAPI,
-    store,
-  } = useTreeViewContext<TSignatures, TOptionalSignatures>();
+  const { runItemPlugins, instance, publicAPI, store } = useTreeViewContext<
+    TSignatures,
+    TOptionalSignatures
+  >();
   const depthContext = React.useContext(TreeViewItemDepthContext);
 
   const depth = useSelector(
@@ -76,7 +73,7 @@ export const useTreeItem = <
   const checkboxRef = React.useRef<HTMLButtonElement>(null);
 
   const treeId = useSelector(store, selectorTreeViewId);
-  const isSelectionEnabledForItem = useSelector(store, selectorIsItemSelectionEnabled);
+  const isSelectionEnabledForItem = useSelector(store, selectorIsItemSelectionEnabled, itemId);
   const isCheckboxSelectionEnabled = useSelector(store, selectorIsCheckboxSelectionEnabled);
   const idAttribute = generateTreeItemIdAttribute({ itemId, treeId, id });
   const shouldBeAccessibleWithTab = useSelector(
@@ -312,8 +309,8 @@ export const useTreeItem = <
       onDoubleClick: createLabelHandleDoubleClick(externalEventHandlers),
     };
 
-    if (labelContext?.isItemEditable) {
-      props.editable = status.editable;
+    if (status.editable) {
+      props.editable = true;
     }
 
     return props;

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.types.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.types.ts
@@ -81,7 +81,6 @@ export type UseTreeItemIconContainerSlotProps<ExternalProps = {}> = ExternalProp
 export interface UseTreeItemLabelSlotOwnProps {
   children: React.ReactNode;
   onDoubleClick: TreeViewCancellableEventHandler<React.MouseEvent>;
-  editable?: true;
 }
 
 export type UseTreeItemLabelSlotProps<ExternalProps = {}> = ExternalProps &

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.types.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.types.ts
@@ -81,10 +81,7 @@ export type UseTreeItemIconContainerSlotProps<ExternalProps = {}> = ExternalProp
 export interface UseTreeItemLabelSlotOwnProps {
   children: React.ReactNode;
   onDoubleClick: TreeViewCancellableEventHandler<React.MouseEvent>;
-  /**
-   * Only defined when the `isItemEditable` experimental feature is enabled.
-   */
-  editable?: boolean;
+  editable?: true;
 }
 
 export type UseTreeItemLabelSlotProps<ExternalProps = {}> = ExternalProps &

--- a/test/utils/tree-view/fakeContextValue.ts
+++ b/test/utils/tree-view/fakeContextValue.ts
@@ -14,18 +14,9 @@ export const getFakeContextValue = (
   }),
   wrapItem: ({ children }) => children,
   wrapRoot: ({ children }) => children,
-  items: {
-    onItemClick: () => {},
-  },
   icons: {
     slots: {},
     slotProps: {},
-  },
-  selection: {
-    multiSelect: false,
-    checkboxSelection: features.checkboxSelection ?? false,
-    disableSelection: false,
-    selectionPropagation: {},
   },
   rootRef: {
     current: null,
@@ -43,7 +34,14 @@ export const getFakeContextValue = (
       error: null,
     },
     expansion: { expandedItemsMap: new Map(), expansionTrigger: 'content' },
-    selection: { selectedItemsMap: new Map() },
+    selection: {
+      selectedItemsMap: new Map(),
+      rawSelectedItems: null,
+      isEnabled: true,
+      isMultiSelectEnabled: false,
+      isCheckboxSelectionEnabled: features.checkboxSelection ?? false,
+      selectionPropagation: { parents: false, descendants: false },
+    },
     focus: { focusedItemId: null, defaultFocusableItemId: null },
   }),
 });


### PR DESCRIPTION
On my way to entirely remove the context value :sunglasses: 

## Follow up

- Remove `useTreeViewIcons` in favor of a change similar to #16990 (that way we remove something MUI specific from the plugin system that will be used in the Base UI implementation).
- Drop the ability for the plugins to add stuff to the context (this will unlock #16357)