### PR TITLE
[core] Remove redundant `overridesResolver` in `styled` components

### DIFF
--- a/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
@@ -52,7 +52,7 @@ export interface HeatmapItemOwnerState {
 const HeatmapCell = styled('rect', {
   name: 'MuiHeatmap',
   slot: 'Cell',
-  overridesResolver: (_, styles) => styles.arc,
+  overridesResolver: (_, styles) => styles.arc, // FIXME: Inconsistent naming with slot
 })<{ ownerState: HeatmapItemOwnerState }>(({ ownerState }) => ({
   filter:
     (ownerState.isHighlighted && 'saturate(120%)') ||

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -216,7 +216,6 @@ const useAggregatedData = (): {
 const BarPlotRoot = styled('g', {
   name: 'MuiBarPlot',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({
   [`& .${barElementClasses.root}`]: {
     transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsAxisHighlightPath.ts
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsAxisHighlightPath.ts
@@ -5,7 +5,6 @@ import { ChartsAxisHighlightType } from './ChartsAxisHighlight.types';
 export const ChartsAxisHighlightPath = styled('path', {
   name: 'MuiChartsAxisHighlight',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: { axisHighlight: ChartsAxisHighlightType } }>(({ theme }) => ({
   pointerEvents: 'none',
   variants: [

--- a/packages/x-charts/src/ChartsGrid/styledComponents.tsx
+++ b/packages/x-charts/src/ChartsGrid/styledComponents.tsx
@@ -14,7 +14,6 @@ export const GridRoot = styled('g', {
 export const GridLine = styled('line', {
   name: 'MuiChartsGrid',
   slot: 'Line',
-  overridesResolver: (props, styles) => styles.line,
 })(({ theme }) => ({
   stroke: (theme.vars || theme).palette.divider,
   shapeRendering: 'crispEdges',

--- a/packages/x-charts/src/ChartsLabel/ChartsLabelGradient.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelGradient.tsx
@@ -62,7 +62,6 @@ const getRotation = (
 const Root = styled('div', {
   name: 'MuiChartsLabelGradient',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: ChartsLabelGradientProps & { isRtl: boolean } }>(({ ownerState }) => {
   const rotation = getRotation(
     ownerState.direction,

--- a/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelMark.tsx
@@ -33,7 +33,6 @@ export interface ChartsLabelMarkProps {
 const Root = styled('div', {
   name: 'MuiChartsLabelMark',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: ChartsLabelMarkProps }>(() => {
   return {
     display: 'flex',

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -40,7 +40,6 @@ export interface ChartsLegendProps {
 const RootElement = styled('ul', {
   name: 'MuiChartsLegend',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: ChartsLegendProps }>(({ ownerState, theme }) => ({
   ...theme.typography.caption,
   color: (theme.vars || theme).palette.text.primary,

--- a/packages/x-charts/src/ChartsLegend/ContinuousColorLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ContinuousColorLegend.tsx
@@ -109,7 +109,6 @@ const templateAreas = (reverse?: boolean) => {
 const RootElement = styled('ul', {
   name: 'MuiContinuousColorLegend',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: ContinuousColorLegendProps }>(({ theme, ownerState }) => ({
   ...theme.typography.caption,
   color: (theme.vars || theme).palette.text.primary,

--- a/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.tsx
@@ -61,7 +61,6 @@ export interface PiecewiseColorLegendProps
 const RootElement = styled('ul', {
   name: 'MuiPiecewiseColorLegend',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PiecewiseColorLegendProps }>(({ theme, ownerState }) => {
   return {
     ...theme.typography.caption,

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -40,7 +40,6 @@ export interface ChartsTooltipContainerProps extends Partial<PopperProps> {
 const ChartsTooltipRoot = styled(Popper, {
   name: 'MuiChartsTooltip',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })(({ theme }) => ({
   pointerEvents: 'none',
   zIndex: theme.zIndex.modal,

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipTable.ts
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipTable.ts
@@ -8,7 +8,7 @@ import { chartsTooltipClasses } from './chartsTooltipClasses';
 export const ChartsTooltipPaper = styled('div', {
   name: 'MuiChartsTooltip',
   slot: 'Container',
-  overridesResolver: (props, styles) => styles.paper,
+  overridesResolver: (props, styles) => styles.paper, // FIXME: Inconsistent naming with slot
 })(({ theme }) => ({
   backgroundColor: (theme.vars || theme).palette.background.paper,
   color: (theme.vars || theme).palette.text.primary,
@@ -22,7 +22,6 @@ export const ChartsTooltipPaper = styled('div', {
 export const ChartsTooltipTable = styled('table', {
   name: 'MuiChartsTooltip',
   slot: 'Table',
-  overridesResolver: (props, styles) => styles.table,
 })(({ theme }) => ({
   borderSpacing: 0,
   [`& .${chartsTooltipClasses.markContainer}`]: {
@@ -47,7 +46,6 @@ export const ChartsTooltipTable = styled('table', {
 export const ChartsTooltipRow = styled('tr', {
   name: 'MuiChartsTooltip',
   slot: 'Row',
-  overridesResolver: (props, styles) => styles.row,
 })(({ theme }) => ({
   'tr:first-of-type& td': {
     paddingTop: theme.spacing(0.5),

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -184,7 +184,6 @@ function shortenLabels(
 const XAxisRoot = styled(AxisRoot, {
   name: 'MuiChartsXAxis',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })({});
 
 const defaultProps = {

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -104,7 +104,6 @@ function shortenLabels(
 const YAxisRoot = styled(AxisRoot, {
   name: 'MuiChartsYAxis',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })({});
 
 const defaultProps = {

--- a/packages/x-charts/src/Gauge/GaugeReferenceArc.tsx
+++ b/packages/x-charts/src/Gauge/GaugeReferenceArc.tsx
@@ -7,7 +7,6 @@ import { useGaugeState } from './GaugeProvider';
 const StyledPath = styled('path', {
   name: 'MuiGauge',
   slot: 'ReferenceArc',
-  overridesResolver: (props, styles) => styles.referenceArc,
 })(({ theme }) => ({
   fill: (theme.vars || theme).palette.divider,
 }));

--- a/packages/x-charts/src/Gauge/GaugeValueArc.tsx
+++ b/packages/x-charts/src/Gauge/GaugeValueArc.tsx
@@ -9,7 +9,6 @@ import { useGaugeState } from './GaugeProvider';
 const StyledPath = styled('path', {
   name: 'MuiGauge',
   slot: 'ReferenceArc',
-  overridesResolver: (props, styles) => styles.referenceArc,
 })(({ theme }) => ({
   fill: (theme.vars || theme).palette.primary.main,
 }));

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -42,7 +42,6 @@ export interface AreaPlotProps
 const AreaPlotRoot = styled('g', {
   name: 'MuiAreaPlot',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({
   [`& .${areaElementClasses.root}`]: {
     transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -43,7 +43,6 @@ export interface LinePlotProps
 const LinePlotRoot = styled('g', {
   name: 'MuiAreaPlot',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({
   [`& .${lineElementClasses.root}`]: {
     transition: 'opacity 0.2s ease-in, fill 0.2s ease-in',

--- a/packages/x-charts/src/LineChart/MarkElement.tsx
+++ b/packages/x-charts/src/LineChart/MarkElement.tsx
@@ -18,7 +18,6 @@ import { useStore } from '../internals/store/useStore';
 const MarkElementPath = styled('path', {
   name: 'MuiMarkElement',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: MarkElementOwnerState }>(({ ownerState, theme }) => ({
   fill: (theme.vars || theme).palette.background.paper,
   stroke: ownerState.color,

--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -64,7 +64,7 @@ const useUtilityClasses = (ownerState: PieArcOwnerState) => {
 const PieArcRoot = styled('path', {
   name: 'MuiPieArc',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.arc,
+  overridesResolver: (_, styles) => styles.arc, // FIXME: Inconsistent naming with slot
 })<{ ownerState: PieArcOwnerState }>(({ theme }) => ({
   // Got to move stroke to an element prop instead of style.
   stroke: (theme.vars || theme).palette.background.paper,

--- a/packages/x-charts/src/PieChart/PieArcLabel.tsx
+++ b/packages/x-charts/src/PieChart/PieArcLabel.tsx
@@ -66,7 +66,6 @@ const useUtilityClasses = (ownerState: PieArcLabelOwnerState) => {
 const PieArcLabelRoot = styled('text', {
   name: 'MuiPieArcLabel',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })(({ theme }) => ({
   fill: (theme.vars || theme).palette.text.primary,
   textAnchor: 'middle',

--- a/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
+++ b/packages/x-charts/src/internals/components/AxisSharedComponents.tsx
@@ -4,7 +4,6 @@ import { axisClasses } from '../../ChartsAxis/axisClasses';
 export const AxisRoot = styled('g', {
   name: 'MuiChartsAxis',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
   [`& .${axisClasses.tickLabel}`]: {
     /* The tick label is measured using only its style prop, so applying properties that change its size will cause the

--- a/packages/x-charts/src/internals/components/ChartsWrapper/ChartsWrapper.tsx
+++ b/packages/x-charts/src/internals/components/ChartsWrapper/ChartsWrapper.tsx
@@ -55,7 +55,6 @@ const getAlign = (direction?: Direction, position?: Position) => {
 const Root = styled('div', {
   name: 'MuiChartsWrapper',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: ChartsWrapperProps }>(({ ownerState }) => ({
   display: 'flex',
   flexDirection: getDirection(ownerState.legendDirection, ownerState.legendPosition),

--- a/packages/x-data-grid-premium/src/components/GridFooterCell.tsx
+++ b/packages/x-data-grid-premium/src/components/GridFooterCell.tsx
@@ -10,7 +10,6 @@ import { DataGridPremiumProcessedProps } from '../models/dataGridPremiumProps';
 const GridFooterCellRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FooterCell',
-  overridesResolver: (_, styles) => styles.footerCell,
 })<{ ownerState: OwnerState }>({
   fontWeight: vars.typography.fontWeight.medium,
   color: vars.colors.foreground.accent,

--- a/packages/x-data-grid-pro/src/components/GridDetailPanel.tsx
+++ b/packages/x-data-grid-pro/src/components/GridDetailPanel.tsx
@@ -13,7 +13,6 @@ type OwnerState = DataGridProProcessedProps;
 const DetailPanel = styled('div', {
   name: 'MuiDataGrid',
   slot: 'DetailPanel',
-  overridesResolver: (props, styles) => styles.detailPanel,
 })<{ ownerState: OwnerState }>({
   width:
     'calc(var(--DataGrid-rowWidth) - var(--DataGrid-hasScrollY) * var(--DataGrid-scrollbarSize))',

--- a/packages/x-data-grid/src/components/GridRowCount.tsx
+++ b/packages/x-data-grid/src/components/GridRowCount.tsx
@@ -35,7 +35,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridRowCountRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'RowCount',
-  overridesResolver: (props, styles) => styles.rowCount,
 })<{ ownerState: OwnerState }>({
   alignItems: 'center',
   display: 'flex',

--- a/packages/x-data-grid/src/components/GridSelectedRowCount.tsx
+++ b/packages/x-data-grid/src/components/GridSelectedRowCount.tsx
@@ -34,7 +34,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridSelectedRowCountRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'SelectedRowCount',
-  overridesResolver: (props, styles) => styles.selectedRowCount,
 })<{ ownerState: OwnerState }>({
   alignItems: 'center',
   display: 'flex',

--- a/packages/x-data-grid/src/components/GridSkeletonLoadingOverlay.tsx
+++ b/packages/x-data-grid/src/components/GridSkeletonLoadingOverlay.tsx
@@ -30,7 +30,6 @@ import { attachPinnedStyle } from '../internals/utils';
 const SkeletonOverlay = styled('div', {
   name: 'MuiDataGrid',
   slot: 'SkeletonLoadingOverlay',
-  overridesResolver: (props, styles) => styles.skeletonLoadingOverlay,
 })({
   minWidth: '100%',
   width: 'max-content', // prevents overflow: clip; cutting off the x axis

--- a/packages/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/x-data-grid/src/components/base/GridOverlays.tsx
@@ -34,7 +34,6 @@ const GridOverlayWrapperRoot = styled('div', {
   slot: 'OverlayWrapper',
   shouldForwardProp: (prop) =>
     prop !== 'overlayType' && prop !== 'loadingOverlayVariant' && prop !== 'right',
-  overridesResolver: (props, styles) => styles.overlayWrapper,
 })<GridOverlayWrapperRootProps>(({ overlayType, loadingOverlayVariant, right }) =>
   // Skeleton overlay should flow with the scroll container and not be sticky
   loadingOverlayVariant !== 'skeleton'
@@ -57,7 +56,6 @@ const GridOverlayWrapperInner = styled('div', {
   name: 'MuiDataGrid',
   slot: 'OverlayWrapperInner',
   shouldForwardProp: (prop) => prop !== 'overlayType' && prop !== 'loadingOverlayVariant',
-  overridesResolver: (props, styles) => styles.overlayWrapperInner,
 })({});
 
 type OwnerState = { classes: DataGridProcessedProps['classes'] };

--- a/packages/x-data-grid/src/components/columnHeaders/GridBaseColumnHeaders.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridBaseColumnHeaders.tsx
@@ -22,7 +22,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridColumnHeadersRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'ColumnHeaders',
-  overridesResolver: (props, styles) => styles.columnHeaders,
 })<{ ownerState: OwnerState }>({
   display: 'flex',
   flexDirection: 'column',

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -24,7 +24,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridColumnHeaderTitleRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'ColumnHeaderTitle',
-  overridesResolver: (props, styles) => styles.columnHeaderTitle,
 })<{ ownerState: OwnerState }>({
   textOverflow: 'ellipsis',
   overflow: 'hidden',

--- a/packages/x-data-grid/src/components/columnHeaders/GridIconButtonContainer.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridIconButtonContainer.tsx
@@ -24,7 +24,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridIconButtonContainerRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'IconButtonContainer',
-  overridesResolver: (props, styles) => styles.iconButtonContainer,
 })<{ ownerState: OwnerState }>(() => ({
   display: 'flex',
   visibility: 'hidden',

--- a/packages/x-data-grid/src/components/containers/GridFooterContainer.tsx
+++ b/packages/x-data-grid/src/components/containers/GridFooterContainer.tsx
@@ -27,7 +27,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridFooterContainerRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FooterContainer',
-  overridesResolver: (props, styles) => styles.footerContainer,
 })<{ ownerState: OwnerState }>({
   display: 'flex',
   justifyContent: 'space-between',

--- a/packages/x-data-grid/src/components/panel/GridPanelFooter.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanelFooter.tsx
@@ -23,7 +23,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridPanelFooterRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'PanelFooter',
-  overridesResolver: (props, styles) => styles.panelFooter,
 })<{ ownerState: OwnerState }>({
   padding: vars.spacing(1),
   display: 'flex',

--- a/packages/x-data-grid/src/components/panel/GridPanelHeader.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanelHeader.tsx
@@ -23,7 +23,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridPanelHeaderRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'PanelHeader',
-  overridesResolver: (props, styles) => styles.panelHeader,
 })<{ ownerState: OwnerState }>({
   padding: vars.spacing(1),
 });

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterForm.tsx
@@ -148,7 +148,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridFilterFormRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FilterForm',
-  overridesResolver: (props, styles) => styles.filterForm,
 })<{ ownerState: OwnerState }>({
   display: 'flex',
   gap: vars.spacing(1.5),
@@ -157,7 +156,6 @@ const GridFilterFormRoot = styled('div', {
 const FilterFormDeleteIcon = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FilterFormDeleteIcon',
-  overridesResolver: (_, styles) => styles.filterFormDeleteIcon,
 })<{ ownerState: OwnerState }>({
   flexShrink: 0,
   display: 'flex',
@@ -168,7 +166,6 @@ const FilterFormDeleteIcon = styled('div', {
 const FilterFormLogicOperatorInput = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FilterFormLogicOperatorInput',
-  overridesResolver: (_, styles) => styles.filterFormLogicOperatorInput,
 })<{ ownerState: OwnerState }>({
   minWidth: 75,
   justifyContent: 'end',
@@ -177,19 +174,16 @@ const FilterFormLogicOperatorInput = styled('div', {
 const FilterFormColumnInput = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FilterFormColumnInput',
-  overridesResolver: (_, styles) => styles.filterFormColumnInput,
 })<{ ownerState: OwnerState }>({ width: 150 });
 
 const FilterFormOperatorInput = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FilterFormOperatorInput',
-  overridesResolver: (_, styles) => styles.filterFormOperatorInput,
 })<{ ownerState: OwnerState }>({ width: 150 });
 
 const FilterFormValueInput = styled('div', {
   name: 'MuiDataGrid',
   slot: 'FilterFormValueInput',
-  overridesResolver: (_, styles) => styles.filterFormValueInput,
 })<{ ownerState: OwnerState }>({ width: 190 });
 
 const getLogicOperatorLocaleKey = (logicOperator: GridLogicOperator) => {

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarFilterButton.tsx
@@ -38,7 +38,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const GridToolbarFilterListRoot = styled('ul', {
   name: 'MuiDataGrid',
   slot: 'ToolbarFilterList',
-  overridesResolver: (_props, styles) => styles.toolbarFilterList,
 })<{ ownerState: OwnerState }>({
   margin: vars.spacing(1, 1, 0.5),
   padding: vars.spacing(0, 1),

--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
@@ -26,7 +26,6 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 const VirtualScrollerRenderZoneRoot = styled('div', {
   name: 'MuiDataGrid',
   slot: 'VirtualScrollerRenderZone',
-  overridesResolver: (props, styles) => styles.virtualScrollerRenderZone,
 })<{ ownerState: OwnerState }>({
   position: 'absolute',
   display: 'flex', // Prevents margin collapsing when using `getRowSpacing`

--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -79,7 +79,6 @@ type OwnerState = DataGridProcessedProps;
 export const GridColumnHeaderRow = styled('div', {
   name: 'MuiDataGrid',
   slot: 'ColumnHeaderRow',
-  overridesResolver: (_, styles) => styles.columnHeaderRow,
 })<{ ownerState: OwnerState }>({
   display: 'flex',
 });

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -63,7 +63,6 @@ const releaseInfo = '__RELEASE_INFO__';
 const DateRangeCalendarRoot = styled('div', {
   name: 'MuiDateRangeCalendar',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: DateRangeCalendarOwnerState }>({
   display: 'flex',
   flexDirection: 'row',
@@ -72,7 +71,7 @@ const DateRangeCalendarRoot = styled('div', {
 const DateRangeCalendarMonthContainer = styled('div', {
   name: 'MuiDateRangeCalendar',
   slot: 'Container',
-  overridesResolver: (_, styles) => styles.monthContainer,
+  overridesResolver: (_, styles) => styles.monthContainer, // FIXME: Inconsistent naming with slot
 })(({ theme }) => ({
   '&:not(:last-of-type)': {
     borderRight: `1px solid ${(theme.vars || theme).palette.divider}`,

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePickerToolbar.tsx
@@ -46,7 +46,6 @@ export interface ExportedDateRangePickerToolbarProps extends ExportedBaseToolbar
 const DateRangePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiDateRangePickerToolbar',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{
   ownerState: PickerToolbarOwnerState;
 }>({});
@@ -54,7 +53,6 @@ const DateRangePickerToolbarRoot = styled(PickersToolbar, {
 const DateRangePickerToolbarContainer = styled('div', {
   name: 'MuiDateRangePickerToolbar',
   slot: 'Container',
-  overridesResolver: (_, styles) => styles.container,
 })({
   display: 'flex',
 });

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTabs.tsx
@@ -79,7 +79,6 @@ const useUtilityClasses = (classes: Partial<DateTimeRangePickerTabsClasses> | un
 const DateTimeRangePickerTabsRoot = styled('div', {
   name: 'MuiDateTimeRangePickerTabs',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: PickerOwnerState }>(({ theme }) => ({
   display: 'flex',
   justifyContent: 'space-between',
@@ -91,7 +90,6 @@ const DateTimeRangePickerTabsRoot = styled('div', {
 const DateTimeRangePickerTab = styled(Button, {
   name: 'MuiDateTimeRangePickerTabs',
   slot: 'TabButton',
-  overridesResolver: (_, styles) => styles.tabButton,
 })({
   textTransform: 'none',
 });
@@ -99,7 +97,6 @@ const DateTimeRangePickerTab = styled(Button, {
 const DateTimeRangePickerTabFiller = styled('div', {
   name: 'MuiDateTimeRangePickerTabs',
   slot: 'Filler',
-  overridesResolver: (_, styles) => styles.filler,
 })({ width: 40 });
 
 const tabOptions: TabValue[] = ['start-date', 'start-time', 'end-date', 'end-time'];

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerToolbar.tsx
@@ -50,7 +50,6 @@ export interface ExportedDateTimeRangePickerToolbarProps extends ExportedBaseToo
 const DateTimeRangePickerToolbarRoot = styled('div', {
   name: 'MuiDateTimeRangePickerToolbar',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{
   ownerState: PickerToolbarOwnerState;
 }>({
@@ -61,7 +60,6 @@ const DateTimeRangePickerToolbarRoot = styled('div', {
 const DateTimeRangePickerToolbarStart = styled(DateTimePickerToolbar, {
   name: 'MuiDateTimeRangePickerToolbar',
   slot: 'StartToolbar',
-  overridesResolver: (_, styles) => styles.startToolbar,
 })<{ ownerState?: PickerToolbarOwnerState }>({
   borderBottom: 'none',
   paddingBottom: 0,
@@ -70,7 +68,6 @@ const DateTimeRangePickerToolbarStart = styled(DateTimePickerToolbar, {
 const DateTimeRangePickerToolbarEnd = styled(DateTimePickerToolbar, {
   name: 'MuiDateTimeRangePickerToolbar',
   slot: 'EndToolbar',
-  overridesResolver: (_, styles) => styles.endToolbar,
 })<{ ownerState?: PickerToolbarOwnerState }>({});
 
 type DateTimeRangePickerToolbarComponent = ((

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerTabs.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerTabs.tsx
@@ -47,7 +47,6 @@ const useUtilityClasses = (classes: Partial<TimeRangePickerTabsClasses> | undefi
 const TimeRangePickerTabsRoot = styled(Tabs, {
   name: 'MuiTimeRangePickerTabs',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })(({ theme }) => ({
   boxShadow: `0 -1px 0 0 inset ${(theme.vars || theme).palette.divider}`,
   '&:last-child': {
@@ -62,7 +61,6 @@ const TimeRangePickerTabsRoot = styled(Tabs, {
 const TimeRangePickerTab = styled(Tab, {
   name: 'MuiTimeRangePickerTabs',
   slot: 'Tab',
-  overridesResolver: (_, styles) => styles.tab,
 })(({ theme }) => ({
   minHeight: '48px',
   gap: theme.spacing(1),

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerToolbar.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerToolbar.tsx
@@ -62,7 +62,6 @@ export interface ExportedTimeRangePickerToolbarProps
 const TimeRangePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiTimeRangePickerToolbar',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: PickerToolbarOwnerState }>(({ theme }) => ({
   borderBottom: `1px solid ${(theme.vars || theme).palette.divider}`,
   padding: '12px 0px 8px 0px',
@@ -79,7 +78,6 @@ const TimeRangePickerToolbarContainer = styled('div', {
   name: 'MuiTimeRangePickerToolbar',
   slot: 'Container',
   shouldForwardProp: (prop) => prop !== 'pickerVariant',
-  overridesResolver: (_, styles) => styles.container,
 })<{ pickerVariant: PickerVariant }>({
   display: 'flex',
   flex: 1,
@@ -104,7 +102,6 @@ const TimeRangePickerToolbarContainer = styled('div', {
 const TimeRangePickerToolbarTimeContainer = styled('div', {
   name: 'MuiTimeRangePickerToolbar',
   slot: 'TimeContainer',
-  overridesResolver: (_, styles) => styles.timeContainer,
 })({
   display: 'flex',
   justifyContent: 'space-around',
@@ -114,7 +111,6 @@ const TimeRangePickerToolbarTimeContainer = styled('div', {
 const TimeRangePickerToolbarSeparator = styled(PickersToolbarText, {
   name: 'MuiTimeRangePickerToolbar',
   slot: 'Separator',
-  overridesResolver: (props, styles) => styles.separator,
 })({
   cursor: 'default',
 });

--- a/packages/x-date-pickers-pro/src/internals/utils/createMultiInputRangeField/createMultiInputRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/internals/utils/createMultiInputRangeField/createMultiInputRangeField.tsx
@@ -47,14 +47,12 @@ export function createMultiInputRangeField<TManager extends PickerAnyRangeManage
     {
       name,
       slot: 'Root',
-      overridesResolver: (props, styles) => styles.root,
     },
   )({});
 
   const MultiInputRangeFieldSeparator = styled(Typography, {
     name,
     slot: 'Separator',
-    overridesResolver: (props, styles) => styles.separator,
   })({
     lineHeight: '1.4375em', // 23px
   });

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -65,7 +65,6 @@ function useDateCalendarDefaultizedProps(
 const DateCalendarRoot = styled(PickerViewRoot, {
   name: 'MuiDateCalendar',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerOwnerState }>({
   display: 'flex',
   flexDirection: 'column',
@@ -75,7 +74,6 @@ const DateCalendarRoot = styled(PickerViewRoot, {
 const DateCalendarViewTransitionContainer = styled(PickersFadeTransitionGroup, {
   name: 'MuiDateCalendar',
   slot: 'ViewTransitionContainer',
-  overridesResolver: (props, styles) => styles.viewTransitionContainer,
 })<{ ownerState: PickerOwnerState }>({});
 
 type DateCalendarComponent = ((

--- a/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DayCalendar.tsx
@@ -136,13 +136,11 @@ const weeksContainerHeight = (DAY_SIZE + DAY_MARGIN * 2) * 6;
 const PickersCalendarDayRoot = styled('div', {
   name: 'MuiDayCalendar',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({});
 
 const PickersCalendarDayHeader = styled('div', {
   name: 'MuiDayCalendar',
   slot: 'Header',
-  overridesResolver: (_, styles) => styles.header,
 })({
   display: 'flex',
   justifyContent: 'center',
@@ -152,7 +150,6 @@ const PickersCalendarDayHeader = styled('div', {
 const PickersCalendarWeekDayLabel = styled(Typography, {
   name: 'MuiDayCalendar',
   slot: 'WeekDayLabel',
-  overridesResolver: (_, styles) => styles.weekDayLabel,
 })(({ theme }) => ({
   width: 36,
   height: 40,
@@ -167,7 +164,6 @@ const PickersCalendarWeekDayLabel = styled(Typography, {
 const PickersCalendarWeekNumberLabel = styled(Typography, {
   name: 'MuiDayCalendar',
   slot: 'WeekNumberLabel',
-  overridesResolver: (_, styles) => styles.weekNumberLabel,
 })(({ theme }) => ({
   width: 36,
   height: 40,
@@ -182,7 +178,6 @@ const PickersCalendarWeekNumberLabel = styled(Typography, {
 const PickersCalendarWeekNumber = styled(Typography, {
   name: 'MuiDayCalendar',
   slot: 'WeekNumber',
-  overridesResolver: (_, styles) => styles.weekNumber,
 })(({ theme }) => ({
   ...theme.typography.caption,
   width: DAY_SIZE,
@@ -199,7 +194,6 @@ const PickersCalendarWeekNumber = styled(Typography, {
 const PickersCalendarLoadingContainer = styled('div', {
   name: 'MuiDayCalendar',
   slot: 'LoadingContainer',
-  overridesResolver: (_, styles) => styles.loadingContainer,
 })({
   display: 'flex',
   justifyContent: 'center',
@@ -210,7 +204,6 @@ const PickersCalendarLoadingContainer = styled('div', {
 const PickersCalendarSlideTransition = styled(PickersSlideTransition, {
   name: 'MuiDayCalendar',
   slot: 'SlideTransition',
-  overridesResolver: (_, styles) => styles.slideTransition,
 })({
   minHeight: weeksContainerHeight,
 });
@@ -218,13 +211,11 @@ const PickersCalendarSlideTransition = styled(PickersSlideTransition, {
 const PickersCalendarWeekContainer = styled('div', {
   name: 'MuiDayCalendar',
   slot: 'MonthContainer',
-  overridesResolver: (_, styles) => styles.monthContainer,
 })({ overflow: 'hidden' });
 
 const PickersCalendarWeek = styled('div', {
   name: 'MuiDayCalendar',
   slot: 'WeekContainer',
-  overridesResolver: (_, styles) => styles.weekContainer,
 })({
   margin: `${DAY_MARGIN}px 0`,
   display: 'flex',

--- a/packages/x-date-pickers/src/DateCalendar/PickersFadeTransitionGroup.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/PickersFadeTransitionGroup.tsx
@@ -31,7 +31,6 @@ const useUtilityClasses = (classes: Partial<PickersFadeTransitionGroupClasses> |
 const PickersFadeTransitionGroupRoot = styled(TransitionGroup, {
   name: 'MuiPickersFadeTransitionGroup',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({
   display: 'block',
   position: 'relative',

--- a/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DatePicker/DatePickerToolbar.tsx
@@ -43,13 +43,11 @@ const useUtilityClasses = (classes: Partial<DatePickerToolbarClasses> | undefine
 const DatePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiDatePickerToolbar',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({});
 
 const DatePickerToolbarTitle = styled(Typography, {
   name: 'MuiDatePickerToolbar',
   slot: 'Title',
-  overridesResolver: (_, styles) => styles.title,
 })<{ ownerState: PickerToolbarOwnerState }>({
   variants: [
     {

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerTabs.tsx
@@ -72,7 +72,6 @@ const useUtilityClasses = (classes: Partial<DateTimePickerTabsClasses> | undefin
 const DateTimePickerTabsRoot = styled(Tabs, {
   name: 'MuiDateTimePickerTabs',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: PickerOwnerState }>(({ theme }) => ({
   boxShadow: `0 -1px 0 0 inset ${(theme.vars || theme).palette.divider}`,
   '&:last-child': {

--- a/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/DateTimePicker/DateTimePickerToolbar.tsx
@@ -70,7 +70,6 @@ const useUtilityClasses = (
 const DateTimePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiDateTimePickerToolbar',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'toolbarVariant',
 })<{ ownerState: PickerToolbarOwnerState; toolbarVariant: PickerVariant }>(({ theme }) => ({
   paddingLeft: 16,
@@ -107,7 +106,6 @@ const DateTimePickerToolbarRoot = styled(PickersToolbar, {
 const DateTimePickerToolbarDateContainer = styled('div', {
   name: 'MuiDateTimePickerToolbar',
   slot: 'DateContainer',
-  overridesResolver: (props, styles) => styles.dateContainer,
 })<{ ownerState: PickerToolbarOwnerState }>({
   display: 'flex',
   flexDirection: 'column',
@@ -117,7 +115,6 @@ const DateTimePickerToolbarDateContainer = styled('div', {
 const DateTimePickerToolbarTimeContainer = styled('div', {
   name: 'MuiDateTimePickerToolbar',
   slot: 'TimeContainer',
-  overridesResolver: (props, styles) => styles.timeContainer,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'toolbarVariant',
 })<{ ownerState: PickerToolbarOwnerState; toolbarVariant: PickerVariant }>({
   display: 'flex',
@@ -166,7 +163,6 @@ const DateTimePickerToolbarTimeContainer = styled('div', {
 const DateTimePickerToolbarTimeDigitsContainer = styled('div', {
   name: 'MuiDateTimePickerToolbar',
   slot: 'TimeDigitsContainer',
-  overridesResolver: (props, styles) => styles.timeDigitsContainer,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'toolbarVariant',
 })<{ ownerState: PickerToolbarOwnerState; toolbarVariant: PickerVariant }>({
   display: 'flex',
@@ -187,7 +183,6 @@ const DateTimePickerToolbarTimeDigitsContainer = styled('div', {
 const DateTimePickerToolbarSeparator = styled(PickersToolbarText, {
   name: 'MuiDateTimePickerToolbar',
   slot: 'Separator',
-  overridesResolver: (props, styles) => styles.separator,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'toolbarVariant',
 })<{ ownerState: PickerToolbarOwnerState; toolbarVariant: PickerVariant }>({
   margin: '0 4px 0 2px',

--- a/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
+++ b/packages/x-date-pickers/src/DayCalendarSkeleton/DayCalendarSkeleton.tsx
@@ -39,7 +39,6 @@ const useUtilityClasses = (classes: Partial<DayCalendarSkeletonClasses> | undefi
 const DayCalendarSkeletonRoot = styled('div', {
   name: 'MuiDayCalendarSkeleton',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })({
   alignSelf: 'start',
 });
@@ -47,7 +46,6 @@ const DayCalendarSkeletonRoot = styled('div', {
 const DayCalendarSkeletonWeek = styled('div', {
   name: 'MuiDayCalendarSkeleton',
   slot: 'Week',
-  overridesResolver: (props, styles) => styles.week,
 })({
   margin: `${DAY_MARGIN}px 0`,
   display: 'flex',
@@ -57,7 +55,6 @@ const DayCalendarSkeletonWeek = styled('div', {
 const DayCalendarSkeletonDay = styled(Skeleton, {
   name: 'MuiDayCalendarSkeleton',
   slot: 'DaySkeleton',
-  overridesResolver: (props, styles) => styles.daySkeleton,
 })({
   margin: `0 ${DAY_MARGIN}px`,
   '&[data-day-in-month="0"]': {

--- a/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
+++ b/packages/x-date-pickers/src/DigitalClock/DigitalClock.tsx
@@ -37,7 +37,6 @@ const useUtilityClasses = (classes: Partial<DigitalClockClasses> | undefined) =>
 const DigitalClockRoot = styled(PickerViewRoot, {
   name: 'MuiDigitalClock',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: DigitalClockOwnerState }>({
   overflowY: 'auto',
   width: '100%',
@@ -61,7 +60,6 @@ const DigitalClockRoot = styled(PickerViewRoot, {
 const DigitalClockList = styled(MenuList, {
   name: 'MuiDigitalClock',
   slot: 'List',
-  overridesResolver: (props, styles) => styles.list,
 })({
   padding: 0,
 });
@@ -70,7 +68,6 @@ export const DigitalClockItem = styled(MenuItem, {
   name: 'MuiDigitalClock',
   slot: 'Item',
   shouldForwardProp: (prop) => prop !== 'itemValue' && prop !== 'formattedValue',
-  overridesResolver: (props, styles) => styles.item,
 })(({ theme }) => ({
   padding: '8px 16px',
   margin: '2px 4px',

--- a/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
+++ b/packages/x-date-pickers/src/MonthCalendar/MonthCalendar.tsx
@@ -52,7 +52,6 @@ export function useMonthCalendarDefaultizedProps(
 const MonthCalendarRoot = styled('div', {
   name: 'MuiMonthCalendar',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'monthsPerRow',
 })<{ ownerState: PickerOwnerState; monthsPerRow: 3 | 4 }>({
   display: 'flex',

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClock.tsx
@@ -42,7 +42,6 @@ const useUtilityClasses = (classes: Partial<MultiSectionDigitalClockClasses> | u
 const MultiSectionDigitalClockRoot = styled(PickerViewRoot, {
   name: 'MuiMultiSectionDigitalClock',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: PickerOwnerState }>(({ theme }) => ({
   flexDirection: 'row',
   width: '100%',

--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -62,7 +62,6 @@ const useUtilityClasses = (classes: Partial<MultiSectionDigitalClockClasses> | u
 const MultiSectionDigitalClockSectionRoot = styled(MenuList, {
   name: 'MuiMultiSectionDigitalClockSection',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{ ownerState: MultiSectionDigitalClockSectionOwnerState }>(({ theme }) => ({
   maxHeight: DIGITAL_CLOCK_VIEW_HEIGHT,
   width: 56,
@@ -104,7 +103,6 @@ const MultiSectionDigitalClockSectionRoot = styled(MenuList, {
 const MultiSectionDigitalClockSectionItem = styled(MenuItem, {
   name: 'MuiMultiSectionDigitalClockSection',
   slot: 'Item',
-  overridesResolver: (_, styles) => styles.item,
 })(({ theme }) => ({
   padding: 8,
   margin: '2px 4px',

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -29,7 +29,6 @@ export interface PickersActionBarProps extends DialogActionsProps {
 const PickersActionBarRoot = styled(DialogActions, {
   name: 'MuiPickersLayout',
   slot: 'ActionBar',
-  overridesResolver: (_, styles) => styles.actionBar,
 })({});
 
 /**

--- a/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
+++ b/packages/x-date-pickers/src/PickersCalendarHeader/PickersCalendarHeader.tsx
@@ -40,7 +40,6 @@ const useUtilityClasses = (classes: Partial<PickersCalendarHeaderClasses> | unde
 const PickersCalendarHeaderRoot = styled('div', {
   name: 'MuiPickersCalendarHeader',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{
   ownerState: PickerOwnerState;
 }>({
@@ -58,7 +57,6 @@ const PickersCalendarHeaderRoot = styled('div', {
 const PickersCalendarHeaderLabelContainer = styled('div', {
   name: 'MuiPickersCalendarHeader',
   slot: 'LabelContainer',
-  overridesResolver: (_, styles) => styles.labelContainer,
 })<{
   ownerState: PickerOwnerState;
 }>(({ theme }) => ({
@@ -74,7 +72,6 @@ const PickersCalendarHeaderLabelContainer = styled('div', {
 const PickersCalendarHeaderLabel = styled('div', {
   name: 'MuiPickersCalendarHeader',
   slot: 'Label',
-  overridesResolver: (_, styles) => styles.label,
 })<{
   ownerState: PickerOwnerState;
 }>({
@@ -84,7 +81,6 @@ const PickersCalendarHeaderLabel = styled('div', {
 const PickersCalendarHeaderSwitchViewButton = styled(IconButton, {
   name: 'MuiPickersCalendarHeader',
   slot: 'SwitchViewButton',
-  overridesResolver: (_, styles) => styles.switchViewButton,
 })<{
   ownerState: PickerOwnerState;
 }>({
@@ -104,7 +100,6 @@ const PickersCalendarHeaderSwitchViewButton = styled(IconButton, {
 const PickersCalendarHeaderSwitchViewIcon = styled(ArrowDropDownIcon, {
   name: 'MuiPickersCalendarHeader',
   slot: 'SwitchViewIcon',
-  overridesResolver: (_, styles) => styles.switchViewIcon,
 })<{
   ownerState: PickerOwnerState;
 }>(({ theme }) => ({

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -30,7 +30,6 @@ const useUtilityClasses = (
 export const PickersLayoutRoot = styled('div', {
   name: 'MuiPickersLayout',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerLayoutOwnerState }>({
   display: 'grid',
   gridAutoColumns: 'max-content auto max-content',
@@ -79,7 +78,6 @@ export const PickersLayoutRoot = styled('div', {
 export const PickersLayoutContentWrapper = styled('div', {
   name: 'MuiPickersLayout',
   slot: 'ContentWrapper',
-  overridesResolver: (props, styles) => styles.contentWrapper,
 })<{ ownerState: PickerLayoutOwnerState }>({
   gridColumn: '2 / 4',
   gridRow: 2,

--- a/packages/x-date-pickers/src/PickersSectionList/PickersSectionList.tsx
+++ b/packages/x-date-pickers/src/PickersSectionList/PickersSectionList.tsx
@@ -16,7 +16,6 @@ import { usePickerPrivateContext } from '../internals/hooks/usePickerPrivateCont
 export const PickersSectionListRoot = styled('div', {
   name: 'MuiPickersSectionList',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })({
   direction: 'ltr /*! @noflip */' as any,
   outline: 'none',
@@ -25,13 +24,11 @@ export const PickersSectionListRoot = styled('div', {
 export const PickersSectionListSection = styled('span', {
   name: 'MuiPickersSectionList',
   slot: 'Section',
-  overridesResolver: (props, styles) => styles.section,
 })({});
 
 export const PickersSectionListSectionSeparator = styled('span', {
   name: 'MuiPickersSectionList',
   slot: 'SectionSeparator',
-  overridesResolver: (props, styles) => styles.sectionSeparator,
 })({
   whiteSpace: 'pre',
 });
@@ -39,7 +36,6 @@ export const PickersSectionListSectionSeparator = styled('span', {
 export const PickersSectionListSectionContent = styled('span', {
   name: 'MuiPickersSectionList',
   slot: 'SectionContent',
-  overridesResolver: (props, styles) => styles.sectionContent,
 })({
   outline: 'none',
 });

--- a/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
+++ b/packages/x-date-pickers/src/PickersShortcuts/PickersShortcuts.tsx
@@ -49,7 +49,6 @@ export interface PickersShortcutsProps<TValue extends PickerValidValue>
 const PickersShortcutsRoot = styled(List, {
   name: 'MuiPickersLayout',
   slot: 'Shortcuts',
-  overridesResolver: (_, styles) => styles.shortcuts,
 })({});
 
 /**

--- a/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
@@ -32,7 +32,6 @@ export interface PickerFilledInputOwnerState extends PickerTextFieldOwnerState {
 const PickersFilledInputRoot = styled(PickersInputBaseRoot, {
   name: 'MuiPickersFilledInput',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'disableUnderline',
 })<{ ownerState: PickerFilledInputOwnerState }>(({ theme }) => {
   const light = theme.palette.mode === 'light';
@@ -147,7 +146,6 @@ const PickersFilledInputRoot = styled(PickersInputBaseRoot, {
 const PickersFilledSectionsContainer = styled(PickersInputBaseSectionsContainer, {
   name: 'MuiPickersFilledInput',
   slot: 'sectionsContainer',
-  overridesResolver: (props, styles) => styles.sectionsContainer,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'hiddenLabel',
 })<{ ownerState: PickerFilledInputOwnerState }>({
   paddingTop: 25,

--- a/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
@@ -28,7 +28,6 @@ interface PickerInputOwnerState extends PickerTextFieldOwnerState {
 const PickersInputRoot = styled(PickersInputBaseRoot, {
   name: 'MuiPickersInput',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'disableUnderline',
 })<{ ownerState: PickerInputOwnerState }>(({ theme }) => {
   const light = theme.palette.mode === 'light';

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -31,7 +31,6 @@ const round = (value: number) => Math.round(value * 1e5) / 1e5;
 export const PickersInputBaseRoot = styled('div', {
   name: 'MuiPickersInputBase',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerTextFieldOwnerState }>(({ theme }) => ({
   ...theme.typography.body1,
   color: (theme.vars || theme).palette.text.primary,
@@ -54,7 +53,6 @@ export const PickersInputBaseRoot = styled('div', {
 export const PickersInputBaseSectionsContainer = styled(PickersSectionListRoot, {
   name: 'MuiPickersInputBase',
   slot: 'SectionsContainer',
-  overridesResolver: (props, styles) => styles.sectionsContainer,
 })<{ ownerState: PickerTextFieldOwnerState }>(({ theme }) => ({
   padding: '4px 0 5px',
   fontFamily: theme.typography.fontFamily,
@@ -109,7 +107,6 @@ export const PickersInputBaseSectionsContainer = styled(PickersSectionListRoot, 
 const PickersInputBaseSection = styled(PickersSectionListSection, {
   name: 'MuiPickersInputBase',
   slot: 'Section',
-  overridesResolver: (props, styles) => styles.section,
 })(({ theme }) => ({
   fontFamily: theme.typography.fontFamily,
   fontSize: 'inherit',
@@ -122,7 +119,7 @@ const PickersInputBaseSection = styled(PickersSectionListSection, {
 const PickersInputBaseSectionContent = styled(PickersSectionListSectionContent, {
   name: 'MuiPickersInputBase',
   slot: 'SectionContent',
-  overridesResolver: (props, styles) => styles.content,
+  overridesResolver: (props, styles) => styles.content, // FIXME: Inconsistent naming with slot
 })(({ theme }) => ({
   fontFamily: theme.typography.fontFamily,
   lineHeight: '1.4375em', // 23px
@@ -134,7 +131,6 @@ const PickersInputBaseSectionContent = styled(PickersSectionListSectionContent, 
 const PickersInputBaseSectionSeparator = styled(PickersSectionListSectionSeparator, {
   name: 'MuiPickersInputBase',
   slot: 'Separator',
-  overridesResolver: (props, styles) => styles.separator,
 })(() => ({
   whiteSpace: 'pre',
   letterSpacing: 'inherit',
@@ -143,7 +139,7 @@ const PickersInputBaseSectionSeparator = styled(PickersSectionListSectionSeparat
 const PickersInputBaseInput = styled('input', {
   name: 'MuiPickersInputBase',
   slot: 'Input',
-  overridesResolver: (props, styles) => styles.hiddenInput,
+  overridesResolver: (props, styles) => styles.hiddenInput, // FIXME: Inconsistent naming with slot
 })({
   ...visuallyHidden,
 });
@@ -151,7 +147,6 @@ const PickersInputBaseInput = styled('input', {
 const PickersInputBaseActiveBar = styled('div', {
   name: 'MuiPickersInputBase',
   slot: 'ActiveBar',
-  overridesResolver: (props, styles) => styles.activeBar,
 })<{ ownerState: { sectionOffsets: number[] } }>(({ theme, ownerState }) => ({
   display: 'none',
   position: 'absolute',

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/Outline.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/Outline.tsx
@@ -13,7 +13,6 @@ interface OutlineProps extends React.HTMLAttributes<HTMLFieldSetElement> {
 const OutlineRoot = styled('fieldset', {
   name: 'MuiPickersOutlinedInput',
   slot: 'NotchedOutline',
-  overridesResolver: (props, styles) => styles.notchedOutline,
 })<{ ownerState: PickerTextFieldOwnerState }>(({ theme }) => {
   const borderColor =
     theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
@@ -24,7 +24,6 @@ export interface PickersOutlinedInputProps extends PickersInputBaseProps {
 const PickersOutlinedInputRoot = styled(PickersInputBaseRoot, {
   name: 'MuiPickersOutlinedInput',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerTextFieldOwnerState }>(({ theme }) => {
   const borderColor =
     theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
@@ -76,7 +75,6 @@ const PickersOutlinedInputRoot = styled(PickersInputBaseRoot, {
 const PickersOutlinedInputSectionsContainer = styled(PickersInputBaseSectionsContainer, {
   name: 'MuiPickersOutlinedInput',
   slot: 'SectionsContainer',
-  overridesResolver: (props, styles) => styles.sectionsContainer,
 })<{ ownerState: PickerTextFieldOwnerState }>({
   padding: '16.5px 0',
   variants: [

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
@@ -30,7 +30,6 @@ const VARIANT_COMPONENT = {
 const PickersTextFieldRoot = styled(FormControl, {
   name: 'MuiPickersTextField',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerTextFieldOwnerState }>({});
 
 const useUtilityClasses = (

--- a/packages/x-date-pickers/src/TimeClock/Clock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/Clock.tsx
@@ -82,7 +82,6 @@ const useUtilityClasses = (
 const ClockRoot = styled('div', {
   name: 'MuiClock',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })(({ theme }) => ({
   display: 'flex',
   justifyContent: 'center',
@@ -93,7 +92,6 @@ const ClockRoot = styled('div', {
 const ClockClock = styled('div', {
   name: 'MuiClock',
   slot: 'Clock',
-  overridesResolver: (_, styles) => styles.clock,
 })({
   backgroundColor: 'rgba(0,0,0,.07)',
   borderRadius: '50%',
@@ -107,7 +105,6 @@ const ClockClock = styled('div', {
 const ClockWrapper = styled('div', {
   name: 'MuiClock',
   slot: 'Wrapper',
-  overridesResolver: (_, styles) => styles.wrapper,
 })({
   '&:focus': {
     outline: 'none',
@@ -117,7 +114,6 @@ const ClockWrapper = styled('div', {
 const ClockSquareMask = styled('div', {
   name: 'MuiClock',
   slot: 'SquareMask',
-  overridesResolver: (_, styles) => styles.squareMask,
 })<{ ownerState: ClockOwnerState }>({
   width: '100%',
   height: '100%',
@@ -146,7 +142,6 @@ const ClockSquareMask = styled('div', {
 const ClockPin = styled('div', {
   name: 'MuiClock',
   slot: 'Pin',
-  overridesResolver: (_, styles) => styles.pin,
 })(({ theme }) => ({
   width: 6,
   height: 6,
@@ -184,7 +179,6 @@ const meridiemButtonCommonStyles = (
 const ClockAmButton = styled(IconButton, {
   name: 'MuiClock',
   slot: 'AmButton',
-  overridesResolver: (_, styles) => styles.amButton,
 })<{ ownerState: ClockOwnerState }>(({ theme }) => ({
   ...meridiemButtonCommonStyles(theme, 'am'),
   // keeping it here to make TS happy
@@ -195,7 +189,6 @@ const ClockAmButton = styled(IconButton, {
 const ClockPmButton = styled(IconButton, {
   name: 'MuiClock',
   slot: 'PmButton',
-  overridesResolver: (_, styles) => styles.pmButton,
 })<{ ownerState: ClockOwnerState }>(({ theme }) => ({
   ...meridiemButtonCommonStyles(theme, 'pm'),
   // keeping it here to make TS happy
@@ -205,8 +198,7 @@ const ClockPmButton = styled(IconButton, {
 
 const ClockMeridiemText = styled(Typography, {
   name: 'MuiClock',
-  slot: 'meridiemText',
-  overridesResolver: (_, styles) => styles.meridiemText,
+  slot: 'MeridiemText',
 })({
   overflow: 'hidden',
   whiteSpace: 'nowrap',

--- a/packages/x-date-pickers/src/TimeClock/ClockPointer.tsx
+++ b/packages/x-date-pickers/src/TimeClock/ClockPointer.tsx
@@ -46,7 +46,6 @@ const useUtilityClasses = (classes: Partial<ClockPointerClasses> | undefined) =>
 const ClockPointerRoot = styled('div', {
   name: 'MuiClockPointer',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })<{
   ownerState: ClockPointerOwnerState;
 }>(({ theme }) => ({
@@ -69,7 +68,6 @@ const ClockPointerRoot = styled('div', {
 const ClockPointerThumb = styled('div', {
   name: 'MuiClockPointer',
   slot: 'Thumb',
-  overridesResolver: (_, styles) => styles.thumb,
 })<{
   ownerState: ClockPointerOwnerState;
 }>(({ theme }) => ({

--- a/packages/x-date-pickers/src/TimeClock/TimeClock.tsx
+++ b/packages/x-date-pickers/src/TimeClock/TimeClock.tsx
@@ -34,7 +34,6 @@ const useUtilityClasses = (classes: Partial<TimeClockClasses> | undefined) => {
 const TimeClockRoot = styled(PickerViewRoot, {
   name: 'MuiTimeClock',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerOwnerState }>({
   display: 'flex',
   flexDirection: 'column',
@@ -44,7 +43,6 @@ const TimeClockRoot = styled(PickerViewRoot, {
 const TimeClockArrowSwitcher = styled(PickersArrowSwitcher, {
   name: 'MuiTimeClock',
   slot: 'ArrowSwitcher',
-  overridesResolver: (props, styles) => styles.arrowSwitcher,
 })<{ ownerState: PickerOwnerState }>({
   position: 'absolute',
   right: 12,

--- a/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
+++ b/packages/x-date-pickers/src/TimePicker/TimePickerToolbar.tsx
@@ -62,7 +62,6 @@ const useUtilityClasses = (
 const TimePickerToolbarRoot = styled(PickersToolbar, {
   name: 'MuiTimePickerToolbar',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{
   ownerState: PickerToolbarOwnerState;
 }>({});
@@ -70,7 +69,6 @@ const TimePickerToolbarRoot = styled(PickersToolbar, {
 const TimePickerToolbarSeparator = styled(PickersToolbarText, {
   name: 'MuiTimePickerToolbar',
   slot: 'Separator',
-  overridesResolver: (props, styles) => styles.separator,
 })({
   outline: 0,
   margin: '0 4px 0 2px',

--- a/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
@@ -102,7 +102,6 @@ const useUtilityClasses = (classes: Partial<PickerPopperClasses> | undefined) =>
 const PickerPopperRoot = styled(MuiPopper, {
   name: 'MuiPickerPopper',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })(({ theme }) => ({
   zIndex: theme.zIndex.modal,
 }));
@@ -110,7 +109,6 @@ const PickerPopperRoot = styled(MuiPopper, {
 const PickerPopperPaper = styled(MuiPaper, {
   name: 'MuiPickerPopper',
   slot: 'Paper',
-  overridesResolver: (_, styles) => styles.paper,
 })<{
   ownerState: PickerPopperOwnerState;
 }>({

--- a/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersArrowSwitcher/PickersArrowSwitcher.tsx
@@ -18,7 +18,6 @@ import { PickerOwnerState } from '../../../models';
 const PickersArrowSwitcherRoot = styled('div', {
   name: 'MuiPickersArrowSwitcher',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{
   ownerState: PickerOwnerState;
 }>({
@@ -28,7 +27,6 @@ const PickersArrowSwitcherRoot = styled('div', {
 const PickersArrowSwitcherSpacer = styled('div', {
   name: 'MuiPickersArrowSwitcher',
   slot: 'Spacer',
-  overridesResolver: (props, styles) => styles.spacer,
 })<{
   ownerState: PickerOwnerState;
 }>(({ theme }) => ({
@@ -38,7 +36,6 @@ const PickersArrowSwitcherSpacer = styled('div', {
 const PickersArrowSwitcherButton = styled(IconButton, {
   name: 'MuiPickersArrowSwitcher',
   slot: 'Button',
-  overridesResolver: (props, styles) => styles.button,
 })<{
   ownerState: PickerOwnerState;
 }>({

--- a/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbar.tsx
@@ -28,7 +28,6 @@ const useUtilityClasses = (classes: Partial<PickersToolbarClasses> | undefined) 
 const PickersToolbarRoot = styled('div', {
   name: 'MuiPickersToolbar',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: PickerToolbarOwnerState }>(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
@@ -52,7 +51,6 @@ const PickersToolbarRoot = styled('div', {
 const PickersToolbarContent = styled('div', {
   name: 'MuiPickersToolbar',
   slot: 'Content',
-  overridesResolver: (props, styles) => styles.content,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'landscapeDirection',
 })<{
   ownerState: PickerToolbarOwnerState;

--- a/packages/x-date-pickers/src/internals/components/PickersToolbarButton.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbarButton.tsx
@@ -30,7 +30,6 @@ const useUtilityClasses = (classes: Partial<PickersToolbarButtonClasses> | undef
 const PickersToolbarButtonRoot = styled(Button, {
   name: 'MuiPickersToolbarButton',
   slot: 'Root',
-  overridesResolver: (_, styles) => styles.root,
 })({
   padding: 0,
   minWidth: 16,

--- a/packages/x-date-pickers/src/internals/components/PickersToolbarText.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersToolbarText.tsx
@@ -31,7 +31,6 @@ const useUtilityClasses = (classes: Partial<PickersToolbarTextClasses> | undefin
 const PickersToolbarTextRoot = styled(Typography, {
   name: 'MuiPickersToolbarText',
   slot: 'Root',
-  overridesResolver: (_, styles) => [styles.root],
 })<{
   component?: React.ElementType;
 }>(({ theme }) => ({

--- a/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
+++ b/packages/x-tree-view-pro/src/RichTreeViewPro/RichTreeViewPro.tsx
@@ -42,7 +42,6 @@ const useUtilityClasses = <R extends {}, Multiple extends boolean | undefined>(
 export const RichTreeViewProRoot = styled('ul', {
   name: 'MuiRichTreeViewPro',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: RichTreeViewProProps<any, any> }>({
   padding: 0,
   margin: 0,

--- a/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
+++ b/packages/x-tree-view/src/RichTreeView/RichTreeView.tsx
@@ -47,7 +47,6 @@ const useUtilityClasses = <R extends {}, Multiple extends boolean | undefined>(
 export const RichTreeViewRoot = styled('ul', {
   name: 'MuiRichTreeView',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })({
   padding: 0,
   margin: 0,

--- a/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
+++ b/packages/x-tree-view/src/SimpleTreeView/SimpleTreeView.tsx
@@ -39,7 +39,6 @@ const useUtilityClasses = <Multiple extends boolean | undefined>(
 export const SimpleTreeViewRoot = styled('ul', {
   name: 'MuiSimpleTreeView',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: SimpleTreeViewProps<any> }>({
   padding: 0,
   margin: 0,

--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -25,7 +25,6 @@ const useThemeProps = createUseThemeProps('MuiTreeItem');
 export const TreeItemRoot = styled('li', {
   name: 'MuiTreeItem',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
 })({
   listStyle: 'none',
   margin: 0,
@@ -36,7 +35,6 @@ export const TreeItemRoot = styled('li', {
 export const TreeItemContent = styled('div', {
   name: 'MuiTreeItem',
   slot: 'Content',
-  overridesResolver: (props, styles) => styles.content,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'status',
 })<{ status: UseTreeItemStatus }>(({ theme }) => ({
   padding: theme.spacing(0.5, 1),
@@ -96,7 +94,6 @@ export const TreeItemContent = styled('div', {
 export const TreeItemLabel = styled('div', {
   name: 'MuiTreeItem',
   slot: 'Label',
-  overridesResolver: (props, styles) => styles.label,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'editable',
 })<{ editable?: boolean }>(({ theme }) => ({
   width: '100%',
@@ -119,7 +116,6 @@ export const TreeItemLabel = styled('div', {
 export const TreeItemIconContainer = styled('div', {
   name: 'MuiTreeItem',
   slot: 'IconContainer',
-  overridesResolver: (props, styles) => styles.iconContainer,
 })({
   width: 16,
   display: 'flex',
@@ -143,7 +139,6 @@ export const TreeItemGroupTransition = styled(Collapse, {
 export const TreeItemErrorContainer = styled('div', {
   name: 'MuiTreeItem',
   slot: 'ErrorIcon',
-  overridesResolver: (props, styles) => styles.errorIcon,
 })({
   position: 'absolute',
   right: -3,
@@ -156,7 +151,6 @@ export const TreeItemErrorContainer = styled('div', {
 export const TreeItemLoadingContainer = styled(CircularProgress, {
   name: 'MuiTreeItem',
   slot: 'LoadingIcon',
-  overridesResolver: (props, styles) => styles.loadingIcon,
 })({
   color: 'text.primary',
 });
@@ -175,7 +169,6 @@ export const TreeItemCheckbox = styled(
   {
     name: 'MuiTreeItem',
     slot: 'Checkbox',
-    overridesResolver: (props, styles) => styles.checkbox,
   },
 )({
   padding: 0,

--- a/packages/x-tree-view/src/TreeItemDragAndDropOverlay/TreeItemDragAndDropOverlay.tsx
+++ b/packages/x-tree-view/src/TreeItemDragAndDropOverlay/TreeItemDragAndDropOverlay.tsx
@@ -10,7 +10,6 @@ import { styled } from '../internals/zero-styled';
 const TreeItemDragAndDropOverlayRoot = styled('div', {
   name: 'MuiTreeItemDragAndDropOverlay',
   slot: 'Root',
-  overridesResolver: (props, styles) => styles.root,
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'action',
 })<{ action?: TreeViewItemsReorderingAction | null }>(({ theme }) => ({
   position: 'absolute',

--- a/packages/x-tree-view/src/TreeItemLabelInput/TreeItemLabelInput.tsx
+++ b/packages/x-tree-view/src/TreeItemLabelInput/TreeItemLabelInput.tsx
@@ -6,7 +6,6 @@ import { styled } from '../internals/zero-styled';
 const TreeItemLabelInput = styled('input', {
   name: 'MuiTreeItem',
   slot: 'LabelInput',
-  overridesResolver: (props, styles) => styles.labelInput,
 })(({ theme }) => ({
   ...theme.typography.body1,
   width: '100%',


### PR DESCRIPTION
These overrides resolvers are redundant.

Note for the charts, pickers & tree-view: I have added a `FIXME` comment for all the places where the name of the slot doesn't match the name of the overrides resolver, e.g. `slot: 'container', overridesResolver: styles => styles.monthContainer`. I wasn't sure if the name of the slot or the name of the resolver should be updated.