### PR TITLE
[charts] Export 'series' class as part of barElementClasses

### DIFF
--- a/docs/pages/x/api/charts/bar-element.json
+++ b/docs/pages/x/api/charts/bar-element.json
@@ -43,7 +43,7 @@
     {
       "key": "series",
       "className": "MuiBarElement-series",
-      "description": "Styles applied to the root element for a specified series.\nTo be used like this: `&.${barElementClasses.series}-${seriesId}`.",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${barElementClasses.series}-${seriesId}`.",
       "isGlobal": false
     }
   ],

--- a/docs/pages/x/api/charts/bar-element.json
+++ b/docs/pages/x/api/charts/bar-element.json
@@ -39,6 +39,12 @@
       "className": "MuiBarElement-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiBarElement-series",
+      "description": "Styles applied to the root element for a specified series.\nTo be used like this: `&.${barElementClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiBarElement",

--- a/docs/translations/api-docs/charts/bar-element/bar-element.json
+++ b/docs/translations/api-docs/charts/bar-element/bar-element.json
@@ -15,7 +15,11 @@
       "nodeName": "the root element",
       "conditions": "it is highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. To be used like this: <code>&amp;.${barElementClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   },
   "slotDescriptions": { "bar": "The component that renders the bar." }
 }

--- a/docs/translations/api-docs/charts/bar-element/bar-element.json
+++ b/docs/translations/api-docs/charts/bar-element/bar-element.json
@@ -17,7 +17,7 @@
     },
     "root": { "description": "Styles applied to the root element." },
     "series": {
-      "description": "Styles applied to {{nodeName}}. To be used like this: <code>&amp;.${barElementClasses.series}-${seriesId}</code>.",
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${barElementClasses.series}-${seriesId}</code>.",
       "nodeName": "the root element for a specified series"
     }
   },

--- a/packages/x-charts/src/BarChart/barElementClasses.ts
+++ b/packages/x-charts/src/BarChart/barElementClasses.ts
@@ -10,10 +10,10 @@ export interface BarElementClasses {
   highlighted: string;
   /** Styles applied to the root element if it is faded. */
   faded: string;
-   /** Styles applied to the root element for a specified series.
+  /** Styles applied to the root element for a specified series.
    *  To be used like this: `&.${barElementClasses.series}-${seriesId}`.
    */
-   series: string;
+  series: string;
 }
 
 export type BarElementClassKey = keyof BarElementClasses;

--- a/packages/x-charts/src/BarChart/barElementClasses.ts
+++ b/packages/x-charts/src/BarChart/barElementClasses.ts
@@ -10,6 +10,10 @@ export interface BarElementClasses {
   highlighted: string;
   /** Styles applied to the root element if it is faded. */
   faded: string;
+   /** Styles applied to the root element for a specified series.
+   *  To be used like this: `&.${barElementClasses.series}-${seriesId}`.
+   */
+   series: string;
 }
 
 export type BarElementClassKey = keyof BarElementClasses;
@@ -31,6 +35,7 @@ export const barElementClasses: BarElementClasses = generateUtilityClasses('MuiB
   'root',
   'highlighted',
   'faded',
+  'series',
 ]);
 
 export const useUtilityClasses = (ownerState: BarElementOwnerState) => {

--- a/packages/x-charts/src/BarChart/barElementClasses.ts
+++ b/packages/x-charts/src/BarChart/barElementClasses.ts
@@ -11,7 +11,7 @@ export interface BarElementClasses {
   /** Styles applied to the root element if it is faded. */
   faded: string;
   /** Styles applied to the root element for a specified series.
-   *  To be used like this: `&.${barElementClasses.series}-${seriesId}`.
+   *  Needs to be suffixed with the series ID: `.${barElementClasses.series}-${seriesId}`.
    */
   series: string;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- Added `series` key to `barElementClasses` so users can write:
  ```ts
  `${barElementClasses.series}-${seriesId}`
  
