### PR TITLE
[docs] Remove double border on DataGrid- Quickstart 

### DIFF
--- a/docs/data/data-grid/quickstart/quickstart.md
+++ b/docs/data/data-grid/quickstart/quickstart.md
@@ -96,7 +96,7 @@ const columns: GridColDef[] = [
 
 With the component and utilites imported, and rows and columns defined, you're now ready to render the Data Grid as shown below:
 
-{{"demo": "RenderComponent.js", "defaultCodeOpen": true}}
+{{"demo": "RenderComponent.js", "defaultCodeOpen": true, "bg": "inline"}}
 
 ## TypeScript
 


### PR DESCRIPTION
DataGrid- Quickstart: Remove the double border on the demo to keep consistency

Before:
<img width="1375" alt="Screenshot 2025-05-21 at 10 22 37" src="https://github.com/user-attachments/assets/ec11fa29-5985-4b7a-a38e-7511bc3ee4bb" />

After:
<img width="1375" alt="Screenshot 2025-05-21 at 10 23 06" src="https://github.com/user-attachments/assets/229524b6-cdeb-46f0-8c41-8108e43a1c89" />


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
