### PR TITLE
[core] Always use the correct babel runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,5 @@
 // @ts-check
 const path = require('path');
-const fs = require('fs');
 const generateReleaseInfo = require('./packages/x-license/generateReleaseInfo');
 
 /**
@@ -40,16 +39,6 @@ const defaultAlias = {
   test: resolveAliasPath('./test'),
   packages: resolveAliasPath('./packages'),
 };
-
-const packageJsonPath = path.resolve('./package.json');
-const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
-const babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
-
-if (!babelRuntimeVersion) {
-  throw new Error(
-    'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
-  );
-}
 
 /** @type {babel.ConfigFunction} */
 module.exports = function getBabelConfig(api) {
@@ -92,7 +81,8 @@ module.exports = function getBabelConfig(api) {
       '@babel/plugin-transform-runtime',
       {
         useESModules,
-        version: babelRuntimeVersion,
+        // any package needs to declare 7.27.0 as a runtime dependency. default is ^7.0.0
+        version: process.env.MUI_BABEL_RUNTIME_VERSION || '^7.27.0',
       },
     ],
     [

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 // @ts-check
 const path = require('path');
+const fs = require('fs');
 const generateReleaseInfo = require('./packages/x-license/generateReleaseInfo');
 
 /**
@@ -39,6 +40,16 @@ const defaultAlias = {
   test: resolveAliasPath('./test'),
   packages: resolveAliasPath('./packages'),
 };
+
+const packageJsonPath = path.resolve('./package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+const babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
+
+if (!babelRuntimeVersion) {
+  throw new Error(
+    'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
+  );
+}
 
 /** @type {babel.ConfigFunction} */
 module.exports = function getBabelConfig(api) {
@@ -81,8 +92,7 @@ module.exports = function getBabelConfig(api) {
       '@babel/plugin-transform-runtime',
       {
         useESModules,
-        // any package needs to declare 7.25.0 as a runtime dependency. default is ^7.0.0
-        version: process.env.MUI_BABEL_RUNTIME_VERSION || '^7.25.0',
+        version: babelRuntimeVersion,
       },
     ],
     [

--- a/packages/x-charts-vendor/.babelrc.js
+++ b/packages/x-charts-vendor/.babelrc.js
@@ -12,6 +12,12 @@ const packageJsonPath = path.resolve('./package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
 const babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
 
+if (!babelRuntimeVersion) {
+  throw new Error(
+    'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
+  );
+}
+
 module.exports = function getBabelConfig(api) {
   const useESModules = api.env(['modern', 'stable', 'rollup']);
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -53,13 +53,6 @@ async function run(argv) {
   const packageJsonPath = path.resolve('./package.json');
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
 
-  const babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
-  if (!babelRuntimeVersion) {
-    throw new Error(
-      'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
-    );
-  }
-
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');
   const srcDir = path.resolve('./src');
   const extensions = ['.js', '.ts', '.tsx'];
@@ -90,7 +83,6 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
-    MUI_BABEL_RUNTIME_VERSION: babelRuntimeVersion,
     MUI_OUT_FILE_EXTENSION: outFileExtension,
     ...getVersionEnvVariables(packageJson),
   };

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -53,6 +53,13 @@ async function run(argv) {
   const packageJsonPath = path.resolve('./package.json');
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
 
+  const babelRuntimeVersion = packageJson.dependencies['@babel/runtime'];
+  if (!babelRuntimeVersion) {
+    throw new Error(
+      'package.json needs to have a dependency on `@babel/runtime` when building with `@babel/plugin-transform-runtime`.',
+    );
+  }
+
   const babelConfigPath = path.resolve(getWorkspaceRoot(), 'babel.config.js');
   const srcDir = path.resolve('./src');
   const extensions = ['.js', '.ts', '.tsx'];
@@ -83,6 +90,7 @@ async function run(argv) {
     NODE_ENV: 'production',
     BABEL_ENV: bundle,
     MUI_BUILD_VERBOSE: verbose,
+    MUI_BABEL_RUNTIME_VERSION: babelRuntimeVersion,
     MUI_OUT_FILE_EXTENSION: outFileExtension,
     ...getVersionEnvVariables(packageJson),
   };


### PR DESCRIPTION
Based on https://github.com/mui/mui-x/pull/17058#pullrequestreview-2738900330

I was wondering if we should move this logic to the main babel config. Because for now the babel runtime version is managed by the `build.mjs`. I reverted the modification because I struggled with relative path. But I could try again if you think it's an improvement to force the correct version for all scripts