### PR TITLE
[scheduler] Fix data attributes in `<TimeGrid.Event />`

### DIFF
--- a/docs/data/scheduler/primitives/DayGridPrimitives.js
+++ b/docs/data/scheduler/primitives/DayGridPrimitives.js
@@ -73,10 +73,7 @@ export default function DayGridPrimitives() {
       const weekDays = getDayList({ date: weekStart, amount: 7 });
       const weekDaysWithEvents = weekDays.map((date) => ({
         date,
-        events: events.filter(
-          (event) =>
-            event.start.hasSame(date, 'day') || event.end.hasSame(date, 'day'),
-        ),
+        events: events.filter((event) => event.start.hasSame(date, 'day')),
       }));
       tempWeeks.push(weekDaysWithEvents);
     }

--- a/docs/data/scheduler/primitives/DayGridPrimitives.tsx
+++ b/docs/data/scheduler/primitives/DayGridPrimitives.tsx
@@ -81,10 +81,7 @@ export default function DayGridPrimitives() {
       const weekDays = getDayList({ date: weekStart, amount: 7 });
       const weekDaysWithEvents = weekDays.map((date) => ({
         date,
-        events: events.filter(
-          (event) =>
-            event.start.hasSame(date, 'day') || event.end.hasSame(date, 'day'),
-        ),
+        events: events.filter((event) => event.start.hasSame(date, 'day')),
       }));
       tempWeeks.push(weekDaysWithEvents);
     }

--- a/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEvent.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEvent.tsx
@@ -59,17 +59,17 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
 
   const props = React.useMemo(() => ({ style }), [style]);
 
-  const state = useEvent({ start, end });
+  const { state, props: eventProps } = useEvent({ start, end });
 
   return useRenderElement('div', componentProps, {
     state,
     ref: [forwardedRef, buttonRef],
-    props: [props, elementProps, getButtonProps],
+    props: [props, eventProps, elementProps, getButtonProps],
   });
 });
 
 export namespace TimeGridEvent {
-  export interface State extends useEvent.ReturnValue {}
+  export interface State extends useEvent.State {}
 
   export interface Props extends BaseUIComponentProps<'div', State>, useEvent.Parameters {}
 }


### PR DESCRIPTION
The Time Grid Event had `data-state={[Object object}] data-props={[Object object}]` because I forgot to decompose the returned object :angel: 