### PR TITLE
[infra] Add write permission for actions in issue status label handler

### DIFF
--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -16,5 +16,6 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: write
     name: Handle status labels
     uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@master


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/issue-status-label-handler.yml` file. The change grants write permissions to the `actions` scope.

This is needed for the status label handler workflow to delete the cache and create a new one.

Related PR: https://github.com/mui/mui-public/pull/297

* [`.github/workflows/issue-status-label-handler.yml`](diffhunk://#diff-39f7419b803abac83bb454886d44600de03f9138be0137c41055b5c4dbf51a56R19): Added `actions: write` permission in the `permissions` section.