### PR TITLE
[infra] Add Scheduler as an option to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -30,6 +30,7 @@ body:
         - Date and Time Pickers
         - Charts
         - Tree View
+        - Scheduler
   - type: textarea
     attributes:
       label: Steps to reproduce


### PR DESCRIPTION
this was missing in the bug template.
If we don't want to include this yet we can close this and add it in at a later time.