### PR TITLE
[charts][docs] Fix Population pyramid demo

### DIFF
--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -45,6 +45,8 @@ const numberFormatter = Intl.NumberFormat('en-US', {
 const numberWithSuffixFormatter = new Intl.NumberFormat('en-US', {
   notation: 'compact',
 });
+const valueFormatter = (population) =>
+  population ? `${numberFormatter.format(Math.abs(population))}` : '';
 
 export default function PopulationPyramidBarChart() {
   return (
@@ -61,13 +63,14 @@ export default function PopulationPyramidBarChart() {
             data: male.map((population) => -population),
             label: 'Male',
             type: 'bar',
-            valueFormatter: (population) => `${numberFormatter.format(-population)}`,
+            valueFormatter,
             stack: 'stack',
           },
           {
             data: female,
             label: 'Female',
             type: 'bar',
+            valueFormatter,
             stack: 'stack',
           },
         ]}

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -85,8 +85,14 @@ export default function PopulationPyramidBarChart() {
               numberWithSuffixFormatter.format(Math.abs(population)),
             disableLine: true,
             disableTicks: true,
+            domainLimit(min, max) {
+              const extremum = Math.max(-min, max);
+              const roundedExtremum = Math.ceil(extremum / 100_000) * 100_000;
+              return { min: -roundedExtremum, max: roundedExtremum };
+            },
           },
         ]}
