### PR TITLE
[charts-pro] Hide values outside minStart and maxEnd in zoom slider

### DIFF
--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -86,6 +86,12 @@ When formatting the zoom slider tooltip, the `valueFormatter` is called with `zo
 
 {{"demo": "ZoomSliderTooltip.js"}}
 
+### Limits
+
+The zoom slider uses the same limits as the zooming options. You can set the `minStart`, `maxEnd`, `minSpan`, and `maxSpan` properties on the axis config to restrict the zoom slider range.
+
+Values outside the `minStart` and `maxEnd` range will not be displayed in the zoom slider.
+
 ### Composition
 
 When using composition, you can render the axes' sliders by rendering the `ChartZoomSlider` component.

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
@@ -67,16 +67,15 @@ export function ChartAxisZoomSliderTrack({
     }
 
     const pointerDownPoint = getSVGPoint(element, event);
-    let zoomFromPointerDown = calculateZoomFromPoint(store.getSnapshot(), axisId, pointerDownPoint);
+    const zoomFromPointerDown = calculateZoomFromPoint(
+      store.getSnapshot(),
+      axisId,
+      pointerDownPoint,
+    );
 
     if (zoomFromPointerDown === null) {
       return;
     }
-
-    const { minStart, maxEnd } = selectorChartAxisZoomOptionsLookup(store.getSnapshot(), axisId);
-
-    // Ensure the zoomFromPointerDown is within the min and max range
-    zoomFromPointerDown = Math.max(Math.min(zoomFromPointerDown, maxEnd), minStart);
 
     const onPointerMove = rafThrottle(function onPointerMove(pointerMoveEvent: PointerEvent) {
       const pointerMovePoint = getSVGPoint(element, pointerMoveEvent);

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/zoom-utils.ts
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/zoom-utils.ts
@@ -2,6 +2,7 @@ import {
   AxisId,
   ChartState,
   DefaultizedZoomOptions,
+  selectorChartAxisZoomOptionsLookup,
   selectorChartDrawingArea,
   selectorChartRawAxis,
   ZoomData,
@@ -16,16 +17,20 @@ export function calculateZoomFromPoint(state: ChartState<any>, axisId: AxisId, p
   }
 
   const axisDirection = axis.position === 'right' || axis.position === 'left' ? 'y' : 'x';
+  const { minStart, maxEnd } = selectorChartAxisZoomOptionsLookup(state, axisId);
+  const range = maxEnd - minStart;
 
   let pointerZoom: number;
   if (axisDirection === 'x') {
-    pointerZoom = ((point.x - left) / width) * 100;
+    pointerZoom = ((point.x - left) / width) * range;
   } else {
-    pointerZoom = ((top + height - point.y) / height) * 100;
+    pointerZoom = ((top + height - point.y) / height) * range;
   }
 
   if (axis.reverse) {
-    pointerZoom = 100 - pointerZoom;
+    pointerZoom = maxEnd - pointerZoom;
+  } else {
+    pointerZoom += minStart;
   }
 
   return pointerZoom;


### PR DESCRIPTION
Hide values outside minStart and maxEnd in zoom slider, as suggested by @alexfauquette [here](https://mui-org.slack.com/archives/C02EQ97NV8F/p1749132360626009). 

