### PR TITLE
[DateRangePicker] Fix to reset range position after closing mobile Picker

### DIFF
--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -59,7 +59,9 @@ export const useDesktopRangePicker = <
     viewContainerRole,
     localeText,
     getStepNavigation,
-    onPopperExited: useEventCallback(() => rangePositionResponse.setRangePosition('start')),
+    onPopperExited: useEventCallback(() =>
+      rangePositionResponse.setRangePosition(props.defaultRangePosition ?? 'start'),
+    ),
   });
 
   const Field = slots.field;

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -63,7 +63,9 @@ export const useMobileRangePicker = <
     viewContainerRole: 'dialog',
     localeText,
     getStepNavigation,
-    onPopperExited: useEventCallback(() => rangePositionResponse.setRangePosition('start')),
+    onPopperExited: useEventCallback(() =>
+      rangePositionResponse.setRangePosition(props.defaultRangePosition ?? 'start'),
+    ),
   });
 
   const labelId = providerProps.privateContextValue.labelId;

--- a/packages/x-date-pickers/src/internals/components/PickersModalDialog.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickersModalDialog.tsx
@@ -75,7 +75,7 @@ export function PickersModalDialog(props: React.PropsWithChildren<PickersModalDi
   const { children, slots, slotProps } = props;
 
   const { open } = usePickerContext();
-  const { dismissViews } = usePickerPrivateContext();
+  const { dismissViews, onPopperExited } = usePickerPrivateContext();
 
   const Dialog = slots?.dialog ?? PickersModalDialogRoot;
   const Transition = slots?.mobileTransition ?? Fade;
@@ -83,7 +83,10 @@ export function PickersModalDialog(props: React.PropsWithChildren<PickersModalDi
   return (
     <Dialog
       open={open}
-      onClose={dismissViews}
+      onClose={() => {
+        dismissViews();
+        onPopperExited?.();
+      }}
       {...slotProps?.dialog}
       TransitionComponent={Transition}
       TransitionProps={slotProps?.mobileTransition}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1667,6 +1667,9 @@ importers:
       '@types/react-router':
         specifier: ^5.1.20
         version: 5.1.20
+      '@types/react-transition-group':
+        specifier: ^4.4.12
+        version: 4.4.12(@types/react@19.0.12)
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.0

--- a/test/package.json
+++ b/test/package.json
@@ -25,6 +25,7 @@
     "@types/prop-types": "^15.7.14",
     "@types/react": "^19.0.12",
     "@types/react-router": "^5.1.20",
+    "@types/react-transition-group": "^4.4.12",
     "@types/semver": "^7.7.0",
     "chai": "^4.5.0",
     "dayjs": "^1.11.13",

--- a/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
+++ b/test/utils/pickers/describeValue/testPickerOpenCloseLifeCycle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { config } from 'react-transition-group';
-import { fireEvent, screen } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { PickerRangeValue, PickerValidValue } from '@mui/x-date-pickers/internals';
 import {
   getExpectedOnChangeCount,
@@ -421,6 +421,8 @@ export const testPickerOpenCloseLifeCycle: DescribeValueTestSuite<PickerValidVal
     }
 
     await user.keyboard('[Escape]');
+
+    await waitFor(() => expect(screen.queryByRole(viewWrapperRole)).to.equal(null));
 
     // open the picker again
     await openPickerAsync(user, {


### PR DESCRIPTION
For now, the range position is reset to `start` only when the Desktop range Picker is closed.
This PR fixes to do the same for Mobile Picker and adds to ensure this behavior is stable.