### PR TITLE
[charts-pro] Make `linear` and `bump` curves pointy

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/curves/linear.ts
+++ b/packages/x-charts-pro/src/FunnelChart/curves/linear.ts
@@ -21,15 +21,21 @@ export class Linear implements CurveGenerator {
 
   private isHorizontal: boolean = false;
 
+  private isIncreasing: boolean = false;
+
   private gap: number = 0;
 
   private borderRadius: number = 0;
+
+  private min: Point = { x: 0, y: 0 };
+
+  private max: Point = { x: 0, y: 0 };
 
   private points: Point[] = [];
 
   constructor(
     context: CanvasRenderingContext2D,
-    { isHorizontal, gap, position, sections, borderRadius }: CurveOptions,
+    { isHorizontal, gap, position, sections, borderRadius, min, max, isIncreasing }: CurveOptions,
   ) {
     this.context = context;
     this.isHorizontal = isHorizontal ?? false;
@@ -37,6 +43,16 @@ export class Linear implements CurveGenerator {
     this.position = position ?? 0;
     this.sections = sections ?? 1;
     this.borderRadius = borderRadius ?? 0;
+    this.isIncreasing = isIncreasing ?? false;
+    this.min = min ?? { x: 0, y: 0 };
+    this.max = max ?? { x: 0, y: 0 };
+
+    if (isIncreasing) {
+      const currentMin = this.min;
+      const currentMax = this.max;
+      this.min = currentMax;
+      this.max = currentMin;
+    }
   }
 
   areaStart(): void {}
@@ -51,12 +67,29 @@ export class Linear implements CurveGenerator {
     if (this.gap > 0) {
       return this.borderRadius;
     }
-    if (this.position === 0) {
-      return [0, 0, this.borderRadius, this.borderRadius];
+
+    if (this.isIncreasing) {
+      // Is largest section
+      if (this.position === this.sections - 1) {
+        return [this.borderRadius, this.borderRadius];
+      }
+      // Is smallest section and shaped like a triangle
+      if (this.position === 0) {
+        return [0, 0, this.borderRadius];
+      }
     }
-    if (this.position === this.sections - 1) {
-      return [this.borderRadius, this.borderRadius];
+
+    if (!this.isIncreasing) {
+      // Is largest section
+      if (this.position === 0) {
+        return [0, 0, this.borderRadius, this.borderRadius];
+      }
+      // Is smallest section and shaped like a triangle
+      if (this.position === this.sections - 1) {
+        return [this.borderRadius];
+      }
     }
+
     return 0;
   }
 
@@ -97,6 +130,31 @@ export class Linear implements CurveGenerator {
         y: yGap,
       };
     });
+
+    // In the last section, to form a triangle we need 3 points instead of 4
+    // Else the algorithm will break.
+    const isLastSection = this.position === this.sections - 1;
+    const isFirstSection = this.position === 0;
+
+    if (isFirstSection && this.isIncreasing) {
+      this.points = [
+        this.points[0],
+        this.isHorizontal
+          ? { x: this.max.x, y: (this.max.y + this.min.y) / 2 }
+          : { x: (this.max.x + this.min.x) / 2, y: this.max.y },
+        this.points[2],
+      ];
+    }
+
+    if (isLastSection && !this.isIncreasing) {
+      this.points = [
+        this.points[0],
+        this.isHorizontal
+          ? { x: this.max.x, y: (this.max.y + this.min.y) / 2 }
+          : { x: (this.max.x + this.min.x) / 2, y: this.max.y },
+        this.points[3],
+      ];
+    }
 
     borderRadiusPolygon(this.context, this.points, this.getBorderRadius());
   }


### PR DESCRIPTION
## Questions

Should I add this behind a prop? Or allow the old shape behind a prop? 
Maybe `bump` doesn't need to be pointy? 🤔

## Work

I re-wrote how the bump curve works. 
I want in a future PR to move away from using these as "svg path generators" and instead use it to calculate the points first, then the points can be used in the chart for things like calculating label position.
Rendering the svg paths becomes trivial once we have all the points. 