### PR TITLE
[pickers] Fix to not process default prevented propagated events

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
@@ -159,6 +159,11 @@ export const useFieldV7TextField = <
   });
 
   const handleRootClick = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // The click event on the clear or open button would propagate to the input, trigger this handler and result in an inadvertent section selection.
+    // We avoid this by checking if the call of `handleInputClick` is actually intended, or a propagated call, which should be skipped.
+    if (event.isDefaultPrevented()) {
+      return;
+    }
     onClick?.(event);
     rootProps.onClick(event);
   });

--- a/test/utils/pickers/describePicker/describePicker.tsx
+++ b/test/utils/pickers/describePicker/describePicker.tsx
@@ -187,6 +187,23 @@ function innerDescribePicker(ElementToTest: React.ElementType, options: Describe
       },
     );
   });
+
+  testSkipIf(variant === 'static' || fieldType === 'multi-input')(
+    'should bring the focus back to the open button when the picker is closed',
+    async () => {
+      const { user } = render(<ElementToTest />);
+
+      const openButton = screen.getByRole('button', { name: /Choose/ });
+      // open Picker
+      await user.click(openButton);
+
+      // close Picker
+      await user.keyboard('[Escape]');
+
+      expect(openButton).to.toHaveFocus();
+      expect(document.activeElement).to.equal(openButton);
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
## The issue

The click or keyboard event was propagating up top and this handler was processing it and focusing the input.

## Solution

Aligning approach with the v6 hook:
https://github.com/mui/mui-x/blob/15f6ad2bd497646b6976aae79a3a2af795884785/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts#L204-L209


Add a "describe" test to assert the expected behavior.

## Behavior comparison

### Before

https://github.com/user-attachments/assets/e03bed88-4611-495c-ac5d-12b387a20863


### After

https://github.com/user-attachments/assets/9843c54b-28d5-46d8-ab2d-572a9a18a461

