### PR TITLE
[charts][docs] Add some more context on Heatmap

### DIFF
--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -15,12 +15,16 @@ The first two numbers in each tuple correspond to the x and y indexes of the cel
 The third number is the value for the given cell.
 
 ```jsx
-series={[{
-    data: [
+<Heatmap
+  series={[
+    {
+      data: [
         [0, 2, 2.7], // Cell (0, 2) receives the value 2.7
         [1, 2, 4.5], // Cell (1, 2) receives the value 4.5
-    ]
-}]}
+      ],
+    },
+  ]}
+/>
 ```
 
 You can specify x and y ticks with the `xAxis` and `yAxis` props.


### PR DESCRIPTION
The previous demo was confusing, the first time I read it, beyond noticing the code style difference was not knowing what I was looking at. I imagine this is hard for an LLM to understand too.

Before:
<img width="879" alt="SCR-20250605-sszt" src="https://github.com/user-attachments/assets/636d5e9e-d818-4099-a385-51124bf63405" />

After:
<img width="846" alt="SCR-20250606-bidv" src="https://github.com/user-attachments/assets/72782248-272e-48c3-86b2-8e1703150334" />

Preview: https://deploy-preview-18256--material-ui-x.netlify.app/x/react-charts/heatmap/