### PR TITLE
[docs] Update Localization Provider JSDoc link

### DIFF
--- a/docs/pages/x/api/date-pickers/localization-provider.json
+++ b/docs/pages/x/api/date-pickers/localization-provider.json
@@ -4,7 +4,7 @@
     "dateAdapter": {
       "type": { "name": "func" },
       "seeMoreLink": {
-        "url": "https://mui.com/x/react-date-pickers/quickstart/#setup-your-date-library-adapter",
+        "url": "https://next.mui.com/x/react-date-pickers/quickstart/#integrate-provider-and-adapter",
         "text": "date adapter setup section"
       }
     },

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -30,7 +30,7 @@ export interface LocalizationProviderProps<TLocale> {
   children?: React.ReactNode;
   /**
    * Date library adapter class function.
-   * @see See the localization provider {@link https://mui.com/x/react-date-pickers/quickstart/#setup-your-date-library-adapter date adapter setup section} for more details.
+   * @see See the localization provider {@link https://next.mui.com/x/react-date-pickers/quickstart/#integrate-provider-and-adapter date adapter setup section} for more details.
    */
   dateAdapter?: new (...args: any) => MuiPickersAdapter<TLocale>;
   /** Formats that are used for any child pickers */
@@ -164,7 +164,7 @@ LocalizationProvider.propTypes = {
   children: PropTypes.node,
   /**
    * Date library adapter class function.
-   * @see See the localization provider {@link https://mui.com/x/react-date-pickers/quickstart/#setup-your-date-library-adapter date adapter setup section} for more details.
+   * @see See the localization provider {@link https://next.mui.com/x/react-date-pickers/quickstart/#integrate-provider-and-adapter date adapter setup section} for more details.
    */
   dateAdapter: PropTypes.func,
   /**


### PR DESCRIPTION
Follow up on https://github.com/mui/mui-x/pull/17200.

The updated link does not exist on v8, hence updating to use `next.` and the appropriate section hash.