### PR TITLE
[code-infra] Use vitest for `no-direct-state-access` tests

### DIFF
--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -10,7 +10,7 @@
     "@typescript-eslint/utils": "^8.33.0"
   },
   "scripts": {
-    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/eslint-plugin-material-ui/**/*.test.js' --timeout 3000"
+    "test": "vitest"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin-material-ui/src/rules/no-direct-state-access.test.ts
+++ b/packages/eslint-plugin-material-ui/src/rules/no-direct-state-access.test.ts
@@ -1,18 +1,13 @@
-// The polyfill of `import.meta.url` used in @eslint/eslintrc tests the presence
-// of `document` to detect if it's on node or web. However, JSDOM sets `document`
-// so it thinks it's on the web and can't import correctly other modules.
-// The workaround here resets the `document` to make it detect that it's on node.
-// It can removed once this repo became an ESM package.
-const originalDocument = global.document;
-global.document = undefined;
+import { afterAll, it, describe } from 'vitest';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import TSESlintParser from '@typescript-eslint/parser';
+import rule from './no-direct-state-access';
+import path from 'node:path';
 
-const path = require('path');
-const mocha = require('mocha');
-const { RuleTester } = require('@typescript-eslint/rule-tester');
-const TSESlintParser = require('@typescript-eslint/parser');
-const rule = require('./no-direct-state-access');
-
-RuleTester.afterAll = mocha.after;
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.describe = describe;
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -76,5 +71,3 @@ const useCustomHook = () => {
     },
   ],
 });
-
-global.document = originalDocument;

--- a/packages/eslint-plugin-material-ui/tsconfig.json
+++ b/packages/eslint-plugin-material-ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/eslint-plugin-material-ui/vitest.config.mts
+++ b/packages/eslint-plugin-material-ui/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
@mui/code-infra Should I make these tests run on ci with the other tests? I don't think they were being used before 🤔

This is in the step to remove mocha