### PR TITLE
[pickers] Support different `start` and `end` `referenceDate` props on range components

### DIFF
--- a/docs/data/date-pickers/base-concepts/ReferenceDateRange.js
+++ b/docs/data/date-pickers/base-concepts/ReferenceDateRange.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateTimeRangePicker } from '@mui/x-date-pickers-pro/DateTimeRangePicker';
+
+export default function ReferenceDateRange() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateTimeRangePicker
+        referenceDate={[dayjs('2022-04-17T07:45'), dayjs('2022-04-21T17:30')]}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/base-concepts/ReferenceDateRange.tsx
+++ b/docs/data/date-pickers/base-concepts/ReferenceDateRange.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import dayjs from 'dayjs';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DateTimeRangePicker } from '@mui/x-date-pickers-pro/DateTimeRangePicker';
+
+export default function ReferenceDateRange() {
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateTimeRangePicker
+        referenceDate={[dayjs('2022-04-17T07:45'), dayjs('2022-04-21T17:30')]}
+      />
+    </LocalizationProvider>
+  );
+}

--- a/docs/data/date-pickers/base-concepts/ReferenceDateRange.tsx.preview
+++ b/docs/data/date-pickers/base-concepts/ReferenceDateRange.tsx.preview
@@ -1,0 +1,3 @@
+<DateTimeRangePicker
+  referenceDate={[dayjs('2022-04-17T07:45'), dayjs('2022-04-21T17:30')]}
+/>

--- a/docs/data/date-pickers/base-concepts/base-concepts.md
+++ b/docs/data/date-pickers/base-concepts/base-concepts.md
@@ -147,6 +147,16 @@ For example, in a Time Picker, it allows you to choose the date of your value:
 
 {{"demo": "ReferenceDateExplicitTimePicker.js"}}
 
+Reference date can be unique for each range component position.
+You can pass an array of dates to the `referenceDate` prop to set the reference date for each position in the range.
+This might be useful when you want different time values for start and end positions in a Date Time Range Picker.
+
+:::info
+Try selecting a date the demo below, then move to next position to observe the end reference date usage.
+:::
+
+{{"demo": "ReferenceDateRange.js"}}
+
 ## Testing caveats
 
 ### Responsive components

--- a/docs/pages/x/api/date-pickers/date-range-calendar.json
+++ b/docs/pages/x/api/date-pickers/date-range-calendar.json
@@ -80,7 +80,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-range-picker.json
@@ -109,7 +109,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/date-time-range-picker.json
@@ -123,7 +123,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-range-picker.json
@@ -102,7 +102,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/desktop-date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-date-time-range-picker.json
@@ -119,7 +119,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/desktop-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/desktop-time-range-picker.json
@@ -87,7 +87,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "selectedSections": {

--- a/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-range-picker.json
@@ -98,7 +98,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/mobile-date-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-date-time-range-picker.json
@@ -115,7 +115,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/mobile-time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/mobile-time-range-picker.json
@@ -85,7 +85,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "selectedSections": {

--- a/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-range-field.json
@@ -45,7 +45,7 @@
     },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
     "selectedSections": {

--- a/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-date-time-range-field.json
@@ -52,7 +52,7 @@
     },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
     "selectedSections": {

--- a/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/multi-input-time-range-field.json
@@ -48,7 +48,7 @@
     },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
     "selectedSections": {

--- a/docs/pages/x/api/date-pickers/single-input-date-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-range-field.json
@@ -84,7 +84,7 @@
     },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
     "required": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-date-time-range-field.json
@@ -91,7 +91,7 @@
     },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
     "required": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/single-input-time-range-field.json
+++ b/docs/pages/x/api/date-pickers/single-input-time-range-field.json
@@ -87,7 +87,7 @@
     },
     "readOnly": { "type": { "name": "bool" }, "default": "false" },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used."
     },
     "required": { "type": { "name": "bool" }, "default": "false" },

