### PR TITLE
[docs] Prevent stale rows to appear on sort and filter change in the lazy loading demo

### DIFF
--- a/docs/data/data-grid/row-updates/LazyLoadingGrid.js
+++ b/docs/data/data-grid/row-updates/LazyLoadingGrid.js
@@ -20,6 +20,7 @@ export default function LazyLoadingGrid() {
   const apiRef = useGridApiRef();
   const [initialRows, setInitialRows] = React.useState([]);
   const [rowCount, setRowCount] = React.useState(0);
+  const fetchReference = React.useRef(0);
 
   const fetchRow = React.useCallback(
     async (params) => {
@@ -72,7 +73,11 @@ export default function LazyLoadingGrid() {
   // Fetch rows as they become visible in the viewport
   const handleFetchRows = React.useCallback(
     async (params) => {
+      const reference = fetchReference.current;
       const { slice, total } = await fetchRow(params);
+      if (reference !== fetchReference.current) {
+        return;
+      }
 
       apiRef.current?.unstable_replaceRows(params.firstRowToRender, slice);
       setRowCount(total);
@@ -85,7 +90,8 @@ export default function LazyLoadingGrid() {
     [handleFetchRows],
   );
 
-  const resetRows = React.useCallback(() => {
+  const handleModelChange = React.useCallback(() => {
+    fetchReference.current += 1;
     setInitialRows([]);
   }, []);
 
@@ -101,8 +107,8 @@ export default function LazyLoadingGrid() {
         filterMode="server"
         rowsLoadingMode="server"
         onFetchRows={debouncedHandleFetchRows}
-        onSortModelChange={resetRows}
-        onFilterModelChange={resetRows}
+        onSortModelChange={handleModelChange}
+        onFilterModelChange={handleModelChange}
       />
     </div>
   );

--- a/docs/data/data-grid/row-updates/LazyLoadingGrid.tsx
+++ b/docs/data/data-grid/row-updates/LazyLoadingGrid.tsx
@@ -28,6 +28,7 @@ export default function LazyLoadingGrid() {
   const apiRef = useGridApiRef();
   const [initialRows, setInitialRows] = React.useState<typeof rowsServerSide>([]);
   const [rowCount, setRowCount] = React.useState(0);
+  const fetchReference = React.useRef(0);
 
   const fetchRow = React.useCallback(
     async (params: GridFetchRowsParams) => {
@@ -80,7 +81,11 @@ export default function LazyLoadingGrid() {
   // Fetch rows as they become visible in the viewport
   const handleFetchRows = React.useCallback(
     async (params: GridFetchRowsParams) => {
+      const reference = fetchReference.current;
       const { slice, total } = await fetchRow(params);
+      if (reference !== fetchReference.current) {
+        return;
+      }
 
       apiRef.current?.unstable_replaceRows(params.firstRowToRender, slice);
       setRowCount(total);
@@ -93,7 +98,8 @@ export default function LazyLoadingGrid() {
     [handleFetchRows],
   );
 
-  const resetRows = React.useCallback(() => {
+  const handleModelChange = React.useCallback(() => {
+    fetchReference.current += 1;
     setInitialRows([]);
   }, []);
 
@@ -109,8 +115,8 @@ export default function LazyLoadingGrid() {
         filterMode="server"
         rowsLoadingMode="server"
         onFetchRows={debouncedHandleFetchRows}
-        onSortModelChange={resetRows}
-        onFilterModelChange={resetRows}
+        onSortModelChange={handleModelChange}
+        onFilterModelChange={handleModelChange}
       />
     </div>
   );

--- a/docs/data/data-grid/row-updates/LazyLoadingGrid.tsx.preview
+++ b/docs/data/data-grid/row-updates/LazyLoadingGrid.tsx.preview
@@ -8,6 +8,6 @@
   filterMode="server"
   rowsLoadingMode="server"
   onFetchRows={debouncedHandleFetchRows}
-  onSortModelChange={resetRows}
-  onFilterModelChange={resetRows}
+  onSortModelChange={handleModelChange}
+  onFilterModelChange={handleModelChange}
 />


### PR DESCRIPTION
Found out while debugging https://github.com/mui/mui-x/pull/18460

Related demo https://mui.com/x/react-data-grid/row-updates/#lazy-loading

Reproduction steps
1. scroll to load more rows
2. apply sorting (best visible with rating)
3. scroll up/down to make a new request before the previous one is resolved
4. repeat 2 and 3 couple of times

Rows appear not sorted according to the model

In addition to this, console errors appear
