### PR TITLE
[DataGrid] Fix `registerPipeProcessor()` for Node v20

### DIFF
--- a/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
+++ b/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridPipeProcessing.ts
@@ -81,10 +81,8 @@ export const useGridPipeProcessing = (apiRef: RefObject<GridPrivateApiCommon>) =
       const oldProcessor = groupCache.processors.get(id);
       if (oldProcessor !== processor) {
         groupCache.processors.set(id, processor);
-        groupCache.processorsAsArray = Array.from(
-          cache.current[group]!.processors.values().filter(
-            (processorValue) => processorValue !== null,
-          ),
+        groupCache.processorsAsArray = Array.from(cache.current[group]!.processors.values()).filter(
+          (processorValue) => processorValue !== null,
         );
         runAppliers(groupCache);
       }
@@ -92,10 +90,8 @@ export const useGridPipeProcessing = (apiRef: RefObject<GridPrivateApiCommon>) =
       return () => {
         cache.current[group]!.processors.set(id, null);
         cache.current[group]!.processorsAsArray = Array.from(
-          cache.current[group]!.processors.values().filter(
-            (processorValue) => processorValue !== null,
-          ),
-        );
+          cache.current[group]!.processors.values(),
+        ).filter((processorValue) => processorValue !== null);
       };
     },
     [runAppliers],


### PR DESCRIPTION
Fixes regression added by https://github.com/mui/mui-x/pull/17558
On Node v20, `filter` does not exist on `MapIterator`