### PR TITLE
[charts] Use clip-path attribute for border-radius on bar charts

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/previews/BarPreviewPlot.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/previews/BarPreviewPlot.tsx
@@ -63,6 +63,7 @@ function useBarPreviewData(axisId: AxisId, drawingArea: ChartDrawingArea) {
 
   const xAxes = useSelector(store, selectorChartPreviewComputedXAxis, [axisId]);
   const yAxes = useSelector(store, selectorChartPreviewComputedYAxis, [axisId]);
+  const withoutBorderRadius = true; // We don't support border radius in preview plots
 
-  return useBarPlotData(drawingArea, xAxes, yAxes);
+  return useBarPlotData(drawingArea, xAxes, yAxes, withoutBorderRadius);
 }

--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -201,27 +201,29 @@ function generateClipPath(
   height: number,
 ) {
   const id = `${stackId ?? seriesId}-${dataIndex}`;
+  const bR = Math.min(borderRadius, width / 2, height / 2);
+
   if (layout === 'vertical') {
     const positiveStack = positiveStacks.get(id);
 
     if (positiveStack && positiveStack.seriesId === seriesId) {
-      return `path("M0,${height} v-${height - borderRadius} a${borderRadius},${borderRadius} 0 0 1 ${borderRadius},-${borderRadius} h${width - borderRadius * 2} a${borderRadius},${borderRadius} 0 0 1 ${borderRadius},${borderRadius} v${height - borderRadius} Z")`;
+      return `path("M0,${height} v-${height - bR} a${bR},${bR} 0 0 1 ${bR},-${bR} h${width - bR * 2} a${bR},${bR} 0 0 1 ${bR},${bR} v${height} Z")`;
     }
 
     const negativeStack = negativeStacks.get(id);
     if (negativeStack && negativeStack.seriesId === seriesId) {
-      return `path("M0,0 v${height - borderRadius} a${borderRadius},${borderRadius} 0 0 0 ${borderRadius},${borderRadius} h${width - borderRadius * 2} a${borderRadius},${borderRadius} 0 0 0 ${borderRadius},-${borderRadius} v-${height - borderRadius} Z")`;
+      return `path("M0,0 v${height - bR} a${bR},${bR} 0 0 0 ${bR},${bR} h${width - bR * 2} a${bR},${bR} 0 0 0 ${bR},-${bR} v-${height - bR} Z")`;
     }
   } else if (layout === 'horizontal') {
     const positiveStack = positiveStacks.get(id);
 
     if (positiveStack && positiveStack.seriesId === seriesId) {
-      return `path("M0,0 h${width - borderRadius} a${borderRadius},${borderRadius} 0 0 1 ${borderRadius},${borderRadius} v${height - borderRadius * 2} a${borderRadius},${borderRadius} 0 0 1 -${borderRadius},${borderRadius} h-${width - borderRadius} Z")`;
+      return `path("M0,0 h${width - bR} a${bR},${bR} 0 0 1 ${bR},${bR} v${height - bR * 2} a${bR},${bR} 0 0 1 -${bR},${bR} h-${width - bR} Z")`;
     }
 
     const negativeStack = negativeStacks.get(id);
     if (negativeStack && negativeStack.seriesId === seriesId) {
-      return `path("M${width},0 h-${width - borderRadius} a${borderRadius},${borderRadius} 0 0 0 -${borderRadius},${borderRadius} v${height - borderRadius * 2} a${borderRadius},${borderRadius} 0 0 0 ${borderRadius},${borderRadius} h${width - borderRadius} Z")`;
+      return `path("M${width},0 h-${width - bR} a${bR},${bR} 0 0 0 -${bR},${bR} v${height - bR * 2} a${bR},${bR} 0 0 0 ${bR},${bR} h${width - bR} Z")`;
     }
   }
 

--- a/packages/x-charts/src/BarChart/types.ts
+++ b/packages/x-charts/src/BarChart/types.ts
@@ -22,6 +22,7 @@ export interface ProcessedBarData extends AnimationData {
   color: string;
   value: number | null;
   maskId: string;
+  stackId?: string;
 }
 
 export interface MaskData extends AnimationData {


### PR DESCRIPTION
Use clip-path attribute for border-radius on bar charts. Fixes https://github.com/mui/mui-x/issues/14690.

### Border radius too large

I think it more gracefully handles border radius is too large. Basically, the border radius can never exceed half of the bar's width or height.  

Before:

<img width="837" height="617" alt="image" src="https://github.com/user-attachments/assets/89af39bf-201e-4a22-b29f-600a83817381" />


After:

<img width="830" height="616" alt="image" src="https://github.com/user-attachments/assets/450c9048-d279-4170-a547-db868ab4c8eb" />

Also, when a bar's section is too short, before we would 

Before:

<img width="829" height="614" alt="image" src="https://github.com/user-attachments/assets/a0941867-a3ca-4083-a6a7-62f2dbd41d29" />




### Animation

Animation also looks good (10x slowdown):


https://github.com/user-attachments/assets/bae7bee9-7e38-4077-b682-227f77b800db


