### PR TITLE
[charts] Refactor axis types

### DIFF
--- a/docs/pages/x/api/charts/bar-chart-pro.json
+++ b/docs/pages/x/api/charts/bar-chart-pro.json
@@ -55,7 +55,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/bar-chart.json
+++ b/docs/pages/x/api/charts/bar-chart.json
@@ -49,7 +49,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/chart-container.json
+++ b/docs/pages/x/api/charts/chart-container.json
@@ -25,7 +25,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/funnel-chart.json
+++ b/docs/pages/x/api/charts/funnel-chart.json
@@ -52,7 +52,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/heatmap.json
+++ b/docs/pages/x/api/charts/heatmap.json
@@ -43,7 +43,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/line-chart-pro.json
+++ b/docs/pages/x/api/charts/line-chart-pro.json
@@ -52,7 +52,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/line-chart.json
+++ b/docs/pages/x/api/charts/line-chart.json
@@ -46,7 +46,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart-pro.json
+++ b/docs/pages/x/api/charts/scatter-chart-pro.json
@@ -51,7 +51,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/scatter-chart.json
+++ b/docs/pages/x/api/charts/scatter-chart.json
@@ -45,7 +45,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/docs/pages/x/api/charts/spark-line-chart.json
+++ b/docs/pages/x/api/charts/spark-line-chart.json
@@ -31,7 +31,7 @@
     "onAxisClick": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: MouseEvent, data: null | AxisData) => void",
+        "type": "function(event: MouseEvent, data: null | ChartsAxisData) => void",
         "describedArgs": ["event", "data"]
       }
     },

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -217,7 +217,7 @@ BarChartPro.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -302,7 +302,7 @@ FunnelChart.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import { CurveFactory, line as d3Line } from '@mui/x-charts-vendor/d3-shape';
-import { getCurveFactory, AxisDefaultized, cartesianSeriesTypes } from '@mui/x-charts/internals';
+import { getCurveFactory, ComputedAxis, cartesianSeriesTypes } from '@mui/x-charts/internals';
 import { useXAxes, useYAxes } from '@mui/x-charts/hooks';
 import { useTheme } from '@mui/material/styles';
 import { FunnelItemIdentifier, FunnelDataPoints, FunnelCurveType } from './funnel.types';
@@ -70,7 +70,7 @@ const useAggregatedData = () => {
 
       const bandWidth =
         ((isXAxisBand || isYAxisBand) &&
-          (baseScaleConfig as AxisDefaultized<'band'>).scale?.bandwidth()) ||
+          (baseScaleConfig as ComputedAxis<'band'>).scale?.bandwidth()) ||
         0;
 
       const xScale = xAxis[xAxisId].scale;

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -287,7 +287,7 @@ Heatmap.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -220,7 +220,7 @@ LineChartPro.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -202,7 +202,7 @@ ScatterChartPro.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -252,7 +252,7 @@ BarChart.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { barElementClasses } from './barElementClasses';
 import { BarElement, BarElementSlotProps, BarElementSlots } from './BarElement';
-import { AxisDefaultized } from '../models/axis';
+import { ComputedAxis } from '../models/axis';
 import { BarItemIdentifier } from '../models';
 import getColor from './seriesConfig/getColor';
 import { useChartId, useDrawingArea, useXAxes, useYAxes } from '../hooks';
