### PR TITLE
[l10n] Improve Italian (it-IT) locale

### DIFF
--- a/packages/x-date-pickers/src/locales/itIT.ts
+++ b/packages/x-date-pickers/src/locales/itIT.ts
@@ -31,8 +31,8 @@ const itITPickers: Partial<PickersLocaleText> = {
   endTime: 'Ora di fine',
 
   // Action bar
-  cancelButtonLabel: 'Cancellare',
-  clearButtonLabel: 'Sgomberare',
+  cancelButtonLabel: 'Annulla',
+  clearButtonLabel: 'Pulisci',
   okButtonLabel: 'OK',
   todayButtonLabel: 'Oggi',
   nextStepButtonLabel: 'Successivo',


### PR DESCRIPTION
Related to  #3211

The changes concern both the verb tenses and the vocabulary used:

- In Italian, we're used to see the text on buttons in the imperative form, not in the infinitive, so 'Cancellare' would become 'Cancella' and 'Sgomberare' would become 'Sgombera'.
- I've never seen the verb "sgomberare" as a translation of "clear" in a IT context. It's mostly used in the sense of clearing a room or a physical space, rather than a digital one. Also "cancellare" is usually a translation of "delete", while "cancel" is usually translated as "annullare", in the sense of "I don't want to apply this change, return to its previous state" and I believe this is what "cancel" means in this particular case, but I may be mistaken.

I hope I was able to get my point across, please, feel free to ask for clarification if needed!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
