### PR TITLE
[DataGridPro] Ignore `rowCount` response when new children are fetched with the data source

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
@@ -129,7 +129,6 @@ export const useGridDataSourceBasePro = <Api extends GridPrivateApiPro>(
         const rows = cachedData.rows;
         nestedDataManager.setRequestSettled(id);
         apiRef.current.updateNestedRows(rows, rowNode.path);
-        apiRef.current.setRowCount(cachedData.rowCount === undefined ? -1 : cachedData.rowCount);
         apiRef.current.setRowChildrenExpansion(id, true);
         apiRef.current.dataSource.setChildrenLoading(id, false);
         return;
@@ -158,9 +157,6 @@ export const useGridDataSourceBasePro = <Api extends GridPrivateApiPro>(
           cache.set(key, response);
         });
 
-        apiRef.current.setRowCount(
-          getRowsResponse.rowCount === undefined ? -1 : getRowsResponse.rowCount,
-        );
         // Remove existing outdated rows before setting the new ones
         const rowsToDelete: GridRowModelUpdate[] = [];
         getRowsResponse.rows.forEach((row) => {


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/17626

v7 ignored `undefined` values for the `rowCount` while fetching children
https://github.com/mui/mui-x/blob/v7.x/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSource.ts#L185

v8 sets it to -1

I think that we can remove this altogether as it does not make sense to update root row count while updating children.
If you do, you don't have a mean to update the data via the same response, so your count cannot be correct.