### PR TITLE
[charts] Add default plugins in `ChartDataProvider`

### DIFF
--- a/packages/x-charts-pro/src/ChartDataProviderPro/ChartDataProviderPro.tsx
+++ b/packages/x-charts-pro/src/ChartDataProviderPro/ChartDataProviderPro.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/x-charts/internals';
 import { ChartDataProviderProps } from '@mui/x-charts/ChartDataProvider';
 import { useLicenseVerifier } from '@mui/x-license/useLicenseVerifier';
-import { AllPluginSignatures } from '../internals/plugins/allPlugins';
+import { AllPluginSignatures, DEFAULT_PLUGINS } from '../internals/plugins/allPlugins';
 import { useChartDataProviderProProps } from './useChartDataProviderProProps';
 import { getReleaseInfo } from '../internals/utils/releaseInfo';
 
@@ -54,7 +54,10 @@ function ChartDataProviderPro<
   TSeries extends ChartSeriesType = ChartSeriesType,
   TSignatures extends readonly ChartAnyPluginSignature[] = AllPluginSignatures<TSeries>,
 >(props: ChartDataProviderProProps<TSeries, TSignatures>) {
-  const { children, chartProviderProps } = useChartDataProviderProProps(props);
+  const { children, chartProviderProps } = useChartDataProviderProProps({
+    ...props,
+    plugins: props.plugins ?? DEFAULT_PLUGINS,
+  });
 
   useLicenseVerifier(packageIdentifier, releaseInfo);
 

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -298,7 +298,7 @@ Heatmap.propTypes = {
    */
   series: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
-   * The configuration helpers used to compute attributes according to the serries type.
+   * The configuration helpers used to compute attributes according to the series type.
    * @ignore Unstable props for internal usage.
    */
   seriesConfig: PropTypes.object,

--- a/packages/x-charts/src/ChartDataProvider/useChartDataProviderProps.ts
+++ b/packages/x-charts/src/ChartDataProvider/useChartDataProviderProps.ts
@@ -5,7 +5,7 @@ import { ChartProviderProps } from '../context/ChartProvider';
 import { ChartAnyPluginSignature, MergeSignaturesProperty } from '../internals/plugins/models';
 import { ChartSeriesType } from '../models/seriesType/config';
 import { ChartCorePluginSignatures } from '../internals/plugins/corePlugins';
-import { AllPluginSignatures } from '../internals/plugins/allPlugins';
+import { AllPluginSignatures, DEFAULT_PLUGINS } from '../internals/plugins/allPlugins';
 
 export const useChartDataProviderProps = <
   TSeries extends ChartSeriesType = ChartSeriesType,
@@ -13,12 +13,12 @@ export const useChartDataProviderProps = <
 >(
   props: ChartDataProviderProps<TSeries, TSignatures>,
 ) => {
-  const { children, plugins, seriesConfig, ...other } = props;
+  const { children, plugins = DEFAULT_PLUGINS, seriesConfig, ...other } = props;
 
   const theme = useTheme();
 
   const chartProviderProps: ChartProviderProps<TSeries, TSignatures> = {
-    plugins,
+    plugins: plugins as ChartProviderProps<TSeries, TSignatures>['plugins'],
     seriesConfig,
     pluginParams: {
       theme: theme.palette.mode,

--- a/packages/x-charts/src/RadarChart/RadarDataProvider/RadarDataProvider.tsx
+++ b/packages/x-charts/src/RadarChart/RadarDataProvider/RadarDataProvider.tsx
@@ -230,7 +230,7 @@ RadarDataProvider.propTypes = {
    */
   series: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
-   * The configuration helpers used to compute attributes according to the serries type.
+   * The configuration helpers used to compute attributes according to the series type.
    * @ignore Unstable props for internal usage.
    */
   seriesConfig: PropTypes.object,

--- a/packages/x-charts/src/context/ChartProvider/ChartProvider.types.ts
+++ b/packages/x-charts/src/context/ChartProvider/ChartProvider.types.ts
@@ -48,7 +48,7 @@ export interface ChartProviderProps<
   plugins?: ConvertSignaturesIntoPlugins<TSignatures>;
   pluginParams?: ChartPluginParams<TSignatures>;
   /**
-   * The configuration helpers used to compute attributes according to the serries type.
+   * The configuration helpers used to compute attributes according to the series type.
    * @ignore Unstable props for internal usage.
    */
   seriesConfig?: ChartSeriesConfig<TSeries>;

--- a/packages/x-charts/src/internals/plugins/allPlugins.ts
+++ b/packages/x-charts/src/internals/plugins/allPlugins.ts
@@ -28,4 +28,4 @@ export const DEFAULT_PLUGINS = [
   useChartInteraction,
   useChartHighlight,
   useChartVoronoi,
-];
+] as const;


### PR DESCRIPTION
Add default plugins in `ChartDataProvider` and `ChartDataProviderPro` if the `plugins` prop is `undefined` or `null`. 

I don't think we need to consider this a breaking change since plugins only add extra functionality.

Unblocks https://github.com/mui/mui-x/pull/17285.