### PR TITLE
[DateTimeRangePicker] Fix focused view behavior

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
@@ -53,7 +53,6 @@ const rendererInterceptor = function RendererInterceptor(
 
   const finalProps = {
     ...otherProps,
-    focusedView: null,
     sx: [
       {
         [`&.${multiSectionDigitalClockClasses.root}`]: {

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
@@ -54,6 +54,29 @@ describe('<DesktopDateTimeRangePicker />', () => {
       const sectionsContainer = getFieldSectionsContainer();
       expectFieldValueV7(sectionsContainer, '04/11/2022 02:15 PM – MM/DD/YYYY hh:mm aa');
     });
+
+    it('should cycle focused views among the visible step after selection', () => {
+      render(<DesktopDateTimeRangePicker />);
+
+      openPicker({ type: 'date-time-range', initialFocus: 'start', fieldType: 'single-input' });
+
+      const day = screen.getByRole('gridcell', { name: '10' });
+      expect(day).toHaveFocus();
+      fireEvent.click(day);
+
+      const hours = screen.getByRole('option', { name: '12 hours' });
+      expect(hours).toHaveFocus();
+      fireEvent.click(hours);
+
+      const minutes = screen.getByRole('option', { name: '0 minutes' });
+      expect(minutes).toHaveFocus();
+      fireEvent.click(minutes);
+
+      const meridiem = screen.getByRole('option', { name: 'AM' });
+      expect(meridiem).toHaveFocus();
+      const sectionsContainer = getFieldSectionsContainer();
+      expectFieldValueV7(sectionsContainer, '01/10/2018 12:00 AM – MM/DD/YYYY hh:mm aa');
+    });
   });
 
   describe('disabled dates', () => {

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
@@ -57,7 +57,6 @@ const rendererInterceptor = function RendererInterceptor(
 
   const finalProps = {
     ...otherRendererProps,
-    focusedView: null,
     sx: [
       {
         width: DIALOG_WIDTH,

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/MobileDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/tests/MobileDateTimeRangePicker.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { screen } from '@mui/internal-test-utils';
+import {
+  createPickerRenderer,
+  openPicker,
+  getFieldSectionsContainer,
+  expectFieldValueV7,
+} from 'test/utils/pickers';
+import { MobileDateTimeRangePicker } from '@mui/x-date-pickers-pro/MobileDateTimeRangePicker';
+
+describe('<MobileDateTimeRangePicker />', () => {
+  const { render } = createPickerRenderer({
+    clock: 'fake',
+    clockConfig: new Date(2018, 0, 10, 10, 16, 0),
+    clockOptions: { toFake: ['Date'] },
+  });
+
+  describe('value selection', () => {
+    it('should cycle focused views among the visible step after selection', async () => {
+      const { user } = render(<MobileDateTimeRangePicker />);
+
+      openPicker({ type: 'date-time-range', initialFocus: 'start', fieldType: 'single-input' });
+
+      const day = screen.getByRole('gridcell', { name: '10' });
+      expect(day).toHaveFocus();
+      await user.click(day);
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      await user.click(screen.getByRole('option', { name: '12 hours' }));
+
+      const minutes = screen.getByRole('option', { name: '0 minutes' });
+      expect(minutes).toHaveFocus();
+      await user.click(minutes);
+
+      const meridiem = screen.getByRole('option', { name: 'AM' });
+      expect(meridiem).toHaveFocus();
+      const sectionsContainer = getFieldSectionsContainer();
+      expectFieldValueV7(sectionsContainer, '01/10/2018 12:00 AM – MM/DD/YYYY hh:mm aa');
+    });
+  });
+});


### PR DESCRIPTION
- Remove override of `focusedView` to `null` which stopped defined value from taking effect
- Add tests asserting expected behavior


### Before

#### DesktopDateTimeRangePicker

https://github.com/user-attachments/assets/5245eec9-1073-4c98-a7bf-45b3e5ac5028

#### MobileDateTimeRangePicker

https://github.com/user-attachments/assets/df3445eb-121c-4940-a09b-4052fd862007

### After

#### DesktopDateTimeRangePicker

https://github.com/user-attachments/assets/08bda9c0-188b-44a4-83e8-e8d700c20b0b

#### MobileDateTimeRangePicker

https://github.com/user-attachments/assets/aa746214-575a-4c4a-ac06-56b03bda8533