### PR TITLE
[docs] Sync Stack Overflow docs with reality

### DIFF
--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -58,12 +58,12 @@ You can use a starter template to build a reproduction case with:
 
 We use Stack Overflow for how-to questions. Answers are crowdsourced from expert developers in the MUI X community as well as MUI X maintainers.
 
-You can search through existing questions and answers to see if someone has asked a similar question using one of [these tags](https://stackoverflow.com/questions/tagged/mui-x+or+mui-x-charts+or+mui-x-data-grid+or+mui-x-date-picker):
+You can search through existing questions and answers to see if someone has asked a similar question using one of [these tags](https://stackoverflow.com/questions/tagged/mui-x-charts+or+mui-x-data-grid+or+mui-x-date-picker+or+mui-x-tree-view):
 
-- mui-x
 - mui-x-data-grid
 - mui-x-date-picker
 - mui-x-charts
+- mui-x-tree-view
 
 If you cannot find your answer, [ask a new question](https://stackoverflow.com/questions/ask?tags=reactjs%20mui-x) using the relevant tags.
 


### PR DESCRIPTION
Reflect https://www.notion.so/mui-org/devex-Fix-Stack-Overflow-tags-structure-1b9cbfe7b66080828083e7eccddf6d62

I noticed this because in https://app.ahrefs.com/site-audit/3523498/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CcontentType%2Cdepth%2CincomingAllLinks&current=26-03-2025T032224P0100&filterId=9b88587038fc9bb2e08e0ff143d5f328&issueId=c64d89a6-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating we have 

<img width="808" alt="SCR-20250331-cqyw" src="https://github.com/user-attachments/assets/1d2439bb-fd78-4414-ba53-31507ba59618" />

cc @mapache-salvaje for awareness.