### PR TITLE
Bump `react-router` to ^7.5.2 [SECURITY]

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -86,7 +86,7 @@
     "react-docgen": "^5.4.3",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.55.0",
-    "react-router": "^7.5.1",
+    "react-router": "^7.5.2",
     "react-runner": "^1.0.5",
     "react-simple-code-editor": "^0.14.1",
     "recast": "^0.23.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,8 +608,8 @@ importers:
         specifier: ^7.55.0
         version: 7.55.0(react@19.0.0)
       react-router:
-        specifier: ^7.5.1
-        version: 7.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^7.5.2
+        version: 7.5.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-runner:
         specifier: ^1.0.5
         version: 1.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1692,8 +1692,8 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       react-router:
-        specifier: ^7.5.1
-        version: 7.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^7.5.2
+        version: 7.5.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1779,8 +1779,8 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       react-router:
-        specifier: ^7.5.1
-        version: 7.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^7.5.2
+        version: 7.5.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1914,8 +1914,8 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       react-router:
-        specifier: ^7.5.1
-        version: 7.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^7.5.2
+        version: 7.5.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -9120,8 +9120,8 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.5.1:
-    resolution: {integrity: sha512-/jjU3fcYNd2bwz9Q0xt5TwyiyoO8XjSEFXJY4O/lMAlkGTHWuHRAbR9Etik+lSDqMC7A7mz3UlXzgYT6Vl58sA==}
+  react-router@7.5.2:
+    resolution: {integrity: sha512-9Rw8r199klMnlGZ8VAsV/I8WrIF6IyJ90JQUdboupx1cdkgYqwnrYjH+I/nY/7cA1X5zia4mDJqH36npP7sxGQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -19221,7 +19221,7 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-router@7.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  react-router@7.5.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       cookie: 1.0.2
       react: 19.0.0

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -34,7 +34,7 @@
     "chai": "^4.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.5.1",
+    "react-router": "^7.5.2",
     "react-transition-group": "^4.4.5",
     "tsx": "^4.19.3"
   }

--- a/test/package.json
+++ b/test/package.json
@@ -34,7 +34,7 @@
     "prop-types": "^15.8.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.5.1",
+    "react-router": "^7.5.2",
     "react-transition-group": "^4.4.5",
     "semver": "^7.7.1",
     "stylis": "^4.3.6",

--- a/test/regressions/package.json
+++ b/test/regressions/package.json
@@ -36,7 +36,7 @@
     "chai": "^4.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.5.1",
+    "react-router": "^7.5.2",
     "react-transition-group": "^4.4.5",
     "tsx": "^4.19.3"
   }


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/pull/17541 (and supercedes).