### PR TITLE
[code-infra] Update some data-grid tests for vitest

### DIFF
--- a/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/aggregation.DataGridPremium.test.tsx
@@ -16,8 +16,7 @@ import {
   useGridApiRef,
   GridColDef,
 } from '@mui/x-data-grid-premium';
-
-const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+import { isJSDOM } from 'test/utils/skipIf';
 
 const baselineProps: DataGridPremiumProps = {
   autoHeight: isJSDOM,
@@ -45,7 +44,7 @@ const baselineProps: DataGridPremiumProps = {
 };
 
 describe('<DataGridPremium /> - Aggregation', () => {
-  const { render, clock } = createRenderer({ clock: 'fake' });
+  const { render } = createRenderer();
 
   let apiRef: RefObject<GridApi | null>;
 
@@ -388,31 +387,29 @@ describe('<DataGridPremium /> - Aggregation', () => {
   });
 
   describe('Column menu', () => {
-    it('should render select on aggregable column', () => {
+    it('should render select on aggregable column', async () => {
       render(<Test />);
 
-      act(() => apiRef.current?.showColumnMenu('id'));
-      clock.runToLast();
+      await act(async () => apiRef.current?.showColumnMenu('id'));
 
       expect(screen.queryByLabelText('Aggregation')).not.to.equal(null);
     });
 
-    it('should update the aggregation when changing "Aggregation" select value', () => {
-      render(<Test />);
+    it('should update the aggregation when changing "Aggregation" select value', async () => {
+      const { user } = render(<Test />);
 
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5']);
 
-      act(() => apiRef.current?.showColumnMenu('id'));
-      clock.runToLast();
-      fireUserEvent.mousePress(screen.getByLabelText('Aggregation'));
-      fireUserEvent.mousePress(
+      await act(async () => apiRef.current?.showColumnMenu('id'));
+
+      await user.click(screen.getByLabelText('Aggregation'));
+      await user.click(
         within(
           screen.getByRole('listbox', {
             name: 'Aggregation',
           }),
         ).getByText('max'),
       );
-      clock.runToLast();
 
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2', '3', '4', '5', '5' /* Agg */]);
     });
@@ -557,7 +554,6 @@ describe('<DataGridPremium /> - Aggregation', () => {
       );
 
       act(() => apiRef.current?.showColumnMenu('id'));
-      clock.runToLast();
 
       expect(screen.queryAllByLabelText('Aggregation')).to.have.length(0);
     });

--- a/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -13,7 +13,14 @@ import {
   GridColDef,
 } from '@mui/x-data-grid-pro';
 import { useBasicDemoData } from '@mui/x-data-grid-generator';
-import { createRenderer, fireEvent, screen, createEvent, act } from '@mui/internal-test-utils';
+import {
+  createRenderer,
+  fireEvent,
+  screen,
+  createEvent,
+  act,
+  waitFor,
+} from '@mui/internal-test-utils';
 import {
   $,
   $$,
@@ -39,7 +46,7 @@ function createDragOverEvent(target: ChildNode) {
 }
 
 describe('<DataGridPro /> - Column pinning', () => {
-  const { render, clock } = createRenderer();
+  const { render } = createRenderer();
 
   let apiRef: RefObject<GridApi | null>;
 
@@ -505,10 +512,8 @@ describe('<DataGridPro /> - Column pinning', () => {
     });
 
     describe('with fake timers', () => {
-      clock.withFakeTimers();
-
-      it('should not render menu items if the column has `pinnable` equals to false', () => {
-        render(
+      it('should not render menu items if the column has `pinnable` equals to false', async () => {
+        const { user } = render(
           <TestCase
             columns={[
               { field: 'brand', pinnable: true },
@@ -519,16 +524,17 @@ describe('<DataGridPro /> - Column pinning', () => {
         );
 
         const brandHeader = document.querySelector('[role="columnheader"][data-field="brand"]')!;
-        fireEvent.click(brandHeader.querySelector('button[aria-label="brand column menu"]')!);
+        await user.click(brandHeader.querySelector('button[aria-label="brand column menu"]')!);
         expect(screen.queryByRole('menuitem', { name: 'Pin to left' })).not.to.equal(null);
-        fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+        await user.keyboard('[Escape]');
 
-        clock.runToLast();
         // Ensure that the first menu was closed
-        expect(screen.queryByRole('menuitem', { name: 'Pin to left' })).to.equal(null);
+        await waitFor(() => {
+          expect(screen.queryByRole('menuitem', { name: 'Pin to left' })).to.equal(null);
+        });
 
         const yearHeader = document.querySelector('[role="columnheader"][data-field="year"]')!;
-        fireEvent.click(yearHeader.querySelector('button[aria-label="year column menu"]')!);
+        await user.click(yearHeader.querySelector('button[aria-label="year column menu"]')!);
         expect(screen.queryByRole('menuitem', { name: 'Pin to left' })).to.equal(null);
       });
     });

--- a/packages/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
@@ -23,7 +23,7 @@ const rows: GridRowsProp = [{ id: 1 }];
 const columns: GridColDef[] = [{ field: 'id' }, { field: 'idBis' }];
 
 describe('<DataGridPro /> - Columns visibility', () => {
-  const { render } = createRenderer({ clock: 'fake' });
+  const { render } = createRenderer();
 
   let apiRef: RefObject<GridApi | null>;
 

--- a/packages/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnsVisibility.DataGridPro.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
 import { RefObject } from '@mui/x-internals/types';
-import { createRenderer, fireEvent, act, screen } from '@mui/internal-test-utils';
+import { createRenderer, act, screen } from '@mui/internal-test-utils';
 import {
   DataGridPro,
   DataGridProProps,
@@ -121,8 +121,8 @@ describe('<DataGridPro /> - Columns visibility', () => {
     });
   });
 
-  it('should not hide column when resizing a column after hiding it and showing it again', () => {
-    render(
+  it('should not hide column when resizing a column after hiding it and showing it again', async () => {
+    const { user } = render(
       <TestDataGridPro
         initialState={{
           columns: { columnVisibilityModel: {} },
@@ -132,15 +132,28 @@ describe('<DataGridPro /> - Columns visibility', () => {
     );
 
     const showHideAllCheckbox = screen.getByRole('checkbox', { name: 'Show/Hide All' });
-    fireEvent.click(showHideAllCheckbox);
+    await user.click(showHideAllCheckbox);
     expect(getColumnHeadersTextContent()).to.deep.equal([]);
-    fireEvent.click(document.querySelector('[role="tooltip"] [name="id"]')!);
+    await user.click(document.querySelector('[role="tooltip"] [name="id"]')!);
     expect(getColumnHeadersTextContent()).to.deep.equal(['id']);
 
     const separator = document.querySelector(`.${gridClasses['columnSeparator--resizable']}`)!;
-    fireEvent.mouseDown(separator, { clientX: 100 });
-    fireEvent.mouseMove(separator, { clientX: 110, buttons: 1 });
-    fireEvent.mouseUp(separator);
+    await user.pointer([
+      {
+        keys: '[MouseLeft>]',
+        target: separator,
+        coords: { clientX: 100 },
+      },
+      {
+        target: separator,
+        coords: { clientX: 110 },
+      },
+      {
+        keys: '[/MouseLeft]',
+        target: separator,
+        coords: { clientX: 110 },
+      },
+    ]);
 
     expect(getColumnHeadersTextContent()).to.deep.equal(['id']);
   });

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMockServer } from '@mui/x-data-grid-generator';
-import { createRenderer, waitFor, within } from '@mui/internal-test-utils';
+import { act, createRenderer, waitFor, within } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { RefObject } from '@mui/x-internals/types';
 import {
@@ -175,7 +175,8 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
 
     const firstChildId = (apiRef.current.state.rows.tree[GRID_ROOT_GROUP_ID] as GridGroupNode)
       .children[0];
-    apiRef.current?.dataSource.fetchRows(firstChildId);
+
+    await act(() => apiRef.current?.dataSource.fetchRows(firstChildId));
 
     await waitFor(() => {
       expect(fetchRowsSpy.callCount).to.equal(2);

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -177,7 +177,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
       .children[0];
 
     await act(async () => {
-      apiRef.current?.dataSource.fetchRows(firstChildId)
+      apiRef.current?.dataSource.fetchRows(firstChildId);
     });
 
     await waitFor(() => {

--- a/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceTreeData.DataGridPro.test.tsx
@@ -176,7 +176,9 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source tree data', () => {
     const firstChildId = (apiRef.current.state.rows.tree[GRID_ROOT_GROUP_ID] as GridGroupNode)
       .children[0];
 
-    await act(() => apiRef.current?.dataSource.fetchRows(firstChildId));
+    await act(async () => {
+      apiRef.current?.dataSource.fetchRows(firstChildId)
+    });
 
     await waitFor(() => {
       expect(fetchRowsSpy.callCount).to.equal(2);

--- a/packages/x-data-grid-pro/src/tests/infiniteLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/infiniteLoader.DataGridPro.test.tsx
@@ -3,10 +3,10 @@ import { act, createRenderer, waitFor } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { DataGridPro } from '@mui/x-data-grid-pro';
 import { spy, restore } from 'sinon';
-import { getColumnValues, sleep } from 'test/utils/helperFn';
+import { getColumnValues } from 'test/utils/helperFn';
 import { testSkipIf, isJSDOM } from 'test/utils/skipIf';
 
-describe('<DataGridPro /> - Infnite loader', () => {
+describe('<DataGridPro /> - Infinite loader', () => {
   afterEach(() => {
     restore();
   });
@@ -40,11 +40,8 @@ describe('<DataGridPro /> - Infnite loader', () => {
       const { container, setProps } = render(<TestCase rows={baseRows} />);
       const virtualScroller = container.querySelector('.MuiDataGrid-virtualScroller')!;
 
-      await act(async () => {
-        // arbitrary number to make sure that the bottom of the grid window is reached.
-        virtualScroller.scrollTop = 12345;
-        virtualScroller.dispatchEvent(new Event('scroll'));
-      });
+      // arbitrary number to make sure that the bottom of the grid window is reached.
+      await act(async () => virtualScroller.scrollTo({ top: 12345, behavior: 'instant' }));
 
       await waitFor(() => {
         expect(handleRowsScrollEnd.callCount).to.equal(1);
@@ -65,10 +62,7 @@ describe('<DataGridPro /> - Infnite loader', () => {
 
       expect(handleRowsScrollEnd.callCount).to.equal(1);
 
-      await act(async () => {
-        virtualScroller.scrollTop = 12345;
-        virtualScroller.dispatchEvent(new Event('scroll'));
-      });
+      await act(async () => virtualScroller.scrollTo({ top: 12345, behavior: 'instant' }));
 
       await waitFor(() => {
         expect(handleRowsScrollEnd.callCount).to.equal(2);
@@ -194,12 +188,11 @@ describe('<DataGridPro /> - Infnite loader', () => {
       // on the initial render, last row is not visible and the `observe` method is not called
       expect(observe.callCount).to.equal(0);
       // arbitrary number to make sure that the bottom of the grid window is reached.
-      virtualScroller.scrollTop = 12345;
-      virtualScroller.dispatchEvent(new Event('scroll'));
-      // wait for the next render cycle
-      await sleep(0);
+      await act(async () => virtualScroller.scrollTo({ top: 12345, behavior: 'instant' }));
       // observer was attached
-      expect(observe.callCount).to.equal(1);
+      await waitFor(() => {
+        expect(observe.callCount).to.equal(1);
+      });
     },
   );
 });

--- a/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/cells.DataGrid.test.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { createRenderer, fireEvent } from '@mui/internal-test-utils';
+import { createRenderer, fireEvent, waitFor } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { DataGrid, GridValueFormatter } from '@mui/x-data-grid';
 import { getCell } from 'test/utils/helperFn';
-import { fireUserEvent } from 'test/utils/fireUserEvent';
 import { getBasicGridData } from '@mui/x-data-grid-generator';
 import { describeSkipIf, testSkipIf, isJSDOM } from 'test/utils/skipIf';
 
 describe('<DataGrid /> - Cells', () => {
-  const { render } = createRenderer({ clock: 'fake' });
+  const { render } = createRenderer();
 
   const baselineProps = {
     autoHeight: isJSDOM,
@@ -160,7 +159,7 @@ describe('<DataGrid /> - Cells', () => {
     expect(valueFormatter.lastCall.args[2].field).to.equal('isActive');
   });
 
-  it('should throw when focusing cell without updating the state', () => {
+  it('should throw when focusing cell without updating the state', async () => {
     render(
       <div style={{ width: 300, height: 500 }}>
         <DataGrid
@@ -171,8 +170,6 @@ describe('<DataGrid /> - Cells', () => {
       </div>,
     );
 
-    fireUserEvent.mousePress(getCell(0, 0));
-
     expect(() => {
       getCell(1, 0).focus();
     }).toWarnDev(['MUI X: The cell with id=1 and field=brand received focus.']);
@@ -180,11 +177,11 @@ describe('<DataGrid /> - Cells', () => {
 
   testSkipIf(isJSDOM)(
     'should keep the focused cell/row rendered in the DOM if it scrolls outside the viewport',
-    () => {
+    async () => {
       const rowHeight = 50;
       const defaultData = getBasicGridData(20, 20);
 
-      render(
+      const { user } = render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid columns={defaultData.columns} rows={defaultData.rows} rowHeight={rowHeight} />
         </div>,
@@ -193,17 +190,17 @@ describe('<DataGrid /> - Cells', () => {
       const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
 
       const cell = getCell(1, 3);
-      fireUserEvent.mousePress(cell);
+      await user.click(cell);
 
       const activeElementTextContent = document.activeElement?.textContent;
       const columnWidth = document.activeElement!.clientWidth;
 
-      const scrollTop = 10 * rowHeight;
-      fireEvent.scroll(virtualScroller, { target: { scrollTop } });
+      const tenRows = 10 * rowHeight;
+      fireEvent.scroll(virtualScroller, { target: { scrollTop: tenRows } });
       expect(document.activeElement?.textContent).to.equal(activeElementTextContent);
 
-      const scrollLeft = 10 * columnWidth;
-      fireEvent.scroll(virtualScroller, { target: { scrollLeft } });
+      const tenColumns = 10 * columnWidth;
+      fireEvent.scroll(virtualScroller, { target: { scrollLeft: tenColumns } });
 
       expect(document.activeElement?.textContent).to.equal(activeElementTextContent);
     },
@@ -221,7 +218,7 @@ describe('<DataGrid /> - Cells', () => {
         rows.push({ id: i });
       }
 
-      render(
+      const { user } = render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid columns={columns} rows={rows} rowHeight={rowHeight} />
         </div>,
@@ -230,17 +227,19 @@ describe('<DataGrid /> - Cells', () => {
       const virtualScroller = document.querySelector('.MuiDataGrid-virtualScroller')!;
 
       const thirdRowCell = getCell(2, 0);
-      fireUserEvent.mousePress(thirdRowCell);
+      await user.click(thirdRowCell);
 
-      let scrollTop = 6 * rowHeight;
-      virtualScroller.scrollTop = scrollTop;
-      virtualScroller.dispatchEvent(new Event('scroll'));
-      expect(virtualScroller.scrollTop).to.equal(scrollTop);
+      const sixRows = 6 * rowHeight;
+      fireEvent.scroll(virtualScroller, { target: { scrollTop: sixRows } });
+      await waitFor(() => {
+        expect(virtualScroller.scrollTop).to.equal(300);
+      });
 
-      scrollTop = 2 * rowHeight;
-      virtualScroller.scrollTop = scrollTop;
-      virtualScroller.dispatchEvent(new Event('scroll'));
-      expect(virtualScroller.scrollTop).to.equal(scrollTop);
+      const twoRows = 2 * rowHeight;
+      fireEvent.scroll(virtualScroller, { target: { scrollTop: twoRows } });
+      await waitFor(() => {
+        expect(virtualScroller.scrollTop).to.equal(twoRows);
+      });
     },
   );
 });

--- a/packages/x-data-grid/src/tests/columnHeaders.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/columnHeaders.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, within } from '@mui/internal-test-utils';
+import { createRenderer, screen, waitFor, within } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { DataGrid } from '@mui/x-data-grid';
 import { getColumnHeaderCell, getColumnHeadersTextContent } from 'test/utils/helperFn';
@@ -128,7 +128,9 @@ describe('<DataGrid /> - Column headers', () => {
       expect(screen.queryByRole('menu')).not.to.equal(null);
 
       await user.click(within(getColumnHeaderCell(0)).getByLabelText('brand column menu'));
-      expect(screen.queryByRole('menu')).to.equal(null);
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).to.equal(null);
+      });
     });
   });
 

--- a/packages/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/columnSpanning.DataGrid.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, within } from '@mui/internal-test-utils';
+import { act, createRenderer, screen, waitFor, within } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { DataGrid, gridClasses, GridColDef } from '@mui/x-data-grid';
 import { getCell, getActiveCell, getColumnHeaderCell } from 'test/utils/helperFn';
-import { fireUserEvent } from 'test/utils/fireUserEvent';
 import { testSkipIf, isJSDOM } from 'test/utils/skipIf';
 
 describe('<DataGrid /> - Column spanning', () => {
-  const { render, clock } = createRenderer({ clock: 'fake' });
+  const { render } = createRenderer();
 
   const baselineProps = {
     rows: [
@@ -118,64 +117,64 @@ describe('<DataGrid /> - Column spanning', () => {
       { field: 'rating' },
     ];
 
-    it('should move to the cell right when pressing "ArrowRight"', () => {
-      render(
+    it('should move to the cell right when pressing "ArrowRight"', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={columns} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 0));
+      await user.click(getCell(0, 0));
       expect(getActiveCell()).to.equal('0-0');
 
-      fireEvent.keyDown(getCell(0, 0), { key: 'ArrowRight' });
+      await user.keyboard('{ArrowRight}');
       expect(getActiveCell()).to.equal('0-2');
     });
 
-    it('should move to the cell left when pressing "ArrowLeft"', () => {
-      render(
+    it('should move to the cell left when pressing "ArrowLeft"', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={columns} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 2));
+      await user.click(getCell(0, 2));
       expect(getActiveCell()).to.equal('0-2');
 
-      fireEvent.keyDown(getCell(0, 2), { key: 'ArrowLeft' });
+      await user.keyboard('{ArrowLeft}');
       expect(getActiveCell()).to.equal('0-0');
     });
 
-    it('should move to the cell above when pressing "ArrowUp"', () => {
-      render(
+    it('should move to the cell above when pressing "ArrowUp"', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={columns} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(1, 1));
+      await user.click(getCell(1, 1));
       expect(getActiveCell()).to.equal('1-1');
 
-      fireEvent.keyDown(getCell(1, 1), { key: 'ArrowUp' });
+      await user.keyboard('{ArrowUp}');
       expect(getActiveCell()).to.equal('0-0');
     });
 
-    it('should move to the cell below when pressing "ArrowDown"', () => {
-      render(
+    it('should move to the cell below when pressing "ArrowDown"', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={columns} disableVirtualization={isJSDOM} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(1, 3));
+      await user.click(getCell(1, 3));
       expect(getActiveCell()).to.equal('1-3');
 
-      fireEvent.keyDown(getCell(1, 3), { key: 'ArrowDown' });
+      await user.keyboard('{ArrowDown}');
       expect(getActiveCell()).to.equal('2-2');
     });
 
-    it('should move down by the amount of rows visible on screen when pressing "PageDown"', () => {
-      render(
+    it('should move down by the amount of rows visible on screen when pressing "PageDown"', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid
             {...baselineProps}
@@ -186,30 +185,30 @@ describe('<DataGrid /> - Column spanning', () => {
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 3));
+      await user.click(getCell(0, 3));
       expect(getActiveCell()).to.equal('0-3');
 
-      fireEvent.keyDown(getCell(0, 3), { key: 'PageDown' });
+      await user.keyboard('{PageDown}');
       expect(getActiveCell()).to.equal('2-2');
     });
 
-    it('should move up by the amount of rows visible on screen when pressing "PageUp"', () => {
-      render(
+    it('should move up by the amount of rows visible on screen when pressing "PageUp"', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={columns} autoHeight={isJSDOM} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(2, 1));
+      await user.click(getCell(2, 1));
       expect(getActiveCell()).to.equal('2-1');
 
-      fireEvent.keyDown(getCell(2, 1), { key: 'PageUp' });
+      await user.keyboard('{PageUp}');
       expect(getActiveCell()).to.equal('0-0');
     });
 
-    it('should move to the cell below when pressing "Enter" after editing', () => {
+    it('should move to the cell below when pressing "Enter" after editing', async () => {
       const editableColumns = columns.map((column) => ({ ...column, editable: true }));
-      render(
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid
             {...baselineProps}
@@ -220,55 +219,51 @@ describe('<DataGrid /> - Column spanning', () => {
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(1, 3));
+      await user.click(getCell(1, 3));
       expect(getActiveCell()).to.equal('1-3');
 
-      // start editing
-      fireEvent.keyDown(getCell(1, 3), { key: 'Enter' });
+      // start editing / commit
+      await user.keyboard('{Enter}{Enter}');
 
-      // commit
-      fireEvent.keyDown(getCell(1, 3).querySelector('input')!, { key: 'Enter' });
       expect(getActiveCell()).to.equal('2-2');
     });
 
-    it('should move to the cell on the right when pressing "Tab" after editing', () => {
+    it('should move to the cell on the right when pressing "Tab" after editing', async () => {
       const editableColumns = columns.map((column) => ({ ...column, editable: true }));
-      render(
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={editableColumns} disableVirtualization={isJSDOM} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(1, 1));
+      await user.click(getCell(1, 1));
       expect(getActiveCell()).to.equal('1-1');
 
       // start editing
-      fireEvent.keyDown(getCell(1, 1), { key: 'Enter' });
+      await user.keyboard('{Enter}{Tab}');
 
-      fireEvent.keyDown(getCell(1, 1).querySelector('input')!, { key: 'Tab' });
       expect(getActiveCell()).to.equal('1-3');
     });
 
     it('should move to the cell on the left when pressing "Shift+Tab" after editing', async () => {
       const editableColumns = columns.map((column) => ({ ...column, editable: true }));
-      render(
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid {...baselineProps} columns={editableColumns} disableVirtualization={isJSDOM} />
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 2));
+      await user.click(getCell(0, 2));
       expect(getActiveCell()).to.equal('0-2');
 
       // start editing
-      fireEvent.keyDown(getCell(0, 2), { key: 'Enter' });
+      await user.keyboard('{Enter}{Shift>}{Tab}{/Shift}');
 
-      fireEvent.keyDown(getCell(0, 2).querySelector('input')!, { key: 'Tab', shiftKey: true });
       expect(getActiveCell()).to.equal('0-0');
     });
 
     // needs virtualization
-    testSkipIf(isJSDOM)('should work with row virtualization', () => {
+    testSkipIf(isJSDOM)('should work with row virtualization', async () => {
       const rows = [
         {
           id: 0,
@@ -299,7 +294,7 @@ describe('<DataGrid /> - Column spanning', () => {
 
       const rowHeight = 52;
 
-      render(
+      const { user } = render(
         <div style={{ width: 500, height: (rows.length + 1) * rowHeight }}>
           <DataGrid
             columns={[
@@ -314,23 +309,18 @@ describe('<DataGrid /> - Column spanning', () => {
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(1, 1));
+      await user.click(getCell(1, 1));
       expect(getActiveCell()).to.equal('1-1');
 
-      fireEvent.keyDown(getCell(1, 1), { key: 'ArrowDown' });
+      await user.keyboard('{ArrowDown}{ArrowDown}');
 
-      const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
-      // trigger virtualization
-      virtualScroller.dispatchEvent(new Event('scroll'));
-
-      fireEvent.keyDown(getCell(2, 1), { key: 'ArrowDown' });
       const activeCell = getActiveCell();
       expect(activeCell).to.equal('3-0');
     });
 
     // needs layout
-    testSkipIf(isJSDOM)('should work with column virtualization', () => {
-      render(
+    testSkipIf(isJSDOM)('should work with column virtualization', async () => {
+      const { user } = render(
         <div style={{ width: 200, height: 200 }}>
           <DataGrid
             columns={[
@@ -345,18 +335,17 @@ describe('<DataGrid /> - Column spanning', () => {
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 0));
+      await user.click(getCell(0, 0));
 
-      fireEvent.keyDown(getCell(0, 0), { key: 'ArrowRight' });
-      document.querySelector(`.${gridClasses.virtualScroller}`)!.dispatchEvent(new Event('scroll'));
+      await user.keyboard('{ArrowRight}');
 
       expect(() => getCell(0, 3)).not.to.throw();
       // should not be rendered because of first column colSpan
       expect(() => getCell(0, 2)).to.throw(/not found/);
     });
 
-    it('should work with filtering', () => {
-      render(
+    it('should work with filtering', async () => {
+      const { user } = render(
         <div style={{ width: 500, height: 300 }}>
           <DataGrid
             {...baselineProps}
@@ -421,19 +410,19 @@ describe('<DataGrid /> - Column spanning', () => {
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 0));
+      await user.click(getCell(0, 0));
       expect(getActiveCell()).to.equal('0-0');
 
-      fireEvent.keyDown(getCell(0, 0), { key: 'ArrowDown' });
+      await user.keyboard('{ArrowDown}');
       expect(getActiveCell()).to.equal('1-0');
 
-      fireEvent.keyDown(getCell(1, 0), { key: 'ArrowRight' });
+      await user.keyboard('{ArrowRight}');
       expect(getActiveCell()).to.equal('1-2');
     });
 
     // needs layout
-    testSkipIf(isJSDOM)('should scroll the whole cell into view when `colSpan` > 1', () => {
-      render(
+    testSkipIf(isJSDOM)('should scroll the whole cell into view when `colSpan` > 1', async () => {
+      const { user } = render(
         <div style={{ width: 200, height: 200 }}>
           <DataGrid
             columns={[
@@ -449,27 +438,25 @@ describe('<DataGrid /> - Column spanning', () => {
         </div>,
       );
 
-      fireUserEvent.mousePress(getCell(0, 0));
+      await user.click(getCell(0, 0));
 
       const virtualScroller = document.querySelector<HTMLElement>(
         `.${gridClasses.virtualScroller}`,
       )!;
 
-      fireEvent.keyDown(getCell(0, 0), { key: 'ArrowRight' });
-      virtualScroller.dispatchEvent(new Event('scroll'));
-      fireEvent.keyDown(getCell(0, 2), { key: 'ArrowRight' });
-      virtualScroller.dispatchEvent(new Event('scroll'));
+      await user.keyboard('{ArrowRight}{ArrowRight}');
+
       expect(getActiveCell()).to.equal('0-3');
       // should be scrolled to the end of the cell
       expect(virtualScroller.scrollLeft).to.equal(3 * 100);
 
-      fireEvent.keyDown(getCell(0, 3), { key: 'ArrowLeft' });
-      virtualScroller.dispatchEvent(new Event('scroll'));
-      fireEvent.keyDown(getCell(0, 2), { key: 'ArrowLeft' });
-      virtualScroller.dispatchEvent(new Event('scroll'));
+      await user.keyboard('{ArrowLeft}{ArrowLeft}');
 
       expect(getActiveCell()).to.equal('0-0');
-      expect(virtualScroller.scrollLeft).to.equal(0);
+
+      await waitFor(() => {
+        expect(virtualScroller.scrollLeft).to.equal(0);
+      });
     });
   });
 
@@ -552,8 +539,8 @@ describe('<DataGrid /> - Column spanning', () => {
     expect(() => getCell(1, 3)).not.to.throw();
   });
 
-  it('should apply `colSpan` properly after hiding a column', () => {
-    render(
+  it('should apply `colSpan` properly after hiding a column', async () => {
+    const { user } = render(
       <div style={{ width: 500, height: 300 }}>
         <DataGrid
           {...baselineProps}
@@ -568,12 +555,13 @@ describe('<DataGrid /> - Column spanning', () => {
     );
 
     // hide `category` column
-    fireEvent.click(within(getColumnHeaderCell(1)).getByLabelText('category column menu'));
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Hide column' }));
-    clock.runToLast();
+    await user.click(within(getColumnHeaderCell(1)).getByLabelText('category column menu'));
+    await user.click(screen.getByRole('menuitem', { name: 'Hide column' }));
 
     // Nike row
-    expect(() => getCell(0, 0)).not.to.throw();
+    await waitFor(() => {
+      expect(() => getCell(0, 0)).not.to.throw();
+    });
     expect(() => getCell(0, 1)).to.throw(/not found/);
     expect(() => getCell(0, 2)).not.to.throw();
 
@@ -607,7 +595,7 @@ describe('<DataGrid /> - Column spanning', () => {
     expect(getCell(0, 2)).to.have.attribute('aria-colspan', '1');
   });
 
-  it('should work with pagination', () => {
+  it('should work with pagination', async () => {
     const rows = [
       {
         id: 0,
@@ -698,19 +686,19 @@ describe('<DataGrid /> - Column spanning', () => {
       );
     }
 
-    render(<TestCase />);
+    const { user } = render(<TestCase />);
 
     checkRows(0, ['Nike', 'Adidas']);
 
-    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    await user.click(screen.getByRole('button', { name: /next page/i }));
     checkRows(1, ['Puma', 'Nike']);
 
-    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    await user.click(screen.getByRole('button', { name: /next page/i }));
     checkRows(2, ['Adidas', 'Puma']);
   });
 
   // Need layout for column virtualization
-  testSkipIf(isJSDOM)('should work with column virtualization', () => {
+  testSkipIf(isJSDOM)('should work with column virtualization', async () => {
     render(
       <div style={{ width: 390, height: 300 }}>
         <DataGrid
@@ -743,8 +731,7 @@ describe('<DataGrid /> - Column spanning', () => {
 
     const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
     // scroll to the very end
-    virtualScroller.scrollLeft = 1000;
-    virtualScroller.dispatchEvent(new Event('scroll'));
+    await act(async () => virtualScroller.scrollTo({ left: 1000, behavior: 'instant' }));
 
     expect(getCell(0, 5).offsetLeft).to.equal(
       getCell(1, 5).offsetLeft,
@@ -758,7 +745,7 @@ describe('<DataGrid /> - Column spanning', () => {
   });
 
   // Need layout for column virtualization
-  testSkipIf(isJSDOM)('should work with both column and row virtualization', () => {
+  testSkipIf(isJSDOM)('should work with both column and row virtualization', async () => {
     const rowHeight = 50;
 
     render(
@@ -799,17 +786,23 @@ describe('<DataGrid /> - Column spanning', () => {
     );
 
     const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
-    // scroll to the very end
-    virtualScroller.scrollLeft = 1000;
-    // hide first row to trigger row virtualization
-    virtualScroller.scrollTop = rowHeight + 10;
-    virtualScroller.dispatchEvent(new Event('scroll'));
-    clock.runToLast();
 
-    expect(getCell(2, 5).offsetLeft).to.equal(
-      getCell(1, 5).offsetLeft,
-      'last cells in both rows should be aligned after scroll',
+    await act(async () =>
+      virtualScroller.scrollTo({
+        // hide first row to trigger row virtualization
+        top: rowHeight + 10,
+        // scroll to the very end
+        left: 1000,
+        behavior: 'instant',
+      }),
     );
+
+    await waitFor(() => {
+      expect(getCell(2, 5).offsetLeft).to.equal(
+        getCell(1, 5).offsetLeft,
+        'last cells in both rows should be aligned after scroll',
+      );
+    });
 
     expect(getColumnHeaderCell(5).offsetLeft).to.equal(
       getCell(1, 5).offsetLeft,
@@ -818,7 +811,7 @@ describe('<DataGrid /> - Column spanning', () => {
   });
 
   // Need layout for column virtualization
-  testSkipIf(isJSDOM)('should work with pagination and column virtualization', () => {
+  testSkipIf(isJSDOM)('should work with pagination and column virtualization', async () => {
     const rowHeight = 50;
 
     function TestCase() {
@@ -899,9 +892,9 @@ describe('<DataGrid /> - Column spanning', () => {
       );
     }
 
-    render(<TestCase />);
+    const { user } = render(<TestCase />);
 
-    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    await user.click(screen.getByRole('button', { name: /next page/i }));
 
     expect(getCell(5, 4).offsetLeft).to.equal(
       getCell(4, 4).offsetLeft,
@@ -914,16 +907,22 @@ describe('<DataGrid /> - Column spanning', () => {
     );
 
     const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
-    // scroll to the very end
-    virtualScroller.scrollLeft = 1000;
-    // hide first row to trigger row virtualization
-    virtualScroller.scrollTop = rowHeight + 10;
-    virtualScroller.dispatchEvent(new Event('scroll'));
-
-    expect(getCell(5, 5).offsetLeft).to.equal(
-      getCell(4, 5).offsetLeft,
-      'last cells in both rows should be aligned after scroll',
+    await act(async () =>
+      virtualScroller.scrollTo({
+        // hide first row to trigger row virtualization
+        top: rowHeight + 10,
+        // scroll to the very end
+        left: 1000,
+        behavior: 'instant',
+      }),
     );
+
+    await waitFor(() => {
+      expect(getCell(5, 5).offsetLeft).to.equal(
+        getCell(4, 5).offsetLeft,
+        'last cells in both rows should be aligned after scroll',
+      );
+    });
 
     expect(getColumnHeaderCell(5).offsetLeft).to.equal(
       getCell(4, 5).offsetLeft,

--- a/packages/x-data-grid/src/tests/columns.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/columns.DataGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import {
   DataGrid,
   DataGridProps,
@@ -132,40 +132,42 @@ describe('<DataGrid /> - Columns', () => {
 
   // https://github.com/mui/mui-x/issues/13719
   // Needs layout
-  testSkipIf(isJSDOM)('should not crash when updating columns immediately after scrolling', () => {
-    const data = [
-      { id: 1, value: 'A' },
-      { id: 2, value: 'B' },
-      { id: 3, value: 'C' },
-      { id: 4, value: 'D' },
-      { id: 5, value: 'E' },
-      { id: 6, value: 'E' },
-      { id: 7, value: 'F' },
-      { id: 8, value: 'G' },
-      { id: 9, value: 'H' },
-    ];
+  testSkipIf(isJSDOM)(
+    'should not crash when updating columns immediately after scrolling',
+    async () => {
+      const data = [
+        { id: 1, value: 'A' },
+        { id: 2, value: 'B' },
+        { id: 3, value: 'C' },
+        { id: 4, value: 'D' },
+        { id: 5, value: 'E' },
+        { id: 6, value: 'E' },
+        { id: 7, value: 'F' },
+        { id: 8, value: 'G' },
+        { id: 9, value: 'H' },
+      ];
 
-    function DynamicVirtualizationRange() {
-      const [cols, setCols] = React.useState<GridColDef[]>([{ field: 'id' }, { field: 'value' }]);
+      function DynamicVirtualizationRange() {
+        const [cols, setCols] = React.useState<GridColDef[]>([{ field: 'id' }, { field: 'value' }]);
 
-      return (
-        <div style={{ width: '100%' }}>
-          <button onClick={() => setCols([{ field: 'id' }])}>Update columns</button>
-          <div style={{ height: 400 }}>
-            <DataGrid rows={data} columns={cols} />
+        return (
+          <div style={{ width: '100%' }}>
+            <button onClick={() => setCols([{ field: 'id' }])}>Update columns</button>
+            <div style={{ height: 400 }}>
+              <DataGrid rows={data} columns={cols} />
+            </div>
           </div>
-        </div>
-      );
-    }
+        );
+      }
 
-    render(<DynamicVirtualizationRange />);
+      const { user } = render(<DynamicVirtualizationRange />);
 
-    const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
-    virtualScroller.scrollTop = 1_000;
-    virtualScroller.dispatchEvent(new Event('scroll'));
+      const virtualScroller = document.querySelector(`.${gridClasses.virtualScroller}`)!;
+      await act(async () => virtualScroller.scrollTo({ top: 1_000, behavior: 'instant' }));
 
-    fireEvent.click(screen.getByText('Update columns'));
-  });
+      await user.click(screen.getByText('Update columns'));
+    },
+  );
 
   it('should revert to the default column properties if not specified otherwise', async () => {
     const columns1: GridColDef[] = [{ field: 'status', type: 'string' }];

--- a/packages/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/quickFiltering.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, screen, fireEvent, reactMajor } from '@mui/internal-test-utils';
+import { createRenderer, screen, reactMajor, waitFor, act } from '@mui/internal-test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
@@ -11,10 +11,10 @@ import {
   getGridStringQuickFilterFn,
 } from '@mui/x-data-grid';
 import { getColumnValues, sleep } from 'test/utils/helperFn';
-import { testSkipIf, isJSDOM } from 'test/utils/skipIf';
+import { isJSDOM } from 'test/utils/skipIf';
 
 describe('<DataGrid /> - Quick filter', () => {
-  const { render, clock } = createRenderer();
+  const { render } = createRenderer();
 
   const baselineProps = {
     autoHeight: isJSDOM,
@@ -59,24 +59,21 @@ describe('<DataGrid /> - Quick filter', () => {
   }
 
   describe('component', () => {
-    clock.withFakeTimers();
-
-    it('should apply filter', () => {
-      render(<TestCase />);
+    it('should apply filter', async () => {
+      const { user } = render(<TestCase />);
 
       expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas', 'Puma']);
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'a' },
-      });
-      clock.runToLast();
+      await user.type(screen.getByRole('searchbox'), 'a');
 
-      expect(getColumnValues(0)).to.deep.equal(['Adidas', 'Puma']);
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal(['Adidas', 'Puma']);
+      });
     });
 
-    it('should allow to customize input splitting', () => {
+    it('should allow to customize input splitting', async () => {
       const onFilterModelChange = spy();
 
-      render(
+      const { user } = render(
         <TestCase
           onFilterModelChange={onFilterModelChange}
           slotProps={{
@@ -92,25 +89,22 @@ describe('<DataGrid /> - Quick filter', () => {
 
       expect(onFilterModelChange.callCount).to.equal(0);
 
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'adid, nik' },
-      });
-      clock.runToLast();
-      expect(onFilterModelChange.lastCall.firstArg).to.deep.equal({
-        items: [],
-        logicOperator: 'and',
-        quickFilterValues: ['adid', 'nik'],
-        quickFilterLogicOperator: 'and',
+      await user.type(screen.getByRole('searchbox'), 'adid, nik');
+
+      await waitFor(() => {
+        expect(onFilterModelChange.lastCall.firstArg).to.deep.equal({
+          items: [],
+          logicOperator: 'and',
+          quickFilterValues: ['adid', 'nik'],
+          quickFilterLogicOperator: 'and',
+        });
       });
     });
 
-    it('should no prettify user input', () => {
-      render(<TestCase />);
+    it('should no prettify user input', async () => {
+      const { user } = render(<TestCase />);
 
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'adidas   nike' },
-      });
-      clock.runToLast();
+      await user.type(screen.getByRole('searchbox'), 'adidas   nike');
 
       expect(screen.getByRole<HTMLInputElement>('searchbox').value).to.equal('adidas   nike');
     });
@@ -162,26 +156,23 @@ describe('<DataGrid /> - Quick filter', () => {
   });
 
   describe('quick filter logic', () => {
-    clock.withFakeTimers();
+    it('should return rows that match all values by default', async () => {
+      const { user } = render(<TestCase />);
 
-    it('should return rows that match all values by default', () => {
-      render(<TestCase />);
+      await user.type(screen.getByRole('searchbox'), 'adid');
 
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'adid' },
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal(['Adidas']);
       });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal(['Adidas']);
+      await user.type(screen.getByRole('searchbox'), ' nik');
 
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'adid nik' },
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal([]);
       });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal([]);
     });
 
-    it('should return rows that match some values if quickFilterLogicOperator="or"', () => {
-      render(
+    it('should return rows that match some values if quickFilterLogicOperator="or"', async () => {
+      const { user } = render(
         <TestCase
           initialState={{
             filter: { filterModel: { items: [], quickFilterLogicOperator: GridLogicOperator.Or } },
@@ -189,21 +180,21 @@ describe('<DataGrid /> - Quick filter', () => {
         />,
       );
 
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'adid' },
-      });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal(['Adidas']);
+      await user.type(screen.getByRole('searchbox'), 'adid');
 
-      fireEvent.change(screen.getByRole('searchbox'), {
-        target: { value: 'adid nik' },
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal(['Adidas']);
       });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas']);
+
+      await user.type(screen.getByRole('searchbox'), ' nik');
+
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal(['Nike', 'Adidas']);
+      });
     });
 
-    it('should ignore hidden columns by default', () => {
-      render(
+    it('should ignore hidden columns by default', async () => {
+      const { user } = render(
         <TestCase
           columns={[{ field: 'id' }, { field: 'brand' }]}
           initialState={{
@@ -213,17 +204,19 @@ describe('<DataGrid /> - Quick filter', () => {
         />,
       );
 
-      fireEvent.change(screen.getByRole('searchbox'), { target: { value: '1' } });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal([]);
+      await user.type(screen.getByRole('searchbox'), '1');
 
-      fireEvent.change(screen.getByRole('searchbox'), { target: { value: '2' } });
-      clock.runToLast();
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal([]);
+      });
+
+      await user.type(screen.getByRole('searchbox'), '[Backspace]2');
+
       expect(getColumnValues(0)).to.deep.equal([]);
     });
 
-    it('should search hidden columns when quickFilterExcludeHiddenColumns=false', () => {
-      render(
+    it('should search hidden columns when quickFilterExcludeHiddenColumns=false', async () => {
+      const { user } = render(
         <TestCase
           columns={[{ field: 'id' }, { field: 'brand' }]}
           initialState={{
@@ -233,17 +226,21 @@ describe('<DataGrid /> - Quick filter', () => {
         />,
       );
 
-      fireEvent.change(screen.getByRole('searchbox'), { target: { value: '1' } });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal(['Adidas']);
+      await user.type(screen.getByRole('searchbox'), '1');
 
-      fireEvent.change(screen.getByRole('searchbox'), { target: { value: '2' } });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal(['Puma']);
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal(['Adidas']);
+      });
+
+      await user.type(screen.getByRole('searchbox'), '[Backspace]2');
+
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal(['Puma']);
+      });
     });
 
-    it('should ignore hidden columns when quickFilterExcludeHiddenColumns=true', () => {
-      render(
+    it('should ignore hidden columns when quickFilterExcludeHiddenColumns=true', async () => {
+      const { user } = render(
         <TestCase
           columns={[{ field: 'id' }, { field: 'brand' }]}
           initialState={{
@@ -253,12 +250,12 @@ describe('<DataGrid /> - Quick filter', () => {
         />,
       );
 
-      fireEvent.change(screen.getByRole('searchbox'), { target: { value: '1' } });
-      clock.runToLast();
-      expect(getColumnValues(0)).to.deep.equal([]);
+      await user.type(screen.getByRole('searchbox'), '1');
+      await waitFor(() => {
+        expect(getColumnValues(0)).to.deep.equal([]);
+      });
 
-      fireEvent.change(screen.getByRole('searchbox'), { target: { value: '2' } });
-      clock.runToLast();
+      await user.type(screen.getByRole('searchbox'), '[Backspace]2');
       expect(getColumnValues(0)).to.deep.equal([]);
     });
 
@@ -284,7 +281,6 @@ describe('<DataGrid /> - Quick filter', () => {
           quickFilterExcludeHiddenColumns: true,
         },
       });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal([]);
     });
 
@@ -318,12 +314,10 @@ describe('<DataGrid /> - Quick filter', () => {
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
 
       setProps({ columnVisibilityModel: { brand: false } });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal([]);
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount + 1);
 
       setProps({ columnVisibilityModel: { brand: true } });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['1']);
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount + 2);
     });
@@ -351,12 +345,10 @@ describe('<DataGrid /> - Quick filter', () => {
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(0);
 
       setProps({ columnVisibilityModel: { brand: false } });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2']);
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(0);
 
       setProps({ columnVisibilityModel: { brand: true } });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['0', '1', '2']);
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(0);
     });
@@ -388,20 +380,16 @@ describe('<DataGrid /> - Quick filter', () => {
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
 
       setProps({ columnVisibilityModel: { brand: false } });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['1']);
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
 
       setProps({ columnVisibilityModel: { brand: true } });
-      clock.runToLast();
       expect(getColumnValues(0)).to.deep.equal(['1']);
       expect(getApplyQuickFilterFnSpy.callCount).to.equal(initialCallCount);
     });
   });
 
   describe('column type: string', () => {
-    clock.withFakeTimers();
-
     const getRows = ({ quickFilterValues }: Pick<GridFilterModel, 'quickFilterValues'>) => {
       const { unmount } = render(
         <TestCase
@@ -510,8 +498,6 @@ describe('<DataGrid /> - Quick filter', () => {
   });
 
   describe('column type: number', () => {
-    clock.withFakeTimers();
-
     const getRows = ({ quickFilterValues }: Pick<GridFilterModel, 'quickFilterValues'>) => {
       const { unmount } = render(
         <TestCase
@@ -564,8 +550,6 @@ describe('<DataGrid /> - Quick filter', () => {
   });
 
   describe('column type: singleSelect', () => {
-    clock.withFakeTimers();
-
     const getRows = ({ quickFilterValues }: Pick<GridFilterModel, 'quickFilterValues'>) => {
       const { unmount } = render(
         <TestCase
@@ -643,11 +627,11 @@ describe('<DataGrid /> - Quick filter', () => {
   });
 
   // https://github.com/mui/mui-x/issues/6783
-  testSkipIf(isJSDOM)('should not override user input when typing', async () => {
+  it('should not override user input when typing', async () => {
     // Warning: this test doesn't fail consistently as it is timing-sensitive.
     const debounceMs = 50;
 
-    render(
+    const { user } = render(
       <TestCase
         slotProps={{
           toolbar: {
@@ -661,16 +645,16 @@ describe('<DataGrid /> - Quick filter', () => {
 
     expect(searchBox.value).to.equal('');
 
-    fireEvent.change(searchBox, { target: { value: 'a' } });
-    await sleep(debounceMs - 2);
+    await user.type(screen.getByRole('searchbox'), `a`);
+    await act(() => sleep(debounceMs - 2));
     expect(searchBox.value).to.equal('a');
 
-    fireEvent.change(searchBox, { target: { value: 'ab' } });
-    await sleep(10);
+    await user.type(screen.getByRole('searchbox'), `b`);
+    await act(() => sleep(10));
     expect(searchBox.value).to.equal('ab');
 
-    fireEvent.change(searchBox, { target: { value: 'abc' } });
-    await sleep(debounceMs * 2);
+    await user.type(screen.getByRole('searchbox'), `c`);
+    await act(() => sleep(debounceMs * 2));
     expect(searchBox.value).to.equal('abc');
   });
 

--- a/packages/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -45,7 +45,7 @@ describe('<DataGrid /> - Toolbar', () => {
       expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'brand']);
 
       await user.click(screen.getByLabelText('Columns'));
-      await user.click(screen.getByRole('tooltip').querySelector('[name="id"]')!);
+      await user.click(document.querySelector('[role="tooltip"] [name="id"]')!);
 
       expect(getColumnHeadersTextContent()).to.deep.equal(['brand']);
     });
@@ -93,7 +93,7 @@ describe('<DataGrid /> - Toolbar', () => {
       const button = screen.getByRole('button', { name: 'Columns' });
       await user.click(button);
 
-      const column: HTMLElement = screen.getByRole('tooltip').querySelector('[name="id"]')!;
+      const column: HTMLElement = document.querySelector('[role="tooltip"] [name="id"]')!;
       await user.click(column);
 
       expect(column).toHaveFocus();

--- a/packages/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -3,8 +3,7 @@ import { createRenderer, screen } from '@mui/internal-test-utils';
 import { getColumnHeadersTextContent } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import { DataGrid, GridColumnsManagementProps } from '@mui/x-data-grid';
-
-const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+import { isJSDOM } from 'test/utils/skipIf';
 
 describe('<DataGrid /> - Toolbar', () => {
   const { render } = createRenderer();

--- a/packages/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent, screen, act } from '@mui/internal-test-utils';
+import { createRenderer, screen } from '@mui/internal-test-utils';
 import { getColumnHeadersTextContent } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import { DataGrid, GridColumnsManagementProps } from '@mui/x-data-grid';
@@ -7,7 +7,7 @@ import { DataGrid, GridColumnsManagementProps } from '@mui/x-data-grid';
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Toolbar', () => {
-  const { render } = createRenderer({ clock: 'fake' });
+  const { render } = createRenderer();
 
   const baselineProps = {
     autoHeight: isJSDOM,
@@ -36,8 +36,8 @@ describe('<DataGrid /> - Toolbar', () => {
   };
 
   describe('column selector', () => {
-    it('should hide "id" column when hiding it from the column selector', () => {
-      render(
+    it('should hide "id" column when hiding it from the column selector', async () => {
+      const { user } = render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid {...baselineProps} showToolbar />
         </div>,
@@ -45,13 +45,13 @@ describe('<DataGrid /> - Toolbar', () => {
 
       expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'brand']);
 
-      fireEvent.click(screen.getByLabelText('Columns'));
-      fireEvent.click(screen.getByRole('tooltip').querySelector('[name="id"]')!);
+      await user.click(screen.getByLabelText('Columns'));
+      await user.click(screen.getByRole('tooltip').querySelector('[name="id"]')!);
 
       expect(getColumnHeadersTextContent()).to.deep.equal(['brand']);
     });
 
-    it('should show and hide all columns when clicking "Show/Hide All" checkbox from the column selector', () => {
+    it('should show and hide all columns when clicking "Show/Hide All" checkbox from the column selector', async () => {
       const customColumns = [
         {
           field: 'id',
@@ -61,7 +61,7 @@ describe('<DataGrid /> - Toolbar', () => {
         },
       ];
 
-      render(
+      const { user } = render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
@@ -76,33 +76,31 @@ describe('<DataGrid /> - Toolbar', () => {
         </div>,
       );
 
-      fireEvent.click(screen.getByLabelText('Columns'));
+      await user.click(screen.getByLabelText('Columns'));
       const showHideAllCheckbox = screen.getByRole('checkbox', { name: 'Show/Hide All' });
-      fireEvent.click(showHideAllCheckbox);
+      await user.click(showHideAllCheckbox);
       expect(getColumnHeadersTextContent()).to.deep.equal(['id', 'brand']);
-      fireEvent.click(showHideAllCheckbox);
+      await user.click(showHideAllCheckbox);
       expect(getColumnHeadersTextContent()).to.deep.equal([]);
     });
 
-    it('should keep the focus on the switch after toggling a column', () => {
-      render(
+    it('should keep the focus on the switch after toggling a column', async () => {
+      const { user } = render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid {...baselineProps} showToolbar />
         </div>,
       );
 
       const button = screen.getByRole('button', { name: 'Columns' });
-      act(() => button.focus());
-      fireEvent.click(button);
+      await user.click(button);
 
       const column: HTMLElement = screen.getByRole('tooltip').querySelector('[name="id"]')!;
-      act(() => column.focus());
-      fireEvent.click(column);
+      await user.click(column);
 
       expect(column).toHaveFocus();
     });
 
-    it('should allow to override search predicate function', () => {
+    it('should allow to override search predicate function', async () => {
       const customColumns = [
         {
           field: 'id',
@@ -123,7 +121,7 @@ describe('<DataGrid /> - Toolbar', () => {
         );
       };
 
-      render(
+      const { user } = render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
             {...baselineProps}
@@ -138,10 +136,10 @@ describe('<DataGrid /> - Toolbar', () => {
         </div>,
       );
 
-      fireEvent.click(screen.getByLabelText('Columns'));
+      await user.click(screen.getByLabelText('Columns'));
 
       const searchInput = document.querySelector('input[type="search"]')!;
-      fireEvent.change(searchInput, { target: { value: 'test' } });
+      await user.type(searchInput, 'test');
 
       expect(document.querySelector('[role="tooltip"] [name="id"]')).not.to.equal(null);
     });


### PR DESCRIPTION
These are improvements made during the [`vitest` PR ](https://github.com/mui/mui-x/pull/14508)

I'm moving the changes out so that PR is leaner. 

The changes mostly revolve around:
- removing `clock='fake'` usage.
- using `user` events rather than `fireEvent` where applicable.
