### PR TITLE
[infra] Added reusable issue status label handler workflow

### DIFF
--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -1,0 +1,20 @@
+name: No Response
+
+on:
+  issue_comment:
+    # on 'issue_comment.created' we check if the comment comes from the author and remove the "status: waiting for author" label
+    # additionally we reopen the issue when it is closed and the author comments on it
+    types: [created]
+  issues:
+    # on 'issues.closed' events we simply remove the "status: waiting for author" or "status: waiting for maintainer" label
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  statusHandling:
+    permissions:
+      contents: read
+      issues: write
+    name: Handle status labels
+    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@master


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to manage issue status labels based on issue comments and issue state changes. The workflow is designed to enhance the automation of label management, ensuring that issues are correctly labeled based on their current status.

New GitHub Actions workflow:

* [`.github/workflows/issue-status-label-handler.yml`](diffhunk://#diff-39f7419b803abac83bb454886d44600de03f9138be0137c41055b5c4dbf51a56R1-R20): Added a workflow named "No Response" that handles issue comments and issue state changes to manage status labels. It triggers on `issue_comment.created` and `issues.closed` events, and it uses a shared workflow from `mui/mui-public`.