### PR TITLE
[docs] Fix AI Assistant Panel Trigger demo

### DIFF
--- a/docs/data/data-grid/components/ai-assistant-panel/GridAiAssistantPanelTrigger.js
+++ b/docs/data/data-grid/components/ai-assistant-panel/GridAiAssistantPanelTrigger.js
@@ -4,6 +4,7 @@ import {
   Toolbar,
   ToolbarButton,
   AiAssistantPanelTrigger,
+  GridAiAssistantPanel,
 } from '@mui/x-data-grid-premium';
 import { mockPromptResolver, useDemoData } from '@mui/x-data-grid-generator';
 import Tooltip from '@mui/material/Tooltip';
@@ -33,8 +34,8 @@ export default function GridAiAssistantPanelTrigger() {
       <DataGridPremium
         {...data}
         loading={loading}
-        slots={{ toolbar: CustomToolbar }}
         aiAssistant
+        slots={{ toolbar: CustomToolbar, aiAssistantPanel: GridAiAssistantPanel }}
         onPrompt={mockPromptResolver}
         showToolbar
       />

--- a/docs/data/data-grid/components/ai-assistant-panel/GridAiAssistantPanelTrigger.tsx
+++ b/docs/data/data-grid/components/ai-assistant-panel/GridAiAssistantPanelTrigger.tsx
@@ -4,6 +4,7 @@ import {
   Toolbar,
   ToolbarButton,
   AiAssistantPanelTrigger,
+  GridAiAssistantPanel,
 } from '@mui/x-data-grid-premium';
 import { mockPromptResolver, useDemoData } from '@mui/x-data-grid-generator';
 import Tooltip from '@mui/material/Tooltip';
@@ -33,8 +34,8 @@ export default function GridAiAssistantPanelTrigger() {
       <DataGridPremium
         {...data}
         loading={loading}
-        slots={{ toolbar: CustomToolbar }}
         aiAssistant
+        slots={{ toolbar: CustomToolbar, aiAssistantPanel: GridAiAssistantPanel }}
         onPrompt={mockPromptResolver}
         showToolbar
       />

--- a/docs/data/data-grid/components/ai-assistant-panel/GridAiAssistantPanelTrigger.tsx.preview
+++ b/docs/data/data-grid/components/ai-assistant-panel/GridAiAssistantPanelTrigger.tsx.preview
@@ -1,8 +1,8 @@
 <DataGridPremium
   {...data}
   loading={loading}
-  slots={{ toolbar: CustomToolbar }}
   aiAssistant
+  slots={{ toolbar: CustomToolbar, aiAssistantPanel: GridAiAssistantPanel }}
   onPrompt={mockPromptResolver}
   showToolbar
 />


### PR DESCRIPTION
Fixes the demo on the AI Assistant Panel component docs. Currently, the trigger isn't opening the panel because we are not passing the component to the slot.