### PR TITLE
[docs] Add link to version

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -208,7 +208,8 @@ function AppWrapper(props) {
       metadata: '',
       name: 'MUI X',
       versions: [
-        { text: 'v7', href: `https://mui.com${languagePrefix}/x/introduction/` },
+        { text: 'latest', href: `https://mui.com${languagePrefix}/x/introduction/` },
+        { text: 'v7', href: `https://v7.mui.com${languagePrefix}/x/introduction/` },
         { text: `v${process.env.LIB_VERSION}`, current: true },
         { text: 'v5', href: `https://v5.mui.com${languagePrefix}/x/introduction/` },
         { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
@@ -221,8 +222,12 @@ function AppWrapper(props) {
         name: 'Data Grid',
         versions: [
           {
-            text: 'v7',
+            text: 'latest',
             href: `https://mui.com${languagePrefix}/x/react-data-grid/`,
+          },
+          {
+            text: 'v7',
+            href: `https://v7.mui.com${languagePrefix}/x/react-data-grid/`,
           },
           { text: `v${process.env.DATA_GRID_VERSION}`, current: true },
           { text: 'v5', href: `https://v5.mui.com${languagePrefix}/x/react-data-grid/` },
@@ -235,8 +240,12 @@ function AppWrapper(props) {
         name: 'Date Pickers',
         versions: [
           {
-            text: 'v7',
+            text: 'latest',
             href: `https://mui.com${languagePrefix}/x/react-date-pickers/`,
+          },
+          {
+            text: 'v7',
+            href: `https://v7.mui.com${languagePrefix}/x/react-date-pickers/`,
           },
           { text: `v${process.env.DATE_PICKERS_VERSION}`, current: true },
           {
@@ -251,8 +260,12 @@ function AppWrapper(props) {
         name: 'Charts',
         versions: [
           {
-            text: 'v7',
+            text: 'latest',
             href: `https://mui.com${languagePrefix}/x/react-charts/`,
+          },
+          {
+            text: 'v7',
+            href: `https://v7.mui.com${languagePrefix}/x/react-charts/`,
           },
           { text: `v${process.env.CHARTS_VERSION}`, current: true },
         ],
@@ -263,8 +276,12 @@ function AppWrapper(props) {
         name: 'Tree View',
         versions: [
           {
-            text: 'v7',
+            text: 'latest',
             href: `https://mui.com${languagePrefix}/x/react-tree-view/getting-started`,
+          },
+          {
+            text: 'v7',
+            href: `https://v7.mui.com${languagePrefix}/x/react-tree-view/getting-started`,
           },
           { text: `v${process.env.TREE_VIEW_VERSION}`, current: true },
         ],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
     "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
-    "build:codesandbox": "yarn release:build",
+    "build:codesandbox": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true yarn release:build",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "release:version": "lerna version --exact --no-changelog --no-push --no-git-tag-version --no-private",


### PR DESCRIPTION
The link in https://v6.mui.com/x/introduction/ to v7 is outdated now.
 
<img width="296" alt="SCR-20250428-bura" src="https://github.com/user-attachments/assets/61661661-608b-49fc-94f0-ea0fedce797b" />

I have noticed this from https://mui-org.slack.com/archives/C041SDSF32L/p1745416149123639. I thought we might fix this, quick-win. It could help people migrate https://tools-public.mui.com/prod/pages/npmVersion?package=@mui/x-data-grid

<img width="335" alt="SCR-20250428-byfi" src="https://github.com/user-attachments/assets/c58e8350-8a4f-4607-99af-fef2a507a91c" />

I also used the opportunity to fix the CI on this branch. v6.x is on LTS in case we need to release hot fixes: https://mui.com/x/introduction/support/#supported-versions.

---

For the future, steps added in https://www.notion.so/mui-org/Name-vX-0-0-1e2cbfe7b66080ce89fef5ac5eaeb4e7?pvs=4#1e2cbfe7b66080498d6ecfc8c5969d2d and marked it as done https://www.notion.so/mui-org/MUI-X-v8-0-0-1e2cbfe7b6608092934afbe7e2b5df22?pvs=4#1e2cbfe7b6608025b9b5ffee59f2e2e4. We could also have a "View all versions" link like in https://v6.mui.com/material-ui/getting-started/ but this is a different discussion. I'm not sure where we would show this. 

Otherwise, there are still stuff to do to complete v8.x release, from this release notion page.