### PR TITLE
[tree view][docs] Fix heading structure

### DIFF
--- a/docs/src/modules/components/overview/CommunityOrPro.tsx
+++ b/docs/src/modules/components/overview/CommunityOrPro.tsx
@@ -36,7 +36,7 @@ export default function CommunityOrPro({
           </Typography>
           <Typography
             variant="h4"
-            component="h3"
+            component="h2"
             fontWeight="semiBold"
             color="text.primary"
             fontSize="1.625rem"


### PR DESCRIPTION
https://mui.com/x/react-tree-view/ feels a bit strange:

<img width="669" alt="SCR-20250422-nztt" src="https://github.com/user-attachments/assets/5f05948e-91fb-431e-9ddf-78aff8d34af8" />

(annotation through https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)