### PR TITLE
[docs] Fix Data Grid advanced list view demo

### DIFF
--- a/docs/data/data-grid/list-view/ListViewAdvanced.js
+++ b/docs/data/data-grid/list-view/ListViewAdvanced.js
@@ -25,15 +25,14 @@ import { formatDate, formatSize, stringAvatar } from './utils';
 import { ActionDrawer } from './components/ActionDrawer';
 import { RenameDialog } from './components/RenameDialog';
 
-export default function ListViewAdvanced(props) {
+export default function ListViewAdvanced({ window }) {
   // This is used only for the example - renders the drawer inside the container
-  const containerRef = React.useRef(null);
-  const container = () => containerRef.current;
+  const container = window !== undefined ? window().document.body : undefined;
 
   const theme = useTheme();
   const isBelowMd = useMediaQuery(theme.breakpoints.down('md'));
 
-  const isDocsDemo = props.window !== undefined;
+  const isDocsDemo = window !== undefined;
   const isListView = isDocsDemo ? true : isBelowMd;
 
   const apiRef = useGridApiRef();
@@ -264,7 +263,6 @@ export default function ListViewAdvanced(props) {
     <React.Fragment>
       <CSSBaseline />
       <div
-        ref={containerRef}
         style={{
           maxWidth: '100%',
           height: 600,

--- a/docs/data/data-grid/list-view/ListViewAdvanced.tsx
+++ b/docs/data/data-grid/list-view/ListViewAdvanced.tsx
@@ -31,7 +31,7 @@ import { RenameDialog } from './components/RenameDialog';
 declare module '@mui/x-data-grid' {
   interface ToolbarPropsOverrides {
     listView: boolean;
-    container: () => HTMLElement;
+    container: HTMLElement;
     handleDelete: (ids: GridRowId[]) => void;
     handleUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   }
@@ -42,15 +42,14 @@ interface Props {
   window?: () => Window;
 }
 
-export default function ListViewAdvanced(props: Props) {
+export default function ListViewAdvanced({ window }: Props) {
   // This is used only for the example - renders the drawer inside the container
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const container = () => containerRef.current as HTMLElement;
+  const container = window !== undefined ? window().document.body : undefined;
 
   const theme = useTheme();
   const isBelowMd = useMediaQuery(theme.breakpoints.down('md'));
 
-  const isDocsDemo = props.window !== undefined;
+  const isDocsDemo = window !== undefined;
   const isListView = isDocsDemo ? true : isBelowMd;
 
   const apiRef = useGridApiRef();
@@ -288,7 +287,6 @@ export default function ListViewAdvanced(props: Props) {
     <React.Fragment>
       <CSSBaseline />
       <div
-        ref={containerRef}
         style={{
           maxWidth: '100%',
           height: 600,

--- a/docs/data/data-grid/list-view/components/Drawer.js
+++ b/docs/data/data-grid/list-view/components/Drawer.js
@@ -70,12 +70,14 @@ export function Drawer(props) {
       {...other}
       anchor={anchor}
       container={container}
-      PaperProps={{
-        sx: {
-          boxSizing: 'border-box',
-          ...(isBottomDrawer
-            ? { pb: 1, maxHeight: 'calc(100% - 100px)' }
-            : { width }),
+      slotProps={{
+        paper: {
+          sx: {
+            boxSizing: 'border-box',
+            ...(isBottomDrawer
+              ? { pb: 1, maxHeight: 'calc(100% - 100px)' }
+              : { width }),
+          },
         },
       }}
       disableSwipeToOpen

--- a/docs/data/data-grid/list-view/components/Drawer.tsx
+++ b/docs/data/data-grid/list-view/components/Drawer.tsx
@@ -66,7 +66,7 @@ export function DrawerHeader(props: DrawerHeaderProps) {
 
 export interface DrawerProps extends Omit<MUISwipeableDrawerProps, 'onOpen'> {
   width?: number;
-  container?: () => HTMLElement;
+  container?: HTMLElement;
 }
 
 export function Drawer(props: DrawerProps) {
@@ -79,12 +79,14 @@ export function Drawer(props: DrawerProps) {
       {...other}
       anchor={anchor}
       container={container}
-      PaperProps={{
-        sx: {
-          boxSizing: 'border-box',
-          ...(isBottomDrawer
-            ? { pb: 1, maxHeight: 'calc(100% - 100px)' }
-            : { width }),
+      slotProps={{
+        paper: {
+          sx: {
+            boxSizing: 'border-box',
+            ...(isBottomDrawer
+              ? { pb: 1, maxHeight: 'calc(100% - 100px)' }
+              : { width }),
+          },
         },
       }}
       disableSwipeToOpen

--- a/docs/data/data-grid/list-view/components/RenameDialog.tsx
+++ b/docs/data/data-grid/list-view/components/RenameDialog.tsx
@@ -11,7 +11,7 @@ import { RowModel } from '../types';
 export interface RenameDialogProps {
   params: Pick<GridRowParams<RowModel>, 'row'> | null;
   open: boolean;
-  container?: () => HTMLElement;
+  container?: HTMLElement;
   onSave: (id: GridRowId, value: string) => void;
   onClose: () => void;
 }


### PR DESCRIPTION
Use the `window` prop that gets passed to iframe demos instead of a ref on the container element.

Fixes #17056 

**Before**

https://next.mui.com/x/react-data-grid/list-view/#advanced-usage

https://github.com/user-attachments/assets/3eb9a113-15a7-4633-9e22-92dd1197e4fc

**After**

https://deploy-preview-17064--material-ui-x.netlify.app/x/react-data-grid/list-view/#advanced-usage

https://github.com/user-attachments/assets/69951e66-84bf-4ff3-bdea-a8a7dec3887d
