### PR TITLE
[charts] Clean and document Heatmap Tooltip

### DIFF
--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -1,7 +1,7 @@
 ---
 title: React Heatmap chart
 productId: x-charts
-components: Heatmap, HeatmapPlot, HeatmapTooltip
+components: Heatmap, HeatmapPlot, HeatmapTooltip, HeatmapTooltipContent
 ---
 
 # Charts - Heatmap [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')
@@ -27,16 +27,14 @@ You can specify x and y ticks with the `xAxis` and `yAxis` props.
 
 {{"demo": "BasicHeatmap.js"}}
 
-## Customization
-
-### Color mapping
+## Color mapping
 
 To customize the color mapping, use the `zAxis` configuration.
 You can either use the piecewise or continuous [color mapping](https://mui.com/x/react-charts/styling/#values-color).
 
 {{"demo": "ColorConfig.js"}}
 
-### Highlight
+## Highlight
 
 You can chose to highlight the hovered element by setting `highlightScope.highlight` to `'item'`.
 To fade the other item, set `highlightScope.fade` to `'global'`.
@@ -50,12 +48,26 @@ In the following demo, we replace the highlight saturation by a border radius an
 
 {{"demo": "HighlightClasses.js"}}
 
+## Common features
+
+Those feature are similar in most charts.
+So they benefit from dedicated pages.
+
 ### Axes
 
 The Heatmap axes can be customized like any other chart axis.
-The available options are available in the [dedicated page](/x/react-charts/axis/#axis-customization).
+The available options are available in the [dedicated page](/x/react-charts/axis/#axis-customization/).
 
-### Tooltip 🚧
+### Tooltip
+
+The Heatmap has an item tooltip that can be customized as described in the [Tooltip documentation page](/x/react-charts/tooltip/).
+
+The specificity of the Heatmap Tooltip is its default content.
+You can import the default tooltip, or only its content as follow:
+
+```js
+import { HeatmapTooltip, HeatmapTooltipContent } from '@mui/x-charts/Heatmap',
+```
 
 ## Legend 🚧
 

--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -57,7 +57,7 @@ If you'd like to learn more about the shared features, you can visit their dedic
 ### Axes
 
 The Heatmap axes can be customized like any other chart axis.
-The available options are available in the [axis customization page](/x/react-charts/axis/#axis-customization/).
+The available options are available in the [axis customization page](/x/react-charts/axis/#axis-customization).
 
 ### Tooltip
 

--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -56,14 +56,14 @@ So they benefit from dedicated pages.
 ### Axes
 
 The Heatmap axes can be customized like any other chart axis.
-The available options are available in the [dedicated page](/x/react-charts/axis/#axis-customization/).
+The available options are available in the [axis customization page](/x/react-charts/axis/#axis-customization/).
 
 ### Tooltip
 
 The Heatmap has an item tooltip that can be customized as described in the [Tooltip documentation page](/x/react-charts/tooltip/).
 
-The specificity of the Heatmap Tooltip is its default content.
-You can import the default tooltip, or only its content as follow:
+The only difference of the Heatmap Tooltip is its default content.
+You can import the default tooltip, or only its content as follows:
 
 ```js
 import { HeatmapTooltip, HeatmapTooltipContent } from '@mui/x-charts/Heatmap',

--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -50,8 +50,9 @@ In the following demo, we replace the highlight saturation by a border radius an
 
 ## Common features
 
-Those feature are similar in most charts.
-So they benefit from dedicated pages.
+The heatmap shares several features with other charts.
+This section only explains the details that are specific to the heatmap.
+If you'd like to learn more about the shared features, you can visit their dedicated pages.
 
 ### Axes
 

--- a/docs/data/chartsApiPages.ts
+++ b/docs/data/chartsApiPages.ts
@@ -164,6 +164,11 @@ const chartsApiPages: MuiPage[] = [
     plan: 'pro',
   },
   {
+    pathname: '/x/api/charts/heatmap-tooltip-content',
+    title: 'HeatmapTooltipContent',
+    plan: 'pro',
+  },
+  {
     pathname: '/x/api/charts/line-chart',
     title: 'LineChart',
   },

--- a/docs/pages/x/api/charts/heatmap-tooltip-content.js
+++ b/docs/pages/x/api/charts/heatmap-tooltip-content.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './heatmap-tooltip-content.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+Page.getInitialProps = () => {
+  const req = require.context(
+    'docsx/translations/api-docs/charts/heatmap-tooltip-content',
+    false,
+    /\.\/heatmap-tooltip-content.*.json$/,
+  );
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    descriptions,
+    pageContent: jsonPageContent,
+  };
+};

--- a/docs/pages/x/api/charts/heatmap-tooltip-content.json
+++ b/docs/pages/x/api/charts/heatmap-tooltip-content.json
@@ -1,0 +1,75 @@
+{
+  "props": { "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } } },
+  "name": "HeatmapTooltipContent",
+  "imports": [
+    "import { HeatmapTooltipContent } from '@mui/x-charts-pro/Heatmap';",
+    "import { HeatmapTooltipContent } from '@mui/x-charts-pro';"
+  ],
+  "classes": [
+    {
+      "key": "axisValueCell",
+      "className": "MuiHeatmapTooltipContent-axisValueCell",
+      "description": "Styles applied to the axisValueCell element. Only available for axis tooltip.",
+      "isGlobal": false
+    },
+    {
+      "key": "cell",
+      "className": "MuiHeatmapTooltipContent-cell",
+      "description": "Styles applied to the cell element.",
+      "isGlobal": false
+    },
+    {
+      "key": "labelCell",
+      "className": "MuiHeatmapTooltipContent-labelCell",
+      "description": "Styles applied to the labelCell element.",
+      "isGlobal": false
+    },
+    {
+      "key": "mark",
+      "className": "MuiHeatmapTooltipContent-mark",
+      "description": "Styles applied to the mark element.",
+      "isGlobal": false
+    },
+    {
+      "key": "markContainer",
+      "className": "MuiHeatmapTooltipContent-markContainer",
+      "description": "Styles applied to the markContainer element.",
+      "isGlobal": false
+    },
+    {
+      "key": "paper",
+      "className": "MuiHeatmapTooltipContent-paper",
+      "description": "Styles applied to the paper element.",
+      "isGlobal": false
+    },
+    {
+      "key": "root",
+      "className": "MuiHeatmapTooltipContent-root",
+      "description": "Styles applied to the root element.",
+      "isGlobal": false
+    },
+    {
+      "key": "row",
+      "className": "MuiHeatmapTooltipContent-row",
+      "description": "Styles applied to the row element.",
+      "isGlobal": false
+    },
+    {
+      "key": "table",
+      "className": "MuiHeatmapTooltipContent-table",
+      "description": "Styles applied to the table element.",
+      "isGlobal": false
+    },
+    {
+      "key": "valueCell",
+      "className": "MuiHeatmapTooltipContent-valueCell",
+      "description": "Styles applied to the valueCell element.",
+      "isGlobal": false
+    }
+  ],
+  "muiName": "MuiHeatmapTooltipContent",
+  "filename": "/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltipContent.tsx",
+  "inheritance": null,
+  "demos": "<ul><li><a href=\"/x/react-charts/heatmap/\">Charts - Heatmap <a href=\"/x/introduction/licensing/#pro-plan\" title=\"Pro plan\"><span class=\"plan-pro\"></span></a></a></li></ul>",
+  "cssComponent": false
+}

--- a/docs/translations/api-docs/charts/heatmap-tooltip-content/heatmap-tooltip-content.json
+++ b/docs/translations/api-docs/charts/heatmap-tooltip-content/heatmap-tooltip-content.json
@@ -1,0 +1,30 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "classes": { "description": "Override or extend the styles applied to the component." }
+  },
+  "classDescriptions": {
+    "axisValueCell": {
+      "description": "Styles applied to {{nodeName}}. Only available for axis tooltip.",
+      "nodeName": "the axisValueCell element"
+    },
+    "cell": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the cell element" },
+    "labelCell": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the labelCell element"
+    },
+    "mark": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the mark element" },
+    "markContainer": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the markContainer element"
+    },
+    "paper": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the paper element" },
+    "root": { "description": "Styles applied to the root element." },
+    "row": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the row element" },
+    "table": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the table element" },
+    "valueCell": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the valueCell element"
+    }
+  }
+}

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -27,7 +27,7 @@ import { ChartContainerProProps } from '../ChartContainerPro';
 import { HeatmapSeriesType } from '../models/seriesType/heatmap';
 import { HeatmapPlot } from './HeatmapPlot';
 import { seriesConfig as heatmapSeriesConfig } from './seriesConfig';
-import { HeatmapTooltip, HeatmapTooltipProps } from './HeatmapTooltip/HeatmapTooltip';
+import { HeatmapTooltip, HeatmapTooltipProps } from './HeatmapTooltip';
 import { HeatmapItemSlotProps, HeatmapItemSlots } from './HeatmapItem';
 import { HEATMAP_PLUGINS, HeatmapPluginsSignatures } from './Heatmap.plugins';
 import { ChartDataProviderPro } from '../ChartDataProviderPro';

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.classes.ts
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.classes.ts
@@ -1,0 +1,21 @@
+import composeClasses from '@mui/utils/composeClasses';
+import { getChartsTooltipUtilityClass } from '@mui/x-charts/ChartsTooltip';
+import { HeatmapTooltipProps } from './HeatmapTooltip.types';
+
+export const useUtilityClasses = (props: Pick<HeatmapTooltipProps, 'classes'>) => {
+  const { classes } = props;
+
+  const slots = {
+    root: ['root'],
+    paper: ['paper'],
+    table: ['table'],
+    row: ['row'],
+    cell: ['cell'],
+    mark: ['mark'],
+    markContainer: ['markContainer'],
+    labelCell: ['labelCell'],
+    valueCell: ['valueCell'],
+  };
+
+  return composeClasses(slots, getChartsTooltipUtilityClass, classes);
+};

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.tsx
@@ -1,129 +1,18 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import HTMLElementType from '@mui/utils/HTMLElementType';
-import composeClasses from '@mui/utils/composeClasses';
-import {
-  ChartsTooltipPaper,
-  ChartsTooltipTable,
-  ChartsTooltipRow,
-  ChartsTooltipCell,
-  useItemTooltip,
-  ChartsTooltipContainerProps,
-  getChartsTooltipUtilityClass,
-  ChartsTooltipContainer,
-} from '@mui/x-charts/ChartsTooltip';
-import { useXAxis, useYAxis } from '@mui/x-charts/hooks';
-import { getLabel, ChartsLabelMark } from '@mui/x-charts/internals';
-import { useHeatmapSeriesContext } from '../../hooks/useHeatmapSeries';
-import { HeatmapTooltipAxesValue } from './HeatmapTooltipAxesValue';
-
-export interface HeatmapTooltipProps
-  extends Omit<ChartsTooltipContainerProps, 'trigger' | 'children'> {
-  /**
-   * Select the kind of tooltip to display
-   * - 'item': Shows data about the item below the mouse.
-   * - 'none': Does not display tooltip
-   * @default 'item'
-   */
-  trigger?: 'item' | 'none';
-}
-
-const useUtilityClasses = (props: Pick<HeatmapTooltipProps, 'classes'>) => {
-  const { classes } = props;
-
-  const slots = {
-    root: ['root'],
-    paper: ['paper'],
-    table: ['table'],
-    row: ['row'],
-    cell: ['cell'],
-    mark: ['mark'],
-    markContainer: ['markContainer'],
-    labelCell: ['labelCell'],
-    valueCell: ['valueCell'],
-  };
-
-  return composeClasses(slots, getChartsTooltipUtilityClass, classes);
-};
-
-function DefaultHeatmapTooltipContent(props: Pick<HeatmapTooltipProps, 'classes'>) {
-  const classes = useUtilityClasses(props);
-
-  const xAxis = useXAxis();
-  const yAxis = useYAxis();
-  const heatmapSeries = useHeatmapSeriesContext();
-
-  const tooltipData = useItemTooltip<'heatmap'>();
-
-  if (!tooltipData || !heatmapSeries || heatmapSeries.seriesOrder.length === 0) {
-    return null;
-  }
-
-  const { series, seriesOrder } = heatmapSeries;
-  const seriesId = seriesOrder[0];
-
-  const { color, value, identifier, markType } = tooltipData;
-
-  const [xIndex, yIndex] = value;
-
-  const formattedX =
-    xAxis.valueFormatter?.(xAxis.data![xIndex], {
-      location: 'tooltip',
-      scale: xAxis.scale,
-    }) ?? xAxis.data![xIndex].toLocaleString();
-  const formattedY =
-    yAxis.valueFormatter?.(yAxis.data![yIndex], { location: 'tooltip', scale: yAxis.scale }) ??
-    yAxis.data![yIndex].toLocaleString();
-  const formattedValue = series[seriesId].valueFormatter(value, {
-    dataIndex: identifier.dataIndex,
-  });
-
-  const seriesLabel = getLabel(series[seriesId].label, 'tooltip');
-
-  return (
-    <ChartsTooltipPaper className={classes.paper}>
-      <ChartsTooltipTable className={classes.table}>
-        <HeatmapTooltipAxesValue>
-          <span>{formattedX}</span>
-          <span>{formattedY}</span>
-        </HeatmapTooltipAxesValue>
-        <tbody>
-          <ChartsTooltipRow className={classes.row}>
-            <ChartsTooltipCell className={clsx(classes.labelCell, classes.cell)} component="th">
-              <div className={classes.markContainer}>
-                <ChartsLabelMark type={markType} color={color} className={classes.mark} />
-              </div>
-              {seriesLabel}
-            </ChartsTooltipCell>
-            <ChartsTooltipCell className={clsx(classes.valueCell, classes.cell)} component="td">
-              {formattedValue}
-            </ChartsTooltipCell>
-          </ChartsTooltipRow>
-        </tbody>
-      </ChartsTooltipTable>
-    </ChartsTooltipPaper>
-  );
-}
-
-DefaultHeatmapTooltipContent.propTypes = {
-  // ----------------------------- Warning --------------------------------
-  // | These PropTypes are generated from the TypeScript type definitions |
-  // | To update them edit the TypeScript types and run "pnpm proptypes"  |
-  // ----------------------------------------------------------------------
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-} as any;
+import { ChartsTooltipContainer } from '@mui/x-charts/ChartsTooltip';
+import { HeatmapTooltipContent } from './HeatmapTooltipContent';
+import { HeatmapTooltipProps } from './HeatmapTooltip.types';
+import { useUtilityClasses } from './HeatmapTooltip.classes';
 
 function HeatmapTooltip(props: HeatmapTooltipProps) {
   const classes = useUtilityClasses({ classes: props.classes });
 
   return (
     <ChartsTooltipContainer trigger="item" {...props} classes={classes}>
-      <DefaultHeatmapTooltipContent classes={classes} />
+      <HeatmapTooltipContent classes={classes} />
     </ChartsTooltipContainer>
   );
 }

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.types.ts
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltip.types.ts
@@ -1,0 +1,12 @@
+import { ChartsTooltipContainerProps } from '@mui/x-charts/ChartsTooltip';
+
+export interface HeatmapTooltipProps
+  extends Omit<ChartsTooltipContainerProps, 'trigger' | 'children'> {
+  /**
+   * Select the kind of tooltip to display
+   * - 'item': Shows data about the item below the mouse.
+   * - 'none': Does not display tooltip
+   * @default 'item'
+   */
+  trigger?: 'item' | 'none';
+}

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltipContent.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/HeatmapTooltipContent.tsx
@@ -1,0 +1,89 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import {
+  ChartsTooltipPaper,
+  ChartsTooltipTable,
+  ChartsTooltipRow,
+  ChartsTooltipCell,
+  useItemTooltip,
+} from '@mui/x-charts/ChartsTooltip';
+import { useXAxis, useYAxis } from '@mui/x-charts/hooks';
+import { getLabel, ChartsLabelMark } from '@mui/x-charts/internals';
+import { useHeatmapSeriesContext } from '../../hooks/useHeatmapSeries';
+import { HeatmapTooltipAxesValue } from './HeatmapTooltipAxesValue';
+import { HeatmapTooltipProps } from './HeatmapTooltip.types';
+import { useUtilityClasses } from './HeatmapTooltip.classes';
+
+export interface HeatmapTooltipContentProps extends Pick<HeatmapTooltipProps, 'classes'> {}
+
+export function HeatmapTooltipContent(props: HeatmapTooltipContentProps) {
+  const classes = useUtilityClasses(props);
+
+  const xAxis = useXAxis();
+  const yAxis = useYAxis();
+  const heatmapSeries = useHeatmapSeriesContext();
+
+  const tooltipData = useItemTooltip<'heatmap'>();
+
+  if (!tooltipData || !heatmapSeries || heatmapSeries.seriesOrder.length === 0) {
+    return null;
+  }
+
+  const { series, seriesOrder } = heatmapSeries;
+  const seriesId = seriesOrder[0];
+
+  const { color, value, identifier, markType } = tooltipData;
+
+  const [xIndex, yIndex] = value;
+
+  const formattedX =
+    xAxis.valueFormatter?.(xAxis.data![xIndex], {
+      location: 'tooltip',
+      scale: xAxis.scale,
+    }) ?? xAxis.data![xIndex].toLocaleString();
+  const formattedY =
+    yAxis.valueFormatter?.(yAxis.data![yIndex], { location: 'tooltip', scale: yAxis.scale }) ??
+    yAxis.data![yIndex].toLocaleString();
+  const formattedValue = series[seriesId].valueFormatter(value, {
+    dataIndex: identifier.dataIndex,
+  });
+
+  const seriesLabel = getLabel(series[seriesId].label, 'tooltip');
+
+  return (
+    <ChartsTooltipPaper className={classes.paper}>
+      <ChartsTooltipTable className={classes.table}>
+        <HeatmapTooltipAxesValue>
+          <span>{formattedX}</span>
+          <span>{formattedY}</span>
+        </HeatmapTooltipAxesValue>
+        <tbody>
+          <ChartsTooltipRow className={classes.row}>
+            <ChartsTooltipCell className={clsx(classes.labelCell, classes.cell)} component="th">
+              <div className={classes.markContainer}>
+                <ChartsLabelMark type={markType} color={color} className={classes.mark} />
+              </div>
+              {seriesLabel}
+            </ChartsTooltipCell>
+            <ChartsTooltipCell className={clsx(classes.valueCell, classes.cell)} component="td">
+              {formattedValue}
+            </ChartsTooltipCell>
+          </ChartsTooltipRow>
+        </tbody>
+      </ChartsTooltipTable>
+    </ChartsTooltipPaper>
+  );
+}
+
+HeatmapTooltipContent.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // | To update them edit the TypeScript types and run "pnpm proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+} as any;

--- a/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/index.ts
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapTooltip/index.ts
@@ -1,1 +1,3 @@
 export * from './HeatmapTooltip';
+export * from './HeatmapTooltipContent';
+export type { HeatmapTooltipProps } from './HeatmapTooltip.types';

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -228,6 +228,8 @@
   { "name": "HeatmapClassKey", "kind": "TypeAlias" },
   { "name": "HeatmapPlot", "kind": "Function" },
   { "name": "HeatmapTooltip", "kind": "Function" },
+  { "name": "HeatmapTooltipContent", "kind": "Function" },
+  { "name": "HeatmapTooltipContentProps", "kind": "Interface" },
   { "name": "HeatmapTooltipProps", "kind": "Interface" },
   { "name": "HighlightElementClassKey", "kind": "TypeAlias" },
   { "name": "HighlightItemData", "kind": "TypeAlias" },


### PR DESCRIPTION
The Heatmap got kind forgotten in the tooltip refactoring.

While updating the docs, I also made the content of the tooltip available to have a 1-1 correspondence with the DX of common tooltip