### PR TITLE
[charts] Add uncertainty area to line with forecast demo

### DIFF
--- a/docs/data/charts/line-demo/LineWithUncertaintyArea.js
+++ b/docs/data/charts/line-demo/LineWithUncertaintyArea.js
@@ -14,7 +14,8 @@ import {
   useYScale,
 } from '@mui/x-charts/hooks';
 import * as d3Shape from '@mui/x-charts-vendor/d3-shape';
-import { useTheme } from '@mui/system';
+
+import { useTheme } from '@mui/material/styles';
 
 function CustomAnimatedLine(props) {
   const { limit, sxBefore, sxAfter, ...other } = props;

--- a/docs/data/charts/line-demo/LineWithUncertaintyArea.js
+++ b/docs/data/charts/line-demo/LineWithUncertaintyArea.js
@@ -1,0 +1,162 @@
+import * as React from 'react';
+import { AnimatedLine, LinePlot, MarkPlot } from '@mui/x-charts/LineChart';
+import { ChartContainer } from '@mui/x-charts/ChartContainer';
+import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
+import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
+import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
+import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
+import {
+  useChartId,
+  useDrawingArea,
+  useLineSeries,
+  useXAxis,
+  useXScale,
+  useYScale,
+} from '@mui/x-charts/hooks';
+import * as d3Shape from '@mui/x-charts-vendor/d3-shape';
+import { useTheme } from '@mui/system';
+
+function CustomAnimatedLine(props) {
+  const { limit, sxBefore, sxAfter, ...other } = props;
+  const { top, bottom, height, left, width } = useDrawingArea();
+  const scale = useXScale();
+  const chartId = useChartId();
+
+  if (limit === undefined) {
+    return <AnimatedLine {...other} />;
+  }
+
+  const limitPosition = scale(limit); // Convert value to x coordinate.
+
+  if (limitPosition === undefined) {
+    return <AnimatedLine {...other} />;
+  }
+
+  const clipIdleft = `${chartId}-${props.ownerState.id}-line-limit-${limit}-1`;
+  const clipIdRight = `${chartId}-${props.ownerState.id}-line-limit-${limit}-2`;
+  return (
+    <React.Fragment>
+      {/* Clip to show the line before the limit */}
+      <clipPath id={clipIdleft}>
+        <rect
+          x={left}
+          y={0}
+          width={limitPosition - left}
+          height={top + height + bottom}
+        />
+      </clipPath>
+      {/* Clip to show the line after the limit */}
+      <clipPath id={clipIdRight}>
+        <rect
+          x={limitPosition}
+          y={0}
+          width={left + width - limitPosition}
+          height={top + height + bottom}
+        />
+      </clipPath>
+      <g clipPath={`url(#${clipIdleft})`} className="line-before">
+        <AnimatedLine {...other} />
+      </g>
+      <g clipPath={`url(#${clipIdRight})`} className="line-after">
+        <AnimatedLine {...other} />
+      </g>
+    </React.Fragment>
+  );
+}
+
+function ForecastArea({ limit, forecast }) {
+  const lineSeries = useLineSeries();
+  const xAxis = useXAxis();
+  const xScale = useXScale();
+  const yScale = useYScale();
+
+  const xAxisData = xAxis.data?.slice(limit) ?? [];
+
+  if (!yScale) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      {lineSeries.map((series) => {
+        const data = xAxisData.map((v, i) => ({
+          x: v,
+          y0: forecast[i].y0,
+          y1: forecast[i].y1,
+        }));
+
+        const path = d3Shape
+          .area()
+          .x((d) => xScale(d.x))
+          .y0((d) => yScale(d.y0))
+          .y1((d) => yScale(d.y1))(data);
+
+        return <path key={`forecast-aria-${series.id}`} d={path} fill="#0000ff44" />;
+      })}
+    </React.Fragment>
+  );
+}
+
+function ShadedBackground({ limit }) {
+  const { top, bottom, height, left, width } = useDrawingArea();
+  const scale = useXScale();
+  const limitPosition = scale(limit);
+  const theme = useTheme();
+  const fill =
+    theme.palette.mode === 'dark'
+      ? theme.palette.grey[900]
+      : theme.palette.grey[400];
+
+  return (
+    <rect
+      x={limitPosition}
+      y={0}
+      width={left + width - limitPosition}
+      height={top + height + bottom}
+      fill={fill}
+      opacity={0.4}
+    />
+  );
+}
+
+export default function LineWithUncertaintyArea() {
+  const id = React.useId();
+  const clipPathId = `${id}-clip-path`;
+
+  return (
+    <ChartContainer
+      series={[
+        {
+          type: 'line',
+          data: [1, 2, 3, 4, 1, 2, 3, 4, 5],
+          valueFormatter: (v, i) => `${v}${i.dataIndex > 5 ? ' (estimated)' : ''}`,
+        },
+      ]}
+      xAxis={[{ data: [0, 1, 2, 3, 4, 5, 6, 7, 8] }]}
+      height={200}
+      sx={{ '& .line-after path': { strokeDasharray: '10 5' } }}
+    >
+      <ChartsXAxis />
+      <ChartsYAxis />
+      <g clipPath={`url(#${clipPathId})`}>
+        <ShadedBackground limit={5} />
+        <LinePlot
+          slots={{ line: CustomAnimatedLine }}
+          slotProps={{ line: { limit: 5 } }}
+        />
+        <ForecastArea
+          limit={5}
+          forecast={[
+            { y0: 2, y1: 2 },
+            { y0: 2.3, y1: 4 },
+            { y0: 3, y1: 5 },
+            { y0: 4.4, y1: 5.8 },
+          ]}
+        />
+        <MarkPlot />
+      </g>
+      <ChartsTooltip />
+      <ChartsClipPath id={clipPathId} />
+    </ChartContainer>
+  );
+}

