### PR TITLE
[charts-pro] Add range selection to zoom slider

### DIFF
--- a/docs/data/charts/zoom-and-pan/ZoomSlider.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSlider.js
@@ -50,9 +50,9 @@ export default function ZoomSlider() {
       height={400}
       margin={{ bottom: 40 }}
       initialZoom={[
-        { axisId: 'x', start: 10, end: 90 },
+        { axisId: 'x', start: 45, end: 55 },
         { axisId: 'x2', start: 30, end: 70 },
-        { axisId: 'y', start: 10, end: 90 },
+        { axisId: 'y', start: 40, end: 60 },
         { axisId: 'y2', start: 30, end: 70 },
       ]}
     />

--- a/docs/data/charts/zoom-and-pan/ZoomSlider.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSlider.tsx
@@ -50,9 +50,9 @@ export default function ZoomSlider() {
       height={400}
       margin={{ bottom: 40 }}
       initialZoom={[
-        { axisId: 'x', start: 10, end: 90 },
+        { axisId: 'x', start: 45, end: 55 },
         { axisId: 'x2', start: 30, end: 70 },
-        { axisId: 'y', start: 10, end: 90 },
+        { axisId: 'y', start: 40, end: 60 },
         { axisId: 'y2', start: 30, end: 70 },
       ]}
     />

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -112,6 +112,7 @@ BarChartPro.propTypes = {
     current: PropTypes.shape({
       exportAsImage: PropTypes.func.isRequired,
       exportAsPrint: PropTypes.func.isRequired,
+      setAxisZoomData: PropTypes.func.isRequired,
       setZoomData: PropTypes.func.isRequired,
     }),
   }),

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -183,17 +183,41 @@ function ChartAxisZoomSliderTrack({
 
         const zoomOptions = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
 
-        instance.setAxisZoomData(axisId, (prevZoomData) => ({
-          ...prevZoomData,
-          start:
-            pointerZoom > startingPoint
-              ? prevZoomData.start
-              : calculateZoomStart(pointerZoom, prevZoomData, zoomOptions),
-          end:
-            pointerZoom > startingPoint
-              ? calculateZoomEnd(pointerZoom, prevZoomData, zoomOptions)
-              : prevZoomData.end,
-        }));
+        instance.setAxisZoomData(axisId, (prevZoomData) => {
+          if (pointerZoom > startingPoint) {
+            const end = calculateZoomEnd(
+              pointerZoom,
+              { ...prevZoomData, start: startingPoint },
+              zoomOptions,
+            );
+
+            /* If the starting point is too close to the end that minSpan wouldn't be respected, we need to update the
+             * start point. */
+            const start = calculateZoomStart(
+              startingPoint,
+              { ...prevZoomData, start: startingPoint, end },
+              zoomOptions,
+            );
+
+            return { ...prevZoomData, start, end };
+          }
+
+          const start = calculateZoomStart(
+            pointerZoom,
+            { ...prevZoomData, end: startingPoint },
+            zoomOptions,
+          );
+
+          /* If the starting point is too close to the start that minSpan wouldn't be respected, we need to update the
+           * start point. */
+          const end = calculateZoomEnd(
+            startingPoint,
+            { ...prevZoomData, start, end: startingPoint },
+            zoomOptions,
+          );
+
+          return { ...prevZoomData, start, end };
+        });
         firstMoveRef.current = false;
       }),
     [axisId, instance, store, svgRef],

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -339,7 +339,7 @@ function ChartAxisZoomSliderActiveTrack({
 
     const onPointerUp = () => {
       activePreviewRect.removeEventListener('pointermove', onPointerMove);
-      activePreviewRect.removeEventListener('pointerup', onPointerUp);
+      document.removeEventListener('pointerup', onPointerUp);
       setShowTooltip(null);
     };
 
@@ -367,7 +367,7 @@ function ChartAxisZoomSliderActiveTrack({
       pointerZoomMax = 100 - (axisZoomData.end - pointerDownZoom);
 
       setShowTooltip('both');
-      activePreviewRect.addEventListener('pointerup', onPointerUp);
+      document.addEventListener('pointerup', onPointerUp);
       activePreviewRect.addEventListener('pointermove', onPointerMove);
     };
 

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -172,11 +172,16 @@ function ChartAxisZoomSliderTrack({
     }
 
     const pointerDownPoint = getSVGPoint(element, event);
-    const pointerDownZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerDownPoint);
+    let pointerDownZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerDownPoint);
 
     if (pointerDownZoom === null) {
       return;
     }
+
+    const { minStart, maxEnd } = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
+
+    // Ensure the pointerDownZoom is within the min and max range
+    pointerDownZoom = Math.max(Math.min(pointerDownZoom, maxEnd), minStart);
 
     let pointerMoved = false;
 

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -231,7 +231,7 @@ function ChartAxisZoomSliderTrack({
     const onPointerUp = function onPointerUp(pointerUpEvent: PointerEvent) {
       rect.releasePointerCapture(pointerUpEvent.pointerId);
       rect.removeEventListener('pointermove', onPointerMove);
-      rect.removeEventListener('pointerup', onPointerUp);
+      document.removeEventListener('pointerup', onPointerUp);
 
       if (pointerMoved) {
         return;

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -31,6 +31,7 @@ const ZoomSliderTrack = styled('rect')(({ theme }) => ({
       theme.palette.mode === 'dark'
         ? (theme.vars || theme).palette.grey[800]
         : (theme.vars || theme).palette.grey[300],
+    cursor: 'crosshair',
   },
 }));
 

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -172,24 +172,28 @@ function ChartAxisZoomSliderTrack({
     }
 
     const pointerDownPoint = getSVGPoint(element, event);
-    let pointerDownZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerDownPoint);
+    let zoomFromPointerDown = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerDownPoint);
 
-    if (pointerDownZoom === null) {
+    if (zoomFromPointerDown === null) {
       return;
     }
 
     const { minStart, maxEnd } = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
 
-    // Ensure the pointerDownZoom is within the min and max range
-    pointerDownZoom = Math.max(Math.min(pointerDownZoom, maxEnd), minStart);
+    // Ensure the zoomFromPointerDown is within the min and max range
+    zoomFromPointerDown = Math.max(Math.min(zoomFromPointerDown, maxEnd), minStart);
 
     let pointerMoved = false;
 
     const onPointerMove = rafThrottle(function onPointerMove(pointerMoveEvent: PointerEvent) {
       const pointerMovePoint = getSVGPoint(element, pointerMoveEvent);
-      const pointerZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerMovePoint);
+      const zoomFromPointerMove = calculateZoomFromPoint(
+        store.getSnapshot(),
+        axisId,
+        pointerMovePoint,
+      );
 
-      if (pointerZoom === null) {
+      if (zoomFromPointerMove === null) {
         return;
       }
 
@@ -197,18 +201,18 @@ function ChartAxisZoomSliderTrack({
       const zoomOptions = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
 
       instance.setAxisZoomData(axisId, (prevZoomData) => {
-        if (pointerZoom > pointerDownZoom) {
+        if (zoomFromPointerMove > zoomFromPointerDown) {
           const end = calculateZoomEnd(
-            pointerZoom,
-            { ...prevZoomData, start: pointerDownZoom },
+            zoomFromPointerMove,
+            { ...prevZoomData, start: zoomFromPointerDown },
             zoomOptions,
           );
 
           /* If the starting point is too close to the end that minSpan wouldn't be respected, we need to update the
            * start point. */
           const start = calculateZoomStart(
-            pointerDownZoom,
-            { ...prevZoomData, start: pointerDownZoom, end },
+            zoomFromPointerDown,
+            { ...prevZoomData, start: zoomFromPointerDown, end },
             zoomOptions,
           );
 
@@ -216,16 +220,16 @@ function ChartAxisZoomSliderTrack({
         }
 
         const start = calculateZoomStart(
-          pointerZoom,
-          { ...prevZoomData, end: pointerDownZoom },
+          zoomFromPointerMove,
+          { ...prevZoomData, end: zoomFromPointerDown },
           zoomOptions,
         );
 
         /* If the starting point is too close to the start that minSpan wouldn't be respected, we need to update the
          * start point. */
         const end = calculateZoomEnd(
-          pointerDownZoom,
-          { ...prevZoomData, start, end: pointerDownZoom },
+          zoomFromPointerDown,
+          { ...prevZoomData, start, end: zoomFromPointerDown },
           zoomOptions,
         );
 
@@ -245,9 +249,9 @@ function ChartAxisZoomSliderTrack({
       // If the pointer didn't move, we still need to respect the zoom constraints (minSpan, etc.)
       // In that case, we assume the start to be the pointerZoom and calculate the end.
       const pointerUpPoint = getSVGPoint(element, pointerUpEvent);
-      const pointerUpZoom = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerUpPoint);
+      const zoomFromPointerUp = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerUpPoint);
 
-      if (pointerUpZoom === null) {
+      if (zoomFromPointerUp === null) {
         return;
       }
 
@@ -255,8 +259,8 @@ function ChartAxisZoomSliderTrack({
 
       instance.setAxisZoomData(axisId, (prev) => ({
         ...prev,
-        start: pointerUpZoom,
-        end: calculateZoomEnd(pointerUpZoom, prev, zoomOptions),
+        start: zoomFromPointerUp,
+        end: calculateZoomEnd(zoomFromPointerUp, prev, zoomOptions),
       }));
     };
 
@@ -269,8 +273,8 @@ function ChartAxisZoomSliderTrack({
 
     instance.setAxisZoomData(axisId, (prev) => ({
       ...prev,
-      start: pointerDownZoom,
-      end: pointerDownZoom,
+      start: zoomFromPointerDown,
+      end: zoomFromPointerDown,
     }));
   };
 

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSlider.tsx
@@ -181,6 +181,7 @@ function ChartAxisZoomSliderTrack({
           return;
         }
 
+        // TODO: Handle min span, etc.
         // pointerZoom = Math.max(pointerZoomMin, Math.min(pointerZoomMax, pointerZoom));
 
         instance.setAxisZoomData(axisId, (prevZoomData) => ({

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -114,6 +114,7 @@ FunnelChart.propTypes = {
     current: PropTypes.shape({
       exportAsImage: PropTypes.func.isRequired,
       exportAsPrint: PropTypes.func.isRequired,
+      setAxisZoomData: PropTypes.func.isRequired,
       setZoomData: PropTypes.func.isRequired,
     }),
   }),

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -125,6 +125,7 @@ LineChartPro.propTypes = {
     current: PropTypes.shape({
       exportAsImage: PropTypes.func.isRequired,
       exportAsPrint: PropTypes.func.isRequired,
+      setAxisZoomData: PropTypes.func.isRequired,
       setZoomData: PropTypes.func.isRequired,
     }),
   }),

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -110,6 +110,7 @@ ScatterChartPro.propTypes = {
     current: PropTypes.shape({
       exportAsImage: PropTypes.func.isRequired,
       exportAsPrint: PropTypes.func.isRequired,
+      setAxisZoomData: PropTypes.func.isRequired,
       setZoomData: PropTypes.func.isRequired,
     }),
   }),

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -156,6 +156,21 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
     [onZoomChange, store, removeIsInteracting],
   );
 
+  const setAxisZoomData = React.useCallback(
+    (axisId: AxisId, zoomData: ZoomData | ((prev: ZoomData) => ZoomData)) => {
+      setZoomDataCallback((prev) =>
+        prev.map((z) => {
+          if (z.axisId !== axisId) {
+            return z;
+          }
+
+          return typeof zoomData === 'function' ? zoomData(z) : zoomData;
+        }),
+      );
+    },
+    [setZoomDataCallback],
+  );
+
   const moveZoomRange = React.useCallback(
     (axisId: AxisId, by: number) => {
       setZoomDataCallback((prevZoomData) => {
@@ -509,11 +524,13 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
   return {
     publicAPI: {
       setZoomData: setZoomDataCallback,
+      setAxisZoomData,
       zoomIn,
       zoomOut,
     },
     instance: {
       setZoomData: setZoomDataCallback,
+      setAxisZoomData,
       moveZoomRange,
       zoomIn,
       zoomOut,

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.ts
@@ -159,12 +159,12 @@ export const useChartProZoom: ChartPlugin<UseChartProZoomSignature> = ({
   const setAxisZoomData = React.useCallback(
     (axisId: AxisId, zoomData: ZoomData | ((prev: ZoomData) => ZoomData)) => {
       setZoomDataCallback((prev) =>
-        prev.map((z) => {
-          if (z.axisId !== axisId) {
-            return z;
+        prev.map((prevZoom) => {
+          if (prevZoom.axisId !== axisId) {
+            return prevZoom;
           }
 
-          return typeof zoomData === 'function' ? zoomData(z) : zoomData;
+          return typeof zoomData === 'function' ? zoomData(prevZoom) : zoomData;
         }),
       );
     },

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
@@ -55,7 +55,7 @@ export interface UseChartProZoomPublicApi {
   setZoomData: (value: ZoomData[] | ((prev: ZoomData[]) => ZoomData[])) => void;
   /**
    * Set the zoom data for an axis.
-   * @param axisId
+   * @param {AxisId} axisId The id of the axis to set the zoom data for.
    * @param {ZoomData | ((prev: ZoomData) => ZoomData)} value  The new value. Can either be the new zoom data, or an updater function.
    * @returns {void}
    */

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.types.ts
@@ -53,6 +53,13 @@ export interface UseChartProZoomPublicApi {
    * @returns {void}
    */
   setZoomData: (value: ZoomData[] | ((prev: ZoomData[]) => ZoomData[])) => void;
+  /**
+   * Set the zoom data for an axis.
+   * @param axisId
+   * @param {ZoomData | ((prev: ZoomData) => ZoomData)} value  The new value. Can either be the new zoom data, or an updater function.
+   * @returns {void}
+   */
+  setAxisZoomData: (axisId: AxisId, value: ZoomData | ((prev: ZoomData) => ZoomData)) => void;
 }
 
 export interface UseChartProZoomInstance extends UseChartProZoomPublicApi {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
@@ -184,3 +184,16 @@ export const selectorChartYAxis = createSelector(
       getFilters,
     }),
 );
+
+export const selectorChartRawAxis = createSelector(
+  [selectorChartRawXAxis, selectorChartRawYAxis, (state, axisId: AxisId) => axisId],
+  (xAxes, yAxes, axisId) => {
+    const axis = xAxes?.find((a) => a.id === axisId) ?? yAxes?.find((a) => a.id === axisId) ?? null;
+
+    if (!axis) {
+      return undefined;
+    }
+
+    return axis;
+  },
+);


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/15383.

Adds a range selection to zoom slider. It respects all zoom options (e.g., `minSpan`, `minStart`). 


https://github.com/user-attachments/assets/821146a8-2827-40ac-8a5d-c08519bae817


### Some edge cases

Selection starts too close to the end and the cursor goes to the right, so the `minSpan` of 10 wouldn't be respected. In this case, we need to move the start to the left.


https://github.com/user-attachments/assets/3ca28e61-8cd0-450c-8d24-7bcc52a91f4f

Selection starts outside `minStart`. In this case, we move the start to `minStart` and adjust the end accordingly.

https://github.com/user-attachments/assets/40571f5d-e262-42e6-9edf-9ebd9be6f564

