### PR TITLE
[charts] Enable tooltip disable portal

### DIFF
--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -207,9 +207,9 @@ Here's how the Bar Chart is composed:
         <ChartsAxisHighlight />
       </g>
       <ChartsAxis />
-      <ChartsTooltip />
       <ChartsClipPath id={clipPathId} />
     </ChartsSurface>
+    <ChartsTooltip />
   </ChartsWrapper>
 </ChartDataProvider>
 ```

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -294,9 +294,9 @@ Here's how the Line Chart is composed:
         <MarkPlot />
       </g>
       <LineHighlightPlot />
-      <ChartsTooltip />
       <ChartsClipPath id={clipPathId} />
     </ChartsSurface>
+    <ChartsTooltip />
   </ChartsWrapper>
 </ChartDataProvider>
 ```

--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -138,8 +138,8 @@ Here's how the Pie Chart is composed:
     <ChartsSurface>
       <PiePlot />
       <ChartsOverlay />
-      <ChartsTooltip trigger="item" />
     </ChartsSurface>
+    <ChartsTooltip trigger="item" />
   </ChartsWrapper>
 </ChartDataProvider>
 ```

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -137,8 +137,8 @@ Here's how the Radar Chart is composed:
       <RadarSeriesMarks />
       {/* Other components */}
       <ChartsOverlay />
-      <ChartsTooltip />
     </ChartsSurface>
+    <ChartsTooltip />
   </ChartsWrapper>
 </RadarDataProvider>
 ```

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -154,8 +154,8 @@ Here's how the Scatter Chart is composed:
       </g>
       <ChartsOverlay />
       <ChartsAxisHighlight />
-      <ChartsTooltip trigger="item" />
     </ChartsSurface>
