### PR TITLE
[scheduler] Add temporary dark mode styles (view switcher) and standalone week view demo

### DIFF
--- a/docs/data/scheduler/event-calendar/StandaloneWeekView.js
+++ b/docs/data/scheduler/event-calendar/StandaloneWeekView.js
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { DateTime } from 'luxon';
+
+import { WeekView } from '@mui/x-scheduler/joy/week-view';
+import classes from './StandaloneWeekView.module.css';
+
+const events = [
+  {
+    id: '1',
+    start: DateTime.fromISO('2025-05-26T07:30:00'),
+    end: DateTime.fromISO('2025-05-26T08:15:00'),
+    title: 'Footing',
+  },
+  {
+    id: '2',
+    start: DateTime.fromISO('2025-05-26T16:00:00'),
+    end: DateTime.fromISO('2025-05-26T17:00:00'),
+    title: 'Weekly',
+  },
+  {
+    id: '3',
+    start: DateTime.fromISO('2025-05-27T10:00:00'),
+    end: DateTime.fromISO('2025-05-27T11:00:00'),
+    title: 'Backlog grooming',
+  },
+  {
+    id: '4',
+    start: DateTime.fromISO('2025-05-27T19:00:00'),
+    end: DateTime.fromISO('2025-05-27T22:00:00'),
+    title: 'Pizza party',
+  },
+  {
+    id: '5',
+    start: DateTime.fromISO('2025-05-28T08:00:00'),
+    end: DateTime.fromISO('2025-05-28T17:00:00'),
+    title: 'Scheduler deep dive',
+  },
+  {
+    id: '1',
+    start: DateTime.fromISO('2025-05-29T07:30:00'),
+    end: DateTime.fromISO('2025-05-29T08:15:00'),
+    title: 'Footing',
+  },
+  {
+    id: '1',
+    start: DateTime.fromISO('2025-05-30T15:00:00'),
+    end: DateTime.fromISO('2025-05-30T15:45:00'),
+    title: 'Retrospective',
+  },
+];
+
+export default function StandaloneWeekView() {
+  return <WeekView events={events} className={classes.Container} />;
+}

--- a/docs/data/scheduler/event-calendar/StandaloneWeekView.module.css
+++ b/docs/data/scheduler/event-calendar/StandaloneWeekView.module.css
@@ -1,0 +1,3 @@
+.Container {
+  height: 400px;
+}

--- a/docs/data/scheduler/event-calendar/StandaloneWeekView.tsx
+++ b/docs/data/scheduler/event-calendar/StandaloneWeekView.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { DateTime } from 'luxon';
+import { CalendarEvent } from '@mui/x-scheduler/joy';
+import { WeekView } from '@mui/x-scheduler/joy/week-view';
+import classes from './StandaloneWeekView.module.css';
+
+const events: CalendarEvent[] = [
+  {
+    id: '1',
+    start: DateTime.fromISO('2025-05-26T07:30:00'),
+    end: DateTime.fromISO('2025-05-26T08:15:00'),
+    title: 'Footing',
+  },
+  {
+    id: '2',
+    start: DateTime.fromISO('2025-05-26T16:00:00'),
+    end: DateTime.fromISO('2025-05-26T17:00:00'),
+    title: 'Weekly',
+  },
+  {
+    id: '3',
+    start: DateTime.fromISO('2025-05-27T10:00:00'),
+    end: DateTime.fromISO('2025-05-27T11:00:00'),
+    title: 'Backlog grooming',
+  },
+  {
+    id: '4',
+    start: DateTime.fromISO('2025-05-27T19:00:00'),
+    end: DateTime.fromISO('2025-05-27T22:00:00'),
+    title: 'Pizza party',
+  },
+  {
+    id: '5',
+    start: DateTime.fromISO('2025-05-28T08:00:00'),
+    end: DateTime.fromISO('2025-05-28T17:00:00'),
+    title: 'Scheduler deep dive',
+  },
+  {
+    id: '1',
+    start: DateTime.fromISO('2025-05-29T07:30:00'),
+    end: DateTime.fromISO('2025-05-29T08:15:00'),
+    title: 'Footing',
+  },
+  {
+    id: '1',
+    start: DateTime.fromISO('2025-05-30T15:00:00'),
+    end: DateTime.fromISO('2025-05-30T15:45:00'),
+    title: 'Retrospective',
+  },
+];
+
+export default function StandaloneWeekView() {
+  return <WeekView events={events} className={classes.Container} />;
+}