--- a/docs/data/charts/line-demo/LineWithUncertaintyArea.js
+++ b/docs/data/charts/line-demo/LineWithUncertaintyArea.js
@@ -91,7 +91,7 @@ function ForecastArea({ limit, forecast }) {
           .y0((d) => yScale(d.y0))
           .y1((d) => yScale(d.y1))(data);
 
-        return <path key={`forecast-aria-${series.id}`} d={path} fill="#0000ff44" />;
+        return <path key={`forecast-area-${series.id}`} d={path} fill="#0000ff44" />;
       })}
     </React.Fragment>
   );

--- a/docs/data/charts/line-demo/LineWithUncertaintyArea.tsx
+++ b/docs/data/charts/line-demo/LineWithUncertaintyArea.tsx
@@ -19,7 +19,8 @@ import {
   useYScale,
 } from '@mui/x-charts/hooks';
 import * as d3Shape from '@mui/x-charts-vendor/d3-shape';
-import { SxProps, Theme, useTheme } from '@mui/system';
+import { SxProps } from '@mui/system';
+import { useTheme, Theme } from '@mui/material/styles';
 
 interface CustomAnimatedLineProps extends AnimatedLineProps {
   limit?: number;

--- a/docs/data/charts/line-demo/LineWithUncertaintyArea.tsx
+++ b/docs/data/charts/line-demo/LineWithUncertaintyArea.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react';
+import {
+  AnimatedLine,
+  AnimatedLineProps,
+  LinePlot,
+  MarkPlot,
+} from '@mui/x-charts/LineChart';
+import { ChartContainer } from '@mui/x-charts/ChartContainer';
+import { ChartsXAxis } from '@mui/x-charts/ChartsXAxis';
+import { ChartsYAxis } from '@mui/x-charts/ChartsYAxis';
+import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
+import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
+import {
+  useChartId,
+  useDrawingArea,
+  useLineSeries,
+  useXAxis,
+  useXScale,
+  useYScale,
+} from '@mui/x-charts/hooks';
+import * as d3Shape from '@mui/x-charts-vendor/d3-shape';
+import { SxProps, Theme, useTheme } from '@mui/system';
+
+interface CustomAnimatedLineProps extends AnimatedLineProps {
+  limit?: number;
+  sxBefore?: SxProps<Theme>;
+  sxAfter?: SxProps<Theme>;
+}
+
+function CustomAnimatedLine(props: CustomAnimatedLineProps) {
+  const { limit, sxBefore, sxAfter, ...other } = props;
+  const { top, bottom, height, left, width } = useDrawingArea();
+  const scale = useXScale();
+  const chartId = useChartId();
+
+  if (limit === undefined) {
+    return <AnimatedLine {...other} />;
+  }
+
+  const limitPosition = scale(limit); // Convert value to x coordinate.
+
+  if (limitPosition === undefined) {
+    return <AnimatedLine {...other} />;
+  }
+
+  const clipIdleft = `${chartId}-${props.ownerState.id}-line-limit-${limit}-1`;
+  const clipIdRight = `${chartId}-${props.ownerState.id}-line-limit-${limit}-2`;
+  return (
+    <React.Fragment>
+      {/* Clip to show the line before the limit */}
+      <clipPath id={clipIdleft}>
+        <rect
+          x={left}
+          y={0}
+          width={limitPosition - left}
+          height={top + height + bottom}
+        />
+      </clipPath>
+      {/* Clip to show the line after the limit */}
+      <clipPath id={clipIdRight}>
+        <rect
+          x={limitPosition}
+          y={0}
+          width={left + width - limitPosition}
+          height={top + height + bottom}
+        />
+      </clipPath>
+      <g clipPath={`url(#${clipIdleft})`} className="line-before">
+        <AnimatedLine {...other} />
+      </g>
+      <g clipPath={`url(#${clipIdRight})`} className="line-after">
+        <AnimatedLine {...other} />
+      </g>
+    </React.Fragment>
+  );
+}
+
+function ForecastArea({
+  limit,
+  forecast,
+}: {
+  limit: number;
+  forecast: { y0: number; y1: number }[];
+}) {
+  const lineSeries = useLineSeries();
+  const xAxis = useXAxis();
+  const xScale = useXScale();
+  const yScale = useYScale();
+
+  const xAxisData: number[] = xAxis.data?.slice(limit) ?? [];
+
+  if (!yScale) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      {lineSeries.map((series) => {
+        const data = xAxisData.map((v, i) => ({
+          x: v,
+          y0: forecast[i].y0,
+          y1: forecast[i].y1,
+        }));
+
+        const path = d3Shape
+          .area<(typeof data)[number]>()
+          .x((d) => xScale(d.x)!)
+          .y0((d) => yScale(d.y0)!)
+          .y1((d) => yScale(d.y1)!)(data)!;
+
+        return <path key={`forecast-aria-${series.id}`} d={path} fill="#0000ff44" />;
+      })}
+    </React.Fragment>
+  );
+}
+
+function ShadedBackground({ limit }: { limit: number }) {
+  const { top, bottom, height, left, width } = useDrawingArea();
+  const scale = useXScale();
+  const limitPosition = scale(limit)!;
+  const theme = useTheme();
+  const fill =
+    theme.palette.mode === 'dark'
+      ? theme.palette.grey[900]
+      : theme.palette.grey[400];
+
+  return (
+    <rect
+      x={limitPosition}
+      y={0}
+      width={left + width - limitPosition}
+      height={top + height + bottom}
+      fill={fill}
+      opacity={0.4}
+    />
+  );
+}
+
+export default function LineWithUncertaintyArea() {
+  const id = React.useId();
+  const clipPathId = `${id}-clip-path`;
+
+  return (
+    <ChartContainer
+      series={[
+        {
+          type: 'line',
+          data: [1, 2, 3, 4, 1, 2, 3, 4, 5],
+          valueFormatter: (v, i) => `${v}${i.dataIndex > 5 ? ' (estimated)' : ''}`,
+        },
+      ]}
+      xAxis={[{ data: [0, 1, 2, 3, 4, 5, 6, 7, 8] }]}
+      height={200}
+      sx={{ '& .line-after path': { strokeDasharray: '10 5' } }}
+    >
+      <ChartsXAxis />
+      <ChartsYAxis />
+
+      <g clipPath={`url(#${clipPathId})`}>
+        <ShadedBackground limit={5} />
+        <LinePlot
+          slots={{ line: CustomAnimatedLine }}
+          slotProps={{ line: { limit: 5 } as any }}
+        />
+        <ForecastArea
+          limit={5}
+          forecast={[
+            { y0: 2, y1: 2 },
+            { y0: 2.3, y1: 4 },
+            { y0: 3, y1: 5 },
+            { y0: 4.4, y1: 5.8 },
+          ]}
+        />
+        <MarkPlot />
+      </g>
+      <ChartsTooltip />
+      <ChartsClipPath id={clipPathId} />
+    </ChartContainer>
+  );
+}

