### PR TITLE
[DataGridPro] Fix duplicate nested rows for dynamically updated row IDs

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/gridRowsUtils.ts
@@ -395,6 +395,7 @@ export function computeRowsUpdates(
   getRowId: DataGridProcessedProps['getRowId'],
 ) {
   const nonPinnedRowsUpdates: GridRowModelUpdate[] = [];
+  const insertedNodes = new Set<GridRowId>();
 
   updates.forEach((update) => {
     const id = getRowIdFromRowModel(
@@ -416,9 +417,12 @@ export function computeRowsUpdates(
       }
     } else {
       nonPinnedRowsUpdates.push(update);
+      if (update._action !== 'delete') {
+        insertedNodes.add(id);
+      }
     }
   });
-  return nonPinnedRowsUpdates;
+  return { nonPinnedRowsUpdates, insertedNodes };
 }
 
 let warnedOnceInvalidRowHeight = false;


### PR DESCRIPTION
Reported in https://mui.zendesk.com/agent/tickets/28655

Reproduction Tree Data: https://stackblitz.com/edit/vwnrw8kg?file=src%2FDemo.tsx
Reproduction Row Grouping: https://stackblitz.com/edit/cqu1xgfv?file=src%2FDemo.tsx

For the nested Data Source rows (tree data and row grouping), if the IDs of rows are constantly updating the Data Grid treats them as new rows and doesn't remove the previous ones. This PR aims to fix that.