### PR TITLE
[DataGrid] Prevent scrollbars from showing on top

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -261,6 +261,8 @@ export const GridRootStyles = styled('div', {
     flexDirection: 'column',
     overflow: 'hidden',
     overflowAnchor: 'none', // Keep the same scrolling position
+    transform: 'translate(0, 0)', // Create a stacking context to keep scrollbars from showing on top
+
     [`.${c.main} > *:first-child${ignoreSsrWarning}`]: {
       borderTopLeftRadius: 'var(--unstable_DataGrid-radius)',
       borderTopRightRadius: 'var(--unstable_DataGrid-radius)',


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/17029

Create a stacking context to prevent the scrollbars from showing over other elements.

Before: https://stackblitz.com/edit/react-yjbgmx5t?file=Demo.tsx