### PR TITLE
[charts-pro] add benchmark for zoomed in scatter chart

### DIFF
--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -51,9 +51,14 @@ describe('ScatterChartPro', () => {
       const { findByText } = render(
         <ScatterChartPro
           xAxis={[
-            { id: 'x', data: xData, valueFormatter: (v: number) => v.toLocaleString('en-US') },
+            {
+              id: 'x',
+              data: xData,
+              valueFormatter: (v: number) => v.toLocaleString('en-US'),
+              zoom: { minSpan: 0 },
+            },
           ]}
-          yAxis={[{ id: 'y' }]}
+          yAxis={[{ id: 'y', zoom: { minSpan: 0 } }]}
           series={[{ data }]}
           width={500}
           height={300}

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe } from 'vitest';
+import { bench, describe, it } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
 
@@ -63,13 +63,13 @@ describe('ScatterChartPro', () => {
           width={500}
           height={300}
           initialZoom={[
-            { axisId: 'x', start: 50, end: 50.00001 },
-            { axisId: 'y', start: 50, end: 50.00001 },
+            { axisId: 'x', start: 50, end: 50.0001 },
+            { axisId: 'y', start: 50, end: 50.0001 },
           ]}
         />,
       );
 
-      await findByText(dataLength.toLocaleString('en-US'), { ignore: 'span' });
+      await findByText('50.00006', { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -63,13 +63,13 @@ describe('ScatterChartPro', () => {
           width={500}
           height={300}
           initialZoom={[
-            { axisId: 'x', start: 50, end: 50.001 },
-            { axisId: 'y', start: 50, end: 50.001 },
+            { axisId: 'x', start: 50, end: 50.01 },
+            { axisId: 'y', start: 50, end: 50.01 },
           ]}
         />,
       );
 
-      await findByText('50.0006', { ignore: 'span' });
+      await findByText('50.006', { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -63,13 +63,13 @@ describe('ScatterChartPro', () => {
           width={500}
           height={300}
           initialZoom={[
-            { axisId: 'x', start: 50, end: 50.01 },
-            { axisId: 'y', start: 50, end: 50.01 },
+            { axisId: 'x', start: 50, end: 50.1 },
+            { axisId: 'y', start: 50, end: 50.1 },
           ]}
         />,
       );
 
-      await findByText('50.006', { ignore: 'span' });
+      await findByText('50.06', { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { render, cleanup } from '@testing-library/react';
-import { bench, describe, it } from 'vitest';
+import { bench, describe } from 'vitest';
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import { options } from '../utils/options';
 
@@ -63,13 +63,13 @@ describe('ScatterChartPro', () => {
           width={500}
           height={300}
           initialZoom={[
-            { axisId: 'x', start: 50, end: 50.0001 },
-            { axisId: 'y', start: 50, end: 50.0001 },
+            { axisId: 'x', start: 50, end: 50.001 },
+            { axisId: 'y', start: 50, end: 50.001 },
           ]}
         />,
       );
 
-      await findByText('50.00006', { ignore: 'span' });
+      await findByText('50.0006', { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -24,7 +24,7 @@ describe('ScatterChartPro', () => {
               id: 'x',
               data: xData,
               zoom: { filterMode: 'discard' },
-              valueFormatter: (v) => v.toLocaleString('en-US'),
+              valueFormatter: (v: number) => v.toLocaleString('en-US'),
             },
           ]}
           initialZoom={[{ axisId: 'x', start: 20, end: 70 }]}
@@ -39,6 +39,32 @@ describe('ScatterChartPro', () => {
       );
 
       await findByText('60', { ignore: 'span' });
+
+      cleanup();
+    },
+    options,
+  );
+
+  bench(
+    'ScatterChartPro with big data amount and zoomed in',
+    async () => {
+      const { findByText } = render(
+        <ScatterChartPro
+          xAxis={[
+            { id: 'x', data: xData, valueFormatter: (v: number) => v.toLocaleString('en-US') },
+          ]}
+          yAxis={[{ id: 'y' }]}
+          series={[{ data }]}
+          width={500}
+          height={300}
+          initialZoom={[
+            { axisId: 'x', start: 50, end: 50.00001 },
+            { axisId: 'y', start: 50, end: 50.00001 },
+          ]}
+        />,
+      );
+
+      await findByText(dataLength.toLocaleString('en-US'), { ignore: 'span' });
 
       cleanup();
     },


### PR DESCRIPTION
Add benchmark for zoomed in scatter chart.

Used to compare with [this performance improvement](https://github.com/mui/mui-x/pull/17755).