### PR TITLE
[tree view][bug] Fix Keyboard navigation error - RichTreeView

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.test.tsx
@@ -139,6 +139,64 @@ describeTreeView<
         expect(view.getFocusedItemId()).to.equal('1.1');
       });
 
+      it("should move the focus to the last visible and enabled descendant of the previous sibling", () => {
+        const view = render({
+          items: [
+            {
+              id: '1',
+              children: [
+                { id: '1-1' },
+                {
+                  id: '1-2',
+                  children: [
+                    { id: '1-2-1' },
+                    { id: '1-2-2' },
+                    { id: '1-2-3' },
+                  ],
+                },
+              ],
+            },
+            { id: '2' },
+          ],
+          defaultExpandedItems: ['1', '1-2'],
+        });
+      
+        act(() => {
+          view.getItemRoot('2').focus();
+        });
+        fireEvent.keyDown(view.getItemRoot('2'), { key: 'ArrowUp' });
+        expect(view.getFocusedItemId()).to.equal('1-2-3');
+      });
+
+      it("should move the focus to the last visible descendant of the previous sibling, skipping disabled items", () => {
+        const view = render({
+          items: [
+            {
+              id: '1',
+              children: [
+                { id: '1-1' },
+                {
+                  id: '1-2',
+                  children: [
+                    { id: '1-2-1' },
+                    { id: '1-2-2' },
+                    { id: '1-2-3', disabled: true},
+                  ],
+                },
+              ],
+            },
+            { id: '2' },
+          ],
+          defaultExpandedItems: ['1', '1-2'],
+        });
+      
+        act(() => {
+          view.getItemRoot('2').focus();
+        });
+        fireEvent.keyDown(view.getItemRoot('2'), { key: 'ArrowUp' });
+              expect(view.getFocusedItemId()).to.equal('1-2-2');
+      });
+
       it('should skip disabled items', () => {
         const view = render({
           items: [{ id: '1' }, { id: '2', disabled: true }, { id: '3' }],

--- a/packages/x-tree-view/src/internals/utils/tree.ts
+++ b/packages/x-tree-view/src/internals/utils/tree.ts
@@ -75,8 +75,9 @@ export const getPreviousNavigableItem = (
   );
   while (selectorIsItemExpanded(state, currentItemId) && lastNavigableChild != null) {
     currentItemId = lastNavigableChild;
-    lastNavigableChild = selectorItemOrderedChildrenIds(state, currentItemId).find((childId) =>
-      selectorCanItemBeFocused(state, childId),
+    lastNavigableChild = getLastNavigableItemInArray(
+      state,
+      selectorItemOrderedChildrenIds(state, currentItemId),
     );
   }
 


### PR DESCRIPTION
This PR fixes the following **issue**: [https://github.com/mui/mui-x/issues/15649](https://github.com/mui/mui-x/issues/15649)

### Cause
The issue was in the `useTreeViewKeyboardNavigation` hook, as @flaviendelangle pointed out, specifically in the following line inside the loop:
```
lastNavigableChild = selectorItemOrderedChildrenIds(state, currentItemId).find((childId) =>
  selectorCanItemBeFocused(state, childId),
);
```
This uses `.find(...)`, which returns the first focusable child, not the last one.
As a result, when navigating down into the previous sibling’s descendants, we incorrectly select the **first** child ("1 2 1") instead of the **last** visible focusable item ("1 2 5").

### Fix

- `getLastNavigableItemInArray` correctly returns the last focusable item in the subtree, so we don’t need to override it with `.find(...)`. By simply removing the `.find(...)` step and reusing `getLastNavigableItemInArray` in the loop, we ensure that the navigation behaves as expected, it goes to the last focusable descendant of the previous sibling.

- Added two tests to cover this case and prevent regressions

### Demo
https://github.com/user-attachments/assets/0306c4d3-7289-4b6e-9cb4-022598f69554


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
