### PR TITLE
[DataGrid] Fix error caused by `forwardRef` to `ClickAwayListener`

### DIFF
--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -27,7 +27,7 @@ import MUIInputAdornment, { inputAdornmentClasses } from '@mui/material/InputAdo
 import MUITooltip from '@mui/material/Tooltip';
 import MUIPagination, { tablePaginationClasses } from '@mui/material/TablePagination';
 import MUIPopper, { PopperProps as MUIPopperProps } from '@mui/material/Popper';
-import MUIClickAwayListener from '@mui/material/ClickAwayListener';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 import MUIGrow from '@mui/material/Grow';
 import MUIPaper from '@mui/material/Paper';
 import MUIInputLabel from '@mui/material/InputLabel';
@@ -69,8 +69,6 @@ import { useGridApiContext } from '../hooks/utils/useGridApiContext';
 import { useGridRootProps } from '../hooks/utils/useGridRootProps';
 
 export { useMaterialCSSVariables } from './variables';
-
-const ClickAwayListener = forwardRef(MUIClickAwayListener);
 
 const InputAdornment = styled(MUIInputAdornment)({
   [`&.${inputAdornmentClasses.positionEnd} .${iconButtonClasses.sizeSmall}`]: {


### PR DESCRIPTION
Docs state that the component cannot hold a ref
https://mui.com/material-ui/api/click-away-listener/

Because of our own `forwardRef` implementation, warning is visible only in React <= 18

To reproduce:
Load the grid and check the console

Also visible in our CI
https://app.circleci.com/pipelines/github/mui/mui-x/85474/workflows/b784d8d7-e3ef-4421-b122-f783f9f33ede/jobs/489491
```
Chrome Headless 134.0.0.0 (Linux x86_64) ERROR: 'Warning: forwardRef render functions accept exactly two parameters: props and ref. %s', 'Did you forget to use the ref parameter?'
Chrome Headless 134.0.0.0 (Linux x86_64) ERROR: 'Warning: forwardRef render functions do not support propTypes or defaultProps. Did you accidentally pass a React component?'
```
