### PR TITLE
[pickers] Add `usePickerAdapter` hook

### DIFF
--- a/docs/data/date-pickers/custom-components/UsePickerAdapter.js
+++ b/docs/data/date-pickers/custom-components/UsePickerAdapter.js
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import IconButton from '@mui/material/IconButton';
+import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import ChevronRight from '@mui/icons-material/ChevronRight';
+import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
+import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
+import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { usePickerAdapter } from '@mui/x-date-pickers/hooks';
+
+const CustomCalendarHeaderRoot = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '8px 16px',
+  alignItems: 'center',
+});
+
+function CustomCalendarHeader(props) {
+  const adapter = usePickerAdapter();
+  const {
+    currentMonth,
+    onMonthChange,
+    format = `${adapter.formats.month} ${adapter.formats.year}`,
+  } = props;
+
+  const selectNextMonth = () => onMonthChange(adapter.addMonths(currentMonth, 1));
+  const selectNextYear = () => onMonthChange(adapter.addYears(currentMonth, 1));
+  const selectPreviousMonth = () =>
+    onMonthChange(adapter.addMonths(currentMonth, -1));
+  const selectPreviousYear = () => onMonthChange(adapter.addYears(currentMonth, -1));
+
+  return (
+    <CustomCalendarHeaderRoot>
+      <Stack spacing={1} direction="row">
+        <IconButton onClick={selectPreviousYear} title="Previous year">
+          <KeyboardDoubleArrowLeftIcon />
+        </IconButton>
+        <IconButton onClick={selectPreviousMonth} title="Previous month">
+          <ChevronLeft />
+        </IconButton>
+      </Stack>
+      <Typography variant="body2">
+        {adapter.formatByString(currentMonth, format)}
+      </Typography>
+      <Stack spacing={1} direction="row">
+        <IconButton onClick={selectNextMonth} title="Next month">
+          <ChevronRight />
+        </IconButton>
+        <IconButton onClick={selectNextYear} title="Next year">
+          <KeyboardDoubleArrowRightIcon />
+        </IconButton>
+      </Stack>
+    </CustomCalendarHeaderRoot>
+  );
+}
+
+export default function UsePickerAdapter() {
+  return (
+    <Stack spacing={2} direction="row" flexWrap="wrap">
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <DemoContainer components={['DateCalendar']}>
+          <DemoItem label="AdapterDayjs" alignItems="center">
+            <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
+          </DemoItem>
+        </DemoContainer>
+      </LocalizationProvider>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DemoContainer components={['DateCalendar']}>
+          <DemoItem label="AdapterDateFns" alignItems="center">
+            <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
+          </DemoItem>
+        </DemoContainer>
+      </LocalizationProvider>
+    </Stack>
+  );
+}

--- a/docs/data/date-pickers/custom-components/UsePickerAdapter.tsx
+++ b/docs/data/date-pickers/custom-components/UsePickerAdapter.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import IconButton from '@mui/material/IconButton';
+import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import ChevronRight from '@mui/icons-material/ChevronRight';
+import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
+import KeyboardDoubleArrowRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
+import { DemoContainer, DemoItem } from '@mui/x-date-pickers/internals/demo';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
+import { PickersCalendarHeaderProps } from '@mui/x-date-pickers/PickersCalendarHeader';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { usePickerAdapter } from '@mui/x-date-pickers/hooks';
+
+const CustomCalendarHeaderRoot = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '8px 16px',
+  alignItems: 'center',
+});
+
+function CustomCalendarHeader(props: PickersCalendarHeaderProps) {
+  const adapter = usePickerAdapter();
+  const {
+    currentMonth,
+    onMonthChange,
+    format = `${adapter.formats.month} ${adapter.formats.year}`,
+  } = props;
+
+  const selectNextMonth = () => onMonthChange(adapter.addMonths(currentMonth, 1));
+  const selectNextYear = () => onMonthChange(adapter.addYears(currentMonth, 1));
+  const selectPreviousMonth = () =>
+    onMonthChange(adapter.addMonths(currentMonth, -1));
+  const selectPreviousYear = () => onMonthChange(adapter.addYears(currentMonth, -1));
+
+  return (
+    <CustomCalendarHeaderRoot>
+      <Stack spacing={1} direction="row">
+        <IconButton onClick={selectPreviousYear} title="Previous year">
+          <KeyboardDoubleArrowLeftIcon />
+        </IconButton>
+        <IconButton onClick={selectPreviousMonth} title="Previous month">
+          <ChevronLeft />
+        </IconButton>
+      </Stack>
+      <Typography variant="body2">
+        {adapter.formatByString(currentMonth, format)}
+      </Typography>
+      <Stack spacing={1} direction="row">
+        <IconButton onClick={selectNextMonth} title="Next month">
+          <ChevronRight />
+        </IconButton>
+        <IconButton onClick={selectNextYear} title="Next year">
+          <KeyboardDoubleArrowRightIcon />
+        </IconButton>
+      </Stack>
+    </CustomCalendarHeaderRoot>
+  );
+}
+
+export default function UsePickerAdapter() {
+  return (
+    <Stack spacing={2} direction="row" flexWrap="wrap">
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <DemoContainer components={['DateCalendar']}>
+          <DemoItem label="AdapterDayjs" alignItems="center">
+            <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
+          </DemoItem>
+        </DemoContainer>
+      </LocalizationProvider>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DemoContainer components={['DateCalendar']}>
+          <DemoItem label="AdapterDateFns" alignItems="center">
+            <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
+          </DemoItem>
+        </DemoContainer>
+      </LocalizationProvider>
+    </Stack>
+  );
+}

