### PR TITLE
[charts] Add a default value formatter for continuous scales

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
@@ -330,7 +330,7 @@ export function ChartAxisZoomSliderActiveTrack({
 function getZoomSliderTooltipsText(axis: ComputedAxis, drawingArea: ChartDrawingArea) {
   const formatValue = (value: Date | number | null) => {
     if (axis.valueFormatter) {
-      return axis.valueFormatter(value, { location: 'zoom-slider-tooltip' });
+      return axis.valueFormatter(value, { location: 'zoom-slider-tooltip', scale: axis.scale });
     }
 
     return `${value}`;

--- a/packages/x-charts/src/internals/defaultValueFormatters.ts
+++ b/packages/x-charts/src/internals/defaultValueFormatters.ts
@@ -1,0 +1,21 @@
+import { AxisValueFormatterContext, ContinuousScaleName } from '../models/axis';
+
+/**
+ * Creates a default formatter function for continuous scales (e.g., linear, sqrt, log).
+ * @returns A formatter function for continuous values.
+ */
+export function createScalarFormatter<
+  S extends ContinuousScaleName = ContinuousScaleName,
+  V extends any = any,
+>(tickNumber: number) {
+  return function defaultScalarValueFormatter(
+    value: V,
+    context: AxisValueFormatterContext<S>,
+  ): string {
+    if (context.location === 'tick' || context.location === 'zoom-slider-tooltip') {
+      return context.scale.tickFormat(tickNumber)(value);
+    }
+
+    return `${value}`;
+  };
+}

--- a/packages/x-charts/src/internals/defaultValueFormatters.ts
+++ b/packages/x-charts/src/internals/defaultValueFormatters.ts
@@ -1,18 +1,18 @@
-import { AxisValueFormatterContext, ContinuousScaleName } from '../models/axis';
+import { AxisValueFormatterContext, ScaleName } from '../models/axis';
 
 /**
  * Creates a default formatter function for continuous scales (e.g., linear, sqrt, log).
  * @returns A formatter function for continuous values.
  */
-export function createScalarFormatter<
-  S extends ContinuousScaleName = ContinuousScaleName,
-  V extends any = any,
->(tickNumber: number) {
-  return function defaultScalarValueFormatter(
-    value: V,
+export function createScalarFormatter(tickNumber: number) {
+  return function defaultScalarValueFormatter<S extends ScaleName = ScaleName>(
+    value: any,
     context: AxisValueFormatterContext<S>,
   ): string {
-    if (context.location === 'tick' || context.location === 'zoom-slider-tooltip') {
+    if (
+      (context.location === 'tick' || context.location === 'zoom-slider-tooltip') &&
+      'tickFormat' in context.scale
+    ) {
       return context.scale.tickFormat(tickNumber)(value);
     }
 

--- a/packages/x-charts/src/internals/defaultValueFormatters.ts
+++ b/packages/x-charts/src/internals/defaultValueFormatters.ts
@@ -1,12 +1,10 @@
-import { AxisValueFormatterContext, ContinuousScaleName } from '../models/axis';
-
-const numberFormatter = new Intl.NumberFormat(undefined, { maximumSignificantDigits: 2 });
+import { AxisValueFormatterContext, ContinuousScaleName, D3ContinuousScale } from '../models/axis';
 
 /**
  * Creates a default formatter function for continuous scales (e.g., linear, sqrt, log).
  * @returns A formatter function for continuous values.
  */
-export function createScalarFormatter(tickNumber: number) {
+export function createScalarFormatter(tickNumber: number, zoomScale: D3ContinuousScale) {
   return function defaultScalarValueFormatter<S extends ContinuousScaleName = ContinuousScaleName>(
     value: any,
     context: AxisValueFormatterContext<S>,
@@ -15,8 +13,8 @@ export function createScalarFormatter(tickNumber: number) {
       return context.scale.tickFormat(tickNumber)(value);
     }
 
-    if (context.location === 'zoom-slider-tooltip' && typeof value === 'number') {
-      return numberFormatter.format(value);
+    if (context.location === 'zoom-slider-tooltip') {
+      return zoomScale.tickFormat(2)(value);
     }
 
     return `${value}`;

--- a/packages/x-charts/src/internals/defaultValueFormatters.ts
+++ b/packages/x-charts/src/internals/defaultValueFormatters.ts
@@ -1,19 +1,22 @@
-import { AxisValueFormatterContext, ScaleName } from '../models/axis';
+import { AxisValueFormatterContext, ContinuousScaleName } from '../models/axis';
+
+const numberFormatter = new Intl.NumberFormat(undefined, { maximumSignificantDigits: 2 });
 
 /**
  * Creates a default formatter function for continuous scales (e.g., linear, sqrt, log).
  * @returns A formatter function for continuous values.
  */
 export function createScalarFormatter(tickNumber: number) {
-  return function defaultScalarValueFormatter<S extends ScaleName = ScaleName>(
+  return function defaultScalarValueFormatter<S extends ContinuousScaleName = ContinuousScaleName>(
     value: any,
     context: AxisValueFormatterContext<S>,
   ): string {
-    if (
-      (context.location === 'tick' || context.location === 'zoom-slider-tooltip') &&
-      'tickFormat' in context.scale
-    ) {
+    if (context.location === 'tick') {
       return context.scale.tickFormat(tickNumber)(value);
+    }
+
+    if (context.location === 'zoom-slider-tooltip' && typeof value === 'number') {
+      return numberFormatter.format(value);
     }
 
     return `${value}`;

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -212,7 +212,14 @@ export function computeAxisValue<T extends ChartSeriesType>({
       colorScale: axis.colorMap && getColorScale(axis.colorMap),
       valueFormatter:
         axis.valueFormatter ??
-        (createScalarFormatter(tickNumber) as <TScaleName extends ScaleName>(
+        (createScalarFormatter(
+          tickNumber,
+          getScale(
+            scaleType,
+            range.map((v) => scale.invert(v)),
+            range,
+          ),
+        ) as <TScaleName extends ScaleName>(
           value: any,
           context: AxisValueFormatterContext<TScaleName>,
         ) => string),

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -11,6 +11,7 @@ import {
   DefaultedXAxis,
   DefaultedYAxis,
   DefaultedAxis,
+  AxisValueFormatterContext,
 } from '../../../../models/axis';
 import { CartesianChartSeriesType, ChartSeriesType } from '../../../../models/seriesType/config';
 import { getColorScale, getOrdinalColorScale } from '../../../colorScale';
@@ -209,7 +210,12 @@ export function computeAxisValue<T extends ChartSeriesType>({
       scale: finalScale.domain(domain) as any,
       tickNumber,
       colorScale: axis.colorMap && getColorScale(axis.colorMap),
-      valueFormatter: axis.valueFormatter ?? createScalarFormatter(tickNumber),
+      valueFormatter:
+        axis.valueFormatter ??
+        (createScalarFormatter(tickNumber) as <TScaleName extends ScaleName>(
+          value: any,
+          context: AxisValueFormatterContext<TScaleName>,
+        ) => string),
     };
   });
   return {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -1,4 +1,5 @@
 import { scaleBand, scalePoint } from '@mui/x-charts-vendor/d3-scale';
+import { createScalarFormatter } from '../../../defaultValueFormatters';
 import { AxisConfig, ScaleName } from '../../../../models';
 import {
   ChartsXAxisProps,
@@ -208,6 +209,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
       scale: finalScale.domain(domain) as any,
       tickNumber,
       colorScale: axis.colorMap && getColorScale(axis.colorMap),
+      valueFormatter: axis.valueFormatter ?? createScalarFormatter(tickNumber),
     };
   });
   return {

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -326,7 +326,7 @@ export type AxisValueFormatterContext<S extends ScaleName = ScaleName> =
        * - `'legend'` The value is displayed in the legend when using color legend.
        * - `'zoom-slider-tooltip'` The value is displayed in the zoom slider tooltip.
        */
-      location: 'legend' | 'zoom-slider-tooltip';
+      location: 'legend';
     }
   | {
       /**
@@ -334,8 +334,9 @@ export type AxisValueFormatterContext<S extends ScaleName = ScaleName> =
        * - `'tick'` The value is displayed on the axis ticks.
        * - `'tooltip'` The value is displayed in the tooltip when hovering the chart.
        * - `'legend'` The value is displayed in the legend when using color legend.
+       * - `'zoom-slider-tooltip'` The value is displayed in the zoom slider tooltip.
        */
-      location: 'tick' | 'tooltip';
+      location: 'tick' | 'tooltip' | 'zoom-slider-tooltip';
       /**
        * The d3-scale instance associated to the axis.
        */


### PR DESCRIPTION

Follow-up to https://github.com/mui/mui-x/pull/18054. 
Fixes https://github.com/mui/mui-x/issues/18022.

Add a default value formatter for continuous scales. 



