### PR TITLE
[DataGrid] Fix cell editing of computed columns with data source

### DIFF
--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -3,6 +3,7 @@ import { RefObject } from '@mui/x-internals/types';
 import { warnOnce } from '@mui/x-internals/warning';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
+import { isDeepEqual } from '@mui/x-internals/isDeepEqual';
 import { useGridEvent, useGridEventPriority } from '../../utils/useGridEvent';
 import { GridEventListener } from '../../../models/events/gridEventListener';
 import {
@@ -424,7 +425,7 @@ export const useGridCellEditing = (
       const rowUpdate = apiRef.current.getRowWithUpdatedValuesFromCellEditing(id, field);
 
       if (props.dataSource?.updateRow) {
-        if (row[field] === rowUpdate[field]) {
+        if (isDeepEqual(row, rowUpdate)) {
           finishCellEditMode();
           return;
         }


### PR DESCRIPTION
I noticed that if there is a column which does not have a respective property in row data and using `dataSource` and cell editing, `dataSource.editRow` does not fire. This can happen with computed columns, for example. 

This is due to the code checking if the `row[field]` has changed. In this case it would be always undefined and the `updateStateToStopCellEditMode` would return early without calling `dataSource.editRow`. `useGridRowEditing` uses `isDeepEqual` instead to check if something in the row has been changed. I thought it might be reasonable to use it in `useGridCellEditing` as well. Perhaps it wouldn't even be necessary to do that checking, but I will leave that decision to you.

Here is a sandbox inspired by the following demo: https://mui.com/x/react-data-grid/editing/#value-parser-and-value-setter
https://stackblitz.com/edit/tswwgcr5-5zr3q5b1?file=src%2FDemo.tsx

Editing the `Computed` column causes no updates to the grid nor it fires the `dataSource.updateRow`.

Here is the same sandbox with this PR's changes:
`TODO add link here when deployment is finished`

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
