### PR TITLE
[DataGrid][charts] Remove sx prop merging from `useComponentRenderer`

### DIFF
--- a/packages/x-internals/src/useComponentRenderer/useComponentRenderer.test.tsx
+++ b/packages/x-internals/src/useComponentRenderer/useComponentRenderer.test.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen } from '@mui/internal-test-utils';
-import Box, { BoxProps } from '@mui/material/Box';
-import { testSkipIf } from 'test/utils/skipIf';
 import { RenderProp, useComponentRenderer } from './useComponentRenderer';
-
-const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('useComponentRenderer', () => {
   const { render } = createRenderer();
@@ -97,26 +93,5 @@ describe('useComponentRenderer', () => {
       'style',
       'color: blue; outline: blue solid 1px; background-color: blue;',
     );
-  });
-
-  // Doesn't work with mocked window.getComputedStyle
-  testSkipIf(isJSDOM)('should merge sx props', () => {
-    function TestComponentWithSxProp(
-      props: BoxProps & { render?: RenderProp<BoxProps, { someState: string }> },
-    ) {
-      const { render: renderProp, ...other } = props;
-      return useComponentRenderer(Box, renderProp, other as Omit<BoxProps, 'color'>);
-    }
-    render(
-      <TestComponentWithSxProp
-        data-testid="rendered-element"
-        sx={{ color: 'blue', outline: '1px solid red' }}
-        render={<Box sx={{ backgroundColor: 'blue', outline: 'blue solid 1px' }} />}
-      />,
-    );
-    const computedStyle = window.getComputedStyle(screen.getByTestId('rendered-element'));
-    expect(computedStyle.color).to.equal('rgb(0, 0, 255)');
-    expect(computedStyle.backgroundColor).to.equal('rgb(0, 0, 255)');
-    expect(computedStyle.outline).to.equal('rgb(0, 0, 255) solid 1px');
   });
 });

--- a/packages/x-internals/src/useComponentRenderer/useComponentRenderer.tsx
+++ b/packages/x-internals/src/useComponentRenderer/useComponentRenderer.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import type { SxProps } from '@mui/system';
 
 export type RenderProp<Props, State = {}> =
   | ((props: Props, state: State) => React.ReactElement<unknown>)
@@ -34,9 +33,6 @@ export function useComponentRenderer<
     if (render.props.style || props.style) {
       props.style = { ...props.style, ...render.props.style };
     }
-    if ((render.props as any).sx || (props as any).sx) {
-      (props as any).sx = mergeSx((props as any).sx, (render.props as any).sx);
-    }
     return React.cloneElement(render, props);
   }
 
@@ -49,11 +45,4 @@ function mergeClassNames(className: string | undefined, otherClassName: string |
   }
 
   return `${className} ${otherClassName}`;
-}
-
-function mergeSx(sx1: SxProps, sx2: SxProps) {
-  if (!sx1 || !sx2) {
-    return sx1 || sx2;
-  }
-  return (Array.isArray(sx1) ? sx1 : [sx1]).concat(Array.isArray(sx2) ? sx2 : [sx2]);
 }


### PR DESCRIPTION
First part of https://github.com/mui/mui-x/issues/18205.

Remove `sx` prop merging from `useComponentRenderer` as it isn't being used in the Data Grid nor Charts. If everything works well, then I'll go ahead and replace `useComponentRenderer` with Base UI's version in a follow-up PR.
