### PR TITLE
[infra] Use `String.raw` for creating the remote regex

### DIFF
--- a/scripts/createReleasePR.mjs
+++ b/scripts/createReleasePR.mjs
@@ -53,7 +53,8 @@ const REPO = 'mui-x';
 
 // we need to disable the no-useless-escape to include the `/` in the regex single character capturing group
 // eslint-disable-next-line no-useless-escape
-const getRemoteRegex = (owner) => new RegExp(`([\/:])${owner}\/${REPO}(\.git)?\s+\(push\)`);
+const getRemoteRegex = (owner) =>
+  new RegExp(String.raw`([\/:])${owner}\/${REPO}(\.git)?\s+\(push\)`);
 
 /**
  * Command line arguments for the script


### PR DESCRIPTION
this is fixing a bug that snuck in for the release preparation script in #18345 