--- a/docs/data/date-pickers/custom-components/UsePickerAdapter.tsx.preview
+++ b/docs/data/date-pickers/custom-components/UsePickerAdapter.tsx.preview
@@ -1,0 +1,14 @@
+<LocalizationProvider dateAdapter={AdapterDayjs}>
+  <DemoContainer components={['DateCalendar']}>
+    <DemoItem label="AdapterDayjs" alignItems="center">
+      <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
+    </DemoItem>
+  </DemoContainer>
+</LocalizationProvider>
+<LocalizationProvider dateAdapter={AdapterDateFns}>
+  <DemoContainer components={['DateCalendar']}>
+    <DemoItem label="AdapterDateFns" alignItems="center">
+      <DateCalendar slots={{ calendarHeader: CustomCalendarHeader }} />
+    </DemoItem>
+  </DemoContainer>
+</LocalizationProvider>

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -251,6 +251,13 @@ You can pass custom components to replace the icons, as shown below:
 
 {{"demo": "ArrowSwitcherComponent.js", "defaultCodeOpen": false}}
 
+## Access date adapter
+
+In case you are building a custom component that needs to work with multiple date libraries, you can access the date adapter instance by using the `usePickerAdapter` hook.
+This hook returns the date adapter instance used by the picker, which you can use to format dates, parse strings, and perform other date-related operations.
+
+{{"demo": "UsePickerAdapter.js", "defaultCodeOpen": false}}
+
 ## Shortcuts
 
 You can add shortcuts to every Picker component.

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -256,6 +256,10 @@ You can pass custom components to replace the icons, as shown below:
 In case you are building a custom component that needs to work with multiple date libraries, you can access the date adapter instance by using the `usePickerAdapter` hook.
 This hook returns the date adapter instance used by the picker, which you can use to format dates, parse strings, and perform other date-related operations.
 
+:::success
+If your application uses a single date library, prefer using the date library directly in your components to avoid unnecessary complexity and possible breaking changes.
+:::
+
 {{"demo": "UsePickerAdapter.js", "defaultCodeOpen": false}}
 
 ## Shortcuts

--- a/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
+++ b/packages/x-date-pickers/src/DateCalendar/DateCalendar.tsx
@@ -9,7 +9,6 @@ import useId from '@mui/utils/useId';
 import useEventCallback from '@mui/utils/useEventCallback';
 import { DateCalendarProps, DateCalendarDefaultizedProps } from './DateCalendar.types';
 import { useCalendarState } from './useCalendarState';
-import { useUtils } from '../internals/hooks/useUtils';
 import { PickersFadeTransitionGroup } from './PickersFadeTransitionGroup';
 import { DayCalendar } from './DayCalendar';
 import { MonthCalendar } from '../MonthCalendar';
