### PR TITLE
[charts-pro] Allow disabling Heatmap tooltip

### DIFF
--- a/docs/pages/x/api/charts/heatmap-tooltip.json
+++ b/docs/pages/x/api/charts/heatmap-tooltip.json
@@ -68,7 +68,11 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "transition": { "type": { "name": "bool" }, "default": "false" }
+    "transition": { "type": { "name": "bool" }, "default": "false" },
+    "trigger": {
+      "type": { "name": "enum", "description": "'item'<br>&#124;&nbsp;'none'" },
+      "default": "'item'"
+    }
   },
   "name": "HeatmapTooltip",
   "imports": [

--- a/docs/translations/api-docs/charts/heatmap-tooltip/heatmap-tooltip.json
+++ b/docs/translations/api-docs/charts/heatmap-tooltip/heatmap-tooltip.json
@@ -39,6 +39,9 @@
     },
     "transition": {
       "description": "Help supporting a react-transition-group/Transition component."
+    },
+    "trigger": {
+      "description": "Select the kind of tooltip to display - &#39;item&#39;: Shows data about the item below the mouse. - &#39;none&#39;: Does not display tooltip"
     }
   },
   "classDescriptions": {

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.test.tsx
@@ -8,13 +8,10 @@ import { Heatmap } from './Heatmap';
 describe('<Heatmap /> - License', () => {
   const { render } = createRenderer();
 
-  beforeEach(() => {
+  it('should render watermark when the license is missing', async () => {
     Object.keys(sharedLicenseStatuses).forEach((key) => {
       delete sharedLicenseStatuses[key];
     });
-  });
-
-  it('should render watermark when the license is missing', async () => {
     LicenseInfo.setLicenseKey('');
 
     expect(() =>

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip.tsx
@@ -19,7 +19,15 @@ import { getLabel, ChartsLabelMark } from '@mui/x-charts/internals';
 import { useHeatmapSeriesContext } from '../hooks/useHeatmapSeries';
 
 export interface HeatmapTooltipProps
-  extends Omit<ChartsTooltipContainerProps, 'trigger' | 'children'> {}
+  extends Omit<ChartsTooltipContainerProps, 'trigger' | 'children'> {
+  /**
+   * Select the kind of tooltip to display
+   * - 'item': Shows data about the item below the mouse.
+   * - 'none': Does not display tooltip
+   * @default 'item'
+   */
+  trigger?: 'item' | 'none';
+}
 
 const useUtilityClasses = (ownerState: { classes: HeatmapTooltipProps['classes'] }) => {
   const { classes } = ownerState;
@@ -116,7 +124,7 @@ function HeatmapTooltip(props: HeatmapTooltipProps) {
   const classes = useUtilityClasses({ classes: props.classes });
 
   return (
-    <ChartsTooltipContainer {...props} classes={classes} trigger="item">
+    <ChartsTooltipContainer trigger="item" {...props} classes={classes}>
       <DefaultHeatmapTooltipContent classes={classes} />
     </ChartsTooltipContainer>
   );
@@ -350,6 +358,13 @@ HeatmapTooltip.propTypes = {
    * @default false
    */
   transition: PropTypes.bool,
+  /**
+   * Select the kind of tooltip to display
+   * - 'item': Shows data about the item below the mouse.
+   * - 'none': Does not display tooltip
+   * @default 'item'
+   */
+  trigger: PropTypes.oneOf(['item', 'none']),
 } as any;
 
 export { HeatmapTooltip };

--- a/packages/x-charts-pro/src/hooks/useFunnelSeries.test.tsx
+++ b/packages/x-charts-pro/src/hooks/useFunnelSeries.test.tsx
@@ -1,8 +1,12 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { useFunnelSeries, useFunnelSeriesContext } from './useFunnelSeries';
-import { Unstable_FunnelChart as FunnelChart, FunnelSeriesType } from '../FunnelChart';
+import {
+  DefaultizedFunnelSeriesType,
+  Unstable_FunnelChart as FunnelChart,
+  FunnelSeriesType,
+} from '../FunnelChart';
 
 const mockSeries: FunnelSeriesType[] = [
   {
@@ -60,9 +64,12 @@ describe('useFunnelSeries', () => {
       `Make sure that they exist and their series are using the "funnel" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => useFunnelSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedFunnelSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => useFunnelSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => useFunnelSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts-pro/src/hooks/useHeatmapSeries.test.tsx
+++ b/packages/x-charts-pro/src/hooks/useHeatmapSeries.test.tsx
@@ -1,9 +1,9 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { useHeatmapSeries, useHeatmapSeriesContext } from './useHeatmapSeries';
 import { Heatmap } from '../Heatmap';
-import { HeatmapSeriesType } from '../models';
+import { DefaultizedHeatmapSeriesType, HeatmapSeriesType } from '../models';
 
 const mockSeries: HeatmapSeriesType[] = [
   {
@@ -19,9 +19,9 @@ const mockSeries: HeatmapSeriesType[] = [
     type: 'heatmap',
     id: '2',
     data: [
-      [3, 2, 20],
-      [3, 3, 70],
-      [3, 4, 90],
+      [1, 0, 20],
+      [1, 1, 70],
+      [1, 2, 90],
     ],
   },
 ];
@@ -30,8 +30,8 @@ const defaultProps = {
   series: mockSeries,
   height: 400,
   width: 400,
-  xAxis: [{ data: [1, 2, 3, 4] }],
-  yAxis: [{ data: ['A', 'B', 'C', 'D', 'E'] }],
+  xAxis: [{ data: [1, 2, 3] }],
+  yAxis: [{ data: ['A', 'B', 'C'] }],
 };
 
 const options: any = {
@@ -71,9 +71,12 @@ describe('useHeatmapSeries', () => {
       `Make sure that they exist and their series are using the "heatmap" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => useHeatmapSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedHeatmapSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => useHeatmapSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => useHeatmapSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts-vendor/tsconfig.json
+++ b/packages/x-charts-vendor/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "types": ["mocha", "node"]
   },
+  "include": ["src/**/*", "../../test/utils/addChaiAssertions.ts"],
   "exclude": ["es", "lib", "jest.config.ts"]
 }

--- a/packages/x-charts/src/hooks/useBarSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useBarSeries.test.tsx
@@ -1,8 +1,8 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { useBarSeries, useBarSeriesContext } from './useBarSeries';
-import { BarSeriesType } from '../models';
+import { BarSeriesType, DefaultizedBarSeriesType } from '../models';
 import { BarChart } from '../BarChart';
 
 const mockSeries: BarSeriesType[] = [
@@ -61,9 +61,12 @@ describe('useBarSeries', () => {
       `Make sure that they exist and their series are using the "bar" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => useBarSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedBarSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => useBarSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => useBarSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/useInteractionItemProps.ts
+++ b/packages/x-charts/src/hooks/useInteractionItemProps.ts
@@ -6,7 +6,10 @@ import { UseChartHighlightSignature } from '../internals/plugins/featurePlugins/
 import { UseChartInteractionSignature } from '../internals/plugins/featurePlugins/useChartInteraction';
 
 const onPointerDown = (event: React.PointerEvent) => {
-  if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+  if (
+    'hasPointerCapture' in event.currentTarget &&
+    event.currentTarget.hasPointerCapture(event.pointerId)
+  ) {
     event.currentTarget.releasePointerCapture(event.pointerId);
   }
 };

--- a/packages/x-charts/src/hooks/useLineSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useLineSeries.test.tsx
@@ -1,8 +1,8 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { useLineSeries, useLineSeriesContext } from './useLineSeries';
-import { LineSeriesType } from '../models';
+import { DefaultizedLineSeriesType, LineSeriesType } from '../models';
 import { LineChart } from '../LineChart';
 
 const mockSeries: LineSeriesType[] = [
@@ -61,9 +61,12 @@ describe('useLineSeries', () => {
       `Make sure that they exist and their series are using the "line" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => useLineSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedLineSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => useLineSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => useLineSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/usePieSeries.test.tsx
+++ b/packages/x-charts/src/hooks/usePieSeries.test.tsx
@@ -1,8 +1,8 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { usePieSeries, usePieSeriesContext } from './usePieSeries';
-import { PieSeriesType } from '../models';
+import { DefaultizedPieSeriesType, PieSeriesType } from '../models';
 import { PieChart } from '../PieChart';
 
 const mockSeries: PieSeriesType[] = [
@@ -61,9 +61,12 @@ describe('usePieSeries', () => {
       `Make sure that they exist and their series are using the "pie" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => usePieSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedPieSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => usePieSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => usePieSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/useRadarSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useRadarSeries.test.tsx
@@ -1,8 +1,8 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { useRadarSeries, useRadarSeriesContext } from './useRadarSeries';
-import { RadarSeriesType } from '../models';
+import { DefaultizedRadarSeriesType, RadarSeriesType } from '../models';
 import { Unstable_RadarChart as RadarChart } from '../RadarChart';
 
 const mockSeries: RadarSeriesType[] = [
@@ -62,9 +62,12 @@ describe('useRadarSeries', () => {
       `Make sure that they exist and their series are using the "radar" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => useRadarSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedRadarSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => useRadarSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => useRadarSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/hooks/useScatterSeries.test.tsx
+++ b/packages/x-charts/src/hooks/useScatterSeries.test.tsx
@@ -1,8 +1,8 @@
-import { renderHook } from '@mui/internal-test-utils';
+import { renderHook, RenderHookResult } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import * as React from 'react';
 import { useScatterSeries, useScatterSeriesContext } from './useScatterSeries';
-import { ScatterSeriesType } from '../models';
+import { DefaultizedScatterSeriesType, ScatterSeriesType } from '../models';
 import { ScatterChart } from '../ScatterChart';
 
 const mockSeries: ScatterSeriesType[] = [
@@ -67,9 +67,12 @@ describe('useScatterSeries', () => {
       `Make sure that they exist and their series are using the "scatter" series type.`,
     ].join('\n');
 
-    expect(() => renderHook(() => useScatterSeries(['1', '3']), options)).toWarnDev(message);
+    let render: RenderHookResult<DefaultizedScatterSeriesType[], unknown> | undefined;
 
-    const { result } = renderHook(() => useScatterSeries(['1', '3']), options);
-    expect(result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
+    expect(() => {
+      render = renderHook(() => useScatterSeries(['1', '3']), options);
+    }).toWarnDev(message);
+
+    expect(render?.result.current?.map((v) => v?.id)).to.deep.equal([mockSeries[0].id]);
   });
 });

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
@@ -105,7 +105,10 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
         return;
       }
 
-      if ((target as HTMLElement).hasPointerCapture(event.pointerId)) {
+      if (
+        'hasPointerCapture' in target &&
+        (target as HTMLElement).hasPointerCapture(event.pointerId)
+      ) {
         (target as HTMLElement).releasePointerCapture(event.pointerId);
       }
     };

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
@@ -165,7 +165,10 @@ export const useChartPolarAxis: ChartPlugin<UseChartPolarAxisSignature<any>> = (
         return;
       }
 
-      if ((target as HTMLElement).hasPointerCapture(event.pointerId)) {
+      if (
+        'hasPointerCapture' in target &&
+        (target as HTMLElement).hasPointerCapture(event.pointerId)
+      ) {
         (target as HTMLElement).releasePointerCapture(event.pointerId);
       }
     };

--- a/test/utils/setupJSDOM.js
+++ b/test/utils/setupJSDOM.js
@@ -17,7 +17,4 @@ window.getComputedStyle = function getComputedStyleMock() {
   };
 };
 
-// JSDOM has no support for pointer capture
-window.SVGElement.prototype.hasPointerCapture = () => false;
-
 module.exports = { ...coreExports, mochaHooks };


### PR DESCRIPTION
I've noticed we couldn't remove the tooltip of the Heatmap while testing. Added it on this PR. 

Also bundled a few test changes to prevent `act` warnings