### PR TITLE
[core] Move loadStyleSheets to internals and use it in data grid and charts

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/common.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/common.ts
@@ -1,5 +1,3 @@
-import ownerDocument from '@mui/utils/ownerDocument';
-
 export function createExportIframe(title?: string): HTMLIFrameElement {
   const iframeEl = document.createElement('iframe');
   iframeEl.style.position = 'absolute';
@@ -7,55 +5,4 @@ export function createExportIframe(title?: string): HTMLIFrameElement {
   iframeEl.style.height = '0px';
   iframeEl.title = title || document.title;
   return iframeEl;
-}
-
-export function loadStyleSheets(document: Document, element: HTMLElement | SVGElement) {
-  const stylesheetLoadPromises: Promise<void>[] = [];
-  const doc = ownerDocument(element);
-
-  const rootCandidate = element.getRootNode();
-  const root =
-    rootCandidate.constructor.name === 'ShadowRoot' ? (rootCandidate as ShadowRoot) : doc;
-  const headStyleElements = root!.querySelectorAll("style, link[rel='stylesheet']");
-
-  for (let i = 0; i < headStyleElements.length; i += 1) {
-    const node = headStyleElements[i];
-    if (node.tagName === 'STYLE') {
-      const newHeadStyleElements = document.createElement(node.tagName);
-      const sheet = (node as HTMLStyleElement).sheet;
-
-      if (sheet) {
-        let styleCSS = '';
-        // NOTE: for-of is not supported by IE
-        for (let j = 0; j < sheet.cssRules.length; j += 1) {
-          if (typeof sheet.cssRules[j].cssText === 'string') {
-            styleCSS += `${sheet.cssRules[j].cssText}\r\n`;
-          }
-        }
-        newHeadStyleElements.appendChild(document.createTextNode(styleCSS));
-        document.head.appendChild(newHeadStyleElements);
-      }
-    } else if (node.getAttribute('href')) {
-      // If `href` tag is empty, avoid loading these links
-
-      const newHeadStyleElements = document.createElement(node.tagName);
-
-      for (let j = 0; j < node.attributes.length; j += 1) {
-        const attr = node.attributes[j];
-        if (attr) {
-          newHeadStyleElements.setAttribute(attr.nodeName, attr.nodeValue || '');
-        }
-      }
-
-      stylesheetLoadPromises.push(
-        new Promise((resolve) => {
-          newHeadStyleElements.addEventListener('load', () => resolve());
-        }),
-      );
-
-      document.head.appendChild(newHeadStyleElements);
-    }
-  }
-
-  return Promise.all(stylesheetLoadPromises);
 }

--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
@@ -1,5 +1,6 @@
 import ownerDocument from '@mui/utils/ownerDocument';
-import { createExportIframe, loadStyleSheets } from './common';
+import { loadStyleSheets } from '@mui/x-internals/export';
+import { createExportIframe } from './common';
 import { ChartImageExportOptions } from './useChartProExport.types';
 
 export const getDrawDocument = async () => {
@@ -45,7 +46,11 @@ export async function exportImage(
     exportDoc.body.innerHTML = container.innerHTML;
     exportDoc.body.style.margin = '0px';
 
-    await loadStyleSheets(exportDoc, element);
+    const rootCandidate = element.getRootNode();
+    const root =
+      rootCandidate.constructor.name === 'ShadowRoot' ? (rootCandidate as ShadowRoot) : doc;
+
+    await Promise.all(loadStyleSheets(exportDoc, root));
 
     resolve();
   };

--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/print.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/print.ts
@@ -1,5 +1,6 @@
 import ownerDocument from '@mui/utils/ownerDocument';
-import { createExportIframe, loadStyleSheets } from './common';
+import { loadStyleSheets } from '@mui/x-internals/export';
+import { createExportIframe } from './common';
 import { ChartPrintExportOptions } from './useChartProExport.types';
 
 export function printChart(
@@ -16,7 +17,11 @@ export function printChart(
     container.appendChild(elementClone);
     printDoc.body.innerHTML = container.innerHTML;
 
-    await loadStyleSheets(printDoc, element);
+    const rootCandidate = element.getRootNode();
+    const root =
+      rootCandidate.constructor.name === 'ShadowRoot' ? (rootCandidate as ShadowRoot) : doc;
+
+    await Promise.all(loadStyleSheets(printDoc, root));
 
     printWindow.contentWindow!.print();
 

--- a/packages/x-internals/src/export/index.ts
+++ b/packages/x-internals/src/export/index.ts
@@ -1,0 +1,1 @@
+export { loadStyleSheets } from './loadStyleSheets';

--- a/packages/x-internals/src/export/loadStyleSheets.tsx
+++ b/packages/x-internals/src/export/loadStyleSheets.tsx
@@ -1,0 +1,51 @@
+/**
+ * Loads all stylesheets from the given root element into the document.
+ * @returns an array of promises that resolve when each stylesheet is loaded
+ * @param document Document to load stylesheets into
+ * @param root Document or ShadowRoot to load stylesheets from
+ */
+export function loadStyleSheets(document: Document, root: Document | ShadowRoot) {
+  const stylesheetLoadPromises: Promise<void>[] = [];
+  const headStyleElements = root.querySelectorAll("style, link[rel='stylesheet']");
+
+  for (let i = 0; i < headStyleElements.length; i += 1) {
+    const node = headStyleElements[i];
+    if (node.tagName === 'STYLE') {
+      const newHeadStyleElements = document.createElement(node.tagName);
+      const sheet = (node as HTMLStyleElement).sheet;
+
+      if (sheet) {
+        let styleCSS = '';
+        // NOTE: for-of is not supported by IE
+        for (let j = 0; j < sheet.cssRules.length; j += 1) {
+          if (typeof sheet.cssRules[j].cssText === 'string') {
+            styleCSS += `${sheet.cssRules[j].cssText}\r\n`;
+          }
+        }
+        newHeadStyleElements.appendChild(document.createTextNode(styleCSS));
+        document.head.appendChild(newHeadStyleElements);
+      }
+    } else if (node.getAttribute('href')) {
+      // If `href` tag is empty, avoid loading these links
+
+      const newHeadStyleElements = document.createElement(node.tagName);
+
+      for (let j = 0; j < node.attributes.length; j += 1) {
+        const attr = node.attributes[j];
+        if (attr) {
+          newHeadStyleElements.setAttribute(attr.nodeName, attr.nodeValue || '');
+        }
+      }
+
+      stylesheetLoadPromises.push(
+        new Promise((resolve) => {
+          newHeadStyleElements.addEventListener('load', () => resolve());
+        }),
+      );
+
+      document.head.appendChild(newHeadStyleElements);
+    }
+  }
+
+  return stylesheetLoadPromises;
+}

--- a/packages/x-internals/src/export/loadStyleSheets.tsx
+++ b/packages/x-internals/src/export/loadStyleSheets.tsx
@@ -16,7 +16,6 @@ export function loadStyleSheets(document: Document, root: Document | ShadowRoot)
 
       if (sheet) {
         let styleCSS = '';
-        // NOTE: for-of is not supported by IE
         for (let j = 0; j < sheet.cssRules.length; j += 1) {
           if (typeof sheet.cssRules[j].cssText === 'string') {
             styleCSS += `${sheet.cssRules[j].cssText}\r\n`;


### PR DESCRIPTION
Move `loadStyleSheets` to `@mui/x-internals` and use it in data grid and charts.