### PR TITLE
[code-infra] Set `isolatedModules=true` in tsconfig

### DIFF
--- a/docs/scripts/tsconfig.json
+++ b/docs/scripts/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["api/buildApi.ts", "i18n.js"],
   "compilerOptions": {
     "allowJs": true,
-    "isolatedModules": true,
     "noEmit": true,
     "noUnusedLocals": true,
     "resolveJsonModule": true,

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
-    "isolatedModules": true,
     /* files are emitted by babel */
     "noEmit": true,
     "noUnusedLocals": true,

--- a/packages/x-tree-view-pro/src/internals/index.ts
+++ b/packages/x-tree-view-pro/src/internals/index.ts
@@ -1,1 +1,1 @@
-export { UseTreeViewItemsReorderingSignature } from './plugins/useTreeViewItemsReordering';
+export type { UseTreeViewItemsReorderingSignature } from './plugins/useTreeViewItemsReordering';

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -4,8 +4,7 @@
     "skipLibCheck": true,
     "incremental": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true
+    "resolveJsonModule": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "baseUrl": "./",
     "allowJs": true,
     "allowImportingTsExtensions": true,
+    "isolatedModules": true,
     "paths": {
       "@mui/x-data-grid": ["./packages/x-data-grid/src"],
       "@mui/x-data-grid/*": ["./packages/x-data-grid/src/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "baseUrl": "./",
     "allowJs": true,
     "allowImportingTsExtensions": true,
+    // Prevents errors like https://github.com/mui/mui-x/issues/17772
     "isolatedModules": true,
     "paths": {
       "@mui/x-data-grid": ["./packages/x-data-grid/src"],

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -38,8 +38,7 @@
     "skipLibCheck": true,
     "incremental": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true
+    "resolveJsonModule": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
Prevents missing required `export type` in some instances.

Eg: https://github.com/mui/mui-x/issues/17772