### PR TITLE
[charts] Add population pyramid demo

### DIFF
--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { Stack, Typography } from '@mui/material';
+
+const ageGroups = [
+  '0-4 yrs',
+  '5-9 yrs',
+  '10-14 yrs',
+  '15-19 yrs',
+  '20-24 yrs',
+  '25-29 yrs',
+  '30-34 yrs',
+  '35-39 yrs',
+  '40-44 yrs',
+  '45-49 yrs',
+  '50-54 yrs',
+  '55-59 yrs',
+  '60-64 yrs',
+  '65-69 yrs',
+  '70-74 yrs',
+  '75-79 yrs',
+  '80-84 yrs',
+  '85-89 yrs',
+  '90-94 yrs',
+  '95-99 yrs',
+  '100+ yrs',
+];
+
+const male = [
+  766227, 1097221, 1189663, 1183580, 1620461, 1933726, 1796779, 1808706, 2067075,
+  2061862, 2258061, 2068112, 2042614, 1478069, 1012668, 696606, 476263, 201240,
+  50323, 8291, 1139,
+];
+
+const female = [
+  727814, 1044863, 1122176, 1104293, 1484776, 1695058, 1593655, 1673805, 1967944,
+  2000130, 2231491, 2045845, 2105499, 1585781, 1152098, 899933, 762492, 445118,
+  168603, 36739, 5770,
+];
+
+const numberFormatter = Intl.NumberFormat(undefined, {
+  useGrouping: true,
+});
+
+export default function PopulationPyramidBarChart() {
+  return (
+    <Stack width="100%">
+      <Typography variant="h6" textAlign="center">
+        South Korea Population Pyramid - 2022
+      </Typography>
+      <BarChart
+        height={500}
+        series={[
+          {
+            data: male.map((d) => -d),
+            label: 'Male',
+            type: 'bar',
+            valueFormatter: (d) => `${numberFormatter.format(-d)}`,
+            stack: 'stack',
+          },
+          {
+            data: female,
+            label: 'Female',
+            type: 'bar',
+            stack: 'stack',
+          },
+        ]}
+        yAxis={[{ data: ageGroups, width: 70 }]}
+        xAxis={[
+          {
+            valueFormatter: (d) => `${numberFormatter.format(Math.abs(d))}`,
+          },
+        ]}
+        layout="horizontal"
+        margin={{ right: 70 }}
+      />
+      <Typography variant="caption">Source: KOSIS</Typography>
+    </Stack>
+  );
+}

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -42,26 +42,9 @@ const female = [
 const numberFormatter = Intl.NumberFormat('en-US', {
   useGrouping: true,
 });
-
-function formatWithSuffix(number) {
-  const suffixes = [
-    { value: 1e6, symbol: 'M' },
-    { value: 1e3, symbol: 'k' },
-  ];
-
-  const suffix = suffixes.find((s) => Math.abs(number) >= s.value);
-
-  if (!suffix) {
-    return new Intl.NumberFormat('en-US').format(number);
-  }
-
-  const formattedValue = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 1,
-  }).format(number / suffix.value);
-
-  return formattedValue + suffix.symbol;
-}
+const numberWithSuffixFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+});
 
 export default function PopulationPyramidBarChart() {
   return (
@@ -96,7 +79,7 @@ export default function PopulationPyramidBarChart() {
         ]}
         xAxis={[
           {
-            valueFormatter: (d) => formatWithSuffix(Math.abs(d)),
+            valueFormatter: (d) => numberWithSuffixFormatter.format(Math.abs(d)),
             disableLine: true,
             disableTicks: true,
           },

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import { BarChart } from '@mui/x-charts/BarChart';
-import { Stack, Typography } from '@mui/material';
 
 const ageGroups = [
   '0-4 yrs',
@@ -38,9 +39,29 @@ const female = [
   168603, 36739, 5770,
 ];
 
-const numberFormatter = Intl.NumberFormat(undefined, {
+const numberFormatter = Intl.NumberFormat('en-US', {
   useGrouping: true,
 });
+
+function formatWithSuffix(number) {
+  const suffixes = [
+    { value: 1e6, symbol: 'M' },
+    { value: 1e3, symbol: 'k' },
+  ];
+
+  const suffix = suffixes.find((s) => Math.abs(number) >= s.value);
+
+  if (!suffix) {
+    return new Intl.NumberFormat('en-US').format(number);
+  }
+
+  const formattedValue = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  }).format(number / suffix.value);
+
+  return formattedValue + suffix.symbol;
+}
 
 export default function PopulationPyramidBarChart() {
   return (
@@ -75,7 +96,7 @@ export default function PopulationPyramidBarChart() {
         ]}
         xAxis={[
           {
-            valueFormatter: (d) => `${numberFormatter.format(Math.abs(d))}`,
+            valueFormatter: (d) => formatWithSuffix(Math.abs(d)),
             disableLine: true,
             disableTicks: true,
           },

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -65,10 +65,19 @@ export default function PopulationPyramidBarChart() {
             stack: 'stack',
           },
         ]}
-        yAxis={[{ data: ageGroups, width: 70 }]}
+        yAxis={[
+          {
+            data: ageGroups,
+            width: 70,
+            disableLine: true,
+            disableTicks: true,
+          },
+        ]}
         xAxis={[
           {
             valueFormatter: (d) => `${numberFormatter.format(Math.abs(d))}`,
+            disableLine: true,
+            disableTicks: true,
           },
         ]}
         layout="horizontal"

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -40,26 +40,9 @@ const female = [
 const numberFormatter = Intl.NumberFormat('en-US', {
   useGrouping: true,
 });
-
-function formatWithSuffix(number: number) {
-  const suffixes = [
-    { value: 1e6, symbol: 'M' },
-    { value: 1e3, symbol: 'k' },
-  ];
-
-  const suffix = suffixes.find((s) => Math.abs(number) >= s.value);
-
-  if (!suffix) {
-    return new Intl.NumberFormat('en-US').format(number);
-  }
-
-  const formattedValue = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 1,
-  }).format(number / suffix.value);
-
-  return formattedValue + suffix.symbol;
-}
+const numberWithSuffixFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+});
 
 export default function PopulationPyramidBarChart() {
   return (
@@ -94,7 +77,8 @@ export default function PopulationPyramidBarChart() {
         ]}
         xAxis={[
           {
-            valueFormatter: (d: number) => formatWithSuffix(Math.abs(d)),
+            valueFormatter: (d: number) =>
+              numberWithSuffixFormatter.format(Math.abs(d)),
             disableLine: true,
             disableTicks: true,
           },

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { Stack, Typography } from '@mui/material';
+
+const ageGroups = [
+  '0-4 yrs',
+  '5-9 yrs',
+  '10-14 yrs',
+  '15-19 yrs',
+  '20-24 yrs',
+  '25-29 yrs',
+  '30-34 yrs',
+  '35-39 yrs',
+  '40-44 yrs',
+  '45-49 yrs',
+  '50-54 yrs',
+  '55-59 yrs',
+  '60-64 yrs',
+  '65-69 yrs',
+  '70-74 yrs',
+  '75-79 yrs',
+  '80-84 yrs',
+  '85-89 yrs',
+  '90-94 yrs',
+  '95-99 yrs',
+  '100+ yrs',
+];
+const male = [
+  766227, 1097221, 1189663, 1183580, 1620461, 1933726, 1796779, 1808706, 2067075,
+  2061862, 2258061, 2068112, 2042614, 1478069, 1012668, 696606, 476263, 201240,
+  50323, 8291, 1139,
+];
+const female = [
+  727814, 1044863, 1122176, 1104293, 1484776, 1695058, 1593655, 1673805, 1967944,
+  2000130, 2231491, 2045845, 2105499, 1585781, 1152098, 899933, 762492, 445118,
+  168603, 36739, 5770,
+];
+
+const numberFormatter = Intl.NumberFormat(undefined, {
+  useGrouping: true,
+});
+
+export default function PopulationPyramidBarChart() {
+  return (
+    <Stack width="100%">
+      <Typography variant="h6" textAlign="center">
+        South Korea Population Pyramid - 2022
+      </Typography>
+      <BarChart
+        height={500}
+        series={[
+          {
+            data: male.map((d) => -d),
+            label: 'Male',
+            type: 'bar',
+            valueFormatter: (d: number | null) => `${numberFormatter.format(-d!)}`,
+            stack: 'stack',
+          },
+          {
+            data: female,
+            label: 'Female',
+            type: 'bar',
+            stack: 'stack',
+          },
+        ]}
+        yAxis={[{ data: ageGroups, width: 70 }]}
+        xAxis={[
+          {
+            valueFormatter: (d: number) => `${numberFormatter.format(Math.abs(d))}`,
+          },
+        ]}
+        layout="horizontal"
+        margin={{ right: 70 }}
+      />
+      <Typography variant="caption">Source: KOSIS</Typography>
+    </Stack>
+  );
+}

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import { BarChart } from '@mui/x-charts/BarChart';
-import { Stack, Typography } from '@mui/material';
 
 const ageGroups = [
   '0-4 yrs',
@@ -36,9 +37,29 @@ const female = [
   168603, 36739, 5770,
 ];
 
-const numberFormatter = Intl.NumberFormat(undefined, {
+const numberFormatter = Intl.NumberFormat('en-US', {
   useGrouping: true,
 });
+
+function formatWithSuffix(number: number) {
+  const suffixes = [
+    { value: 1e6, symbol: 'M' },
+    { value: 1e3, symbol: 'k' },
+  ];
+
+  const suffix = suffixes.find((s) => Math.abs(number) >= s.value);
+
+  if (!suffix) {
+    return new Intl.NumberFormat('en-US').format(number);
+  }
+
+  const formattedValue = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  }).format(number / suffix.value);
+
+  return formattedValue + suffix.symbol;
+}
 
 export default function PopulationPyramidBarChart() {
   return (
@@ -73,7 +94,7 @@ export default function PopulationPyramidBarChart() {
         ]}
         xAxis={[
           {
-            valueFormatter: (d: number) => `${numberFormatter.format(Math.abs(d))}`,
+            valueFormatter: (d: number) => formatWithSuffix(Math.abs(d)),
             disableLine: true,
             disableTicks: true,
           },

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -63,10 +63,19 @@ export default function PopulationPyramidBarChart() {
             stack: 'stack',
           },
         ]}
-        yAxis={[{ data: ageGroups, width: 70 }]}
+        yAxis={[
+          {
+            data: ageGroups,
+            width: 70,
+            disableLine: true,
+            disableTicks: true,
+          },
+        ]}
         xAxis={[
           {
             valueFormatter: (d: number) => `${numberFormatter.format(Math.abs(d))}`,
+            disableLine: true,
+            disableTicks: true,
           },
         ]}
         layout="horizontal"

--- a/docs/data/charts/bar-demo/bar-demo.md
+++ b/docs/data/charts/bar-demo/bar-demo.md
@@ -35,3 +35,7 @@ components: BarChart, BarElement, BarPlot
 ## BiaxialBarChart
 
 {{"demo": "BiaxialBarChart.js"}}
+
+## Population pyramid
+
+{{"demo": "PopulationPyramidBarChart.js"}}


### PR DESCRIPTION
Add a population pyramid demo with data for South Korea in 2022.

![image](https://github.com/user-attachments/assets/bd9b33c9-0fef-428c-ad55-9e75b757f180)


Data source: [KOSIS](https://kosis.kr/statHtml/statHtml.do?orgId=101&tblId=DT_1BPA001&conn_path=I2&language=en).