### PR TITLE
[charts-pro] Show axis value in zoom slider tooltip

### DIFF
--- a/docs/data/charts/zoom-and-pan/ZoomSlider.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSlider.js
@@ -1,7 +1,7 @@
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import * as React from 'react';
 
-const dataLength = 800;
+const dataLength = 801;
 const data = Array.from({ length: dataLength }).map((_, i) => ({
   x: i,
   y: 50 + Math.sin(i / 5) * 25,

--- a/docs/data/charts/zoom-and-pan/ZoomSlider.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSlider.tsx
@@ -1,7 +1,7 @@
 import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
 import * as React from 'react';
 
-const dataLength = 800;
+const dataLength = 801;
 const data = Array.from({ length: dataLength }).map((_, i) => ({
   x: i,
   y: 50 + Math.sin(i / 5) * 25,

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
@@ -349,7 +349,7 @@ function getZoomSliderTooltipsText(axis: ComputedAxis, drawingArea: ChartDrawing
     [start, end] = [end, start]; // Reverse the start and end if the axis is reversed
   }
 
-  const startValue = invertScale(axis.scale, axis.data ?? [], start) ?? axis.data?.[0];
+  const startValue = invertScale(axis.scale, axis.data ?? [], start) ?? axis.data?.at(0);
   const endValue = invertScale(axis.scale, axis.data ?? [], end) ?? axis.data?.at(-1);
 
   const tooltipStart = formatValue(startValue);

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
@@ -345,6 +345,10 @@ function getZoomSliderTooltipsText(axis: ComputedAxis, drawingArea: ChartDrawing
     [start, end] = [end, start]; // Invert for y-axis
   }
 
+  if (axis.reverse) {
+    [start, end] = [end, start]; // Reverse the start and end if the axis is reversed
+  }
+
   const startValue = invertScale(axis.scale, axis.data ?? [], start) ?? axis.data?.[0];
   const endValue = invertScale(axis.scale, axis.data ?? [], end) ?? axis.data?.at(-1);
 

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -52,6 +52,7 @@ export * from './consumeSlots';
 export * from './consumeThemeProps';
 export * from './defaultizeMargin';
 export * from './dateHelpers';
+export * from './invertScale';
 
 // contexts
 export { getAxisExtremum } from './plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum';

--- a/packages/x-charts/src/internals/invertScale.ts
+++ b/packages/x-charts/src/internals/invertScale.ts
@@ -1,0 +1,15 @@
+import { D3Scale } from '../models/axis';
+import { isBandScale } from './isBandScale';
+
+export function invertScale<T>(scale: D3Scale, data: readonly T[], value: number) {
+  if (isBandScale(scale)) {
+    const dataIndex =
+      scale.bandwidth() === 0
+        ? Math.floor((value - Math.min(...scale.range()) + scale.step() / 2) / scale.step())
+        : Math.floor((value - Math.min(...scale.range())) / scale.step());
+
+    return data[dataIndex];
+  }
+
+  return scale.invert(value);
+}

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
@@ -185,6 +185,11 @@ export const selectorChartYAxis = createSelector(
     }),
 );
 
+export const selectorChartAxis = createSelector(
+  [selectorChartXAxis, selectorChartYAxis, (_, axisId: AxisId) => axisId],
+  (xAxes, yAxes, axisId) => xAxes?.axis[axisId] ?? yAxes?.axis[axisId],
+);
+
 export const selectorChartRawAxis = createSelector(
   [selectorChartRawXAxis, selectorChartRawYAxis, (state, axisId: AxisId) => axisId],
   (xAxes, yAxes, axisId) => {

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -324,8 +324,9 @@ export type AxisValueFormatterContext<S extends ScaleName = ScaleName> =
        * - `'tick'` The value is displayed on the axis ticks.
        * - `'tooltip'` The value is displayed in the tooltip when hovering the chart.
        * - `'legend'` The value is displayed in the legend when using color legend.
+       * - `'zoom-slider-tooltip'` The value is displayed in the zoom slider tooltip.
        */
-      location: 'legend';
+      location: 'legend' | 'zoom-slider-tooltip';
     }
   | {
       /**


### PR DESCRIPTION
Show axis value in zoom slider tooltip instead of a value 0-100. 

I had misunderstood the designs and we were never meant to show a range 0-100, so this PR is fixing that issue. 

https://github.com/user-attachments/assets/53acddf3-0ac4-404b-958c-019b259bb155

