### PR TITLE
[code-infra] Remove clock=fake from `describeValidation`

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValidation.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValidation.DesktopDateRangePicker.test.tsx
@@ -2,7 +2,7 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 
 describe('<DesktopDateRangePicker /> - Describe Validation', () => {
-  const { render } = createPickerRenderer({ clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0) });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(DesktopDateRangePicker, () => ({
     render,

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValidation.DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/describeValidation.DesktopDateRangePicker.test.tsx
@@ -2,14 +2,10 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker';
 
 describe('<DesktopDateRangePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
-    clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
-  });
+  const { render } = createPickerRenderer({ clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0) });
 
   describeRangeValidation(DesktopDateRangePicker, () => ({
     render,
-    clock,
     componentFamily: 'picker',
     views: ['day'],
     variant: 'desktop',

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeValidation.DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeValidation.DesktopDateTimeRangePicker.test.tsx
@@ -2,14 +2,10 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { DesktopDateTimeRangePicker } from '../DesktopDateTimeRangePicker';
 
 describe('<DesktopDateTimeRangePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
-    clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
-  });
+  const { render } = createPickerRenderer({ clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0) });
 
   describeRangeValidation(DesktopDateTimeRangePicker, () => ({
     render,
-    clock,
     views: ['day', 'hours', 'minutes'],
     componentFamily: 'picker',
     variant: 'desktop',

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeValidation.DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/describeValidation.DesktopDateTimeRangePicker.test.tsx
@@ -2,7 +2,7 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { DesktopDateTimeRangePicker } from '../DesktopDateTimeRangePicker';
 
 describe('<DesktopDateTimeRangePicker /> - Describe Validation', () => {
-  const { render } = createPickerRenderer({ clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0) });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(DesktopDateTimeRangePicker, () => ({
     render,

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeValidation.DesktopTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/describeValidation.DesktopTimeRangePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { DesktopTimeRangePicker } from '@mui/x-date-pickers-pro/DesktopTimeRangePicker';
 
 describe('<DesktopTimeRangePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(DesktopTimeRangePicker, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'picker',
     variant: 'desktop',

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeValidation.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeValidation.MobileDateRangePicker.test.tsx
@@ -2,9 +2,7 @@ import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePi
 import { createPickerRenderer, describeRangeValidation } from 'test/utils/pickers';
 
 describe('<MobileDateRangePicker /> - Describe Validation', () => {
-  const { render } = createPickerRenderer({
-    clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
-  });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(MobileDateRangePicker, () => ({
     render,

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeValidation.MobileDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/tests/describeValidation.MobileDateRangePicker.test.tsx
@@ -2,14 +2,12 @@ import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePi
 import { createPickerRenderer, describeRangeValidation } from 'test/utils/pickers';
 
 describe('<MobileDateRangePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
+  const { render } = createPickerRenderer({
     clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
   });
 
   describeRangeValidation(MobileDateRangePicker, () => ({
     render,
-    clock,
     componentFamily: 'picker',
     views: ['day'],
     variant: 'mobile',

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValidation.MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValidation.MobileDateTimeRangePicker.test.tsx
@@ -2,14 +2,12 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { MobileDateTimeRangePicker } from '@mui/x-date-pickers-pro/MobileDateTimeRangePicker';
 
 describe('<MobileDateTimeRangePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
+  const { render } = createPickerRenderer({
     clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
   });
 
   describeRangeValidation(MobileDateTimeRangePicker, () => ({
     render,
-    clock,
     views: ['day', 'hours', 'minutes'],
     componentFamily: 'picker',
     variant: 'mobile',

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValidation.MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/describeValidation.MobileDateTimeRangePicker.test.tsx
@@ -2,9 +2,7 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { MobileDateTimeRangePicker } from '@mui/x-date-pickers-pro/MobileDateTimeRangePicker';
 
 describe('<MobileDateTimeRangePicker /> - Describe Validation', () => {
-  const { render } = createPickerRenderer({
-    clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
-  });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(MobileDateTimeRangePicker, () => ({
     render,

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValidation.MobileTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/tests/describeValidation.MobileTimeRangePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeRangeValidation } from 'test/utils/picker
 import { MobileTimeRangePicker } from '@mui/x-date-pickers-pro/MobileTimeRangePicker';
 
 describe('<MobileTimeRangePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(MobileTimeRangePicker, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'picker',
     variant: 'mobile',

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/describeValidation.MultiInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/tests/describeValidation.MultiInputDateRangeField.test.tsx
@@ -7,11 +7,10 @@ import {
 } from 'test/utils/pickers';
 
 describe('<MultiInputDateRangeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(MultiInputDateRangeField, () => ({
     render,
-    clock,
     componentFamily: 'field',
     fieldType: 'multi-input',
     views: ['year', 'month', 'day'],

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/describeValidation.MultiInputDateTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/tests/describeValidation.MultiInputDateTimeRangeField.test.tsx
@@ -7,11 +7,10 @@ import {
 } from 'test/utils/pickers';
 
 describe('<MultiInputDateTimeRangeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(MultiInputDateTimeRangeField, () => ({
     render,
-    clock,
     componentFamily: 'field',
     fieldType: 'multi-input',
     views: ['year', 'month', 'day', 'hours', 'minutes'],

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/describeValidation.MultiInputTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/describeValidation.MultiInputTimeRangeField.test.tsx
@@ -7,14 +7,12 @@ import {
 } from 'test/utils/pickers';
 
 describe('<MultiInputTimeRangeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
+  const { render } = createPickerRenderer({
     clockConfig: new Date(2018, 0, 10),
   });
 
   describeRangeValidation(MultiInputTimeRangeField, () => ({
     render,
-    clock,
     componentFamily: 'field',
     views: ['hours', 'minutes'],
     fieldType: 'multi-input',

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/describeValidation.MultiInputTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/tests/describeValidation.MultiInputTimeRangeField.test.tsx
@@ -7,9 +7,7 @@ import {
 } from 'test/utils/pickers';
 
 describe('<MultiInputTimeRangeField /> - Describe Validation', () => {
-  const { render } = createPickerRenderer({
-    clockConfig: new Date(2018, 0, 10),
-  });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(MultiInputTimeRangeField, () => ({
     render,

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describeValidation.SingleInputDateRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/tests/describeValidation.SingleInputDateRangeField.test.tsx
@@ -2,11 +2,10 @@ import { SingleInputDateRangeField } from '@mui/x-date-pickers-pro/SingleInputDa
 import { createPickerRenderer, describeRangeValidation } from 'test/utils/pickers';
 
 describe('<SingleInputDateRangeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(SingleInputDateRangeField, () => ({
     render,
-    clock,
     componentFamily: 'field',
     views: ['year', 'month', 'day'],
     fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describeValidation.SingleInputDateTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/tests/describeValidation.SingleInputDateTimeRangeField.test.tsx
@@ -2,11 +2,10 @@ import { SingleInputDateTimeRangeField } from '@mui/x-date-pickers-pro/SingleInp
 import { createPickerRenderer, describeRangeValidation } from 'test/utils/pickers';
 
 describe('<SingleInputDateTimeRangeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(SingleInputDateTimeRangeField, () => ({
     render,
-    clock,
     componentFamily: 'field',
     views: ['year', 'month', 'day', 'hours', 'minutes', 'seconds'],
     fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describeValidation.SingleInputTimeRangeField.test.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/tests/describeValidation.SingleInputTimeRangeField.test.tsx
@@ -2,11 +2,10 @@ import { SingleInputTimeRangeField } from '@mui/x-date-pickers-pro/SingleInputTi
 import { createPickerRenderer, describeRangeValidation } from 'test/utils/pickers';
 
 describe('<SingleInputTimeRangeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeRangeValidation(SingleInputTimeRangeField, () => ({
     render,
-    clock,
     componentFamily: 'field',
     views: ['hours', 'minutes', 'seconds'],
     fieldType: 'single-input',

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.test.tsx
@@ -7,10 +7,7 @@ import { createPickerRenderer, adapterToUse, describeRangeValidation } from 'tes
 import { describeConformance } from 'test/utils/describeConformance';
 
 describe('<StaticDateRangePicker />', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
-    clockConfig: new Date(2018, 0, 1, 0, 0, 0, 0),
-  });
+  const { render, clock } = createPickerRenderer();
 
   describeConformance(<StaticDateRangePicker />, () => ({
     classes: {} as any,

--- a/packages/x-date-pickers/src/DateCalendar/tests/describeValidation.DateCalendar.test.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/tests/describeValidation.DateCalendar.test.tsx
@@ -2,11 +2,10 @@ import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
 import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 
 describe('<DateCalendar /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(DateCalendar, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day'],
     componentFamily: 'calendar',
   }));

--- a/packages/x-date-pickers/src/DateField/tests/describeValidation.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/describeValidation.DateField.test.tsx
@@ -2,11 +2,10 @@ import { DateField } from '@mui/x-date-pickers/DateField';
 import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 
 describe('<DateField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(DateField, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day'],
     componentFamily: 'field',
   }));

--- a/packages/x-date-pickers/src/DateTimeField/tests/describeValidation.DateTimeField.test.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/tests/describeValidation.DateTimeField.test.tsx
@@ -2,11 +2,10 @@ import { DateTimeField } from '@mui/x-date-pickers/DateTimeField';
 import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 
 describe('<DateTimeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(DateTimeField, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day', 'hours', 'minutes'],
     componentFamily: 'field',
   }));

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/describeValidation.DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/describeValidation.DesktopDatePicker.test.tsx
@@ -2,13 +2,12 @@ import { createPickerRenderer, describeValidation, describePicker } from 'test/u
 import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 
 describe('<DesktopDatePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describePicker(DesktopDatePicker, { render, fieldType: 'single-input', variant: 'desktop' });
 
   describeValidation(DesktopDatePicker, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day'],
     componentFamily: 'picker',
   }));

--- a/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describeValidation.DesktopDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDateTimePicker/tests/describeValidation.DesktopDateTimePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { DesktopDateTimePicker } from '@mui/x-date-pickers/DesktopDateTimePicker';
 
 describe('<DesktopDateTimePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(DesktopDateTimePicker, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day', 'hours', 'minutes'],
     componentFamily: 'picker',
   }));

--- a/packages/x-date-pickers/src/DesktopTimePicker/tests/describeValidation.DesktopTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopTimePicker/tests/describeValidation.DesktopTimePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker';
 
 describe('<DesktopTimePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(DesktopTimePicker, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'picker',
   }));

--- a/packages/x-date-pickers/src/DigitalClock/tests/describeValidation.DigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/tests/describeValidation.DigitalClock.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { DigitalClock } from '@mui/x-date-pickers/DigitalClock';
 
 describe('<DigitalClock /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(DigitalClock, () => ({
     render,
-    clock,
     views: ['hours'],
     componentFamily: 'digital-clock',
   }));

--- a/packages/x-date-pickers/src/MobileDatePicker/tests/describeValidation.MobileDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDatePicker/tests/describeValidation.MobileDatePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 
 describe('<MobileDatePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(MobileDatePicker, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day'],
     componentFamily: 'picker',
   }));

--- a/packages/x-date-pickers/src/MobileDateTimePicker/tests/describeValidation.MobileDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileDateTimePicker/tests/describeValidation.MobileDateTimePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker';
 
 describe('<MobileDateTimePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(MobileDateTimePicker, () => ({
     render,
-    clock,
     views: ['year', 'day', 'hours', 'minutes'],
     componentFamily: 'picker',
   }));

--- a/packages/x-date-pickers/src/MobileTimePicker/tests/describeValidation.MobileTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/MobileTimePicker/tests/describeValidation.MobileTimePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker';
 
 describe('<MobileTimePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(MobileTimePicker, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'picker',
   }));

--- a/packages/x-date-pickers/src/MonthCalendar/tests/describeValidation.MonthCalendar.test.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/tests/describeValidation.MonthCalendar.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { MonthCalendar } from '@mui/x-date-pickers/MonthCalendar';
 
 describe('<MonthCalendar /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(MonthCalendar, () => ({
     render,
-    clock,
     views: ['month'],
     componentFamily: 'calendar',
   }));

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describeValidation.MultiSectionDigitalClock.test.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/tests/describeValidation.MultiSectionDigitalClock.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { MultiSectionDigitalClock } from '@mui/x-date-pickers/MultiSectionDigitalClock';
 
 describe('<MultiSectionDigitalClock /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(MultiSectionDigitalClock, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'multi-section-digital-clock',
   }));

--- a/packages/x-date-pickers/src/StaticDatePicker/tests/describeValidation.StaticDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDatePicker/tests/describeValidation.StaticDatePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 
 describe('<StaticDatePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(StaticDatePicker, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day'],
     componentFamily: 'static-picker',
   }));

--- a/packages/x-date-pickers/src/StaticDateTimePicker/tests/describeValidation.StaticDateTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticDateTimePicker/tests/describeValidation.StaticDateTimePicker.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { StaticDateTimePicker } from '@mui/x-date-pickers/StaticDateTimePicker';
 
 describe('<StaticDateTimePicker /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(StaticDateTimePicker, () => ({
     render,
-    clock,
     views: ['year', 'month', 'day', 'hours', 'minutes'],
     componentFamily: 'static-picker',
   }));

--- a/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
+++ b/packages/x-date-pickers/src/StaticTimePicker/StaticTimePicker.test.tsx
@@ -8,14 +8,12 @@ import { describeConformance } from 'test/utils/describeConformance';
 import { testSkipIf, hasTouchSupport } from 'test/utils/skipIf';
 
 describe('<StaticTimePicker />', () => {
-  const { render, clock } = createPickerRenderer({
-    clock: 'fake',
+  const { render } = createPickerRenderer({
     clockConfig: new Date(2018, 2, 12, 8, 16, 0),
   });
 
   describeValidation(StaticTimePicker, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'static-picker',
   }));

--- a/packages/x-date-pickers/src/TimeField/tests/describeValidation.TimeField.test.tsx
+++ b/packages/x-date-pickers/src/TimeField/tests/describeValidation.TimeField.test.tsx
@@ -2,11 +2,10 @@ import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 import { TimeField } from '@mui/x-date-pickers/TimeField';
 
 describe('<TimeField /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(TimeField, () => ({
     render,
-    clock,
     views: ['hours', 'minutes'],
     componentFamily: 'field',
   }));

--- a/packages/x-date-pickers/src/YearCalendar/tests/describeValidation.YearCalendar.test.tsx
+++ b/packages/x-date-pickers/src/YearCalendar/tests/describeValidation.YearCalendar.test.tsx
@@ -2,11 +2,10 @@ import { YearCalendar } from '@mui/x-date-pickers/YearCalendar';
 import { createPickerRenderer, describeValidation } from 'test/utils/pickers';
 
 describe('<YearCalendar /> - Describe Validation', () => {
-  const { render, clock } = createPickerRenderer({ clock: 'fake' });
+  const { render } = createPickerRenderer();
 
   describeValidation(YearCalendar, () => ({
     render,
-    clock,
     views: ['year'],
     componentFamily: 'calendar',
   }));

--- a/packages/x-date-pickers/src/internals/hooks/useField/buildSectionsFromFormat.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/buildSectionsFromFormat.ts
@@ -154,7 +154,7 @@ const createSection = ({
     } else {
       if (sectionConfig.maxLength == null) {
         throw new Error(
-          `MUI X: The token ${token} should have a 'maxDigitNumber' property on it's adapter`,
+          `MUI X: The token ${token} should have a 'maxLength' property on it's adapter`,
         );
       }
 

--- a/test/utils/pickers/describeRangeValidation/testDayViewRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/testDayViewRangeValidation.tsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { screen } from '@mui/internal-test-utils';
 import { adapterToUse } from 'test/utils/pickers';
 import { describeSkipIf } from 'test/utils/skipIf';
+import { DescribeRangeValidationTestSuite } from './describeRangeValidation.types';
 
 const isDisabled = (el: HTMLElement) => el.getAttribute('disabled') !== null;
 
@@ -31,7 +32,10 @@ const testMonthSwitcherAreDisable = (areDisable: [boolean, boolean]) => {
   }
 };
 
-export function testDayViewRangeValidation(ElementToTest, getOptions) {
+export const testDayViewRangeValidation: DescribeRangeValidationTestSuite = (
+  ElementToTest,
+  getOptions,
+) => {
   const { componentFamily, views, variant = 'desktop' } = getOptions();
   describeSkipIf(!views.includes('day') || componentFamily === 'field')(
     'validation in day view:',
@@ -52,7 +56,7 @@ export function testDayViewRangeValidation(ElementToTest, getOptions) {
         render(
           <ElementToTest
             {...defaultProps}
-            shouldDisableDate={(date) =>
+            shouldDisableDate={(date: any) =>
               adapterToUse.isAfter(date, adapterToUse.date('2018-03-10'))
             }
           />,
@@ -63,10 +67,10 @@ export function testDayViewRangeValidation(ElementToTest, getOptions) {
       });
 
       it('should apply disablePast', () => {
-        const { render, clock } = getOptions();
+        const { render } = getOptions();
 
         let now;
-        function WithFakeTimer(props) {
+        function WithFakeTimer(props: any) {
           now = adapterToUse.date();
           const { referenceDate, ...otherProps } = props;
           return <ElementToTest value={[now, null]} {...otherProps} />;
@@ -89,7 +93,6 @@ export function testDayViewRangeValidation(ElementToTest, getOptions) {
 
         if (!adapterToUse.isSameMonth(yesterday, tomorrow)) {
           setProps({ value: [yesterday, null] });
-          clock.runToLast();
         }
         testDisabledDate(
           adapterToUse.format(yesterday, 'dayOfMonth'),
@@ -99,10 +102,10 @@ export function testDayViewRangeValidation(ElementToTest, getOptions) {
       });
 
       it('should apply disableFuture', () => {
-        const { render, clock } = getOptions();
+        const { render } = getOptions();
 
         let now;
-        function WithFakeTimer(props) {
+        function WithFakeTimer(props: any) {
           now = adapterToUse.date();
           const { referenceDate, ...otherProps } = props;
           return <ElementToTest value={[now, null]} {...otherProps} />;
@@ -125,7 +128,6 @@ export function testDayViewRangeValidation(ElementToTest, getOptions) {
 
         if (!adapterToUse.isSameMonth(yesterday, tomorrow)) {
           setProps({ value: [yesterday, null] });
-          clock.runToLast();
         }
         testDisabledDate(
           adapterToUse.format(yesterday, 'dayOfMonth'),
@@ -173,4 +175,4 @@ export function testDayViewRangeValidation(ElementToTest, getOptions) {
       });
     },
   );
-}
+};

--- a/test/utils/pickers/describeRangeValidation/testTextFieldKeyboardRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/testTextFieldKeyboardRangeValidation.tsx
@@ -54,7 +54,9 @@ export const testTextFieldKeyboardRangeValidation: DescribeRangeValidationTestSu
       const { setProps } = render(
         <ElementToTest
           onError={onErrorMock}
-          shouldDisableDate={(date) => adapterToUse.isAfter(date, adapterToUse.date('2018-03-11'))}
+          shouldDisableDate={(date: any) =>
+            adapterToUse.isAfter(date, adapterToUse.date('2018-03-11'))
+          }
         />,
       );
       act(() => {
@@ -88,7 +90,8 @@ export const testTextFieldKeyboardRangeValidation: DescribeRangeValidationTestSu
       testInvalidStatus([true, true], fieldType);
 
       setProps({
-        shouldDisableDate: (date) => adapterToUse.isBefore(date, adapterToUse.date('2018-03-13')),
+        shouldDisableDate: (date: any) =>
+          adapterToUse.isBefore(date, adapterToUse.date('2018-03-13')),
       });
 
       expect(onErrorMock.callCount).to.equal(3);

--- a/test/utils/pickers/describeRangeValidation/testTextFieldRangeValidation.tsx
+++ b/test/utils/pickers/describeRangeValidation/testTextFieldRangeValidation.tsx
@@ -63,7 +63,9 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
         <ElementToTest
           onError={onErrorMock}
           value={[adapterToUse.date('2018-03-09'), adapterToUse.date('2018-03-10')]}
-          shouldDisableDate={(date) => adapterToUse.isAfter(date, adapterToUse.date('2018-03-10'))}
+          shouldDisableDate={(date: any) =>
+            adapterToUse.isAfter(date, adapterToUse.date('2018-03-10'))
+          }
         />,
       );
 
@@ -91,7 +93,8 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
 
       setProps({
         value: [adapterToUse.date('2018-03-12'), adapterToUse.date('2018-03-13')],
-        shouldDisableDate: (date) => adapterToUse.isBefore(date, adapterToUse.date('2018-03-13')),
+        shouldDisableDate: (date: any) =>
+          adapterToUse.isBefore(date, adapterToUse.date('2018-03-13')),
       });
 
       expect(onErrorMock.callCount).to.equal(3);
@@ -105,7 +108,7 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
         <ElementToTest
           onError={onErrorMock}
           value={[adapterToUse.date('2018-03-09'), adapterToUse.date('2018-03-10')]}
-          shouldDisableDate={(date, position) =>
+          shouldDisableDate={(date: any, position: string) =>
             position === 'end' ? adapterToUse.isAfter(date, adapterToUse.date('2018-03-10')) : false
           }
         />,
@@ -132,7 +135,7 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
 
       setProps({
         value: [adapterToUse.date('2018-03-12'), adapterToUse.date('2018-03-13')],
-        shouldDisableDate: (date, position) =>
+        shouldDisableDate: (date: any, position: string) =>
           position === 'end' ? adapterToUse.isBefore(date, adapterToUse.date('2018-03-13')) : false,
       });
 
@@ -147,7 +150,7 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
         <ElementToTest
           onError={onErrorMock}
           value={[adapterToUse.date('2018-03-09'), adapterToUse.date('2018-03-10')]}
-          shouldDisableDate={(date, position) =>
+          shouldDisableDate={(date: any, position: string) =>
             position === 'start'
               ? adapterToUse.isAfter(date, adapterToUse.date('2018-03-10'))
               : false
@@ -175,7 +178,7 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
       testInvalidStatus([true, false], fieldType);
 
       setProps({
-        shouldDisableDate: (date, position) =>
+        shouldDisableDate: (date: any, position: string) =>
           position === 'start'
             ? adapterToUse.isBefore(date, adapterToUse.date('2018-03-13'))
             : false,
@@ -188,7 +191,7 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
     it('should apply disablePast', () => {
       const onErrorMock = spy();
       let now;
-      function WithFakeTimer(props) {
+      function WithFakeTimer(props: any) {
         now = adapterToUse.date();
         return <ElementToTest value={[now, now]} {...props} />;
       }
@@ -226,7 +229,7 @@ export const testTextFieldRangeValidation: DescribeRangeValidationTestSuite = (
     it('should apply disableFuture', () => {
       const onErrorMock = spy();
       let now;
-      function WithFakeTimer(props) {
+      function WithFakeTimer(props: any) {
         now = adapterToUse.date();
         return <ElementToTest value={[now, now]} {...props} />;
       }

--- a/test/utils/pickers/describeValidation/describeValidation.types.ts
+++ b/test/utils/pickers/describeValidation/describeValidation.types.ts
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import { MuiRenderResult, createRenderer } from '@mui/internal-test-utils/createRenderer';
+import { MuiRenderResult } from '@mui/internal-test-utils/createRenderer';
 import { DateOrTimeView } from '@mui/x-date-pickers/models';
 import { PickerComponentFamily } from '../describe.types';
 
 export interface DescribeValidationInputOptions {
   render: (node: React.ReactElement<any>) => MuiRenderResult;
-  // TODO: Export `Clock` from monorepo
-  clock: ReturnType<typeof createRenderer>['clock'];
   after?: () => void;
   componentFamily: PickerComponentFamily;
   views: DateOrTimeView[];

--- a/test/utils/pickers/describeValidation/testDayViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testDayViewValidation.tsx
@@ -6,7 +6,7 @@ import { describeSkipIf, testSkipIf } from 'test/utils/skipIf';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 
 export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest, getOptions) => {
-  const { componentFamily, views, render, clock, withDate, withTime } = getOptions();
+  const { componentFamily, views, render, withDate, withTime } = getOptions();
 
   describeSkipIf(componentFamily === 'field' || !views.includes('day'))('day view:', () => {
     const defaultProps = {
@@ -48,7 +48,6 @@ export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest
       expect(screen.getByRole('gridcell', { name: '30' })).to.have.attribute('disabled');
 
       setProps({ value: adapterToUse.date('2019-01-01') });
-      clock.runToLast();
 
       expect(screen.getByRole('gridcell', { name: '1' })).not.to.have.attribute('disabled');
       expect(screen.getByRole('gridcell', { name: '15' })).not.to.have.attribute('disabled');
@@ -69,7 +68,6 @@ export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest
       expect(screen.getByRole('gridcell', { name: '30' })).to.have.attribute('disabled');
 
       setProps({ value: adapterToUse.date('2018-02-01') });
-      clock.runToLast();
 
       expect(screen.getByRole('gridcell', { name: '1' })).not.to.have.attribute('disabled');
       expect(screen.getByRole('gridcell', { name: '15' })).not.to.have.attribute('disabled');
@@ -93,7 +91,6 @@ export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest
 
       if (!adapterToUse.isSameMonth(now, tomorrow)) {
         setProps({ value: tomorrow });
-        clock.runToLast();
       }
       expect(
         screen.getByRole('gridcell', { name: adapterToUse.format(tomorrow, 'dayOfMonth') }),
@@ -101,7 +98,6 @@ export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest
 
       if (!adapterToUse.isSameMonth(yesterday, tomorrow)) {
         setProps({ value: yesterday });
-        clock.runToLast();
       }
       expect(
         screen.getByRole('gridcell', { name: adapterToUse.format(yesterday, 'dayOfMonth') }),
@@ -125,7 +121,6 @@ export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest
 
       if (!adapterToUse.isSameMonth(now, tomorrow)) {
         setProps({ value: tomorrow });
-        clock.runToLast();
       }
       expect(
         screen.getByRole('gridcell', { name: adapterToUse.format(tomorrow, 'dayOfMonth') }),
@@ -133,7 +128,6 @@ export const testDayViewValidation: DescribeValidationTestSuite = (ElementToTest
 
       if (!adapterToUse.isSameMonth(yesterday, tomorrow)) {
         setProps({ value: yesterday });
-        clock.runToLast();
       }
       expect(
         screen.getByRole('gridcell', { name: adapterToUse.format(yesterday, 'dayOfMonth') }),

--- a/test/utils/pickers/describeValidation/testMinutesViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testMinutesViewValidation.tsx
@@ -11,7 +11,7 @@ export const testMinutesViewValidation: DescribeValidationTestSuite = (
   ElementToTest,
   getOption,
 ) => {
-  const { componentFamily, views, render, clock, withDate, withTime, variant } = getOption();
+  const { componentFamily, views, render, withDate, withTime, variant } = getOption();
 
   describeSkipIf(
     !views.includes('minutes') || !variant || componentFamily !== 'picker' || variant === 'desktop',
@@ -30,7 +30,7 @@ export const testMinutesViewValidation: DescribeValidationTestSuite = (
         <ElementToTest
           {...defaultProps}
           value={adapterToUse.date('2018-03-12T08:15:00')}
-          shouldDisableTime={(date) =>
+          shouldDisableTime={(date: any) =>
             adapterToUse.isAfter(date, adapterToUse.date('2018-03-12T08:20:00'))
           }
         />,
@@ -58,7 +58,7 @@ export const testMinutesViewValidation: DescribeValidationTestSuite = (
 
     it('should apply disablePast', () => {
       let now;
-      function WithFakeTimer(props) {
+      function WithFakeTimer(props: any) {
         now = adapterToUse.date();
         return <ElementToTest value={now} {...props} />;
       }
@@ -92,7 +92,6 @@ export const testMinutesViewValidation: DescribeValidationTestSuite = (
       }
 
       setProps({ value: tomorrow });
-      clock.runToLast();
       expect(
         screen.getByRole('option', { name: toMinutesLabel(previousMinutesOptionValue) }),
       ).not.to.have.attribute('aria-disabled');
@@ -103,7 +102,7 @@ export const testMinutesViewValidation: DescribeValidationTestSuite = (
 
     it('should apply disableFuture', () => {
       let now;
-      function WithFakeTimer(props) {
+      function WithFakeTimer(props: any) {
         now = adapterToUse.date();
         return <ElementToTest value={now} {...props} />;
       }
@@ -137,7 +136,6 @@ export const testMinutesViewValidation: DescribeValidationTestSuite = (
       }
 
       setProps({ value: yesterday });
-      clock.runToLast();
       expect(
         screen.getByRole('option', { name: toMinutesLabel(previousMinutesOptionValue) }),
       ).not.to.have.attribute('aria-disabled');

--- a/test/utils/pickers/describeValidation/testMonthViewValidation.tsx
+++ b/test/utils/pickers/describeValidation/testMonthViewValidation.tsx
@@ -6,7 +6,7 @@ import { describeSkipIf } from 'test/utils/skipIf';
 import { DescribeValidationTestSuite } from './describeValidation.types';
 
 export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTest, getOptions) => {
-  const { views, componentFamily, render, clock } = getOptions();
+  const { views, componentFamily, render } = getOptions();
 
   describeSkipIf(componentFamily === 'field' || !views.includes('month'))('month view:', () => {
     const defaultProps = {
@@ -28,7 +28,7 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
         <ElementToTest
           {...defaultProps}
           value={null}
-          shouldDisableMonth={(date) => adapterToUse.getMonth(date) === 3}
+          shouldDisableMonth={(date: any) => adapterToUse.getMonth(date) === 3}
         />,
       );
 
@@ -39,7 +39,7 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
 
     it('should apply disablePast', () => {
       let now;
-      function WithFakeTimer(props) {
+      function WithFakeTimer(props: any) {
         now = adapterToUse.date();
         return <ElementToTest value={now} {...props} />;
       }
@@ -54,7 +54,6 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
 
       if (!adapterToUse.isSameYear(now, nextMonth)) {
         setProps({ value: nextMonth });
-        clock.runToLast();
       }
       expect(screen.getByText(adapterToUse.format(nextMonth, 'monthShort'))).not.to.have.attribute(
         'disabled',
@@ -62,7 +61,6 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
 
       if (!adapterToUse.isSameYear(prevMonth, nextMonth)) {
         setProps({ value: prevMonth });
-        clock.runToLast();
       }
       expect(screen.getByText(adapterToUse.format(prevMonth, 'monthShort'))).to.have.attribute(
         'disabled',
@@ -73,7 +71,7 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
 
     it('should apply disableFuture', () => {
       let now;
-      function WithFakeTimer(props) {
+      function WithFakeTimer(props: any) {
         now = adapterToUse.date();
         return <ElementToTest value={now} {...props} />;
       }
@@ -88,7 +86,6 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
 
       if (!adapterToUse.isSameYear(now, nextMonth)) {
         setProps({ value: nextMonth });
-        clock.runToLast();
       }
       expect(screen.getByText(adapterToUse.format(nextMonth, 'monthShort'))).to.have.attribute(
         'disabled',
@@ -96,7 +93,6 @@ export const testMonthViewValidation: DescribeValidationTestSuite = (ElementToTe
 
       if (!adapterToUse.isSameYear(prevMonth, nextMonth)) {
         setProps({ value: prevMonth });
-        clock.runToLast();
       }
       expect(screen.getByText(adapterToUse.format(prevMonth, 'monthShort'))).not.to.have.attribute(
         'disabled',

--- a/test/utils/pickers/describeValidation/testTextFieldValidation.tsx
+++ b/test/utils/pickers/describeValidation/testTextFieldValidation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers, SinonFakeTimers } from 'sinon';
 import { TimeView } from '@mui/x-date-pickers/models';
 import { adapterToUse, getFieldInputRoot } from 'test/utils/pickers';
 import { describeSkipIf, testSkipIf } from 'test/utils/skipIf';
@@ -137,33 +137,44 @@ export const testTextFieldValidation: DescribeValidationTestSuite = (ElementToTe
       expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'true');
     });
 
-    testSkipIf(!withDate)('should apply disablePast', () => {
-      let now;
-      function WithFakeTimer(props: any) {
-        now = adapterToUse.date();
-        return <ElementToTest value={now} {...props} />;
-      }
+    describeSkipIf(!withDate)('with fake timers', () => {
+      // TODO: temporary for vitest. Can move to `vi.useFakeTimers`
+      let timer: SinonFakeTimers | null = null;
+      beforeEach(() => {
+        timer = useFakeTimers({ now: new Date(2018, 0, 1), toFake: ['Date'] });
+      });
+      afterEach(() => {
+        timer?.restore();
+      });
 
-      const onErrorMock = spy();
-      const { setProps } = render(<WithFakeTimer disablePast onError={onErrorMock} />);
+      it('should apply disablePast', () => {
+        let now;
+        function WithFakeTimer(props: any) {
+          now = adapterToUse.date();
+          return <ElementToTest value={now} {...props} />;
+        }
 
-      const tomorrow = adapterToUse.addDays(now, 1);
-      const yesterday = adapterToUse.addDays(now, -1);
+        const onErrorMock = spy();
+        const { setProps } = render(<WithFakeTimer disablePast onError={onErrorMock} />);
 
-      expect(onErrorMock.callCount).to.equal(0);
-      expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'false');
+        const tomorrow = adapterToUse.addDays(now, 1);
+        const yesterday = adapterToUse.addDays(now, -1);
 
-      setProps({ value: yesterday });
+        expect(onErrorMock.callCount).to.equal(0);
+        expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'false');
 
-      expect(onErrorMock.callCount).to.equal(1);
-      expect(onErrorMock.lastCall.args[0]).to.equal('disablePast');
-      expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'true');
+        setProps({ value: yesterday });
 
-      setProps({ value: tomorrow });
+        expect(onErrorMock.callCount).to.equal(1);
+        expect(onErrorMock.lastCall.args[0]).to.equal('disablePast');
+        expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'true');
 
-      expect(onErrorMock.callCount).to.equal(2);
-      expect(onErrorMock.lastCall.args[0]).to.equal(null);
-      expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'false');
+        setProps({ value: tomorrow });
+
+        expect(onErrorMock.callCount).to.equal(2);
+        expect(onErrorMock.lastCall.args[0]).to.equal(null);
+        expect(getFieldInputRoot()).to.have.attribute('aria-invalid', 'false');
+      });
     });
 
     testSkipIf(!withDate)('should apply disableFuture', () => {


### PR DESCRIPTION
These are improvements made during the [`vitest` PR ](https://github.com/mui/mui-x/pull/14508)

I'm moving the changes out so that PR is leaner. 

The main change here is removing the fake date usage from most of the `describeValidation` logic.
I've left it only where necessary, in the `should apply disablePast` tests

An alternative would be to always fake the date, which would probably work, but I preferred a more precise approach.
