### PR TITLE
[DataGridPro] Fix pinned columns order in column management

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
@@ -3,7 +3,7 @@ import { RefObject } from '@mui/x-internals/types';
 import {
   GridPipeProcessor,
   useGridRegisterPipeProcessor,
-  gridVisiblePinnedColumnDefinitionsSelector,
+  gridPinnedColumnsSelector,
 } from '@mui/x-data-grid/internals';
 import { DataGridProProcessedProps } from '../../../models/dataGridProProps';
 import { GridPrivateApiPro } from '../../../models/gridApiPro';
@@ -30,13 +30,13 @@ export const useGridColumnPinningPreProcessors = (
       const savedState = apiRef.current.state;
       apiRef.current.state = { ...savedState, columns: columnsState as unknown as any };
 
-      const visibleColumns = gridVisiblePinnedColumnDefinitionsSelector(apiRef);
+      const pinnedColumns = gridPinnedColumnsSelector(apiRef);
 
       apiRef.current.state = savedState;
       // HACK: Ends here //
 
-      const leftPinnedColumns = visibleColumns.left.map((c) => c.field);
-      const rightPinnedColumns = visibleColumns.right.map((c) => c.field);
+      const leftPinnedColumns = pinnedColumns.left || [];
+      const rightPinnedColumns = pinnedColumns.right || [];
 
       let newOrderedFields: string[];
       const allPinnedColumns = [...leftPinnedColumns, ...rightPinnedColumns];

--- a/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
@@ -30,13 +30,18 @@ export const useGridColumnPinningPreProcessors = (
       const savedState = apiRef.current.state;
       apiRef.current.state = { ...savedState, columns: columnsState as unknown as any };
 
+      const existingColumns = new Set(columnsState.orderedFields);
       const pinnedColumns = gridPinnedColumnsSelector(apiRef);
 
       apiRef.current.state = savedState;
       // HACK: Ends here //
 
-      const leftPinnedColumns = pinnedColumns.left || [];
-      const rightPinnedColumns = pinnedColumns.right || [];
+      const leftPinnedColumns = (pinnedColumns.left || []).filter((field) =>
+        existingColumns.has(field),
+      );
+      const rightPinnedColumns = (pinnedColumns.right || []).filter((field) =>
+        existingColumns.has(field),
+      );
 
       let newOrderedFields: string[];
       const allPinnedColumns = [...leftPinnedColumns, ...rightPinnedColumns];

--- a/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinningPreProcessors.ts
@@ -3,7 +3,7 @@ import { RefObject } from '@mui/x-internals/types';
 import {
   GridPipeProcessor,
   useGridRegisterPipeProcessor,
-  gridPinnedColumnsSelector,
+  gridExistingPinnedColumnSelector,
 } from '@mui/x-data-grid/internals';
 import { DataGridProProcessedProps } from '../../../models/dataGridProProps';
 import { GridPrivateApiPro } from '../../../models/gridApiPro';
@@ -30,18 +30,13 @@ export const useGridColumnPinningPreProcessors = (
       const savedState = apiRef.current.state;
       apiRef.current.state = { ...savedState, columns: columnsState as unknown as any };
 
-      const existingColumns = new Set(columnsState.orderedFields);
-      const pinnedColumns = gridPinnedColumnsSelector(apiRef);
+      const pinnedColumns = gridExistingPinnedColumnSelector(apiRef);
 
       apiRef.current.state = savedState;
       // HACK: Ends here //
 
-      const leftPinnedColumns = (pinnedColumns.left || []).filter((field) =>
-        existingColumns.has(field),
-      );
-      const rightPinnedColumns = (pinnedColumns.right || []).filter((field) =>
-        existingColumns.has(field),
-      );
+      const leftPinnedColumns = pinnedColumns.left;
+      const rightPinnedColumns = pinnedColumns.right;
 
       let newOrderedFields: string[];
       const allPinnedColumns = [...leftPinnedColumns, ...rightPinnedColumns];

--- a/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -720,4 +720,104 @@ describe('<DataGridPro /> - Column pinning', () => {
       expect(ageCellColumnGroupHeader.textContent).to.equal('Basic info');
     });
   });
+
+  describe('pinned columns order in column management', () => {
+    it('should keep pinned column order in column management panel when toggling columns', async () => {
+      const { user } = render(
+        <DataGridPro
+          rows={[{ id: 1, brand: 'Nike' }]}
+          columns={[{ field: 'id' }, { field: 'brand' }]}
+          showToolbar
+          initialState={{
+            pinnedColumns: {
+              left: ['brand', 'id'],
+            },
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+      const columnCheckboxes = screen.getAllByRole('checkbox');
+
+      expect(columnCheckboxes[0]).to.have.attribute('name', 'brand');
+      expect(columnCheckboxes[1]).to.have.attribute('name', 'id');
+
+      await user.click(columnCheckboxes[1]);
+
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+      const checkboxesAfterToggle = screen.getAllByRole('checkbox');
+
+      expect(checkboxesAfterToggle[0]).to.have.attribute('name', 'brand');
+      expect(checkboxesAfterToggle[1]).to.have.attribute('name', 'id');
+    });
+
+    it('should keep pinned column order in column management panel when clicking show/hide all checkbox', async () => {
+      const { user } = render(
+        <DataGridPro
+          rows={[{ id: 0, brand: 'Nike' }]}
+          columns={[{ field: 'id' }, { field: 'brand' }]}
+          showToolbar
+          initialState={{
+            pinnedColumns: {
+              left: ['brand', 'id'],
+            },
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+      const columnCheckboxes = screen.getAllByRole('checkbox');
+
+      expect(columnCheckboxes[0]).to.have.attribute('name', 'brand');
+      expect(columnCheckboxes[1]).to.have.attribute('name', 'id');
+
+      await user.click(columnCheckboxes[columnCheckboxes.length - 1]);
+
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+      const checkboxesAfterToggle = screen.getAllByRole('checkbox');
+      expect(checkboxesAfterToggle[0]).to.have.attribute('name', 'brand');
+      expect(checkboxesAfterToggle[1]).to.have.attribute('name', 'id');
+    });
+
+    it('should keep pinned column order in column management panel when pressing reset', async () => {
+      const { user } = render(
+        <DataGridPro
+          rows={[{ id: 0, brand: 'Nike' }]}
+          columns={[{ field: 'id' }, { field: 'brand' }]}
+          showToolbar
+          initialState={{
+            pinnedColumns: {
+              left: ['brand', 'id'],
+            },
+            columns: {
+              columnVisibilityModel: { id: false },
+            },
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+      const columnCheckboxes = screen.getAllByRole('checkbox');
+
+      expect(columnCheckboxes[0]).to.have.attribute('name', 'brand');
+      expect(columnCheckboxes[1]).to.have.attribute('name', 'id');
+
+      await user.click(columnCheckboxes[1]);
+
+      await user.click(screen.getByRole('button', { name: 'Reset' }));
+
+      const checkboxesAfterReset = screen.getAllByRole('checkbox');
+
+      expect(checkboxesAfterReset[0]).to.have.attribute('name', 'brand');
+
+      expect(checkboxesAfterReset[1]).to.have.attribute('name', 'id');
+    });
+  });
 });

--- a/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -724,13 +724,13 @@ describe('<DataGridPro /> - Column pinning', () => {
   describe('pinned columns order in column management', () => {
     it('should keep pinned column order in column management panel when toggling columns', async () => {
       const { user } = render(
-        <DataGridPro
+        <TestCase
           rows={[{ id: 1, brand: 'Nike' }]}
           columns={[{ field: 'id' }, { field: 'brand' }]}
           showToolbar
           initialState={{
             pinnedColumns: {
-              left: ['brand', 'id'],
+              left: ['brand'],
             },
           }}
         />,
@@ -756,13 +756,13 @@ describe('<DataGridPro /> - Column pinning', () => {
 
     it('should keep pinned column order in column management panel when clicking show/hide all checkbox', async () => {
       const { user } = render(
-        <DataGridPro
+        <TestCase
           rows={[{ id: 0, brand: 'Nike' }]}
           columns={[{ field: 'id' }, { field: 'brand' }]}
           showToolbar
           initialState={{
             pinnedColumns: {
-              left: ['brand', 'id'],
+              left: ['brand'],
             },
           }}
         />,
@@ -785,16 +785,14 @@ describe('<DataGridPro /> - Column pinning', () => {
       expect(checkboxesAfterToggle[1]).to.have.attribute('name', 'id');
     });
 
-    it('should keep pinned column order in column management panel when pressing reset', async () => {
+    it('should update column order when pinned columns are updated', async () => {
       const { user } = render(
-        <DataGridPro
-          rows={[{ id: 0, brand: 'Nike' }]}
-          columns={[{ field: 'id' }, { field: 'brand' }]}
+        <TestCase
+          rows={[{ id: 0, brand: 'Nike', price: 100 }]}
+          columns={[{ field: 'id' }, { field: 'brand' }, { field: 'price' }]}
           showToolbar
           initialState={{
-            pinnedColumns: {
-              left: ['brand', 'id'],
-            },
+            pinnedColumns: {},
             columns: {
               columnVisibilityModel: { id: false },
             },
@@ -806,18 +804,20 @@ describe('<DataGridPro /> - Column pinning', () => {
 
       const columnCheckboxes = screen.getAllByRole('checkbox');
 
-      expect(columnCheckboxes[0]).to.have.attribute('name', 'brand');
-      expect(columnCheckboxes[1]).to.have.attribute('name', 'id');
+      expect(columnCheckboxes[0]).to.have.attribute('name', 'id');
+      expect(columnCheckboxes[1]).to.have.attribute('name', 'brand');
+      expect(columnCheckboxes[2]).to.have.attribute('name', 'price');
 
-      await user.click(columnCheckboxes[1]);
+      await act(() => {
+        apiRef.current?.pinColumn('brand', GridPinnedColumnPosition.LEFT);
+        apiRef.current?.pinColumn('id', GridPinnedColumnPosition.RIGHT);
+      });
 
-      await user.click(screen.getByRole('button', { name: 'Reset' }));
+      const checkboxesAfterPinning = screen.getAllByRole('checkbox');
 
-      const checkboxesAfterReset = screen.getAllByRole('checkbox');
-
-      expect(checkboxesAfterReset[0]).to.have.attribute('name', 'brand');
-
-      expect(checkboxesAfterReset[1]).to.have.attribute('name', 'id');
+      expect(checkboxesAfterPinning[0]).to.have.attribute('name', 'brand');
+      expect(checkboxesAfterPinning[1]).to.have.attribute('name', 'price');
+      expect(checkboxesAfterPinning[2]).to.have.attribute('name', 'id');
     });
   });
 });

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -57,13 +57,17 @@ export const gridColumnDefinitionsSelector = createSelectorMemoized(
     const leftPinnedFields = pinnedColumns.left || [];
     const rightPinnedFields = pinnedColumns.right || [];
 
-    const visibleLeftPinnedFields = leftPinnedFields.filter(field => allFields.includes(field));
-    const visibleRightPinnedFields = rightPinnedFields.filter(field => allFields.includes(field));
+    const visibleLeftPinnedFields = leftPinnedFields.filter((field) => allFields.includes(field));
+    const visibleRightPinnedFields = rightPinnedFields.filter((field) => allFields.includes(field));
     const unpinnedFields = allFields.filter(
-      field => !leftPinnedFields.includes(field) && !rightPinnedFields.includes(field)
+      (field) => !leftPinnedFields.includes(field) && !rightPinnedFields.includes(field),
     );
 
-    const orderedFields = [...visibleLeftPinnedFields, ...unpinnedFields, ...visibleRightPinnedFields];
+    const orderedFields = [
+      ...visibleLeftPinnedFields,
+      ...unpinnedFields,
+      ...visibleRightPinnedFields,
+    ];
     return orderedFields.map((field) => lookup[field]);
   },
 );
@@ -108,7 +112,6 @@ export const gridVisibleColumnFieldsSelector = createSelectorMemoized(
   gridVisibleColumnDefinitionsSelector,
   (visibleColumns) => visibleColumns.map((column) => column.field),
 );
-
 
 /**
  * Get the visible pinned columns.

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -53,7 +53,8 @@ export const gridColumnDefinitionsSelector = createSelectorMemoized(
   gridColumnFieldsSelector,
   gridColumnLookupSelector,
   gridPinnedColumnsSelector,
-  (allFields, lookup, pinnedColumns) => {
+  gridIsRtlSelector,
+  (allFields, lookup, pinnedColumns, isRtl) => {
     const leftPinnedFields = pinnedColumns.left || [];
     const rightPinnedFields = pinnedColumns.right || [];
 
@@ -63,11 +64,9 @@ export const gridColumnDefinitionsSelector = createSelectorMemoized(
       (field) => !leftPinnedFields.includes(field) && !rightPinnedFields.includes(field),
     );
 
-    const orderedFields = [
-      ...visibleLeftPinnedFields,
-      ...unpinnedFields,
-      ...visibleRightPinnedFields,
-    ];
+    const orderedFields = isRtl
+      ? [...visibleRightPinnedFields, ...unpinnedFields, ...visibleLeftPinnedFields]
+      : [...visibleLeftPinnedFields, ...unpinnedFields, ...visibleRightPinnedFields];
     return orderedFields.map((field) => lookup[field]);
   },
 );

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -105,7 +105,7 @@ export const gridExistingPinnedColumnSelector = createSelectorMemoized(
   gridPinnedColumnsSelector,
   gridColumnFieldsSelector,
   gridIsRtlSelector,
-  (model, orderedFields, isRtl) => filterVisibleColumns(model, orderedFields, isRtl),
+  (model, orderedFields, isRtl) => filterMissingColumns(model, orderedFields, isRtl),
 );
 
 /**
@@ -118,7 +118,7 @@ export const gridVisiblePinnedColumnDefinitionsSelector = createSelectorMemoized
   gridVisibleColumnFieldsSelector,
   gridIsRtlSelector,
   (columnsState, model, visibleColumnFields, isRtl) => {
-    const visiblePinnedFields = filterVisibleColumns(model, visibleColumnFields, isRtl);
+    const visiblePinnedFields = filterMissingColumns(model, visibleColumnFields, isRtl);
     const visiblePinnedColumns = {
       left: visiblePinnedFields.left.map((field) => columnsState.lookup[field]),
       right: visiblePinnedFields.right.map((field) => columnsState.lookup[field]),
@@ -127,7 +127,7 @@ export const gridVisiblePinnedColumnDefinitionsSelector = createSelectorMemoized
   },
 );
 
-function filterVisibleColumns(
+function filterMissingColumns(
   pinnedColumns: GridPinnedColumnFields,
   columns: string[],
   invert?: boolean,

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -97,6 +97,18 @@ export const gridPinnedColumnsSelector = createRootSelector(
 );
 
 /**
+ * Get all existing pinned columns. Place the columns on the side that depends on the rtl state.
+ * @category Pinned Columns
+ * @ignore - Do not document
+ */
+export const gridExistingPinnedColumnSelector = createSelectorMemoized(
+  gridPinnedColumnsSelector,
+  gridColumnFieldsSelector,
+  gridIsRtlSelector,
+  (model, orderedFields, isRtl) => filterVisibleColumns(model, orderedFields, isRtl),
+);
+
+/**
  * Get the visible pinned columns.
  * @category Visible Columns
  */

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -38,37 +38,13 @@ export const gridColumnLookupSelector = createSelector(
 );
 
 /**
- * Get the visible pinned columns model.
- * @category Visible Columns
- */
-export const gridPinnedColumnsSelector = createRootSelector(
-  (state: GridStateCommunity) => state.pinnedColumns,
-);
-
-/**
  * Get an array of column definitions in the order rendered on screen..
  * @category Columns
  */
 export const gridColumnDefinitionsSelector = createSelectorMemoized(
   gridColumnFieldsSelector,
   gridColumnLookupSelector,
-  gridPinnedColumnsSelector,
-  gridIsRtlSelector,
-  (allFields, lookup, pinnedColumns, isRtl) => {
-    const leftPinnedFields = pinnedColumns.left || [];
-    const rightPinnedFields = pinnedColumns.right || [];
-
-    const visibleLeftPinnedFields = leftPinnedFields.filter((field) => allFields.includes(field));
-    const visibleRightPinnedFields = rightPinnedFields.filter((field) => allFields.includes(field));
-    const unpinnedFields = allFields.filter(
-      (field) => !leftPinnedFields.includes(field) && !rightPinnedFields.includes(field),
-    );
-
-    const orderedFields = isRtl
-      ? [...visibleRightPinnedFields, ...unpinnedFields, ...visibleLeftPinnedFields]
-      : [...visibleLeftPinnedFields, ...unpinnedFields, ...visibleRightPinnedFields];
-    return orderedFields.map((field) => lookup[field]);
-  },
+  (allFields, lookup) => allFields.map((field) => lookup[field]),
 );
 
 /**
@@ -110,6 +86,14 @@ export const gridVisibleColumnDefinitionsSelector = createSelectorMemoized(
 export const gridVisibleColumnFieldsSelector = createSelectorMemoized(
   gridVisibleColumnDefinitionsSelector,
   (visibleColumns) => visibleColumns.map((column) => column.field),
+);
+
+/**
+ * Get the visible pinned columns model.
+ * @category Visible Columns
+ */
+export const gridPinnedColumnsSelector = createRootSelector(
+  (state: GridStateCommunity) => state.pinnedColumns,
 );
 
 /**

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -38,13 +38,34 @@ export const gridColumnLookupSelector = createSelector(
 );
 
 /**
+ * Get the visible pinned columns model.
+ * @category Visible Columns
+ */
+export const gridPinnedColumnsSelector = createRootSelector(
+  (state: GridStateCommunity) => state.pinnedColumns,
+);
+
+/**
  * Get an array of column definitions in the order rendered on screen..
  * @category Columns
  */
 export const gridColumnDefinitionsSelector = createSelectorMemoized(
   gridColumnFieldsSelector,
   gridColumnLookupSelector,
-  (allFields, lookup) => allFields.map((field) => lookup[field]),
+  gridPinnedColumnsSelector,
+  (allFields, lookup, pinnedColumns) => {
+    const leftPinnedFields = pinnedColumns.left || [];
+    const rightPinnedFields = pinnedColumns.right || [];
+
+    const visibleLeftPinnedFields = leftPinnedFields.filter(field => allFields.includes(field));
+    const visibleRightPinnedFields = rightPinnedFields.filter(field => allFields.includes(field));
+    const unpinnedFields = allFields.filter(
+      field => !leftPinnedFields.includes(field) && !rightPinnedFields.includes(field)
+    );
+
+    const orderedFields = [...visibleLeftPinnedFields, ...unpinnedFields, ...visibleRightPinnedFields];
+    return orderedFields.map((field) => lookup[field]);
+  },
 );
 
 /**
@@ -88,13 +109,6 @@ export const gridVisibleColumnFieldsSelector = createSelectorMemoized(
   (visibleColumns) => visibleColumns.map((column) => column.field),
 );
 
-/**
- * Get the visible pinned columns model.
- * @category Visible Columns
- */
-export const gridPinnedColumnsSelector = createRootSelector(
-  (state: GridStateCommunity) => state.pinnedColumns,
-);
 
 /**
  * Get the visible pinned columns.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Fixes #17889

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


The column management section was not respecting order of pinned columns when users were changing visibility of columns. As a result this user interaction led to change in the order of the columns in column panel.

This fix ensures column management section keeps the same order as the pinned columns in the grid.
