### PR TITLE
[l10n] Improve Swedish (sv-SE) locale

### DIFF
--- a/packages/x-data-grid/src/locales/svSE.ts
+++ b/packages/x-data-grid/src/locales/svSE.ts
@@ -166,9 +166,9 @@ const svSEGrid: Partial<GridLocaleText> = {
   actionsCellMore: 'mer',
 
   // Column pinning text
-  pinToLeft: 'Fäst till vänster',
-  pinToRight: 'Fäst till höger',
-  unpin: 'Ta bort fästning',
+  pinToLeft: 'Lås till vänster',
+  pinToRight: 'Lås till höger',
+  unpin: 'Lås upp',
 
   // Tree Data
   treeDataGroupingHeaderName: 'Grupp',


### PR DESCRIPTION
I work in a Swedish company and we have heard multiple times that the translations regarding column pinning in Swedish are a bit weird. For example "Ta bort fästning" literally means "Remove fortress".

Here are suggestions for new texts from our UX team.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
