### PR TITLE
[infra] Update github label references to use 'scope' instead of 'component' 

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -24,14 +24,14 @@ jobs:
     name: Benchmarks Charts
     runs-on: ubuntu-latest
     # L1: Run the benchmarks for pushes to the master or next branch and if the changes are in the charts package based on on.push.paths
-    # L2: Run the benchmarks if we add the label 'component: charts' to the pull request
-    # L3: Run the benchmarks for pull requests with the label 'component: charts'
+    # L2: Run the benchmarks if we add the label 'scope: charts' to the pull request
+    # L3: Run the benchmarks for pull requests with the label 'scope: charts'
     # Yaml syntax looks a little weird, but it is correct.
     if: >-
       ${{
           (github.event_name == 'push') ||
-          (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'component: charts') ||
-          (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'component: charts'))
+          (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'scope: charts') ||
+          (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'scope: charts'))
       }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docs/data/charts/composition/composition.md
+++ b/docs/data/charts/composition/composition.md
@@ -1,7 +1,7 @@
 ---
 title: React Chart composition
 productId: x-charts
-githubLabel: 'component: charts'
+githubLabel: 'scope: charts'
 components: ChartContainer, ChartContainerPro, ChartsGrid, ChartDataProvider, ChartDataProviderPro, ChartsSurface
 packageName: '@mui/x-charts'
 ---

--- a/docs/data/charts/gauge/gauge.md
+++ b/docs/data/charts/gauge/gauge.md
@@ -3,7 +3,7 @@ title: React Gauge chart
 productId: x-charts
 components: Gauge, GaugeContainer
 packageName: '@mui/x-charts'
-githubLabel: 'component: charts'
+githubLabel: 'scope: charts'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/meter/
 ---
 

--- a/docs/data/charts/overview/overview.md
+++ b/docs/data/charts/overview/overview.md
@@ -1,7 +1,7 @@
 ---
 title: React Charts
 productId: x-charts
-githubLabel: 'component: charts'
+githubLabel: 'scope: charts'
 packageName: '@mui/x-charts'
 ---
 

--- a/docs/data/charts/quickstart/quickstart.md
+++ b/docs/data/charts/quickstart/quickstart.md
@@ -1,6 +1,6 @@
 ---
 productId: x-charts
-githubLabel: 'component: charts'
+githubLabel: 'scope: charts'
 packageName: '@mui/x-charts'
 ---
 

