### PR TITLE
[code-infra] Add back a `Playwright` renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,6 +94,10 @@
       "matchPackageNames": ["@mui/internal-*", "@mui/docs"]
     },
     {
+      "groupName": "Playwright",
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"]
+    },
+    {
       "matchDepTypes": ["action"],
       "pinDigests": true,
       "automerge": true


### PR DESCRIPTION
Add back the Playwright rule removed in https://github.com/mui/mui-x/pull/17460 to avoid PRs like this:  https://github.com/mui/mui-x/pull/18382.