### PR TITLE
[DataGrid] Use `exclude` selection model type if quick filter does not have actual values

### DIFF
--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -1331,5 +1331,29 @@ describe('<DataGridPro /> - Row selection', () => {
       );
       expect(onRowSelectionModelChange.callCount).to.equal(0);
     });
+
+    it('should call onRowSelectionModelChange with the `exclude` set when select all checkbox is clicked', async () => {
+      const onRowSelectionModelChange = spy();
+      const { user } = render(
+        <TestDataGridSelection
+          checkboxSelection
+          onRowSelectionModelChange={onRowSelectionModelChange}
+          initialState={{
+            filter: {
+              filterModel: {
+                items: [],
+                quickFilterValues: [''],
+              },
+            },
+          }}
+        />,
+      );
+      const selectAllCheckbox = screen.getByRole('checkbox', { name: 'Select all rows' });
+      await user.click(selectAllCheckbox);
+      expect(onRowSelectionModelChange.lastCall.args[0]).to.deep.equal({
+        type: 'exclude',
+        ids: new Set(),
+      });
+    });
   });
 });

--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -1332,7 +1332,7 @@ describe('<DataGridPro /> - Row selection', () => {
       expect(onRowSelectionModelChange.callCount).to.equal(0);
     });
 
-    it('should call onRowSelectionModelChange with the `exclude` set when select all checkbox is clicked', async () => {
+    it('should call onRowSelectionModelChange with the `exclude` set when select all checkbox is clicked and filters are empty', async () => {
       const onRowSelectionModelChange = spy();
       const { user } = render(
         <TestDataGridSelection

--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -718,7 +718,9 @@ export const useGridRowSelection = (
     (value: boolean) => {
       const filterModel = gridFilterModelSelector(apiRef);
       const quickFilterModel = gridQuickFilterValuesSelector(apiRef);
-      const hasFilters = filterModel.items.length > 0 || (quickFilterModel?.length || 0) > 0;
+      const hasFilters =
+        filterModel.items.length > 0 || quickFilterModel?.some((val) => val.length);
+
       if (
         !props.isRowSelectable &&
         !props.checkboxSelectionVisibleOnly &&


### PR DESCRIPTION
Extracted from https://github.com/mui/mui-x/pull/17743

Makes the grid use `exclude` selection type if quick filter has values, but they are all empty strings

like
```ts
initialState={{
  filter: {
    filterModel: {
      items: [],
      quickFilterValues: [''],
    },
  },
}}
```
