### PR TITLE
[charts] Fix CSS vars support for dark theme

### DIFF
--- a/packages/x-charts/src/ChartsOverlay/ChartsLoadingOverlay.tsx
+++ b/packages/x-charts/src/ChartsOverlay/ChartsLoadingOverlay.tsx
@@ -7,7 +7,7 @@ import type { CommonOverlayProps } from './ChartsOverlay';
 const StyledText = styled('text')(({ theme }) => ({
   ...theme.typography.body2,
   stroke: 'none',
-  fill: theme.palette.text.primary,
+  fill: (theme.vars || theme).palette.text.primary,
   shapeRendering: 'crispEdges',
   textAnchor: 'middle',
   dominantBaseline: 'middle',

--- a/packages/x-charts/src/ChartsOverlay/ChartsNoDataOverlay.tsx
+++ b/packages/x-charts/src/ChartsOverlay/ChartsNoDataOverlay.tsx
@@ -7,7 +7,7 @@ import type { CommonOverlayProps } from './ChartsOverlay';
 const StyledText = styled('text')(({ theme }) => ({
   ...theme.typography.body2,
   stroke: 'none',
-  fill: theme.palette.text.primary,
+  fill: (theme.vars || theme).palette.text.primary,
   shapeRendering: 'crispEdges',
   textAnchor: 'middle',
   dominantBaseline: 'middle',


### PR DESCRIPTION
Extracted from #17062

The idea is to have `theme.palette` containing all the colors, and `theme.vars.palette` containing the same structure but with CSS variables.

The advantage of `theme.vars.palette` is that toggle the dark/light does not modify the JS object. only the CSS vars value are impacted. So you can switch without having to re-render the all page