### PR TITLE
[charts] Add `disableTruncation` to cartesian axes

### DIFF
--- a/docs/data/charts/axis/MarginAndLabelPosition.js
+++ b/docs/data/charts/axis/MarginAndLabelPosition.js
@@ -7,6 +7,7 @@ import { BarChart } from '@mui/x-charts/BarChart';
 
 export default function MarginAndLabelPosition() {
   const [fixMargin, setFixMargin] = React.useState(true);
+  const [disableTruncation, setDisableTruncation] = React.useState(false);
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -17,6 +18,16 @@ export default function MarginAndLabelPosition() {
             <Checkbox onChange={(event) => setFixMargin(event.target.checked)} />
           }
           label="Increase axes size"
+          labelPlacement="end"
+        />
+        <FormControlLabel
+          checked={disableTruncation}
+          control={
+            <Checkbox
+              onChange={(event) => setDisableTruncation(event.target.checked)}
+            />
+          }
+          label="Disable truncation"
           labelPlacement="end"
         />
       </Stack>
@@ -32,6 +43,7 @@ export default function MarginAndLabelPosition() {
                 : usAirportPassengers.find((item) => item.code === value).fullName,
             label: 'airports',
             height: fixMargin ? 75 : undefined,
+            disableTruncation,
           },
         ]}
         // Other props
@@ -50,6 +62,7 @@ export default function MarginAndLabelPosition() {
             valueFormatter: (value) => `${(value / 1000).toLocaleString()}k`,
             label: 'passengers',
             width: fixMargin ? 85 : undefined,
+            disableTruncation,
           },
         ]}
       />

--- a/docs/data/charts/axis/MarginAndLabelPosition.tsx
+++ b/docs/data/charts/axis/MarginAndLabelPosition.tsx
@@ -7,6 +7,7 @@ import { BarChart } from '@mui/x-charts/BarChart';
 
 export default function MarginAndLabelPosition() {
   const [fixMargin, setFixMargin] = React.useState(true);
+  const [disableTruncation, setDisableTruncation] = React.useState(false);
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -17,6 +18,16 @@ export default function MarginAndLabelPosition() {
             <Checkbox onChange={(event) => setFixMargin(event.target.checked)} />
           }
           label="Increase axes size"
+          labelPlacement="end"
+        />
+        <FormControlLabel
+          checked={disableTruncation}
+          control={
+            <Checkbox
+              onChange={(event) => setDisableTruncation(event.target.checked)}
+            />
+          }
+          label="Disable truncation"
           labelPlacement="end"
         />
       </Stack>
@@ -32,6 +43,7 @@ export default function MarginAndLabelPosition() {
                 : usAirportPassengers.find((item) => item.code === value)!.fullName,
             label: 'airports',
             height: fixMargin ? 75 : undefined,
+            disableTruncation,
           },
         ]}
         // Other props
@@ -50,6 +62,7 @@ export default function MarginAndLabelPosition() {
             valueFormatter: (value: number) => `${(value / 1000).toLocaleString()}k`,
             label: 'passengers',
             width: fixMargin ? 85 : undefined,
+            disableTruncation,
           },
         ]}
       />

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -232,6 +232,8 @@ In the following demo, the size of the x- and y-axes is modified to increase the
 The first and last tick labels may bleed into the margin. If that margin is not enough to display the label, it might be clipped.
 To avoid this, you can use the `margin` prop to increase the space between the chart and the edge of the container.
 
+Alternatively you can disable clipping altogether by setting the desired axis's `disableTruncation` property to true.
+
 {{"demo": "MarginAndLabelPosition.js"}}
 
 ### Rendering

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -234,6 +234,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     sx,
     offset,
     height: axisHeight,
+    disableTruncation,
   } = defaultizedProps;
 
   const theme = useTheme();
@@ -337,15 +338,16 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     axisHeight - (label ? labelHeight + AXIS_LABEL_TICK_LABEL_GAP : 0) - tickSize - TICK_LABEL_GAP,
   );
 
-  const tickLabels = isHydrated
-    ? shortenLabels(
-        visibleLabels,
-        drawingArea,
-        tickLabelsMaxHeight,
-        isRtl,
-        axisTickLabelProps.style,
-      )
-    : new Map(Array.from(visibleLabels).map((item) => [item, item.formattedValue]));
+  const tickLabels =
+    !disableTruncation && isHydrated
+      ? shortenLabels(
+          visibleLabels,
+          drawingArea,
+          tickLabelsMaxHeight,
+          isRtl,
+          axisTickLabelProps.style,
+        )
+      : new Map(Array.from(visibleLabels).map((item) => [item, item.formattedValue]));
 
   return (
     <XAxisRoot

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -150,6 +150,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
     sx,
     offset,
     width: axisWidth,
+    disableTruncation,
   } = defaultizedProps;
 
   const theme = useTheme();
@@ -259,9 +260,10 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
       TICK_LABEL_GAP,
   );
 
-  const tickLabels = isHydrated
-    ? shortenLabels(yTicks, drawingArea, tickLabelsMaxWidth, isRtl, axisTickLabelProps.style)
-    : new Map(Array.from(yTicks).map((item) => [item, item.formattedValue]));
+  const tickLabels =
+    !disableTruncation && isHydrated
+      ? shortenLabels(yTicks, drawingArea, tickLabelsMaxWidth, isRtl, axisTickLabelProps.style)
+      : new Map(Array.from(yTicks).map((item) => [item, item.formattedValue]));
 
   return (
     <YAxisRoot

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -135,6 +135,11 @@ export interface ChartsAxisProps extends TickParams {
 
 export interface ChartsYAxisProps extends ChartsAxisProps {
   axis?: 'y';
+  /**
+   * When true, the tick labels will not be truncated.
+   * @default false
+   */
+  disableTruncation?: boolean;
 }
 
 export interface ChartsXAxisProps extends ChartsAxisProps {
@@ -145,6 +150,11 @@ export interface ChartsXAxisProps extends ChartsAxisProps {
    * @default 4
    */
   tickLabelMinGap?: number;
+  /**
+   * When true, the tick labels will not be truncated.
+   * @default false
+   */
+  disableTruncation?: boolean;
 }
 
 type AxisSideConfig<AxisProps extends ChartsAxisProps> = AxisProps extends ChartsXAxisProps


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17595.

Add `disableTruncation` to cartesian axes. This is especially useful when customizing tick labels. In that cases, users might not want to receive the truncated values and prefer dealing with the original label values instead. 