### PR TITLE
[code-infra] Remove required checkout step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,36 +324,28 @@ workflows:
           <<: *default-context
       - test_unit:
           <<: *default-context
-          requires:
-            - checkout
-      - test_lint:
-          <<: *default-context
-          requires:
-            - checkout
-      - test_static:
-          <<: *default-context
-          requires:
-            - checkout
+
       - test_browser:
           <<: *default-context
-          requires:
-            - checkout
+
+      - test_lint:
+          <<: *default-context
+
+      - test_static:
+          <<: *default-context
+
       - test_types:
           <<: *default-context
-          requires:
-            - checkout
+
       - test_e2e:
           <<: *default-context
-          requires:
-            - checkout
+
       - test_regressions:
           <<: *default-context
-          requires:
-            - checkout
+
       - run_danger:
           <<: *default-context
-          requires:
-            - checkout
+
   e2e-website:
     when:
       equal: [e2e-website, << pipeline.parameters.workflow >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,7 @@ workflows:
     jobs:
       - checkout:
           <<: *default-context
+
       - test_unit:
           <<: *default-context
 


### PR DESCRIPTION
Remove `requires: - checkout` for circleci steps. 

It doesn't speed up the tests, and only blocks running the cases we forget to dedupe the installs.

This should trim ~2 minutes from the overall wait time for the tests to run, since all tests wait for this to finish. 