### PR TITLE
[charts] Improve performance in scatter chart 

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -287,7 +287,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
     const handleDown = (event: PointerEvent) => {
       panningEventCacheRef.current.push(event);
       const point = getSVGPoint(element, event);
-      if (!instance.isPointInside(point)) {
+      if (!instance.isPointInside(point.x, point.y)) {
         return;
       }
       // If there is only one pointer, prevent selecting text
@@ -352,7 +352,7 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
 
       const point = getSVGPoint(element, event);
 
-      if (!instance.isPointInside(point)) {
+      if (!instance.isPointInside(point.x, point.y)) {
         return;
       }
 

--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -293,7 +293,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     tickLabelMinGap,
     reverse,
     isMounted,
-    isPointInside: (x: number) => instance.isPointInside({ x, y: -1 }, { direction: 'x' }),
+    isPointInside: (x: number) => instance.isPointInside(x, 0, { direction: 'x' }),
   });
 
   const axisLabelProps = useSlotProps({
@@ -363,7 +363,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         const xTickLabel = labelOffset ?? 0;
         const yTickLabel = positionSign * (tickSize + TICK_LABEL_GAP);
 
-        const showTick = instance.isPointInside({ x: tickOffset, y: -1 }, { direction: 'x' });
+        const showTick = instance.isPointInside(tickOffset, -1, { direction: 'x' });
         const tickLabel = tickLabels.get(item);
         const showTickLabel = visibleLabels.has(item);
 

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -281,7 +281,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
         const skipLabel =
           typeof tickLabelInterval === 'function' && !tickLabelInterval?.(value, index);
 
-        const showLabel = instance.isPointInside({ x: -1, y: tickOffset }, { direction: 'y' });
+        const showLabel = instance.isPointInside(-1, tickOffset, { direction: 'y' });
         const tickLabel = tickLabels.get(item);
 
         if (!showLabel) {

--- a/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
+++ b/packages/x-charts/src/LineChart/LineHighlightPlot.tsx
@@ -105,7 +105,7 @@ function LineHighlightPlot(props: LineHighlightPlotProps) {
           const x = xScale(xData[highlightedIndex]);
           const y = yScale(stackedData[highlightedIndex][1])!; // This should not be undefined since y should not be a band scale
 
-          if (!instance.isPointInside({ x, y })) {
+          if (!instance.isPointInside(x, y)) {
             return null;
           }
 

--- a/packages/x-charts/src/LineChart/MarkPlot.tsx
+++ b/packages/x-charts/src/LineChart/MarkPlot.tsx
@@ -138,7 +138,7 @@ function MarkPlot(props: MarkPlotProps) {
                     // Remove missing data point
                     return false;
                   }
-                  if (!instance.isPointInside({ x, y })) {
+                  if (!instance.isPointInside(x, y)) {
                     // Remove out of range
                     return false;
                   }

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -86,7 +86,7 @@ function Scatter(props: ScatterProps) {
       const x = getXPosition(scatterPoint.x);
       const y = getYPosition(scatterPoint.y);
 
-      const isInRange = instance.isPointInside({ x, y });
+      const isInRange = instance.isPointInside(x, y);
 
       if (isInRange) {
         const currentItem = {

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -151,7 +151,7 @@ export function useTicks(
       const value = ticks[i];
       const offset = scale(value);
 
-      if (instance.isPointInside({ x: offset, y: offset }, { direction })) {
+      if (instance.isPointInside(offset, offset, { direction })) {
         visibleTicks.push({
           value,
           formattedValue:

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.ts
@@ -189,7 +189,8 @@ export const useChartDimensions: ChartPlugin<UseChartDimensionsSignature> = ({
   const drawingArea = useSelector(store, selectorChartDrawingArea);
   const isPointInside = React.useCallback(
     (
-      { x, y }: { x: number; y: number },
+      x: number,
+      y: number,
       options?: {
         targetElement?: Element;
         direction?: 'x' | 'y';

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.types.ts
@@ -70,16 +70,16 @@ export interface UseChartDimensionsState {
 export interface UseChartDimensionsInstance {
   /**
    * Checks if a point is inside the drawing area.
-   * @param {Object} point The point to check.
-   * @param {number} point.x The x coordinate of the point.
-   * @param {number} point.y The y coordinate of the point.
+   * @param {number} x The x coordinate of the point.
+   * @param {number} y The y coordinate of the point.
    * @param {Object} options The options of the check.
    * @param {Element} [options.targetElement] The element to check if it is allowed to overflow the drawing area.
    * @param {'x' | 'y'} [options.direction] The direction to check.
    * @returns {boolean} `true` if the point is inside the drawing area, `false` otherwise.
    */
   isPointInside: (
-    point: { x: number; y: number },
+    x: number,
+    y: number,
     options?: {
       targetElement?: Element;
       direction?: 'x' | 'y';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
@@ -81,7 +81,11 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
       const target = 'targetTouches' in event ? event.targetTouches[0] : event;
       const svgPoint = getSVGPoint(element, target);
 
-      if (!instance.isPointInside(svgPoint, { targetElement: event.target as SVGElement })) {
+      if (
+        !instance.isPointInside(svgPoint.x, svgPoint.y, {
+          targetElement: event.target as SVGElement,
+        })
+      ) {
         instance.cleanInteraction?.();
         return;
       }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
@@ -124,7 +124,11 @@ export const useChartPolarAxis: ChartPlugin<UseChartPolarAxisSignature<any>> = (
       mousePosition.current.y = svgPoint.y;
 
       // Test if it's in the drawing area
-      if (!instance.isPointInside(svgPoint, { targetElement: event.target as SVGElement })) {
+      if (
+        !instance.isPointInside(svgPoint.x, svgPoint.y, {
+          targetElement: event.target as SVGElement,
+        })
+      ) {
         if (mousePosition.current.isInChart) {
           instance?.cleanInteraction();
           mousePosition.current.isInChart = false;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartVoronoi/useChartVoronoi.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartVoronoi/useChartVoronoi.ts
@@ -75,7 +75,7 @@ export const useChartVoronoi: ChartPlugin<UseChartVoronoiSignature> = ({
         const pointX = getXPosition(x);
         const pointY = getYPosition(y);
 
-        if (!instance.isPointInside({ x: pointX, y: pointY })) {
+        if (!instance.isPointInside(pointX, pointY)) {
           // If the point is not displayed we move them to a trash coordinate.
           // This avoids managing index mapping before/after filtering.
           // The trash point is far enough such that any point in the drawing area will be closer to the mouse than the trash coordinate.
@@ -124,7 +124,7 @@ export const useChartVoronoi: ChartPlugin<UseChartVoronoiSignature> = ({
       // Get mouse coordinate in global SVG space
       const svgPoint = getSVGPoint(element, event);
 
-      if (!instance.isPointInside(svgPoint)) {
+      if (!instance.isPointInside(svgPoint.x, svgPoint.y)) {
         lastFind.current = undefined;
         return 'outside-chart';
       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Improve performance in scatter chart by reducing the amount of allocations made. `isPointInside` is called many times when calculating which points to show, so by moving from object arguments to positional arguments the performance improved slightly. 