@@ -122,9 +122,7 @@ const useAggregatedData = (): {
 
       checkScaleErrors(verticalLayout, seriesId, series[seriesId], xAxisId, xAxis, yAxisId, yAxis);
 
-      const baseScaleConfig = (
-        verticalLayout ? xAxisConfig : yAxisConfig
-      ) as AxisDefaultized<'band'>;
+      const baseScaleConfig = (verticalLayout ? xAxisConfig : yAxisConfig) as ComputedAxis<'band'>;
 
       const xScale = xAxisConfig.scale;
       const yScale = yAxisConfig.scale;

--- a/packages/x-charts/src/BarChart/checkScaleErrors.ts
+++ b/packages/x-charts/src/BarChart/checkScaleErrors.ts
@@ -1,6 +1,12 @@
 import { warnOnce } from '@mui/x-internals/warning';
 import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '../constants';
-import { ComputedAxis, AxisId, isBandScaleConfig, isPointScaleConfig } from '../models/axis';
+import {
+  AxisId,
+  isBandScaleConfig,
+  isPointScaleConfig,
+  ComputedXAxis,
+  ComputedYAxis,
+} from '../models/axis';
 import { DefaultizedBarSeriesType } from '../models/seriesType/bar';
 import { SeriesId } from '../models/seriesType/common';
 
@@ -18,9 +24,9 @@ export function checkScaleErrors(
   seriesId: SeriesId,
   series: DefaultizedBarSeriesType & { stackedData: [number, number][] },
   xAxisId: AxisId,
-  xAxis: { [axisId: AxisId]: ComputedAxis },
+  xAxis: { [axisId: AxisId]: ComputedXAxis },
   yAxisId: AxisId,
-  yAxis: { [axisId: AxisId]: ComputedAxis },
+  yAxis: { [axisId: AxisId]: ComputedYAxis },
 ): void {
   const xAxisConfig = xAxis[xAxisId];
   const yAxisConfig = yAxis[yAxisId];

--- a/packages/x-charts/src/BarChart/checkScaleErrors.ts
+++ b/packages/x-charts/src/BarChart/checkScaleErrors.ts
@@ -1,6 +1,6 @@
 import { warnOnce } from '@mui/x-internals/warning';
 import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '../constants';
-import { AxisDefaultized, AxisId, isBandScaleConfig, isPointScaleConfig } from '../models/axis';
+import { ComputedAxis, AxisId, isBandScaleConfig, isPointScaleConfig } from '../models/axis';
 import { DefaultizedBarSeriesType } from '../models/seriesType/bar';
 import { SeriesId } from '../models/seriesType/common';
 
@@ -18,9 +18,9 @@ export function checkScaleErrors(
   seriesId: SeriesId,
   series: DefaultizedBarSeriesType & { stackedData: [number, number][] },
   xAxisId: AxisId,
-  xAxis: { [axisId: AxisId]: AxisDefaultized },
+  xAxis: { [axisId: AxisId]: ComputedAxis },
   yAxisId: AxisId,
-  yAxis: { [axisId: AxisId]: AxisDefaultized },
+  yAxis: { [axisId: AxisId]: ComputedAxis },
 ): void {
   const xAxisConfig = xAxis[xAxisId];
   const yAxisConfig = yAxis[yAxisId];

--- a/packages/x-charts/src/ChartContainer/ChartContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ChartContainer.tsx
@@ -129,7 +129,7 @@ ChartContainer.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/ChartsGrid/ChartsHorizontalGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsHorizontalGrid.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useTicks } from '../hooks/useTicks';
-import { ComputedAxis, ChartsYAxisProps, ScaleName } from '../models/axis';
+import { ComputedYAxis } from '../models/axis';
 import { GridLine } from './styledComponents';
 import { ChartsGridClasses } from './chartsGridClasses';
 
 interface ChartsGridHorizontalProps {
-  axis: ComputedAxis<ScaleName, any, ChartsYAxisProps>;
+  axis: ComputedYAxis;
   start: number;
   end: number;
   classes: Partial<ChartsGridClasses>;

--- a/packages/x-charts/src/ChartsGrid/ChartsHorizontalGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsHorizontalGrid.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useTicks } from '../hooks/useTicks';
-import { AxisDefaultized, ChartsYAxisProps, ScaleName } from '../models/axis';
+import { ComputedAxis, ChartsYAxisProps, ScaleName } from '../models/axis';
 import { GridLine } from './styledComponents';
 import { ChartsGridClasses } from './chartsGridClasses';
 
 interface ChartsGridHorizontalProps {
-  axis: AxisDefaultized<ScaleName, any, ChartsYAxisProps>;
+  axis: ComputedAxis<ScaleName, any, ChartsYAxisProps>;
   start: number;
   end: number;
   classes: Partial<ChartsGridClasses>;

--- a/packages/x-charts/src/ChartsGrid/ChartsVerticalGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsVerticalGrid.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useTicks } from '../hooks/useTicks';
-import { ComputedAxis, ChartsXAxisProps, ScaleName } from '../models/axis';
+import { ComputedXAxis } from '../models/axis';
 import { GridLine } from './styledComponents';
 import { ChartsGridClasses } from './chartsGridClasses';
 
 interface ChartsGridVerticalProps {
-  axis: ComputedAxis<ScaleName, any, ChartsXAxisProps>;
+  axis: ComputedXAxis;
   start: number;
   end: number;
   classes: Partial<ChartsGridClasses>;

--- a/packages/x-charts/src/ChartsGrid/ChartsVerticalGrid.tsx
+++ b/packages/x-charts/src/ChartsGrid/ChartsVerticalGrid.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useTicks } from '../hooks/useTicks';
-import { AxisDefaultized, ChartsXAxisProps, ScaleName } from '../models/axis';
+import { ComputedAxis, ChartsXAxisProps, ScaleName } from '../models/axis';
 import { GridLine } from './styledComponents';
 import { ChartsGridClasses } from './chartsGridClasses';
 
 interface ChartsGridVerticalProps {
-  axis: AxisDefaultized<ScaleName, any, ChartsXAxisProps>;
+  axis: ComputedAxis<ScaleName, any, ChartsXAxisProps>;
   start: number;
   end: number;
   classes: Partial<ChartsGridClasses>;

--- a/packages/x-charts/src/ChartsLegend/ContinuousColorLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ContinuousColorLegend.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { styled, SxProps, Theme } from '@mui/material/styles';
 import clsx from 'clsx';
 import { AppendKeys } from '@mui/x-internals/types';
-import { AxisDefaultized } from '../models/axis';
+import { ComputedAxis } from '../models/axis';
 import { useAxis } from './useAxis';
 import { ColorLegendSelector } from './colorLegend.types';
 import { ChartsLabel } from '../ChartsLabel/ChartsLabel';
@@ -179,8 +179,8 @@ const getText = (
   }
   return label?.({ value, formattedValue }) ?? formattedValue;
 };
-const isZAxis = (axis: AxisDefaultized | ZAxisDefaultized): axis is ZAxisDefaultized =>
-  (axis as AxisDefaultized).scale === undefined;
+const isZAxis = (axis: ComputedAxis | ZAxisDefaultized): axis is ZAxisDefaultized =>
+  (axis as ComputedAxis).scale === undefined;
 
 const ContinuousColorLegend = consumeThemeProps(
   'MuiContinuousColorLegend',

--- a/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.tsx
@@ -15,7 +15,7 @@ import {
 } from './piecewiseColorLegendClasses';
 import { ColorLegendSelector } from './colorLegend.types';
 import { PiecewiseLabelFormatterParams } from './piecewiseColorLegend.types';
-import { AxisDefaultized } from '../models/axis';
+import { ComputedAxis } from '../models/axis';
 import { useAxis } from './useAxis';
 import { PiecewiseColorLegendItemContext } from './legendContext.types';
 import { piecewiseColorDefaultLabelFormatter } from './piecewiseColorDefaultLabelFormatter';
@@ -182,7 +182,7 @@ const PiecewiseColorLegend = consumeThemeProps(
       return null;
     }
     const valueFormatter = (v: number | Date) =>
-      (axisItem as AxisDefaultized).valueFormatter?.(v, {
+      (axisItem as ComputedAxis).valueFormatter?.(v, {
         location: 'legend',
       }) ?? v.toLocaleString();
 

--- a/packages/x-charts/src/ChartsLegend/useAxis.ts
+++ b/packages/x-charts/src/ChartsLegend/useAxis.ts
@@ -1,5 +1,5 @@
 'use client';
-import { AxisDefaultized } from '../models/axis';
+import { ComputedAxis } from '../models/axis';
 import { ZAxisDefaultized } from '../models/z-axis';
 import { useZAxes } from '../hooks/useZAxis';
 import { useXAxes, useYAxes } from '../hooks/useAxis';
@@ -11,7 +11,7 @@ import { ColorLegendSelector } from './colorLegend.types';
 export function useAxis({
   axisDirection,
   axisId,
-}: ColorLegendSelector): ZAxisDefaultized | AxisDefaultized {
+}: ColorLegendSelector): ZAxisDefaultized | ComputedAxis {
   const { xAxis, xAxisIds } = useXAxes();
   const { yAxis, yAxisIds } = useYAxes();
   const { zAxis, zAxisIds } = useZAxes();

--- a/packages/x-charts/src/ChartsTooltip/useAxisTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/useAxisTooltip.tsx
@@ -7,7 +7,7 @@ import {
   ChartsSeriesConfig,
   PolarChartSeriesType,
 } from '../models/seriesType/config';
-import { AxisDefaultized, PolarAxisDefaultized, AxisId } from '../models/axis';
+import { ComputedAxis, PolarAxisDefaultized, AxisId } from '../models/axis';
 import { useStore } from '../internals/store/useStore';
 import { useSelector } from '../internals/store/useSelector';
 import { getLabel } from '../internals/getLabel';
@@ -38,7 +38,7 @@ export interface UseAxisTooltipReturnValue<
   AxisValueT extends string | number | Date = string | number | Date,
 > {
   axisDirection: SeriesT extends CartesianChartSeriesType ? 'x' | 'y' : 'rotation' | 'radius';
-  mainAxis: SeriesT extends CartesianChartSeriesType ? AxisDefaultized : PolarAxisDefaultized;
+  mainAxis: SeriesT extends CartesianChartSeriesType ? ComputedAxis : PolarAxisDefaultized;
   axisId: AxisId;
   axisValue: AxisValueT;
   axisFormattedValue: string;
@@ -68,7 +68,7 @@ interface SeriesItem<T extends CartesianChartSeriesType | PolarChartSeriesType> 
 }
 
 function defaultAxisTooltipConfig(
-  axis: AxisDefaultized | PolarAxisDefaultized,
+  axis: ComputedAxis | PolarAxisDefaultized,
   dataIndex: number,
   axisDirection: 'x' | 'y' | 'rotation',
 ): UseAxisTooltipReturnValue {

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -10,7 +10,7 @@ import { useIsHydrated } from '../hooks/useIsHydrated';
 import { doesTextFitInRect, ellipsize } from '../internals/ellipsize';
 import { getStringSize } from '../internals/domUtils';
 import { useTicks, TickItemType } from '../hooks/useTicks';
-import { AxisConfig, AxisDefaultized, ChartsXAxisProps, ScaleName } from '../models/axis';
+import { AxisConfig, ComputedAxis, ChartsXAxisProps, ScaleName } from '../models/axis';
 import { getAxisUtilityClass } from '../ChartsAxis/axisClasses';
 import { AxisRoot } from '../internals/components/AxisSharedComponents';
 import { ChartsText, ChartsTextProps } from '../ChartsText';
@@ -55,7 +55,7 @@ function getVisibleLabels(
     isMounted,
     isPointInside,
   }: Pick<ChartsXAxisProps, 'tickLabelInterval' | 'tickLabelStyle'> &
-    Pick<AxisDefaultized<ScaleName, any, ChartsXAxisProps>, 'reverse'> & {
+    Pick<ComputedAxis<ScaleName, any, ChartsXAxisProps>, 'reverse'> & {
       isMounted: boolean;
       tickLabelMinGap: NonNullable<ChartsXAxisProps['tickLabelMinGap']>;
       isPointInside: (position: number) => boolean;

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -10,7 +10,7 @@ import { useIsHydrated } from '../hooks/useIsHydrated';
 import { doesTextFitInRect, ellipsize } from '../internals/ellipsize';
 import { getStringSize } from '../internals/domUtils';
 import { useTicks, TickItemType } from '../hooks/useTicks';
-import { AxisConfig, ComputedAxis, ChartsXAxisProps, ScaleName } from '../models/axis';
+import { AxisConfig, ChartsXAxisProps, ComputedXAxis } from '../models/axis';
 import { getAxisUtilityClass } from '../ChartsAxis/axisClasses';
 import { AxisRoot } from '../internals/components/AxisSharedComponents';
 import { ChartsText, ChartsTextProps } from '../ChartsText';
@@ -55,7 +55,7 @@ function getVisibleLabels(
     isMounted,
     isPointInside,
   }: Pick<ChartsXAxisProps, 'tickLabelInterval' | 'tickLabelStyle'> &
-    Pick<ComputedAxis<ScaleName, any, ChartsXAxisProps>, 'reverse'> & {
+    Pick<ComputedXAxis, 'reverse'> & {
       isMounted: boolean;
       tickLabelMinGap: NonNullable<ChartsXAxisProps['tickLabelMinGap']>;
       isPointInside: (position: number) => boolean;

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -276,7 +276,7 @@ LineChart.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -244,7 +244,7 @@ ScatterChart.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -335,7 +335,7 @@ SparkLineChart.propTypes = {
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick: PropTypes.func,
   /**

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -16,7 +16,7 @@ import { zoomScaleRange } from './zoom';
 import { getAxisExtremum } from './getAxisExtremum';
 import type { ChartDrawingArea } from '../../../../hooks';
 import { ChartSeriesConfig } from '../../models/seriesConfig';
-import { DefaultizedAxisConfig, DefaultizedZoomOptions } from './useChartCartesianAxis.types';
+import { ComputedAxisConfig, DefaultizedZoomOptions } from './useChartCartesianAxis.types';
 import { ProcessedSeries } from '../../corePlugins/useChartSeries/useChartSeries.types';
 import { GetZoomAxisFilters, ZoomData } from './zoom.types';
 import { getAxisTriggerTooltip } from './getAxisTriggerTooltip';
@@ -50,7 +50,7 @@ const DEFAULT_CATEGORY_GAP_RATIO = 0.2;
 const DEFAULT_BAR_GAP_RATIO = 0.1;
 
 export type ComputeResult<T extends ChartsAxisProps> = {
-  axis: DefaultizedAxisConfig<T>;
+  axis: ComputedAxisConfig<T>;
   axisIds: string[];
 };
 
@@ -102,7 +102,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
     allAxis[0].id,
   );
 
-  const completeAxis: DefaultizedAxisConfig<ChartsAxisProps> = {};
+  const completeAxis: ComputedAxisConfig<ChartsAxisProps> = {};
   allAxis.forEach((eachAxis, axisIndex) => {
     const axis = eachAxis as Readonly<AxisConfig<ScaleName, any, Readonly<ChartsAxisProps>>>;
     const zoomOption = zoomOptions?.[axis.id];

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/defaultizeAxis.ts
@@ -1,4 +1,3 @@
-import { MakeOptional } from '@mui/x-internals/types';
 import {
   DEFAULT_X_AXIS_KEY,
   DEFAULT_Y_AXIS_KEY,
@@ -6,14 +5,14 @@ import {
   DEFAULT_AXIS_SIZE_WIDTH,
   AXIS_LABEL_DEFAULT_HEIGHT,
 } from '../../../../constants';
-import { AxisConfig, ScaleName } from '../../../../models';
-import { ChartsXAxisProps, ChartsYAxisProps } from '../../../../models/axis';
+import { XAxis, YAxis } from '../../../../models';
+import { DefaultedXAxis, DefaultedYAxis } from '../../../../models/axis';
 import { DatasetType } from '../../../../models/seriesType/config';
 
 export function defaultizeXAxis(
-  inAxis: readonly MakeOptional<AxisConfig<ScaleName, any, ChartsXAxisProps>, 'id'>[] | undefined,
+  inAxes: readonly XAxis[] | undefined,
   dataset: Readonly<DatasetType> | undefined,
-): Array<AxisConfig<ScaleName, any, ChartsXAxisProps>> {
+): DefaultedXAxis[] {
   const offsets = {
     top: 0,
     bottom: 0,
@@ -21,8 +20,8 @@ export function defaultizeXAxis(
   };
 
   const inputAxes =
-    inAxis && inAxis.length > 0
-      ? inAxis
+    inAxes && inAxes.length > 0
+      ? inAxes
       : [{ id: DEFAULT_X_AXIS_KEY, scaleType: 'linear' as const }];
 
   const parsedAxes = inputAxes.map((axisConfig, index) => {
@@ -67,14 +66,14 @@ export function defaultizeXAxis(
 }
 
 export function defaultizeYAxis(
-  inAxis: readonly MakeOptional<AxisConfig<ScaleName, any, ChartsYAxisProps>, 'id'>[] | undefined,
+  inAxes: readonly YAxis[] | undefined,
   dataset: Readonly<DatasetType> | undefined,
-): Array<AxisConfig<ScaleName, any, ChartsYAxisProps>> {
+): DefaultedYAxis[] {
   const offsets = { right: 0, left: 0, none: 0 };
 
   const inputAxes =
-    inAxis && inAxis.length > 0
-      ? inAxis
+    inAxes && inAxes.length > 0
+      ? inAxes
       : [{ id: DEFAULT_Y_AXIS_KEY, scaleType: 'linear' as const }];
 
   const parsedAxes = inputAxes.map((axisConfig, index) => {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue.ts
@@ -1,5 +1,5 @@
 import { isBandScale } from '../../../isBandScale';
-import { AxisDefaultized } from '../../../../models/axis';
+import { ComputedAxis } from '../../../../models/axis';
 
 function getAsANumber(value: number | Date) {
   return value instanceof Date ? value.getTime() : value;
@@ -9,7 +9,7 @@ function getAsANumber(value: number | Date) {
  * For a pointer coordinate, this function returns the dataIndex associated.
  * Returns `-1` if no dataIndex matches.
  */
-export function getAxisIndex(axisConfig: AxisDefaultized, pointerValue: number): number {
+export function getAxisIndex(axisConfig: ComputedAxis, pointerValue: number): number {
   const { scale, data: axisData, reverse } = axisConfig;
 
   if (!isBandScale(scale)) {
@@ -61,7 +61,7 @@ export function getAxisIndex(axisConfig: AxisDefaultized, pointerValue: number):
  * Returns `null` if the coordinate has no value associated.
  */
 export function getAxisValue(
-  axisConfig: AxisDefaultized,
+  axisConfig: ComputedAxis,
   pointerValue: number,
   dataIndex: number,
 ): number | Date | null {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.types.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.types.ts
@@ -1,23 +1,26 @@
 import type { ChartPluginSignature } from '../../models';
 import type { ChartSeriesType, DatasetType } from '../../../../models/seriesType/config';
 import type {
-  AxisDefaultized,
+  ComputedAxis,
   ScaleName,
-  ChartsXAxisProps,
-  ChartsYAxisProps,
   AxisId,
-  AxisConfig,
   ChartsAxisData,
   YAxis,
   XAxis,
+  DefaultedXAxis,
+  DefaultedYAxis,
 } from '../../../../models/axis';
 import type { UseChartSeriesSignature } from '../../corePlugins/useChartSeries';
 import type { ZoomData, ZoomOptions } from './zoom.types';
 import type { UseChartInteractionSignature } from '../useChartInteraction';
 import type { ChartsAxisProps } from '../../../../ChartsAxis';
 
-export type DefaultizedAxisConfig<AxisProps extends ChartsAxisProps> = {
-  [axisId: AxisId]: AxisDefaultized<ScaleName, any, AxisProps>;
+/**
+ * The axes' configuration after computing.
+ * An axis in this state already contains a scale function and all the necessary properties to be rendered.
+ */
+export type ComputedAxisConfig<AxisProps extends ChartsAxisProps> = {
+  [axisId: AxisId]: ComputedAxis<ScaleName, any, AxisProps>;
 };
 
 export interface UseChartCartesianAxisParameters<S extends ScaleName = ScaleName> {
@@ -41,7 +44,7 @@ export interface UseChartCartesianAxisParameters<S extends ScaleName = ScaleName
    * The function called for onClick events.
    * The second argument contains information about all line/bar elements at the current mouse position.
    * @param {MouseEvent} event The mouse event recorded on the `<svg/>` element.
-   * @param {null | AxisData} data The data about the clicked axis and items associated with it.
+   * @param {null | ChartsAxisData} data The data about the clicked axis and items associated with it.
    */
   onAxisClick?: (event: MouseEvent, data: null | ChartsAxisData) => void;
   /**
@@ -54,8 +57,8 @@ export interface UseChartCartesianAxisParameters<S extends ScaleName = ScaleName
 
 export type UseChartCartesianAxisDefaultizedParameters<S extends ScaleName = ScaleName> =
   UseChartCartesianAxisParameters<S> & {
-    defaultizedXAxis: AxisConfig<S, any, ChartsXAxisProps>[];
-    defaultizedYAxis: AxisConfig<S, any, ChartsYAxisProps>[];
+    defaultizedXAxis: DefaultedXAxis<S>[];
+    defaultizedYAxis: DefaultedYAxis<S>[];
   };
 
 export interface DefaultizedZoomOptions extends Required<ZoomOptions> {
@@ -72,8 +75,8 @@ export interface UseChartCartesianAxisState {
     zoomData: readonly ZoomData[];
   };
   cartesianAxis: {
-    x: AxisConfig<ScaleName, any, ChartsXAxisProps>[];
-    y: AxisConfig<ScaleName, any, ChartsYAxisProps>[];
+    x: DefaultedXAxis[];
+    y: DefaultedYAxis[];
   };
 }
 

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/colorProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/colorProcessor.types.ts
@@ -1,4 +1,4 @@
-import type { AxisDefaultized } from '../../../../models/axis';
+import type { ComputedAxis } from '../../../../models/axis';
 import type { DefaultizedSeriesType } from '../../../../models/seriesType';
 import type { ZAxisDefaultized } from '../../../../models/z-axis';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
@@ -20,7 +20,7 @@ export type ColorGetter<TSeriesType extends ChartSeriesType> = TSeriesType exten
  */
 export type ColorProcessor<TSeriesType extends ChartSeriesType> = (
   series: DefaultizedSeriesType<TSeriesType>,
-  xAxis?: AxisDefaultized,
-  yAxis?: AxisDefaultized,
+  xAxis?: ComputedAxis,
+  yAxis?: ComputedAxis,
   zAxis?: ZAxisDefaultized,
 ) => ColorGetter<TSeriesType>;

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/colorProcessor.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/colorProcessor.types.ts
@@ -1,4 +1,4 @@
-import type { ComputedAxis } from '../../../../models/axis';
+import type { ComputedXAxis, ComputedYAxis } from '../../../../models/axis';
 import type { DefaultizedSeriesType } from '../../../../models/seriesType';
 import type { ZAxisDefaultized } from '../../../../models/z-axis';
 import type { ChartSeriesType } from '../../../../models/seriesType/config';
@@ -20,7 +20,7 @@ export type ColorGetter<TSeriesType extends ChartSeriesType> = TSeriesType exten
  */
 export type ColorProcessor<TSeriesType extends ChartSeriesType> = (
   series: DefaultizedSeriesType<TSeriesType>,
-  xAxis?: ComputedAxis,
-  yAxis?: ComputedAxis,
+  xAxis?: ComputedXAxis,
+  yAxis?: ComputedYAxis,
   zAxis?: ZAxisDefaultized,
 ) => ColorGetter<TSeriesType>;

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipGetter.types.ts
@@ -6,13 +6,12 @@ import type {
 } from '../../../../models/seriesType/config';
 import { SeriesId } from '../../../../models/seriesType/common';
 import {
-  ComputedAxis,
   AxisId,
-  ChartsXAxisProps,
-  ChartsYAxisProps,
   ChartsRotationAxisProps,
   ChartsRadiusAxisProps,
   PolarAxisDefaultized,
+  ComputedXAxis,
+  ComputedYAxis,
 } from '../../../../models/axis';
 import { ChartsLabelMarkProps } from '../../../../ChartsLabel/ChartsLabelMark';
 import { ColorGetter } from './colorProcessor.types';
@@ -69,8 +68,8 @@ export type ItemTooltipWithMultipleValues<T extends 'radar' = 'radar'> = Pick<
 };
 
 export interface TooltipGetterAxesConfig {
-  x?: ComputedAxis<any, any, ChartsXAxisProps>;
-  y?: ComputedAxis<any, any, ChartsYAxisProps>;
+  x?: ComputedXAxis;
+  y?: ComputedYAxis;
   rotation?: PolarAxisDefaultized<any, any, ChartsRotationAxisProps>;
   radius?: PolarAxisDefaultized<any, any, ChartsRadiusAxisProps>;
 }

--- a/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipGetter.types.ts
+++ b/packages/x-charts/src/internals/plugins/models/seriesConfig/tooltipGetter.types.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../../../models/seriesType/config';
 import { SeriesId } from '../../../../models/seriesType/common';
 import {
-  AxisDefaultized,
+  ComputedAxis,
   AxisId,
   ChartsXAxisProps,
   ChartsYAxisProps,
@@ -69,8 +69,8 @@ export type ItemTooltipWithMultipleValues<T extends 'radar' = 'radar'> = Pick<
 };
 
 export interface TooltipGetterAxesConfig {
-  x?: AxisDefaultized<any, any, ChartsXAxisProps>;
-  y?: AxisDefaultized<any, any, ChartsYAxisProps>;
+  x?: ComputedAxis<any, any, ChartsXAxisProps>;
+  y?: ComputedAxis<any, any, ChartsYAxisProps>;
   rotation?: PolarAxisDefaultized<any, any, ChartsRotationAxisProps>;
   radius?: PolarAxisDefaultized<any, any, ChartsRadiusAxisProps>;
 }

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -471,6 +471,16 @@ export type ComputedAxis<
     : AxisProps extends ChartsYAxisProps
       ? MakeRequired<AxisSideConfig<AxisProps>, 'width'>
       : AxisSideConfig<AxisProps>);
+export type ComputedXAxis<S extends ScaleName = ScaleName, V = any> = ComputedAxis<
+  S,
+  V,
+  ChartsXAxisProps
+>;
+export type ComputedYAxis<S extends ScaleName = ScaleName, V = any> = ComputedAxis<
+  S,
+  V,
+  ChartsYAxisProps
+>;
 
 export function isBandScaleConfig(
   scaleConfig: AxisConfig<ScaleName>,

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -451,7 +451,7 @@ export type PolarAxisDefaultized<
     triggerTooltip?: boolean;
   };
 
-export type AxisDefaultized<
+export type ComputedAxis<
   S extends ScaleName = ScaleName,
   V = any,
   AxisProps extends ChartsAxisProps = ChartsXAxisProps | ChartsYAxisProps,
@@ -514,3 +514,20 @@ export type RotationAxis<S extends ScaleName = ScaleName, V = any> = S extends S
 export type RadiusAxis<S extends 'linear' = 'linear', V = any> = S extends 'linear'
   ? AxisConfig<S, V, ChartsRadiusAxisProps>
   : never;
+
+/**
+ * The x-axis configuration with missing values filled with default values.
+ */
+export type DefaultedXAxis<S extends ScaleName = ScaleName, V = any> = AxisConfig<
+  S,
+  V,
+  ChartsXAxisProps
+>;
+/**
+ * The y-axis configuration with missing values filled with default values.
+ */
+export type DefaultedYAxis<S extends ScaleName = ScaleName, V = any> = AxisConfig<
+  S,
+  V,
+  ChartsYAxisProps
+>;


### PR DESCRIPTION
Created types for the intermediate steps of axis processing. 

The type for the data we get directly from props is `XAxis`. After `defaultizeXAxis`, it's `DefaultedXAxis`. After `computeAxisValue` it's `ComputedAxis`. 

Most important changes are in the `useChartCartesianAxis` directory and in the `src/models/axis.ts` file.

If this makes sense, I can apply this to other axes (rotation and radius).