+        grid={{ vertical: true }}
       />
       <Typography variant="caption">Source: KOSIS</Typography>
     </Stack>

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.js
@@ -4,39 +4,39 @@ import Typography from '@mui/material/Typography';
 import { BarChart } from '@mui/x-charts/BarChart';
 
 const ageGroups = [
-  '0-4 yrs',
-  '5-9 yrs',
-  '10-14 yrs',
-  '15-19 yrs',
-  '20-24 yrs',
-  '25-29 yrs',
-  '30-34 yrs',
-  '35-39 yrs',
-  '40-44 yrs',
-  '45-49 yrs',
-  '50-54 yrs',
-  '55-59 yrs',
-  '60-64 yrs',
-  '65-69 yrs',
-  '70-74 yrs',
-  '75-79 yrs',
-  '80-84 yrs',
-  '85-89 yrs',
-  '90-94 yrs',
-  '95-99 yrs',
   '100+ yrs',
+  '95-99 yrs',
+  '90-94 yrs',
+  '85-89 yrs',
+  '80-84 yrs',
+  '75-79 yrs',
+  '70-74 yrs',
+  '65-69 yrs',
+  '60-64 yrs',
+  '55-59 yrs',
+  '50-54 yrs',
+  '45-49 yrs',
+  '40-44 yrs',
+  '35-39 yrs',
+  '30-34 yrs',
+  '25-29 yrs',
+  '20-24 yrs',
+  '15-19 yrs',
+  '10-14 yrs',
+  '5-9 yrs',
+  '0-4 yrs',
 ];
 
 const male = [
-  766227, 1097221, 1189663, 1183580, 1620461, 1933726, 1796779, 1808706, 2067075,
-  2061862, 2258061, 2068112, 2042614, 1478069, 1012668, 696606, 476263, 201240,
-  50323, 8291, 1139,
+  1139, 8291, 50323, 201240, 476263, 696606, 1012668, 1478069, 2042614, 2068112,
+  2258061, 2061862, 2067075, 1808706, 1796779, 1933726, 1620461, 1183580, 1189663,
+  1097221, 766227,
 ];
 
 const female = [
-  727814, 1044863, 1122176, 1104293, 1484776, 1695058, 1593655, 1673805, 1967944,
-  2000130, 2231491, 2045845, 2105499, 1585781, 1152098, 899933, 762492, 445118,
-  168603, 36739, 5770,
+  5770, 36739, 168603, 445118, 762492, 899933, 1152098, 1585781, 2105499, 2045845,
+  2231491, 2000130, 1967944, 1673805, 1593655, 1695058, 1484776, 1104293, 1122176,
+  1044863, 727814,
 ];
 
 const numberFormatter = Intl.NumberFormat('en-US', {
@@ -48,18 +48,20 @@ const numberWithSuffixFormatter = new Intl.NumberFormat('en-US', {
 
 export default function PopulationPyramidBarChart() {
   return (
-    <Stack width="100%">
-      <Typography variant="h6" textAlign="center">
+    <Stack width="100%" sx={{ mx: [0, 4] }}>
+      <Typography variant="h6" component="span" textAlign="center">
         South Korea Population Pyramid - 2022
       </Typography>
       <BarChart
         height={500}
+        layout="horizontal"
+        margin={{ right: 0, left: 0 }}
         series={[
           {
-            data: male.map((d) => -d),
+            data: male.map((population) => -population),
             label: 'Male',
             type: 'bar',
-            valueFormatter: (d) => `${numberFormatter.format(-d)}`,
+            valueFormatter: (population) => `${numberFormatter.format(-population)}`,
             stack: 'stack',
           },
           {
@@ -72,20 +74,19 @@ export default function PopulationPyramidBarChart() {
         yAxis={[
           {
             data: ageGroups,
-            width: 70,
+            width: 60,
             disableLine: true,
             disableTicks: true,
           },
         ]}
         xAxis={[
           {
-            valueFormatter: (d) => numberWithSuffixFormatter.format(Math.abs(d)),
+            valueFormatter: (population) =>
+              numberWithSuffixFormatter.format(Math.abs(population)),
             disableLine: true,
             disableTicks: true,
           },
         ]}
-        layout="horizontal"
-        margin={{ right: 70 }}
       />
       <Typography variant="caption">Source: KOSIS</Typography>
     </Stack>

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -4,37 +4,39 @@ import Typography from '@mui/material/Typography';
 import { BarChart } from '@mui/x-charts/BarChart';
 
 const ageGroups = [
-  '0-4 yrs',
-  '5-9 yrs',
-  '10-14 yrs',
-  '15-19 yrs',
-  '20-24 yrs',
-  '25-29 yrs',
-  '30-34 yrs',
-  '35-39 yrs',
-  '40-44 yrs',
-  '45-49 yrs',
-  '50-54 yrs',
-  '55-59 yrs',
-  '60-64 yrs',
-  '65-69 yrs',
-  '70-74 yrs',
-  '75-79 yrs',
-  '80-84 yrs',
-  '85-89 yrs',
-  '90-94 yrs',
-  '95-99 yrs',
   '100+ yrs',
+  '95-99 yrs',
+  '90-94 yrs',
+  '85-89 yrs',
+  '80-84 yrs',
+  '75-79 yrs',
+  '70-74 yrs',
+  '65-69 yrs',
+  '60-64 yrs',
+  '55-59 yrs',
+  '50-54 yrs',
+  '45-49 yrs',
+  '40-44 yrs',
+  '35-39 yrs',
+  '30-34 yrs',
+  '25-29 yrs',
+  '20-24 yrs',
+  '15-19 yrs',
+  '10-14 yrs',
+  '5-9 yrs',
+  '0-4 yrs',
 ];
+
 const male = [
-  766227, 1097221, 1189663, 1183580, 1620461, 1933726, 1796779, 1808706, 2067075,
-  2061862, 2258061, 2068112, 2042614, 1478069, 1012668, 696606, 476263, 201240,
-  50323, 8291, 1139,
+  1139, 8291, 50323, 201240, 476263, 696606, 1012668, 1478069, 2042614, 2068112,
+  2258061, 2061862, 2067075, 1808706, 1796779, 1933726, 1620461, 1183580, 1189663,
+  1097221, 766227,
 ];
+
 const female = [
-  727814, 1044863, 1122176, 1104293, 1484776, 1695058, 1593655, 1673805, 1967944,
-  2000130, 2231491, 2045845, 2105499, 1585781, 1152098, 899933, 762492, 445118,
-  168603, 36739, 5770,
+  5770, 36739, 168603, 445118, 762492, 899933, 1152098, 1585781, 2105499, 2045845,
+  2231491, 2000130, 1967944, 1673805, 1593655, 1695058, 1484776, 1104293, 1122176,
+  1044863, 727814,
 ];
 
 const numberFormatter = Intl.NumberFormat('en-US', {
@@ -46,18 +48,21 @@ const numberWithSuffixFormatter = new Intl.NumberFormat('en-US', {
 
 export default function PopulationPyramidBarChart() {
   return (
-    <Stack width="100%">
-      <Typography variant="h6" textAlign="center">
+    <Stack width="100%" sx={{ mx: [0, 4] }}>
+      <Typography variant="h6" component="span" textAlign="center">
         South Korea Population Pyramid - 2022
       </Typography>
       <BarChart
         height={500}
+        layout="horizontal"
+        margin={{ right: 0, left: 0 }}
         series={[
           {
-            data: male.map((d) => -d),
+            data: male.map((population) => -population),
             label: 'Male',
             type: 'bar',
-            valueFormatter: (d: number | null) => `${numberFormatter.format(-d!)}`,
+            valueFormatter: (population: number | null) =>
+              `${numberFormatter.format(-population!)}`,
             stack: 'stack',
           },
           {
@@ -70,21 +75,19 @@ export default function PopulationPyramidBarChart() {
         yAxis={[
           {
             data: ageGroups,
-            width: 70,
+            width: 60,
             disableLine: true,
             disableTicks: true,
           },
         ]}
         xAxis={[
           {
-            valueFormatter: (d: number) =>
-              numberWithSuffixFormatter.format(Math.abs(d)),
+            valueFormatter: (population: number) =>
+              numberWithSuffixFormatter.format(Math.abs(population)),
             disableLine: true,
             disableTicks: true,
           },
         ]}
-        layout="horizontal"
-        margin={{ right: 70 }}
       />
       <Typography variant="caption">Source: KOSIS</Typography>
     </Stack>

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -86,8 +86,14 @@ export default function PopulationPyramidBarChart() {
               numberWithSuffixFormatter.format(Math.abs(population)),
             disableLine: true,
             disableTicks: true,
+            domainLimit(min, max) {
+              const extremum = Math.max(-min, max);
+              const roundedExtremum = Math.ceil(extremum / 100_000) * 100_000;
+              return { min: -roundedExtremum, max: roundedExtremum };
+            },
           },
         ]}
+        grid={{ vertical: true }}
       />
       <Typography variant="caption">Source: KOSIS</Typography>
     </Stack>

--- a/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
+++ b/docs/data/charts/bar-demo/PopulationPyramidBarChart.tsx
@@ -45,6 +45,8 @@ const numberFormatter = Intl.NumberFormat('en-US', {
 const numberWithSuffixFormatter = new Intl.NumberFormat('en-US', {
   notation: 'compact',
 });
+const valueFormatter = (population: number | null) =>
+  population ? `${numberFormatter.format(Math.abs(population))}` : '';
 
 export default function PopulationPyramidBarChart() {
   return (
@@ -61,14 +63,14 @@ export default function PopulationPyramidBarChart() {
             data: male.map((population) => -population),
             label: 'Male',
             type: 'bar',
-            valueFormatter: (population: number | null) =>
-              `${numberFormatter.format(-population!)}`,
+            valueFormatter,
             stack: 'stack',
           },
           {
             data: female,
             label: 'Female',
             type: 'bar',
+            valueFormatter,
             stack: 'stack',
           },
         ]}


### PR DESCRIPTION
A continuation of #17652 and #17980. https://mui.com/x/react-charts/bar-demo/#population-pyramid has a number of problems:

1. I have never seen an age pyramid rendered in this order. This is the "right" way IMHO: https://en.wikipedia.org/wiki/Population_pyramid.
2. It's hard to read on mobile: 

<img width="207" alt="SCR-20250525-brlp" src="https://github.com/user-attachments/assets/2c1c8601-5f3f-4f11-8dea-05216cdd4942" />

3. We render a h6 in the page, orphan from the other headers.

Preview: https://deploy-preview-17987--material-ui-x.netlify.app/x/react-charts/bar-demo/#population-pyramid

---

**Off-topics**:  I don't understand this: https://github.com/mui/mui-x/blob/ecc9177a6a522ab5f699fe1affbfc3387f289ed5/packages/x-charts/src/constants/index.ts#L5-L10

I thought we would get 0 for all those values. I had to set `margin={{ right: 0, left: 0 }}` and then use CSS to set the margin that I wanted, with responsive values. Proposing this for the next major: #17988.