### PR TITLE
[data grid] Fix export menu button tooltip being interactive when menu is open

### DIFF
--- a/packages/x-data-grid/src/components/toolbarV8/GridToolbar.tsx
+++ b/packages/x-data-grid/src/components/toolbarV8/GridToolbar.tsx
@@ -151,7 +151,10 @@ function GridToolbar(props: GridToolbarProps) {
 
       {showExportMenu && (
         <React.Fragment>
-          <rootProps.slots.baseTooltip title={apiRef.current.getLocaleText('toolbarExport')}>
+          <rootProps.slots.baseTooltip
+            title={apiRef.current.getLocaleText('toolbarExport')}
+            disableInteractive={exportMenuOpen}
+          >
             <ToolbarButton
               ref={exportMenuTriggerRef}
               id={exportMenuTriggerId}

--- a/packages/x-data-grid/src/models/gridBaseSlots.ts
+++ b/packages/x-data-grid/src/models/gridBaseSlots.ts
@@ -320,6 +320,7 @@ export type TooltipProps = CommonProps & {
   children: React.ReactElement<any, any>;
   enterDelay?: number;
   title: React.ReactNode;
+  disableInteractive?: boolean;
 };
 
 export type IconProps = CommonProps<SVGSVGElement> & {


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18321. Related to https://github.com/mui/mui-x/pull/18210#discussion_r2135301517.

Fix export menu button tooltip being interactive when menu is open.

The solution was to `disableInteractive` when the tooltip is open. Please read the accessibility concerns [here](https://github.com/mui/mui-x/pull/18327#discussion_r2139518811).


Before:

https://github.com/user-attachments/assets/0b412576-813c-4c70-ac3a-d88f4052c147

After:


https://github.com/user-attachments/assets/55086c62-8a1f-47d7-898e-4a99f63627bb

