### PR TITLE
[docs] Fix country columns throwing on grouping

### DIFF
--- a/packages/x-data-grid-generator/src/columns/commodities.columns.tsx
+++ b/packages/x-data-grid-generator/src/columns/commodities.columns.tsx
@@ -251,7 +251,7 @@ export const getCommodityColumns = (editable = false): GridColDefGenerator[] => 
       return value;
     },
     valueFormatter: (value: { label: string }) => value?.label,
-    groupingValueGetter: (value: { code: string }) => value.code,
+    groupingValueGetter: (value: { label: string }) => value.label,
     sortComparator: (v1, v2, param1, param2) =>
       gridStringOrNumberComparator(v1.label, v2.label, param1, param2),
     editable,

--- a/packages/x-data-grid-generator/src/columns/employees.columns.tsx
+++ b/packages/x-data-grid-generator/src/columns/employees.columns.tsx
@@ -118,6 +118,7 @@ export const getEmployeeColumns = (): GridColDefGenerator[] => [
     generateData: randomCountry,
     renderCell: renderCountry,
     renderEditCell: renderEditCountry,
+    groupingValueGetter: (value: { label: string }) => value.label,
     sortComparator: (v1, v2, param1, param2) =>
       gridStringOrNumberComparator(v1.label, v2.label, param1, param2),
     width: 150,

--- a/packages/x-data-grid-generator/src/renderer/renderCountry.tsx
+++ b/packages/x-data-grid-generator/src/renderer/renderCountry.tsx
@@ -66,5 +66,9 @@ export function renderCountry(params: GridRenderCellParams<CountryIsoOption, any
     return null;
   }
 
+  if (params.rowNode.type === 'group') {
+    return params.value;
+  }
+
   return <Country value={params.value} />;
 }


### PR DESCRIPTION
Fixes grouping by country reported in https://github.com/mui/mui-x/pull/16992/files#r2037611001
It affects both "Employee" and "Commodity" datasets.

Before:
<img width="577" src="https://github.com/user-attachments/assets/099e71dd-3ae6-4e1e-b14e-63aa59616e98" />

After:
<img width="575" src="https://github.com/user-attachments/assets/5cdf5fff-2235-4054-a431-3887cff1575a" />
