### PR TITLE
[charts] fix charts visuals flakiness

### DIFF
--- a/test/regressions/TestViewer.tsx
+++ b/test/regressions/TestViewer.tsx
@@ -61,7 +61,7 @@ function TestViewer(props: any) {
           },
         }}
       />
-      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest} shouldRunToFrame={isChartTest}>
+      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest} shouldRunAllTimers={isChartTest}>
         <LoadFont
           isDataGridTest={isDataGridTest}
           isDataGridPivotTest={isDataGridPivotTest}
@@ -75,7 +75,7 @@ function TestViewer(props: any) {
 }
 
 function MockTime(
-  props: React.PropsWithChildren<{ shouldAdvanceTime: boolean; shouldRunToFrame: boolean }>,
+  props: React.PropsWithChildren<{ shouldAdvanceTime: boolean; shouldRunAllTimers: boolean }>,
 ) {
   const [ready, setReady] = React.useState(false);
 
@@ -86,11 +86,10 @@ function MockTime(
   }, [props.shouldAdvanceTime]);
 
   React.useEffect(() => {
-    if (props.shouldRunToFrame && ready) {
-      fakeClock?.runToFrame();
-      fakeClock?.runToFrame();
+    if (props.shouldRunAllTimers && ready) {
+      fakeClock?.runAll();
     }
-  }, [props.shouldRunToFrame, ready]);
+  }, [props.shouldRunAllTimers, ready]);
 
   return ready ? props.children : null;
 }

--- a/test/regressions/TestViewer.tsx
+++ b/test/regressions/TestViewer.tsx
@@ -31,7 +31,7 @@ const StyledBox = styled('div', {
 );
 
 function TestViewer(props: any) {
-  const { children, isDataGridTest, isDataGridPivotTest, isChartTest, path } = props;
+  const { children, isDataGridTest, isDataGridPivotTest, isPrintExportChartTest, path } = props;
 
   return (
     <React.Fragment>
@@ -61,7 +61,7 @@ function TestViewer(props: any) {
           },
         }}
       />
-      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest}>
+      <MockTime shouldAdvanceTime={isDataGridTest || isPrintExportChartTest}>
         <LoadFont
           isDataGridTest={isDataGridTest}
           isDataGridPivotTest={isDataGridPivotTest}

--- a/test/regressions/TestViewer.tsx
+++ b/test/regressions/TestViewer.tsx
@@ -61,7 +61,7 @@ function TestViewer(props: any) {
           },
         }}
       />
-      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest} shouldRunToLast={isChartTest}>
+      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest}>
         <LoadFont
           isDataGridTest={isDataGridTest}
           isDataGridPivotTest={isDataGridPivotTest}
@@ -74,9 +74,7 @@ function TestViewer(props: any) {
   );
 }
 
-function MockTime(
-  props: React.PropsWithChildren<{ shouldAdvanceTime: boolean; shouldRunToLast: boolean }>,
-) {
+function MockTime(props: React.PropsWithChildren<{ shouldAdvanceTime: boolean }>) {
   const [ready, setReady] = React.useState(false);
 
   React.useEffect(() => {
@@ -84,12 +82,6 @@ function MockTime(
     setReady(true);
     return dispose;
   }, [props.shouldAdvanceTime]);
-
-  React.useEffect(() => {
-    if (props.shouldRunToLast && ready) {
-      fakeClock?.runToLastAsync();
-    }
-  }, [props.shouldRunToLast, ready]);
 
   return ready ? props.children : null;
 }

--- a/test/regressions/TestViewer.tsx
+++ b/test/regressions/TestViewer.tsx
@@ -61,7 +61,7 @@ function TestViewer(props: any) {
           },
         }}
       />
-      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest} shouldRunAllTimers={isChartTest}>
+      <MockTime shouldAdvanceTime={isDataGridTest || isChartTest} shouldRunToLast={isChartTest}>
         <LoadFont
           isDataGridTest={isDataGridTest}
           isDataGridPivotTest={isDataGridPivotTest}
