### PR TITLE
[DataGridPro] Fix flex column width if it is a pinned column

### DIFF
--- a/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/columns.DataGridPro.test.tsx
@@ -32,11 +32,12 @@ describe('<DataGridPro /> - Columns', () => {
     columns: [{ field: 'brand' }],
   };
 
-  function Test(props: Partial<DataGridProProps>) {
+  function Test(props: Partial<DataGridProProps> & { width?: number; height?: number }) {
     apiRef = useGridApiRef();
+    const { width = 300, height = 500, ...otherProps } = props;
     return (
-      <div style={{ width: 300, height: 500 }}>
-        <DataGridPro apiRef={apiRef} {...baselineProps} {...props} />
+      <div style={{ width, height }}>
+        <DataGridPro apiRef={apiRef} {...baselineProps} {...otherProps} />
       </div>
     );
   }
@@ -710,6 +711,47 @@ describe('<DataGridPro /> - Columns', () => {
       // @ts-ignore
       act(() => privateApi.current.requestPipeProcessorsApplication('hydrateColumns'));
       expect(gridColumnFieldsSelector(apiRef)).to.deep.equal(['__check__', 'brand', 'id']);
+    });
+  });
+
+  describeSkipIf(isJSDOM)('flex columns with pinned columns', () => {
+    it('should maintain correct widths and positions when flex columns are set', () => {
+      render(
+        <Test
+          columns={[
+            { field: 'name', headerName: 'Name', flex: 1, minWidth: 100, editable: true },
+            { field: 'email', headerName: 'Email', width: 200, editable: true },
+          ]}
+          initialState={{ pinnedColumns: { left: ['name'] } }}
+        />,
+      );
+
+      const firstColumn = getColumnHeaderCell(0);
+      expect(firstColumn.offsetWidth).to.equal(100);
+      const secondColumn = getColumnHeaderCell(1);
+      expect(secondColumn.offsetWidth).to.equal(200);
+    });
+
+    it('should grow flex column beyond minWidth when space is available', () => {
+      const columns = [
+        { field: 'name', headerName: 'Name', flex: 1, minWidth: 200, editable: true },
+        { field: 'email', headerName: 'Email', width: 200, editable: true },
+      ];
+
+      render(
+        <Test
+          width={600}
+          columns={columns}
+          initialState={{ pinnedColumns: { left: ['name'] } }}
+          disableVirtualization
+        />,
+      );
+
+      const firstColumn = getColumnHeaderCell(0);
+      const secondColumn = getColumnHeaderCell(1);
+
+      expect(firstColumn.offsetWidth).to.equal(398);
+      expect(secondColumn.offsetWidth).to.equal(200);
     });
   });
 });

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -219,7 +219,12 @@ export const hydrateColumnsWidth = (
     });
 
     Object.keys(computedColumnWidths).forEach((field) => {
-      columnsLookup[field].computedWidth = computedColumnWidths[field].computedWidth;
+      if (columnsLookup[field].computedWidth !== computedColumnWidths[field].computedWidth) {
+        columnsLookup[field] = {
+          ...columnsLookup[field],
+          computedWidth: computedColumnWidths[field].computedWidth,
+        };
+      }
     });
   }
 

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -268,9 +268,9 @@ export const applyInitialState = (
     cleanOrderedFields.length === 0
       ? columnsState.orderedFields
       : [
-        ...cleanOrderedFields,
-        ...columnsState.orderedFields.filter((field) => !orderedFieldsLookup[field]),
-      ];
+          ...cleanOrderedFields,
+          ...columnsState.orderedFields.filter((field) => !orderedFieldsLookup[field]),
+        ];
 
   const newColumnLookup: GridColumnRawLookup = { ...columnsState.lookup };
   for (let i = 0; i < columnsWithUpdatedDimensions.length; i += 1) {

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsUtils.ts
@@ -219,12 +219,10 @@ export const hydrateColumnsWidth = (
     });
 
     Object.keys(computedColumnWidths).forEach((field) => {
-      if (columnsLookup[field].computedWidth !== computedColumnWidths[field].computedWidth) {
-        columnsLookup[field] = {
-          ...columnsLookup[field],
-          computedWidth: computedColumnWidths[field].computedWidth,
-        };
-      }
+      columnsLookup[field] = {
+        ...columnsLookup[field],
+        computedWidth: computedColumnWidths[field].computedWidth,
+      };
     });
   }
 
@@ -270,9 +268,9 @@ export const applyInitialState = (
     cleanOrderedFields.length === 0
       ? columnsState.orderedFields
       : [
-          ...cleanOrderedFields,
-          ...columnsState.orderedFields.filter((field) => !orderedFieldsLookup[field]),
-        ];
+        ...cleanOrderedFields,
+        ...columnsState.orderedFields.filter((field) => !orderedFieldsLookup[field]),
+      ];
 
   const newColumnLookup: GridColumnRawLookup = { ...columnsState.lookup };
   for (let i = 0; i < columnsWithUpdatedDimensions.length; i += 1) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #17969


When updating flex column widths, we were mutating the `columnsLookup` obj directly which could cause missing the state update. This change creates a new object
for the column lookup to ensure the component properly detects and applies the width changes.

This fixes issues where flex column width changes weren't being reflected in the UI,
particularly when using pinned columns.