--- a/docs/pages/x/api/date-pickers/static-date-range-picker.json
+++ b/docs/pages/x/api/date-pickers/static-date-range-picker.json
@@ -86,7 +86,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "renderLoading": {

--- a/docs/pages/x/api/date-pickers/time-range-picker.json
+++ b/docs/pages/x/api/date-pickers/time-range-picker.json
@@ -89,7 +89,7 @@
       "default": "`@media(prefers-reduced-motion: reduce)` || `navigator.userAgent` matches Android <10 or iOS <13"
     },
     "referenceDate": {
-      "type": { "name": "object" },
+      "type": { "name": "union", "description": "Array&lt;object&gt;<br>&#124;&nbsp;object" },
       "default": "The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`."
     },
     "selectedSections": {

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -45,7 +45,11 @@ import {
   isStartOfRange,
   isWithinRange,
 } from '../internals/utils/date-utils';
-import { calculateRangeChange, calculateRangePreview } from '../internals/utils/date-range-manager';
+import {
+  calculateRangeChange,
+  calculateRangePreview,
+  resolveReferenceDate,
+} from '../internals/utils/date-range-manager';
 import { RangePosition } from '../models';
 import { DateRangePickerDay, dateRangePickerDayClasses as dayClasses } from '../DateRangePickerDay';
 import { rangeValueManager } from '../internals/utils/valueManagers';
@@ -341,7 +345,7 @@ const DateRangeCalendar = React.forwardRef(function DateRangeCalendar(
 
   const { calendarState, setVisibleDate, onMonthSwitchingAnimationEnd } = useCalendarState({
     value: value[0] || value[1],
-    referenceDate,
+    referenceDate: resolveReferenceDate(referenceDate, rangePosition),
     disableFuture,
     disablePast,
     maxDate,

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.tsx
@@ -805,7 +805,10 @@ DateRangeCalendar.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object.isRequired),
+    PropTypes.object,
+  ]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
+++ b/packages/x-date-pickers-pro/src/DateRangeCalendar/DateRangeCalendar.types.ts
@@ -108,7 +108,7 @@ export interface DateRangeCalendarProps
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`.
    */
-  referenceDate?: PickerValidDate;
+  referenceDate?: PickerValidDate | [PickerValidDate, PickerValidDate];
   /**
    * The number of calendars to render.
    * @default 2

--- a/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateRangePicker/DateRangePicker.tsx
@@ -266,7 +266,7 @@ DateRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePicker.tsx
@@ -311,7 +311,7 @@ DateTimeRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTimeWrapper.tsx
+++ b/packages/x-date-pickers-pro/src/DateTimeRangePicker/DateTimeRangePickerTimeWrapper.tsx
@@ -10,7 +10,7 @@ import {
 import { PickerValidDate } from '@mui/x-date-pickers/models';
 import { usePickerAdapter } from '@mui/x-date-pickers/hooks';
 import { isRangeValid } from '../internals/utils/date-utils';
-import { calculateRangeChange } from '../internals/utils/date-range-manager';
+import { calculateRangeChange, resolveReferenceDate } from '../internals/utils/date-range-manager';
 import { usePickerRangePositionContext } from '../hooks';
 
 export type DateTimeRangePickerTimeWrapperProps<
@@ -47,8 +47,17 @@ function DateTimeRangePickerTimeWrapper<
 >(props: DateTimeRangePickerTimeWrapperProps<TComponentProps>) {
   const adapter = usePickerAdapter();
 
-  const { viewRenderer, value, onChange, defaultValue, onViewChange, views, className, ...other } =
-    props;
+  const {
+    viewRenderer,
+    value,
+    onChange,
+    defaultValue,
+    onViewChange,
+    views,
+    className,
+    referenceDate: referenceDateProp,
+    ...other
+  } = props;
 
   const { rangePosition } = usePickerRangePositionContext();
 
@@ -59,6 +68,7 @@ function DateTimeRangePickerTimeWrapper<
   const currentValue = (rangePosition === 'start' ? value?.[0] : value?.[1]) ?? null;
   const currentDefaultValue =
     (rangePosition === 'start' ? defaultValue?.[0] : defaultValue?.[1]) ?? null;
+  const referenceDate = resolveReferenceDate(referenceDateProp, rangePosition);
   const handleOnChange = (
     newDate: PickerValidDate | null,
     selectionState: PickerSelectionState,
@@ -79,6 +89,7 @@ function DateTimeRangePickerTimeWrapper<
 
   return viewRenderer({
     ...other,
+    referenceDate,
     views,
     onViewChange,
     value: currentValue,

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -306,7 +306,7 @@ DesktopDateRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateRangePicker/tests/DesktopDateRangePicker.test.tsx
@@ -693,6 +693,23 @@ describe('<DesktopDateRangePicker />', () => {
       expect(onAccept.callCount).to.equal(0);
       expect(onClose.callCount).to.equal(0);
     });
+
+    it('should work with separate start and end "reference" dates', async () => {
+      const { user } = render(
+        <DesktopDateRangePicker
+          referenceDate={[adapterToUse.date('2018-01-01'), adapterToUse.date('2018-01-06')]}
+          defaultRangePosition="end"
+        />,
+      );
+
+      await openPickerAsync(user, {
+        type: 'date-range',
+        initialFocus: 'start',
+        fieldType: 'single-input',
+      });
+
+      expect(document.activeElement).to.equal(getPickerDay('6'));
+    });
   });
 
   describe('disabled dates', () => {

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
@@ -38,6 +38,7 @@ import { DateTimeRangePickerTimeWrapper } from '../DateTimeRangePicker/DateTimeR
 import { RANGE_VIEW_HEIGHT } from '../internals/constants/dimensions';
 import { usePickerRangePositionContext } from '../hooks';
 import { PickerRangeStep } from '../internals/utils/createRangePickerStepNavigation';
+import { resolveReferenceDate } from '../internals/utils/date-range-manager';
 
 const STEPS: PickerRangeStep[] = [
   { views: null, rangePosition: 'start' },
@@ -66,10 +67,13 @@ const rendererInterceptor = function RendererInterceptor(
     ],
   };
   const isTimeViewActive = isInternalTimeView(popperView);
+  const referenceDate = resolveReferenceDate(rendererProps.referenceDate, rangePosition);
   return (
     <React.Fragment>
       {viewRenderers.day?.({
         ...rendererProps,
+        referenceDate,
+        rangePosition,
         availableRangePositions: [rangePosition],
         view: !isTimeViewActive ? popperView : 'day',
         views: rendererProps.views.filter(isDatePickerView),
@@ -78,6 +82,7 @@ const rendererInterceptor = function RendererInterceptor(
       <Divider orientation="vertical" sx={{ gridColumn: 2 }} />
       <DateTimeRangePickerTimeWrapper
         {...finalProps}
+        referenceDate={referenceDate}
         view={isTimeViewActive ? popperView : 'hours'}
         views={finalProps.views.filter(isInternalTimeView)}
         openTo={isInternalTimeView(openTo) ? openTo : 'hours'}

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/DesktopDateTimeRangePicker.tsx
@@ -453,7 +453,7 @@ DesktopDateTimeRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopDateTimeRangePicker/tests/DesktopDateTimeRangePicker.test.tsx
@@ -8,7 +8,7 @@ import {
   expectFieldValueV7,
 } from 'test/utils/pickers';
 import { vi } from 'vitest';
-import { DesktopDateTimeRangePicker } from '../DesktopDateTimeRangePicker';
+import { DesktopDateTimeRangePicker } from '@mui/x-date-pickers-pro/DesktopDateTimeRangePicker';
 
 describe('<DesktopDateTimeRangePicker />', () => {
   const { render } = createPickerRenderer();
@@ -93,6 +93,34 @@ describe('<DesktopDateTimeRangePicker />', () => {
       expect(meridiem).toHaveFocus();
       const sectionsContainer = getFieldSectionsContainer();
       expectFieldValueV7(sectionsContainer, '01/10/2018 12:00 AM – MM/DD/YYYY hh:mm aa');
+    });
+
+    it('should work with separate start and end "reference" dates', async () => {
+      const { user } = render(
+        <DesktopDateTimeRangePicker
+          referenceDate={[
+            adapterToUse.date('2018-01-01T10:15:00'),
+            adapterToUse.date('2018-01-06T14:20:00'),
+          ]}
+        />,
+      );
+
+      await openPickerAsync(user, {
+        type: 'date-time-range',
+        initialFocus: 'start',
+        fieldType: 'single-input',
+      });
+
+      expect(document.activeElement).to.equal(screen.getByRole('gridcell', { name: '1' }));
+
+      await user.click(screen.getByRole('gridcell', { name: '1' }));
+      expect(screen.getByRole('option', { name: '10 hours', selected: true })).not.to.equal(null);
+      expect(screen.getByRole('option', { name: '15 minutes', selected: true })).not.to.equal(null);
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+      await user.click(screen.getByRole('gridcell', { name: '2' }));
+      expect(screen.getByRole('option', { name: '2 hours', selected: true })).not.to.equal(null);
+      expect(screen.getByRole('option', { name: '20 minutes', selected: true })).not.to.equal(null);
     });
   });
 

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/DesktopTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/DesktopTimeRangePicker.tsx
@@ -360,7 +360,7 @@ DesktopTimeRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * The currently selected sections.
    * This prop accepts four formats:

--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/DesktopTimeRangePicker.test.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/tests/DesktopTimeRangePicker.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { screen } from '@mui/internal-test-utils';
+import { createPickerRenderer, adapterToUse, openPickerAsync } from 'test/utils/pickers';
+import { vi } from 'vitest';
+import { DesktopTimeRangePicker } from '@mui/x-date-pickers-pro/DesktopTimeRangePicker';
+
+describe('<DesktopTimeRangePicker />', () => {
+  const { render } = createPickerRenderer();
+
+  beforeEach(() => {
+    vi.setSystemTime(new Date(2018, 0, 10, 10, 16, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('value selection', () => {
+    it('should work with separate start and end "reference" dates', async () => {
+      const { user } = render(
+        <DesktopTimeRangePicker
+          referenceDate={[
+            adapterToUse.date('2018-01-01T10:15:00'),
+            adapterToUse.date('2018-01-06T14:20:00'),
+          ]}
+        />,
+      );
+
+      await openPickerAsync(user, {
+        type: 'time-range',
+        initialFocus: 'start',
+        fieldType: 'single-input',
+      });
+
+      expect(document.activeElement).to.equal(screen.getByRole('option', { name: '10 hours' }));
+      await user.click(screen.getByRole('option', { name: '10 hours' }));
+
+      expect(screen.getByRole('option', { name: '15 minutes', selected: true })).not.to.equal(null);
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+      await user.tab(); // Move focus to the end time hour from the "Next" button
+
+      expect(document.activeElement).to.equal(screen.getByRole('option', { name: '2 hours' }));
+      await user.click(screen.getByRole('option', { name: '2 hours' }));
+      expect(screen.getByRole('option', { name: '20 minutes', selected: true })).not.to.equal(null);
+    });
+  });
+});

--- a/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -303,7 +303,7 @@ MobileDateRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileDateTimeRangePicker/MobileDateTimeRangePicker.tsx
@@ -453,7 +453,7 @@ MobileDateTimeRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/MobileTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/MobileTimeRangePicker.tsx
@@ -340,7 +340,7 @@ MobileTimeRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * The currently selected sections.
    * This prop accepts four formats:

--- a/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateRangeField/MultiInputDateRangeField.tsx
@@ -159,7 +159,7 @@ MultiInputDateRangeField.propTypes = {
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * The currently selected sections.
    * This prop accepts four formats:

--- a/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputDateTimeRangeField/MultiInputDateTimeRangeField.tsx
@@ -193,7 +193,7 @@ MultiInputDateTimeRangeField.propTypes = {
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * The currently selected sections.
    * This prop accepts four formats:

--- a/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/MultiInputTimeRangeField/MultiInputTimeRangeField.tsx
@@ -175,7 +175,7 @@ MultiInputTimeRangeField.propTypes = {
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * The currently selected sections.
    * This prop accepts four formats:

--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -247,7 +247,7 @@ SingleInputDateRangeField.propTypes = {
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * If `true`, the label is displayed as required and the `input` element is required.
    * @default false

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -280,7 +280,7 @@ SingleInputDateTimeRangeField.propTypes = {
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * If `true`, the label is displayed as required and the `input` element is required.
    * @default false

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
@@ -262,7 +262,7 @@ SingleInputTimeRangeField.propTypes = {
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * If `true`, the label is displayed as required and the `input` element is required.
    * @default false

--- a/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -237,7 +237,7 @@ StaticDateRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * Component rendered on the "day" view when `props.loading` is true.
    * @returns {React.ReactNode} The node to render when loading.

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePicker.tsx
@@ -241,7 +241,7 @@ TimeRangePicker.propTypes = {
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate: PropTypes.object,
+  referenceDate: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
   /**
    * The currently selected sections.
    * This prop accepts four formats:

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerTimeWrapper.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/TimeRangePickerTimeWrapper.tsx
@@ -10,7 +10,7 @@ import {
 import { PickerValidDate } from '@mui/x-date-pickers/models';
 import { usePickerAdapter } from '@mui/x-date-pickers/hooks';
 import { isRangeValid } from '../internals/utils/date-utils';
-import { calculateRangeChange } from '../internals/utils/date-range-manager';
+import { calculateRangeChange, resolveReferenceDate } from '../internals/utils/date-range-manager';
 import { usePickerRangePositionContext } from '../hooks';
 
 export type TimeRangePickerTimeWrapperProps<
@@ -47,8 +47,17 @@ function TimeRangePickerTimeWrapper<
 >(props: TimeRangePickerTimeWrapperProps<TComponentProps>) {
   const adapter = usePickerAdapter();
 
-  const { viewRenderer, value, onChange, defaultValue, onViewChange, views, className, ...other } =
-    props;
+  const {
+    viewRenderer,
+    value,
+    onChange,
+    defaultValue,
+    onViewChange,
+    views,
+    className,
+    referenceDate: referenceDateProp,
+    ...other
+  } = props;
 
   const { rangePosition } = usePickerRangePositionContext();
 
@@ -59,6 +68,7 @@ function TimeRangePickerTimeWrapper<
   const currentValue = (rangePosition === 'start' ? value?.[0] : value?.[1]) ?? null;
   const currentDefaultValue =
     (rangePosition === 'start' ? defaultValue?.[0] : defaultValue?.[1]) ?? null;
+  const referenceDate = resolveReferenceDate(referenceDateProp, rangePosition);
   const handleOnChange = (
     newDate: PickerValidDate | null,
     selectionState: PickerSelectionState,
@@ -79,6 +89,7 @@ function TimeRangePickerTimeWrapper<
 
   return viewRenderer({
     ...other,
+    referenceDate,
     views,
     onViewChange,
     value: currentValue,

--- a/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
@@ -25,7 +25,7 @@ interface CalculateRangeChangeResponse {
 export function resolveReferenceDate(
   referenceDate: PickerValidDate | [PickerValidDate, PickerValidDate] | undefined,
   rangePosition: RangePosition,
-) {
+): PickerValidDate | undefined {
   if (Array.isArray(referenceDate)) {
     return rangePosition === 'start' ? referenceDate[0] : referenceDate[1];
   }

--- a/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/date-range-manager.ts
@@ -14,12 +14,22 @@ interface CalculateRangeChangeOptions {
    */
   allowRangeFlip?: boolean;
   shouldMergeDateAndTime?: boolean;
-  referenceDate?: PickerValidDate;
+  referenceDate?: PickerValidDate | [PickerValidDate, PickerValidDate];
 }
 
 interface CalculateRangeChangeResponse {
   nextSelection: RangePosition;
   newRange: PickerRangeValue;
+}
+
+export function resolveReferenceDate(
+  referenceDate: PickerValidDate | [PickerValidDate, PickerValidDate] | undefined,
+  rangePosition: RangePosition,
+) {
+  if (Array.isArray(referenceDate)) {
+    return rangePosition === 'start' ? referenceDate[0] : referenceDate[1];
+  }
+  return referenceDate;
 }
 
 export function calculateRangeChange({
@@ -46,7 +56,7 @@ export function calculateRangeChange({
 
   const newSelectedDate =
     referenceDate && selectedDate && shouldMergeDateAndTime
-      ? mergeDateAndTime(adapter, selectedDate, referenceDate)
+      ? mergeDateAndTime(adapter, selectedDate, resolveReferenceDate(referenceDate, rangePosition)!)
       : selectedDate;
 
   if (rangePosition === 'start') {

--- a/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
+++ b/packages/x-date-pickers-pro/src/internals/utils/valueManagers.ts
@@ -42,10 +42,12 @@ export const rangeValueManager: RangePickerValueManager = {
     }
 
     const referenceDate = referenceDateProp ?? getDefaultReferenceDate(params);
+    const startReferenceDate = Array.isArray(referenceDate) ? referenceDate[0]! : referenceDate;
+    const endReferenceDate = Array.isArray(referenceDate) ? referenceDate[1]! : referenceDate;
 
     return [
-      shouldKeepStartDate ? value[0]! : referenceDate,
-      shouldKeepEndDate ? value[1]! : referenceDate,
+      shouldKeepStartDate ? value[0]! : startReferenceDate,
+      shouldKeepEndDate ? value[1]! : endReferenceDate,
     ];
   },
   cleanValue: (utils, value) =>

--- a/packages/x-date-pickers/src/internals/hooks/useClockReferenceDate.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useClockReferenceDate.ts
@@ -28,8 +28,8 @@ export const useClockReferenceDate = <TProps extends {}>({
         granularity: SECTION_TYPE_GRANULARITY.day,
         timezone,
         getTodayDate: () => getTodayDate(adapter, timezone, 'date'),
-      }), // We only want to compute the reference date on mount.
-    [], // eslint-disable-line react-hooks/exhaustive-deps
+      }), // We want the `referenceDate` to update on prop and `timezone` change (https://github.com/mui/mui-x/issues/10804)
+    [referenceDateProp, timezone], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   return value ?? referenceDate;

--- a/packages/x-date-pickers/src/internals/hooks/useControlledValue.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useControlledValue.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useControlled from '@mui/utils/useControlled';
-import type { PickerValueManager } from '../models';
+import type { PickerRangeValue, PickerValueManager } from '../models';
 import { PickersTimezone, PickerValidDate } from '../../models';
 import { PickerValidValue } from '../models';
 import { usePickerAdapter } from '../../hooks/usePickerAdapter';
@@ -53,7 +53,7 @@ export const useControlledValue = <
       return inputTimezone;
     }
     if (referenceDate) {
-      return adapter.getTimezone(referenceDate);
+      return adapter.getTimezone(Array.isArray(referenceDate) ? referenceDate[0] : referenceDate);
     }
     return 'default';
   }, [timezoneProp, inputTimezone, referenceDate, adapter]);
@@ -88,7 +88,7 @@ interface UseValueWithTimezoneParameters<
    * It does not need to have its default value.
    * This is only used to determine the timezone to use when `props.value` and `props.defaultValue` are not defined.
    */
-  referenceDate: PickerValidDate | undefined;
+  referenceDate?: TValue extends PickerRangeValue ? TValue | PickerValidDate : PickerValidDate;
   onChange: TChange | undefined;
   valueManager: PickerValueManager<TValue, any>;
 }

--- a/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useField.types.ts
@@ -15,7 +15,12 @@ import {
 } from '../../../models';
 import { InternalPropNames } from '../../../hooks/useSplitFieldProps';
 import type { PickersSectionElement, PickersSectionListRef } from '../../../PickersSectionList';
-import { FormProps, InferNonNullablePickerValue, PickerValidValue } from '../../models';
+import {
+  FormProps,
+  InferNonNullablePickerValue,
+  PickerRangeValue,
+  PickerValidValue,
+} from '../../models';
 
 export interface UseFieldParameters<
   TValue extends PickerValidValue,
@@ -50,7 +55,7 @@ export interface UseFieldInternalProps<
    * For example, on time fields it will be used to determine the date to set.
    * @default The closest valid date using the validation props, except callbacks such as `shouldDisableDate`. Value is rounded to the most granular section used.
    */
-  referenceDate?: PickerValidDate;
+  referenceDate?: TValue extends PickerRangeValue ? TValue | PickerValidDate : PickerValidDate;
   /**
    * Callback fired when the value changes.
    * @template TValue The value type. It will be the same type as `value` or `null`. It can be in `[start, end]` format in case of range value.

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.types.ts
@@ -13,6 +13,7 @@ import {
   DateOrTimeViewWithMeridiem,
   FormProps,
   PickerOrientation,
+  PickerRangeValue,
   PickerValidValue,
   PickerValueManager,
   PickerVariant,
@@ -75,7 +76,7 @@ export interface UsePickerBaseProps<
    * The date used to generate the new value when both `value` and `defaultValue` are empty.
    * @default The closest valid date-time using the validation props, except callbacks like `shouldDisable<...>`.
    */
-  referenceDate?: PickerValidDate;
+  referenceDate?: TValue extends PickerRangeValue ? TValue | PickerValidDate : PickerValidDate;
   /**
    * Force rendering in particular orientation.
    */
@@ -145,7 +146,7 @@ export interface UsePickerProps<
 > extends UsePickerBaseProps<TValue, TView, TError, TExternalProps>,
     UsePickerNonStaticProps {
   // We don't add JSDoc here because we want the `referenceDate` JSDoc to be the one from the view which has more context.
-  referenceDate?: PickerValidDate;
+  referenceDate?: TValue extends PickerRangeValue ? TValue | PickerValidDate : PickerValidDate;
   className?: string;
   sx?: SxProps<Theme>;
 }

--- a/packages/x-date-pickers/src/internals/models/manager.ts
+++ b/packages/x-date-pickers/src/internals/models/manager.ts
@@ -6,7 +6,7 @@ import type {
   PickerValueType,
 } from '../../models';
 import type { GetDefaultReferenceDateProps } from '../utils/getDefaultReferenceDate';
-import { InferNonNullablePickerValue, PickerValidValue } from './value';
+import { InferNonNullablePickerValue, PickerRangeValue, PickerValidValue } from './value';
 import type { UseFieldInternalProps } from '../hooks/useField';
 
 export type PickerAnyManager = PickerManager<any, any, any, any, any>;
@@ -82,7 +82,7 @@ export interface PickerValueManager<TValue extends PickerValidValue, TError> {
    * @template TValue The value type. It will be the same type as `value` or `null`. It can be in `[start, end]` format in case of range value.
    * Method returning the reference value to use when mounting the component.
    * @param {object} params The params of the method.
-   * @param {PickerValidDate | undefined} params.referenceDate The referenceDate provided by the user.
+   * @param {PickerValidDate | PickerValidDate[] | undefined} params.referenceDate The referenceDate provided by the user.
    * @param {TValue} params.value The value provided by the user.
    * @param {GetDefaultReferenceDateProps} params.props The validation props needed to compute the reference value.
    * @param {MuiPickersAdapter} params.adapter The Picker date adapter instance.
@@ -92,7 +92,7 @@ export interface PickerValueManager<TValue extends PickerValidValue, TError> {
    * @returns {TValue} The reference value to use for non-provided dates.
    */
   getInitialReferenceValue: (params: {
-    referenceDate: PickerValidDate | undefined;
+    referenceDate?: TValue extends PickerRangeValue ? TValue | PickerValidDate : PickerValidDate;
     value: TValue;
     props: GetDefaultReferenceDateProps;
     adapter: MuiPickersAdapter;


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/17510.

- Support `referenceDate` prop in the form of `[start, end]` on range components 
- Expand relevant documentation section in base concepts