### PR TITLE
[charts] Use Map for string cache instead of object

### DIFF
--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -5,15 +5,8 @@ function isSsr(): boolean {
   return typeof window === 'undefined';
 }
 
-interface StringCache {
-  widthCache: Record<string, { width: number; height: number }>;
-  cacheCount: number;
-}
+const stringCache = new Map<string, { width: number; height: number }>();
 
-const stringCache: StringCache = {
-  widthCache: {},
-  cacheCount: 0,
-};
 const MAX_CACHE_NUM = 2000;
 const SPAN_STYLE = {
   position: 'absolute',
@@ -114,8 +107,9 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
   const styleString = getStyleString(style);
   const cacheKey = `${str}-${styleString}`;
 
-  if (stringCache.widthCache[cacheKey]) {
-    return stringCache.widthCache[cacheKey];
+  const size = stringCache.get(cacheKey);
+  if (size) {
+    return size;
   }
 
   try {
@@ -139,13 +133,10 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
     const rect = measurementSpan.getBoundingClientRect();
     const result = { width: rect.width, height: rect.height };
 
-    stringCache.widthCache[cacheKey] = result;
+    stringCache.set(cacheKey, result);
 
-    if (stringCache.cacheCount + 1 > MAX_CACHE_NUM) {
-      stringCache.cacheCount = 0;
-      stringCache.widthCache = {};
-    } else {
-      stringCache.cacheCount += 1;
+    if (stringCache.size + 1 > MAX_CACHE_NUM) {
+      stringCache.clear();
     }
 
     if (process.env.NODE_ENV === 'test') {
@@ -166,9 +157,3 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
     return { width: 0, height: 0 };
   }
 };
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function unstable_cleanupDOM() {
-  // const measurementSpan = document.getElementById(MEASUREMENT_SPAN_ID);
-  // measurementSpan?.remove();
-}

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -42,7 +42,6 @@ export * from './configInit';
 export * from './getLabel';
 export * from './getSVGPoint';
 export * from './isDefined';
-export { unstable_cleanupDOM } from './domUtils';
 export * from './getScale';
 export * from './stackSeries';
 export * from './getCurve';

--- a/test/setupVitest.ts
+++ b/test/setupVitest.ts
@@ -10,7 +10,6 @@ import sinon from 'sinon';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingDataGrid } from '@mui/x-data-grid';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingDataGridPro } from '@mui/x-data-grid-pro';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingTreeView } from '@mui/x-tree-view';
-import { unstable_cleanupDOM as unstable_cleanupDOMCharts } from '@mui/x-charts/internals';
 import failOnConsole from 'vitest-fail-on-console';
 import { clearWarningsCache } from '@mui/x-internals/warning';
 import { isJSDOM } from './utils/skipIf';
@@ -38,7 +37,6 @@ afterEach(() => {
   unstable_resetCleanupTrackingDataGrid();
   unstable_resetCleanupTrackingDataGridPro();
   unstable_resetCleanupTrackingTreeView();
-  unstable_cleanupDOMCharts();
 
   // Restore Sinon default sandbox to avoid memory leak
   // See https://github.com/sinonjs/sinon/issues/1866

--- a/test/utils/mochaHooks.js
+++ b/test/utils/mochaHooks.js
@@ -3,7 +3,6 @@ import { restore } from 'sinon';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingDataGrid } from '@mui/x-data-grid';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingDataGridPro } from '@mui/x-data-grid-pro';
 import { unstable_resetCleanupTracking as unstable_resetCleanupTrackingTreeView } from '@mui/x-tree-view';
-import { unstable_cleanupDOM as unstable_cleanupDOMCharts } from '@mui/x-charts/internals';
 import { clearWarningsCache } from '@mui/x-internals/warning';
 import { generateTestLicenseKey, setupTestLicenseKey } from './testLicense';
 
@@ -40,7 +39,6 @@ export function createXMochaHooks(coreMochaHooks = {}) {
     unstable_resetCleanupTrackingDataGrid();
     unstable_resetCleanupTrackingDataGridPro();
     unstable_resetCleanupTrackingTreeView();
-    unstable_cleanupDOMCharts();
 
     // Restore Sinon default sandbox to avoid memory leak
     // See https://github.com/sinonjs/sinon/issues/1866


### PR DESCRIPTION
Use Map for string cache instead of object. We get entry counting for free. 

Also removed `unstable_cleanupDOM` since it wasn't doing anything.