### PR TITLE
[docs] Fix paths in `ResponsiveChartContainer` migration guide

### DIFF
--- a/docs/data/migration/migration-charts-v7/migration-charts-v7.md
+++ b/docs/data/migration/migration-charts-v7/migration-charts-v7.md
@@ -225,8 +225,8 @@ You can now use `ChartContainer` as a responsive container which works now exact
 ```diff
 -import { ResponsiveChartContainer } from '@mui/x-charts/ResponsiveChartContainer';
 -import { ResponsiveChartContainerPro } from '@mui/x-charts-pro/ResponsiveChartContainerPro';
-+import { ChartContainer } from '@mui/x-charts/ResponsiveChartContainer';
-+import { ChartContainerPro } from '@mui/x-charts-pro/ResponsiveChartContainerPro';
++import { ChartContainer } from '@mui/x-charts/ChartContainer';
++import { ChartContainerPro } from '@mui/x-charts-pro/ChartContainerPro';
 
 -<ResponsiveChartContainer>
 +<ChartContainer>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The current version stills tells to import from `ResponsiveChartContainer`, but component is now in a different file too.

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
