### PR TITLE
[docs][pickers] Fix adapter version resolving when opening demo to edit

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "rimraf ./export && cross-env NODE_ENV=production next build && pnpm build-sw",
+    "build:adapter-dependencies": "tsx ../scripts/buildPickerAdapterDeps.ts",
+    "build": "rimraf ./export && pnpm build:adapter-dependencies && cross-env NODE_ENV=production next build && pnpm build-sw",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "next dev --port 3001",
+    "dev": "pnpm build:adapter-dependencies && next dev --port 3001",
     "deploy": "git push -f upstream master:docs-v8",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "serve": "serve ./export -l 3010",

--- a/docs/src/modules/utils/adapter-dependencies.json
+++ b/docs/src/modules/utils/adapter-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "date-fns": "4.1.0",
+  "date-fns-jalali": "4.1.0-0",
+  "dayjs": "1.11.13",
+  "luxon": "3.6.1",
+  "moment": "2.30.1",
+  "moment-hijri": "3.0.0",
+  "moment-jalaali": "0.10.4"
+}

--- a/docs/src/modules/utils/postProcessImport.test.ts
+++ b/docs/src/modules/utils/postProcessImport.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
-// eslint-disable-next-line import/no-relative-packages
-import pickersPackageJson from '../../../../packages/x-date-pickers/package.json';
+import adapterDependencies from './adapter-dependencies.json';
 import { ADAPTER_TO_LIBRARY, postProcessImport } from './postProcessImport';
 
 describe('postProcessImport', () => {
@@ -13,7 +12,7 @@ describe('postProcessImport', () => {
 
         const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
         expect(resolvedDep).to.deep.equal({
-          [expectedLibrary]: pickersPackageJson.devDependencies[expectedLibrary],
+          [expectedLibrary]: adapterDependencies[expectedLibrary],
         });
       });
     });
@@ -32,7 +31,7 @@ describe('postProcessImport', () => {
 
         const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
         expect(resolvedDep).to.deep.equal({
-          [expectedLibrary]: pickersPackageJson.devDependencies[expectedLibrary],
+          [expectedLibrary]: adapterDependencies[expectedLibrary],
         });
       });
     });
@@ -51,7 +50,7 @@ describe('postProcessImport', () => {
 
         const expectedLibrary = ADAPTER_TO_LIBRARY[adapter];
         expect(resolvedDep).to.deep.equal({
-          [expectedLibrary]: pickersPackageJson.devDependencies[expectedLibrary],
+          [expectedLibrary]: adapterDependencies[expectedLibrary],
         });
       });
     });

--- a/docs/src/modules/utils/postProcessImport.ts
+++ b/docs/src/modules/utils/postProcessImport.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line import/no-relative-packages
-import pickersPackageJson from '../../../../packages/x-date-pickers/package.json';
+import adapterDependencies from './adapter-dependencies.json';
 
-export const ADAPTER_TO_LIBRARY: Record<string, keyof typeof pickersPackageJson.devDependencies> = {
+export const ADAPTER_TO_LIBRARY: Record<string, keyof typeof adapterDependencies> = {
   AdapterDateFns: 'date-fns',
   AdapterDateFnsJalali: 'date-fns-jalali',
   AdapterDayjs: 'dayjs',
@@ -27,7 +26,7 @@ export const postProcessImport = (importName: string): Record<string, string> | 
         `Can't determine required npm package for adapter '${dateAdapterMatch[1]}'`,
       );
     }
-    return { [packageName]: pickersPackageJson.devDependencies[packageName] ?? 'latest' };
+    return { [packageName]: adapterDependencies[packageName] ?? 'latest' };
   }
   return null;
 };

--- a/scripts/buildPickerAdapterDeps.ts
+++ b/scripts/buildPickerAdapterDeps.ts
@@ -1,0 +1,35 @@
+import childProcess from 'node:child_process';
+import path from 'node:path';
+import * as fse from 'fs-extra';
+
+interface ListedDependency {
+  name: string;
+  devDependencies?: {
+    [key: string]: {
+      version: string;
+    };
+  };
+}
+
+const adapterLibs = childProcess.execSync(
+  'pnpm list date-fns date-fns-jalali dayjs luxon moment moment-hijri moment-jalaali --json',
+  { cwd: path.resolve(__dirname, '../packages/x-date-pickers') },
+);
+const jsonListedDependencies: ListedDependency[] = JSON.parse(adapterLibs.toString());
+const adapterDependencyMap = Object.entries(jsonListedDependencies[0].devDependencies).reduce(
+  (result, [libraryName, libraryInfo]) => {
+    result[libraryName] = libraryInfo.version;
+    return result;
+  },
+  {},
+);
+try {
+  fse.writeJSON(
+    path.resolve(__dirname, '../docs/src/modules/utils/adapter-dependencies.json'),
+    adapterDependencyMap,
+    { encoding: 'utf8' },
+  );
+} catch (error) {
+  console.error('Error writing adapter dependencies:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
Fixes an issue where, after migration to [pnpm catalogs](https://github.com/mui/mui-x/pull/18302), our [`postProcessImport`](https://github.com/mui/mui-x/blob/master/docs/src/modules/utils/postProcessImport.ts) script resolves adapter dependencies to the `catalog:` version and results in the following failures when code examples are opened. 🙈 

![Screenshot 2025-06-13 at 17 42 05](https://github.com/user-attachments/assets/7b326cca-9fdf-434a-9f6e-0e8d99d0c6ad)
![Screenshot 2025-06-13 at 17 42 45](https://github.com/user-attachments/assets/cc3e2856-8d00-4fae-b012-5d50ab3278bd)
