### PR TITLE
[fields] Ensure fresh `disabled` value is used when focusing or clicking

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/editing.DateField.test.tsx
@@ -469,6 +469,46 @@ describe('<DateField /> - Editing', () => {
       fireEvent.change(input, { target: { value: '1/DD/YYYY' } });
       expect(getCleanedSelectedContent()).to.equal('01');
     });
+
+    it('should be editable after reenabling field', async () => {
+      // Test with accessible DOM structure
+      let view = renderWithProps({
+        enableAccessibleFieldDOMStructure: true,
+        disabled: true,
+      });
+
+      view.setProps({
+        enableAccessibleFieldDOMStructure: true,
+        disabled: false,
+      });
+
+      await act(async () => {
+        view.getSection(2).focus();
+      });
+
+      view.pressKey(undefined, '2');
+      expectFieldValueV7(view.getSectionsContainer(), 'MM/DD/0002');
+
+      view.unmount();
+
+      // Test with non-accessible DOM structure
+      view = renderWithProps({
+        enableAccessibleFieldDOMStructure: false,
+        disabled: true,
+      });
+
+      view.setProps({
+        enableAccessibleFieldDOMStructure: false,
+        disabled: false,
+      });
+
+      await view.selectSectionAsync('year');
+
+      await view.user.keyboard('3');
+      expectFieldValueV6(getTextbox(), 'MM/DD/0003');
+
+      view.unmount();
+    });
   });
 
   describeAdapters(

--- a/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/selection.DateField.test.tsx
@@ -56,7 +56,7 @@ describe('<DateField /> - Selection', () => {
       expect(getCleanedSelectedContent()).to.equal('- YYYY');
     });
 
-    it('should not select 1st section (v7) on mount (`autoFocus = false` and `disabled = true`)', () => {
+    it('should not select 1st section (v7) on mount (`autoFocus = true` and `disabled = true`)', () => {
       // Test with accessible DOM structure
       const view = renderWithProps({
         enableAccessibleFieldDOMStructure: true,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContainerProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContainerProps.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import useEventCallback from '@mui/utils/useEventCallback';
 import { UseFieldStateReturnValue } from './useFieldState';
 import { UseFieldInternalProps } from './useField.types';
 
@@ -21,7 +20,7 @@ export function useFieldSectionContainerProps(
     internalPropsWithDefaults: { disabled = false },
   } = parameters;
 
-  const createHandleClick = useEventCallback(
+  const createHandleClick = React.useCallback(
     (sectionIndex: number) => (event: React.MouseEvent<HTMLDivElement>) => {
       // The click event on the clear button would propagate to the input, trigger this handler and result in a wrong section selection.
       // We avoid this by checking if the call to this function is actually intended, or a side effect.
@@ -31,6 +30,7 @@ export function useFieldSectionContainerProps(
 
       setSelectedSections(sectionIndex);
     },
+    [disabled, setSelectedSections],
   );
   return React.useCallback(
     (sectionIndex) => ({

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
@@ -150,12 +150,15 @@ export function useFieldSectionContentProps(
     event.dataTransfer.dropEffect = 'none';
   });
 
-  const createFocusHandler = useEventCallback((sectionIndex: number) => () => {
-    if (disabled) {
-      return;
-    }
-    setSelectedSections(sectionIndex);
-  });
+  const createFocusHandler = React.useCallback(
+    (sectionIndex: number) => () => {
+      if (disabled) {
+        return;
+      }
+      setSelectedSections(sectionIndex);
+    },
+    [disabled, setSelectedSections],
+  );
 
   return React.useCallback(
     (section, sectionIndex) => {


### PR DESCRIPTION
Closes #17895


## Changelog
Fixes old disable value when reenabling pickers


- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
