### PR TITLE
[charts] Fix responsive height for ChartsWrapper

### DIFF
--- a/packages/x-charts/src/internals/components/ChartsWrapper/ChartsWrapper.tsx
+++ b/packages/x-charts/src/internals/components/ChartsWrapper/ChartsWrapper.tsx
@@ -58,6 +58,7 @@ const Root = styled('div', {
   slot: 'Root',
 })<{ ownerState: ChartsWrapperProps }>(({ ownerState }) => ({
   display: 'flex',
+  height: '100%',
   flexDirection: getDirection(ownerState.legendDirection, ownerState.legendPosition),
   flex: 1,
   justifyContent: 'center',


### PR DESCRIPTION
Fix #17985


The before/after.

From top to bottom:

- Funnel chart
- Bar chart
- Chart Container + BarPlot

![image](https://github.com/user-attachments/assets/efb14a70-f23a-46a8-b63c-d0d89f0a7731)

![image](https://github.com/user-attachments/assets/e5485fb8-38fc-4add-bb03-b2404ef70359)
