### PR TITLE
[infra] Remove last deprecated `ponyfillGlobal` usage

### DIFF
--- a/packages/x-license/src/utils/licenseInfo.ts
+++ b/packages/x-license/src/utils/licenseInfo.ts
@@ -1,5 +1,3 @@
-import { ponyfillGlobal } from '@mui/utils';
-
 /**
  * @ignore - do not document.
  */
@@ -7,19 +5,24 @@ export interface MuiLicenseInfo {
   key: string | undefined;
 }
 
+declare namespace globalThis {
+  // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
+  let __MUI_LICENSE_INFO__: MuiLicenseInfo;
+}
+
 // Store the license information in a global, so it can be shared
 // when module duplication occurs. The duplication of the modules can happen
 // if using multiple version of MUI X at the same time of the bundler
 // decide to duplicate to improve the size of the chunks.
 // eslint-disable-next-line no-underscore-dangle
-ponyfillGlobal.__MUI_LICENSE_INFO__ = ponyfillGlobal.__MUI_LICENSE_INFO__ || {
+globalThis.__MUI_LICENSE_INFO__ = globalThis.__MUI_LICENSE_INFO__ || {
   key: undefined,
 };
 
 export class LicenseInfo {
   private static getLicenseInfo() {
     // eslint-disable-next-line no-underscore-dangle
-    return ponyfillGlobal.__MUI_LICENSE_INFO__;
+    return globalThis.__MUI_LICENSE_INFO__;
   }
 
   public static getLicenseKey(): MuiLicenseInfo['key'] {

--- a/test/utils/licenseRelease.js
+++ b/test/utils/licenseRelease.js
@@ -1,4 +1,2 @@
-import { ponyfillGlobal } from '@mui/utils';
-
 // eslint-disable-next-line no-underscore-dangle
-ponyfillGlobal.__MUI_RELEASE_INFO__ = 'MTU5NjMxOTIwMDAwMA=='; // 2020-08-02
+globalThis.__MUI_RELEASE_INFO__ = 'MTU5NjMxOTIwMDAwMA=='; // 2020-08-02


### PR DESCRIPTION
Follow-up on https://github.com/mui/mui-x/pull/17986.
Related to https://github.com/mui/material-ui/pull/45606.