### PR TITLE
[docs] Explicitly state that `groupingColDef` reference needs to be stable

### DIFF
--- a/docs/data/data-grid/aggregation/AggregationTreeData.js
+++ b/docs/data/data-grid/aggregation/AggregationTreeData.js
@@ -127,6 +127,11 @@ const getTreeDataPath = (row) => row.hierarchy;
 
 const getRowId = (row) => row.hierarchy.join('/');
 
+const groupingColDef = {
+  headerName: 'Files',
+  width: 350,
+};
+
 export default function AggregationTreeData() {
   return (
     <div style={{ height: 400, width: '100%' }}>
@@ -136,7 +141,7 @@ export default function AggregationTreeData() {
         columns={columns}
         getTreeDataPath={getTreeDataPath}
         getRowId={getRowId}
-        groupingColDef={{ headerName: 'Files', width: 350 }}
+        groupingColDef={groupingColDef}
         initialState={{
           aggregation: {
             model: {

--- a/docs/data/data-grid/aggregation/AggregationTreeData.tsx
+++ b/docs/data/data-grid/aggregation/AggregationTreeData.tsx
@@ -4,6 +4,7 @@ import {
   GridColDef,
   GridRowsProp,
   DataGridPremiumProps,
+  GridGroupingColDefOverride,
 } from '@mui/x-data-grid-premium';
 
 interface File {
@@ -140,6 +141,11 @@ const getTreeDataPath: DataGridPremiumProps<File>['getTreeDataPath'] = (row) =>
 const getRowId: DataGridPremiumProps<File>['getRowId'] = (row) =>
   row.hierarchy.join('/');
 
+const groupingColDef: GridGroupingColDefOverride<File> = {
+  headerName: 'Files',
+  width: 350,
+};
+
 export default function AggregationTreeData() {
   return (
     <div style={{ height: 400, width: '100%' }}>
@@ -149,7 +155,7 @@ export default function AggregationTreeData() {
         columns={columns}
         getTreeDataPath={getTreeDataPath}
         getRowId={getRowId}
-        groupingColDef={{ headerName: 'Files', width: 350 }}
+        groupingColDef={groupingColDef}
         initialState={{
           aggregation: {
             model: {

--- a/docs/data/data-grid/aggregation/AggregationTreeData.tsx.preview
+++ b/docs/data/data-grid/aggregation/AggregationTreeData.tsx.preview
@@ -4,7 +4,7 @@
   columns={columns}
   getTreeDataPath={getTreeDataPath}
   getRowId={getRowId}
-  groupingColDef={{ headerName: 'Files', width: 350 }}
+  groupingColDef={groupingColDef}
   initialState={{
     aggregation: {
       model: {

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingGroupedRows.js
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingGroupedRows.js
@@ -6,6 +6,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  width: 250,
+};
+
 export default function ColumnAutosizingGroupedRows() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
@@ -34,7 +38,7 @@ export default function ColumnAutosizingGroupedRows() {
         columns={columns}
         apiRef={apiRef}
         initialState={initialState}
-        groupingColDef={{ width: 250 }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingGroupedRows.tsx
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingGroupedRows.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  width: 250,
+};
 
 export default function ColumnAutosizingGroupedRows() {
   const data = useMovieData();
@@ -34,7 +40,7 @@ export default function ColumnAutosizingGroupedRows() {
         columns={columns}
         apiRef={apiRef}
         initialState={initialState}
-        groupingColDef={{ width: 250 }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/column-dimensions/ColumnAutosizingGroupedRows.tsx.preview
+++ b/docs/data/data-grid/column-dimensions/ColumnAutosizingGroupedRows.tsx.preview
@@ -3,5 +3,5 @@
   columns={columns}
   apiRef={apiRef}
   initialState={initialState}
-  groupingColDef={{ width: 250 }}
+  groupingColDef={groupingColDef}
 />

--- a/docs/data/data-grid/column-menu/ColumnMenuGridPremium.js
+++ b/docs/data/data-grid/column-menu/ColumnMenuGridPremium.js
@@ -6,6 +6,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  leafField: 'title',
+};
+
 export default function ColumnMenuGridPremium() {
   const apiRef = useGridApiRef();
   const data = useMovieData();
@@ -35,9 +39,7 @@ export default function ColumnMenuGridPremium() {
       <DataGridPremium
         {...data}
         apiRef={apiRef}
-        groupingColDef={{
-          leafField: 'title',
-        }}
+        groupingColDef={groupingColDef}
         initialState={initialState}
       />
     </div>

--- a/docs/data/data-grid/column-menu/ColumnMenuGridPremium.tsx
+++ b/docs/data/data-grid/column-menu/ColumnMenuGridPremium.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  leafField: 'title',
+};
 
 export default function ColumnMenuGridPremium() {
   const apiRef = useGridApiRef();
@@ -35,9 +41,7 @@ export default function ColumnMenuGridPremium() {
       <DataGridPremium
         {...data}
         apiRef={apiRef}
-        groupingColDef={{
-          leafField: 'title',
-        }}
+        groupingColDef={groupingColDef}
         initialState={initialState}
       />
     </div>

--- a/docs/data/data-grid/column-menu/ColumnMenuGridPremium.tsx.preview
+++ b/docs/data/data-grid/column-menu/ColumnMenuGridPremium.tsx.preview
@@ -1,8 +1,6 @@
 <DataGridPremium
   {...data}
   apiRef={apiRef}
-  groupingColDef={{
-    leafField: 'title',
-  }}
+  groupingColDef={groupingColDef}
   initialState={initialState}
 />

--- a/docs/data/data-grid/column-menu/ColumnMenuGridPremiumSnap.js
+++ b/docs/data/data-grid/column-menu/ColumnMenuGridPremiumSnap.js
@@ -6,6 +6,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  leafField: 'title',
+};
+
 // This demo is used in visual regression tests to spot regressions in the column menu
 export default function ColumnMenuGridPremiumSnap() {
   const apiRef = useGridApiRef();
@@ -44,7 +48,7 @@ export default function ColumnMenuGridPremiumSnap() {
       <DataGridPremium
         {...data}
         apiRef={apiRef}
-        groupingColDef={{ leafField: 'title' }}
+        groupingColDef={groupingColDef}
         initialState={initialState}
       />
     </div>

--- a/docs/data/data-grid/column-menu/ColumnMenuGridPremiumSnap.tsx
+++ b/docs/data/data-grid/column-menu/ColumnMenuGridPremiumSnap.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  leafField: 'title',
+};
 
 // This demo is used in visual regression tests to spot regressions in the column menu
 export default function ColumnMenuGridPremiumSnap() {
@@ -44,7 +50,7 @@ export default function ColumnMenuGridPremiumSnap() {
       <DataGridPremium
         {...data}
         apiRef={apiRef}
-        groupingColDef={{ leafField: 'title' }}
+        groupingColDef={groupingColDef}
         initialState={initialState}
       />
     </div>

--- a/docs/data/data-grid/column-menu/ColumnMenuGridPremiumSnap.tsx.preview
+++ b/docs/data/data-grid/column-menu/ColumnMenuGridPremiumSnap.tsx.preview
@@ -1,6 +1,6 @@
 <DataGridPremium
   {...data}
   apiRef={apiRef}
-  groupingColDef={{ leafField: 'title' }}
+  groupingColDef={groupingColDef}
   initialState={initialState}
 />

--- a/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefCallback.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefCallback.js
@@ -25,6 +25,32 @@ export default function RowGroupingCustomGroupingColDefCallback() {
 
   const rowGroupingModelStr = rowGroupingModel.join('-');
 
+  const groupingColDef = React.useCallback(
+    (params) => {
+      const override = {};
+      if (params.fields.includes('director')) {
+        return {
+          headerName: 'Director',
+          valueFormatter: (value, row) => {
+            const rowId = apiRef.current?.getRowId(row);
+            if (!rowId) {
+              return undefined;
+            }
+
+            const rowNode = apiRef.current?.getRowNode(rowId);
+            if (rowNode?.type === 'group' && rowNode?.groupingField === 'director') {
+              return `by ${rowNode.groupingKey ?? ''}`;
+            }
+            return undefined;
+          },
+        };
+      }
+
+      return override;
+    },
+    [apiRef],
+  );
+
   return (
     <div style={{ width: '100%' }}>
       <Stack
@@ -53,31 +79,7 @@ export default function RowGroupingCustomGroupingColDefCallback() {
           disableRowSelectionOnClick
           rowGroupingModel={rowGroupingModel}
           initialState={initialState}
-          groupingColDef={(params) => {
-            const override = {};
-            if (params.fields.includes('director')) {
-              return {
-                headerName: 'Director',
-                valueFormatter: (value, row) => {
-                  const rowId = apiRef.current?.getRowId(row);
-                  if (!rowId) {
-                    return undefined;
-                  }
-
-                  const rowNode = apiRef.current?.getRowNode(rowId);
-                  if (
-                    rowNode?.type === 'group' &&
-                    rowNode?.groupingField === 'director'
-                  ) {
-                    return `by ${rowNode.groupingKey ?? ''}`;
-                  }
-                  return undefined;
-                },
-              };
-            }
-
-            return override;
-          }}
+          groupingColDef={groupingColDef}
         />
       </Box>
     </div>

--- a/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefCallback.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefCallback.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {
   DataGridPremium,
   GridGroupingColDefOverride,
+  GridGroupingColDefOverrideParams,
+  GridRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
@@ -25,6 +27,32 @@ export default function RowGroupingCustomGroupingColDefCallback() {
   });
 
   const rowGroupingModelStr = rowGroupingModel.join('-');
+
+  const groupingColDef = React.useCallback(
+    (params: GridGroupingColDefOverrideParams) => {
+      const override: GridGroupingColDefOverride = {};
+      if (params.fields.includes('director')) {
+        return {
+          headerName: 'Director',
+          valueFormatter: (value: string, row: GridRowModel) => {
+            const rowId = apiRef.current?.getRowId(row);
+            if (!rowId) {
+              return undefined;
+            }
+
+            const rowNode = apiRef.current?.getRowNode(rowId);
+            if (rowNode?.type === 'group' && rowNode?.groupingField === 'director') {
+              return `by ${rowNode.groupingKey ?? ''}`;
+            }
+            return undefined;
+          },
+        };
+      }
+
+      return override;
+    },
+    [apiRef],
+  );
 
   return (
     <div style={{ width: '100%' }}>
@@ -54,31 +82,7 @@ export default function RowGroupingCustomGroupingColDefCallback() {
           disableRowSelectionOnClick
           rowGroupingModel={rowGroupingModel}
           initialState={initialState}
-          groupingColDef={(params) => {
-            const override: GridGroupingColDefOverride = {};
-            if (params.fields.includes('director')) {
-              return {
-                headerName: 'Director',
-                valueFormatter: (value, row) => {
-                  const rowId = apiRef.current?.getRowId(row);
-                  if (!rowId) {
-                    return undefined;
-                  }
-
-                  const rowNode = apiRef.current?.getRowNode(rowId);
-                  if (
-                    rowNode?.type === 'group' &&
-                    rowNode?.groupingField === 'director'
-                  ) {
-                    return `by ${rowNode.groupingKey ?? ''}`;
-                  }
-                  return undefined;
-                },
-              };
-            }
-
-            return override;
-          }}
+          groupingColDef={groupingColDef}
         />
       </Box>
     </div>

--- a/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefObject.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefObject.js
@@ -6,6 +6,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  headerName: 'Group',
+};
+
 export default function RowGroupingCustomGroupingColDefObject() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
@@ -26,9 +30,7 @@ export default function RowGroupingCustomGroupingColDefObject() {
         apiRef={apiRef}
         disableRowSelectionOnClick
         initialState={initialState}
-        groupingColDef={{
-          headerName: 'Group',
-        }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefObject.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefObject.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  headerName: 'Group',
+};
 
 export default function RowGroupingCustomGroupingColDefObject() {
   const data = useMovieData();
@@ -26,9 +32,7 @@ export default function RowGroupingCustomGroupingColDefObject() {
         apiRef={apiRef}
         disableRowSelectionOnClick
         initialState={initialState}
-        groupingColDef={{
-          headerName: 'Group',
-        }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefObject.tsx.preview
+++ b/docs/data/data-grid/row-grouping/RowGroupingCustomGroupingColDefObject.tsx.preview
@@ -3,7 +3,5 @@
   apiRef={apiRef}
   disableRowSelectionOnClick
   initialState={initialState}
-  groupingColDef={{
-    headerName: 'Group',
-  }}
+  groupingColDef={groupingColDef}
 />

--- a/docs/data/data-grid/row-grouping/RowGroupingFilteringSingleGroupingColDef.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingFilteringSingleGroupingColDef.js
@@ -27,6 +27,14 @@ export default function RowGroupingFilteringSingleGroupingColDef() {
     },
   });
 
+  const groupingColDef = React.useMemo(
+    () => ({
+      mainGroupingCriteria:
+        mainGroupingCriteria === 'undefined' ? undefined : mainGroupingCriteria,
+    }),
+    [mainGroupingCriteria],
+  );
+
   return (
     <Box sx={{ width: '100%' }}>
       <FormControl fullWidth>
@@ -55,12 +63,7 @@ export default function RowGroupingFilteringSingleGroupingColDef() {
           disableRowSelectionOnClick
           defaultGroupingExpansionDepth={-1}
           initialState={initialState}
-          groupingColDef={{
-            mainGroupingCriteria:
-              mainGroupingCriteria === 'undefined'
-                ? undefined
-                : mainGroupingCriteria,
-          }}
+          groupingColDef={groupingColDef}
         />
       </Box>
     </Box>

--- a/docs/data/data-grid/row-grouping/RowGroupingFilteringSingleGroupingColDef.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingFilteringSingleGroupingColDef.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
@@ -26,6 +28,15 @@ export default function RowGroupingFilteringSingleGroupingColDef() {
       },
     },
   });
+
+  const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> =
+    React.useMemo(
+      () => ({
+        mainGroupingCriteria:
+          mainGroupingCriteria === 'undefined' ? undefined : mainGroupingCriteria,
+      }),
+      [mainGroupingCriteria],
+    );
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -55,12 +66,7 @@ export default function RowGroupingFilteringSingleGroupingColDef() {
           disableRowSelectionOnClick
           defaultGroupingExpansionDepth={-1}
           initialState={initialState}
-          groupingColDef={{
-            mainGroupingCriteria:
-              mainGroupingCriteria === 'undefined'
-                ? undefined
-                : mainGroupingCriteria,
-          }}
+          groupingColDef={groupingColDef}
         />
       </Box>
     </Box>

--- a/docs/data/data-grid/row-grouping/RowGroupingFullExample.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingFullExample.js
@@ -7,6 +7,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useDemoData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  leafField: 'traderEmail',
+};
+
 export default function RowGroupingFullExample() {
   const { data, loading } = useDemoData({
     dataSet: 'Commodity',
@@ -37,9 +41,7 @@ export default function RowGroupingFullExample() {
         loading={loading}
         disableRowSelectionOnClick
         initialState={initialState}
-        groupingColDef={{
-          leafField: 'traderEmail',
-        }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingFullExample.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingFullExample.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 import {
   DataGridPremium,
   GRID_ROW_GROUPING_SINGLE_GROUPING_FIELD,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useDemoData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  leafField: 'traderEmail',
+};
 
 export default function RowGroupingFullExample() {
   const { data, loading } = useDemoData({
@@ -37,9 +43,7 @@ export default function RowGroupingFullExample() {
         loading={loading}
         disableRowSelectionOnClick
         initialState={initialState}
-        groupingColDef={{
-          leafField: 'traderEmail',
-        }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingFullExample.tsx.preview
+++ b/docs/data/data-grid/row-grouping/RowGroupingFullExample.tsx.preview
@@ -4,7 +4,5 @@
   loading={loading}
   disableRowSelectionOnClick
   initialState={initialState}
-  groupingColDef={{
-    leafField: 'traderEmail',
-  }}
+  groupingColDef={groupingColDef}
 />

--- a/docs/data/data-grid/row-grouping/RowGroupingHideDescendantCount.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingHideDescendantCount.js
@@ -6,6 +6,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  hideDescendantCount: true,
+};
+
 export default function RowGroupingHideDescendantCount() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
@@ -26,9 +30,7 @@ export default function RowGroupingHideDescendantCount() {
         apiRef={apiRef}
         disableRowSelectionOnClick
         initialState={initialState}
-        groupingColDef={{
-          hideDescendantCount: true,
-        }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingHideDescendantCount.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingHideDescendantCount.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  hideDescendantCount: true,
+};
 
 export default function RowGroupingHideDescendantCount() {
   const data = useMovieData();
@@ -26,9 +32,7 @@ export default function RowGroupingHideDescendantCount() {
         apiRef={apiRef}
         disableRowSelectionOnClick
         initialState={initialState}
-        groupingColDef={{
-          hideDescendantCount: true,
-        }}
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingHideDescendantCount.tsx.preview
+++ b/docs/data/data-grid/row-grouping/RowGroupingHideDescendantCount.tsx.preview
@@ -3,7 +3,5 @@
   apiRef={apiRef}
   disableRowSelectionOnClick
   initialState={initialState}
-  groupingColDef={{
-    hideDescendantCount: true,
-  }}
+  groupingColDef={groupingColDef}
 />

--- a/docs/data/data-grid/row-grouping/RowGroupingLeafWithValue.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingLeafWithValue.js
@@ -6,6 +6,10 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = {
+  leafField: 'title',
+};
+
 export default function RowGroupingLeafWithValue() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
@@ -30,7 +34,7 @@ export default function RowGroupingLeafWithValue() {
       <DataGridPremium
         {...data}
         apiRef={apiRef}
-        groupingColDef={{ leafField: 'title' }}
+        groupingColDef={groupingColDef}
         initialState={initialState}
       />
     </div>

--- a/docs/data/data-grid/row-grouping/RowGroupingLeafWithValue.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingLeafWithValue.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  leafField: 'title',
+};
 
 export default function RowGroupingLeafWithValue() {
   const data = useMovieData();
@@ -30,7 +36,7 @@ export default function RowGroupingLeafWithValue() {
       <DataGridPremium
         {...data}
         apiRef={apiRef}
-        groupingColDef={{ leafField: 'title' }}
+        groupingColDef={groupingColDef}
         initialState={initialState}
       />
     </div>

--- a/docs/data/data-grid/row-grouping/RowGroupingLeafWithValue.tsx.preview
+++ b/docs/data/data-grid/row-grouping/RowGroupingLeafWithValue.tsx.preview
@@ -1,6 +1,6 @@
 <DataGridPremium
   {...data}
   apiRef={apiRef}
-  groupingColDef={{ leafField: 'title' }}
+  groupingColDef={groupingColDef}
   initialState={initialState}
 />

--- a/docs/data/data-grid/row-grouping/RowGroupingSortingMultipleGroupingColDef.js
+++ b/docs/data/data-grid/row-grouping/RowGroupingSortingMultipleGroupingColDef.js
@@ -6,6 +6,14 @@ import {
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
 
+const groupingColDef = (params) =>
+  params.fields.includes('director')
+    ? {
+        leafField: 'title',
+        mainGroupingCriteria: 'director',
+      }
+    : {};
+
 export default function RowGroupingSortingMultipleGroupingColDef() {
   const data = useMovieData();
   const apiRef = useGridApiRef();
@@ -28,14 +36,7 @@ export default function RowGroupingSortingMultipleGroupingColDef() {
         defaultGroupingExpansionDepth={-1}
         initialState={initialState}
         rowGroupingColumnMode="multiple"
-        groupingColDef={(params) =>
-          params.fields.includes('director')
-            ? {
-                leafField: 'title',
-                mainGroupingCriteria: 'director',
-              }
-            : {}
-        }
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingSortingMultipleGroupingColDef.tsx
+++ b/docs/data/data-grid/row-grouping/RowGroupingSortingMultipleGroupingColDef.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
 import {
   DataGridPremium,
+  GridGroupingColDefOverrideParams,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMovieData } from '@mui/x-data-grid-generator';
+
+const groupingColDef = (params: GridGroupingColDefOverrideParams) =>
+  params.fields.includes('director')
+    ? {
+        leafField: 'title',
+        mainGroupingCriteria: 'director',
+      }
+    : {};
 
 export default function RowGroupingSortingMultipleGroupingColDef() {
   const data = useMovieData();
@@ -28,14 +37,7 @@ export default function RowGroupingSortingMultipleGroupingColDef() {
         defaultGroupingExpansionDepth={-1}
         initialState={initialState}
         rowGroupingColumnMode="multiple"
-        groupingColDef={(params) =>
-          params.fields.includes('director')
-            ? {
-                leafField: 'title',
-                mainGroupingCriteria: 'director',
-              }
-            : {}
-        }
+        groupingColDef={groupingColDef}
       />
     </div>
   );

--- a/docs/data/data-grid/row-grouping/RowGroupingSortingMultipleGroupingColDef.tsx.preview
+++ b/docs/data/data-grid/row-grouping/RowGroupingSortingMultipleGroupingColDef.tsx.preview
@@ -5,12 +5,5 @@
   defaultGroupingExpansionDepth={-1}
   initialState={initialState}
   rowGroupingColumnMode="multiple"
-  groupingColDef={(params) =>
-    params.fields.includes('director')
-      ? {
-          leafField: 'title',
-          mainGroupingCriteria: 'director',
-        }
-      : {}
-  }
+  groupingColDef={groupingColDef}
 />

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -78,7 +78,7 @@ To override properties for specific grouping columns, or to apply different over
 The callback is called for each grouping column, and it receives the respective column's fields as parameters.
 
 :::warning
-`groupingColDef` prop, same as `columns` prop should keep the same reference between two renders.
+The `groupingColDef` prop, same as `columns` prop, should keep the same reference between two renders.
 Otherwise, the grouping column processing can happen multiple times and outside of the required order, resulting in a wrong column placement.
 :::
 

--- a/docs/data/data-grid/row-grouping/row-grouping.md
+++ b/docs/data/data-grid/row-grouping/row-grouping.md
@@ -77,6 +77,11 @@ This means that if `rowGroupingColumnMode` is set to `multiple`, then all column
 To override properties for specific grouping columns, or to apply different overrides based on the current grouping criteria, you can pass a callback function to `groupingColDef` instead of an object with its config.
 The callback is called for each grouping column, and it receives the respective column's fields as parameters.
 
+:::warning
+`groupingColDef` prop, same as `columns` prop should keep the same reference between two renders.
+Otherwise, the grouping column processing can happen multiple times and outside of the required order, resulting in a wrong column placement.
+:::
+
 The demo below illustrates this approach to provide buttons for toggling between different grouping criteria:
 
 {{"demo": "RowGroupingCustomGroupingColDefCallback.js", "bg": "inline", "defaultCodeOpen": false}}

--- a/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.js
+++ b/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.js
@@ -7,6 +7,10 @@ import {
 import { useMockServer } from '@mui/x-data-grid-generator';
 import Button from '@mui/material/Button';
 
+const groupingColDef = {
+  width: 250,
+};
+
 export default function ServerSideRowGroupingFullDataGrid() {
   const apiRef = useGridApiRef();
 
@@ -70,9 +74,7 @@ export default function ServerSideRowGroupingFullDataGrid() {
           apiRef={apiRef}
           initialState={initialState}
           showToolbar
-          groupingColDef={{
-            width: 250,
-          }}
+          groupingColDef={groupingColDef}
         />
       </div>
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx
+++ b/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx
@@ -2,11 +2,17 @@ import * as React from 'react';
 import {
   DataGridPremium,
   GridDataSource,
+  GridGroupingColDefOverride,
+  GridValidRowModel,
   useGridApiRef,
   useKeepGroupedColumnsHidden,
 } from '@mui/x-data-grid-premium';
 import { useMockServer } from '@mui/x-data-grid-generator';
 import Button from '@mui/material/Button';
+
+const groupingColDef: GridGroupingColDefOverride<GridValidRowModel> = {
+  width: 250,
+};
 
 export default function ServerSideRowGroupingFullDataGrid() {
   const apiRef = useGridApiRef();
@@ -71,9 +77,7 @@ export default function ServerSideRowGroupingFullDataGrid() {
           apiRef={apiRef}
           initialState={initialState}
           showToolbar
-          groupingColDef={{
-            width: 250,
-          }}
+          groupingColDef={groupingColDef}
         />
       </div>
     </div>

--- a/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx.preview
+++ b/docs/data/data-grid/server-side-data/ServerSideRowGroupingFullDataGrid.tsx.preview
@@ -7,8 +7,6 @@
     apiRef={apiRef}
     initialState={initialState}
     showToolbar
-    groupingColDef={{
-      width: 250,
-    }}
+    groupingColDef={groupingColDef}
   />
 </div>

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts
@@ -21,7 +21,6 @@ export const useGridDataSourceRowGroupingPreProcessors = (
   props: Pick<
     DataGridPremiumProcessedProps,
     | 'disableRowGrouping'
-    | 'groupingColDef'
     | 'rowGroupingColumnMode'
     | 'defaultGroupingExpansionDepth'
     | 'isGroupExpandedByDefault'

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
@@ -60,7 +60,6 @@ export const useGridRowGrouping = (
     | 'onRowGroupingModelChange'
     | 'defaultGroupingExpansionDepth'
     | 'isGroupExpandedByDefault'
-    | 'groupingColDef'
     | 'rowGroupingColumnMode'
     | 'disableRowGrouping'
     | 'slotProps'


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/17409

I have noticed that we are not stating anywhere that `groupingColDef` needs to have a stable reference.
In most cases it goes unnoticed, but if you have other hooks reacting on `hydrateColumns` then `groupingColDef` can cause problems (example with column pinning in the issue above).

I have added a warning and updated our demos to show the correct setup