### PR TITLE
[infra] Use `playwright` docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,9 @@ jobs:
           playwright: true
           react-version: << parameters.react-version >>
       - run:
+          name: Install ffmpeg
+          command: apt update && apt upgrade -y && apt install ffmpeg -y
+      - run:
           name: Run visual regression tests
           command: xvfb-run pnpm test:regressions
       - run:


### PR DESCRIPTION
Revert changes introduced in https://github.com/mui/mui-x/pull/17214, since we no longer use mocha and tests work on vitest with Node 22.

Allowed by https://github.com/mui/mui-x/pull/18071.

This should hopefully avoid the insanely flaky CI lately. 🙈 