### PR TITLE
[codemod] Add `showToolbar` prop when using toolbar component

### DIFF
--- a/docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md
+++ b/docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md
@@ -216,7 +216,7 @@ You have to import it from `@mui/x-license` instead:
 
 - `GridSortItem` interface is not exported anymore.
 - `createUseGridApiEventHandler()` is not exported anymore.
-- The `showToolbar` prop is now required to display the toolbar.
+- ✅ The `showToolbar` prop is now required to display the toolbar.
 
   It is no longer necessary to pass `GridToolbar` as a slot to display the default toolbar.
 

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -329,6 +329,7 @@ The list includes these transformers
 - [`rename-imports`](#rename-imports)
 - [`reform-row-selection-model`](#reform-row-selection-model)
 - [`rename-package`](#rename-package)
+- [`add-showToolbar-prop`](#add-showToolbar-prop)
 
 #### `remove-stabilized-v8-experimentalFeatures`
 
@@ -462,6 +463,25 @@ Reorganizes the imports moved from `@mui/x-data-grid-pro` and `@mui/x-data-grid-
 
 ```bash
 npx @mui/x-codemod@next v8.0.0/data-grid/rename-package <path>
+```
+
+#### `add-showToolbar-prop`
+
+Adds the `showToolbar` prop to the Data Grid components that are using `slots.toolbar` prop.
+
+```diff
+ <DataGridPremium
+  slots={{
+    toolbar: GridToolbar,
+  }}
++ showToolbar
+ />
+```
+
+<!-- #default-branch-switch -->
+
+```bash
+npx @mui/x-codemod@next v8.0.0/data-grid/add-showToolbar-prop <path>
 ```
 
 ### Pickers codemods

--- a/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/actual.spec.js
+++ b/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/actual.spec.js
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+
+<DataGrid
+  slots={{
+    toolbar: GridToolbar,
+  }}
+/>

--- a/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/add-showToolbar-prop.test.ts
+++ b/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/add-showToolbar-prop.test.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from '.';
+import readFile from '../../../util/readFile';
+
+function read(fileName) {
+  return readFile(path.join(__dirname, fileName));
+}
+
+describe('v8.0.0/data-grid', () => {
+  describe('add showToolbar prop', () => {
+    it(`transforms props as needed - js`, () => {
+      const actual = transform({ source: read(`./actual.spec.js`) }, { jscodeshift }, {});
+
+      const expected = read(`./expected.spec.js`);
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
+    it(`should be idempotent - js`, () => {
+      const actual = transform({ source: read(`./expected.spec.js`) }, { jscodeshift }, {});
+
+      const expected = read(`./expected.spec.js`);
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
+    it('transforms props as needed - ts', () => {
+      const actual = transform(
+        { source: read('./ts-actual.spec.tsx') },
+        { jscodeshift: jscodeshift.withParser('tsx') },
+        {},
+      );
+      const expected = read('./ts-expected.spec.tsx');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+
+    it('should be idempotent - ts', () => {
+      const actual = transform(
+        { source: read('./ts-expected.spec.tsx') },
+        { jscodeshift: jscodeshift.withParser('tsx') },
+        {},
+      );
+
+      const expected = read('./ts-expected.spec.tsx');
+      expect(actual).to.equal(expected, 'The transformed version should be correct');
+    });
+  });
+});

--- a/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/expected.spec.js
+++ b/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/expected.spec.js
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+
+<DataGrid
+  slots={{
+    toolbar: GridToolbar,
+  }}
+  showToolbar />

--- a/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/index.ts
+++ b/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/index.ts
@@ -1,0 +1,77 @@
+import type { Identifier, JSXIdentifier, ImportSpecifier, ObjectProperty } from 'jscodeshift';
+import type { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
+
+export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // List of DataGrid components
+  const dataGridComponents = new Set(['DataGrid', 'DataGridPro', 'DataGridPremium']);
+  // List of allowed import sources
+  const dataGridSources = new Set([
+    '@mui/x-data-grid',
+    '@mui/x-data-grid-pro',
+    '@mui/x-data-grid-premium',
+  ]);
+
+  // Find relevant DataGrid imports
+  const importedDataGrids = new Set();
+  root.find(j.ImportDeclaration).forEach((path) => {
+    if (dataGridSources.has(path.node.source.value as string)) {
+      path.node.specifiers?.forEach((specifier) => {
+        if (
+          (specifier as ImportSpecifier).imported &&
+          dataGridComponents.has((specifier as ImportSpecifier).imported.name)
+        ) {
+          const localName = (specifier as ImportSpecifier).local?.name;
+          if (localName) {
+            importedDataGrids.add(localName);
+          }
+        }
+      });
+    }
+  });
+
+  if (importedDataGrids.size === 0) {
+    return file.source;
+  }
+
+  root.find(j.JSXOpeningElement).forEach((path) => {
+    if (!importedDataGrids.has((path.node.name as JSXIdentifier).name)) {
+      return;
+    }
+
+    let hasSlotsToolbar = false;
+    let hasShowToolbar = false;
+
+    path.node.attributes?.forEach((attr) => {
+      if (attr.type === 'JSXAttribute') {
+        if (attr.name.name === 'slots') {
+          if (
+            attr.value &&
+            attr.value.type === 'JSXExpressionContainer' &&
+            attr.value.expression.type === 'ObjectExpression'
+          ) {
+            hasSlotsToolbar = attr.value.expression.properties.some(
+              (prop) => ((prop as ObjectProperty).key as Identifier).name === 'toolbar',
+            );
+          }
+        }
+        if (attr.name.name === 'showToolbar') {
+          hasShowToolbar = true;
+        }
+      }
+    });
+
+    if (hasSlotsToolbar && !hasShowToolbar) {
+      path.node.attributes?.push(j.jsxAttribute(j.jsxIdentifier('showToolbar')));
+    }
+  });
+
+  const printOptions = options.printOptions || {
+    quote: 'single',
+    trailingComma: true,
+  };
+
+  return root.toSource(printOptions);
+}

--- a/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/ts-actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/ts-actual.spec.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import MyCustomToolbar from 'some-awesome-library';
+
+function GridToolbar() {
+  return <MyCustomToolbar />;
+}
+// prettier-ignore
+function App() {
+  return (
+    <DataGrid
+      slots={{
+        toolbar: GridToolbar,
+      }}
+    />
+  );
+}
+
+export default App;

--- a/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/ts-expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/data-grid/add-showToolbar-prop/ts-expected.spec.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import MyCustomToolbar from 'some-awesome-library';
+
+function GridToolbar() {
+  return <MyCustomToolbar />;
+}
+// prettier-ignore
+function App() {
+  return (
+    (<DataGrid
+      slots={{
+        toolbar: GridToolbar,
+      }}
+      showToolbar />)
+  );
+}
+
+export default App;

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/actual.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/actual.spec.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import * as React from 'react';
-import { DataGrid, useGridApiRef } from '@mui/x-data-grid';
+import { DataGrid, useGridApiRef, GridToolbar } from '@mui/x-data-grid';
 import { DataGridPro, LicenseInfo } from '@mui/x-data-grid-pro';
 import { DataGridPremium, selectedGridRowsSelector } from '@mui/x-data-grid-premium';
 
@@ -37,6 +37,9 @@ const [rowSelectionModel1, setRowSelectionModel1] = React.useState([4, 5, 6]);
       ariaV8: true,
     }}
     unstable_rowSpanning
+    slots={{
+      toolbar: GridToolbar,
+    }}
   />
   <DataGridPremium
     {...props}

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/expected.spec.tsx
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/expected.spec.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import * as React from 'react';
-import { DataGrid, useGridApiRef } from '@mui/x-data-grid';
+import { DataGrid, useGridApiRef, GridToolbar } from '@mui/x-data-grid';
 import { DataGridPro } from '@mui/x-data-grid-pro';
 import { LicenseInfo } from '@mui/x-license';
 import { DataGridPremium, gridRowSelectionIdsSelector } from '@mui/x-data-grid-premium';
@@ -25,7 +25,12 @@ const [rowSelectionModel1, setRowSelectionModel1] = React.useState([4, 5, 6]);
       warnIfFocusStateIsNotSynced: true,
     }}
     rowSpanning />
-  <DataGridPremium rowSpanning />
+  <DataGridPremium
+    rowSpanning
+    slots={{
+      toolbar: GridToolbar,
+    }}
+    showToolbar />
   <DataGridPremium
     {...props}
   />

--- a/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/index.ts
+++ b/packages/x-codemod/src/v8.0.0/data-grid/preset-safe/index.ts
@@ -4,6 +4,7 @@ import renameProps from '../rename-props';
 import reformRowSelectionModel from '../reform-row-selection-model';
 import renameImports from '../rename-imports';
 import renamePackage from '../rename-package';
+import addShowToolbarProp from '../add-showToolbar-prop';
 import { JsCodeShiftAPI, JsCodeShiftFileInfo } from '../../../types';
 
 export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftAPI, options: any) {
@@ -13,5 +14,6 @@ export default function transformer(file: JsCodeShiftFileInfo, api: JsCodeShiftA
   file.source = reformRowSelectionModel(file, api, options);
   file.source = renameImports(file, api, options);
   file.source = renamePackage(file, api, options);
+  file.source = addShowToolbarProp(file, api, options);
   return file.source;
 }


### PR DESCRIPTION
- Adds `showToolbar` prop to show toolbar properly.

  ```diff
   <DataGrid
     slots={{
       toolbar: GridToolbar,
     }}
  +  showToolbar
   />
  ```