### PR TITLE
[core] Remove `react-is` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -86,7 +86,6 @@
     "react-docgen": "^5.4.3",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.55.0",
-    "react-is": "^19.0.0",
     "react-router": "^7.5.0",
     "react-runner": "^1.0.5",
     "react-simple-code-editor": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -194,9 +194,6 @@
     "webpack-cli": "^6.0.1",
     "yargs": "^17.7.2"
   },
-  "resolutions": {
-    "react-is": "^19.0.0"
-  },
   "packageManager": "pnpm@10.8.0",
   "engines": {
     "pnpm": "10.8.0"

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "webpack-cli": "^6.0.1",
     "yargs": "^17.7.2"
   },
+  "resolutions": {},
   "packageManager": "pnpm@10.8.0",
   "engines": {
     "pnpm": "10.8.0"

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -45,7 +45,6 @@
     "bezier-easing": "^2.1.0",
     "clsx": "^2.1.1",
     "prop-types": "^15.8.1",
-    "react-is": "^18.3.1 || ^19.0.0",
     "reselect": "^5.1.1",
     "use-sync-external-store": "^1.5.0"
   },
@@ -70,7 +69,6 @@
     "@mui/material": "^7.0.2",
     "@mui/system": "^7.0.2",
     "@types/prop-types": "^15.7.14",
-    "@types/react-is": "^19.0.0",
     "@types/use-sync-external-store": "^1.5.0",
     "csstype": "^3.1.3",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  react-is: ^19.0.0
-
 patchedDependencies:
   babel-plugin-replace-imports@1.0.2:
     hash: 779d8690d607924781aaf4f896bfbd209a78755ddd5b9ebbea5ebce3b2919ba0
@@ -755,9 +752,6 @@ importers:
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
-      react-is:
-        specifier: ^19.0.0
-        version: 19.1.0
       reselect:
         specifier: ^5.1.1
         version: 5.1.1
@@ -777,9 +771,6 @@ importers:
       '@types/prop-types':
         specifier: ^15.7.14
         version: 15.7.14
-      '@types/react-is':
-        specifier: ^19.0.0
-        version: 19.0.0
       '@types/use-sync-external-store':
         specifier: ^1.5.0
         version: 1.5.0
@@ -4449,9 +4440,6 @@ packages:
     resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
     peerDependencies:
       '@types/react': ^19.0.0
-
-  '@types/react-is@19.0.0':
-    resolution: {integrity: sha512-71dSZeeJ0t3aoPyY9x6i+JNSvg5m9EF2i2OlSZI5QoJuI8Ocgor610i+4A10TQmURR+0vLwcVCEYFpXdzM1Biw==}
 
   '@types/react-router@5.1.20':
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
@@ -9180,6 +9168,15 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
 
@@ -13680,10 +13677,6 @@ snapshots:
     dependencies:
       '@types/react': 19.0.12
 
-  '@types/react-is@19.0.0':
-    dependencies:
-      '@types/react': 19.0.12
-
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
@@ -16719,7 +16712,7 @@ snapshots:
 
   hoist-non-react-statics@3.3.2:
     dependencies:
-      react-is: 19.1.0
+      react-is: 16.13.1
 
   homedir-polyfill@1.0.3:
     dependencies:
@@ -19208,13 +19201,13 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
-      react-is: 19.1.0
+      react-is: 17.0.2
 
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
-      react-is: 19.1.0
+      react-is: 18.3.1
 
   pretty-ms@9.2.0:
     dependencies:
@@ -19269,7 +19262,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 19.1.0
+      react-is: 16.13.1
 
   protocols@2.0.2: {}
 
@@ -19362,6 +19355,12 @@ snapshots:
   react-hook-form@7.55.0(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-is@19.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,9 +607,6 @@ importers:
       react-hook-form:
         specifier: ^7.55.0
         version: 7.55.0(react@19.0.0)
-      react-is:
-        specifier: ^19.0.0
-        version: 19.1.0
       react-router:
         specifier: ^7.5.0
         version: 7.5.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)

--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
     },
     {
       "groupName": "React",
-      "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom"]
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
     },
     {
       "groupName": "typescript-eslint",


### PR DESCRIPTION
Follow-up on https://github.com/mui/mui-x/pull/17444#issuecomment-2816551216.

The `react-is` dependency is not used anywhere in this repository explicitly.

Dependencies using it have it listed in the dependencies list (`@mui/utils` & `@mui/material`).

Removing from `@mui/x-charts` package as it seems that it's usage has been removed from the package.