### PR TITLE
[code-infra] Fix `test:unit` warning

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,6 +8,7 @@ module.exports = {
     // We're leaving this to make sure.
     'docs/.next/**',
   ],
+  'node-option': ['no-experimental-detect-module'],
   recursive: true,
   timeout: (process.env.CIRCLECI === 'true' ? 5 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -31,6 +31,7 @@
     "type": "opencollective",
     "url": "https://opencollective.com/mui-org"
   },
+  "type": "module",
   "dependencies": {
     "@babel/core": "^7.26.10",
     "@babel/runtime": "^7.27.0",

--- a/packages/x-codemod/package.json
+++ b/packages/x-codemod/package.json
@@ -31,7 +31,6 @@
     "type": "opencollective",
     "url": "https://opencollective.com/mui-org"
   },
-  "type": "module",
   "dependencies": {
     "@babel/core": "^7.26.10",
     "@babel/runtime": "^7.27.0",


### PR DESCRIPTION
Fix warning when running `pnpm test:unit`


```
(node:35926) [MODULE_TYPELESS_PACKAGE_JSON] Warning: 
Module type of file is not specified and it doesn't parse as CommonJS.
file:///mui-x/packages/x-codemod/src/v6.0.0/pickers/text-props-to-localeText/text-props-to-localeText.test.js 
```

