### PR TITLE
[DataGridPremium] Fix cell display with custom renderers in pivot mode

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/pivoting/utils.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/pivoting/utils.ts
@@ -164,6 +164,7 @@ export const getPivotedData = ({
       valueFormatter: initialColumn.valueFormatter,
       headerName: initialColumn.headerName,
       renderCell: initialColumn.renderCell,
+      display: initialColumn.display,
     };
 
     return attributes;


### PR DESCRIPTION
Before:

<img width="600" src="https://github.com/user-attachments/assets/6c1c29d2-b065-4f04-96ed-b373d99d0c45" />

After:

<img width="600" src="https://github.com/user-attachments/assets/768f0673-b1ee-43d3-9432-61a7273c9145" />
