### PR TITLE
[charts][docs] Fix weird line wrap export

### DIFF
--- a/docs/data/charts/export/export.md
+++ b/docs/data/charts/export/export.md
@@ -8,7 +8,7 @@ components: ScatterChartPro, BarChartPro, LineChartPro
 
 <p class="description">Charts can be printed and exported as PDF.</p>
 
-Export is available on the **Pro**[<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan') versions of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
+Export is available on the Pro version of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
 
 ## Print/Export as PDF
 

--- a/docs/data/charts/export/export.md
+++ b/docs/data/charts/export/export.md
@@ -8,7 +8,7 @@ components: ScatterChartPro, BarChartPro, LineChartPro
 
 <p class="description">Charts can be printed and exported as PDF.</p>
 
-Export is available on the Pro version of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
+Export is available on the Pro version of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
 
 ## Print/Export as PDF
 

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -8,7 +8,7 @@ components: ScatterChartPro, BarChartPro, LineChartPro, ChartZoomSlider
 
 <p class="description">Enables zooming and panning on specific charts or axis.</p>
 
-Zooming is possible on the Pro version of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
+Zooming is possible on the Pro version of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
 
 ## Basic usage
 

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -8,7 +8,7 @@ components: ScatterChartPro, BarChartPro, LineChartPro, ChartZoomSlider
 
 <p class="description">Enables zooming and panning on specific charts or axis.</p>
 
-Zooming is possible on the **Pro**[<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan') versions of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
+Zooming is possible on the Pro version of the charts: `<LineChartPro />`, `<BarChartPro />`, `<ScatterChartPro />`.
 
 ## Basic usage
 


### PR DESCRIPTION
I was almost going to delete the whole sentence, but this is a bit of a larger scope, so stick to fixing the layout and experience:

- Make sure the whole block line break with an unbreakable space (the initial opportunity I saw)
- Remove the logo, it makes the sentence hard to read, breaks the flow, and draws too much visual attention.

Before
<img width="847" alt="SCR-20250506-lzga" src="https://github.com/user-attachments/assets/634d2cc3-9be8-4def-bdc4-eed649a7b7f2" />

After
<img width="858" alt="SCR-20250506-lzzg" src="https://github.com/user-attachments/assets/93ac707d-dc1e-400d-88b2-0c0ace86980f" />

Preview: https://deploy-preview-17715--material-ui-x.netlify.app/x/react-charts/export/.