### PR TITLE
[charts] Add margin-bottom to charts toolbar

### DIFF
--- a/packages/x-charts/src/Toolbar/Toolbar.tsx
+++ b/packages/x-charts/src/Toolbar/Toolbar.tsx
@@ -16,6 +16,7 @@ const ToolbarRoot = styled('div', {
   justifyContent: 'end',
   gap: theme.spacing(0.25),
   padding: theme.spacing(0.5),
+  marginBottom: theme.spacing(1.5),
   minHeight: 44,
   boxSizing: 'border-box',
   border: `1px solid ${(theme.vars || theme).palette.divider}`,


### PR DESCRIPTION
As requested in https://github.com/mui/mui-x/pull/18210#discussion_r2138665564.

Add margin-bottom to charts toolbar.