--- a/docs/data/scheduler/event-calendar/StandaloneWeekView.tsx.preview
+++ b/docs/data/scheduler/event-calendar/StandaloneWeekView.tsx.preview
@@ -1,0 +1,1 @@
+<WeekView events={events} className={classes.Container} />

--- a/docs/data/scheduler/event-calendar/event-calendar.md
+++ b/docs/data/scheduler/event-calendar/event-calendar.md
@@ -29,7 +29,7 @@ TODO: Add a demo of a standalone `<DayView />` when available.
 
 ### Week
 
-TODO: Add a demo of a standalone `<WeekView />` when available.
+{{"demo": "StandaloneWeekView.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ### Month
 

--- a/packages/x-scheduler/src/joy/header-toolbar/HeaderToolbar.css
+++ b/packages/x-scheduler/src/joy/header-toolbar/HeaderToolbar.css
@@ -2,10 +2,12 @@
 
 .HeaderToolbarContainer {
   --toolbar-text: var(--gray-9);
+  --toolbar-base-bg: var(--surface);
 }
 
 .mode-dark .HeaderToolbarContainer {
   --toolbar-text: var(--gray-2);
+  --toolbar-base-bg: var(--gray-9);
 }
 
 .HeaderToolbarContainer {
@@ -21,7 +23,7 @@
 
 .HeaderToolbarButton {
   border: 0;
-  background: var(--surface);
+  background: var(--toolbar-base-bg);
   user-select: none;
   padding: var(--space-3) var(--space-4);
   color: var(--toolbar-text);

--- a/packages/x-scheduler/src/joy/header-toolbar/view-switcher/ViewSwitcher.css
+++ b/packages/x-scheduler/src/joy/header-toolbar/view-switcher/ViewSwitcher.css
@@ -16,7 +16,7 @@
   min-width: 190px;
   padding: var(--space-2);
   border-radius: var(--radius-4);
-  background-color: var(--surface);
+  background-color: var(--toolbar-base-bg);
   outline: 1px solid var(--gray-2);
   box-shadow: var(--shadow-5);
 }
@@ -29,7 +29,7 @@
 
 .ViewSwitcherMainItem {
   border: 0;
-  background: var(--surface);
+  background: var(--toolbar-base-bg);
   user-select: none;
   display: flex;
   align-items: center;

--- a/packages/x-scheduler/src/joy/week-view/WeekView.tsx
+++ b/packages/x-scheduler/src/joy/week-view/WeekView.tsx
@@ -52,7 +52,7 @@ export const WeekView = React.forwardRef(function WeekView(
   }, [events]);
 
   return (
-    <div ref={forwardedRef} className={clsx('WeekViewContainer', className)} {...other}>
+    <div ref={forwardedRef} className={clsx('WeekViewContainer', 'joy', className)} {...other}>
       <TimeGrid.Root className="WeekViewRoot">
         <div ref={headerWrapperRef} className="WeekViewHeader">
           <div className="WeekViewGridRow WeekViewHeaderRow" role="row">


### PR DESCRIPTION
 - Added temporary dark mode styles for the View Switcher to prevent it from looking broken until the final design is ready.
<img width="496" alt="Screenshot 2025-06-04 at 09 43 29" src="https://github.com/user-attachments/assets/70271ce2-2ae5-47cb-b50c-db0b90089d65" />


- Added missing Standalone Week View to the docs.
<img width="1066" alt="Screenshot 2025-06-04 at 09 56 16" src="https://github.com/user-attachments/assets/75543ffe-4786-4046-9e25-e15d5c5ba7e4" />

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
