### PR TITLE
[DataGrid] Fix `onDataSourceError` being called on unmounted DataGrid

### DIFF
--- a/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
@@ -304,6 +304,33 @@ describeSkipIf(isJSDOM)('<DataGrid /> - Data source', () => {
         expect(onDataSourceError.callCount).to.equal(1);
       });
     });
+
+    it('should not call `onDataSourceError` after unmount', async () => {
+      const onDataSourceError = spy();
+      const { promise, reject } = Promise.withResolvers<GridGetRowsResponse>();
+      const getRows = spy(() => promise);
+      const dataSource: GridDataSource = {
+        getRows
+      };
+      const { unmount } = render(<div style={{ width: 300, height: 300 }}>
+        <DataGrid
+            columns={[{ field: 'id' }]}
+            dataSource={dataSource}
+            onDataSourceError={onDataSourceError}
+            initialState={{ pagination: { paginationModel: { page: 0, pageSize: 10 }, rowCount: 0 } }}
+            pagination
+            pageSizeOptions={pageSizeOptions}
+            disableVirtualization
+        />
+      </div>);
+      await waitFor(() => {
+        expect(getRows.called).to.equal(true);
+      });
+      unmount();
+      reject();
+      await promise.catch(() => 'rejected');
+      expect(onDataSourceError.notCalled).to.equal(true);
+    });
   });
 
   describe('Editing', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
