### PR TITLE
[charts] Add grouped axes demo

### DIFF
--- a/docs/data/charts/axis/GroupedAxes.js
+++ b/docs/data/charts/axis/GroupedAxes.js
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import { BarChart } from '@mui/x-charts/BarChart';
 
+import { axisClasses } from '@mui/x-charts/ChartsAxis';
+
 export default function GroupedAxes() {
   return (
     <BarChart
       xAxis={[
         {
+          id: 'months',
           scaleType: 'band',
           data: time,
           valueFormatter: formatShortMonth,
-          height: 30,
+          height: 24,
         },
         {
           scaleType: 'band',
@@ -24,10 +27,8 @@ export default function GroupedAxes() {
       ]}
       {...chartConfig}
       sx={{
-        '& .MuiChartsAxis-directionX .MuiChartsAxis-tickContainer:nth-child(3n - 1) .MuiChartsAxis-tick':
-          {
-            transform: 'scaleY(8)',
-          },
+        [`& .${axisClasses.id}-months .${axisClasses.tickContainer}:nth-child(3n - 1) .${axisClasses.tick}`]:
+          { transform: 'scaleY(4)' },
       }}
     />
   );

--- a/docs/data/charts/axis/GroupedAxes.js
+++ b/docs/data/charts/axis/GroupedAxes.js
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+export default function GroupedAxes() {
+  return (
+    <BarChart
+      xAxis={[
+        {
+          scaleType: 'band',
+          data: time,
+          valueFormatter: formatShortMonth,
+          height: 30,
+        },
+        {
+          scaleType: 'band',
+          data: time.filter((_, index) => index % 3 === 0),
+          valueFormatter: formatQuarterYear,
+          position: 'bottom',
+          tickLabelPlacement: 'middle',
+          height: 35,
+          disableLine: true,
+          disableTicks: true,
+        },
+      ]}
+      {...chartConfig}
+      sx={{
+        '& .MuiChartsAxis-directionX .MuiChartsAxis-tickContainer:nth-child(3n - 1) .MuiChartsAxis-tick':
+          {
+            transform: 'scaleY(8)',
+          },
+      }}
+    />
+  );
+}
+
+const formatQuarterYear = (date, context) => {
+  if (context.location === 'tick') {
+    const quarter = Math.floor(date.getMonth() / 3) + 1;
+    const year = date.getFullYear().toString().slice(-2);
+    return `Q${quarter} '${year}`;
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const formatShortMonth = (date, context) => {
+  if (context.location === 'tick') {
+    return date.toLocaleDateString('en-US', { month: 'short' });
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const time = [
+  new Date(2015, 0, 1),
+  new Date(2015, 1, 1),
+  new Date(2015, 2, 1),
+  new Date(2015, 3, 1),
+  new Date(2015, 4, 1),
+  new Date(2015, 5, 1),
+  new Date(2015, 6, 1),
+  new Date(2015, 7, 1),
+  new Date(2015, 8, 1),
+  new Date(2015, 9, 1),
+  new Date(2015, 10, 1),
+  new Date(2015, 11, 1),
+];
+
+const a = [
+  4000, 3000, 2000, 2780, 1890, 2390, 3490, 2400, 1398, 9800, 3908, 4800, 2400,
+];
+
+const b = [
+  2400, 1398, 9800, 3908, 4800, 3800, 4300, 2181, 2500, 2100, 3000, 2000, 3908,
+];
+
+const getPercents = (array) =>
+  array.map((v, index) => (100 * v) / (a[index] + b[index]));
+
+const chartConfig = {
+  height: 300,
+  series: [
+    {
+      data: getPercents(a),
+      label: 'Income',
+      valueFormatter: (value) => `${(value ?? 0).toFixed(0)}%`,
+    },
+    {
+      data: getPercents(b),
+      label: 'Expenses',
+      valueFormatter: (value) => `${(value ?? 0).toFixed(0)}%`,
+    },
+  ],
+  yAxis: [
+    {
+      valueFormatter: (value) => `${(value ?? 0).toFixed(0)}%`,
+    },
+  ],
+};

--- a/docs/data/charts/axis/GroupedAxes.tsx
+++ b/docs/data/charts/axis/GroupedAxes.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { AxisValueFormatterContext } from '@mui/x-charts/internals';
+import { axisClasses } from '@mui/x-charts/ChartsAxis';
+
+export default function GroupedAxes() {
+  return (
+    <BarChart
+      xAxis={[
+        {
+          id: 'months',
+          scaleType: 'band',
+          data: time,
+          valueFormatter: formatShortMonth,
+          height: 24,
+        },
+        {
+          scaleType: 'band',
+          data: time.filter((_, index) => index % 3 === 0),
+          valueFormatter: formatQuarterYear,
+          position: 'bottom',
+          tickLabelPlacement: 'middle',
+          height: 35,
+          disableLine: true,
+          disableTicks: true,
+        },
+      ]}
+      {...chartConfig}
+      sx={{
+        [`& .${axisClasses.id}-months .${axisClasses.tickContainer}:nth-child(3n - 1) .${axisClasses.tick}`]:
+          { transform: 'scaleY(4)' },
+      }}
+    />
+  );
+}
+
+const formatQuarterYear = (date: Date, context: AxisValueFormatterContext) => {
+  if (context.location === 'tick') {
+    const quarter = Math.floor(date.getMonth() / 3) + 1;
+    const year = date.getFullYear().toString().slice(-2);
+    return `Q${quarter} '${year}`;
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const formatShortMonth = (date: Date, context: AxisValueFormatterContext) => {
+  if (context.location === 'tick') {
+    return date.toLocaleDateString('en-US', { month: 'short' });
+  }
+  return date.toLocaleDateString('en-US', { month: 'long' });
+};
+
+const time = [
+  new Date(2015, 0, 1),
+  new Date(2015, 1, 1),
+  new Date(2015, 2, 1),
+  new Date(2015, 3, 1),
+  new Date(2015, 4, 1),
+  new Date(2015, 5, 1),
+  new Date(2015, 6, 1),
+  new Date(2015, 7, 1),
+  new Date(2015, 8, 1),
+  new Date(2015, 9, 1),
+  new Date(2015, 10, 1),
+  new Date(2015, 11, 1),
+];
+const a = [
+  4000, 3000, 2000, 2780, 1890, 2390, 3490, 2400, 1398, 9800, 3908, 4800, 2400,
+];
+const b = [
+  2400, 1398, 9800, 3908, 4800, 3800, 4300, 2181, 2500, 2100, 3000, 2000, 3908,
+];
+
+const getPercents = (array: number[]) =>
+  array.map((v, index) => (100 * v) / (a[index] + b[index]));
+
+const chartConfig = {
+  height: 300,
+  series: [
+    {
+      data: getPercents(a),
+      label: 'Income',
+      valueFormatter: (value: number | null) => `${(value ?? 0).toFixed(0)}%`,
+    },
+    {
+      data: getPercents(b),
+      label: 'Expenses',
+      valueFormatter: (value: number | null) => `${(value ?? 0).toFixed(0)}%`,
+    },
+  ],
+  yAxis: [
+    {
+      valueFormatter: (value: number | null) => `${(value ?? 0).toFixed(0)}%`,
+    },
+  ],
+} as const;

--- a/docs/data/charts/axis/axis.md
+++ b/docs/data/charts/axis/axis.md
@@ -214,9 +214,13 @@ The axis is still computed and used for the scaling.
 You can display multiple axes on the same side.
 If two or more axes share the same `position`, they are displayed in the order they are defined from closest to the chart to farthest.
 
-To avoid overlapping, you can use the `height` prop for `xAxis` and `width` for `yAxis` to increase the space between the axes.
-
 {{"demo": "MultipleAxes.js"}}
+
+### Grouped Axes
+
+You can group axes together by rendering more than one axis on the same side.
+
+{{"demo": "GroupedAxes.js"}}
 
 ## Axis customization
 

--- a/docs/pages/x/api/charts/charts-axis.json
+++ b/docs/pages/x/api/charts/charts-axis.json
@@ -33,6 +33,12 @@
       "isGlobal": false
     },
     {
+      "key": "id",
+      "className": "MuiChartsAxis-id",
+      "description": "Styles applied to the root element for the axis with the given ID.\nNeeds to be suffixed with the axis ID: `.${axisClasses.id}-${axisId}`.",
+      "isGlobal": false
+    },
+    {
       "key": "label",
       "className": "MuiChartsAxis-label",
       "description": "Styles applied to the group containing the axis label.",

--- a/docs/pages/x/api/charts/charts-x-axis.json
+++ b/docs/pages/x/api/charts/charts-x-axis.json
@@ -66,6 +66,12 @@
       "isGlobal": false
     },
     {
+      "key": "id",
+      "className": "MuiChartsXAxis-id",
+      "description": "Styles applied to the root element for the axis with the given ID.\nNeeds to be suffixed with the axis ID: `.${axisClasses.id}-${axisId}`.",
+      "isGlobal": false
+    },
+    {
       "key": "label",
       "className": "MuiChartsXAxis-label",
       "description": "Styles applied to the group containing the axis label.",

--- a/docs/pages/x/api/charts/charts-y-axis.json
+++ b/docs/pages/x/api/charts/charts-y-axis.json
@@ -65,6 +65,12 @@
       "isGlobal": false
     },
     {
+      "key": "id",
+      "className": "MuiChartsYAxis-id",
+      "description": "Styles applied to the root element for the axis with the given ID.\nNeeds to be suffixed with the axis ID: `.${axisClasses.id}-${axisId}`.",
+      "isGlobal": false
+    },
+    {
       "key": "label",
       "className": "MuiChartsYAxis-label",
       "description": "Styles applied to the group containing the axis label.",

--- a/docs/translations/api-docs/charts/charts-axis/charts-axis.json
+++ b/docs/translations/api-docs/charts/charts-axis/charts-axis.json
@@ -8,6 +8,10 @@
     "bottom": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the bottom axis" },
     "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x-axes" },
     "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y-axes" },
+    "id": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the axis ID: <code>.${axisClasses.id}-${axisId}</code>.",
+      "nodeName": "the root element for the axis with the given ID"
+    },
     "label": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group containing the axis label"

--- a/docs/translations/api-docs/charts/charts-x-axis/charts-x-axis.json
+++ b/docs/translations/api-docs/charts/charts-x-axis/charts-x-axis.json
@@ -44,6 +44,10 @@
     "bottom": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the bottom axis" },
     "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x-axes" },
     "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y-axes" },
+    "id": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the axis ID: <code>.${axisClasses.id}-${axisId}</code>.",
+      "nodeName": "the root element for the axis with the given ID"
+    },
     "label": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group containing the axis label"

--- a/docs/translations/api-docs/charts/charts-y-axis/charts-y-axis.json
+++ b/docs/translations/api-docs/charts/charts-y-axis/charts-y-axis.json
@@ -41,6 +41,10 @@
     "bottom": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the bottom axis" },
     "directionX": { "description": "Styles applied to {{nodeName}}.", "nodeName": "x-axes" },
     "directionY": { "description": "Styles applied to {{nodeName}}.", "nodeName": "y-axes" },
+    "id": {
+      "description": "Styles applied to {{nodeName}}. Needs to be suffixed with the axis ID: <code>.${axisClasses.id}-${axisId}</code>.",
+      "nodeName": "the root element for the axis with the given ID"
+    },
     "label": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group containing the axis label"

--- a/packages/x-charts/src/ChartsAxis/axisClasses.ts
+++ b/packages/x-charts/src/ChartsAxis/axisClasses.ts
@@ -30,6 +30,11 @@ export interface ChartsAxisClasses {
   left: string;
   /** Styles applied to the right axis. */
   right: string;
+  /**
+   * Styles applied to the root element for the axis with the given ID.
+   * Needs to be suffixed with the axis ID: `.${axisClasses.id}-${axisId}`.
+   */
+  id: string;
 }
 
 export type ChartsAxisClassKey = keyof ChartsAxisClasses;
@@ -50,4 +55,5 @@ export const axisClasses: ChartsAxisClasses = generateUtilityClasses('MuiChartsA
   'bottom',
   'left',
   'right',
+  'id',
 ]);

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -26,9 +26,9 @@ import { getDefaultBaseline, getDefaultTextAnchor } from '../ChartsText/defaultT
 import { invertTextAnchor } from '../internals/invertTextAnchor';
 
 const useUtilityClasses = (ownerState: AxisConfig<any, any, ChartsXAxisProps>) => {
-  const { classes, position } = ownerState;
+  const { classes, position, id } = ownerState;
   const slots = {
-    root: ['root', 'directionX', position],
+    root: ['root', 'directionX', position, `id-${id}`],
     line: ['line'],
     tickContainer: ['tickContainer'],
     tick: ['tick'],

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -23,9 +23,9 @@ import { clampAngle } from '../internals/clampAngle';
 import { invertTextAnchor } from '../internals/invertTextAnchor';
 
 const useUtilityClasses = (ownerState: AxisConfig<any, any, ChartsYAxisProps>) => {
-  const { classes, position } = ownerState;
+  const { classes, position, id } = ownerState;
   const slots = {
-    root: ['root', 'directionY', position],
+    root: ['root', 'directionY', position, `id-${id}`],
     line: ['line'],
     tickContainer: ['tickContainer'],
     tick: ['tick'],


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17839.

Add grouped axes demo. To achieve this, I added the axis ID to the class names so it's easier to target the given axis. 

I'm not very fond of the hack to make every third tick bigger than normal, but `line` elements' `x` and `y` properties cannot be styled using CSS. 