### PR TITLE
[x-telemetry][docs] Reduce Telemetry overhead

### DIFF
--- a/docs/data/guides/telemetry/telemetry.md
+++ b/docs/data/guides/telemetry/telemetry.md
@@ -39,7 +39,9 @@ Telemetry collection is specifically associated with the usage of paid MUI X Pr
 
 ## Telemetry in development mode only
 
-[MUI X Telemetry](http://bundlephobia.com/package/@mui/x-telemetry) is designed to operate exclusively during development. In production builds of your application, telemetry is entirely removed, ensuring no runtime overhead or data collection in your live environment. This guarantees that your production application's performance and behavior remain unaffected.
+MUI X Telemetry is designed to operate exclusively during development.
+In production builds of your application, telemetry is entirely removed, ensuring no data collection in your live environment and almost no runtime overhead ([proof](https://bundlephobia.com/package/@mui/x-telemetry)).
+This guarantees that your production application's performance and behavior remain unaffected.
 
 :::info
 Currently, Telemetry is disabled by default and you have full control to opt-in as per your preference.

--- a/packages/x-telemetry/src/runtime/events.ts
+++ b/packages/x-telemetry/src/runtime/events.ts
@@ -1,18 +1,23 @@
 import { TelemetryEventContext } from '../types';
 
+const noop = () => null;
+
 const muiXTelemetryEvents = {
-  licenseVerification: (
-    context: TelemetryEventContext,
-    payload: {
-      packageReleaseInfo: string;
-      packageName: string;
-      licenseStatus?: string;
-    },
-  ) => ({
-    eventName: 'licenseVerification',
-    payload,
-    context,
-  }),
+  licenseVerification:
+    process.env.NODE_ENV === 'production'
+      ? noop
+      : (
+          context: TelemetryEventContext,
+          payload: {
+            packageReleaseInfo: string;
+            packageName: string;
+            licenseStatus?: string;
+          },
+        ) => ({
+          eventName: 'licenseVerification',
+          payload,
+          context,
+        }),
 };
 
 export default muiXTelemetryEvents;


### PR DESCRIPTION
A quick win while I was looking at #18257:

1. I don't feel like https://github.com/mui/mui-x/pull/17244#discussion_r2030289530 was correctly handled.
2. When looking at the overhead of the package in production, with https://bundlejs.com/?q=%40mui%2Fx-telemetry%408.5.1, we get this, before running Prettier:

```jsx
var r = {
    licenseVerification: (t, i) => ({
      eventName: "licenseVerification",
      payload: i,
      context: t,
    }),
  },
  n = r;
var e = () => {},
  l = e,
  s = { enableDebug: e, enableTelemetry: e, disableTelemetry: e };

export {
  n as muiXTelemetryEvents,
  s as muiXTelemetrySettings,
  l as sendMuiXTelemetryEvent,
};
```

456 B / 291 B (gzip)

which we can reduce down to:

```jsx
var r={licenseVerification:()=>{}},n=r;var e=()=>{},l=e,s={enableDebug:e,enableTelemetry:e,disableTelemetry:e};export{n as muiXTelemetryEvents,s as muiXTelemetrySettings,l as sendMuiXTelemetryEvent};
/**
 * @mui/x-telemetry v8.5.1
 *
 * @license MUI X Commercial
 * This source code is licensed under the commercial license found in the
 * LICENSE file in the root directory of this source tree.
 */
```

399 / 260 B (gzip)

