### PR TITLE
[charts] Fix bar chart with partial data

### DIFF
--- a/packages/x-charts/src/BarChart/BarChart.test.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.test.tsx
@@ -51,6 +51,20 @@ describe('<BarChart />', () => {
     expect(screen.getByText('No data to display')).toBeVisible();
   });
 
+  it('should render "No data to display" when series are empty and axes are not empty arrays', () => {
+    render(
+      <BarChart
+        series={[]}
+        width={100}
+        height={100}
+        xAxis={[{ scaleType: 'band', data: ['A'] }]}
+        yAxis={[]}
+      />,
+    );
+
+    expect(screen.getByText('No data to display')).toBeVisible();
+  });
+
   const wrapper = ({ children }: { children?: React.ReactNode }) => (
     <div style={{ width: 400, height: 400 }}>{children}</div>
   );

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -143,6 +143,9 @@ const useAggregatedData = (): {
 
       return baseScaleConfig
         .data!.map((baseValue, dataIndex: number) => {
+          if (currentSeriesData[dataIndex] == null) {
+            return null;
+          }
           const values = stackedData[dataIndex];
           const valueCoordinates = values.map((v) => (verticalLayout ? yScale(v)! : xScale(v)!));
 


### PR DESCRIPTION
Test and Fix #17201 bug

Imported in bar chart the logic from the line chart. If a data item is `== null` it's either that the user set `null` or we overflow that data array. IN both case we can just ignore the data