### PR TITLE
[DataGridPro] Use intersection observer to trigger server-side infinite loading

### DIFF
--- a/packages/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
@@ -63,7 +63,7 @@ import {
   useGridLazyLoader,
   useGridLazyLoaderPreProcessors,
   useGridDataSourceLazyLoader,
-  useGridIntersectionObserver,
+  useGridInfiniteLoadingIntersection,
   headerFilteringStateInitializer,
   useGridHeaderFiltering,
   virtualizationStateInitializer,
@@ -211,7 +211,7 @@ export const useDataGridPremiumComponent = (
   useGridInfiniteLoader(apiRef, props);
   useGridLazyLoader(apiRef, props);
   useGridDataSourceLazyLoader(apiRef, props);
-  useGridIntersectionObserver(apiRef, props);
+  useGridInfiniteLoadingIntersection(apiRef, props);
   useGridColumnMenu(apiRef);
   useGridCsvExport(apiRef, props);
   useGridPrintExport(apiRef, props);

--- a/packages/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
+++ b/packages/x-data-grid-premium/src/DataGridPremium/useDataGridPremiumComponent.tsx
@@ -63,6 +63,7 @@ import {
   useGridLazyLoader,
   useGridLazyLoaderPreProcessors,
   useGridDataSourceLazyLoader,
+  useGridIntersectionObserver,
   headerFilteringStateInitializer,
   useGridHeaderFiltering,
   virtualizationStateInitializer,
@@ -210,6 +211,7 @@ export const useDataGridPremiumComponent = (
   useGridInfiniteLoader(apiRef, props);
   useGridLazyLoader(apiRef, props);
   useGridDataSourceLazyLoader(apiRef, props);
+  useGridIntersectionObserver(apiRef, props);
   useGridColumnMenu(apiRef);
   useGridCsvExport(apiRef, props);
   useGridPrintExport(apiRef, props);

--- a/packages/x-data-grid-pro/src/DataGridPro/useDataGridProComponent.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/useDataGridProComponent.tsx
@@ -88,7 +88,7 @@ import {
   dataSourceStateInitializer,
 } from '../hooks/features/dataSource/useGridDataSourcePro';
 import { useGridDataSourceLazyLoader } from '../hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader';
-import { useGridIntersectionObserver } from '../hooks/features/serverSideLazyLoader/useGridIntersectionObserver';
+import { useGridInfiniteLoadingIntersection } from '../hooks/features/serverSideLazyLoader/useGridInfiniteLoadingIntersection';
 
 export const useDataGridProComponent = (
   apiRef: RefObject<GridPrivateApiPro>,
@@ -168,7 +168,7 @@ export const useDataGridProComponent = (
   useGridInfiniteLoader(apiRef, props);
   useGridLazyLoader(apiRef, props);
   useGridDataSourceLazyLoader(apiRef, props);
-  useGridIntersectionObserver(apiRef, props);
+  useGridInfiniteLoadingIntersection(apiRef, props);
   useGridColumnMenu(apiRef);
   useGridCsvExport(apiRef, props);
   useGridPrintExport(apiRef, props);

--- a/packages/x-data-grid-pro/src/DataGridPro/useDataGridProComponent.tsx
+++ b/packages/x-data-grid-pro/src/DataGridPro/useDataGridProComponent.tsx
@@ -88,6 +88,7 @@ import {
   dataSourceStateInitializer,
 } from '../hooks/features/dataSource/useGridDataSourcePro';
 import { useGridDataSourceLazyLoader } from '../hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader';
+import { useGridIntersectionObserver } from '../hooks/features/serverSideLazyLoader/useGridIntersectionObserver';
 
 export const useDataGridProComponent = (
   apiRef: RefObject<GridPrivateApiPro>,
@@ -167,6 +168,7 @@ export const useDataGridProComponent = (
   useGridInfiniteLoader(apiRef, props);
   useGridLazyLoader(apiRef, props);
   useGridDataSourceLazyLoader(apiRef, props);
+  useGridIntersectionObserver(apiRef, props);
   useGridColumnMenu(apiRef);
   useGridCsvExport(apiRef, props);
   useGridPrintExport(apiRef, props);

--- a/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
@@ -1,30 +1,15 @@
-import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {
   useGridSelector,
   useGridEventPriority,
   gridVisibleColumnDefinitionsSelector,
-  useGridApiMethod,
-  gridDimensionsSelector,
+  useGridEvent,
 } from '@mui/x-data-grid';
-import {
-  useGridVisibleRows,
-  GridInfiniteLoaderPrivateApi,
-  useTimeout,
-  gridHorizontalScrollbarHeightSelector,
-} from '@mui/x-data-grid/internals';
+import { useGridVisibleRows, runIf } from '@mui/x-data-grid/internals';
 import useEventCallback from '@mui/utils/useEventCallback';
-import { styled } from '@mui/system';
 import { GridRowScrollEndParams } from '../../../models';
 import { GridPrivateApiPro } from '../../../models/gridApiPro';
 import { DataGridProProcessedProps } from '../../../models/dataGridProProps';
-
-const InfiniteLoadingTriggerElement = styled('div')({
-  position: 'sticky',
-  left: 0,
-  width: 0,
-  height: 0,
-});
 
 /**
  * @requires useGridColumns (state)
@@ -35,110 +20,24 @@ export const useGridInfiniteLoader = (
   apiRef: RefObject<GridPrivateApiPro>,
   props: Pick<
     DataGridProProcessedProps,
-    'onRowsScrollEnd' | 'pagination' | 'paginationMode' | 'rowsLoadingMode' | 'scrollEndThreshold'
+    'onRowsScrollEnd' | 'pagination' | 'paginationMode' | 'rowsLoadingMode'
   >,
 ): void => {
-  const isReady = useGridSelector(apiRef, gridDimensionsSelector).isReady;
   const visibleColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
   const currentPage = useGridVisibleRows(apiRef, props);
-  const observer = React.useRef<IntersectionObserver>(null);
-  const updateTargetTimeout = useTimeout();
-  const triggerElement = React.useRef<HTMLElement | null>(null);
 
   const isEnabled = props.rowsLoadingMode === 'client' && !!props.onRowsScrollEnd;
 
-  const handleLoadMoreRows = useEventCallback(([entry]: IntersectionObserverEntry[]) => {
-    const currentRatio = entry.intersectionRatio;
-    const isIntersecting = entry.isIntersecting;
-
-    if (isIntersecting && currentRatio === 1) {
-      const viewportPageSize = apiRef.current.getViewportPageSize();
-      const rowScrollEndParams: GridRowScrollEndParams = {
-        visibleColumns,
-        viewportPageSize,
-        visibleRowsCount: currentPage.rows.length,
-      };
-      apiRef.current.publishEvent('rowsScrollEnd', rowScrollEndParams);
-      observer.current?.disconnect();
-      // do not observe this node anymore
-      triggerElement.current = null;
-    }
+  const handleLoadMoreRows = useEventCallback(() => {
+    const viewportPageSize = apiRef.current.getViewportPageSize();
+    const rowScrollEndParams: GridRowScrollEndParams = {
+      visibleColumns,
+      viewportPageSize,
+      visibleRowsCount: currentPage.rows.length,
+    };
+    apiRef.current.publishEvent('rowsScrollEnd', rowScrollEndParams);
   });
 
-  React.useEffect(() => {
-    const virtualScroller = apiRef.current.virtualScrollerRef.current;
-    if (!isEnabled || !isReady || !virtualScroller) {
-      return;
-    }
-    observer.current?.disconnect();
-
-    const horizontalScrollbarHeight = gridHorizontalScrollbarHeightSelector(apiRef);
-    const marginBottom = props.scrollEndThreshold - horizontalScrollbarHeight;
-
-    observer.current = new IntersectionObserver(handleLoadMoreRows, {
-      threshold: 1,
-      root: virtualScroller,
-      rootMargin: `0px 0px ${marginBottom}px 0px`,
-    });
-    if (triggerElement.current) {
-      observer.current.observe(triggerElement.current);
-    }
-  }, [apiRef, isReady, handleLoadMoreRows, isEnabled, props.scrollEndThreshold]);
-
-  const updateTarget = (node: HTMLElement | null) => {
-    if (triggerElement.current !== node) {
-      observer.current?.disconnect();
-
-      triggerElement.current = node;
-      if (triggerElement.current) {
-        observer.current?.observe(triggerElement.current);
-      }
-    }
-  };
-
-  const triggerRef = React.useCallback(
-    (node: HTMLElement | null) => {
-      // Prevent the infite loading working in combination with lazy loading
-      if (!isEnabled) {
-        return;
-      }
-
-      // If the user scrolls through the grid too fast it might happen that the observer is connected to the trigger element
-      // that will be intersecting the root inside the same render cycle (but not intersecting at the time of the connection).
-      // This will cause the observer to not call the callback with `isIntersecting` set to `true`.
-      // https://www.w3.org/TR/intersection-observer/#event-loop
-      // Delaying the connection to the next cycle helps since the observer will always call the callback the first time it is connected.
-      // https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/observe
-      // Related to
-      // https://github.com/mui/mui-x/issues/14116
-      updateTargetTimeout.start(0, () => updateTarget(node));
-    },
-    [isEnabled, updateTargetTimeout],
-  );
-
-  const getInfiniteLoadingTriggerElement = React.useCallback<
-    NonNullable<GridInfiniteLoaderPrivateApi['getInfiniteLoadingTriggerElement']>
-  >(
-    ({ lastRowId }) => {
-      if (!isEnabled) {
-        return null;
-      }
-      return (
-        <InfiniteLoadingTriggerElement
-          ref={triggerRef}
-          // Force rerender on last row change to start observing the new trigger
-          key={`trigger-${lastRowId}`}
-          role="presentation"
-        />
-      );
-    },
-    [isEnabled, triggerRef],
-  );
-
-  const infiniteLoaderPrivateApi: GridInfiniteLoaderPrivateApi = {
-    getInfiniteLoadingTriggerElement,
-  };
-
-  useGridApiMethod(apiRef, infiniteLoaderPrivateApi, 'private');
   useGridEventPriority(apiRef, 'rowsScrollEnd', props.onRowsScrollEnd);
+  useGridEvent(apiRef, 'onIntersection', runIf(isEnabled, handleLoadMoreRows));
 };

--- a/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/infiniteLoader/useGridInfiniteLoader.tsx
@@ -4,6 +4,7 @@ import {
   useGridEventPriority,
   gridVisibleColumnDefinitionsSelector,
   useGridEvent,
+  GridEventListener,
 } from '@mui/x-data-grid';
 import { useGridVisibleRows, runIf } from '@mui/x-data-grid/internals';
 import useEventCallback from '@mui/utils/useEventCallback';
@@ -28,16 +29,18 @@ export const useGridInfiniteLoader = (
 
   const isEnabled = props.rowsLoadingMode === 'client' && !!props.onRowsScrollEnd;
 
-  const handleLoadMoreRows = useEventCallback(() => {
-    const viewportPageSize = apiRef.current.getViewportPageSize();
-    const rowScrollEndParams: GridRowScrollEndParams = {
-      visibleColumns,
-      viewportPageSize,
-      visibleRowsCount: currentPage.rows.length,
-    };
-    apiRef.current.publishEvent('rowsScrollEnd', rowScrollEndParams);
-  });
+  const handleLoadMoreRows: GridEventListener<'rowsScrollEndIntersection'> = useEventCallback(
+    () => {
+      const viewportPageSize = apiRef.current.getViewportPageSize();
+      const rowScrollEndParams: GridRowScrollEndParams = {
+        visibleColumns,
+        viewportPageSize,
+        visibleRowsCount: currentPage.rows.length,
+      };
+      apiRef.current.publishEvent('rowsScrollEnd', rowScrollEndParams);
+    },
+  );
 
   useGridEventPriority(apiRef, 'rowsScrollEnd', props.onRowsScrollEnd);
-  useGridEvent(apiRef, 'onIntersection', runIf(isEnabled, handleLoadMoreRows));
+  useGridEvent(apiRef, 'rowsScrollEndIntersection', runIf(isEnabled, handleLoadMoreRows));
 };

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -11,7 +11,6 @@ import {
   GridGroupNode,
   GridSkeletonRowNode,
   gridPaginationModelSelector,
-  gridDimensionsSelector,
   gridFilteredSortedRowIdsSelector,
   gridRowIdSelector,
 } from '@mui/x-data-grid';
@@ -45,19 +44,13 @@ const getSkeletonRowId = (index: number) => `${GRID_SKELETON_ROW_ROOT_ID}-${inde
 /**
  * @requires useGridRows (state)
  * @requires useGridPagination (state)
- * @requires useGridDimensions (method) - can be after
  * @requires useGridScroll (method
  */
 export const useGridDataSourceLazyLoader = (
   privateApiRef: RefObject<GridPrivateApiPro>,
   props: Pick<
     DataGridProProcessedProps,
-    | 'pagination'
-    | 'paginationMode'
-    | 'dataSource'
-    | 'lazyLoading'
-    | 'lazyLoadingRequestThrottleMs'
-    | 'scrollEndThreshold'
+    'dataSource' | 'lazyLoading' | 'lazyLoadingRequestThrottleMs'
   >,
 ): void => {
   const setStrategyAvailability = React.useCallback(() => {
@@ -354,41 +347,32 @@ export const useGridDataSourceLazyLoader = (
     privateApiRef.current.requestPipeProcessorsApplication('hydrateRows');
   }, [privateApiRef, updateLoadingTrigger, addSkeletonRows]);
 
-  const handleScrolling: GridEventListener<'scrollPositionChange'> = React.useCallback(
-    (newScrollPosition) => {
-      if (rowsStale.current || loadingTrigger.current !== LoadingTrigger.SCROLL_END) {
-        return;
-      }
+  const handleIntersection: GridEventListener<'onIntersection'> = React.useCallback(() => {
+    if (rowsStale.current || loadingTrigger.current !== LoadingTrigger.SCROLL_END) {
+      return;
+    }
 
-      const renderContext = gridRenderContextSelector(privateApiRef);
-      if (previousLastRowIndex.current >= renderContext.lastRowIndex) {
-        return;
-      }
+    const renderContext = gridRenderContextSelector(privateApiRef);
+    if (previousLastRowIndex.current >= renderContext.lastRowIndex) {
+      return;
+    }
 
-      const dimensions = gridDimensionsSelector(privateApiRef);
-      const position = newScrollPosition.top + dimensions.viewportInnerSize.height;
-      const target = dimensions.contentSize.height - props.scrollEndThreshold;
+    previousLastRowIndex.current = renderContext.lastRowIndex;
 
-      if (position >= target) {
-        previousLastRowIndex.current = renderContext.lastRowIndex;
+    const paginationModel = gridPaginationModelSelector(privateApiRef);
+    const sortModel = gridSortModelSelector(privateApiRef);
+    const filterModel = gridFilterModelSelector(privateApiRef);
+    const getRowsParams: GridGetRowsParams = {
+      start: renderContext.lastRowIndex,
+      end: renderContext.lastRowIndex + paginationModel.pageSize - 1,
+      sortModel,
+      filterModel,
+    };
 
-        const paginationModel = gridPaginationModelSelector(privateApiRef);
-        const sortModel = gridSortModelSelector(privateApiRef);
-        const filterModel = gridFilterModelSelector(privateApiRef);
-        const getRowsParams: GridGetRowsParams = {
-          start: renderContext.lastRowIndex,
-          end: renderContext.lastRowIndex + paginationModel.pageSize - 1,
-          sortModel,
-          filterModel,
-        };
+    privateApiRef.current.setLoading(true);
 
-        privateApiRef.current.setLoading(true);
-
-        fetchRows(adjustRowParams(getRowsParams));
-      }
-    },
-    [privateApiRef, props.scrollEndThreshold, adjustRowParams, fetchRows],
-  );
+    fetchRows(adjustRowParams(getRowsParams));
+  }, [privateApiRef, adjustRowParams, fetchRows]);
 
   const handleRenderedRowsIntervalChange = React.useCallback<
     GridEventListener<'renderedRowsIntervalChange'>
@@ -446,6 +430,7 @@ export const useGridDataSourceLazyLoader = (
     () => throttle(handleRenderedRowsIntervalChange, props.lazyLoadingRequestThrottleMs),
     [props.lazyLoadingRequestThrottleMs, handleRenderedRowsIntervalChange],
   );
+
   React.useEffect(() => {
     return () => {
       throttledHandleRenderedRowsIntervalChange.clear();
@@ -519,8 +504,8 @@ export const useGridDataSourceLazyLoader = (
   );
   useGridEvent(
     privateApiRef,
-    'scrollPositionChange',
-    runIf(lazyLoadingRowsUpdateStrategyActive, handleScrolling),
+    'onIntersection',
+    runIf(lazyLoadingRowsUpdateStrategyActive, handleIntersection),
   );
   useGridEvent(
     privateApiRef,

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { throttle } from '@mui/x-internals/throttle';
-import { unstable_debounce as debounce } from '@mui/utils';
+import useEventCallback from '@mui/utils/useEventCallback';
+import debounce from '@mui/utils/debounce';
 import {
   useGridEvent,
   gridSortModelSelector,
@@ -347,8 +348,8 @@ export const useGridDataSourceLazyLoader = (
     privateApiRef.current.requestPipeProcessorsApplication('hydrateRows');
   }, [privateApiRef, updateLoadingTrigger, addSkeletonRows]);
 
-  const handleIntersection: GridEventListener<'rowsScrollEndIntersection'> =
-    React.useCallback(() => {
+  const handleIntersection: GridEventListener<'rowsScrollEndIntersection'> = useEventCallback(
+    () => {
       if (rowsStale.current || loadingTrigger.current !== LoadingTrigger.SCROLL_END) {
         return;
       }
@@ -373,7 +374,8 @@ export const useGridDataSourceLazyLoader = (
       privateApiRef.current.setLoading(true);
 
       fetchRows(adjustRowParams(getRowsParams));
-    }, [privateApiRef, adjustRowParams, fetchRows]);
+    },
+  );
 
   const handleRenderedRowsIntervalChange = React.useCallback<
     GridEventListener<'renderedRowsIntervalChange'>

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -347,32 +347,33 @@ export const useGridDataSourceLazyLoader = (
     privateApiRef.current.requestPipeProcessorsApplication('hydrateRows');
   }, [privateApiRef, updateLoadingTrigger, addSkeletonRows]);
 
-  const handleIntersection: GridEventListener<'onIntersection'> = React.useCallback(() => {
-    if (rowsStale.current || loadingTrigger.current !== LoadingTrigger.SCROLL_END) {
-      return;
-    }
+  const handleIntersection: GridEventListener<'rowsScrollEndIntersection'> =
+    React.useCallback(() => {
+      if (rowsStale.current || loadingTrigger.current !== LoadingTrigger.SCROLL_END) {
+        return;
+      }
 
-    const renderContext = gridRenderContextSelector(privateApiRef);
-    if (previousLastRowIndex.current >= renderContext.lastRowIndex) {
-      return;
-    }
+      const renderContext = gridRenderContextSelector(privateApiRef);
+      if (previousLastRowIndex.current >= renderContext.lastRowIndex) {
+        return;
+      }
 
-    previousLastRowIndex.current = renderContext.lastRowIndex;
+      previousLastRowIndex.current = renderContext.lastRowIndex;
 
-    const paginationModel = gridPaginationModelSelector(privateApiRef);
-    const sortModel = gridSortModelSelector(privateApiRef);
-    const filterModel = gridFilterModelSelector(privateApiRef);
-    const getRowsParams: GridGetRowsParams = {
-      start: renderContext.lastRowIndex,
-      end: renderContext.lastRowIndex + paginationModel.pageSize - 1,
-      sortModel,
-      filterModel,
-    };
+      const paginationModel = gridPaginationModelSelector(privateApiRef);
+      const sortModel = gridSortModelSelector(privateApiRef);
+      const filterModel = gridFilterModelSelector(privateApiRef);
+      const getRowsParams: GridGetRowsParams = {
+        start: renderContext.lastRowIndex,
+        end: renderContext.lastRowIndex + paginationModel.pageSize - 1,
+        sortModel,
+        filterModel,
+      };
 
-    privateApiRef.current.setLoading(true);
+      privateApiRef.current.setLoading(true);
 
-    fetchRows(adjustRowParams(getRowsParams));
-  }, [privateApiRef, adjustRowParams, fetchRows]);
+      fetchRows(adjustRowParams(getRowsParams));
+    }, [privateApiRef, adjustRowParams, fetchRows]);
 
   const handleRenderedRowsIntervalChange = React.useCallback<
     GridEventListener<'renderedRowsIntervalChange'>
@@ -504,7 +505,7 @@ export const useGridDataSourceLazyLoader = (
   );
   useGridEvent(
     privateApiRef,
-    'onIntersection',
+    'rowsScrollEndIntersection',
     runIf(lazyLoadingRowsUpdateStrategyActive, handleIntersection),
   );
   useGridEvent(

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridInfiniteLoadingIntersection.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridInfiniteLoadingIntersection.tsx
@@ -21,7 +21,7 @@ const InfiniteLoadingTriggerElement = styled('div')({
 /**
  * @requires useGridDimensions (method) - can be after
  */
-export const useGridIntersectionObserver = (
+export const useGridInfiniteLoadingIntersection = (
   apiRef: RefObject<GridPrivateApiPro>,
   props: Pick<
     DataGridProProcessedProps,

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridIntersectionObserver.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridIntersectionObserver.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { RefObject } from '@mui/x-internals/types';
+import { useGridSelector, useGridApiMethod, gridDimensionsSelector } from '@mui/x-data-grid';
+import {
+  GridInfiniteLoaderPrivateApi,
+  useTimeout,
+  gridHorizontalScrollbarHeightSelector,
+} from '@mui/x-data-grid/internals';
+import useEventCallback from '@mui/utils/useEventCallback';
+import { styled } from '@mui/system';
+import { GridPrivateApiPro } from '../../../models/gridApiPro';
+import { DataGridProProcessedProps } from '../../../models/dataGridProProps';
+
+const InfiniteLoadingTriggerElement = styled('div')({
+  position: 'sticky',
+  left: 0,
+  width: 0,
+  height: 0,
+});
+
+/**
+ * @requires useGridDimensions (method) - can be after
+ */
+export const useGridIntersectionObserver = (
+  apiRef: RefObject<GridPrivateApiPro>,
+  props: Pick<
+    DataGridProProcessedProps,
+    'onRowsScrollEnd' | 'dataSource' | 'lazyLoading' | 'rowsLoadingMode' | 'scrollEndThreshold'
+  >,
+): void => {
+  const isReady = useGridSelector(apiRef, gridDimensionsSelector).isReady;
+  const observer = React.useRef<IntersectionObserver>(null);
+  const updateTargetTimeout = useTimeout();
+  const triggerElement = React.useRef<HTMLElement | null>(null);
+
+  const isEnabledClientSide = props.rowsLoadingMode === 'client' && !!props.onRowsScrollEnd;
+  const isEnabledServerSide = props.dataSource && props.lazyLoading;
+
+  const isEnabled = isEnabledClientSide || isEnabledServerSide;
+
+  const handleIntersectionChange = useEventCallback(([entry]: IntersectionObserverEntry[]) => {
+    const currentRatio = entry.intersectionRatio;
+    const isIntersecting = entry.isIntersecting;
+
+    if (isIntersecting && currentRatio === 1) {
+      observer.current?.disconnect();
+      // do not observe this node anymore
+      triggerElement.current = null;
+      apiRef.current.publishEvent('onIntersection');
+    }
+  });
+
+  React.useEffect(() => {
+    const virtualScroller = apiRef.current.virtualScrollerRef.current;
+    if (!isEnabled || !isReady || !virtualScroller) {
+      return;
+    }
+    observer.current?.disconnect();
+
+    const horizontalScrollbarHeight = gridHorizontalScrollbarHeightSelector(apiRef);
+    const marginBottom = props.scrollEndThreshold - horizontalScrollbarHeight;
+
+    observer.current = new IntersectionObserver(handleIntersectionChange, {
+      threshold: 1,
+      root: virtualScroller,
+      rootMargin: `0px 0px ${marginBottom}px 0px`,
+    });
+    if (triggerElement.current) {
+      observer.current.observe(triggerElement.current);
+    }
+  }, [apiRef, isReady, handleIntersectionChange, isEnabled, props.scrollEndThreshold]);
+
+  const updateTarget = (node: HTMLElement | null) => {
+    if (triggerElement.current !== node) {
+      observer.current?.disconnect();
+
+      triggerElement.current = node;
+      if (triggerElement.current) {
+        observer.current?.observe(triggerElement.current);
+      }
+    }
+  };
+
+  const triggerRef = React.useCallback(
+    (node: HTMLElement | null) => {
+      // Prevent the infite loading working in combination with lazy loading
+      if (!isEnabled) {
+        return;
+      }
+
+      // If the user scrolls through the grid too fast it might happen that the observer is connected to the trigger element
+      // that will be intersecting the root inside the same render cycle (but not intersecting at the time of the connection).
+      // This will cause the observer to not call the callback with `isIntersecting` set to `true`.
+      // https://www.w3.org/TR/intersection-observer/#event-loop
+      // Delaying the connection to the next cycle helps since the observer will always call the callback the first time it is connected.
+      // https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/observe
+      // Related to
+      // https://github.com/mui/mui-x/issues/14116
+      updateTargetTimeout.start(0, () => updateTarget(node));
+    },
+    [isEnabled, updateTargetTimeout],
+  );
+
+  const getInfiniteLoadingTriggerElement = React.useCallback<
+    NonNullable<GridInfiniteLoaderPrivateApi['getInfiniteLoadingTriggerElement']>
+  >(
+    ({ lastRowId }) => {
+      if (!isEnabled) {
+        return null;
+      }
+      return (
+        <InfiniteLoadingTriggerElement
+          ref={triggerRef}
+          // Force rerender on last row change to start observing the new trigger
+          key={`trigger-${lastRowId}`}
+          role="presentation"
+        />
+      );
+    },
+    [isEnabled, triggerRef],
+  );
+
+  const infiniteLoaderPrivateApi: GridInfiniteLoaderPrivateApi = {
+    getInfiniteLoadingTriggerElement,
+  };
+
+  useGridApiMethod(apiRef, infiniteLoaderPrivateApi, 'private');
+};

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridIntersectionObserver.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridIntersectionObserver.tsx
@@ -46,7 +46,7 @@ export const useGridIntersectionObserver = (
       observer.current?.disconnect();
       // do not observe this node anymore
       triggerElement.current = null;
-      apiRef.current.publishEvent('onIntersection');
+      apiRef.current.publishEvent('rowsScrollEndIntersection');
     }
   });
 

--- a/packages/x-data-grid-pro/src/internals/index.ts
+++ b/packages/x-data-grid-pro/src/internals/index.ts
@@ -44,7 +44,7 @@ export {
 export { useGridLazyLoader } from '../hooks/features/lazyLoader/useGridLazyLoader';
 export { useGridLazyLoaderPreProcessors } from '../hooks/features/lazyLoader/useGridLazyLoaderPreProcessors';
 export { useGridDataSourceLazyLoader } from '../hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader';
-export { useGridIntersectionObserver } from '../hooks/features/serverSideLazyLoader/useGridIntersectionObserver';
+export { useGridInfiniteLoadingIntersection } from '../hooks/features/serverSideLazyLoader/useGridInfiniteLoadingIntersection';
 export { dataSourceStateInitializer } from '../hooks/features/dataSource/useGridDataSourcePro';
 export { useGridDataSourceBasePro } from '../hooks/features/dataSource/useGridDataSourceBasePro';
 export {

--- a/packages/x-data-grid-pro/src/internals/index.ts
+++ b/packages/x-data-grid-pro/src/internals/index.ts
@@ -44,6 +44,7 @@ export {
 export { useGridLazyLoader } from '../hooks/features/lazyLoader/useGridLazyLoader';
 export { useGridLazyLoaderPreProcessors } from '../hooks/features/lazyLoader/useGridLazyLoaderPreProcessors';
 export { useGridDataSourceLazyLoader } from '../hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader';
+export { useGridIntersectionObserver } from '../hooks/features/serverSideLazyLoader/useGridIntersectionObserver';
 export { dataSourceStateInitializer } from '../hooks/features/dataSource/useGridDataSourcePro';
 export { useGridDataSourceBasePro } from '../hooks/features/dataSource/useGridDataSourceBasePro';
 export {

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -344,7 +344,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   describe('Row count updates', () => {
     it('should add skeleton rows once the rowCount becomes known', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response });
+      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
       const { setProps } = render(<TestDataSourceLazyLoader />);
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -363,7 +363,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
     it('should reset the grid if the rowCount becomes unknown', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response });
+      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
       const { setProps } = render(<TestDataSourceLazyLoader rowCount={100} />);
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -380,7 +380,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
     it('should reset the grid if the rowCount becomes smaller than the actual row count', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response });
+      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
       render(
         <TestDataSourceLazyLoader rowCount={100} paginationModel={{ page: 0, pageSize: 30 }} />,
       );
@@ -405,7 +405,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
     it('should allow setting the row count via API', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response });
+      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
       render(<TestDataSourceLazyLoader />);
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -26,6 +26,15 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   let apiRef: RefObject<GridApi | null>;
   let mockServer: ReturnType<typeof useMockServer>;
 
+  const scrollEndThreshold = 60;
+  const rowHeight = 50;
+  const columnHeaderHeight = 50;
+  const gridHeight =
+    4 * rowHeight +
+    columnHeaderHeight +
+    // border
+    2;
+
   // TODO: Resets strictmode calls, need to find a better fix for this, maybe an AbortController?
   function Reset() {
     React.useLayoutEffect(() => {
@@ -34,10 +43,13 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     return null;
   }
 
-  function TestDataSourceLazyLoader(props: Partial<DataGridProProps>) {
+  function TestDataSourceLazyLoader(
+    props: Partial<DataGridProProps> & { mockServerRowCount?: number },
+  ) {
+    const { mockServerRowCount, ...rest } = props;
     apiRef = useGridApiRef();
     mockServer = useMockServer(
-      { rowLength: 100, maxColumns: 1 },
+      { rowLength: mockServerRowCount ?? 100, maxColumns: 1 },
       { useCursorPagination: false, minDelay: 0, maxDelay: 0, verbose: false },
     );
 
@@ -71,7 +83,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
     }
 
     return (
-      <div style={{ width: 300, height: 300 }}>
+      <div style={{ width: 300, height: gridHeight }}>
         <Reset />
         <DataGridPro
           apiRef={apiRef}
@@ -80,7 +92,10 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
           lazyLoading
           initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 }, rowCount: 0 } }}
           disableVirtualization
-          {...props}
+          scrollEndThreshold={scrollEndThreshold}
+          rowHeight={rowHeight}
+          columnHeaderHeight={columnHeaderHeight}
+          {...rest}
         />
       </div>
     );
@@ -237,6 +252,40 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       await waitFor(() => {
         expect(fetchRowsSpy.callCount).to.equal(1);
       });
+    });
+
+    it('should call make a new data source request when there is not enough rows to cover the viewport height', async () => {
+      render(
+        <TestDataSourceLazyLoader
+          initialState={{
+            pagination: { paginationModel: { page: 0, pageSize: 2 }, rowCount: undefined },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(fetchRowsSpy.callCount).to.equal(3); // grid is 4 rows high and the threshold is 60px, so 3 pages are loaded
+      });
+      const lastSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      expect(lastSearchParams.get('end')).to.equal('5'); // 6th row
+    });
+
+    it('should call stop making data source requests if the new rows were not added on the last call', async () => {
+      render(
+        <TestDataSourceLazyLoader
+          mockServerRowCount={2}
+          initialState={{
+            pagination: { paginationModel: { page: 0, pageSize: 2 }, rowCount: undefined },
+          }}
+        />,
+      );
+      await waitFor(() => {
+        expect(fetchRowsSpy.callCount).to.equal(2);
+      });
+      const lastSearchParams = new URL(fetchRowsSpy.lastCall.args[0]).searchParams;
+      // 3rd and 4th row were requested but not added
+      expect(lastSearchParams.get('start')).to.equal('2');
+      expect(lastSearchParams.get('end')).to.equal('3');
     });
 
     it('should reset the scroll position when sorting is applied', async () => {

--- a/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/dataSourceLazyLoader.DataGridPro.test.tsx
@@ -254,11 +254,11 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       });
     });
 
-    it('should call make a new data source request when there is not enough rows to cover the viewport height', async () => {
+    it('should make a new data source request when there is not enough rows to cover the viewport height', async () => {
       render(
         <TestDataSourceLazyLoader
           initialState={{
-            pagination: { paginationModel: { page: 0, pageSize: 2 }, rowCount: undefined },
+            pagination: { paginationModel: { page: 0, pageSize: 2 } },
           }}
         />,
       );
@@ -270,12 +270,12 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
       expect(lastSearchParams.get('end')).to.equal('5'); // 6th row
     });
 
-    it('should call stop making data source requests if the new rows were not added on the last call', async () => {
+    it('should stop making data source requests if the new rows were not added on the last call', async () => {
       render(
         <TestDataSourceLazyLoader
           mockServerRowCount={2}
           initialState={{
-            pagination: { paginationModel: { page: 0, pageSize: 2 }, rowCount: undefined },
+            pagination: { paginationModel: { page: 0, pageSize: 2 } },
           }}
         />,
       );
@@ -344,7 +344,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
   describe('Row count updates', () => {
     it('should add skeleton rows once the rowCount becomes known', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
+      transformGetRowsResponse = (response) => ({ ...response });
       const { setProps } = render(<TestDataSourceLazyLoader />);
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -363,7 +363,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
     it('should reset the grid if the rowCount becomes unknown', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
+      transformGetRowsResponse = (response) => ({ ...response });
       const { setProps } = render(<TestDataSourceLazyLoader rowCount={100} />);
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);
@@ -380,7 +380,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
     it('should reset the grid if the rowCount becomes smaller than the actual row count', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
+      transformGetRowsResponse = (response) => ({ ...response });
       render(
         <TestDataSourceLazyLoader rowCount={100} paginationModel={{ page: 0, pageSize: 30 }} />,
       );
@@ -405,7 +405,7 @@ describeSkipIf(isJSDOM)('<DataGridPro /> - Data source lazy loader', () => {
 
     it('should allow setting the row count via API', async () => {
       // override rowCount
-      transformGetRowsResponse = (response) => ({ ...response, rowCount: undefined });
+      transformGetRowsResponse = (response) => ({ ...response });
       render(<TestDataSourceLazyLoader />);
       // wait until the rows are rendered
       await waitFor(() => expect(getRow(0)).not.to.be.undefined);

--- a/packages/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/x-data-grid/src/models/events/gridEventLookup.ts
@@ -572,6 +572,12 @@ export interface GridEventLookup
    * @ignore - do not document.
    */
   virtualScrollerTouchMove: { params: {}; event: React.TouchEvent };
+  /**
+   * Fired when the area of height `scrollEndThreshold` is entering the viewport from the bottom.
+   * Used to trigger infinite loading.
+   * @ignore - do not document.
+   */
+  onIntersection: {};
 
   // Selection
   /**

--- a/packages/x-data-grid/src/models/events/gridEventLookup.ts
+++ b/packages/x-data-grid/src/models/events/gridEventLookup.ts
@@ -577,7 +577,7 @@ export interface GridEventLookup
    * Used to trigger infinite loading.
    * @ignore - do not document.
    */
-  onIntersection: {};
+  rowsScrollEndIntersection: {};
 
   // Selection
   /**


### PR DESCRIPTION
I have extracted IntersectionObserver logic into a separate hook and moved it to the server side feature folder, since the client side feature is deprecated.
Both client and server side infinite loading are now listening to the new internal event from this hook to handle the data update

There are two main reasons for doing this:
1. With the intersection observer we are covering more cases where the new data fetch should occur. One of them is if the page size is not big enough to fill the whole viewport. With the observer additional data is fetched until the viewport is filled.
2. IntersectionObserver events are far less frequent than scroll events, so handling those reduces the impact on the grid performance
