### PR TITLE
[charts] document series class name

### DIFF
--- a/docs/pages/x/api/charts/area-element.json
+++ b/docs/pages/x/api/charts/area-element.json
@@ -40,6 +40,12 @@
       "className": "MuiAreaElement-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiAreaElement-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${areaElementClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiAreaElement",

--- a/docs/pages/x/api/charts/bar-label.json
+++ b/docs/pages/x/api/charts/bar-label.json
@@ -45,6 +45,12 @@
       "className": "MuiBarLabel-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiBarLabel-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${barLabelClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiBarLabel",

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -94,6 +94,12 @@
       "className": "MuiHeatmap-highlighted",
       "description": "Styles applied to the cell element if highlighted.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiHeatmap-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${heatmapClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "spread": true,

--- a/docs/pages/x/api/charts/line-element.json
+++ b/docs/pages/x/api/charts/line-element.json
@@ -40,6 +40,12 @@
       "className": "MuiLineElement-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiLineElement-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${lineElementClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiLineElement",

--- a/docs/pages/x/api/charts/mark-element.json
+++ b/docs/pages/x/api/charts/mark-element.json
@@ -40,6 +40,12 @@
       "className": "MuiMarkElement-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiMarkElement-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${markElementClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiMarkElement",

--- a/docs/pages/x/api/charts/pie-arc-label.json
+++ b/docs/pages/x/api/charts/pie-arc-label.json
@@ -30,6 +30,12 @@
       "className": "MuiPieArcLabel-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiPieArcLabel-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${pieArcLabelClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiPieArcLabel",

--- a/docs/pages/x/api/charts/pie-arc.json
+++ b/docs/pages/x/api/charts/pie-arc.json
@@ -24,6 +24,12 @@
       "className": "MuiPieArc-root",
       "description": "Styles applied to the root element.",
       "isGlobal": false
+    },
+    {
+      "key": "series",
+      "className": "MuiPieArc-series",
+      "description": "Styles applied to the root element for a specified series.\nNeeds to be suffixed with the series ID: `.${pieArcClasses.series}-${seriesId}`.",
+      "isGlobal": false
     }
   ],
   "muiName": "MuiPieArc",

--- a/docs/translations/api-docs/charts/area-element/area-element.json
+++ b/docs/translations/api-docs/charts/area-element/area-element.json
@@ -16,7 +16,11 @@
       "nodeName": "the root element",
       "conditions": "highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${areaElementClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   },
   "slotDescriptions": { "area": "The component that renders the area." }
 }

--- a/docs/translations/api-docs/charts/bar-label/bar-label.json
+++ b/docs/translations/api-docs/charts/bar-label/bar-label.json
@@ -24,7 +24,11 @@
       "nodeName": "the root element",
       "conditions": "it is highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${barLabelClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   },
   "slotDescriptions": { "barLabel": "The component that renders the bar label." }
 }

--- a/docs/translations/api-docs/charts/heatmap/heatmap.json
+++ b/docs/translations/api-docs/charts/heatmap/heatmap.json
@@ -63,6 +63,10 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the cell element",
       "conditions": "highlighted"
+    },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${heatmapClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
     }
   }
 }

--- a/docs/translations/api-docs/charts/line-element/line-element.json
+++ b/docs/translations/api-docs/charts/line-element/line-element.json
@@ -16,7 +16,11 @@
       "nodeName": "the root element",
       "conditions": "highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${lineElementClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   },
   "slotDescriptions": { "line": "The component that renders the line." }
 }

--- a/docs/translations/api-docs/charts/mark-element/mark-element.json
+++ b/docs/translations/api-docs/charts/mark-element/mark-element.json
@@ -21,6 +21,10 @@
       "nodeName": "the root element",
       "conditions": "highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${markElementClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   }
 }

--- a/docs/translations/api-docs/charts/pie-arc-label/pie-arc-label.json
+++ b/docs/translations/api-docs/charts/pie-arc-label/pie-arc-label.json
@@ -17,6 +17,10 @@
       "nodeName": "the root element",
       "conditions": "highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${pieArcLabelClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   }
 }

--- a/docs/translations/api-docs/charts/pie-arc/pie-arc.json
+++ b/docs/translations/api-docs/charts/pie-arc/pie-arc.json
@@ -12,6 +12,10 @@
       "nodeName": "the root element",
       "conditions": "highlighted"
     },
-    "root": { "description": "Styles applied to the root element." }
+    "root": { "description": "Styles applied to the root element." },
+    "series": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the series ID: <code>.${pieArcClasses.series}-${seriesId}</code>.",
+      "nodeName": "the root element for a specified series"
+    }
   }
 }

