### PR TITLE
[docs][pickers] Update action bar demo to use the `nextOrAccept` action

### DIFF
--- a/docs/data/date-pickers/custom-components/ActionBarComponent.js
+++ b/docs/data/date-pickers/custom-components/ActionBarComponent.js
@@ -1,24 +1,27 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
+import useId from '@mui/utils/useId';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import DialogActions from '@mui/material/DialogActions';
-import useId from '@mui/utils/useId';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 
-import {
-  usePickerActionsContext,
-  usePickerTranslations,
-} from '@mui/x-date-pickers/hooks';
+import { usePickerContext, usePickerTranslations } from '@mui/x-date-pickers/hooks';
 
 function CustomActionBar(props) {
   const { actions, className } = props;
   const translations = usePickerTranslations();
-  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
-    usePickerActionsContext();
+  const {
+    clearValue,
+    setValueToToday,
+    acceptValueChanges,
+    cancelValueChanges,
+    goToNextStep,
+    hasNextStep,
+  } = usePickerContext();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
   const id = useId();
@@ -78,6 +81,46 @@ function CustomActionBar(props) {
             key={actionType}
           >
             {translations.todayButtonLabel}
+          </MenuItem>
+        );
+
+      case 'next':
+        return (
+          <MenuItem
+            onClick={() => {
+              setAnchorEl(null);
+              goToNextStep();
+            }}
+            key={actionType}
+          >
+            {translations.nextStepButtonLabel}
+          </MenuItem>
+        );
+
+      case 'nextOrAccept':
+        if (hasNextStep) {
+          return (
+            <MenuItem
+              onClick={() => {
+                setAnchorEl(null);
+                goToNextStep();
+              }}
+              key={actionType}
+            >
+              {translations.nextStepButtonLabel}
+            </MenuItem>
+          );
+        }
+
+        return (
+          <MenuItem
+            onClick={() => {
+              setAnchorEl(null);
+              acceptValueChanges();
+            }}
+            key={actionType}
+          >
+            {translations.okButtonLabel}
           </MenuItem>
         );
 

--- a/docs/data/date-pickers/custom-components/ActionBarComponent.tsx
+++ b/docs/data/date-pickers/custom-components/ActionBarComponent.tsx
@@ -1,24 +1,27 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
+import useId from '@mui/utils/useId';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import DialogActions from '@mui/material/DialogActions';
-import useId from '@mui/utils/useId';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker';
 import { PickersActionBarProps } from '@mui/x-date-pickers/PickersActionBar';
-import {
-  usePickerActionsContext,
-  usePickerTranslations,
-} from '@mui/x-date-pickers/hooks';
+import { usePickerContext, usePickerTranslations } from '@mui/x-date-pickers/hooks';
 
 function CustomActionBar(props: PickersActionBarProps) {
   const { actions, className } = props;
   const translations = usePickerTranslations();
-  const { clearValue, setValueToToday, acceptValueChanges, cancelValueChanges } =
-    usePickerActionsContext();
+  const {
+    clearValue,
+    setValueToToday,
+    acceptValueChanges,
+    cancelValueChanges,
+    goToNextStep,
+    hasNextStep,
+  } = usePickerContext();
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
   const open = Boolean(anchorEl);
   const id = useId();
@@ -75,6 +78,45 @@ function CustomActionBar(props: PickersActionBarProps) {
             key={actionType}
           >
             {translations.todayButtonLabel}
+          </MenuItem>
+        );
+      case 'next':
+        return (
+          <MenuItem
+            onClick={() => {
+              setAnchorEl(null);
+              goToNextStep();
+            }}
+            key={actionType}
+          >
+            {translations.nextStepButtonLabel}
+          </MenuItem>
+        );
+
+      case 'nextOrAccept':
+        if (hasNextStep) {
+          return (
+            <MenuItem
+              onClick={() => {
+                setAnchorEl(null);
+                goToNextStep();
+              }}
+              key={actionType}
+            >
+              {translations.nextStepButtonLabel}
+            </MenuItem>
+          );
+        }
+
+        return (
+          <MenuItem
+            onClick={() => {
+              setAnchorEl(null);
+              acceptValueChanges();
+            }}
+            key={actionType}
+          >
+            {translations.okButtonLabel}
           </MenuItem>
         );
       default:

--- a/docs/data/date-pickers/custom-components/custom-components.md
+++ b/docs/data/date-pickers/custom-components/custom-components.md
@@ -47,14 +47,16 @@ In the example below, the action bar contains only one button, which resets the 
 
 #### Available actions
 
-The built-in `ActionBar` component supports four different actions:
+The built-in `<PickersActionBar />` component supports the following different actions:
 
-| Action   | Behavior                                                               |
-| :------- | :--------------------------------------------------------------------- |
-| `accept` | Accept the current value and close the picker view                     |
-| `cancel` | Reset to the last accepted date and close the picker view              |
-| `clear`  | Reset to the empty value and close the picker view                     |
-| `today`  | Reset to today's date (and time if relevant) and close the picker view |
+| Action         | Behavior                                                                         |
+| :------------- | :------------------------------------------------------------------------------- |
+| `accept`       | Accept the current value and close the picker view.                              |
+| `cancel`       | Reset to the last accepted date and close the picker view.                       |
+| `clear`        | Reset to the empty value and close the picker view.                              |
+| `next`         | Go to the next step in the value picking process.                                |
+| `nextOrAccept` | Shows the `accept` or `next` action depending on the value picking process step. |
+| `today`        | Reset to today's date (and time if relevant) and close the picker view.          |
 
 ### Component
 

--- a/docs/pages/x/api/date-pickers/pickers-action-bar.json
+++ b/docs/pages/x/api/date-pickers/pickers-action-bar.json
@@ -5,7 +5,7 @@
         "name": "arrayOf",
         "description": "Array&lt;'accept'<br>&#124;&nbsp;'cancel'<br>&#124;&nbsp;'clear'<br>&#124;&nbsp;'next'<br>&#124;&nbsp;'nextOrAccept'<br>&#124;&nbsp;'today'&gt;"
       },
-      "default": "`[]` for Desktop Date Picker and Desktop Date Range Picker\n- `['cancel', 'accept']` for all other Pickers"
+      "default": "`[]` for Pickers with one selection step which `closeOnSelect`.\n- `['cancel', 'nextOrAccept']` for all other Pickers."
     },
     "disableSpacing": { "type": { "name": "bool" }, "default": "false" },
     "sx": {

--- a/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
+++ b/packages/x-date-pickers/src/PickersActionBar/PickersActionBar.tsx
@@ -20,8 +20,8 @@ export interface PickersActionBarProps extends DialogActionsProps {
    * Ordered array of actions to display.
    * If empty, does not display that action bar.
    * @default
-   * - `[]` for Desktop Date Picker and Desktop Date Range Picker
-   * - `['cancel', 'accept']` for all other Pickers
+   * - `[]` for Pickers with one selection step which `closeOnSelect`.
+   * - `['cancel', 'nextOrAccept']` for all other Pickers.
    */
   actions?: PickersActionBarAction[];
 }
@@ -126,8 +126,8 @@ PickersActionBarComponent.propTypes = {
    * Ordered array of actions to display.
    * If empty, does not display that action bar.
    * @default
-   * - `[]` for Desktop Date Picker and Desktop Date Range Picker
-   * - `['cancel', 'accept']` for all other Pickers
+   * - `[]` for Pickers with one selection step which `closeOnSelect`.
+   * - `['cancel', 'nextOrAccept']` for all other Pickers.
    */
   actions: PropTypes.arrayOf(
     PropTypes.oneOf(['accept', 'cancel', 'clear', 'next', 'nextOrAccept', 'today']).isRequired,


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18458.

- Update action bar demo to use the `nextOrAccept` and `next` actions.
- Update text to mention the new actions.
- Update the JSDoc prop to better reflect current behavior.