### PR TITLE
[charts] Add docs on tooltip style

### DIFF
--- a/docs/data/charts/tooltip/TooltipStyle.js
+++ b/docs/data/charts/tooltip/TooltipStyle.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { chartsTooltipClasses } from '@mui/x-charts/ChartsTooltip';
+
+const params = {
+  xAxis: [{ data: [1, 2, 3, 5, 8, 10] }],
+  series: [{ data: [2, 5.5, 2, 8.5, 1.5, 5] }],
+  height: 300,
+  axisHighlight: { x: 'line' },
+};
+
+export default function TooltipStyle() {
+  return (
+    <LineChart
+      {...params}
+      slotProps={{
+        tooltip: {
+          sx: {
+            [`.${chartsTooltipClasses.valueCell}`]: {
+              color: 'red',
+            },
+          },
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/charts/tooltip/TooltipStyle.js
+++ b/docs/data/charts/tooltip/TooltipStyle.js
@@ -16,7 +16,7 @@ export default function TooltipStyle() {
       slotProps={{
         tooltip: {
           sx: {
-            [`& .${chartsTooltipClasses.valueCell}`]: {
+            [`&.${chartsTooltipClasses.root} .${chartsTooltipClasses.valueCell}`]: {
               color: 'red',
             },
           },

--- a/docs/data/charts/tooltip/TooltipStyle.js
+++ b/docs/data/charts/tooltip/TooltipStyle.js
@@ -16,7 +16,7 @@ export default function TooltipStyle() {
       slotProps={{
         tooltip: {
           sx: {
-            [`.${chartsTooltipClasses.valueCell}`]: {
+            [`& .${chartsTooltipClasses.valueCell}`]: {
               color: 'red',
             },
           },

--- a/docs/data/charts/tooltip/TooltipStyle.tsx
+++ b/docs/data/charts/tooltip/TooltipStyle.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { chartsTooltipClasses } from '@mui/x-charts/ChartsTooltip';
+
+const params = {
+  xAxis: [{ data: [1, 2, 3, 5, 8, 10] }],
+  series: [{ data: [2, 5.5, 2, 8.5, 1.5, 5] }],
+  height: 300,
+  axisHighlight: { x: 'line' },
+} as const;
+
+export default function TooltipStyle() {
+  return (
+    <LineChart
+      {...params}
+      slotProps={{
+        tooltip: {
+          sx: {
+            [`.${chartsTooltipClasses.valueCell}`]: {
+              color: 'red',
+            },
+          },
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/charts/tooltip/TooltipStyle.tsx
+++ b/docs/data/charts/tooltip/TooltipStyle.tsx
@@ -16,7 +16,7 @@ export default function TooltipStyle() {
       slotProps={{
         tooltip: {
           sx: {
-            [`& .${chartsTooltipClasses.valueCell}`]: {
+            [`&.${chartsTooltipClasses.root} .${chartsTooltipClasses.valueCell}`]: {
               color: 'red',
             },
           },

--- a/docs/data/charts/tooltip/TooltipStyle.tsx
+++ b/docs/data/charts/tooltip/TooltipStyle.tsx
@@ -16,7 +16,7 @@ export default function TooltipStyle() {
       slotProps={{
         tooltip: {
           sx: {
-            [`.${chartsTooltipClasses.valueCell}`]: {
+            [`& .${chartsTooltipClasses.valueCell}`]: {
               color: 'red',
             },
           },

--- a/docs/data/charts/tooltip/TooltipStyle.tsx.preview
+++ b/docs/data/charts/tooltip/TooltipStyle.tsx.preview
@@ -3,7 +3,7 @@
   slotProps={{
     tooltip: {
       sx: {
-        [`.${chartsTooltipClasses.valueCell}`]: {
+        [`& .${chartsTooltipClasses.valueCell}`]: {
           color: 'red',
         },
       },

--- a/docs/data/charts/tooltip/TooltipStyle.tsx.preview
+++ b/docs/data/charts/tooltip/TooltipStyle.tsx.preview
@@ -1,0 +1,12 @@
+<LineChart
+  {...params}
+  slotProps={{
+    tooltip: {
+      sx: {
+        [`.${chartsTooltipClasses.valueCell}`]: {
+          color: 'red',
+        },
+      },
+    },
+  }}
+/>

--- a/docs/data/charts/tooltip/TooltipStyle.tsx.preview
+++ b/docs/data/charts/tooltip/TooltipStyle.tsx.preview
@@ -3,7 +3,7 @@
   slotProps={{
     tooltip: {
       sx: {
-        [`& .${chartsTooltipClasses.valueCell}`]: {
+        [`&.${chartsTooltipClasses.root} .${chartsTooltipClasses.valueCell}`]: {
           color: 'red',
         },
       },

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -165,7 +165,7 @@ import { chartsTooltipClasses } from '@mui/x-charts';
 
 <LineChart
   sx={{
-    [`.${chartsTooltipClasses.valueCell}`]: {
+    [`& .${chartsTooltipClasses.valueCell}`]: {
       color: 'red',
     },
   }}

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -165,7 +165,7 @@ import { chartsTooltipClasses } from '@mui/x-charts';
 
 <LineChart
   sx={{
-    [`& .${chartsTooltipClasses.valueCell}`]: {
+    [`& .${chartsTooltipClasses.root} .${chartsTooltipClasses.valueCell}`]: {
       color: 'red',
     },
   }}

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -152,6 +152,32 @@ The ChartsTooltipContainer must render before the pointer enters the SVG because
 To override tooltip placement, override to the tooltip with `slots.tooltip`.
 If you want to keep the default content, you can place the `ChartsItemTooltipContent` or `ChartsAxisTooltipContent` in your custom tooltip.
 
+### Styling
+
+The tooltip can be styled using CSS classes, similar to other elements. However, there is one caveat.
+
+:::warning
+
+By default, the tooltip is rendered as a child of the document's body, so using the chart's `sx` prop does not work.
+
+```tsx
+import { chartsTooltipClasses } from '@mui/x-charts';
+
+<LineChart
+  sx={{
+    [`.${chartsTooltipClasses.valueCell}`]: {
+      color: 'red',
+    },
+  }}
+/>;
+```
+
+:::
+
+To apply the same style as we're trying to apply above, we need to use the `sx` property inside `slotProps.tooltip`:
+
+{{"demo": "TooltipStyle.js"}}
+
 ## Composition
 
 If you're using composition, by default, the axis listens for mouse events to get its current x/y values.


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17594.

The tooltip has the particularity that it cannot be styled directly with `sx`. This PR adds a docs section to explain how to style it. 