### PR TITLE
[charts] Expose ChartApi through context

### DIFF
--- a/packages/x-charts-pro/src/ChartContainerPro/ChartProApi.ts
+++ b/packages/x-charts-pro/src/ChartContainerPro/ChartProApi.ts
@@ -20,6 +20,8 @@ type PluginsPerSeriesType = {
  * The API of the chart `apiRef` object.
  * The chart type can be passed as the first generic parameter to narrow down the API to the specific chart type.
  * @example ChartProApi<'bar'>
+ * If the chart is being created using composition, the `composition` value can be used.
+ * @example ChartProApi<'composition'>
  */
 export type ChartProApi<
   TSeries extends keyof PluginsPerSeriesType | undefined = undefined,

--- a/packages/x-charts-pro/src/context/useChartApiContext.ts
+++ b/packages/x-charts-pro/src/context/useChartApiContext.ts
@@ -6,7 +6,7 @@ import { ChartProApi } from '../ChartContainerPro';
  * This is only available when the chart is rendered within a chart or a `ChartDataProvider` component.
  * If you want to access the chart API outside those components, you should use the `apiRef` prop instead.
  * @example
- * const apiRef = useChartApiContext<ChartApi<'bar'>>();
+ * const apiRef = useChartApiContext<ChartProApi<'bar'>>();
  */
 export function useChartApiContext<Api extends ChartProApi>() {
   return useChartApiContextCommunity<Api>();

--- a/packages/x-charts-pro/src/context/useChartApiContext.ts
+++ b/packages/x-charts-pro/src/context/useChartApiContext.ts
@@ -3,9 +3,10 @@ import { ChartProApi } from '../ChartContainerPro';
 
 /**
  * The `useChartApiContext` hook provides access to the chart API.
- * It can be used to interact with the chart when rendering custom components that are descendants of the `ChartDataProvider` component.
+ * This is only available when the chart is rendered within a chart or a `ChartDataProvider` component.
+ * If you want to access the chart API outside those components, you should use the `apiRef` prop instead.
  * @example
- * const apiRef = useChartApiContext<ChartProApi<'bar'>>();
+ * const apiRef = useChartApiContext<ChartApi<'bar'>>();
  */
 export function useChartApiContext<Api extends ChartProApi = ChartProApi>() {
   return useChartApiContextCommunity<Api>();

--- a/packages/x-charts-pro/src/context/useChartApiContext.ts
+++ b/packages/x-charts-pro/src/context/useChartApiContext.ts
@@ -1,0 +1,12 @@
+import { useChartApiContext as useChartApiContextCommunity } from '@mui/x-charts/context';
+import { ChartProApi } from '../ChartContainerPro';
+
+/**
+ * The `useChartApiContext` hook provides access to the chart API.
+ * It can be used to interact with the chart when rendering custom components that are descendants of the `ChartDataProvider` component.
+ * @example
+ * const apiRef = useChartApiContext<ChartProApi<'bar'>>();
+ */
+export function useChartApiContext<Api extends ChartProApi = ChartProApi>() {
+  return useChartApiContextCommunity<Api>();
+}

--- a/packages/x-charts-pro/src/context/useChartApiContext.ts
+++ b/packages/x-charts-pro/src/context/useChartApiContext.ts
@@ -8,6 +8,6 @@ import { ChartProApi } from '../ChartContainerPro';
  * @example
  * const apiRef = useChartApiContext<ChartApi<'bar'>>();
  */
-export function useChartApiContext<Api extends ChartProApi = ChartProApi>() {
+export function useChartApiContext<Api extends ChartProApi>() {
   return useChartApiContextCommunity<Api>();
 }

--- a/packages/x-charts/src/ChartContainer/ChartContainer.tsx
+++ b/packages/x-charts/src/ChartContainer/ChartContainer.tsx
@@ -1,19 +1,46 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { PieChartPluginSignatures } from '../PieChart/PieChart.plugins';
+import { BarChartPluginsSignatures } from '../BarChart/BarChart.plugins';
+import { ScatterChartPluginsSignatures } from '../ScatterChart/ScatterChart.plugins';
+import { LineChartPluginsSignatures } from '../LineChart/LineChart.plugins';
 import { ChartSeriesType } from '../models/seriesType/config';
 import { ChartDataProvider, ChartDataProviderProps } from '../ChartDataProvider';
 import { useChartContainerProps } from './useChartContainerProps';
 import { ChartsSurface, ChartsSurfaceProps } from '../ChartsSurface';
-import { AllPluginSignatures } from '../internals/plugins/allPlugins';
+import { AllPluginSignatures, DefaultPluginSignatures } from '../internals/plugins/allPlugins';
 import { ChartAnyPluginSignature } from '../internals/plugins/models/plugin';
+import { ChartPublicAPI } from '../internals/plugins/models';
 
 export type ChartContainerProps<
   SeriesType extends ChartSeriesType = ChartSeriesType,
   TSignatures extends readonly ChartAnyPluginSignature[] = AllPluginSignatures<SeriesType>,
 > = Omit<ChartDataProviderProps<SeriesType, TSignatures>, 'children'> & ChartsSurfaceProps;
 
-export type ChartApi = NonNullable<NonNullable<ChartContainerProps['apiRef']>['current']>;
+type PluginsPerSeriesType = {
+  line: LineChartPluginsSignatures;
+  scatter: ScatterChartPluginsSignatures;
+  bar: BarChartPluginsSignatures;
+  pie: PieChartPluginSignatures;
+  /* Special value when creating a chart using composition. */
+  composition: DefaultPluginSignatures;
+};
+
+/**
+ * The API of the chart `apiRef` object.
+ * The chart type can be passed as the first generic parameter to narrow down the API to the specific chart type.
+ * @example ChartApi<'bar'>
+ * If the chart is being created using composition, the `composition` value can be used.
+ * @example ChartApi<'composition'>
+ */
+export type ChartApi<
+  TSeries extends keyof PluginsPerSeriesType | undefined = undefined,
+  TSignatures extends
+    readonly ChartAnyPluginSignature[] = TSeries extends keyof PluginsPerSeriesType
+    ? PluginsPerSeriesType[TSeries]
+    : AllPluginSignatures,
+> = ChartPublicAPI<TSignatures>;
 
 /**
  * It sets up the data providers as well as the `<svg>` for the chart.

--- a/packages/x-charts/src/context/index.ts
+++ b/packages/x-charts/src/context/index.ts
@@ -4,3 +4,4 @@ export type {
   HighlightItemData,
   HighlightOptions,
 } from '../internals/plugins/featurePlugins/useChartHighlight';
+export * from './useChartApiContext';

--- a/packages/x-charts/src/context/useChartApiContext.ts
+++ b/packages/x-charts/src/context/useChartApiContext.ts
@@ -1,3 +1,6 @@
+'use client';
+
+import * as React from 'react';
 import { ChartApi } from '../ChartContainer';
 import { useChartContext } from './ChartProvider';
 
@@ -10,8 +13,13 @@ type PluginSignaturesFromApi<Api> =
  * @example
  * const apiRef = useChartApiContext<ChartApi<'bar'>>();
  */
-export function useChartApiContext<Api extends ChartApi = ChartApi>(): Api {
+export function useChartApiContext<Api extends ChartApi = ChartApi>() {
   const { publicAPI } = useChartContext<PluginSignaturesFromApi<Api>>();
+  const apiRef = React.useRef<Api>(publicAPI as unknown as Api);
 
-  return publicAPI as Api;
+  React.useEffect(() => {
+    apiRef.current = publicAPI as unknown as Api;
+  }, [publicAPI]);
+
+  return apiRef;
 }

--- a/packages/x-charts/src/context/useChartApiContext.ts
+++ b/packages/x-charts/src/context/useChartApiContext.ts
@@ -9,7 +9,8 @@ type PluginSignaturesFromApi<Api> =
 
 /**
  * The `useChartApiContext` hook provides access to the chart API.
- * It can be used to interact with the chart when rendering custom components that are descendants of the `ChartDataProvider` component.
+ * This is only available when the chart is rendered within a chart or a `ChartDataProvider` component.
+ * If you want to access the chart API outside those components, you should use the `apiRef` prop instead.
  * @example
  * const apiRef = useChartApiContext<ChartApi<'bar'>>();
  */

--- a/packages/x-charts/src/context/useChartApiContext.ts
+++ b/packages/x-charts/src/context/useChartApiContext.ts
@@ -14,7 +14,7 @@ type PluginSignaturesFromApi<Api> =
  * @example
  * const apiRef = useChartApiContext<ChartApi<'bar'>>();
  */
-export function useChartApiContext<Api extends ChartApi = ChartApi>() {
+export function useChartApiContext<Api extends ChartApi>() {
   const { publicAPI } = useChartContext<PluginSignaturesFromApi<Api>>();
   const apiRef = React.useRef<Api>(publicAPI as unknown as Api);
 

--- a/packages/x-charts/src/context/useChartApiContext.ts
+++ b/packages/x-charts/src/context/useChartApiContext.ts
@@ -1,0 +1,17 @@
+import { ChartApi } from '../ChartContainer';
+import { useChartContext } from './ChartProvider';
+
+type PluginSignaturesFromApi<Api> =
+  Api extends ChartApi<any, infer TSignatures> ? TSignatures : never;
+
+/**
+ * The `useChartApiContext` hook provides access to the chart API.
+ * It can be used to interact with the chart when rendering custom components that are descendants of the `ChartDataProvider` component.
+ * @example
+ * const apiRef = useChartApiContext<ChartApi<'bar'>>();
+ */
+export function useChartApiContext<Api extends ChartApi = ChartApi>(): Api {
+  const { publicAPI } = useChartContext<PluginSignaturesFromApi<Api>>();
+
+  return publicAPI as Api;
+}

--- a/packages/x-charts/src/internals/plugins/allPlugins.ts
+++ b/packages/x-charts/src/internals/plugins/allPlugins.ts
@@ -22,6 +22,14 @@ export type AllPluginSignatures<TSeries extends ChartSeriesType = ChartSeriesTyp
   UseChartVoronoiSignature,
 ];
 
+export type DefaultPluginSignatures<TSeries extends ChartSeriesType = ChartSeriesType> = [
+  UseChartZAxisSignature,
+  UseChartCartesianAxisSignature<TSeries>,
+  UseChartInteractionSignature,
+  UseChartHighlightSignature,
+  UseChartVoronoiSignature,
+];
+
 export const DEFAULT_PLUGINS = [
   useChartZAxis,
   useChartCartesianAxis,

--- a/scripts/x-charts-pro.exports.json
+++ b/scripts/x-charts-pro.exports.json
@@ -423,6 +423,7 @@
   { "name": "useBarSeriesContext", "kind": "Function" },
   { "name": "UseBarSeriesContextReturnValue", "kind": "TypeAlias" },
   { "name": "UseBarSeriesReturnValue", "kind": "TypeAlias" },
+  { "name": "useChartApiContext", "kind": "Function" },
   { "name": "useChartGradientId", "kind": "Function" },
   { "name": "useChartGradientIdObjectBound", "kind": "Function" },
   { "name": "useChartId", "kind": "Function" },

--- a/scripts/x-charts.exports.json
+++ b/scripts/x-charts.exports.json
@@ -381,6 +381,7 @@
   { "name": "useBarSeriesContext", "kind": "Function" },
   { "name": "UseBarSeriesContextReturnValue", "kind": "TypeAlias" },
   { "name": "UseBarSeriesReturnValue", "kind": "TypeAlias" },
+  { "name": "useChartApiContext", "kind": "Function" },
   { "name": "useChartGradientId", "kind": "Function" },
   { "name": "useChartGradientIdObjectBound", "kind": "Function" },
   { "name": "useChartId", "kind": "Function" },


### PR DESCRIPTION
Expose `ChartApi` through context so that descendants of `ChartDataProvider` can access it without having to pass `apiRef` as props. 

I tried to make the API similar to the [Data Grid's](https://mui.com/x/react-data-grid/api-object/#inside-the-data-grid):

Data Grid:
```tsx
function CustomFooter() {
  const apiRef = useGridApiContext();

  return <Button onClick={() => apiRef.current.setPage(1)}>Go to page 1</Button>;
}
```

Charts:
```tsx
function ResetZoomButton(props) {
  const apiRef = useChartApiContext();

  return (
    <ToolbarButton
      {...props}
      onClick={() => {
        apiRef.current.setZoomData((prev) =>
          prev.map((zoom) => ({ ...zoom, start: 0, end: 100 })),
        );
      }}
      render={<Button />}
    />
  );
}
```

This PR doesn't have an example usage. That will be added in this [PR instead](https://github.com/mui/mui-x/pull/17649). I'm only creating this PR to reduce the number of changes from the other one.