### PR TITLE
[DataGridPro] Fix lazy loading params calculated from rendering context

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -409,7 +409,7 @@ export const useGridDataSourceLazyLoader = (
         visibleRows: currentVisibleRows.rows,
         range: {
           firstRowIndex: params.firstRowIndex,
-          lastRowIndex: params.lastRowIndex,
+          lastRowIndex: params.lastRowIndex - 1,
         },
       });
 

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -385,7 +385,7 @@ export const useGridDataSourceLazyLoader = (
       const filterModel = gridFilterModelSelector(privateApiRef);
       const getRowsParams: GridGetRowsParams = {
         start: params.firstRowIndex,
-        end: params.lastRowIndex,
+        end: params.lastRowIndex - 1,
         sortModel,
         filterModel,
       };


### PR DESCRIPTION
Fixes the issue visible at this demo
https://mui.com/x/react-data-grid/server-side-data/lazy-loading/#changing-the-loading-mode

Steps to reproduce
1. Choose row count = 40
2. Scroll to the end of the grid

Expected
Last batch of rows loaded

Actually
More than 40 rows are loaded and row count becomes 50

Root cause for this is that our renderer context end index considers that index to be excluded from the row list. In this specific case, scrolling to the end makes renderer context end at 40.
Lazy loading hook sees that as the beginning of the next page (page ends at index 39) and adjusts request to go to 49 (to get the whole page).

Line that makes the render context set this value is https://github.com/mui/mui-x/blob/v8.5.3/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx#L961

I didn't want to make the update to the virtual scroller as this would change the parameter value for our render context change event. People using it are probably making end index adjustment already, so changing it would cause problems in their code. Instead, I have added this point to https://github.com/mui/mui-x/issues/17846 to assess and update the end index.

This PR fixes server side lazy loader, but the same problem is present in client side lazy loader. It also sends end index that should be excluded https://github.com/mui/mui-x/blob/v8.5.3/packages/x-data-grid-pro/src/hooks/features/lazyLoader/useGridLazyLoader.ts#L49 and using `slice` here matches with this approach https://github.com/mui/mui-x/blob/v8.5.3/docs/data/data-grid/row-updates/LazyLoadingGrid.tsx#L49.

