### PR TITLE
[code-infra] Align build script with core to handle sideEffects

### DIFF
--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -10,9 +10,7 @@
   },
   "homepage": "https://mui.com/x/introduction/licensing/",
   "sideEffects": [
-    "./utils/licenseInfo.js",
-    "./modern/utils/licenseInfo.js",
-    "./node/utils/licenseInfo.js"
+    "./utils/licenseInfo.js"
   ],
   "publishConfig": {
     "access": "public",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -137,7 +137,7 @@ async function run(argv) {
     const rootBundlePackageJson = path.join(outDir, 'package.json');
     await fs.writeFile(
       rootBundlePackageJson,
-      JSON.stringify({ type: 'module', sideEffects: false }),
+      JSON.stringify({ type: 'module', sideEffects: packageJson.sideEffects }),
     );
   }
 


### PR DESCRIPTION
Also remove some of the values from the side effects array as after copying, the relative path would keep working, and the top-level package.json wouldn't be considered anyway for `./esm/utils/licenseInfo.js` by webpack as it finds a closer by package.json.

Solves https://github.com/mui/mui-x/pull/17359#discussion_r2042890008


> Ideally we just import the core script.
> ```tsx
> import '@mui/monorepo/scripts/build.mjs'
> ```
> To be investigated first how much the scripts have diverged.