### PR TITLE
[code-infra] fix tsbuildinfo file being included in npm package

### DIFF
--- a/packages/x-charts-pro/tsconfig.build.json
+++ b/packages/x-charts-pro/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation"]
   },

--- a/packages/x-charts/tsconfig.build.json
+++ b/packages/x-charts/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": [
       "node",

--- a/packages/x-data-grid-generator/tsconfig.build.json
+++ b/packages/x-data-grid-generator/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation"]
   },

--- a/packages/x-data-grid-premium/tsconfig.build.json
+++ b/packages/x-data-grid-premium/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation"]
   },

--- a/packages/x-data-grid-pro/tsconfig.build.json
+++ b/packages/x-data-grid-pro/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation"]
   },

--- a/packages/x-data-grid/tsconfig.build.json
+++ b/packages/x-data-grid/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation", "@emotion/styled", "@mui/types"]
   },

--- a/packages/x-date-pickers-pro/tsconfig.build.json
+++ b/packages/x-date-pickers-pro/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation"]
   },

--- a/packages/x-date-pickers/tsconfig.build.json
+++ b/packages/x-date-pickers/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": [
       "node",

--- a/packages/x-internals/tsconfig.build.json
+++ b/packages/x-internals/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node"]
   },

--- a/packages/x-license/tsconfig.build.json
+++ b/packages/x-license/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src"
   },
   "references": [

--- a/packages/x-tree-view-pro/tsconfig.build.json
+++ b/packages/x-tree-view-pro/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation"]
   },

--- a/packages/x-tree-view/tsconfig.build.json
+++ b/packages/x-tree-view/tsconfig.build.json
@@ -8,6 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "build/esm",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "rootDir": "./src",
     "types": ["node", "@mui/material/themeCssVarsAugmentation", "@emotion/styled"]
   },


### PR DESCRIPTION
`@mui/x-*` v8 packages have a `tsconfig.build.tsbuildinfo` that weights 400-500kB included in their package ([example](https://www.npmjs.com/package/@mui/x-date-pickers/v/8.0.0-beta.2?activeTab=code)). This file is used for incremental compilation, so it is unnecessary to publish it. 

The inclusion of this file was an unintended side-effect of [this PR](https://github.com/mui/mui-x/pull/14386) because of how the `tsBuildInfoFile` property is resolved ([docs](https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile)):

> If `rootDir` and `outDir` are set, then the file is `<outDir>/<relative path to config from rootDir>/<config name>.tsbuildinfo`


Before #14386, `rootDir` was `./src` and `outDir` was `build`, so `tsBuildInfoFile` was `build/../tsconfig.build.tsbuildinfo`, or `./tsconfig.build.tsbuildinfo`.

Then, #14386 changed the `outDir` from `build` to `build/esm`, so the new path for `tsBuildInfoFile` became `build/esm/../tsconfig.build.tsbuildinfo`, or simply `build/tsconfig.build.tsbuildinfo`, which explains why the `tsbuildinfo` file was being included in the package. 

This PR fixes the issue by specifying the old path for `tsBuildInfoFile`, which was `./tsconfig.build.tsbuildinfo`. 