### PR TITLE
v6 resolve issue with missed item on the `itemData.dataIndex` index in series.data

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
@@ -19,6 +19,10 @@ function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeries
   if (itemData.dataIndex === undefined) {
     return null;
   }
+  // this can be missed item on the `itemData.dataIndex` index in series.data
+  if(series.type === 'pie' && !series.data[itemData.dataIndex]) {
+    return null;
+  }
   const { displayedLabel, color } =
     series.type === 'pie'
       ? {

--- a/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
+++ b/packages/x-charts/src/ChartsTooltip/DefaultChartsItemTooltipContent.tsx
@@ -20,7 +20,7 @@ function DefaultChartsItemTooltipContent<T extends ChartSeriesType = ChartSeries
     return null;
   }
   // this can be missed item on the `itemData.dataIndex` index in series.data
-  if(series.type === 'pie' && !series.data[itemData.dataIndex]) {
+  if (series.type === 'pie' && !series.data[itemData.dataIndex]) {
     return null;
   }
   const { displayedLabel, color } =


### PR DESCRIPTION
Fix https://github.com/mui/mui-x/issues/17412

When the data updates - this may be a case when item on the `itemData.dataIndex` index in series.data is missed
Example:
![image](https://github.com/user-attachments/assets/b202f5ae-ea86-413d-948e-4b126dbb012f)
![image](https://github.com/user-attachments/assets/ed91cda7-3422-4b57-bc36-c94e52ce7bd4)

To resolve this issue I've added additional condition for this case and return null (same when itemData.dataIndex is missed)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
