### PR TITLE
[charts] Fix tooltip position

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import HTMLElementType from '@mui/utils/HTMLElementType';
 import useLazyRef from '@mui/utils/useLazyRef';
 import { styled, useThemeProps } from '@mui/material/styles';
-import Popper, { PopperPlacementType, PopperProps } from '@mui/material/Popper';
+import Popper, { PopperProps } from '@mui/material/Popper';
 import NoSsr from '@mui/material/NoSsr';
 import { useSvgRef } from '../hooks/useSvgRef';
 import { TriggerOptions, usePointerType } from './utils';
@@ -123,17 +123,24 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
       {
         name: 'offset',
         options: {
-          offset: ({ placement }: { placement: PopperPlacementType }) => {
+          offset: () => {
             if (pointerType?.pointerType !== 'touch') {
-              return [0, 0];
+              return [0, 8];
             }
-
-            const isBottom = placement.startsWith('bottom');
-            const placementOffset = isBottom ? 32 : 8;
-            return [0, pointerType.height + placementOffset];
+            return [0, 64];
           },
         },
       },
+      ...(pointerType?.pointerType === 'mouse'
+        ? [] // Keep default behavior
+        : [
+            {
+              name: 'flip',
+              options: {
+                fallbackPlacements: ['top-end', 'top-start', 'bottom-end', 'bottom'],
+              },
+            },
+          ]),
     ],
     [pointerType],
   );
@@ -148,9 +155,7 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
         <ChartsTooltipRoot
           className={classes?.root}
           open={popperOpen}
-          placement={
-            pointerType?.pointerType === 'mouse' ? ('right-start' as const) : ('top' as const)
-          }
+          placement={pointerType?.pointerType === 'mouse' ? 'right-start' : 'top'}
           popperRef={popperRef}
           anchorEl={anchorEl}
           modifiers={modifiers}

--- a/packages/x-charts/src/ChartsTooltip/utils.tsx
+++ b/packages/x-charts/src/ChartsTooltip/utils.tsx
@@ -57,7 +57,7 @@ export function useMouseTracker(): UseMouseTrackerReturnValue {
   return mousePosition;
 }
 
-type PointerType = Pick<MousePosition, 'height' | 'pointerType'>;
+type PointerType = Pick<MousePosition, 'pointerType'>;
 
 export function usePointerType(): null | PointerType {
   const svgRef = useSvgRef();
@@ -79,7 +79,6 @@ export function usePointerType(): null | PointerType {
 
     const handleEnter = (event: PointerEvent) => {
       setPointerType({
-        height: event.height,
         pointerType: event.pointerType as PointerType['pointerType'],
       });
     };


### PR DESCRIPTION
The tooltip was not visible on my phone. The reason is the `(event as PointerEvent).height` which returns a value between 10 and 2000 (yes, a x200 range) which of course put the tooltip outside to the screen

I tested on another phone, and it returns 0.

Since this `height` property does not seem reliable, I remove its usage, and replace it with a fixed padding.

I also updatedthe  fallback to avoid as much as possible getting the tooltip below the thumb for right-handed people