### PR TITLE
[charts] Improve `PanGesture` delta tracking and setup gesture infra

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -33,6 +33,7 @@ const defaultAlias = {
   '@mui/x-tree-view': resolveAliasPath('./packages/x-tree-view/src'),
   '@mui/x-tree-view-pro': resolveAliasPath('./packages/x-tree-view-pro/src'),
   '@mui/x-internals': resolveAliasPath('./packages/x-internals/src'),
+  '@mui/x-internal-gestures': resolveAliasPath('./packages/x-internal-gestures/src'),
   '@mui/material-nextjs': '@mui/monorepo/packages/mui-material-nextjs/src',
   '@mui-internal/api-docs-builder': resolveAliasPath(
     './node_modules/@mui/monorepo/packages/api-docs-builder',

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -70,6 +70,7 @@ globalThis.muiDocConfig = {
       '@mui/x-tree-view': getMuiPackageVersion('x-tree-view', muiCommitRef),
       '@mui/x-tree-view-pro': getMuiPackageVersion('x-tree-view-pro', muiCommitRef),
       '@mui/x-internals': getMuiPackageVersion('x-internals', muiCommitRef),
+      '@mui/x-internal-gestures': getMuiPackageVersion('x-internal-gestures', muiCommitRef),
       exceljs: 'latest',
     };
   },

--- a/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
@@ -61,14 +61,18 @@ export type PanGestureEventData<
 > = PointerGestureEventData<CustomData> & {
   /** The centroid position at the start of the gesture */
   initialCentroid: { x: number; y: number };
-  /** Horizontal distance moved in pixels from the start of the current gesture */
+  /** Horizontal distance moved in pixels from last event */
   deltaX: number;
-  /** Vertical distance moved in pixels from the start of the current gesture */
+  /** Vertical distance moved in pixels from last event */
   deltaY: number;
   /** Total accumulated horizontal movement in pixels */
   totalDeltaX: number;
   /** Total accumulated vertical movement in pixels */
   totalDeltaY: number;
+  /** Horizontal distance moved in pixels from the start of the current gesture */
+  activeDeltaX: number;
+  /** Vertical distance moved in pixels from the start of the current gesture */
+  activeDeltaY: number;
   /** The direction of movement with vertical and horizontal components */
   direction: Direction;
   /** Horizontal velocity in pixels per second */
@@ -99,6 +103,10 @@ export type PanGestureState = GestureState & {
   totalDeltaX: number;
   /** Total accumulated vertical delta since gesture tracking began */
   totalDeltaY: number;
+  /** Active horizontal delta since the start of the current gesture */
+  activeDeltaX: number;
+  /** Active horizontal delta since the start of the current gesture */
+  activeDeltaY: number;
   /** Map of pointers that initiated the gesture, used for tracking state */
   startPointers: Map<number, PointerData>;
   /** The last direction of movement detected */
@@ -121,6 +129,8 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
     movementThresholdReached: false,
     totalDeltaX: 0,
     totalDeltaY: 0,
+    activeDeltaX: 0,
+    activeDeltaY: 0,
     lastDirection: {
       vertical: null,
       horizontal: null,
@@ -198,6 +208,8 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
       startCentroid: null,
       lastCentroid: null,
       lastDeltas: null,
+      activeDeltaX: 0,
+      activeDeltaY: 0,
       movementThresholdReached: false,
       lastDirection: {
         vertical: null,
@@ -301,9 +313,11 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
             this.isActive = true;
 
             // Update total accumulated delta
-            this.state.lastDeltas = { x: currentCentroid.x, y: currentCentroid.y };
+            this.state.lastDeltas = { x: lastDeltaX, y: lastDeltaY };
             this.state.totalDeltaX += lastDeltaX;
             this.state.totalDeltaY += lastDeltaY;
+            this.state.activeDeltaX += lastDeltaX;
+            this.state.activeDeltaY += lastDeltaY;
 
             // Emit start event
             this.emitPanEvent(targetElement, 'start', relevantPointers, event, currentCentroid);
@@ -315,6 +329,8 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
             this.state.lastDeltas = { x: lastDeltaX, y: lastDeltaY };
             this.state.totalDeltaX += lastDeltaX;
             this.state.totalDeltaY += lastDeltaY;
+            this.state.activeDeltaX += lastDeltaX;
+            this.state.activeDeltaY += lastDeltaY;
 
             // Emit ongoing event
             this.emitPanEvent(targetElement, 'ongoing', relevantPointers, event, currentCentroid);
@@ -398,6 +414,8 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
       velocity,
       totalDeltaX: this.state.totalDeltaX,
       totalDeltaY: this.state.totalDeltaY,
+      activeDeltaX: this.state.activeDeltaX,
+      activeDeltaY: this.state.activeDeltaY,
       activeGestures,
       customData: this.customData,
     };

--- a/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
@@ -105,7 +105,7 @@ export type PanGestureState = GestureState & {
   totalDeltaY: number;
   /** Active horizontal delta since the start of the current gesture */
   activeDeltaX: number;
-  /** Active horizontal delta since the start of the current gesture */
+  /** Active vertical delta since the start of the current gesture */
   activeDeltaY: number;
   /** Map of pointers that initiated the gesture, used for tracking state */
   startPointers: Map<number, PointerData>;

--- a/scripts/printPkgPrNewPublishDirs.mts
+++ b/scripts/printPkgPrNewPublishDirs.mts
@@ -12,6 +12,7 @@ const publishDirs = {
   '@mui/x-date-pickers': 'packages/x-date-pickers',
   '@mui/x-date-pickers-pro': 'packages/x-date-pickers-pro',
   '@mui/x-internals': 'packages/x-internals',
+  '@mui/x-internal-gestures': 'packages/x-internal-gestures',
   '@mui/x-license': 'packages/x-license',
   // private packages can not be published
   // '@mui/x-scheduler': 'packages/x-scheduler',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
       "@mui/x-license/*": ["./packages/x-license/src/*"],
       "@mui/x-internals": ["./packages/x-internals/src"],
       "@mui/x-internals/*": ["./packages/x-internals/src/*"],
+      "@mui/x-internal-gestures/*": ["./packages/x-internal-gestures/src/*"],
       "@mui/x-telemetry": ["./packages/x-telemetry/src"],
       "@mui/x-telemetry/*": ["./packages/x-telemetry/src/*"],
       "@mui/docs": ["./node_modules/@mui/monorepo/packages/mui-docs/src"],

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -22,6 +22,7 @@
       "@mui/x-license/*": ["./packages/x-license/src/*"],
       "@mui/x-internals": ["./packages/x-internals/src"],
       "@mui/x-internals/*": ["./packages/x-internals/src/*"],
+      "@mui/x-internal-gestures/*": ["./packages/x-internal-gestures/src/*"],
       "@mui/x-telemetry": ["./packages/x-telemetry/src"],
       "@mui/x-telemetry/*": ["./packages/x-telemetry/src/*"],
       "@mui/docs": ["./node_modules/@mui/monorepo/packages/mui-docs/src"],

--- a/webpackBaseConfig.js
+++ b/webpackBaseConfig.js
@@ -24,6 +24,7 @@ module.exports = {
       '@mui/x-license': path.resolve(__dirname, './packages/x-license/src'),
       '@mui/x-telemetry': path.resolve(__dirname, './packages/x-telemetry/src'),
       '@mui/x-internals': path.resolve(__dirname, './packages/x-internals/src'),
+      '@mui/x-internal-gestures': path.resolve(__dirname, './packages/x-internal-gestures/src'),
       '@mui/material-nextjs': path.resolve(
         __dirname,
         './node_modules/@mui/monorepo/packages/mui-material-nextjs/src',


### PR DESCRIPTION
Differentiate `totalDelta` from `activeDelta` and `delta`.

- `delta` is the difference since last event
- `activeDelta` is the difference since pointer down
- `totalDelta` is the total difference across all gestures

This is useful in the charts as the zoom pan calculates the amount of the svg area to pan in percentages, the `totalDelta` is not useful as we need to perform the action relative to the pointer, and the `delta` is too fine-grained, which introduces issues. The `activeDelta` mimics the current behaviour, and is also an useful prop in itself. 