### PR TITLE
[charts] Adjust color palettes

### DIFF
--- a/packages/x-charts/src/colorPalettes/colorPalettes.ts
+++ b/packages/x-charts/src/colorPalettes/colorPalettes.ts
@@ -5,22 +5,22 @@ export type ChartsColor = string | ChartsColorCallback;
 
 export const rainbowSurgePaletteLight = [
   '#4254FB',
-  '#FFB219',
-  '#54C690',
-  '#FF5463',
-  '#F287B3',
-  '#2EAFFF',
-  '#FD8731',
+  '#FFB422',
+  '#FA4F58',
+  '#0DBEFF',
+  '#22BF75',
+  '#FA83B4',
+  '#FF7511',
 ];
 
 export const rainbowSurgePaletteDark = [
-  '#273DFF',
-  '#FAC04E',
-  '#32ae6a',
-  '#F3616E',
+  '#495AFB',
+  '#FFC758',
+  '#F35865',
+  '#30C8FF',
+  '#44CE8D',
   '#F286B3',
-  '#2EAFFF',
-  '#FD8731',
+  '#FF8C39',
 ];
 
 export const rainbowSurgePalette: ChartsColorPaletteCallback = (mode) =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In this PR:

- Slightly adjusted the shades to work better for dark mode.
- We discussed with @joserodolfofreitas today that the order of the colors might work better like this, since in our docs, many demos showcase 3 different values, so the blue, yellow, red are more contrasting and complement each other better

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/98bcda12-041c-4df6-be29-235bb6edc393) | ![image](https://github.com/user-attachments/assets/ff303e81-e786-4509-99ab-21351a341684) |
| ![image](https://github.com/user-attachments/assets/2d84aa3f-b57d-4576-a117-88878dfc9b6c) | ![image](https://github.com/user-attachments/assets/b8dd4d10-83d6-4807-b12c-600f894158b9) |
