### PR TITLE
[charts] advance time in charts regression tests

### DIFF
--- a/test/regressions/TestViewer.tsx
+++ b/test/regressions/TestViewer.tsx
@@ -31,7 +31,7 @@ const StyledBox = styled('div', {
 );
 
 function TestViewer(props: any) {
-  const { children, isDataGridTest, isDataGridPivotTest, path } = props;
+  const { children, isDataGridTest, isDataGridPivotTest, isChartTest, path } = props;
 
   return (
     <React.Fragment>
@@ -61,7 +61,7 @@ function TestViewer(props: any) {
           },
         }}
       />
-      <MockTime isDataGridTest={isDataGridTest}>
+      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest}>
         <LoadFont
           isDataGridTest={isDataGridTest}
           isDataGridPivotTest={isDataGridPivotTest}
@@ -74,14 +74,14 @@ function TestViewer(props: any) {
   );
 }
 
-function MockTime(props: any) {
+function MockTime(props: React.PropsWithChildren<{ shouldAdvanceTime: boolean }>) {
   const [ready, setReady] = React.useState(false);
 
   React.useEffect(() => {
-    const dispose = setupFakeClock(props.isDataGridTest);
+    const dispose = setupFakeClock(props.shouldAdvanceTime);
     setReady(true);
     return dispose;
-  }, [props.isDataGridTest]);
+  }, [props.shouldAdvanceTime]);
 
   return ready ? props.children : null;
 }

--- a/test/regressions/index.tsx
+++ b/test/regressions/index.tsx
@@ -94,8 +94,9 @@ function App() {
       path: '/',
       element: <Root />,
       children: Object.keys(testsBySuite).map((suite) => {
+        const isChartTest = suite.startsWith('docs-charts');
         const isDataGridTest =
-          suite.indexOf('docs-data-grid') === 0 || suite === 'test-regressions-data-grid';
+          suite.startsWith('docs-data-grid') || suite === 'test-regressions-data-grid';
         const isDataGridPivotTest = isDataGridTest && suite.startsWith('docs-data-grid-pivoting');
         return {
           path: suite,
@@ -105,6 +106,7 @@ function App() {
               <TestViewer
                 isDataGridTest={isDataGridTest}
                 isDataGridPivotTest={isDataGridPivotTest}
+                isChartTest={isChartTest}
                 path={computePath(test)}
               >
                 <test.case />


### PR DESCRIPTION
This is necessary to run animation frames before taking a screenshot. This will also unblock changes in https://github.com/mui/mui-x/pull/17285 because the test in that PR requires an animation frame to run before the print dialog is shown. 