### PR TITLE
[DataGrid] Remove internal usage of `material` prop

### DIFF
--- a/packages/x-data-grid-premium/src/components/aiAssistantPanel/GridAiAssistantPanelConversationsMenu.tsx
+++ b/packages/x-data-grid-premium/src/components/aiAssistantPanel/GridAiAssistantPanelConversationsMenu.tsx
@@ -81,7 +81,6 @@ function GridAiAssistantPanelConversationsMenu() {
               <rootProps.slots.baseMenuItem
                 key={`${conversation.id}-${sortedIndex}`}
                 selected={conversationIndex === activeConversationIndex}
-                material={{ dense: true }}
                 onClick={() => {
                   apiRef.current.aiAssistant.setActiveConversationIndex(conversationIndex);
                   handleClose();


### PR DESCRIPTION
The `material` prop should not be used internally, only on docs examples and in user-land.

For now we can live without the dense version of menu items.