### PR TITLE
[charts] Fix spark line not having clip path

### DIFF
--- a/docs/data/charts/sparkline/SparklineLineWidth.js
+++ b/docs/data/charts/sparkline/SparklineLineWidth.js
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import { SparkLineChart } from '@mui/x-charts/SparkLineChart';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Slider from '@mui/material/Slider';
+
+const values = [8, 7, 9, 0, 0, 5, 20, 20, 7];
+
+const settings = {
+  data: values,
+  height: 100,
+  showHighlight: true,
+  showTooltip: true,
+};
+
+export default function SparklineLineWidth() {
+  const [strokeWidth, setStrokeWidth] = React.useState(2);
+  const [disableClipping, setDisableClipping] = React.useState(false);
+  const [clipAreaOffset, setClipAreaOffset] = React.useState(0);
+
+  return (
+    <Stack sx={{ width: '100%' }} direction="column" gap={1}>
+      <Stack direction="row">
+        <FormControlLabel
+          checked={disableClipping}
+          control={
+            <Checkbox
+              onChange={(event) => setDisableClipping(event.target.checked)}
+            />
+          }
+          label="Disable Clipping"
+          labelPlacement="end"
+        />
+        <FormControlLabel
+          value={strokeWidth}
+          control={
+            <Slider
+              aria-label="Stroke Width"
+              valueLabelDisplay="auto"
+              step={1}
+              marks
+              min={1}
+              max={5}
+              onChange={(event, value) => setStrokeWidth(value)}
+            />
+          }
+          label="Stroke Width"
+          labelPlacement="top"
+        />
+        <FormControlLabel
+          value={clipAreaOffset ?? 0}
+          control={
+            <Slider
+              aria-label="Clip Area Offset"
+              valueLabelDisplay="auto"
+              step={1}
+              marks
+              min={0}
+              max={5}
+              onChange={(event, value) => setClipAreaOffset(value)}
+            />
+          }
+          label="Clip Area Offset"
+          labelPlacement="top"
+        />
+      </Stack>
+
+      <Box sx={{ flexGrow: 1 }}>
+        <SparkLineChart
+          {...settings}
+          yAxis={{ min: 0 }}
+          disableClipping={disableClipping}
+          clipAreaOffset={{
+            top: clipAreaOffset,
+            bottom: clipAreaOffset,
+            left: clipAreaOffset,
+            right: clipAreaOffset,
+          }}
+          slotProps={{
+            line: { strokeWidth },
+          }}
+        />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/charts/sparkline/SparklineLineWidth.js
+++ b/docs/data/charts/sparkline/SparklineLineWidth.js
@@ -18,7 +18,7 @@ const settings = {
 export default function SparklineLineWidth() {
   const [strokeWidth, setStrokeWidth] = React.useState(2);
   const [disableClipping, setDisableClipping] = React.useState(false);
-  const [clipAreaOffset, setClipAreaOffset] = React.useState(0);
+  const [clipAreaOffset, setClipAreaOffset] = React.useState(1);
 
   return (
     <Stack sx={{ width: '100%' }} direction="column" gap={1}>
@@ -50,7 +50,7 @@ export default function SparklineLineWidth() {
           labelPlacement="top"
         />
         <FormControlLabel
-          value={clipAreaOffset ?? 0}
+          value={clipAreaOffset}
           control={
             <Slider
               aria-label="Clip Area Offset"

--- a/docs/data/charts/sparkline/SparklineLineWidth.js
+++ b/docs/data/charts/sparkline/SparklineLineWidth.js
@@ -51,10 +51,12 @@ export default function SparklineLineWidth() {
         />
         <FormControlLabel
           value={clipAreaOffset}
+          disabled={disableClipping}
           control={
             <Slider
               aria-label="Clip Area Offset"
               valueLabelDisplay="auto"
+              disabled={disableClipping}
               step={1}
               marks
               min={0}

--- a/docs/data/charts/sparkline/SparklineLineWidth.tsx
+++ b/docs/data/charts/sparkline/SparklineLineWidth.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import { SparkLineChart, SparkLineChartProps } from '@mui/x-charts/SparkLineChart';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Slider from '@mui/material/Slider';
+
+const values = [8, 7, 9, 0, 0, 5, 20, 20, 7];
+
+const settings = {
+  data: values,
+  height: 100,
+  showHighlight: true,
+  showTooltip: true,
+} satisfies Partial<SparkLineChartProps>;
+
+export default function SparklineLineWidth() {
+  const [strokeWidth, setStrokeWidth] = React.useState<number>(2);
+  const [disableClipping, setDisableClipping] = React.useState(false);
+  const [clipAreaOffset, setClipAreaOffset] = React.useState<number>(0);
+
+  return (
+    <Stack sx={{ width: '100%' }} direction="column" gap={1}>
+      <Stack direction="row">
+        <FormControlLabel
+          checked={disableClipping}
+          control={
+            <Checkbox
+              onChange={(event) => setDisableClipping(event.target.checked)}
+            />
+          }
+          label="Disable Clipping"
+          labelPlacement="end"
+        />
+        <FormControlLabel
+          value={strokeWidth}
+          control={
+            <Slider
+              aria-label="Stroke Width"
+              valueLabelDisplay="auto"
+              step={1}
+              marks
+              min={1}
+              max={5}
+              onChange={(event, value) => setStrokeWidth(value)}
+            />
+          }
+          label="Stroke Width"
+          labelPlacement="top"
+        />
+
+        <FormControlLabel
+          value={clipAreaOffset ?? 0}
+          control={
+            <Slider
+              aria-label="Clip Area Offset"
+              valueLabelDisplay="auto"
+              step={1}
+              marks
+              min={0}
+              max={5}
+              onChange={(event, value) => setClipAreaOffset(value)}
+            />
+          }
+          label="Clip Area Offset"
+          labelPlacement="top"
+        />
+      </Stack>
+
+      <Box sx={{ flexGrow: 1 }}>
+        <SparkLineChart
+          {...settings}
+          yAxis={{ min: 0 }}
+          disableClipping={disableClipping}
+          clipAreaOffset={{
+            top: clipAreaOffset,
+            bottom: clipAreaOffset,
+            left: clipAreaOffset,
+            right: clipAreaOffset,
+          }}
+          slotProps={{
+            line: { strokeWidth },
+          }}
+        />
+      </Box>
+    </Stack>
+  );
+}

--- a/docs/data/charts/sparkline/SparklineLineWidth.tsx
+++ b/docs/data/charts/sparkline/SparklineLineWidth.tsx
@@ -18,7 +18,7 @@ const settings = {
 export default function SparklineLineWidth() {
   const [strokeWidth, setStrokeWidth] = React.useState<number>(2);
   const [disableClipping, setDisableClipping] = React.useState(false);
-  const [clipAreaOffset, setClipAreaOffset] = React.useState<number>(0);
+  const [clipAreaOffset, setClipAreaOffset] = React.useState<number>(1);
 
   return (
     <Stack sx={{ width: '100%' }} direction="column" gap={1}>
@@ -51,7 +51,7 @@ export default function SparklineLineWidth() {
         />
 
         <FormControlLabel
-          value={clipAreaOffset ?? 0}
+          value={clipAreaOffset}
           control={
             <Slider
               aria-label="Clip Area Offset"

--- a/docs/data/charts/sparkline/SparklineLineWidth.tsx
+++ b/docs/data/charts/sparkline/SparklineLineWidth.tsx
@@ -52,10 +52,12 @@ export default function SparklineLineWidth() {
 
         <FormControlLabel
           value={clipAreaOffset}
+          disabled={disableClipping}
           control={
             <Slider
               aria-label="Clip Area Offset"
               valueLabelDisplay="auto"
+              disabled={disableClipping}
               step={1}
               marks
               min={0}

--- a/docs/data/charts/sparkline/sparkline.md
+++ b/docs/data/charts/sparkline/sparkline.md
@@ -78,3 +78,15 @@ The `color` prop also accepts a function that is called with the mode (`'light'`
 The following example shows a white line if this page is in dark mode, or a black one if it is in light mode.
 
 {{"demo": "ColorCustomizationMode.js"}}
+
+## Line Width
+
+The lines in a sparkline chart have a stroke width of 2px by default.
+When clipping is enabled and the line is drawn on the edge of the chart, it might be partially clipped.
+
+By default, the sparkline has clipping enabled, but the `clipAreaOffset` prop defaults to 1 to prevent clipping.
+You can disable clipping by setting `disableClipping` to `true`.
+
+The example below shows how the line's stroke width, `disableClipping` and `clipAreaOffset` affect the sparkline rendering.
+
+{{"demo": "SparklineLineWidth.js"}}

--- a/docs/data/charts/sparkline/sparkline.md
+++ b/docs/data/charts/sparkline/sparkline.md
@@ -81,7 +81,7 @@ The following example shows a white line if this page is in dark mode, or a blac
 
 ## Line Width
 
-The lines in a sparkline chart have a stroke width of 2px by default.
+Lines in Sparkline have a stroke width of 2px by default.
 When clipping is enabled and the line is drawn on the edge of the chart, it might be partially clipped.
 
 By default, the sparkline has clipping enabled, but the `clipAreaOffset` prop defaults to 1 to prevent clipping.

--- a/docs/pages/x/api/charts/charts-clip-path.json
+++ b/docs/pages/x/api/charts/charts-clip-path.json
@@ -1,5 +1,13 @@
 {
-  "props": {},
+  "props": {
+    "id": { "type": { "name": "string" }, "required": true },
+    "offset": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      }
+    }
+  },
   "name": "ChartsClipPath",
   "imports": [
     "import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';",

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -5,12 +5,20 @@
       "required": true
     },
     "area": { "type": { "name": "bool" }, "default": "false" },
+    "clipAreaOffset": {
+      "type": {
+        "name": "shape",
+        "description": "{ bottom?: number, left?: number, right?: number, top?: number }"
+      },
+      "default": "{ top: 1, right: 1, bottom: 1, left: 1 }"
+    },
     "color": {
       "type": { "name": "union", "description": "func<br>&#124;&nbsp;string" },
       "default": "rainbowSurgePalette[0]"
     },
     "dataset": { "type": { "name": "arrayOf", "description": "Array&lt;object&gt;" } },
     "disableAxisListener": { "type": { "name": "bool" }, "default": "false" },
+    "disableClipping": { "type": { "name": "bool" }, "default": "false" },
     "disableVoronoi": { "type": { "name": "bool" } },
     "height": { "type": { "name": "number" } },
     "highlightedItem": {

--- a/docs/translations/api-docs/charts/charts-clip-path/charts-clip-path.json
+++ b/docs/translations/api-docs/charts/charts-clip-path/charts-clip-path.json
@@ -1,1 +1,10 @@
-{ "componentDescription": "", "propDescriptions": {}, "classDescriptions": {} }
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "id": { "description": "The id of the clip path." },
+    "offset": {
+      "description": "Offset, in pixels, of the clip path rectangle from the drawing area.<br>A positive value will move the rectangle outside the drawing area."
+    }
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -4,6 +4,9 @@
     "area": {
       "description": "Set to <code>true</code> to fill spark line area. Has no effect if plotType=&#39;bar&#39;."
     },
+    "clipAreaOffset": {
+      "description": "Offset the clipped area by this amount in pixels on each side.<br>This is particularly useful when lines of line charts are clipped due to being drawn at the drawing area edges. This can happen because the default stroke width of lines is 2 px, so a line drawn at the edge of the chart will have half the stroke width clipped."
+    },
     "color": { "description": "Color used to colorize the sparkline." },
     "data": { "description": "Data to plot." },
     "dataset": {
@@ -11,6 +14,9 @@
     },
     "disableAxisListener": {
       "description": "If <code>true</code>, the charts will not listen to the mouse move event. It might break interactive features, but will improve performance."
+    },
+    "disableClipping": {
+      "description": "When <code>true</code>, the chart&#39;s drawing area will not be clipped and elements within can visually overflow the chart."
     },
     "disableVoronoi": { "description": "If true, the voronoi interaction are ignored." },
     "height": {

--- a/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
+++ b/docs/translations/api-docs/charts/spark-line-chart/spark-line-chart.json
@@ -5,7 +5,7 @@
       "description": "Set to <code>true</code> to fill spark line area. Has no effect if plotType=&#39;bar&#39;."
     },
     "clipAreaOffset": {
-      "description": "Offset the clipped area by this amount in pixels on each side.<br>This is particularly useful when lines of line charts are clipped due to being drawn at the drawing area edges. This can happen because the default stroke width of lines is 2 px, so a line drawn at the edge of the chart will have half the stroke width clipped."
+      "description": "The clipped area offset in pixels.<br>This prevents partial clipping of lines when they are drawn on the edge of the drawing area."
     },
     "color": { "description": "Color used to colorize the sparkline." },
     "data": { "description": "Data to plot." },

--- a/packages/x-charts/src/ChartsClipPath/ChartsClipPath.tsx
+++ b/packages/x-charts/src/ChartsClipPath/ChartsClipPath.tsx
@@ -4,7 +4,16 @@ import PropTypes from 'prop-types';
 import { useDrawingArea } from '../hooks/useDrawingArea';
 
 export type ChartsClipPathProps = {
+  /**
+   * The id of the clip path.
+   */
   id: string;
+
+  /**
+   * Offset, in pixels, of the clip path rectangle from the drawing area.
+   *
+   * A positive value will move the rectangle outside the drawing area.
+   */
   offset?: { top?: number; right?: number; bottom?: number; left?: number };
 };
 
@@ -35,7 +44,15 @@ ChartsClipPath.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
   // ----------------------------------------------------------------------
+  /**
+   * The id of the clip path.
+   */
   id: PropTypes.string.isRequired,
+  /**
+   * Offset, in pixels, of the clip path rectangle from the drawing area.
+   *
+   * A positive value will move the rectangle outside the drawing area.
+   */
   offset: PropTypes.shape({
     bottom: PropTypes.number,
     left: PropTypes.number,

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -121,6 +121,24 @@ export interface SparkLineChartProps
    * @default rainbowSurgePalette[0]
    */
   color?: ChartsColor;
+
+  /**
+   * When `true`, the chart's drawing area will not be clipped and elements within can visually overflow the chart.
+   *
+   * @default false
+   */
+  disableClipping?: boolean;
+
+  /**
+   * Offset the clipped area by this amount in pixels on each side.
+   *
+   * This is particularly useful when lines of line charts are clipped due to being drawn at the drawing area edges.
+   * This can happen because the default stroke width of lines is 2 px, so a line drawn at the edge of the chart will
+   * have half the stroke width clipped.
+   *
+   * @default { top: 1, right: 1, bottom: 1, left: 1 }
+   */
+  clipAreaOffset?: { top?: number; right?: number; bottom?: number; left?: number };
 }
 
 const SPARK_LINE_DEFAULT_MARGIN = 5;
@@ -158,10 +176,18 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
     area,
     curve = 'linear',
     className,
+    disableClipping,
+    clipAreaOffset,
     ...other
   } = props;
   const id = useId();
   const clipPathId = `${id}-clip-path`;
+  const clipPathOffset = {
+    top: clipAreaOffset?.top ?? 1,
+    right: clipAreaOffset?.right ?? 1,
+    bottom: clipAreaOffset?.bottom ?? 1,
+    left: clipAreaOffset?.left ?? 1,
+  };
 
   const defaultXHighlight: { x: 'band' | 'none' } =
     showHighlight && plotType === 'bar' ? { x: 'band' } : { x: 'none' };
@@ -232,7 +258,7 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
           </React.Fragment>
         )}
       </g>
-      <ChartsClipPath id={clipPathId} />
+      {disableClipping ? null : <ChartsClipPath id={clipPathId} offset={clipPathOffset} />}
       <ChartsAxisHighlight {...axisHighlight} />
       {showTooltip && <Tooltip {...props.slotProps?.tooltip} />}
 
@@ -261,6 +287,21 @@ SparkLineChart.propTypes = {
   }),
   children: PropTypes.node,
   className: PropTypes.string,
+  /**
+   * Offset the clipped area by this amount in pixels on each side.
+   *
+   * This is particularly useful when lines of line charts are clipped due to being drawn at the drawing area edges.
+   * This can happen because the default stroke width of lines is 2 px, so a line drawn at the edge of the chart will
+   * have half the stroke width clipped.
+   *
+   * @default { top: 1, right: 1, bottom: 1, left: 1 }
+   */
+  clipAreaOffset: PropTypes.shape({
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number,
+    top: PropTypes.number,
+  }),
   /**
    * Color used to colorize the sparkline.
    * @default rainbowSurgePalette[0]
@@ -296,6 +337,12 @@ SparkLineChart.propTypes = {
    * @default false
    */
   disableAxisListener: PropTypes.bool,
+  /**
+   * When `true`, the chart's drawing area will not be clipped and elements within can visually overflow the chart.
+   *
+   * @default false
+   */
+  disableClipping: PropTypes.bool,
   /**
    * If true, the voronoi interaction are ignored.
    */

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -1,6 +1,8 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import useId from '@mui/utils/useId';
+import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
 import { ChartsColor, ChartsColorPalette } from '../colorPalettes';
 import { BarPlot } from '../BarChart';
 import { LinePlot, AreaPlot, LineHighlightPlot } from '../LineChart';
@@ -158,6 +160,8 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
     className,
     ...other
   } = props;
+  const id = useId();
+  const clipPathId = `${id}-clip-path`;
 
   const defaultXHighlight: { x: 'band' | 'none' } =
     showHighlight && plotType === 'bar' ? { x: 'band' } : { x: 'none' };
@@ -217,16 +221,18 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
         axisHighlight?.y === 'none'
       }
     >
-      {plotType === 'bar' && <BarPlot skipAnimation slots={slots} slotProps={slotProps} />}
+      <g clipPath={`url(#${clipPathId})`}>
+        {plotType === 'bar' && <BarPlot skipAnimation slots={slots} slotProps={slotProps} />}
 
-      {plotType === 'line' && (
-        <React.Fragment>
-          <AreaPlot skipAnimation slots={slots} slotProps={slotProps} />
-          <LinePlot skipAnimation slots={slots} slotProps={slotProps} />
-          <LineHighlightPlot slots={slots} slotProps={slotProps} />
-        </React.Fragment>
-      )}
-
+        {plotType === 'line' && (
+          <React.Fragment>
+            <AreaPlot skipAnimation slots={slots} slotProps={slotProps} />
+            <LinePlot skipAnimation slots={slots} slotProps={slotProps} />
+            <LineHighlightPlot slots={slots} slotProps={slotProps} />
+          </React.Fragment>
+        )}
+      </g>
+      <ChartsClipPath id={clipPathId} />
       <ChartsAxisHighlight {...axisHighlight} />
       {showTooltip && <Tooltip {...props.slotProps?.tooltip} />}
 

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';
-import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
+import { ChartsClipPath } from '../ChartsClipPath';
 import { ChartsColor, ChartsColorPalette } from '../colorPalettes';
 import { BarPlot } from '../BarChart';
 import { LinePlot, AreaPlot, LineHighlightPlot } from '../LineChart';

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -130,11 +130,9 @@ export interface SparkLineChartProps
   disableClipping?: boolean;
 
   /**
-   * Offset the clipped area by this amount in pixels on each side.
+   * The clipped area offset in pixels.
    *
-   * This is particularly useful when lines of line charts are clipped due to being drawn at the drawing area edges.
-   * This can happen because the default stroke width of lines is 2 px, so a line drawn at the edge of the chart will
-   * have half the stroke width clipped.
+   * This prevents partial clipping of lines when they are drawn on the edge of the drawing area.
    *
    * @default { top: 1, right: 1, bottom: 1, left: 1 }
    */
@@ -254,10 +252,10 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
           <React.Fragment>
             <AreaPlot skipAnimation slots={slots} slotProps={slotProps} />
             <LinePlot skipAnimation slots={slots} slotProps={slotProps} />
-            <LineHighlightPlot slots={slots} slotProps={slotProps} />
           </React.Fragment>
         )}
       </g>
+      {plotType === 'line' && <LineHighlightPlot slots={slots} slotProps={slotProps} />}
       {disableClipping ? null : <ChartsClipPath id={clipPathId} offset={clipPathOffset} />}
       <ChartsAxisHighlight {...axisHighlight} />
       {showTooltip && <Tooltip {...props.slotProps?.tooltip} />}
@@ -288,11 +286,9 @@ SparkLineChart.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   /**
-   * Offset the clipped area by this amount in pixels on each side.
+   * The clipped area offset in pixels.
    *
-   * This is particularly useful when lines of line charts are clipped due to being drawn at the drawing area edges.
-   * This can happen because the default stroke width of lines is 2 px, so a line drawn at the edge of the chart will
-   * have half the stroke width clipped.
+   * This prevents partial clipping of lines when they are drawn on the edge of the drawing area.
    *
    * @default { top: 1, right: 1, bottom: 1, left: 1 }
    */


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/15221.

Before we weren't respecting the margin because the drawing area wasn't being clipped, but it is now. The examples below have a margin of 5px, which wasn't respected before.

Before:

<img width="364" alt="image" src="https://github.com/user-attachments/assets/459ee236-5831-4cc4-a61f-53d50a6d7cf5" />


After:

<img width="361" alt="image" src="https://github.com/user-attachments/assets/d02fd692-692e-4e5f-b6bb-6729ec63afb6" />


## Changelog

Fix sparkline not clipping elements outside the drawing area. Clipping can be disabled by setting `disableClipping` to true.