### PR TITLE
[data grid][docs] Update `valueFormatter` signature in migration guide

### DIFF
--- a/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
+++ b/docs/data/migration/migration-data-grid-v6/migration-data-grid-v6.md
@@ -276,7 +276,7 @@ See the [Direct state access](/x/react-data-grid/state/#direct-selector-access) 
 - The signature of `GridColDef['valueFormatter']` has been changed for performance reasons:
 
   ```diff
-  -valueFormatter: ({ value }) => value,
+  -valueFormatter: ({ value, row, column, apiRef }) => value,
   +valueFormatter: (value, row, column, apiRef) => value,
   ```
 


### PR DESCRIPTION
Fixes #16895 

The description was not wrong, but I get the point that some devs might be confused by the previous example.