--- a/docs/data/charts/line-demo/LineWithUncertaintyArea.tsx
+++ b/docs/data/charts/line-demo/LineWithUncertaintyArea.tsx
@@ -108,7 +108,7 @@ function ForecastArea({
           .y0((d) => yScale(d.y0)!)
           .y1((d) => yScale(d.y1)!)(data)!;
 
-        return <path key={`forecast-aria-${series.id}`} d={path} fill="#0000ff44" />;
+        return <path key={`forecast-area-${series.id}`} d={path} fill="#0000ff44" />;
       })}
     </React.Fragment>
   );

--- a/docs/data/charts/line-demo/line-demo.md
+++ b/docs/data/charts/line-demo/line-demo.md
@@ -41,12 +41,14 @@ components: LineChart, LineElement, LineHighlightElement, LineHighlightPlot, Lin
 To show that parts of the data have different meanings, you can render stylised lines for each of them.
 
 In the following example, the chart shows a dotted line to exemplify that the data is estimated.
-To do so, the `slots.line` is set with a custom components that render the default line twice.
+To do so, the `slots.line` is set with a custom component that render the default line twice.
 
 - The first one is clipped to show known values (from the left of the chart to the limit).
 - The second one is clipped to show predictions (from the limit to the right of the chart) with dash styling.
 
-{{"demo": "LineWithPrediction.js"}}
+Additionally, an uncertainty area is shown to represent the uncertainty of the forecast.
+
+{{"demo": "LineWithUncertaintyArea.js"}}
 
 ## CustomLineMarks
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17254.

<img width="555" alt="image" src="https://github.com/user-attachments/assets/5f12428c-f859-403e-9b80-d28676e1794a" />

<img width="537" alt="image" src="https://github.com/user-attachments/assets/86a7f1e0-33cd-42dc-a1d9-7742810d134c" />

Happy to update colors if needed. 