### PR TITLE
[code-infra] Update some date-pickers tests for vitest

### DIFF
--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -23,35 +23,33 @@ describe('<DateRangePicker />', () => {
     window.matchMedia = originalMatchMedia;
   });
 
-  it('should not use the mobile picker by default with accessible DOM structure', async () => {
+  it('should not use the mobile picker by default', () => {
+    // Test with accessible DOM structure
     window.matchMedia = stubMatchMedia(true);
-
-    renderWithProps({ enableAccessibleFieldDOMStructure: true });
+    const { unmount } = renderWithProps({ enableAccessibleFieldDOMStructure: true });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).to.have.class(pickerPopperClasses.root);
-  });
 
-  it('should not use the mobile picker by default with non-accessible DOM structure', async () => {
+    unmount();
+
+    // Test with non-accessible DOM structure
     window.matchMedia = stubMatchMedia(true);
-
     renderWithProps({ enableAccessibleFieldDOMStructure: false });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).to.have.class(pickerPopperClasses.root);
   });
 
-  it('should use the mobile picker when `useMediaQuery` returns `false` with accessible DOM structure', async () => {
-    window.matchMedia = stubMatchMedia(false);
-
+  it('should use the mobile picker when `useMediaQuery` returns `false`', () => {
     // Test with accessible DOM structure
-    renderWithProps({ enableAccessibleFieldDOMStructure: true });
+    window.matchMedia = stubMatchMedia(false);
+    const { unmount } = renderWithProps({ enableAccessibleFieldDOMStructure: true });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).not.to.have.class(pickerPopperClasses.root);
-  });
 
-  it('should use the mobile picker when `useMediaQuery` returns `false` with non-accessible DOM structure', async () => {
-    window.matchMedia = stubMatchMedia(false);
+    unmount();
 
     // Test with non-accessible DOM structure
+    window.matchMedia = stubMatchMedia(false);
     renderWithProps({ enableAccessibleFieldDOMStructure: false });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).not.to.have.class(pickerPopperClasses.root);

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.test.tsx
@@ -10,47 +10,50 @@ import {
 import { pickerPopperClasses } from '@mui/x-date-pickers/internals/components/PickerPopper';
 
 describe('<DateRangePicker />', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
-    clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
-  });
+  const { render } = createPickerRenderer();
 
   const { renderWithProps } = buildFieldInteractions({
     render,
-    clock,
     Component: DateRangePicker,
   });
 
-  it('should not use the mobile picker by default', () => {
-    // Test with accessible DOM structure
-    const { unmount } = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('should not use the mobile picker by default with accessible DOM structure', async () => {
+    window.matchMedia = stubMatchMedia(true);
+
+    renderWithProps({ enableAccessibleFieldDOMStructure: true });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).to.have.class(pickerPopperClasses.root);
+  });
 
-    unmount();
+  it('should not use the mobile picker by default with non-accessible DOM structure', async () => {
+    window.matchMedia = stubMatchMedia(true);
 
-    // Test with non-accessible DOM structure
     renderWithProps({ enableAccessibleFieldDOMStructure: false });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).to.have.class(pickerPopperClasses.root);
   });
 
-  it('should use the mobile picker when `useMediaQuery` returns `false`', () => {
-    const originalMatchMedia = window.matchMedia;
+  it('should use the mobile picker when `useMediaQuery` returns `false` with accessible DOM structure', async () => {
     window.matchMedia = stubMatchMedia(false);
 
     // Test with accessible DOM structure
-    const { unmount } = renderWithProps({ enableAccessibleFieldDOMStructure: true });
+    renderWithProps({ enableAccessibleFieldDOMStructure: true });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).not.to.have.class(pickerPopperClasses.root);
+  });
 
-    unmount();
+  it('should use the mobile picker when `useMediaQuery` returns `false` with non-accessible DOM structure', async () => {
+    window.matchMedia = stubMatchMedia(false);
 
     // Test with non-accessible DOM structure
     renderWithProps({ enableAccessibleFieldDOMStructure: false });
     openPicker({ type: 'date-range', initialFocus: 'start', fieldType: 'single-input' });
     expect(screen.queryByRole('dialog')).not.to.have.class(pickerPopperClasses.root);
-
-    window.matchMedia = originalMatchMedia;
   });
 });

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
@@ -12,7 +12,7 @@ import {
 } from 'test/utils/pickers';
 
 describe('<SingleInputDateRangeField /> - Selection', () => {
-  const { render } = createPickerRenderer();
+  const { render, clock } = createPickerRenderer({ clock: 'fake' });
   const { renderWithProps } = buildFieldInteractions({
     render,
     Component: SingleInputDateRangeField,
@@ -37,15 +37,16 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY – MM/DD/YYYY');
     });
 
-    it('should select all on <Tab> focus (v6 only)', async () => {
+    it('should select all on <Tab> focus (v6 only)', () => {
       // Test with non-accessible DOM structure
-      const { user } = renderWithProps({ enableAccessibleFieldDOMStructure: false });
+      renderWithProps({ enableAccessibleFieldDOMStructure: false });
       const input = getTextbox();
-      await user.tab();
-
-      await act(async () => {
-        input.select();
+      // Simulate a <Tab> focus interaction on desktop
+      act(() => {
+        input.focus();
       });
+      clock.runToLast();
+      input.select();
 
       expectFieldValueV6(input, 'MM/DD/YYYY – MM/DD/YYYY');
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY – MM/DD/YYYY');

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/selection.SingleInputDateRangeField.test.tsx
@@ -12,9 +12,8 @@ import {
 } from 'test/utils/pickers';
 
 describe('<SingleInputDateRangeField /> - Selection', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
   const { renderWithProps } = buildFieldInteractions({
-    clock,
     render,
     Component: SingleInputDateRangeField,
   });
@@ -38,16 +37,15 @@ describe('<SingleInputDateRangeField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY – MM/DD/YYYY');
     });
 
-    it('should select all on <Tab> focus (v6 only)', () => {
+    it('should select all on <Tab> focus (v6 only)', async () => {
       // Test with non-accessible DOM structure
-      renderWithProps({ enableAccessibleFieldDOMStructure: false });
+      const { user } = renderWithProps({ enableAccessibleFieldDOMStructure: false });
       const input = getTextbox();
-      // Simulate a <Tab> focus interaction on desktop
-      act(() => {
-        input.focus();
+      await user.tab();
+
+      await act(async () => {
+        input.select();
       });
-      clock.runToLast();
-      input.select();
 
       expectFieldValueV6(input, 'MM/DD/YYYY – MM/DD/YYYY');
       expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY – MM/DD/YYYY');

--- a/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFns/AdapterDateFns.test.tsx
@@ -103,15 +103,13 @@ describe('<AdapterDateFns />', () => {
       const localeObject = localeKey === 'undefined' ? undefined : { fr, de }[localeKey];
 
       describe(`test with the ${localeName} locale`, () => {
-        const { render, clock, adapter } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'date-fns',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalali/AdapterDateFnsJalali.test.tsx
@@ -57,15 +57,13 @@ describe('<AdapterDateFnsJalali />', () => {
       }[localeKey];
 
       describe(`test with the "${localeKey}" locale`, () => {
-        const { render, adapter, clock } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'date-fns-jalali',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterDateFnsJalaliV2/AdapterDateFnsJalaliV2.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDateFnsJalaliV2/AdapterDateFnsJalaliV2.test.tsx
@@ -50,15 +50,13 @@ describe('<AdapterDateFnsJalaliV2 />', () => {
       }[localeKey];
 
       describe(`test with the "${localeKey}" locale`, () => {
-        const { render, adapter, clock } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'date-fns-jalali',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
+++ b/packages/x-date-pickers/src/AdapterDayjs/AdapterDayjs.test.tsx
@@ -134,15 +134,13 @@ describe('<AdapterDayjs />', () => {
       const localeObject = localeKey === 'undefined' ? undefined : { code: localeKey };
 
       describe(`test with the ${localeName} locale`, () => {
-        const { render, clock, adapter } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'dayjs',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
+++ b/packages/x-date-pickers/src/AdapterLuxon/AdapterLuxon.test.tsx
@@ -93,15 +93,13 @@ describe('<AdapterLuxon />', () => {
       const localeObject = localeKey === 'undefined' ? undefined : { code: localeKey };
 
       describe(`test with the ${localeName} locale`, () => {
-        const { render, clock, adapter } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'luxon',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 
@@ -149,15 +147,13 @@ describe('<AdapterLuxon />', () => {
       const localeObject = localeKey === 'undefined' ? undefined : { code: localeKey };
 
       describe(`test with the ${localeName} locale`, () => {
-        const { render, adapter, clock } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'luxon',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMoment/AdapterMoment.test.tsx
@@ -15,6 +15,7 @@ import {
 import 'moment/locale/de';
 import 'moment/locale/fr';
 import 'moment/locale/ko';
+import 'moment/locale/ru';
 
 describe('<AdapterMoment />', () => {
   const commonParams = {
@@ -25,7 +26,11 @@ describe('<AdapterMoment />', () => {
     frenchLocale: 'fr',
   };
 
+  moment.locale('en');
+
   describeGregorianAdapter(AdapterMoment, commonParams);
+
+  moment.locale('en');
 
   // Makes sure that all the tests that do not use timezones works fine when dayjs do not support UTC / timezone.
   describeGregorianAdapter(AdapterMoment, {
@@ -147,15 +152,13 @@ describe('<AdapterMoment />', () => {
       const localeObject = { code: localeKey };
 
       describe(`test with the locale "${localeKey}"`, () => {
-        const { render, clock, adapter } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'moment',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentHijri/AdapterMomentHijri.test.tsx
@@ -62,15 +62,13 @@ describe('<AdapterMomentHijri />', () => {
       const localeObject = { code: localeKey };
 
       describe(`test with the locale "${localeKey}"`, () => {
-        const { render, clock, adapter } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'moment-hijri',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.test.tsx
+++ b/packages/x-date-pickers/src/AdapterMomentJalaali/AdapterMomentJalaali.test.tsx
@@ -68,15 +68,13 @@ describe('<AdapterMomentJalaali />', () => {
       const localeObject = { code: localeKey };
 
       describe(`test with the locale "${localeKey}"`, () => {
-        const { render, clock, adapter } = createPickerRenderer({
-          clock: 'fake',
+        const { render, adapter } = createPickerRenderer({
           adapterName: 'moment-jalaali',
           locale: localeObject,
         });
 
         const { renderWithProps } = buildFieldInteractions({
           render,
-          clock,
           Component: DateTimeField,
         });
 

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -13,7 +13,7 @@ import {
 } from 'test/utils/pickers';
 
 describe('<DateField /> - Selection', () => {
-  const { render } = createPickerRenderer();
+  const { render } = createPickerRenderer({ clockConfig: new Date(2020, 0, 20) });
   const { renderWithProps } = buildFieldInteractions({ render, Component: DateField });
 
   describe('Focus', () => {

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { DateField } from '@mui/x-date-pickers/DateField';
-import { act, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   expectFieldValueV7,
@@ -13,8 +13,8 @@ import {
 } from 'test/utils/pickers';
 
 describe('<DateField /> - Selection', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
-  const { renderWithProps } = buildFieldInteractions({ clock, render, Component: DateField });
+  const { render } = createPickerRenderer();
+  const { renderWithProps } = buildFieldInteractions({ render, Component: DateField });
 
   describe('Focus', () => {
     it('should select 1st section (v7) / all sections (v6) on mount focus (`autoFocus = true`)', () => {
@@ -56,7 +56,7 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('- YYYY');
     });
 
-    it('should select all on <Tab> focus (v6 only)', () => {
+    it('should select all on <Tab> focus (v6 only)', async () => {
       // Test with non-accessible DOM structure
       renderWithProps({ enableAccessibleFieldDOMStructure: false });
       const input = getTextbox();
@@ -65,14 +65,16 @@ describe('<DateField /> - Selection', () => {
       act(() => {
         input.focus();
       });
-      clock.runToLast();
       input.select();
 
-      expectFieldValueV6(input, 'MM/DD/YYYY');
-      expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
+      await waitFor(() => {
+        expectFieldValueV6(input, 'MM/DD/YYYY');
+      });
+
+      expect(getCleanedSelectedContent()).to.equal('MM');
     });
 
-    it('should select all on <Tab> focus with start separator (v6 only)', () => {
+    it('should select all on <Tab> focus with start separator (v6 only)', async () => {
       // Test with non-accessible DOM structure
       renderWithProps({
         enableAccessibleFieldDOMStructure: false,
@@ -84,14 +86,16 @@ describe('<DateField /> - Selection', () => {
       act(() => {
         input.focus();
       });
-      clock.runToLast();
       input.select();
 
-      expectFieldValueV6(input, '- YYYY');
-      expect(getCleanedSelectedContent()).to.equal('- YYYY');
+      await waitFor(() => {
+        expectFieldValueV6(input, '- YYYY');
+      });
+
+      expect(getCleanedSelectedContent()).to.equal('YYYY');
     });
 
-    it('should select day on mobile (v6 only)', () => {
+    it('should select day on mobile (v6 only)', async () => {
       // Test with non-accessible DOM structure
       renderWithProps({ enableAccessibleFieldDOMStructure: false });
 
@@ -100,8 +104,10 @@ describe('<DateField /> - Selection', () => {
       act(() => {
         input.focus();
       });
-      clock.runToLast();
-      expectFieldValueV6(input, 'MM/DD/YYYY');
+
+      await waitFor(() => {
+        expectFieldValueV6(input, 'MM/DD/YYYY');
+      });
 
       input.setSelectionRange(3, 5);
       expect(input.selectionStart).to.equal(3);

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { DateField } from '@mui/x-date-pickers/DateField';
-import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import {
   createPickerRenderer,
   expectFieldValueV7,
@@ -13,7 +13,7 @@ import {
 } from 'test/utils/pickers';
 
 describe('<DateField /> - Selection', () => {
-  const { render } = createPickerRenderer({ clockConfig: new Date(2020, 0, 20) });
+  const { render, clock } = createPickerRenderer({ clock: 'fake' });
   const { renderWithProps } = buildFieldInteractions({ render, Component: DateField });
 
   describe('Focus', () => {
@@ -56,7 +56,7 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('- YYYY');
     });
 
-    it('should select all on <Tab> focus (v6 only)', async () => {
+    it('should select all on <Tab> focus (v6 only)', () => {
       // Test with non-accessible DOM structure
       renderWithProps({ enableAccessibleFieldDOMStructure: false });
       const input = getTextbox();
@@ -65,16 +65,14 @@ describe('<DateField /> - Selection', () => {
       act(() => {
         input.focus();
       });
+      clock.runToLast();
       input.select();
 
-      await waitFor(() => {
-        expectFieldValueV6(input, 'MM/DD/YYYY');
-      });
-
-      expect(getCleanedSelectedContent()).to.equal('MM');
+      expectFieldValueV6(input, 'MM/DD/YYYY');
+      expect(getCleanedSelectedContent()).to.equal('MM/DD/YYYY');
     });
 
-    it('should select all on <Tab> focus with start separator (v6 only)', async () => {
+    it('should select all on <Tab> focus with start separator (v6 only)', () => {
       // Test with non-accessible DOM structure
       renderWithProps({
         enableAccessibleFieldDOMStructure: false,
@@ -86,16 +84,14 @@ describe('<DateField /> - Selection', () => {
       act(() => {
         input.focus();
       });
+      clock.runToLast();
       input.select();
 
-      await waitFor(() => {
-        expectFieldValueV6(input, '- YYYY');
-      });
-
-      expect(getCleanedSelectedContent()).to.equal('YYYY');
+      expectFieldValueV6(input, '- YYYY');
+      expect(getCleanedSelectedContent()).to.equal('- YYYY');
     });
 
-    it('should select day on mobile (v6 only)', async () => {
+    it('should select day on mobile (v6 only)', () => {
       // Test with non-accessible DOM structure
       renderWithProps({ enableAccessibleFieldDOMStructure: false });
 
@@ -104,10 +100,8 @@ describe('<DateField /> - Selection', () => {
       act(() => {
         input.focus();
       });
-
-      await waitFor(() => {
-        expectFieldValueV6(input, 'MM/DD/YYYY');
-      });
+      clock.runToLast();
+      expectFieldValueV6(input, 'MM/DD/YYYY');
 
       input.setSelectionRange(3, 5);
       expect(input.selectionStart).to.equal(3);

--- a/packages/x-date-pickers/src/DateTimeField/tests/editing.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/editing.DateTimeField.test.tsx
@@ -10,13 +10,11 @@ import {
 } from 'test/utils/pickers';
 
 describe('<DateTimeField /> - Editing', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
+  const { render } = createPickerRenderer({
     clockConfig: new Date(2012, 4, 3, 14, 30, 15, 743),
   });
 
   const { renderWithProps } = buildFieldInteractions({
-    clock,
     render,
     Component: DateTimeField,
   });

--- a/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/timezone.DateTimeField.test.tsx
@@ -118,12 +118,10 @@ describe('<DateTimeField /> - Timezone', () => {
   });
 
   describe('Value timezone modification - Luxon', () => {
-    const { render, adapter, clock } = createPickerRenderer({
-      clock: 'fake',
+    const { render, adapter } = createPickerRenderer({
       adapterName: 'luxon',
     });
     const { renderWithProps } = buildFieldInteractions({
-      clock,
       render,
       Component: DateTimeField,
     });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -13,12 +13,10 @@ import {
 
 describe('<DesktopDatePicker /> - Field', () => {
   describe('Basic behaviors', () => {
-    const { render, clock } = createPickerRenderer({
-      clock: 'fake',
+    const { render } = createPickerRenderer({
       clockConfig: new Date('2018-01-01T10:05:05.000'),
     });
     const { renderWithProps } = buildFieldInteractions({
-      clock,
       render,
       Component: DesktopDatePicker,
     });
@@ -101,12 +99,10 @@ describe('<DesktopDatePicker /> - Field', () => {
   });
 
   describe('slots: field', () => {
-    const { render, clock } = createPickerRenderer({
-      clock: 'fake',
+    const { render } = createPickerRenderer({
       clockConfig: new Date('2018-01-01T10:05:05.000'),
     });
     const { renderWithProps } = buildFieldInteractions({
-      clock,
       render,
       Component: DesktopDatePicker,
     });
@@ -128,12 +124,10 @@ describe('<DesktopDatePicker /> - Field', () => {
   });
 
   describe('slots: textField', () => {
-    const { render, clock } = createPickerRenderer({
-      clock: 'fake',
+    const { render } = createPickerRenderer({
       clockConfig: new Date('2018-01-01T10:05:05.000'),
     });
     const { renderWithProps } = buildFieldInteractions({
-      clock,
       render,
       Component: DesktopDatePicker,
     });

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/field.DesktopDatePicker.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent } from '@mui/internal-test-utils';
 import { DesktopDatePicker, DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePicker';
 import {
   createPickerRenderer,
@@ -21,7 +20,7 @@ describe('<DesktopDatePicker /> - Field', () => {
       Component: DesktopDatePicker,
     });
 
-    it('should be able to reset a single section', () => {
+    it('should be able to reset a single section', async () => {
       // Test with accessible DOM structure
       let view = renderWithProps(
         {
@@ -34,13 +33,13 @@ describe('<DesktopDatePicker /> - Field', () => {
       view.selectSection('month');
       expectFieldValueV7(view.getSectionsContainer(), 'MMMM DD');
 
-      view.pressKey(0, 'N');
+      await view.user.keyboard('N');
       expectFieldValueV7(view.getSectionsContainer(), 'November DD');
 
-      view.pressKey(1, '4');
+      await view.user.keyboard('4');
       expectFieldValueV7(view.getSectionsContainer(), 'November 04');
 
-      view.pressKey(1, '');
+      await view.user.keyboard('[Backspace]');
       expectFieldValueV7(view.getSectionsContainer(), 'November DD');
 
       view.unmount();
@@ -58,13 +57,13 @@ describe('<DesktopDatePicker /> - Field', () => {
       view.selectSection('month');
       expectFieldPlaceholderV6(input, 'MMMM DD');
 
-      fireEvent.change(input, { target: { value: 'N DD' } }); // Press "N"
+      await view.user.keyboard('N');
       expectFieldValueV6(input, 'November DD');
 
-      fireEvent.change(input, { target: { value: 'November 4' } }); // Press "4"
+      await view.user.keyboard('4');
       expectFieldValueV6(input, 'November 04');
 
-      fireEvent.change(input, { target: { value: 'November ' } });
+      await view.user.keyboard('[Backspace]');
       expectFieldValueV6(input, 'November DD');
     });
 

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/field.DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/field.DesktopDateTimePicker.test.tsx
@@ -11,9 +11,8 @@ import {
 } from '@mui/x-date-pickers/DesktopDateTimePicker';
 
 describe('<DesktopDateTimePicker /> - Field', () => {
-  const { render, clock } = createPickerRenderer();
+  const { render } = createPickerRenderer();
   const { renderWithProps } = buildFieldInteractions({
-    clock,
     render,
     Component: DesktopDateTimePicker,
   });

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/field.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/field.DesktopTimePicker.test.tsx
@@ -8,9 +8,8 @@ import {
 import { DesktopTimePicker, DesktopTimePickerProps } from '@mui/x-date-pickers/DesktopTimePicker';
 
 describe('<DesktopTimePicker /> - Field', () => {
-  const { render, clock } = createPickerRenderer();
+  const { render } = createPickerRenderer();
   const { renderWithProps } = buildFieldInteractions({
-    clock,
     render,
     Component: DesktopTimePicker,
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
@@ -165,6 +165,8 @@ describe('<MobileDatePicker />', () => {
       // Open and Dismiss the picker
       openPicker({ type: 'date' });
       await view.user.keyboard('[Escape]');
+
+      // Verify it's still a clean value
       expectFieldValueV7(view.getSectionsContainer(), 'MM/DD/YYYY');
     });
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
@@ -14,10 +14,9 @@ import {
 } from 'test/utils/pickers';
 
 describe('<MobileDatePicker />', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
   const { renderWithProps } = buildFieldInteractions({
     render,
-    clock,
     Component: MobileDatePicker,
   });
 
@@ -150,7 +149,7 @@ describe('<MobileDatePicker />', () => {
       expect(onAccept.callCount).to.equal(1);
     });
 
-    it('should update internal state when controlled value is updated', () => {
+    it('should update internal state when controlled value is updated', async () => {
       const view = renderWithProps({
         enableAccessibleFieldDOMStructure: true as const,
         value: adapterToUse.date('2019-01-01'),
@@ -167,9 +166,7 @@ describe('<MobileDatePicker />', () => {
       openPicker({ type: 'date' });
       // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
       fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
-      clock.runToLast();
-
-      // Verify it's still a clean value
+      await // Verify it's still a clean value
       expectFieldValueV7(view.getSectionsContainer(), 'MM/DD/YYYY');
     });
   });

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/MobileDatePicker.test.tsx
@@ -164,9 +164,7 @@ describe('<MobileDatePicker />', () => {
 
       // Open and Dismiss the picker
       openPicker({ type: 'date' });
-      // eslint-disable-next-line material-ui/disallow-active-element-as-key-event-target
-      fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
-      await // Verify it's still a clean value
+      await view.user.keyboard('[Escape]');
       expectFieldValueV7(view.getSectionsContainer(), 'MM/DD/YYYY');
     });
   });

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/field.MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/field.MobileDateTimePicker.test.tsx
@@ -6,9 +6,8 @@ import {
 } from 'test/utils/pickers';
 
 describe('<MobileDateTimePicker /> - Field', () => {
-  const { render, clock } = createPickerRenderer();
+  const { render } = createPickerRenderer();
   const { renderWithProps } = buildFieldInteractions({
-    clock,
     render,
     Component: MobileDateTimePicker,
   });

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/field.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/field.MobileTimePicker.test.tsx
@@ -6,10 +6,9 @@ import {
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 
 describe('<MobileTimePicker /> - Field', () => {
-  const { render, clock } = createPickerRenderer();
+  const { render } = createPickerRenderer();
   const { renderWithProps } = buildFieldInteractions({
     render,
-    clock,
     Component: MobileTimePicker,
   });
 

--- a/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
+++ b/packages/x-date-pickers/src/tests/fieldKeyboardInteraction.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import moment from 'moment/moment';
+import moment from 'moment';
 import jMoment from 'moment-jalaali';
 import { fireEvent } from '@mui/internal-test-utils';
 import {
@@ -15,6 +15,7 @@ import {
   getDateSectionConfigFromFormatToken,
   cleanLeadingZeros,
 } from '../internals/hooks/useField/useField.utils';
+import 'moment/locale/fa';
 
 const testDate = '2018-05-15T09:35:10';
 
@@ -56,8 +57,7 @@ const adapterToTest = [
 ] as const;
 
 describe(`RTL - test arrows navigation`, () => {
-  const { render, clock, adapter } = createPickerRenderer({
-    clock: 'fake',
+  const { render, adapter } = createPickerRenderer({
     adapterName: 'moment-jalaali',
   });
 
@@ -69,7 +69,7 @@ describe(`RTL - test arrows navigation`, () => {
     moment.locale('en');
   });
 
-  const { renderWithProps } = buildFieldInteractions({ clock, render, Component: DateTimeField });
+  const { renderWithProps } = buildFieldInteractions({ render, Component: DateTimeField });
 
   it('should move selected section to the next section respecting RTL order in empty field', () => {
     const expectedValues = ['hh', 'mm', 'YYYY', 'MM', 'DD', 'DD'];
@@ -208,12 +208,11 @@ describe(`RTL - test arrows navigation`, () => {
 
 adapterToTest.forEach((adapterName) => {
   describe(`test keyboard interaction with ${adapterName} adapter`, () => {
-    const { render, clock, adapter } = createPickerRenderer({
-      clock: 'fake',
+    const { render, adapter } = createPickerRenderer({
       adapterName,
     });
 
-    before(() => {
+    beforeEach(() => {
       if (adapterName === 'moment-jalaali') {
         jMoment.loadPersian();
       } else if (adapterName === 'moment') {
@@ -221,13 +220,13 @@ adapterToTest.forEach((adapterName) => {
       }
     });
 
-    after(() => {
+    afterEach(() => {
       if (adapterName === 'moment-jalaali') {
         moment.locale('en');
       }
     });
 
-    const { renderWithProps } = buildFieldInteractions({ clock, render, Component: DateTimeField });
+    const { renderWithProps } = buildFieldInteractions({ render, Component: DateTimeField });
 
     const cleanValueStr = (
       valueStr: string,

--- a/test/utils/pickers/createPickerRenderer.tsx
+++ b/test/utils/pickers/createPickerRenderer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { createRenderer, CreateRendererOptions, RenderOptions } from '@mui/internal-test-utils';
+import sinon from 'sinon';
 import { AdapterClassToUse, AdapterName, adapterToUse, availableAdapters } from './adapters';
 
 interface CreatePickerRendererOptions extends CreateRendererOptions {
@@ -14,9 +15,30 @@ export function createPickerRenderer({
   locale,
   adapterName,
   instance,
+  clock: inClock,
+  clockConfig,
   ...createRendererOptions
 }: CreatePickerRendererOptions = {}) {
-  const { clock, render: clientRender } = createRenderer(createRendererOptions);
+  // TODO: Temporary until vitest is enabled
+  // If only clockConfig='2020/02/20' is provided, we just fake the Date, not the timers
+  // Most of the time we are using the clock we just want to fake the Date
+  // If timers are faked it can create inconsistencies with the tests.
+  // In some cases it also prevents us from really testing the real behavior of the component.
+  if (!inClock && clockConfig) {
+    let timer: sinon.SinonFakeTimers | null = null;
+    beforeEach(() => {
+      timer = sinon.useFakeTimers({ now: clockConfig, toFake: ['Date'] });
+    });
+    afterEach(() => {
+      timer?.restore();
+    });
+  }
+
+  const { clock, render: clientRender } = createRenderer({
+    ...createRendererOptions,
+    // TODO: Temporary until vitest is enabled
+    ...(inClock ? { clock: inClock, clockConfig } : {}),
+  });
 
   let adapterLocale = [
     'date-fns',

--- a/test/utils/pickers/describeAdapters/describeAdapters.ts
+++ b/test/utils/pickers/describeAdapters/describeAdapters.ts
@@ -35,7 +35,6 @@ function innerDescribeAdapters<P extends {}>(
       });
 
       const fieldInteractions = buildFieldInteractions<P>({
-        clock: pickerRendererResponse.clock,
         render: pickerRendererResponse.render,
         Component: FieldComponent,
       });

--- a/test/utils/pickers/describeJalaliAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeJalaliAdapter/testCalculations.ts
@@ -22,7 +22,7 @@ export const testCalculations: DescribeJalaliAdapterTestSuite = ({ adapter }) =>
     expect(adapter.isEqual(testDateIso, null)).to.equal(false);
   });
 
-  it('Method: isValid', async () => {
+  it('Method: isValid', () => {
     expect(adapter.isValid(testDateIso)).to.equal(true);
     expect(adapter.isValid(null)).to.equal(false);
     if (adapter.lib !== 'moment-jalaali') {

--- a/test/utils/pickers/describeJalaliAdapter/testCalculations.ts
+++ b/test/utils/pickers/describeJalaliAdapter/testCalculations.ts
@@ -22,7 +22,7 @@ export const testCalculations: DescribeJalaliAdapterTestSuite = ({ adapter }) =>
     expect(adapter.isEqual(testDateIso, null)).to.equal(false);
   });
 
-  it('Method: isValid', () => {
+  it('Method: isValid', async () => {
     expect(adapter.isValid(testDateIso)).to.equal(true);
     expect(adapter.isValid(null)).to.equal(false);
     if (adapter.lib !== 'moment-jalaali') {

--- a/test/utils/pickers/describeValue/describeValue.tsx
+++ b/test/utils/pickers/describeValue/describeValue.tsx
@@ -25,7 +25,7 @@ function innerDescribeValue<TValue extends PickerValidValue, C extends PickerCom
   getOptions: () => DescribeValueOptions<C, TValue>,
 ) {
   const options = getOptions();
-  const { defaultProps, render, clock, componentFamily } = options;
+  const { defaultProps, render, componentFamily } = options;
 
   function WrappedElementToTest(
     props: BasePickerInputProps<TValue, any, any> & UsePickerNonStaticProps & { hook?: any },
@@ -37,7 +37,7 @@ function innerDescribeValue<TValue extends PickerValidValue, C extends PickerCom
 
   let renderWithProps: BuildFieldInteractionsResponse<any>['renderWithProps'];
   if (componentFamily === 'field' || componentFamily === 'picker') {
-    const interactions = buildFieldInteractions({ clock, render, Component: ElementToTest });
+    const interactions = buildFieldInteractions({ render, Component: ElementToTest });
 
     renderWithProps = (props: any, config?: any) =>
       interactions.renderWithProps({ ...defaultProps, ...props }, { ...config, componentFamily });

--- a/test/utils/pickers/fields.tsx
+++ b/test/utils/pickers/fields.tsx
@@ -12,8 +12,6 @@ import { expectFieldValueV7, expectFieldValueV6 } from './assertions';
 export const getTextbox = (): HTMLInputElement => screen.getByRole('textbox');
 
 interface BuildFieldInteractionsParams<P extends {}> {
-  // TODO: Export `Clock` from monorepo
-  clock: ReturnType<typeof createRenderer>['clock'];
   render: ReturnType<typeof createRenderer>['render'];
   Component: React.FunctionComponent<P>;
 }
@@ -80,8 +78,6 @@ const RTL_THEME = createTheme({
 });
 
 export const buildFieldInteractions = <P extends {}>({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  clock,
   render,
   Component,
 }: BuildFieldInteractionsParams<P>): BuildFieldInteractionsResponse<P> => {


### PR DESCRIPTION
These are improvements made during the [`vitest` PR ](https://github.com/mui/mui-x/pull/14508)

I'm moving the changes out so that PR is leaner. The changes mostly revolve around removing `clock='fake'` usage.

Hopefully these are reasonable enough changes to be merged without issues. 
