### PR TITLE
[pickers] Improve `PickersInputBase` owner state typing

### DIFF
--- a/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
@@ -295,7 +295,7 @@ PickersFilledInput.propTypes = {
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
-  ownerState: PropTypes.any,
+  ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,
   renderSuffix: PropTypes.func,
   sectionListRef: PropTypes.oneOfType([

--- a/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersFilledInput/PickersFilledInput.tsx
@@ -14,7 +14,7 @@ import {
   PickersInputBaseRoot,
   PickersInputBaseSectionsContainer,
 } from '../PickersInputBase/PickersInputBase';
-import { PickerTextFieldOwnerState } from '../PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../../models/fields';
 import { usePickerTextFieldOwnerState } from '../usePickerTextFieldOwnerState';
 
 export interface PickersFilledInputProps extends PickersInputBaseProps {

--- a/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
@@ -11,7 +11,7 @@ import {
 } from './pickersInputClasses';
 import { PickersInputBase, PickersInputBaseProps } from '../PickersInputBase';
 import { PickersInputBaseRoot } from '../PickersInputBase/PickersInputBase';
-import { PickerTextFieldOwnerState } from '../PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../../models/fields';
 import { usePickerTextFieldOwnerState } from '../usePickerTextFieldOwnerState';
 
 export interface PickersInputProps extends PickersInputBaseProps {

--- a/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInput/PickersInput.tsx
@@ -213,7 +213,7 @@ PickersInput.propTypes = {
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
-  ownerState: PropTypes.any,
+  ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,
   renderSuffix: PropTypes.func,
   sectionListRef: PropTypes.oneOfType([

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -24,7 +24,7 @@ import {
   PickersSectionElement,
 } from '../../PickersSectionList';
 import { usePickerTextFieldOwnerState } from '../usePickerTextFieldOwnerState';
-import { PickerTextFieldOwnerState } from '../PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../../models/fields';
 
 const round = (value: number) => Math.round(value * 1e5) / 1e5;
 

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -508,7 +508,7 @@ PickersInputBase.propTypes = {
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
-  ownerState: PropTypes.any,
+  ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,
   renderSuffix: PropTypes.func,
   sectionListRef: PropTypes.oneOfType([

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BoxProps } from '@mui/material/Box';
 import { MuiEvent } from '@mui/x-internals/types';
 import { PickersSectionListProps } from '../../PickersSectionList';
-import { PickerTextFieldOwnerState } from '../PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../../models/fields';
 
 export interface PickersInputPropsUsedByField
   extends Pick<

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { BoxProps } from '@mui/material/Box';
 import { MuiEvent } from '@mui/x-internals/types';
 import { PickersSectionListProps } from '../../PickersSectionList';
+import { PickerTextFieldOwnerState } from '../PickersTextField.types';
 
 export interface PickersInputPropsUsedByField
   extends Pick<
@@ -39,7 +40,7 @@ export interface PickersInputPropsUsedByField
 export interface PickersInputBaseProps
   extends Omit<BoxProps, keyof PickersInputPropsUsedByField>,
     PickersInputPropsUsedByField {
-  ownerState?: any;
+  ownerState?: PickerTextFieldOwnerState;
   margin?: 'dense' | 'none' | 'normal';
   renderSuffix?: (state: {
     disabled?: boolean;

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/Outline.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/Outline.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import { shouldForwardProp } from '@mui/system/createStyled';
 import { usePickerTextFieldOwnerState } from '../usePickerTextFieldOwnerState';
-import { PickerTextFieldOwnerState } from '../PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../../models/fields';
 
 interface OutlineProps extends React.HTMLAttributes<HTMLFieldSetElement> {
   notched: boolean;

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
@@ -15,7 +15,7 @@ import {
   PickersInputBaseRoot,
   PickersInputBaseSectionsContainer,
 } from '../PickersInputBase/PickersInputBase';
-import { PickerTextFieldOwnerState } from '../PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../../models/fields';
 
 export interface PickersOutlinedInputProps extends PickersInputBaseProps {
   notched?: boolean;

--- a/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersOutlinedInput/PickersOutlinedInput.tsx
@@ -199,7 +199,7 @@ PickersOutlinedInput.propTypes = {
   onInput: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
-  ownerState: PropTypes.any,
+  ownerState: PropTypes /* @typescript-to-proptypes-ignore */.any,
   readOnly: PropTypes.bool,
   renderSuffix: PropTypes.func,
   sectionListRef: PropTypes.oneOfType([

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.tsx
@@ -14,12 +14,13 @@ import {
   getPickersTextFieldUtilityClass,
   PickersTextFieldClasses,
 } from './pickersTextFieldClasses';
-import { PickerTextFieldOwnerState, PickersTextFieldProps } from './PickersTextField.types';
+import { PickersTextFieldProps } from './PickersTextField.types';
 import { PickersOutlinedInput } from './PickersOutlinedInput';
 import { PickersFilledInput } from './PickersFilledInput';
 import { PickersInput } from './PickersInput';
 import { useFieldOwnerState } from '../internals/hooks/useFieldOwnerState';
 import { PickerTextFieldOwnerStateContext } from './usePickerTextFieldOwnerState';
+import { PickerTextFieldOwnerState } from '../models/fields';
 
 const VARIANT_COMPONENT = {
   standard: PickersInput,

--- a/packages/x-date-pickers/src/PickersTextField/PickersTextField.types.ts
+++ b/packages/x-date-pickers/src/PickersTextField/PickersTextField.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormControlOwnProps, FormControlProps } from '@mui/material/FormControl';
+import { FormControlProps } from '@mui/material/FormControl';
 import { FormHelperTextProps } from '@mui/material/FormHelperText';
 import { InputLabelProps } from '@mui/material/InputLabel';
 import { TextFieldVariants } from '@mui/material/TextField';
@@ -7,7 +7,6 @@ import { PickersInputPropsUsedByField } from './PickersInputBase/PickersInputBas
 import type { PickersInputProps } from './PickersInput';
 import type { PickersOutlinedInputProps } from './PickersOutlinedInput';
 import type { PickersFilledInputProps } from './PickersFilledInput';
-import { FieldOwnerState } from '../models';
 
 interface PickersTextFieldPropsUsedByField {
   onFocus: React.FocusEventHandler<HTMLDivElement>;
@@ -80,45 +79,3 @@ export type PickersTextFieldProps<Variant extends TextFieldVariants = TextFieldV
     : Variant extends 'standard'
       ? PickersStandardTextFieldProps
       : PickersOutlinedTextFieldProps;
-
-export interface PickerTextFieldOwnerState extends FieldOwnerState {
-  // Should be moved to FieldOwnerState once we drop the textField slot.
-  /**
-   * `true` if the value of the field is currently empty.
-   */
-  isFieldValueEmpty: boolean;
-  // Should be moved to FieldOwnerState once we drop the textField slot.
-  /**
-   * `true` if the field is focused, `false` otherwise.
-   */
-  isFieldFocused: boolean;
-  // Should be moved to FieldOwnerState once we drop the textField slot.
-  /**
-   * `true` if the field has an error, `false` otherwise.
-   */
-  hasFieldError: boolean;
-  /**
-   * The size of the input.
-   */
-  inputSize: Exclude<FormControlOwnProps['size'], undefined>;
-  /**
-   * The color of the input.
-   */
-  inputColor: Exclude<FormControlOwnProps['color'], undefined>;
-  /**
-   * `true` if the input takes up the full width of its container.
-   */
-  isInputInFullWidth: boolean;
-  /**
-   * `true` if the input has a start adornment, `false` otherwise.
-   */
-  hasStartAdornment: boolean;
-  /**
-   * `true` if the input has an end adornment, `false` otherwise.
-   */
-  hasEndAdornment: boolean;
-  /**
-   * `true` if the input has a label, `false` otherwise.
-   */
-  inputHasLabel: boolean;
-}

--- a/packages/x-date-pickers/src/PickersTextField/index.ts
+++ b/packages/x-date-pickers/src/PickersTextField/index.ts
@@ -1,5 +1,5 @@
 export { PickersTextField } from './PickersTextField';
-export type { PickersTextFieldProps } from './PickersTextField.types';
+export type { PickersTextFieldProps, PickerTextFieldOwnerState } from './PickersTextField.types';
 
 export {
   pickersTextFieldClasses,

--- a/packages/x-date-pickers/src/PickersTextField/index.ts
+++ b/packages/x-date-pickers/src/PickersTextField/index.ts
@@ -1,5 +1,5 @@
 export { PickersTextField } from './PickersTextField';
-export type { PickersTextFieldProps, PickerTextFieldOwnerState } from './PickersTextField.types';
+export type { PickersTextFieldProps } from './PickersTextField.types';
 
 export {
   pickersTextFieldClasses,

--- a/packages/x-date-pickers/src/PickersTextField/usePickerTextFieldOwnerState.ts
+++ b/packages/x-date-pickers/src/PickersTextField/usePickerTextFieldOwnerState.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { PickerTextFieldOwnerState } from './PickersTextField.types';
+import { PickerTextFieldOwnerState } from '../models/fields';
 
 export const PickerTextFieldOwnerStateContext =
   React.createContext<PickerTextFieldOwnerState | null>(null);

--- a/packages/x-date-pickers/src/models/fields.ts
+++ b/packages/x-date-pickers/src/models/fields.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { TextFieldProps } from '@mui/material/TextField';
+import { FormControlOwnProps } from '@mui/material/FormControl';
 import type { ExportedPickersSectionListProps } from '../PickersSectionList';
 import type { UseFieldInternalProps, UseFieldReturnValue } from '../internals/hooks/useField';
 import type { PickersTextFieldProps } from '../PickersTextField';
@@ -206,3 +207,45 @@ export type BuiltInFieldTextFieldProps<TEnableAccessibleFieldDOMStructure extend
         | 'type'
       >
     : Partial<Omit<PickersTextFieldProps, keyof ExportedPickersSectionListProps>>;
+
+export interface PickerTextFieldOwnerState extends FieldOwnerState {
+  // Should be moved to FieldOwnerState once we drop the textField slot.
+  /**
+   * `true` if the value of the field is currently empty.
+   */
+  isFieldValueEmpty: boolean;
+  // Should be moved to FieldOwnerState once we drop the textField slot.
+  /**
+   * `true` if the field is focused, `false` otherwise.
+   */
+  isFieldFocused: boolean;
+  // Should be moved to FieldOwnerState once we drop the textField slot.
+  /**
+   * `true` if the field has an error, `false` otherwise.
+   */
+  hasFieldError: boolean;
+  /**
+   * The size of the input.
+   */
+  inputSize: Exclude<FormControlOwnProps['size'], undefined>;
+  /**
+   * The color of the input.
+   */
+  inputColor: Exclude<FormControlOwnProps['color'], undefined>;
+  /**
+   * `true` if the input takes up the full width of its container.
+   */
+  isInputInFullWidth: boolean;
+  /**
+   * `true` if the input has a start adornment, `false` otherwise.
+   */
+  hasStartAdornment: boolean;
+  /**
+   * `true` if the input has an end adornment, `false` otherwise.
+   */
+  hasEndAdornment: boolean;
+  /**
+   * `true` if the input has a label, `false` otherwise.
+   */
+  inputHasLabel: boolean;
+}

--- a/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
@@ -23,7 +23,8 @@ import {
   multiSectionDigitalClockClasses,
   multiSectionDigitalClockSectionClasses,
 } from '../MultiSectionDigitalClock';
-import { pickersInputBaseClasses, PickerTextFieldOwnerState } from '../PickersTextField';
+import { pickersInputBaseClasses } from '../PickersTextField';
+import { PickerTextFieldOwnerState } from '../models/fields';
 
 createTheme({
   components: {

--- a/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
@@ -23,6 +23,7 @@ import {
   multiSectionDigitalClockClasses,
   multiSectionDigitalClockSectionClasses,
 } from '../MultiSectionDigitalClock';
+import { pickersInputBaseClasses, PickerTextFieldOwnerState } from '../PickersTextField';
 
 createTheme({
   components: {
@@ -635,9 +636,12 @@ createTheme({
         someRandomProp: true,
       },
       styleOverrides: {
-        root: {
+        root: ({ ownerState }: { ownerState: PickerTextFieldOwnerState }) => ({
           backgroundColor: 'red',
-        },
+          [`.${pickersInputBaseClasses.activeBar}`]: {
+            backgroundColor: ownerState.isPickerReadOnly ? 'green' : 'blue',
+          },
+        }),
         // @ts-expect-error invalid MuiPickersInputBase class key
         content: {
           backgroundColor: 'blue',

--- a/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
+++ b/packages/x-date-pickers/src/themeAugmentation/themeAugmentation.spec.ts
@@ -24,7 +24,6 @@ import {
   multiSectionDigitalClockSectionClasses,
 } from '../MultiSectionDigitalClock';
 import { pickersInputBaseClasses } from '../PickersTextField';
-import { PickerTextFieldOwnerState } from '../models/fields';
 
 createTheme({
   components: {
@@ -637,7 +636,7 @@ createTheme({
         someRandomProp: true,
       },
       styleOverrides: {
-        root: ({ ownerState }: { ownerState: PickerTextFieldOwnerState }) => ({
+        root: ({ ownerState }) => ({
           backgroundColor: 'red',
           [`.${pickersInputBaseClasses.activeBar}`]: {
             backgroundColor: ownerState.isPickerReadOnly ? 'green' : 'blue',

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -353,6 +353,7 @@
   { "name": "PickersTextFieldProps", "kind": "TypeAlias" },
   { "name": "PickersTimezone", "kind": "TypeAlias" },
   { "name": "PickersTranslationKeys", "kind": "TypeAlias" },
+  { "name": "PickerTextFieldOwnerState", "kind": "Interface" },
   { "name": "PickerValidDate", "kind": "TypeAlias" },
   { "name": "PickerValidDateLookup", "kind": "Interface" },
   { "name": "PickerValueType", "kind": "TypeAlias" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -244,6 +244,7 @@
   { "name": "PickersTextFieldProps", "kind": "TypeAlias" },
   { "name": "PickersTimezone", "kind": "TypeAlias" },
   { "name": "PickersTranslationKeys", "kind": "TypeAlias" },
+  { "name": "PickerTextFieldOwnerState", "kind": "Interface" },
   { "name": "PickerValidDate", "kind": "TypeAlias" },
   { "name": "PickerValidDateLookup", "kind": "Interface" },
   { "name": "PickerValueType", "kind": "TypeAlias" },


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/issues/17297.

Partially solve some slight inconsistencies.

## Before
<img width="361" alt="Screenshot 2025-04-22 at 16 09 57" src="https://github.com/user-attachments/assets/c51d0cc2-7728-4815-9c91-f51595e689a1" />

## After
<img width="918" alt="Screenshot 2025-04-22 at 16 11 06" src="https://github.com/user-attachments/assets/fa355154-6fed-4923-8b1e-22c7d647ac93" />

___
However, the actual type should be only `PickerTextFieldOwnerState`.