### PR TITLE
[DataGrid] Fix panel alignment

### DIFF
--- a/packages/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.tsx
@@ -55,7 +55,6 @@ const GridPanelContent = styled('div', {
   boxShadow: vars.shadows.overlay,
   display: 'flex',
   maxWidth: `calc(100vw - ${vars.spacing(2)})`,
-  margin: vars.spacing(1),
   overflow: 'auto',
 });
 

--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -511,7 +511,14 @@ function BasePopper(props: P['basePopper']) {
   } = props;
 
   const modifiers = React.useMemo(() => {
-    const result = [] as NonNullable<MUIPopperProps['modifiers']>;
+    const result: MUIPopperProps['modifiers'] = [
+      {
+        name: 'preventOverflow',
+        options: {
+          padding: 8,
+        },
+      },
+    ];
     if (flip) {
       result.push({
         name: 'flip',


### PR DESCRIPTION
The panels should be aligned to the side of the trigger

| Before | After |
| --- | --- |
| <img width="311" alt="Screenshot 2025-04-30 at 09 32 00" src="https://github.com/user-attachments/assets/4a0c74a8-a2f4-4cee-acfc-293ad0fe11a2" /> | <img width="307" alt="Screenshot 2025-04-30 at 09 31 21" src="https://github.com/user-attachments/assets/44868064-b788-45b0-97a0-257c7a957184" /> |
