### PR TITLE
[TimePicker] Align DigitalClock scrollbar thickness

### DIFF
--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
@@ -41,6 +41,7 @@ const DigitalClockRoot = styled(PickerViewRoot, {
 })<{ ownerState: DigitalClockOwnerState }>({
   overflowY: 'auto',
   width: '100%',
+  scrollbarWidth: 'thin',
   '@media (prefers-reduced-motion: no-preference)': {
     scrollBehavior: 'auto',
   },


### PR DESCRIPTION
Follow up on https://github.com/mui/mui-x/pull/16774 to align the width of scrollbars between digital clocks.

| Before | After |
|--------|------|
| ![Screenshot 2025-03-31 at 13 27 40](https://github.com/user-attachments/assets/ceab30a9-bb79-4dc2-ac59-dde72c334d29) | ![Screenshot 2025-03-31 at 13 27 53](https://github.com/user-attachments/assets/9b5ed3a5-40c7-49fa-960f-6a96e699ebcc) |