### PR TITLE
[DataGrid] Fix error while editing rows with custom id

### DIFF
--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -535,7 +535,7 @@ export const useGridRowEditing = (
         return;
       }
 
-      const rowUpdate = apiRef.current.getRowWithUpdatedValuesFromRowEditing(row.id);
+      const rowUpdate = apiRef.current.getRowWithUpdatedValuesFromRowEditing(id);
 
       if (processRowUpdate) {
         const handleError = (errorThrown: any) => {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17030

Regression from https://github.com/mui/mui-x/pull/16741
Custom id needs to be passed (if it is there), not the `id` field

Thanks @michelengelen for spotting it
