### PR TITLE
[charts] add `isXInside` and `isYInside`

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -53,12 +53,12 @@ function getVisibleLabels(
     tickLabelMinGap,
     reverse,
     isMounted,
-    isPointInside,
+    isXInside,
   }: Pick<ChartsXAxisProps, 'tickLabelInterval' | 'tickLabelStyle'> &
     Pick<ComputedXAxis, 'reverse'> & {
       isMounted: boolean;
       tickLabelMinGap: NonNullable<ChartsXAxisProps['tickLabelMinGap']>;
-      isPointInside: (position: number) => boolean;
+      isXInside: (x: number) => boolean;
     },
 ): Set<TickItemType> {
   const getTickLabelSize = (tick: TickItemType) => {
@@ -94,7 +94,7 @@ function getVisibleLabels(
         return false;
       }
 
-      if (!isPointInside(textPosition)) {
+      if (!isXInside(textPosition)) {
         return false;
       }
 
@@ -293,7 +293,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
     tickLabelMinGap,
     reverse,
     isMounted,
-    isPointInside: (x: number) => instance.isPointInside(x, 0, { direction: 'x' }),
+    isXInside: instance.isXInside,
   });
 
   const axisLabelProps = useSlotProps({
@@ -363,7 +363,7 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         const xTickLabel = labelOffset ?? 0;
         const yTickLabel = positionSign * (tickSize + TICK_LABEL_GAP);
 
-        const showTick = instance.isPointInside(tickOffset, -1, { direction: 'x' });
+        const showTick = instance.isXInside(tickOffset);
         const tickLabel = tickLabels.get(item);
         const showTickLabel = visibleLabels.has(item);
 

--- a/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
+++ b/packages/x-charts/src/ChartsYAxis/ChartsYAxis.tsx
@@ -281,7 +281,7 @@ function ChartsYAxis(inProps: ChartsYAxisProps) {
         const skipLabel =
           typeof tickLabelInterval === 'function' && !tickLabelInterval?.(value, index);
 
-        const showLabel = instance.isPointInside(-1, tickOffset, { direction: 'y' });
+        const showLabel = instance.isYInside(tickOffset);
         const tickLabel = tickLabels.get(item);
 
         if (!showLabel) {

--- a/packages/x-charts/src/hooks/useTicks.ts
+++ b/packages/x-charts/src/hooks/useTicks.ts
@@ -150,8 +150,9 @@ export function useTicks(
     for (let i = 0; i < ticks.length; i += 1) {
       const value = ticks[i];
       const offset = scale(value);
+      const isInside = direction === 'x' ? instance.isXInside(offset) : instance.isYInside(offset);
 
-      if (instance.isPointInside(offset, offset, { direction })) {
+      if (isInside) {
         visibleTicks.push({
           value,
           formattedValue:

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.ts
@@ -187,37 +187,28 @@ export const useChartDimensions: ChartPlugin<UseChartDimensionsSignature> = ({
   }
 
   const drawingArea = useSelector(store, selectorChartDrawingArea);
+  const isXInside = React.useCallback(
+    (x: number) => x >= drawingArea.left - 1 && x <= drawingArea.left + drawingArea.width,
+    [drawingArea.left, drawingArea.width],
+  );
+
+  const isYInside = React.useCallback(
+    (y: number) => y >= drawingArea.top - 1 && y <= drawingArea.top + drawingArea.height,
+    [drawingArea.height, drawingArea.top],
+  );
   const isPointInside = React.useCallback(
-    (
-      x: number,
-      y: number,
-      options?: {
-        targetElement?: Element;
-        direction?: 'x' | 'y';
-      },
-    ) => {
+    (x: number, y: number, targetElement?: Element) => {
       // For element allowed to overflow, wrapping them in <g data-drawing-container /> make them fully part of the drawing area.
-      if (options?.targetElement && options?.targetElement.closest('[data-drawing-container]')) {
+      if (targetElement && targetElement.closest('[data-drawing-container]')) {
         return true;
       }
 
-      const isInsideX = x >= drawingArea.left - 1 && x <= drawingArea.left + drawingArea.width;
-      const isInsideY = y >= drawingArea.top - 1 && y <= drawingArea.top + drawingArea.height;
-
-      if (options?.direction === 'x') {
-        return isInsideX;
-      }
-
-      if (options?.direction === 'y') {
-        return isInsideY;
-      }
-
-      return isInsideX && isInsideY;
+      return isXInside(x) && isYInside(y);
     },
-    [drawingArea.height, drawingArea.left, drawingArea.top, drawingArea.width],
+    [isXInside, isYInside],
   );
 
-  return { instance: { isPointInside } };
+  return { instance: { isPointInside, isXInside, isYInside } };
 };
 
 useChartDimensions.params = {

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.types.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.types.ts
@@ -72,19 +72,22 @@ export interface UseChartDimensionsInstance {
    * Checks if a point is inside the drawing area.
    * @param {number} x The x coordinate of the point.
    * @param {number} y The y coordinate of the point.
-   * @param {Object} options The options of the check.
-   * @param {Element} [options.targetElement] The element to check if it is allowed to overflow the drawing area.
-   * @param {'x' | 'y'} [options.direction] The direction to check.
+   * @param {Element} targetElement The element to check if it is allowed to overflow the drawing area.
    * @returns {boolean} `true` if the point is inside the drawing area, `false` otherwise.
    */
-  isPointInside: (
-    x: number,
-    y: number,
-    options?: {
-      targetElement?: Element;
-      direction?: 'x' | 'y';
-    },
-  ) => boolean;
+  isPointInside: (x: number, y: number, targetElement?: Element) => boolean;
+  /**
+   * Checks if the x coordinate is inside the drawing area.
+   * @param {number} x The x coordinate of the point.
+   * @returns {boolean} `true` if the point is inside the drawing area, `false` otherwise.
+   */
+  isXInside: (x: number) => boolean;
+  /**
+   * Checks if the y coordinate is inside the drawing area.
+   * @param {number} y The y coordinate of the point.
+   * @returns {boolean} `true` if the point is inside the drawing area, `false` otherwise.
+   */
+  isYInside: (y: number) => boolean;
 }
 
 export type UseChartDimensionsSignature = ChartPluginSignature<{

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxis.ts
@@ -81,11 +81,7 @@ export const useChartCartesianAxis: ChartPlugin<UseChartCartesianAxisSignature<a
       const target = 'targetTouches' in event ? event.targetTouches[0] : event;
       const svgPoint = getSVGPoint(element, target);
 
-      if (
-        !instance.isPointInside(svgPoint.x, svgPoint.y, {
-          targetElement: event.target as SVGElement,
-        })
-      ) {
+      if (!instance.isPointInside(svgPoint.x, svgPoint.y, event.target as SVGElement)) {
         instance.cleanInteraction?.();
         return;
       }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.ts
@@ -124,11 +124,7 @@ export const useChartPolarAxis: ChartPlugin<UseChartPolarAxisSignature<any>> = (
       mousePosition.current.y = svgPoint.y;
 
       // Test if it's in the drawing area
-      if (
-        !instance.isPointInside(svgPoint.x, svgPoint.y, {
-          targetElement: event.target as SVGElement,
-        })
-      ) {
+      if (!instance.isPointInside(svgPoint.x, svgPoint.y, event.target as SVGElement)) {
         if (mousePosition.current.isInChart) {
           instance?.cleanInteraction();
           mousePosition.current.isInChart = false;


### PR DESCRIPTION
Follow-up to [this comment](https://github.com/mui/mui-x/pull/17849#pullrequestreview-2852983848). 

Should improve performance slightly by reducing the number of allocations in the hot path. `isPointInside` is called many times, especially when zoomed in. 