### PR TITLE
[charts] Fix infinite tick number when zoom range is zero

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -200,7 +200,9 @@ export function computeAxisValue<T extends ChartSeriesType>({
     }
 
     const rawTickNumber = getTickNumber({ ...axis, range, domain: axisExtremums });
-    const tickNumber = rawTickNumber / ((zoomRange[1] - zoomRange[0]) / 100);
+    /* If the zoom start and end are the same, `tickNumber` will become infinity, so we should default to 1. */
+    const tickNumber =
+      zoomRange[0] === zoomRange[1] ? 1 : rawTickNumber / ((zoomRange[1] - zoomRange[0]) / 100);
 
     const zoomedRange = zoomScaleRange(range, zoomRange);
 


### PR DESCRIPTION
Fix infinite tick number when zoom range is zero. 

This was causing a crash when the zoom range is zero (i.e., start === end) because d3's `scale.ticks` creates an `Array(tickNumber)` which throws when `tickNumber` is `Infinity`. 