### PR TITLE
[docs] Fix 404 in charts docs

### DIFF
--- a/docs/data/charts/localization/localization.md
+++ b/docs/data/charts/localization/localization.md
@@ -1,7 +1,7 @@
 ---
 title: Charts - Localization
 productId: x-charts
-components: ChartsLocalizationProvider, ChartsDataContainer, ChartsLocalizationProvider
+components: ChartsLocalizationProvider, ChartDataProvider, ChartContainer
 ---
 
 # Charts - Localization

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -1,7 +1,7 @@
 ---
 title: React Radar chart
 productId: x-charts
-components: RadarChart, RadarChartPro, RadarGrid, RadarSeriesArea, RadarSeriesMarks, RadarSeriesPlot, RadarMetricLabels, RadarAxisHighlight, RadarDataProvider
+components: RadarChart, RadarChartPro, RadarGrid, RadarSeriesArea, RadarSeriesMarks, RadarSeriesPlot, RadarMetricLabels, RadarAxisHighlight
 ---
 
 # Charts - Radar

--- a/docs/pages/x/api/charts/chart-container.json
+++ b/docs/pages/x/api/charts/chart-container.json
@@ -93,6 +93,6 @@
   "forwardsRefTo": "SVGSVGElement",
   "filename": "/packages/x-charts/src/ChartContainer/ChartContainer.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-charts/composition/\">Chart composition</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-charts/composition/\">Chart composition</a></li>\n<li><a href=\"/x/react-charts/localization/\">Charts - Localization</a></li></ul>",
   "cssComponent": false
 }

--- a/docs/pages/x/api/charts/chart-data-provider.json
+++ b/docs/pages/x/api/charts/chart-data-provider.json
@@ -33,6 +33,6 @@
   "forwardsRefTo": "SVGSVGElement",
   "filename": "/packages/x-charts/src/ChartDataProvider/ChartDataProvider.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/x/react-charts/composition/\">Chart composition</a></li></ul>",
+  "demos": "<ul><li><a href=\"/x/react-charts/composition/\">Chart composition</a></li>\n<li><a href=\"/x/react-charts/localization/\">Charts - Localization</a></li></ul>",
   "cssComponent": false
 }


### PR DESCRIPTION
The radar data provider API page got removed when adding the pro component

The ChartsDataContainer never existed