### PR TITLE
[scheduler][joy] Small misalignment in "All day" cell on Windows

### DIFF
--- a/packages/x-scheduler/src/joy/internals/components/time-grid/TimeGrid.css
+++ b/packages/x-scheduler/src/joy/internals/components/time-grid/TimeGrid.css
@@ -46,6 +46,7 @@
 
 .TimeGridHeader[style*='--has-scroll: 1'] .TimeGridHeaderRow {
   overflow-y: scroll;
+  overflow-x: hidden;
   scrollbar-color: transparent transparent;
 }
 
@@ -59,6 +60,7 @@
 
 .TimeGridHeader[style*='--has-scroll: 1'] .TimeGridAllDayEventsRow {
   overflow-y: scroll;
+  overflow-x: hidden;
   scrollbar-color: transparent transparent;
 }
 
@@ -138,6 +140,7 @@
 .TimeGridTimeAxis {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   width: var(--fixed-cell-width);
 }
 


### PR DESCRIPTION
Issue #18335 

There is a small visual misalignment in the "All day" cell of the calendar when viewed on Windows.
The misalignment seems to be specific to Windows, everything looks fine on macOS (Chrome, Safari, Firefox checked).
![image (1)](https://github.com/user-attachments/assets/5c2028e4-9791-48b5-b0a4-2824183eb300)

_Expected behavior:_
The "All day" cell should be perfectly aligned with the rest of the grid and headers.

**Demo on VM**
<img width="850" alt="Screenshot 2025-06-11 at 21 41 19" src="https://github.com/user-attachments/assets/89ec9459-1f8c-4d1f-ba9d-cb57fdaa6827" />

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
