### PR TITLE
[charts][docs] Fix highlighting heading structure

### DIFF
--- a/docs/data/charts/highlighting/highlighting.md
+++ b/docs/data/charts/highlighting/highlighting.md
@@ -1,5 +1,4 @@
 ---
-title: Charts - Highlighting
 productId: x-charts
 components: ChartsAxisHighlight
 ---
@@ -11,9 +10,7 @@ components: ChartsAxisHighlight
 It can be used to emphasize a specific data point or series, or to fade out the rest of the chart.
 And it can be controlled by the user or synchronized across multiple charts.
 
-## Highlighting
-
-### Highlighting axis
+## Highlighting axis
 
 You can highlight data based on mouse position.
 By default, those highlights are lines, but it can also be a vertical band if your x-axis use `scaleType: 'band'`.
@@ -29,7 +26,7 @@ axisHighlight={{
 
 {{"demo": "BandHighlight.js" }}
 
-### Highlighting series
+## Highlighting series
 
 In parallel with the tooltip, you can highlight and fade elements.
 
@@ -46,7 +43,7 @@ This kind of interaction is controlled by series properties `highlightScope` whi
 
 {{"demo": "ElementHighlights.js"}}
 
-### Controlled highlight
+## Controlled highlight
 
 The highlight can be controlled by the user when they set `highlightedItem` and `onHighlightChange`.
 
@@ -54,7 +51,7 @@ You can set the `highlightedItem` value based on inputs, and sync it when the us
 
 {{"demo": "ControlledHighlight.js"}}
 
-#### Synchronizing highlights
+### Synchronizing highlights
 
 Having a controlled highlight allows you to control it in multiple charts at the same time.
 You need to ensure that the `series` has the same `ids` and the data is in the same order.


### PR DESCRIPTION
https://mui.com/x/react-charts/highlighting/ looked really strange. I assumed the content was in a page, moved to another page, and we forgot to flatten the headers.

Noticed this in #17580

Preview: https://deploy-preview-17581--material-ui-x.netlify.app/x/react-charts/highlighting/