### PR TITLE
[charts] Add item class to list item around each series in legend

### DIFF
--- a/docs/pages/x/api/charts/charts-legend.json
+++ b/docs/pages/x/api/charts/charts-legend.json
@@ -40,6 +40,12 @@
       "isGlobal": false
     },
     {
+      "key": "item",
+      "className": "MuiChartsLegend-item",
+      "description": "Styles applied to the list item around each series in the legend.",
+      "isGlobal": false
+    },
+    {
       "key": "label",
       "className": "MuiChartsLegend-label",
       "description": "Styles applied to the series label.",

--- a/docs/translations/api-docs/charts/charts-legend/charts-legend.json
+++ b/docs/translations/api-docs/charts/charts-legend/charts-legend.json
@@ -21,6 +21,10 @@
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the legend in row layout"
     },
+    "item": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the list item around each series in the legend"
+    },
     "label": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the series label" },
     "mark": { "description": "Styles applied to {{nodeName}}.", "nodeName": "series mark element" },
     "root": { "description": "Styles applied to the root element." },

--- a/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
+++ b/packages/x-charts/src/ChartsLegend/ChartsLegend.tsx
@@ -107,7 +107,7 @@ const ChartsLegend = consumeSlots(
       >
         {data.items.map((item, i) => {
           return (
-            <li key={item.id}>
+            <li key={item.id} className={classes?.item}>
               <Element
                 className={classes?.series}
                 role={onItemClick ? 'button' : undefined}

--- a/packages/x-charts/src/ChartsLegend/chartsLegendClasses.ts
+++ b/packages/x-charts/src/ChartsLegend/chartsLegendClasses.ts
@@ -7,6 +7,8 @@ import type { ChartsLegendSlotExtension } from './chartsLegend.types';
 export interface ChartsLegendClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the list item around each series in the legend. */
+  item: string;
   /** Styles applied to a series element. */
   series: string;
   /** Styles applied to series mark element. */
@@ -27,6 +29,7 @@ export const useUtilityClasses = (props: ChartsLegendProps & ChartsLegendSlotExt
   const { classes, direction } = props;
   const slots = {
     root: ['root', direction],
+    item: ['item'],
     mark: ['mark'],
     label: ['label'],
     series: ['series'],
@@ -37,6 +40,7 @@ export const useUtilityClasses = (props: ChartsLegendProps & ChartsLegendSlotExt
 
 export const legendClasses: ChartsLegendClasses = generateUtilityClasses('MuiChartsLegend', [
   'root',
+  'item',
   'series',
   'mark',
   'label',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,7 +1058,7 @@ importers:
         version: 7.1.1(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0))(@types/react@19.0.12)(react@19.0.0)
       '@types/prop-types':
         specifier: 'catalog:'
-        version: 15.7.14
+        version: 15.7.15
       csstype:
         specifier: 'catalog:'
         version: 3.1.3


### PR DESCRIPTION
Add item class to list item around each series in legend. 

This is particularly useful when hiding a list item. Since the parent has the `gap` property set, if we hide the child of the list item, the list item will have a width of zero causing a double gap. 