### PR TITLE
Remove `ponyfillGlobal` and `@mui/utils` from `x-telemetry`

### DIFF
--- a/docs/data/guides/telemetry/telemetry.md
+++ b/docs/data/guides/telemetry/telemetry.md
@@ -76,9 +76,7 @@ Note: You can use `muiXTelemetrySettings.enableDebug();` to log telemetry data t
 You can set the `__MUI_X_TELEMETRY_DISABLED__` flag in your application to `false` to enable telemetry:
 
 ```js
-import { ponyfillGlobal } from '@mui/utils';
-
-ponyfillGlobal.__MUI_X_TELEMETRY_DISABLED__ = false;
+(globalThis as any).__MUI_X_TELEMETRY_DISABLED__ = false;
 ```
 
 <!--
@@ -112,9 +110,7 @@ muiXTelemetrySettings.disableTelemetry();
 You can set the `__MUI_X_TELEMETRY_DISABLED__` flag in your application to `true` to disable telemetry:
 
 ```js
-import { ponyfillGlobal } from '@mui/utils';
-
-ponyfillGlobal.__MUI_X_TELEMETRY_DISABLED__ = true;
+(globalThis as any).__MUI_X_TELEMETRY_DISABLED__ = true;
 ```
 
 -->

--- a/packages/x-telemetry/package.json
+++ b/packages/x-telemetry/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@babel/runtime": "^7.27.1",
     "@fingerprintjs/fingerprintjs": "^3.4.2",
-    "@mui/utils": "^7.0.2",
     "ci-info": "^4.2.0",
     "conf": "^11.0.2",
     "is-docker": "^3.0.0",

--- a/packages/x-telemetry/src/runtime/config.test.ts
+++ b/packages/x-telemetry/src/runtime/config.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
 import { expect } from 'chai';
-import { ponyfillGlobal } from '@mui/utils';
 import { vi } from 'vitest';
 import { muiXTelemetrySettings } from '@mui/x-telemetry';
 import { getTelemetryEnvConfig } from './config';
@@ -38,14 +37,14 @@ describe('Telemetry: getTelemetryConfig', () => {
   testConfigWithDisabledEnv('NEXT_PUBLIC_MUI_X_TELEMETRY_DISABLED');
 
   it('should be disabled if global.__MUI_X_TELEMETRY_DISABLED__ is set to `1`', () => {
-    ponyfillGlobal.__MUI_X_TELEMETRY_DISABLED__ = undefined;
+    (globalThis as any).__MUI_X_TELEMETRY_DISABLED__ = undefined;
     vi.stubGlobal('__MUI_X_TELEMETRY_DISABLED__', true);
 
     expect(getTelemetryEnvConfig(true).IS_COLLECTING).equal(false);
   });
 
   it('should be enabled if global.__MUI_X_TELEMETRY_DISABLED__ is set to `0`', () => {
-    ponyfillGlobal.__MUI_X_TELEMETRY_DISABLED__ = undefined;
+    (globalThis as any).__MUI_X_TELEMETRY_DISABLED__ = undefined;
     vi.stubGlobal('__MUI_X_TELEMETRY_DISABLED__', false);
 
     expect(getTelemetryEnvConfig(true).IS_COLLECTING).equal(true);

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -1,5 +1,3 @@
-import { ponyfillGlobal } from '@mui/utils';
-
 interface TelemetryEnvConfig {
   NODE_ENV: string | '<unknown>';
   IS_COLLECTING: boolean | undefined;
@@ -41,7 +39,7 @@ function getBooleanEnvFromEnvObject(envKey: string, envObj: Record<string, any>)
 function getIsTelemetryCollecting(): boolean | undefined {
   // Check global variable
   // eslint-disable-next-line no-underscore-dangle
-  const globalValue = ponyfillGlobal.__MUI_X_TELEMETRY_DISABLED__;
+  const globalValue = (globalThis as any).__MUI_X_TELEMETRY_DISABLED__;
   if (typeof globalValue === 'boolean') {
     // If disabled=true, telemetry is disabled
     // If disabled=false, telemetry is enabled
@@ -103,7 +101,7 @@ function getIsDebugModeEnabled(): boolean {
   try {
     // Check global variable
     // eslint-disable-next-line no-underscore-dangle
-    const globalValue = ponyfillGlobal.__MUI_X_TELEMETRY_DEBUG__;
+    const globalValue = (globalThis as any).__MUI_X_TELEMETRY_DEBUG__;
     if (typeof globalValue === 'boolean') {
       return globalValue;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 7.0.2(@mui/material@7.0.2(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/react@19.0.12)(react@19.0.0)
       '@mui/internal-babel-plugin-display-name':
         specifier: github:mui/mui-public#master&path:./packages/babel-plugin-display-name
-        version: https://codeload.github.com/mui/mui-public/tar.gz/cd8ee237392a83203449987090669ea42fe0b2d6#path:./packages/babel-plugin-display-name(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))
+        version: https://codeload.github.com/mui/mui-public/tar.gz/110aaafe1c186964078ec251ee844c02b6623583#path:./packages/babel-plugin-display-name(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))
       '@mui/internal-babel-plugin-resolve-imports':
         specifier: ^2.0.2
         version: 2.0.2(@babel/core@7.27.1)
@@ -1516,9 +1516,6 @@ importers:
       '@fingerprintjs/fingerprintjs':
         specifier: ^3.4.2
         version: 3.4.2
-      '@mui/utils':
-        specifier: ^7.0.2
-        version: 7.0.2(@types/react@19.0.12)(react@19.0.0)
       ci-info:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3674,8 +3671,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/internal-babel-plugin-display-name@https://codeload.github.com/mui/mui-public/tar.gz/cd8ee237392a83203449987090669ea42fe0b2d6#path:./packages/babel-plugin-display-name':
-    resolution: {path: ./packages/babel-plugin-display-name, tarball: https://codeload.github.com/mui/mui-public/tar.gz/cd8ee237392a83203449987090669ea42fe0b2d6}
+  '@mui/internal-babel-plugin-display-name@https://codeload.github.com/mui/mui-public/tar.gz/110aaafe1c186964078ec251ee844c02b6623583#path:./packages/babel-plugin-display-name':
+    resolution: {path: ./packages/babel-plugin-display-name, tarball: https://codeload.github.com/mui/mui-public/tar.gz/110aaafe1c186964078ec251ee844c02b6623583}
     version: 0.0.0
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -13834,7 +13831,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.12
 
-  '@mui/internal-babel-plugin-display-name@https://codeload.github.com/mui/mui-public/tar.gz/cd8ee237392a83203449987090669ea42fe0b2d6#path:./packages/babel-plugin-display-name(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))':
+  '@mui/internal-babel-plugin-display-name@https://codeload.github.com/mui/mui-public/tar.gz/110aaafe1c186964078ec251ee844c02b6623583#path:./packages/babel-plugin-display-name(@babel/core@7.27.1)(@babel/preset-react@7.27.1(@babel/core@7.27.1))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-module-imports': 7.27.1


### PR DESCRIPTION
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR addresses the deprecation of `ponyfillGlobal` https://github.com/mui/material-ui/pull/45606. 
Additionally, the unused dependency on `@mui/utils` has been removed as it is no longer required.