### PR TITLE
[docs] Add "upgrade to v8" callout on v7 planned pages

### DIFF
--- a/docs/data/data-grid/pivoting/pivoting.md
+++ b/docs/data/data-grid/pivoting/pivoting.md
@@ -4,17 +4,15 @@ title: Data Grid - Pivoting
 
 # Data Grid - Pivoting [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🚧
 
-<p class="description">Turn a column values into columns.</p>
+<p class="description">Rearrange rows and columns to view data from multiple perspectives.</p>
 
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #214](https://github.com/mui/mui-x/issues/214) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::success
+Pivoting is available in MUI X v8+.
+You must [upgrade from v7](https://mui.com/x/migration/migration-data-grid-v7/) to use this feature.
 :::
 
-Pivoting will allow you to take a columns values and turn them into columns.
+The Data Grid Premium's pivoting feature lets users transform the data in their grid by reorganizing rows and columns, creating dynamic cross-tabulations of data.
+This makes it possible to analyze data from different angles and gain insights that would be difficult to see in the default grid view.
 
 ## API
 

--- a/docs/data/data-grid/server-side-data/aggregation.md
+++ b/docs/data/data-grid/server-side-data/aggregation.md
@@ -4,12 +4,11 @@ title: React Data Grid - Server-side aggregation
 
 # Data Grid - Server-side aggregation [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🚧
 
-<p class="description">Aggregation with server-side data source.</p>
+<p class="description">Implement aggregation with server-side data in the Data Grid.</p>
 
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #10860](https://github.com/mui/mui-x/issues/10860) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::success
+Server-side aggregation is available in MUI X v8+.
+You must [upgrade from v7](https://mui.com/x/migration/migration-data-grid-v7/) to use this feature.
 :::
+
+The Data Grid Premium provides tools to give end users the ability to aggregate and compare row values rendered from server-side data.

--- a/docs/data/data-grid/server-side-data/infinite-loading.md
+++ b/docs/data/data-grid/server-side-data/infinite-loading.md
@@ -4,12 +4,14 @@ title: React Data Grid - Server-side infinite loading
 
 # Data Grid - Server-side infinite loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
-<p class="description">Row infinite loading with server-side data source.</p>
+<p class="description">Implement infinite-loading rows with server-side data in the Data Grid.</p>
 
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #10858](https://github.com/mui/mui-x/issues/10858) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with the [current solution](https://mui.com/x/react-data-grid/row-updates/#infinite-loading).
+:::success
+Infinite loading of server-side data is available in MUI X v8+.
+You must [upgrade from v7](https://mui.com/x/migration/migration-data-grid-v7/) to use this feature.
 :::
+
+Infinite loading is a lazy-loading strategy for deferring the loading of resources until they are actually needed, rather than loading everything when a page is first requested.
+Lazy loading changes the way pagination works in the Data Grid by removing page controls and instead loading data dynamically (in a single list) as the user scrolls.
+
+When the total row count is unknown, the Data Grid implements infinite loading to fetch more data when the user scrolls to the bottom.

--- a/docs/data/data-grid/server-side-data/lazy-loading.md
+++ b/docs/data/data-grid/server-side-data/lazy-loading.md
@@ -4,12 +4,12 @@ title: React Data Grid - Server-side lazy loading
 
 # Data Grid - Server-side lazy loading [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
-<p class="description">Row lazy-loading with server-side data source.</p>
+<p class="description">Implement lazy-loading rows with server-side data in the Data Grid.</p>
 
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #10857](https://github.com/mui/mui-x/issues/10857) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with the [current solution](https://mui.com/x/react-data-grid/row-updates/#lazy-loading).
+:::success
+Lazy loading of server-side data is available in MUI X v8+.
+You must [upgrade from v7](https://mui.com/x/migration/migration-data-grid-v7/) to use this feature.
 :::
+
+Lazy loading is a technique for deferring the loading of resources until they are actually needed, rather than loading everything when a page is first requested.
+Lazy loading changes the way pagination works in the Data Grid by removing page controls and instead loading data dynamically (in a single list) as the user scrolls.

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -10,10 +10,7 @@ materialDesign: https://m2.material.io/components/date-pickers
 
 <p class="description">The Time Range Picker lets the user select a range of time.</p>
 
-:::warning
-This feature isn't implemented yet. It's coming.
-
-👍 Upvote [issue #4460](https://github.com/mui/mui-x/issues/4460) if you want to see it land faster.
-
-Don't hesitate to leave a comment on the same issue to influence what gets built. Especially if you already have a use case for this component, or if you are facing a pain point with your current solution.
+:::success
+The Time Range Picker is available in MUI X v8+.
+You must [upgrade from v7](https://mui.com/x/migration/migration-pickers-v7/) to use this component.
 :::


### PR DESCRIPTION
Updates the copy on "planned" pages in the v7 docs to instruct users to upgrade to v8 to use the features.

Preview: https://deploy-preview-17901--material-ui-x.netlify.app/x/react-data-grid/pivoting/