### PR TITLE
[charts] Fix chart direction in docs

### DIFF
--- a/docs/data/charts/composition/composition.md
+++ b/docs/data/charts/composition/composition.md
@@ -230,14 +230,14 @@ The demos use the `slotProps.legend` object, but with composition, you can pass 
 <BarChart
   slotProps={{
     legend: {
-      direction: 'row',
+      direction: 'horizontal',
     }
   }}
 />
 
 // With composition
 <ChartContainer>
-  <ChartsLegend direction="row" />
+  <ChartsLegend direction="horizontal" />
 </ChartContainer>
 ```
 


### PR DESCRIPTION
`ChartsLegend`'s `direction` prop is `vertical` or `horizontal`, not `row` or `column`.

https://github.com/mui/mui-x/blob/937bbc31ace347902dbe78f3ce3a2bc8e62d3ffa/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx#L31

https://github.com/mui/mui-x/blob/3fe74a95d53dc96214fa7584e37f724da7785e13/packages/x-charts/src/ChartsLegend/direction.ts#L1
