### PR TITLE
[DataGrid] Remove unwanted attributes from `QuickFilter` component

### DIFF
--- a/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
+++ b/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
@@ -205,9 +205,7 @@ function QuickFilter(props: QuickFilterProps) {
     'div',
     render,
     {
-      role: 'toolbar',
       className: resolvedClassName,
-      'aria-orientation': 'horizontal',
       'aria-controls': controlId,
       ...other,
       ref,

--- a/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
+++ b/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
@@ -206,7 +206,6 @@ function QuickFilter(props: QuickFilterProps) {
     render,
     {
       className: resolvedClassName,
-      'aria-controls': controlId,
       ...other,
       ref,
     },


### PR DESCRIPTION
Removes `aria-controls` `role` and `aria-orientation` attributes that were accidentally copied over from the toolbar component when working on the quick filter changes here: #16862 