--- a/docs/data/data-grid/components/ai-assistant-panel/ai-assistant-panel.md
+++ b/docs/data/data-grid/components/ai-assistant-panel/ai-assistant-panel.md
@@ -3,7 +3,7 @@ title: Data Grid - AI Assistant Panel component
 productId: x-data-grid
 components: AiAssistantPanelTrigger
 packageName: '@mui/x-data-grid-premium'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - AI Assistant Panel component [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') 🚧

--- a/docs/data/data-grid/components/columns-panel/columns-panel.md
+++ b/docs/data/data-grid/components/columns-panel/columns-panel.md
@@ -2,7 +2,7 @@
 productId: x-data-grid
 components: ColumnsPanelTrigger
 packageName: '@mui/x-data-grid'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Columns Panel component 🚧

--- a/docs/data/data-grid/components/export/export.md
+++ b/docs/data/data-grid/components/export/export.md
@@ -2,7 +2,7 @@
 productId: x-data-grid
 components: ExportPrint, ExportCsv, ExportExcel
 packageName: '@mui/x-data-grid'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Export component

--- a/docs/data/data-grid/components/filter-panel/filter-panel.md
+++ b/docs/data/data-grid/components/filter-panel/filter-panel.md
@@ -2,7 +2,7 @@
 productId: x-data-grid
 components: FilterPanelTrigger
 packageName: '@mui/x-data-grid'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Filter Panel component 🚧

--- a/docs/data/data-grid/components/pivot-panel/pivot-panel.md
+++ b/docs/data/data-grid/components/pivot-panel/pivot-panel.md
@@ -3,7 +3,7 @@ title: Data Grid - Pivot Panel component
 productId: x-data-grid
 components: PivotPanelTrigger
 packageName: '@mui/x-data-grid-premium'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Pivot Panel component [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan') 🚧

--- a/docs/data/data-grid/components/prompt-field/prompt-field.md
+++ b/docs/data/data-grid/components/prompt-field/prompt-field.md
@@ -3,7 +3,7 @@ title: Data Grid - Prompt Field component
 productId: x-data-grid
 components: PromptField, PromptFieldRecord, PromptFieldControl, PromptFieldSend
 packageName: '@mui/x-data-grid-premium'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Prompt Field component [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')

--- a/docs/data/data-grid/components/quick-filter/quick-filter.md
+++ b/docs/data/data-grid/components/quick-filter/quick-filter.md
@@ -2,7 +2,7 @@
 productId: x-data-grid
 components: QuickFilter, QuickFilterControl, QuickFilterClear, QuickFilterTrigger
 packageName: '@mui/x-data-grid'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Quick Filter component

--- a/docs/data/data-grid/components/toolbar/toolbar.md
+++ b/docs/data/data-grid/components/toolbar/toolbar.md
@@ -2,7 +2,7 @@
 productId: x-data-grid
 components: Toolbar, ToolbarButton
 packageName: '@mui/x-data-grid'
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 ---
 
 # Data Grid - Toolbar component

--- a/docs/data/data-grid/overview/overview.md
+++ b/docs/data/data-grid/overview/overview.md
@@ -1,6 +1,6 @@
 ---
 title: React Data Grid component
-githubLabel: 'component: data grid'
+githubLabel: 'scope: data grid'
 packageName: '@mui/x-data-grid'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/grid/
 ---

--- a/docs/data/date-pickers/accessibility/accessibility.md
+++ b/docs/data/date-pickers/accessibility/accessibility.md
@@ -1,7 +1,7 @@
 ---
 productId: x-date-pickers
 title: Date and Time Pickers - Accessibility
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/adapters-locale/adapters-locale.md
+++ b/docs/data/date-pickers/adapters-locale/adapters-locale.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Pickers - Date format and localization
 components: LocalizationProvider
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Picker - Base concepts
 packageName: '@mui/x-date-pickers'
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
 ---

--- a/docs/data/date-pickers/calendar-systems/calendar-systems.md
+++ b/docs/data/date-pickers/calendar-systems/calendar-systems.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Pickers - Calendar systems
 components: LocalizationProvider
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/custom-field/custom-field.md
+++ b/docs/data/date-pickers/custom-field/custom-field.md
@@ -1,7 +1,7 @@
 ---
 productId: x-date-pickers
 title: Date and Time Pickers - Custom field
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 components: PickersSectionList, PickersTextField
 ---

--- a/docs/data/date-pickers/custom-layout/custom-layout.md
+++ b/docs/data/date-pickers/custom-layout/custom-layout.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Pickers - Custom layout
 components: PickersActionBar, PickersLayout
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/date-calendar/date-calendar.md
+++ b/docs/data/date-pickers/date-calendar/date-calendar.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Calendar component
 components: DateCalendar, MonthCalendar, YearCalendar, PickersDay, DayCalendarSkeleton
-githubLabel: 'component: DatePicker'
+githubLabel: 'scope: DatePicker'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/date-field/date-field.md
+++ b/docs/data/date-pickers/date-field/date-field.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Field component
 components: DateField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/date-picker/date-picker.md
+++ b/docs/data/date-pickers/date-picker/date-picker.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Picker component
 components: DatePicker, DesktopDatePicker, MobileDatePicker, StaticDatePicker, DateCalendar
-githubLabel: 'component: DatePicker'
+githubLabel: 'scope: DatePicker'
 packageName: '@mui/x-date-pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 ---

--- a/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
+++ b/docs/data/date-pickers/date-range-calendar/date-range-calendar.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Range Calendar component
 components: DateRangeCalendar
-githubLabel: 'component: DateRangePicker'
+githubLabel: 'scope: DateRangePicker'
 packageName: '@mui/x-date-pickers-pro'
 ---
 

--- a/docs/data/date-pickers/date-range-field/date-range-field.md
+++ b/docs/data/date-pickers/date-range-field/date-range-field.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Range Field components
 components: MultiInputDateRangeField, SingleInputDateRangeField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 

--- a/docs/data/date-pickers/date-range-picker/date-range-picker.md
+++ b/docs/data/date-pickers/date-range-picker/date-range-picker.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Range Picker component
 components: DateRangePicker, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker, DateRangeCalendar, DateRangePickerDay
-githubLabel: 'component: DateRangePicker'
+githubLabel: 'scope: DateRangePicker'
 packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---

--- a/docs/data/date-pickers/date-time-field/date-time-field.md
+++ b/docs/data/date-pickers/date-time-field/date-time-field.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Field component
 components: DateTimeField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/date-time-picker/date-time-picker.md
+++ b/docs/data/date-pickers/date-time-picker/date-time-picker.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Time Picker component
 components: DateTimePicker, DesktopDateTimePicker, MobileDateTimePicker, StaticDateTimePicker, DigitalClock, MultiSectionDigitalClock, TimeClock
-githubLabel: 'component: DateTimePicker'
+githubLabel: 'scope: DateTimePicker'
 packageName: '@mui/x-date-pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 ---

--- a/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
+++ b/docs/data/date-pickers/date-time-range-field/date-time-range-field.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Time Range Field components
 components: MultiInputDateTimeRangeField, SingleInputDateTimeRangeField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 

--- a/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
+++ b/docs/data/date-pickers/date-time-range-picker/date-time-range-picker.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Time Range Picker component
 components: DateTimeRangePicker, DesktopDateTimeRangePicker, MobileDateTimeRangePicker, DateRangeCalendar, DateRangePickerDay, DigitalClock, MultiSectionDigitalClock, DateTimeRangePickerTabs, DateTimeRangePickerToolbar
-githubLabel: 'component: DateTimeRangePicker'
+githubLabel: 'scope: DateTimeRangePicker'
 packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---

--- a/docs/data/date-pickers/digital-clock/digital-clock.md
+++ b/docs/data/date-pickers/digital-clock/digital-clock.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Digital Clock component
 components: DigitalClock, MultiSectionDigitalClock
-githubLabel: 'component: TimePicker'
+githubLabel: 'scope: TimePicker'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/fields/fields.md
+++ b/docs/data/date-pickers/fields/fields.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Fields components
 components: DateField, TimeField, DateTimeField, MultiInputDateRangeField, SingleInputDateRangeField, MultiInputTimeRangeField, SingleInputTimeRangeField, MultiInputDateTimeRangeField, SingleInputDateTimeRangeField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/lifecycle/lifecycle.md
+++ b/docs/data/date-pickers/lifecycle/lifecycle.md
@@ -1,7 +1,7 @@
 ---
 productId: x-date-pickers
 title: Components lifecycle
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/localization/localization.md
+++ b/docs/data/date-pickers/localization/localization.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Pickers - Translated components
 components: LocalizationProvider
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/overview/overview.md
+++ b/docs/data/date-pickers/overview/overview.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Date Picker and Time Picker components
 packageName: '@mui/x-date-pickers'
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
 ---

--- a/docs/data/date-pickers/playground/playground.md
+++ b/docs/data/date-pickers/playground/playground.md
@@ -2,7 +2,7 @@
 product: date-pickers
 title: Date and Time Pickers - Customization playground
 packageName: '@mui/x-date-pickers'
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
 ---

--- a/docs/data/date-pickers/quickstart/quickstart.md
+++ b/docs/data/date-pickers/quickstart/quickstart.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Pickers - Quickstart
 packageName: '@mui/x-date-pickers'
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 materialDesign: https://m2.material.io/components/date-pickers
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
 ---

--- a/docs/data/date-pickers/time-clock/time-clock.md
+++ b/docs/data/date-pickers/time-clock/time-clock.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Time Clock component
 components: TimeClock
-githubLabel: 'component: TimePicker'
+githubLabel: 'scope: TimePicker'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/time-field/time-field.md
+++ b/docs/data/date-pickers/time-field/time-field.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Time Field component
 components: TimeField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/time-picker/time-picker.md
+++ b/docs/data/date-pickers/time-picker/time-picker.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Time Picker component
 components: TimePicker, DesktopTimePicker, MobileTimePicker, StaticTimePicker, DigitalClock, MultiSectionDigitalClock, TimeClock
-githubLabel: 'component: TimePicker'
+githubLabel: 'scope: TimePicker'
 packageName: '@mui/x-date-pickers'
 materialDesign: https://m2.material.io/components/time-pickers
 ---

--- a/docs/data/date-pickers/time-range-field/time-range-field.md
+++ b/docs/data/date-pickers/time-range-field/time-range-field.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Time Range Field components
 components: MultiInputTimeRangeField, SingleInputTimeRangeField
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers-pro'
 ---
 

--- a/docs/data/date-pickers/time-range-picker/time-range-picker.md
+++ b/docs/data/date-pickers/time-range-picker/time-range-picker.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: React Time Range Picker component
 components: TimeRangePicker, DesktopTimeRangePicker, MobileTimeRangePicker, DigitalClock, MultiSectionDigitalClock, TimeRangePickerTabs, TimeRangePickerToolbar
-githubLabel: 'component: TimeRangePicker'
+githubLabel: 'scope: TimeRangePicker'
 packageName: '@mui/x-date-pickers-pro'
 materialDesign: https://m2.material.io/components/date-pickers
 ---

--- a/docs/data/date-pickers/timezone/timezone.md
+++ b/docs/data/date-pickers/timezone/timezone.md
@@ -2,7 +2,7 @@
 productId: x-date-pickers
 title: Date and Time Pickers - UTC and timezones
 components: LocalizationProvider
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/date-pickers/validation/validation.md
+++ b/docs/data/date-pickers/validation/validation.md
@@ -1,7 +1,7 @@
 ---
 productId: x-date-pickers
 components: DatePicker, DesktopDatePicker, MobileDatePicker, StaticDatePicker, TimePicker, DesktopTimePicker, MobileTimePicker, StaticTimePicker, DateTimePicker, DesktopDateTimePicker, MobileDateTimePicker, StaticDateTimePicker, DateRangePicker, DesktopDateRangePicker, MobileDateRangePicker, StaticDateRangePicker, TimeRangePicker, DesktopTimeRangePicker, MobileTimeRangePicker, DateTimeRangePicker, DesktopDateTimeRangePicker, MobileDateTimeRangePicker, DateCalendar
-githubLabel: 'component: pickers'
+githubLabel: 'scope: pickers'
 packageName: '@mui/x-date-pickers'
 ---
 

--- a/docs/data/scheduler/event-calendar/event-calendar.md
+++ b/docs/data/scheduler/event-calendar/event-calendar.md
@@ -2,7 +2,7 @@
 productId: x-scheduler
 title: React Scheduler component
 packageName: '@mui/x-scheduler'
-githubLabel: 'component: scheduler'
+githubLabel: 'scope: scheduler'
 ---
 
 # Scheduler - Overview

--- a/docs/data/scheduler/overview/overview.md
+++ b/docs/data/scheduler/overview/overview.md
@@ -2,7 +2,7 @@
 productId: x-scheduler
 title: React Scheduler component
 packageName: '@mui/x-scheduler'
-githubLabel: 'component: scheduler'
+githubLabel: 'scope: scheduler'
 ---
 
 # Scheduler - Overview

--- a/docs/data/scheduler/primitives/primitives.md
+++ b/docs/data/scheduler/primitives/primitives.md
@@ -2,7 +2,7 @@
 productId: x-scheduler
 title: React Scheduler component
 packageName: '@mui/x-scheduler'
-githubLabel: 'component: scheduler'
+githubLabel: 'scope: scheduler'
 ---
 
 # Scheduler - Overview

--- a/docs/data/tree-view/accessibility/accessibility.md
+++ b/docs/data/tree-view/accessibility/accessibility.md
@@ -1,7 +1,7 @@
 ---
 productId: x-tree-view
 title: Accessibility
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 packageName: '@mui/x-tree-view'
 ---

--- a/docs/data/tree-view/overview/overview.md
+++ b/docs/data/tree-view/overview/overview.md
@@ -1,7 +1,7 @@
 ---
 productId: x-tree-view
 title: Tree View React component
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 packageName: '@mui/x-tree-view'
 ---

--- a/docs/data/tree-view/quickstart/quickstart.md
+++ b/docs/data/tree-view/quickstart/quickstart.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Tree View - Quickstart
 components: SimpleTreeView, RichTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/customization/customization.md
+++ b/docs/data/tree-view/rich-tree-view/customization/customization.md
@@ -2,7 +2,7 @@
 productId: x-tree-view
 components: RichTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/editing/editing.md
+++ b/docs/data/tree-view/rich-tree-view/editing/editing.md
@@ -1,7 +1,7 @@
 ---
 productId: x-tree-view
 components: RichTreeView, TreeItem
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 packageName: '@mui/x-tree-view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 packageName: '@mui/x-tree-view'

--- a/docs/data/tree-view/rich-tree-view/expansion/expansion.md
+++ b/docs/data/tree-view/rich-tree-view/expansion/expansion.md
@@ -2,7 +2,7 @@
 productId: x-tree-view
 components: RichTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/focus/focus.md
+++ b/docs/data/tree-view/rich-tree-view/focus/focus.md
@@ -2,7 +2,7 @@
 productId: x-tree-view
 components: RichTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/headless/headless.md
+++ b/docs/data/tree-view/rich-tree-view/headless/headless.md
@@ -1,7 +1,7 @@
 ---
 productId: x-tree-view
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/items/items.md
+++ b/docs/data/tree-view/rich-tree-view/items/items.md
@@ -2,7 +2,7 @@
 productId: x-tree-view
 components: RichTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/lazy-loading/lazy-loading.md
+++ b/docs/data/tree-view/rich-tree-view/lazy-loading/lazy-loading.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Rich Tree View - Lazy loading
 components: RichTreeViewPro, TreeItem
 packageName: '@mui/x-tree-view-pro'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/ordering/ordering.md
+++ b/docs/data/tree-view/rich-tree-view/ordering/ordering.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Rich Tree View - Ordering
 components: TreeItem, RichTreeViewPro, TreeItemDragAndDropOverlay
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/rich-tree-view/selection/selection.md
+++ b/docs/data/tree-view/rich-tree-view/selection/selection.md
@@ -2,7 +2,7 @@
 productId: x-tree-view
 components: RichTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/simple-tree-view/customization/customization.md
+++ b/docs/data/tree-view/simple-tree-view/customization/customization.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Simple Tree View - Customization
 components: SimpleTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/simple-tree-view/expansion/expansion.md
+++ b/docs/data/tree-view/simple-tree-view/expansion/expansion.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Simple Tree View - Expansion
 components: SimpleTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/simple-tree-view/focus/focus.md
+++ b/docs/data/tree-view/simple-tree-view/focus/focus.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Simple Tree View - Focus
 components: SimpleTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/simple-tree-view/items/items.md
+++ b/docs/data/tree-view/simple-tree-view/items/items.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Simple Tree View - Items
 components: SimpleTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/simple-tree-view/selection/selection.md
+++ b/docs/data/tree-view/simple-tree-view/selection/selection.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Simple Tree View - Selection
 components: SimpleTreeView, TreeItem
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/docs/data/tree-view/tree-item-customization/tree-item-customization.md
+++ b/docs/data/tree-view/tree-item-customization/tree-item-customization.md
@@ -3,7 +3,7 @@ productId: x-tree-view
 title: Tree Item Customization
 components: SimpleTreeView, RichTreeView, TreeItem, TreeItemIcon, TreeItemProvider
 packageName: '@mui/x-tree-view'
-githubLabel: 'component: tree view'
+githubLabel: 'scope: tree view'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 ---
 

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -50,17 +50,20 @@ function resolvePackagesByLabels(labels) {
   const resolvedPackages = [];
   labels.forEach((label) => {
     switch (label.name) {
-      case 'component: data grid':
+      case 'scope: data grid':
         resolvedPackages.push('DataGrid');
         break;
-      case 'component: pickers':
+      case 'scope: pickers':
         resolvedPackages.push('pickers');
         break;
-      case 'component: charts':
+      case 'scope: charts':
         resolvedPackages.push('charts');
         break;
-      case 'component: tree view':
+      case 'scope: tree view':
         resolvedPackages.push('TreeView');
+        break;
+      case 'scope: scheduler':
+        resolvedPackages.push('Scheduler');
         break;
       default:
         break;


### PR DESCRIPTION
update all the mentions of ... 
- `component: data grid`
- `component: charts`
- `component: tree view`
- `component: pickers`

Also added `scope: scheduler` to the package resolution for the release changelog script.

Reference in notion: https://www.notion.so/mui-org/Labeling-in-GitHub-1f1cbfe7b66081d8b18de652877d671e?source=copy_link#209cbfe7b6608054ad79ded07817c187