### PR TITLE
[DataGrid] Avoid ResizeObserver loop error

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRowsMeta.ts
@@ -271,7 +271,10 @@ export const useGridRowsMeta = (
           apiRef.current.unstable_storeRowHeightMeasurement(rowId, height);
         }
         if (!isHeightMetaValid.current) {
-          apiRef.current.requestPipeProcessorsApplication('rowHeight');
+          // Avoids "ResizeObserver loop completed with undelivered notifications" error
+          requestAnimationFrame(() => {
+            apiRef.current.requestPipeProcessorsApplication('rowHeight');
+          });
         }
       }),
   ).current;


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/16197

While this error is a false alarm (see https://github.com/w3c/csswg-drafts/issues/5488), some tools like CRA use `react-error-overlay`, which listens to all errors on `window` and exaggerates the issue.
With `requestAnimationFrame` used, the error is not emitted, and hopefully, we won't see this reported anymore.

Before: https://stackblitz.com/edit/vh7qvlqz?file=src%2FDemo.tsx
After: https://stackblitz.com/edit/vh7qvlqz-13rnmah5?file=src%2FDemo.tsx