+    <ChartsTooltip trigger="item" />
   </ChartsWrapper>
 </ChartDataProvider>
 ```

--- a/docs/data/charts/tooltip/tooltip.md
+++ b/docs/data/charts/tooltip/tooltip.md
@@ -178,6 +178,8 @@ To apply the same style as we're trying to apply above, we need to use the `sx` 
 
 {{"demo": "TooltipStyle.js"}}
 
+You can also disable the portal by setting `slotProps.tooltip.disablePortal` to `true`.
+
 ## Composition
 
 If you're using composition, by default, the axis listens for mouse events to get its current x/y values.

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -94,10 +94,10 @@ const BarChartPro = React.forwardRef(function BarChartPro(
           </g>
           <ChartsAxis {...chartsAxisProps} />
           <ChartZoomSlider />
-          {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
           <ChartsClipPath {...clipPathProps} />
           {children}
         </ChartsSurface>
+        {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -96,10 +96,10 @@ const FunnelChart = React.forwardRef(function FunnelChart(
           <FunnelPlot {...funnelPlotProps} />
           <ChartsOverlay {...overlayProps} />
           <ChartsAxisHighlight {...axisHighlightProps} />
-          {!themedProps.loading && <Tooltip {...themedProps.slotProps?.tooltip} trigger="item" />}
           <ChartsAxis {...chartsAxisProps} />
           {children}
         </ChartsSurface>
+        {!themedProps.loading && <Tooltip {...themedProps.slotProps?.tooltip} trigger="item" />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -7,6 +7,7 @@ import { MakeOptional } from '@mui/x-internals/types';
 import { interpolateRgbBasis } from '@mui/x-charts-vendor/d3-interpolate';
 import { ChartsAxis, ChartsAxisProps } from '@mui/x-charts/ChartsAxis';
 import { ChartsTooltipProps } from '@mui/x-charts/ChartsTooltip';
+import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import {
   ChartsAxisSlots,
   ChartsAxisSlotProps,
@@ -22,13 +23,14 @@ import {
   ChartsOverlaySlots,
 } from '@mui/x-charts/ChartsOverlay';
 import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '@mui/x-charts/constants';
-import { ChartContainerPro, ChartContainerProProps } from '../ChartContainerPro';
+import { ChartContainerProProps } from '../ChartContainerPro';
 import { HeatmapSeriesType } from '../models/seriesType/heatmap';
 import { HeatmapPlot } from './HeatmapPlot';
 import { seriesConfig as heatmapSeriesConfig } from './seriesConfig';
 import { HeatmapTooltip, HeatmapTooltipProps } from './HeatmapTooltip/HeatmapTooltip';
 import { HeatmapItemSlotProps, HeatmapItemSlots } from './HeatmapItem';
 import { HEATMAP_PLUGINS, HeatmapPluginsSignatures } from './Heatmap.plugins';
+import { ChartDataProviderPro } from '../ChartDataProviderPro';
 
 export interface HeatmapSlots extends ChartsAxisSlots, ChartsOverlaySlots, HeatmapItemSlots {
   /**
@@ -181,8 +183,7 @@ const Heatmap = React.forwardRef(function Heatmap(
   const Tooltip = props.slots?.tooltip ?? HeatmapTooltip;
 
   return (
-    <ChartContainerPro<'heatmap', HeatmapPluginsSignatures>
-      ref={ref}
+    <ChartDataProviderPro<'heatmap', HeatmapPluginsSignatures>
       seriesConfig={seriesConfig}
       series={series.map((s) => ({
         type: 'heatmap',
@@ -196,23 +197,24 @@ const Heatmap = React.forwardRef(function Heatmap(
       zAxis={zAxisWithDefault}
       colors={colors}
       dataset={dataset}
-      sx={sx}
       disableAxisListener
       highlightedItem={highlightedItem}
       onHighlightChange={onHighlightChange}
       onAxisClick={onAxisClick}
       plugins={HEATMAP_PLUGINS}
     >
-      <g clipPath={`url(#${clipPathId})`}>
-        <HeatmapPlot slots={slots} slotProps={slotProps} />
-        <ChartsOverlay loading={loading} slots={slots} slotProps={slotProps} />
-      </g>
-      <ChartsAxis slots={slots} slotProps={slotProps} />
-      {!loading && <Tooltip {...slotProps?.tooltip} />}
+      <ChartsSurface ref={ref} sx={sx}>
+        <g clipPath={`url(#${clipPathId})`}>
+          <HeatmapPlot slots={slots} slotProps={slotProps} />
+          <ChartsOverlay loading={loading} slots={slots} slotProps={slotProps} />
+        </g>
+        <ChartsAxis slots={slots} slotProps={slotProps} />
 
-      <ChartsClipPath id={clipPathId} />
-      {children}
-    </ChartContainerPro>
+        <ChartsClipPath id={clipPathId} />
+        {children}
+      </ChartsSurface>
+      {!loading && <Tooltip {...slotProps?.tooltip} />}
+    </ChartDataProviderPro>
   );
 });
 

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -107,10 +107,10 @@ const LineChartPro = React.forwardRef(function LineChartPro(
             <MarkPlot {...markPlotProps} />
           </g>
           <LineHighlightPlot {...lineHighlightPlotProps} />
-          {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
           <ChartsClipPath {...clipPathProps} />
           {children}
         </ChartsSurface>
+        {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -93,9 +93,9 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
           </g>
           <ChartsOverlay {...overlayProps} />
           <ChartsAxisHighlight {...axisHighlightProps} />
-          {!props.loading && <Tooltip {...props?.slotProps?.tooltip} trigger="item" />}
           {children}
         </ChartsSurface>
+        {!props.loading && <Tooltip {...props?.slotProps?.tooltip} trigger="item" />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -168,10 +168,10 @@ const LineChart = React.forwardRef(function LineChart(
             <MarkPlot {...markPlotProps} />
           </g>
           <LineHighlightPlot {...lineHighlightPlotProps} />
-          {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
           <ChartsClipPath {...clipPathProps} />
           {children}
         </ChartsSurface>
+        {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProvider>
   );

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -140,9 +140,9 @@ const PieChart = React.forwardRef(function PieChart(
         <ChartsSurface {...chartsSurfaceProps}>
           <PiePlot slots={slots} slotProps={slotProps} onItemClick={onItemClick} />
           <ChartsOverlay loading={loading} slots={slots} slotProps={slotProps} />
-          {!loading && <Tooltip trigger="item" {...slotProps?.tooltip} />}
           {children}
         </ChartsSurface>
+        {!loading && <Tooltip trigger="item" {...slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProvider>
   );

--- a/packages/x-charts/src/RadarChart/RadarChart.tsx
+++ b/packages/x-charts/src/RadarChart/RadarChart.tsx
@@ -79,9 +79,9 @@ const RadarChart = React.forwardRef(function RadarChart(
           {highlight === 'axis' && <RadarAxisHighlight />}
           <RadarSeriesMarks />
           <ChartsOverlay {...overlayProps} />
-          {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
           {children}
         </ChartsSurface>
+        {!props.loading && <Tooltip {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
     </RadarDataProvider>
   );

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -140,9 +140,9 @@ const ScatterChart = React.forwardRef(function ScatterChart(
           </g>
           <ChartsOverlay {...overlayProps} />
           <ChartsAxisHighlight {...axisHighlightProps} />
-          {!props.loading && <Tooltip trigger="item" {...props.slotProps?.tooltip} />}
           {children}
         </ChartsSurface>
+        {!props.loading && <Tooltip trigger="item" {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProvider>
   );

--- a/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
+++ b/packages/x-charts/src/SparkLineChart/SparkLineChart.tsx
@@ -6,7 +6,9 @@ import { ChartsClipPath } from '../ChartsClipPath';
 import { ChartsColor, ChartsColorPalette } from '../colorPalettes';
 import { BarPlot } from '../BarChart';
 import { LinePlot, AreaPlot, LineHighlightPlot } from '../LineChart';
-import { ChartContainer, ChartContainerProps } from '../ChartContainer';
+import { ChartContainerProps } from '../ChartContainer';
+import { ChartDataProvider } from '../ChartDataProvider';
+import { ChartsSurface } from '../ChartsSurface';
 import { DEFAULT_X_AXIS_KEY, DEFAULT_Y_AXIS_KEY } from '../constants';
 import { ChartsTooltip } from '../ChartsTooltip';
 import { ChartsTooltipSlots, ChartsTooltipSlotProps } from '../ChartsTooltip/ChartTooltip.types';
@@ -205,9 +207,8 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
   }, [color]);
 
   return (
-    <ChartContainer
+    <ChartDataProvider
       {...other}
-      ref={ref}
       series={[
         {
           type: plotType,
@@ -219,7 +220,6 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
       width={width}
       height={height}
       margin={margin}
-      className={className}
       xAxis={[
         {
           id: DEFAULT_X_AXIS_KEY,
@@ -238,30 +238,30 @@ const SparkLineChart = React.forwardRef(function SparkLineChart(
         },
       ]}
       colors={colors}
-      sx={sx}
       disableAxisListener={
         (!showTooltip || slotProps?.tooltip?.trigger !== 'axis') &&
         axisHighlight?.x === 'none' &&
         axisHighlight?.y === 'none'
       }
     >
-      <g clipPath={`url(#${clipPathId})`}>
-        {plotType === 'bar' && <BarPlot skipAnimation slots={slots} slotProps={slotProps} />}
+      <ChartsSurface className={className} ref={ref} sx={sx}>
+        <g clipPath={`url(#${clipPathId})`}>
+          {plotType === 'bar' && <BarPlot skipAnimation slots={slots} slotProps={slotProps} />}
 
-        {plotType === 'line' && (
-          <React.Fragment>
-            <AreaPlot skipAnimation slots={slots} slotProps={slotProps} />
-            <LinePlot skipAnimation slots={slots} slotProps={slotProps} />
-          </React.Fragment>
-        )}
-      </g>
-      {plotType === 'line' && <LineHighlightPlot slots={slots} slotProps={slotProps} />}
-      {disableClipping ? null : <ChartsClipPath id={clipPathId} offset={clipPathOffset} />}
-      <ChartsAxisHighlight {...axisHighlight} />
+          {plotType === 'line' && (
+            <React.Fragment>
+              <AreaPlot skipAnimation slots={slots} slotProps={slotProps} />
+              <LinePlot skipAnimation slots={slots} slotProps={slotProps} />
+            </React.Fragment>
+          )}
+        </g>
+        {plotType === 'line' && <LineHighlightPlot slots={slots} slotProps={slotProps} />}
+        {disableClipping ? null : <ChartsClipPath id={clipPathId} offset={clipPathOffset} />}
+        <ChartsAxisHighlight {...axisHighlight} />
+        {children}
+      </ChartsSurface>
       {showTooltip && <Tooltip {...props.slotProps?.tooltip} />}
-
-      {children}
-    </ChartContainer>
+    </ChartDataProvider>
   );
 });
 


### PR DESCRIPTION
While working on the overview page, I noticed that tooltip portal is problematique when using CSS variables at a specific level.

```jsx
<Box sx={{
  '--main-color': 'red',
  "&: hover": { '--main-color': 'blue' }
}}
>
  // It will no be feasible to access var(--main-color) from the tooltip
  <TheChart />
</Box>
```

The easiest solution I fond is to disable the portal. But for that tooltip should be outside of SVG. WHich is the topic of this PR