### PR TITLE
[docs] Fix AI assistant API URL

### DIFF
--- a/docs/data/data-grid/ai-assistant/ai-assistant.md
+++ b/docs/data/data-grid/ai-assistant/ai-assistant.md
@@ -72,7 +72,7 @@ The Data Grid provides all the necessary elements for integration with MUI's ser
 
    ```ts
    fastify.register(proxy, {
-     upstream: 'https://api.mui.com',
+     upstream: 'https://backend.mui.com',
      prefix: '/api/my-custom-path',
      rewritePrefix: '/v1/datagrid/prompt',
      replyOptions: {


### PR DESCRIPTION
This seems wrong, no? Only https://dashboard.render.com/web/srv-cvvovgc9c44c73f6cit0 runs in production.