### PR TITLE
[docs] Fix 404 link on the marketing page

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -61,5 +61,7 @@
 # 2024
 /x/react-charts/heat-map/ /x/react-charts/heatmap/ 301
 /x/react-charts/tree-map/ /x/react-charts/treemap/ 301
+# 2025
+/x/react-data-grid/features/ /x/react-data-grid/demo/ 301
 
 # Proxies

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -62,6 +62,10 @@
 /x/react-charts/heat-map/ /x/react-charts/heatmap/ 301
 /x/react-charts/tree-map/ /x/react-charts/treemap/ 301
 # 2025
+/x/react-charts/quickstart/ /x/react-charts/getting-started/ 301
+/x/react-data-grid/quickstart/ /x/react-data-grid/getting-started/ 301
+/x/react-date-pickers/quickstart/ /x/react-date-pickers/getting-started/ 301
+/x/react-tree-view/quickstart/ /x/react-tree-view/getting-started/ 301
 /x/react-data-grid/features/ /x/react-data-grid/demo/ 301
 
 # Proxies


### PR DESCRIPTION
Fix #17143

I'm also fixing the other broken ones that are visible in https://app.ahrefs.com/site-audit/3992793/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2Ccompliant%2CincomingAllLinks%2Corigin&current=02-04-2025T045209P0200&filterId=91013c8aafad4fe1f7a0ad504eccad42&issueId=c64da643-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating.

Well, it's not really a fix, as after those changes, we have 301 instead of 404, but we should truly have 200. Now, since we plan to do a MUI X release very soon, we will get those 200 soon enough, so let's be lazy.

**Off-topic**. I would really want to delegate the ahrefs crawls to the team. It takes too much time on my plate. So far, our best guess is that the docs-infra role would be accountable for them, and each team responsible and devex responsible.