### PR TITLE
[docs] Fix derived column pivoting demo crash 

### DIFF
--- a/docs/data/data-grid/pivoting/GridGetPivotDerivedColumns.js
+++ b/docs/data/data-grid/pivoting/GridGetPivotDerivedColumns.js
@@ -31,6 +31,7 @@ const columns = [
     headerName: 'Transaction Date',
     width: 140,
     valueGetter: (value) => new Date(value),
+    groupingValueGetter: (value) => value,
   },
   { field: 'ticker', headerName: 'Ticker' },
   {

--- a/docs/data/data-grid/pivoting/GridGetPivotDerivedColumns.tsx
+++ b/docs/data/data-grid/pivoting/GridGetPivotDerivedColumns.tsx
@@ -39,6 +39,7 @@ const columns: GridColDef[] = [
     headerName: 'Transaction Date',
     width: 140,
     valueGetter: (value) => new Date(value),
+    groupingValueGetter: (value) => value,
   },
   { field: 'ticker', headerName: 'Ticker' },
   {

--- a/docs/data/data-grid/pivoting/GridPivotingFinancial.js
+++ b/docs/data/data-grid/pivoting/GridPivotingFinancial.js
@@ -9,6 +9,7 @@ const columns = [
     headerName: 'Transaction Date',
     width: 140,
     valueGetter: (value) => new Date(value),
+    groupingValueGetter: (value) => value,
   },
   { field: 'ticker', headerName: 'Ticker' },
   {

--- a/docs/data/data-grid/pivoting/GridPivotingFinancial.tsx
+++ b/docs/data/data-grid/pivoting/GridPivotingFinancial.tsx
@@ -13,6 +13,7 @@ const columns: GridColDef[] = [
     headerName: 'Transaction Date',
     width: 140,
     valueGetter: (value) => new Date(value),
+    groupingValueGetter: (value) => value,
   },
   { field: 'ticker', headerName: 'Ticker' },
   {


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/issues/17924

`groupingValueGetter` must be used since grouped column does not support `date`