### PR TITLE
[charts-pro] fix error when importing rasterizehtml

### DIFF
--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
@@ -7,7 +7,7 @@ export const getDrawDocument = async () => {
   try {
     const module = await import('rasterizehtml');
 
-    return module.drawDocument;
+    return module.default.drawDocument;
   } catch (error) {
     throw new Error(
       `MUI X Charts: Failed to import 'rasterizehtml' module. This dependency is mandatory when exporting a chart as an image. Make sure you have it installed as a dependency.`,

--- a/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProExport/exportImage.ts
@@ -7,7 +7,7 @@ export const getDrawDocument = async () => {
   try {
     const module = await import('rasterizehtml');
 
-    return module.default.drawDocument;
+    return (module.default || module).drawDocument;
   } catch (error) {
     throw new Error(
       `MUI X Charts: Failed to import 'rasterizehtml' module. This dependency is mandatory when exporting a chart as an image. Make sure you have it installed as a dependency.`,


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17893.

I've discussed this change with @Janpot and this seems to be the safest way to work in most bundlers for the time being. Although, as a long-term solution we should try to contribute to rasterizehtml and update it to support ESM, fork it, or choose another library. A library that doesn't support ESM might come and bite us in the future. 