### PR TITLE
[infra] Updates to `branch switch comments`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       - run:
           name: '`pnpm dedupe` was run?'
           command: |
-            # #default-branch-switch
+            # #target-branch-reference
             if [[ $(git diff --name-status master | grep pnpm-lock) == "" ]];
             then
                 echo "No changes to dependencies detected. Skipping..."
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: '`pnpm prettier` changes committed?'
           command: |
-            # #default-branch-switch
+            # #target-branch-reference
             if [[ $(git diff --name-status master | grep pnpm-lock) == "" ]];
             then
                 pnpm prettier --check
@@ -224,7 +224,7 @@ jobs:
       - run:
           name: '`pnpm @mui/x-charts-vendor build` was run?'
           command: |
-            # #default-branch-switch 
+            # #target-branch-reference 
             if [[ $(git diff --name-status master | grep pnpm-lock) == "" ]]; 
             then
               echo "No changes to dependencies detected. Skipping..."

--- a/docs/constants.ts
+++ b/docs/constants.ts
@@ -1,2 +1,2 @@
 export const SOURCE_CODE_REPO = 'https://github.com/mui/mui-x';
-export const SOURCE_GITHUB_BRANCH = 'master'; // #default-branch-switch
+export const SOURCE_GITHUB_BRANCH = 'master'; // #target-branch-reference

--- a/docs/data/introduction/support/support.md
+++ b/docs/data/introduction/support/support.md
@@ -49,9 +49,7 @@ You can browse the documentation, find an example close to your use case, and th
 
 You can use a starter template to build a reproduction case with:
 
