### PR TITLE
[docs] Use v6 core packages in MUI X v7 docs

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -39,7 +39,7 @@ function getMuiPackageVersion(packageName, commitRef) {
 }
 
 ponyfillGlobal.muiDocConfig = {
-  csbIncludePeerDependencies: (deps, { versions }) => {
+  csbIncludePeerDependencies: (deps) => {
     const newDeps = { ...deps };
 
     newDeps['@mui/material'] = '^6';

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -42,13 +42,10 @@ ponyfillGlobal.muiDocConfig = {
   csbIncludePeerDependencies: (deps, { versions }) => {
     const newDeps = { ...deps };
 
-    // #default-branch-switch
-    // Check which version of `@mui/material` should be resolved when opening docs examples in StackBlitz or CodeSandbox
-    newDeps['@mui/material'] =
-      versions['@mui/material'] !== 'next' ? versions['@mui/material'] : 'latest';
+    newDeps['@mui/material'] = '^6';
 
     if (newDeps['@mui/x-data-grid-generator']) {
-      newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
+      newDeps['@mui/icons-material'] = '^6';
     }
     return newDeps;
   },


### PR DESCRIPTION
Since `@mui/material@latest` now resolves to v7, our demos at https://mui.com/x/react-data-grid/ do not work in codesandbox.
Here's an example: https://codesandbox.io/p/sandbox/infallible-dust-2zh9wf?file=%2Fpackage.json

<img width="500" alt="Screenshot 2025-03-28 at 23 08 33" src="https://github.com/user-attachments/assets/e28dbbd3-f24c-4480-b2d0-bbc565154b41" />

We need to use v6 core packages to keep it working.