@@ -75,7 +75,7 @@ function TestViewer(props: any) {
 }
 
 function MockTime(
-  props: React.PropsWithChildren<{ shouldAdvanceTime: boolean; shouldRunAllTimers: boolean }>,
+  props: React.PropsWithChildren<{ shouldAdvanceTime: boolean; shouldRunToLast: boolean }>,
 ) {
   const [ready, setReady] = React.useState(false);
 
@@ -86,10 +86,10 @@ function MockTime(
   }, [props.shouldAdvanceTime]);
 
   React.useEffect(() => {
-    if (props.shouldRunAllTimers && ready) {
-      fakeClock?.runAll();
+    if (props.shouldRunToLast && ready) {
+      fakeClock?.runToLastAsync();
     }
-  }, [props.shouldRunAllTimers, ready]);
+  }, [props.shouldRunToLast, ready]);
 
   return ready ? props.children : null;
 }

--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -160,8 +160,7 @@ async function main() {
 
         if (/^\/docs-charts-.*/.test(route)) {
           // Wait for two animation frames to ensure the chart is fully rendered.
-          await waitForAnimationFrame();
-          await waitForAnimationFrame();
+          await sleep(30);
         }
 
         if (timeSensitiveSuites.some((suite) => route.includes(suite))) {
@@ -309,18 +308,4 @@ function sleep(timeoutMS: number | undefined) {
   return new Promise((resolve) => {
     setTimeout(resolve, timeoutMS);
   });
-}
-
-function waitForAnimationFrame() {
-  let resolve: (_: void) => void;
-
-  const promise = new Promise((res) => {
-    resolve = res;
-  });
-
-  requestAnimationFrame(() => {
-    resolve();
-  });
-
-  return promise;
 }

--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -158,6 +158,12 @@ async function main() {
           });
         }
 
+        if (/^\/docs-charts-.*/.test(route)) {
+          // Wait for two animation frames to ensure the chart is fully rendered.
+          await waitForAnimationFrame();
+          await waitForAnimationFrame();
+        }
+
         if (timeSensitiveSuites.some((suite) => route.includes(suite))) {
           await sleep(100);
         }
@@ -303,4 +309,18 @@ function sleep(timeoutMS: number | undefined) {
   return new Promise((resolve) => {
     setTimeout(resolve, timeoutMS);
   });
+}
+
+function waitForAnimationFrame() {
+  let resolve: (_: void) => void;
+
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+
+  requestAnimationFrame(() => {
+    resolve();
+  });
+
+  return promise;
 }

--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -159,8 +159,8 @@ async function main() {
         }
 
         if (/^\/docs-charts-.*/.test(route)) {
-          // Wait for two animation frames to ensure the chart is fully rendered.
-          await sleep(30);
+          // Run one tick of the clock to get the final animation state
+          await sleep(10);
         }
 
         if (timeSensitiveSuites.some((suite) => route.includes(suite))) {

--- a/test/regressions/index.tsx
+++ b/test/regressions/index.tsx
@@ -94,7 +94,8 @@ function App() {
       path: '/',
       element: <Root />,
       children: Object.keys(testsBySuite).map((suite) => {
-        const isChartTest = suite.startsWith('docs-charts');
+        const isPrintExportChartTest =
+          suite.startsWith('docs-charts') && suite.includes('PrintChart');
         const isDataGridTest =
           suite.startsWith('docs-data-grid') || suite === 'test-regressions-data-grid';
         const isDataGridPivotTest = isDataGridTest && suite.startsWith('docs-data-grid-pivoting');
@@ -106,7 +107,7 @@ function App() {
               <TestViewer
                 isDataGridTest={isDataGridTest}
                 isDataGridPivotTest={isDataGridPivotTest}
-                isChartTest={isChartTest}
+                isPrintExportChartTest={isPrintExportChartTest}
                 path={computePath(test)}
               >
                 <test.case />


### PR DESCRIPTION
Second attempt at fixing charts visuals flakiness.

First attempt: https://github.com/mui/mui-x/pull/17469
PR that introduced the flakiness: https://github.com/mui/mui-x/pull/17420

Basically, this PR is reverting the changes in https://github.com/mui/mui-x/pull/17420. We'll only advance time in the print export test. All other chart tests should be unchanged. 