### PR TITLE
[DataGridPro] Added reason to "Select All Rows" selection

### DIFF
--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { RefObject } from '@mui/x-internals/types';
-import { getCell, getColumnHeaderCell, getColumnValues, getRows, includeRowSelection } from 'test/utils/helperFn';
+import {
+  getCell,
+  getColumnHeaderCell,
+  getColumnValues,
+  getRows,
+  includeRowSelection,
+} from 'test/utils/helperFn';
 import { createRenderer, screen, act, fireEvent } from '@mui/internal-test-utils';
 import {
   GridApi,
@@ -1356,7 +1362,7 @@ describe('<DataGridPro /> - Row selection', () => {
     });
   });
 
-describe('prop: rowSelectionModel and onRowSelectionModelChange', () => {
+  describe('prop: rowSelectionModel and onRowSelectionModelChange', () => {
     it('should call onRowSelectionModelChange with the correct reason when clicking on a row', async () => {
       const onRowSelectionModelChange = spy();
       const { user } = render(

--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -727,11 +727,13 @@ export const useGridRowSelection = (
         applyAutoSelection &&
         !hasFilters
       ) {
-
-        apiRef.current.setRowSelectionModel({
-          type: value ? 'exclude' : 'include',
-          ids: new Set(),
-        }, 'multipleRowsSelection');
+        apiRef.current.setRowSelectionModel(
+          {
+            type: value ? 'exclude' : 'include',
+            ids: new Set(),
+          },
+          'multipleRowsSelection',
+        );
       } else {
         apiRef.current.selectRows(getRowsToBeSelected(), value);
       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
fix #18443 

Issue: No reason was provided when **Select All Rows** was used, leading to it being `undefined`.
Fix: Reason is set as `multipleRowsSelection` when **Select All Rows** is used in Datagrid


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
