### PR TITLE
[charts] x-axis: render tick only when tick label is present

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsXAxis.tsx
@@ -363,9 +363,9 @@ function ChartsXAxis(inProps: ChartsXAxisProps) {
         const xTickLabel = labelOffset ?? 0;
         const yTickLabel = positionSign * (tickSize + TICK_LABEL_GAP);
 
-        const showTick = instance.isXInside(tickOffset);
         const tickLabel = tickLabels.get(item);
         const showTickLabel = visibleLabels.has(item);
+        const showTick = instance.isXInside(tickOffset) && tickLabel !== undefined;
 
         return (
           <g


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #18240 
previously:
for cases where chart has a LOG scale, and too many ticks, all of the ticks are rendered but tick labels are rendered only for few items
![Screenshot 2025-06-19 at 02 53 50](https://github.com/user-attachments/assets/265b26ff-da05-488b-960d-278ccef4f01f)

after this change:
This change adds a check in ChartXAxis to render the axis label tick only when the same instance has a tick label available

![Screenshot 2025-06-19 at 02 53 20](https://github.com/user-attachments/assets/424f90dd-4074-4910-979f-c6f7828d7e02)