-<!-- #default-branch-switch -->
-<!-- TODO: Change this in the "old" version branches and remove this comment there. -->
-<!-- Afterwards replace this comment with "version-branch-off" -->
+<!-- #target-branch-reference -->
 
 - A minimal Data Grid [TypeScript template](https://stackblitz.com/github/mui/mui-x/tree/master/bug-reproductions/x-data-grid?file=src/index.tsx)
 - A plain React [JavaScript](https://stackblitz.com/github/stackblitz/starters/tree/main/react) or [TypeScript](https://stackblitz.com/github/stackblitz/starters/tree/main/react-ts) template

--- a/docs/data/migration/migration-charts-v7/migration-charts-v7.md
+++ b/docs/data/migration/migration-charts-v7/migration-charts-v7.md
@@ -74,7 +74,7 @@ The `preset-safe` codemod will automatically adjust the bulk of your code to acc
 
 You can either run it on a specific file, folder, or your entire codebase when choosing the `<path>` argument.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 # Charts-specific

--- a/docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md
+++ b/docs/data/migration/migration-data-grid-v7/migration-data-grid-v7.md
@@ -65,7 +65,7 @@ The `preset-safe` codemod will automatically adjust the bulk of your code to acc
 
 You can either run it on a specific file, folder, or your entire codebase when choosing the `<path>` argument.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 # Data Grid specific

--- a/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
+++ b/docs/data/migration/migration-pickers-v7/migration-pickers-v7.md
@@ -76,7 +76,7 @@ The `preset-safe` codemod will automatically adjust the bulk of your code to acc
 
 You can either run it on a specific file, folder, or your entire codebase when choosing the `<path>` argument.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 # Date and Time Pickers specific

--- a/docs/data/migration/migration-tree-view-v7/migration-tree-view-v7.md
+++ b/docs/data/migration/migration-tree-view-v7/migration-tree-view-v7.md
@@ -61,7 +61,7 @@ The `preset-safe` codemod will automatically adjust the bulk of your code to acc
 
 You can either run it on a specific file, folder, or your entire codebase when choosing the `<path>` argument.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 # Tree View specific

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -45,7 +45,7 @@ ponyfillGlobal.muiDocConfig = {
   csbIncludePeerDependencies: (deps, { versions }) => {
     const newDeps = { ...deps };
 
-    // #default-branch-switch
+    // #npm-tag-reference
     // TODO: Do we really need this? The condition does not make that much sense tbh!
     // Check which version of `@mui/material` should be resolved when opening docs examples in StackBlitz or CodeSandbox
     newDeps['@mui/material'] =

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -32,7 +32,7 @@ LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_LICENSE);
 
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
-    // #default-branch-switch
+    // #npm-tag-reference
     // Use the "next" tag for the master git branch after we start working on the next major version
     // Once the major release is finished we can go back to "latest"
     return 'latest';

--- a/docs/src/modules/components/ChartsInstallationInstructions.js
+++ b/docs/src/modules/components/ChartsInstallationInstructions.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 
-// #default-branch-switch
+// #npm-tag-reference
 
 const packages = {
   Community: '@mui/x-charts',

--- a/docs/src/modules/components/ChartsInstallationInstructions.js
+++ b/docs/src/modules/components/ChartsInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-charts',
-  Pro: '@mui/x-charts-pro',
+  Community: '@mui/x-charts@latest',
+  Pro: '@mui/x-charts-pro@latest',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/ChartsInstallationInstructions.js
+++ b/docs/src/modules/components/ChartsInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-charts@latest',
-  Pro: '@mui/x-charts-pro@latest',
+  Community: '@mui/x-charts',
+  Pro: '@mui/x-charts-pro',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -4,9 +4,9 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-data-grid@latest',
-  Pro: '@mui/x-data-grid-pro@latest',
-  Premium: '@mui/x-data-grid-premium@latest',
+  Community: '@mui/x-data-grid',
+  Pro: '@mui/x-data-grid-pro',
+  Premium: '@mui/x-data-grid-premium',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -4,9 +4,9 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-data-grid',
-  Pro: '@mui/x-data-grid-pro',
-  Premium: '@mui/x-data-grid-premium',
+  Community: '@mui/x-data-grid@latest',
+  Pro: '@mui/x-data-grid-pro@latest',
+  Premium: '@mui/x-data-grid-premium@latest',
 };
 
 export default function DataGridInstallationInstructions() {

--- a/docs/src/modules/components/DataGridInstallationInstructions.js
+++ b/docs/src/modules/components/DataGridInstallationInstructions.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 
-// #default-branch-switch
+// #npm-tag-reference
 
 const packages = {
   Community: '@mui/x-data-grid',

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-date-pickers@latest',
-  Pro: '@mui/x-date-pickers-pro@latest',
+  Community: '@mui/x-date-pickers',
+  Pro: '@mui/x-date-pickers-pro',
 };
 
 const peerDependency = {

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-date-pickers',
-  Pro: '@mui/x-date-pickers-pro',
+  Community: '@mui/x-date-pickers@latest',
+  Pro: '@mui/x-date-pickers-pro@latest',
 };
 
 const peerDependency = {

--- a/docs/src/modules/components/PickersInstallationInstructions.js
+++ b/docs/src/modules/components/PickersInstallationInstructions.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 
-// #default-branch-switch
+// #npm-tag-reference
 
 const packages = {
   Community: '@mui/x-date-pickers',

--- a/docs/src/modules/components/TreeViewInstallationInstructions.js
+++ b/docs/src/modules/components/TreeViewInstallationInstructions.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import InstallationInstructions from './InstallationInstructions';
 
-// #default-branch-switch
+// #npm-tag-reference
 
 const packages = {
   Community: '@mui/x-tree-view',

--- a/docs/src/modules/components/TreeViewInstallationInstructions.js
+++ b/docs/src/modules/components/TreeViewInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-tree-view@latest',
-  Pro: '@mui/x-tree-view-pro@latest',
+  Community: '@mui/x-tree-view',
+  Pro: '@mui/x-tree-view-pro',
 };
 
 export default function TreeViewInstallationInstructions() {

--- a/docs/src/modules/components/TreeViewInstallationInstructions.js
+++ b/docs/src/modules/components/TreeViewInstallationInstructions.js
@@ -4,8 +4,8 @@ import InstallationInstructions from './InstallationInstructions';
 // #npm-tag-reference
 
 const packages = {
-  Community: '@mui/x-tree-view',
-  Pro: '@mui/x-tree-view-pro',
+  Community: '@mui/x-tree-view@latest',
+  Pro: '@mui/x-tree-view-pro@latest',
 };
 
 export default function TreeViewInstallationInstructions() {

--- a/packages/x-codemod/README.md
+++ b/packages/x-codemod/README.md
@@ -10,7 +10,7 @@ This repository contains a collection of codemod scripts based for use with
 
 ## Setup & run
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest <codemod> <paths...>
@@ -66,7 +66,7 @@ A combination of all important transformers for migrating v7 to v8.
 It runs codemods for all MUI X packages (Data Grid, Date and Time Pickers, Tree View, and Charts).
 To run codemods for a specific package, refer to the respective section.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/preset-safe <path|folder>
@@ -85,7 +85,7 @@ The corresponding sub-sections are listed below
 
 The `preset-safe` codemods for Tree View.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/tree-view/preset-safe <path|folder>
@@ -134,7 +134,7 @@ Renames the `TreeItem2` component to `TreeItem` (same for any subcomponents or u
 
 The `preset-safe` codemods for Charts.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/charts/preset-safe <path|folder>
@@ -315,7 +315,7 @@ If there are cases that the codemod cannot handle, you should see a comment with
 
 The `preset-safe` codemods for Data Grid.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/preset-safe <path|folder>
@@ -343,7 +343,7 @@ Remove feature flags for stabilized `experimentalFeatures`.
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/remove-stabilized-experimentalFeatures <path>
@@ -367,7 +367,7 @@ The list includes these props:
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/remove-props <path>
@@ -409,7 +409,7 @@ The list includes these props:
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/rename-props <path>
@@ -427,7 +427,7 @@ This codemod renames the imports of the Data Grid components. The list includes 
 +import { gridRowSelectionIdsSelector, gridRowSelectionCountSelector } from '@mui/x-data-grid';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/rename-imports <path>
@@ -450,7 +450,7 @@ Reforms the controlled `rowSelectionModel` prop value to the new one.
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/reform-row-selection-model <path>
@@ -465,7 +465,7 @@ Reorganizes the imports moved from `@mui/x-data-grid-pro` and `@mui/x-data-grid-
 +import { LicenseInfo } from '@mui/x-license';
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/rename-package <path>
@@ -484,7 +484,7 @@ Adds the `showToolbar` prop to the Data Grid components that are using `slots.to
  />
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/data-grid/add-showToolbar-prop <path>
@@ -496,7 +496,7 @@ npx @mui/x-codemod@latest v8.0.0/data-grid/add-showToolbar-prop <path>
 
 The `preset-safe` codemods for Pickers.
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/pickers/preset-safe <path|folder>
@@ -531,7 +531,7 @@ The list includes these transformers
   +import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
   ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/pickers/rename-adapter-date-fns-imports <path>
@@ -565,7 +565,7 @@ Renames:
  }
 ```
 
-<!-- #default-branch-switch -->
+<!-- #npm-tag-reference -->
 
 ```bash
 npx @mui/x-codemod@latest v8.0.0/pickers/rename-type-imports <path>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,7 +74,7 @@ pnpm docs:deploy
 <!-- #target-branch-reference -->
 
 You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v8)
-Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v7` deployment.
+Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v8` deployment.
 
 ### Publish GitHub release
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,8 +67,6 @@ The documentation must be updated on the `docs-vX` branch (`docs-v4` for `v4.X` 
 
 Push the working branch on the documentation release branch to deploy the documentation with the latest changes.
 
-<!-- #default-branch-switch -->
-
 ```bash
 pnpm docs:deploy
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,6 +71,8 @@ Push the working branch on the documentation release branch to deploy the docume
 pnpm docs:deploy
 ```
 
+<!-- #target-branch-reference --> 
+
 You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v7)
 Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v7` deployment.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,7 +71,7 @@ Push the working branch on the documentation release branch to deploy the docume
 pnpm docs:deploy
 ```
 
-<!-- #target-branch-reference --> 
+<!-- #target-branch-reference -->
 
 You can follow the deployment process [on the Netlify Dashboard](https://app.netlify.com/sites/material-ui-x/deploys?filter=docs-v8)
 Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for the `docs-v7` deployment.

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -433,8 +433,8 @@ yargs(hideBin(process.argv))
           type: 'string',
         })
         .option('release', {
-          // #default-branch-switch
-          // to be done when we branch off v8.x
+          // #target-branch-reference
+          // to be done when we branch off for a new major (e.g. v9)
           default: 'master',
           describe: 'Ref which we want to release',
           type: 'string',


### PR DESCRIPTION
This replaces the `#default-branch-switch` comments with one of the following 3:
- `#target-branch-reference`: the git branch corresponding to where the code is worked on.
- `#npm-tag-reference`: the npm tag corresponding to where the code is published.
- `#host-reference`: the URL corresponding to where the docs are deployed.

According to [this notion document](https://www.notion.so/mui-org/React-Major-release-process-0178410ef26941e6a4f333f80ded127a?pvs=4)