--- a/packages/x-charts-pro/src/FunnelChart/funnelSectionClasses.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelSectionClasses.ts
@@ -12,6 +12,11 @@ export interface FunnelSectionClasses {
   faded: string;
   /** Styles applied to the label element. */
   label: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${funnelSectionClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 function getFunnelSectionUtilityClass(slot: string) {
@@ -33,5 +38,5 @@ export const useUtilityClasses = (props: FunnelSectionProps) => {
 
 export const funnelSectionClasses: FunnelSectionClasses = generateUtilityClasses(
   'MuiFunnelSection',
-  ['root', 'highlighted', 'faded', 'label'],
+  ['root', 'highlighted', 'faded', 'label', 'series'],
 );

--- a/packages/x-charts-pro/src/Heatmap/heatmapClasses.ts
+++ b/packages/x-charts-pro/src/Heatmap/heatmapClasses.ts
@@ -8,6 +8,11 @@ export interface HeatmapClasses {
   highlighted: string;
   /** Styles applied to the cell element if faded. */
   faded: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${heatmapClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type HeatmapClassKey = keyof HeatmapClasses;
@@ -20,7 +25,7 @@ export function getHeatmapUtilityClass(slot: string) {
   return generateUtilityClass('MuiHeatmap', slot);
 }
 export const heatmapClasses: HeatmapClasses = {
-  ...generateUtilityClasses('MuiHeatmap', ['cell']),
+  ...generateUtilityClasses('MuiHeatmap', ['cell', 'series']),
   highlighted: 'Charts-highlighted',
   faded: 'Charts-faded',
 };

--- a/packages/x-charts/src/BarChart/BarLabel/barLabelClasses.tsx
+++ b/packages/x-charts/src/BarChart/BarLabel/barLabelClasses.tsx
@@ -12,6 +12,11 @@ export interface BarLabelClasses {
   faded: string;
   /** Styles applied to the root element if it is animated. */
   animate: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${barLabelClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type BarLabelClassKey = keyof BarLabelClasses;

--- a/packages/x-charts/src/BarChart/barElementClasses.ts
+++ b/packages/x-charts/src/BarChart/barElementClasses.ts
@@ -10,8 +10,9 @@ export interface BarElementClasses {
   highlighted: string;
   /** Styles applied to the root element if it is faded. */
   faded: string;
-  /** Styles applied to the root element for a specified series.
-   *  Needs to be suffixed with the series ID: `.${barElementClasses.series}-${seriesId}`.
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${barElementClasses.series}-${seriesId}`.
    */
   series: string;
 }

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -18,6 +18,11 @@ export interface AreaElementClasses {
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${areaElementClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type AreaElementClassKey = keyof AreaElementClasses;
@@ -39,6 +44,7 @@ export const areaElementClasses: AreaElementClasses = generateUtilityClasses('Mu
   'root',
   'highlighted',
   'faded',
+  'series',
 ]);
 
 const useUtilityClasses = (ownerState: AreaElementOwnerState) => {

--- a/packages/x-charts/src/LineChart/LineElement.tsx
+++ b/packages/x-charts/src/LineChart/LineElement.tsx
@@ -18,6 +18,11 @@ export interface LineElementClasses {
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${lineElementClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type LineElementClassKey = keyof LineElementClasses;
@@ -39,6 +44,7 @@ export const lineElementClasses: LineElementClasses = generateUtilityClasses('Mu
   'root',
   'highlighted',
   'faded',
+  'series',
 ]);
 
 const useUtilityClasses = (ownerState: LineElementOwnerState) => {

--- a/packages/x-charts/src/LineChart/markElementClasses.ts
+++ b/packages/x-charts/src/LineChart/markElementClasses.ts
@@ -12,6 +12,11 @@ export interface MarkElementClasses {
   faded: string;
   /** Styles applied to the root element when animation is not skipped. */
   animate: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${markElementClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type MarkElementClassKey = keyof MarkElementClasses;
@@ -34,6 +39,7 @@ export const markElementClasses: MarkElementClasses = generateUtilityClasses('Mu
   'highlighted',
   'faded',
   'animate',
+  'series',
 ]);
 
 export const useUtilityClasses = (ownerState: MarkElementOwnerState) => {

--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -17,6 +17,11 @@ export interface PieArcClasses {
   highlighted: string;
   /** Styles applied to the root element when faded. */
   faded: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${pieArcClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type PieArcClassKey = keyof PieArcClasses;
@@ -38,6 +43,7 @@ export const pieArcClasses: PieArcClasses = generateUtilityClasses('MuiPieArc', 
   'root',
   'highlighted',
   'faded',
+  'series',
 ]);
 
 const useUtilityClasses = (ownerState: PieArcOwnerState) => {

--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -18,6 +18,11 @@ export interface PieArcLabelClasses {
   faded: string;
   /** Styles applied to the root element when animation is not skipped. */
   animate: string;
+  /**
+   * Styles applied to the root element for a specified series.
+   * Needs to be suffixed with the series ID: `.${pieArcLabelClasses.series}-${seriesId}`.
+   */
+  series: string;
 }
 
 export type PieArcLabelClassKey = keyof PieArcLabelClasses;
@@ -40,6 +45,7 @@ export const pieArcLabelClasses: PieArcLabelClasses = generateUtilityClasses('Mu
   'highlighted',
   'faded',
   'animate',
+  'series',
 ]);
 
 const useUtilityClasses = (ownerState: PieArcLabelOwnerState) => {


### PR DESCRIPTION
Document series class name, e.g., `lineElementClasses.series` since there was some confusion in [this issue](https://github.com/mui/mui-x/issues/15982#issuecomment-2802743632) that it was possible customize elements differently per series. 