### PR TITLE
[DataGridPremium] Fix aggregation label not being used in pivot panel

### DIFF
--- a/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelField.tsx
+++ b/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelField.tsx
@@ -182,7 +182,7 @@ function AggregationSelect({
   return (
     <React.Fragment>
       <rootProps.slots.baseChip
-        label={aggFunc}
+        label={rootProps.aggregationFunctions[aggFunc]?.label ?? aggFunc}
         size="small"
         variant="outlined"
         ref={aggregationMenuTriggerRef}
@@ -211,7 +211,7 @@ function AggregationSelect({
               onClick={() => handleClick(func)}
               {...rootProps.slotProps?.baseMenuItem}
             >
-              {func}
+              {rootProps.aggregationFunctions[func]?.label ?? func}
             </rootProps.slots.baseMenuItem>
           ))}
         </rootProps.slots.baseMenuList>


### PR DESCRIPTION
Fixes label issue I noticed in https://github.com/mui/mui-x/issues/17616#issuecomment-2864379145