### PR TITLE
[infra] Update support label from 'priority' to 'unknown'

### DIFF
--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -1,7 +1,7 @@
 name: 'Priority Support: SLA ⏰'
 description: I'm an MUI X Premium user and we have purchased the Priority Support add-on. I can't find a solution to my problem with MUI X.
 title: '[question] '
-labels: ['status: waiting for maintainer', 'support: priority']
+labels: ['status: waiting for maintainer', 'support: unknown']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Changes the added label back to allow for the priority support workflow to run.