### PR TITLE
[core] avoid json stringify whole window object

### DIFF
--- a/packages/x-internals/src/hash/stringify.ts
+++ b/packages/x-internals/src/hash/stringify.ts
@@ -6,6 +6,9 @@
 export function stringify(input: object | string | number | null) {
   const seen = new WeakSet();
   return JSON.stringify(input, (_, v) => {
+    // Prevent stringify whole window object as this cause security error.
+    // Security error happens due to micro-frontend code used on different host.
+    // For more information check here https://github.com/mui/mui-x/issues/17855.
     if (typeof window !== 'undefined' && v === window) {
       return v.toString();
     }

--- a/packages/x-internals/src/hash/stringify.ts
+++ b/packages/x-internals/src/hash/stringify.ts
@@ -6,6 +6,9 @@
 export function stringify(input: object | string | number | null) {
   const seen = new WeakSet();
   return JSON.stringify(input, (_, v) => {
+    if (typeof window !== 'undefined' && v === window) {
+      return v.toString();
+    }
     if (v !== null && typeof v === 'object') {
       if (seen.has(v)) {
         return null;

--- a/packages/x-internals/src/hash/stringify.ts
+++ b/packages/x-internals/src/hash/stringify.ts
@@ -6,9 +6,7 @@
 export function stringify(input: object | string | number | null) {
   const seen = new WeakSet();
   return JSON.stringify(input, (_, v) => {
-    // Prevent stringify whole window object as this cause security error.
-    // Security error happens due to micro-frontend code used on different host.
-    // For more information check here https://github.com/mui/mui-x/issues/17855.
+    // https://github.com/mui/mui-x/issues/17855
     if (typeof window !== 'undefined' && v === window) {
       return v.toString();
     }


### PR DESCRIPTION
fix https://github.com/mui/mui-x/issues/17855

Issue - stringifying to json whole window object which in case of MFE can't be really accessed to stringify
Fix - just return simple string to stringify in such case ("[object Window]")

* [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
