### PR TITLE
Revert "fix: [pickers] Broken shortcuts layout in RTL mode (#17771)"

### DIFF
--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -70,9 +70,6 @@ export const PickersLayoutRoot = styled('div', {
         [`& .${pickersLayoutClasses.shortcuts}`]: {
           gridColumn: 3,
         },
-        [`& .${pickersLayoutClasses.contentWrapper}`]: {
-          gridColumn: 1,
-        },
       },
     },
   ],


### PR DESCRIPTION
This change did break the Tabbed view in StaticDateTimePicker (and possibly more) ... reverting this and reopening the issue!