### PR TITLE
[DataGridPremium] Fix clipboard import for `singleSelect` columns

### DIFF
--- a/packages/x-data-grid-generator/src/columns/commodities.columns.tsx
+++ b/packages/x-data-grid-generator/src/columns/commodities.columns.tsx
@@ -254,6 +254,7 @@ export const getCommodityColumns = (editable = false): GridColDefGenerator[] => 
     groupingValueGetter: (value: { label: string } | undefined) => value?.label,
     sortComparator: (v1, v2, param1, param2) =>
       gridStringOrNumberComparator(v1.label, v2.label, param1, param2),
+    getOptionValue: (value: { label: string }) => value?.label,
     editable,
     width: 120,
   } as GridColDef<any, CountryIsoOption, string>,

--- a/packages/x-data-grid-generator/src/columns/employees.columns.tsx
+++ b/packages/x-data-grid-generator/src/columns/employees.columns.tsx
@@ -121,6 +121,7 @@ export const getEmployeeColumns = (): GridColDefGenerator[] => [
     groupingValueGetter: (value: { label: string } | undefined) => value?.label,
     sortComparator: (v1, v2, param1, param2) =>
       gridStringOrNumberComparator(v1.label, v2.label, param1, param2),
+    getOptionValue: (value: { label: string }) => value?.label,
     width: 150,
     editable: true,
   } as GridColDef<any, CountryIsoOption, string>,

--- a/packages/x-data-grid/src/colDef/gridSingleSelectColDef.tsx
+++ b/packages/x-data-grid/src/colDef/gridSingleSelectColDef.tsx
@@ -62,10 +62,6 @@ export const GRID_SINGLE_SELECT_COL_DEF: Omit<GridSingleSelectColDef, 'field'> =
       }
       return false;
     });
-    if (valueOption) {
-      return value;
-    }
-    // do not paste the value if it is not in the valueOptions
-    return undefined;
+    return valueOption;
   },
 };


### PR DESCRIPTION
Fixes clipboard import for complex `singleSelect` columns.
I noticed this while responding to a Zendesk ticket on a tangent topic.

Before: https://stackblitz.com/edit/jmuct9np?file=src%2FDemo.tsx
After: 