@@ -27,6 +26,7 @@ import { VIEW_HEIGHT } from '../internals/constants/dimensions';
 import { PickerOwnerState, PickerValidDate } from '../models';
 import { usePickerPrivateContext } from '../internals/hooks/usePickerPrivateContext';
 import { useApplyDefaultValuesToDateValidationProps } from '../managers/useDateManager';
+import { usePickerAdapter } from '../hooks/usePickerAdapter';
 
 const useUtilityClasses = (classes: Partial<DateCalendarClasses> | undefined) => {
   const slots = {
@@ -93,7 +93,7 @@ export const DateCalendar = React.forwardRef(function DateCalendar(
   inProps: DateCalendarProps,
   ref: React.Ref<HTMLDivElement>,
 ) {
-  const utils = useUtils();
+  const adapter = usePickerAdapter();
   const { ownerState } = usePickerPrivateContext();
   const id = useId();
   const props = useDateCalendarDefaultizedProps(inProps, 'MuiDateCalendar');
@@ -180,11 +180,11 @@ export const DateCalendar = React.forwardRef(function DateCalendar(
     disableFuture,
     timezone,
     getCurrentMonthFromVisibleDate: (visibleDate, prevMonth) => {
-      if (utils.isSameMonth(visibleDate, prevMonth)) {
+      if (adapter.isSameMonth(visibleDate, prevMonth)) {
         return prevMonth;
       }
 
-      return utils.startOfMonth(visibleDate);
+      return adapter.startOfMonth(visibleDate);
     },
   });
 
@@ -218,15 +218,15 @@ export const DateCalendar = React.forwardRef(function DateCalendar(
   });
 
   const handleDateMonthChange = useEventCallback((newDate: PickerValidDate) => {
-    const startOfMonth = utils.startOfMonth(newDate);
-    const endOfMonth = utils.endOfMonth(newDate);
+    const startOfMonth = adapter.startOfMonth(newDate);
+    const endOfMonth = adapter.endOfMonth(newDate);
 
     const closestEnabledDate = isDateDisabled(newDate)
       ? findClosestEnabledDate({
-          utils,
+          utils: adapter,
           date: newDate,
-          minDate: utils.isBefore(minDate, startOfMonth) ? startOfMonth : minDate,
-          maxDate: utils.isAfter(maxDate, endOfMonth) ? endOfMonth : maxDate,
+          minDate: adapter.isBefore(minDate, startOfMonth) ? startOfMonth : minDate,
+          maxDate: adapter.isAfter(maxDate, endOfMonth) ? endOfMonth : maxDate,
           disablePast,
           disableFuture,
           isDateDisabled,
@@ -244,15 +244,15 @@ export const DateCalendar = React.forwardRef(function DateCalendar(
   });
 
   const handleDateYearChange = useEventCallback((newDate: PickerValidDate) => {
-    const startOfYear = utils.startOfYear(newDate);
-    const endOfYear = utils.endOfYear(newDate);
+    const startOfYear = adapter.startOfYear(newDate);
+    const endOfYear = adapter.endOfYear(newDate);
 
     const closestEnabledDate = isDateDisabled(newDate)
       ? findClosestEnabledDate({
-          utils,
+          utils: adapter,
           date: newDate,
-          minDate: utils.isBefore(minDate, startOfYear) ? startOfYear : minDate,
-          maxDate: utils.isAfter(maxDate, endOfYear) ? endOfYear : maxDate,
+          minDate: adapter.isBefore(minDate, startOfYear) ? startOfYear : minDate,
+          maxDate: adapter.isAfter(maxDate, endOfYear) ? endOfYear : maxDate,
           disablePast,
           disableFuture,
           isDateDisabled,
@@ -273,7 +273,7 @@ export const DateCalendar = React.forwardRef(function DateCalendar(
     if (day) {
       // If there is a date already selected, then we want to keep its time
       return handleValueChange(
-        mergeDateAndTime(utils, day, value ?? referenceDate),
+        mergeDateAndTime(adapter, day, value ?? referenceDate),
         'finish',
         view,
       );
@@ -283,7 +283,7 @@ export const DateCalendar = React.forwardRef(function DateCalendar(
   });
 
   React.useEffect(() => {
-    if (utils.isValid(value)) {
+    if (adapter.isValid(value)) {
       setVisibleDate({ target: value, reason: 'controlled-value-change' });
     }
   }, [value]); // eslint-disable-line

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -153,9 +153,7 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
   }, [defaultDates, adapter, localeText]);
 
   return (
-    <PickerAdapterContext.Provider value={contextValue}>
-      {children}
-    </PickerAdapterContext.Provider>
+    <PickerAdapterContext.Provider value={contextValue}>{children}</PickerAdapterContext.Provider>
   );
 } as LocalizationProviderComponent;
 

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -11,7 +11,9 @@ export interface MuiPickersAdapterContextValue {
     maxDate: PickerValidDate;
   };
 
+  // TODO v9: Remove in favor of keeping only `adapter` field
   utils: MuiPickersAdapter;
+  adapter: MuiPickersAdapter;
   localeText: PickersInputLocaleText | undefined;
 }
 
@@ -69,9 +71,9 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
 ) {
   const { localeText: inLocaleText, ...otherInProps } = inProps;
 
-  const { utils: parentUtils, localeText: parentLocaleText } = React.useContext(
+  const { adapter: parentAdapter, localeText: parentLocaleText } = React.useContext(
     MuiPickersAdapterContext,
-  ) ?? { utils: undefined, localeText: undefined };
+  ) ?? { utils: undefined, adapter: undefined, localeText: undefined };
 
   const props: LocalizationProviderProps<TLocale> = useThemeProps({
     // We don't want to pass the `localeText` prop to the theme, that way it will always return the theme value,
@@ -94,22 +96,22 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
     [themeLocaleText, parentLocaleText, inLocaleText],
   );
 
-  const utils = React.useMemo(() => {
+  const adapter = React.useMemo(() => {
     if (!DateAdapter) {
-      if (parentUtils) {
-        return parentUtils;
+      if (parentAdapter) {
+        return parentAdapter;
       }
 
       return null;
     }
 
-    const adapter = new DateAdapter({
+    const dateAdapter = new DateAdapter({
       locale: adapterLocale,
       formats: dateFormats,
       instance: dateLibInstance,
     });
 
-    if (!adapter.isMUIAdapter) {
+    if (!dateAdapter.isMUIAdapter) {
       throw new Error(
         [
           'MUI X: The date adapter should be imported from `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`, not from `@date-io`',
@@ -119,27 +121,28 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
       );
     }
 
-    return adapter;
-  }, [DateAdapter, adapterLocale, dateFormats, dateLibInstance, parentUtils]);
+    return dateAdapter;
+  }, [DateAdapter, adapterLocale, dateFormats, dateLibInstance, parentAdapter]);
 
   const defaultDates: MuiPickersAdapterContextNullableValue['defaultDates'] = React.useMemo(() => {
-    if (!utils) {
+    if (!adapter) {
       return null;
     }
 
     return {
-      minDate: utils.date('1900-01-01T00:00:00.000'),
-      maxDate: utils.date('2099-12-31T00:00:00.000'),
+      minDate: adapter.date('1900-01-01T00:00:00.000'),
+      maxDate: adapter.date('2099-12-31T00:00:00.000'),
     };
-  }, [utils]);
+  }, [adapter]);
 
   const contextValue: MuiPickersAdapterContextNullableValue = React.useMemo(() => {
     return {
-      utils,
+      utils: adapter,
+      adapter,
       defaultDates,
       localeText,
     };
-  }, [defaultDates, utils, localeText]);
+  }, [defaultDates, adapter, localeText]);
 
   return (
     <MuiPickersAdapterContext.Provider value={contextValue}>

--- a/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/x-date-pickers/src/LocalizationProvider/LocalizationProvider.tsx
@@ -5,7 +5,7 @@ import { useThemeProps } from '@mui/material/styles';
 import { AdapterFormats, MuiPickersAdapter, PickerValidDate } from '../models';
 import { PickersInputLocaleText } from '../locales';
 
-export interface MuiPickersAdapterContextValue {
+export interface PickersAdapterContextValue {
   defaultDates: {
     minDate: PickerValidDate;
     maxDate: PickerValidDate;
@@ -17,12 +17,20 @@ export interface MuiPickersAdapterContextValue {
   localeText: PickersInputLocaleText | undefined;
 }
 
-export type MuiPickersAdapterContextNullableValue = {
-  [K in keyof MuiPickersAdapterContextValue]: MuiPickersAdapterContextValue[K] | null;
+export type PickerAdapterContextNullableValue = {
+  [K in keyof PickersAdapterContextValue]: PickersAdapterContextValue[K] | null;
 };
 
-export const MuiPickersAdapterContext =
-  React.createContext<MuiPickersAdapterContextNullableValue | null>(null);
+export const PickerAdapterContext = React.createContext<PickerAdapterContextNullableValue | null>(
+  null,
+);
+
+// TODO v9: Remove this public export
+/**
+ * The context that provides the date adapter and default dates to the pickers.
+ * @deprecated Use `usePickersAdapter` hook if you need access to the adapter instead.
+ */
+export const MuiPickersAdapterContext = PickerAdapterContext;
 
 export interface LocalizationProviderProps<TLocale> {
   children?: React.ReactNode;
@@ -72,7 +80,7 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
   const { localeText: inLocaleText, ...otherInProps } = inProps;
 
   const { adapter: parentAdapter, localeText: parentLocaleText } = React.useContext(
-    MuiPickersAdapterContext,
+    PickerAdapterContext,
   ) ?? { utils: undefined, adapter: undefined, localeText: undefined };
 
   const props: LocalizationProviderProps<TLocale> = useThemeProps({
@@ -124,7 +132,7 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
     return dateAdapter;
   }, [DateAdapter, adapterLocale, dateFormats, dateLibInstance, parentAdapter]);
 
-  const defaultDates: MuiPickersAdapterContextNullableValue['defaultDates'] = React.useMemo(() => {
+  const defaultDates: PickerAdapterContextNullableValue['defaultDates'] = React.useMemo(() => {
     if (!adapter) {
       return null;
     }
@@ -135,7 +143,7 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
     };
   }, [adapter]);
 
-  const contextValue: MuiPickersAdapterContextNullableValue = React.useMemo(() => {
+  const contextValue: PickerAdapterContextNullableValue = React.useMemo(() => {
     return {
       utils: adapter,
       adapter,
@@ -145,9 +153,9 @@ export const LocalizationProvider = function LocalizationProvider<TLocale>(
   }, [defaultDates, adapter, localeText]);
 
   return (
-    <MuiPickersAdapterContext.Provider value={contextValue}>
+    <PickerAdapterContext.Provider value={contextValue}>
       {children}
-    </MuiPickersAdapterContext.Provider>
+    </PickerAdapterContext.Provider>
   );
 } as LocalizationProviderComponent;
 

--- a/packages/x-date-pickers/src/hooks/index.tsx
+++ b/packages/x-date-pickers/src/hooks/index.tsx
@@ -4,3 +4,4 @@ export { useParsedFormat } from './useParsedFormat';
 export { usePickerContext } from './usePickerContext';
 export { usePickerActionsContext } from './usePickerActionsContext';
 export { useIsValidValue } from './useIsValidValue';
+export { usePickerAdapter } from './usePickerAdapter';

--- a/packages/x-date-pickers/src/hooks/usePickerAdapter.ts
+++ b/packages/x-date-pickers/src/hooks/usePickerAdapter.ts
@@ -1,0 +1,4 @@
+'use client';
+import { useLocalizationContext } from '../internals/hooks/useUtils';
+
+export const usePickerAdapter = () => useLocalizationContext().adapter;

--- a/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
+++ b/packages/x-date-pickers/src/internals/demo/DemoContainer.tsx
@@ -60,18 +60,16 @@ const getSupportedSectionFromChildName = (childName: string): PickersSupportedSe
   return 'time';
 };
 
-interface DemoItemProps {
+interface DemoItemProps extends Omit<StackProps, 'component'> {
   label?: React.ReactNode;
   component?: string;
-  children: React.ReactNode;
-  sx?: SxProps<Theme>;
 }
 /**
  * WARNING: This is an internal component used in documentation to achieve a desired layout.
  * Please do not use it in your application.
  */
 export function DemoItem(props: DemoItemProps) {
-  const { label, children, component, sx: sxProp } = props;
+  const { label, children, component, sx: sxProp, alignItems = 'stretch' } = props;
 
   let spacing: StackProps['spacing'];
   let sx = sxProp;
@@ -89,7 +87,7 @@ export function DemoItem(props: DemoItemProps) {
   }
 
   return (
-    <Stack direction="column" alignItems="stretch" spacing={spacing} sx={sx}>
+    <Stack direction="column" alignItems={alignItems} spacing={spacing} sx={sx}>
       {label && <Typography variant="body2">{label}</Typography>}
       {children}
     </Stack>

--- a/packages/x-date-pickers/src/internals/hooks/useUtils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useUtils.ts
@@ -19,7 +19,7 @@ export const useLocalizationContext = () => {
     );
   }
 
-  if (localization.utils === null) {
+  if (localization.adapter === null) {
     throw new Error(
       [
         'MUI X: Can not find the date and time pickers adapter from its localization context.',

--- a/packages/x-date-pickers/src/internals/hooks/useUtils.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useUtils.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import {
-  MuiPickersAdapterContext,
-  MuiPickersAdapterContextValue,
+  PickerAdapterContext,
+  PickersAdapterContextValue,
 } from '../../LocalizationProvider/LocalizationProvider';
 import { DEFAULT_LOCALE } from '../../locales/enUS';
 import { PickersLocaleText } from '../../locales/utils/pickersLocaleTextApi';
 import { PickersTimezone, PickerValidDate } from '../../models';
 
 export const useLocalizationContext = () => {
-  const localization = React.useContext(MuiPickersAdapterContext);
+  const localization = React.useContext(PickerAdapterContext);
   if (localization === null) {
     throw new Error(
       [
@@ -59,6 +59,6 @@ export const useNow = (timezone: PickersTimezone): PickerValidDate => {
 };
 
 export interface UseLocalizationContextReturnValue
-  extends Omit<MuiPickersAdapterContextValue, 'localeText'> {
+  extends Omit<PickersAdapterContextValue, 'localeText'> {
   localeText: PickersLocaleText;
 }

--- a/packages/x-date-pickers/src/validation/useValidation.ts
+++ b/packages/x-date-pickers/src/validation/useValidation.ts
@@ -2,14 +2,14 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import { useLocalizationContext } from '../internals/hooks/useUtils';
-import { MuiPickersAdapterContextValue } from '../LocalizationProvider/LocalizationProvider';
+import { PickersAdapterContextValue } from '../LocalizationProvider/LocalizationProvider';
 import { OnErrorProps, PickersTimezone } from '../models';
 import type { PickerValueManager } from '../internals/models';
 import { PickerValidValue } from '../internals/models';
 
 export type Validator<TValue extends PickerValidValue, TError, TValidationProps> = {
   (params: {
-    adapter: MuiPickersAdapterContextValue;
+    adapter: PickersAdapterContextValue;
     value: TValue;
     timezone: PickersTimezone;
     props: TValidationProps;

--- a/scripts/x-date-pickers-pro.exports.json
+++ b/scripts/x-date-pickers-pro.exports.json
@@ -471,6 +471,7 @@
   { "name": "UseMultiInputRangeFieldTextFieldProps", "kind": "TypeAlias" },
   { "name": "useParsedFormat", "kind": "Variable" },
   { "name": "usePickerActionsContext", "kind": "Variable" },
+  { "name": "usePickerAdapter", "kind": "Variable" },
   { "name": "usePickerContext", "kind": "Variable" },
   { "name": "usePickerLayout", "kind": "ExportAssignment" },
   { "name": "usePickerRangePositionContext", "kind": "Function" },

--- a/scripts/x-date-pickers.exports.json
+++ b/scripts/x-date-pickers.exports.json
@@ -317,6 +317,7 @@
   { "name": "useIsValidValue", "kind": "Function" },
   { "name": "useParsedFormat", "kind": "Variable" },
   { "name": "usePickerActionsContext", "kind": "Variable" },
+  { "name": "usePickerAdapter", "kind": "Variable" },
   { "name": "usePickerContext", "kind": "Variable" },
   { "name": "usePickerLayout", "kind": "ExportAssignment" },
   { "name": "usePickerTranslations", "kind": "Variable" },


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18402.

- Add a publicly exported `usePickerAdapter` hook.
- Deprecate `MuiPickersAdapterContext`
- Add demo using `usePickerAdapter`

Leaving the refactor to use `usePickerAdapter` instead of `useUtils` internally for a follow-up.
