### PR TITLE
[charts-pro] Add `funnelDirection` to control pyramid direction

### DIFF
--- a/docs/data/charts/funnel/FunnelCurves.js
+++ b/docs/data/charts/funnel/FunnelCurves.js
@@ -50,6 +50,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -64,6 +65,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}

--- a/docs/data/charts/funnel/FunnelCurves.js
+++ b/docs/data/charts/funnel/FunnelCurves.js
@@ -50,7 +50,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
-                dataDirection: 'increasing',
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -65,7 +65,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
-                dataDirection: 'increasing',
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}

--- a/docs/data/charts/funnel/FunnelCurves.js
+++ b/docs/data/charts/funnel/FunnelCurves.js
@@ -50,6 +50,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
+                dataDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -64,6 +65,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
+                dataDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}

--- a/docs/data/charts/funnel/FunnelCurves.js
+++ b/docs/data/charts/funnel/FunnelCurves.js
@@ -50,7 +50,6 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
-                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -65,7 +64,6 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
-                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}

--- a/docs/data/charts/funnel/FunnelCurves.tsx
+++ b/docs/data/charts/funnel/FunnelCurves.tsx
@@ -52,7 +52,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
-                dataDirection: 'increasing',
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -67,7 +67,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
-                dataDirection: 'increasing',
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}

--- a/docs/data/charts/funnel/FunnelCurves.tsx
+++ b/docs/data/charts/funnel/FunnelCurves.tsx
@@ -41,6 +41,11 @@ export default function FunnelCurves() {
             options: ['filled', 'outlined'],
             defaultValue: 'filled',
           },
+          direction: {
+            knob: 'select',
+            options: ['decreasing', 'increasing'],
+            defaultValue: 'decreasing',
+          },
         } as const
       }
       renderDemo={(props) => (
@@ -52,7 +57,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
-                funnelDirection: 'increasing',
+                direction: props.direction,
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -67,7 +72,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
-                funnelDirection: 'increasing',
+                direction: props.direction,
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -84,6 +89,7 @@ export default function FunnelCurves() {
   series={[{ 
     curve: '${props.curveType}',
     variant: '${props.variant}',
+    direction: '${props.direction}',
     ${props.curveType === 'bump' ? '// ' : ''}borderRadius: ${props.borderRadius},
   }]}
   gap={${props.gap}}

--- a/docs/data/charts/funnel/FunnelCurves.tsx
+++ b/docs/data/charts/funnel/FunnelCurves.tsx
@@ -41,11 +41,6 @@ export default function FunnelCurves() {
             options: ['filled', 'outlined'],
             defaultValue: 'filled',
           },
-          direction: {
-            knob: 'select',
-            options: ['decreasing', 'increasing'],
-            defaultValue: 'decreasing',
-          },
         } as const
       }
       renderDemo={(props) => (
@@ -57,7 +52,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
-                direction: props.direction,
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -72,7 +67,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
-                direction: props.direction,
+                funnelDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -89,7 +84,6 @@ export default function FunnelCurves() {
   series={[{ 
     curve: '${props.curveType}',
     variant: '${props.variant}',
-    direction: '${props.direction}',
     ${props.curveType === 'bump' ? '// ' : ''}borderRadius: ${props.borderRadius},
   }]}
   gap={${props.gap}}

--- a/docs/data/charts/funnel/FunnelCurves.tsx
+++ b/docs/data/charts/funnel/FunnelCurves.tsx
@@ -52,6 +52,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'vertical',
                 variant: props.variant,
+                dataDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}
@@ -66,6 +67,7 @@ export default function FunnelCurves() {
                 borderRadius: props.borderRadius,
                 layout: 'horizontal',
                 variant: props.variant,
+                dataDirection: 'increasing',
                 ...populationByEducationLevelPercentageSeries,
               },
             ]}

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -151,7 +151,7 @@ const useAggregatedData = () => {
               })
             : currentSeries.sectionLabel;
 
-        const isIncreasing = currentSeries.direction === 'increasing';
+        const isIncreasing = currentSeries.funnelDirection === 'increasing';
 
         const curve = getFunnelCurve(currentSeries.curve, {
           isHorizontal,

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -151,7 +151,7 @@ const useAggregatedData = () => {
               })
             : currentSeries.sectionLabel;
 
-        const isIncreasing = currentSeries.dataDirection === 'increasing';
+        const isIncreasing = currentSeries.funnelDirection === 'increasing';
 
         const curve = getFunnelCurve(currentSeries.curve, {
           isHorizontal,

--- a/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelPlot.tsx
@@ -151,7 +151,7 @@ const useAggregatedData = () => {
               })
             : currentSeries.sectionLabel;
 
-        const isIncreasing = currentSeries.funnelDirection === 'increasing';
+        const isIncreasing = currentSeries.direction === 'increasing';
 
         const curve = getFunnelCurve(currentSeries.curve, {
           isHorizontal,

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -89,16 +89,13 @@ export interface FunnelSeriesType
    */
   variant?: 'filled' | 'outlined';
   /**
-   * Denotes if the funnel is increasing or decreasing.
-   * Only used in the `pyramid` and `step-pyramid` curves.
+   * Toggles the direction the funnel is drawn.
    *
-   * - `increasing`, funnel is drawn with a point at the top and a wide base.
    * - `decreasing`, funnel is drawn with a wide top and a point at the base.
-   * - `auto`, the direction is determined automatically based on the first and last data points.
-   *
-   * @default 'auto'
+   * - `increasing`, funnel is drawn with a point at the top and a wide base.
+   * @default 'decreasing'
    */
-  funnelDirection?: 'increasing' | 'decreasing' | 'auto';
+  direction?: 'increasing' | 'decreasing';
 }
 
 /**
@@ -133,13 +130,9 @@ export type FunnelItem = {
 };
 
 export interface DefaultizedFunnelSeriesType
-  extends Omit<
-    DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'>,
-    'funnelDirection'
-  > {
+  extends DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'> {
   dataPoints: FunnelDataPoints[][];
   data: Readonly<MakeRequired<FunnelValueType, 'id' | 'color'>[]>;
-  funnelDirection: 'increasing' | 'decreasing';
 }
 
 export type FunnelDataPoints = Record<'x' | 'y', number> & {

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -88,6 +88,15 @@ export interface FunnelSeriesType
    * @default 'filled'
    */
   variant?: 'filled' | 'outlined';
+  /**
+   * Denotes if the data is increasing or decreasing.
+   * - `increasing`, first data point is smaller than the last data point.
+   * - `decreasing`, first data point is greater than the last data point.
+   * - `auto`, the data direction is determined automatically based on the first and last data points.
+   *
+   * @default 'auto'
+   */
+  dataDirection?: 'increasing' | 'decreasing' | 'auto';
 }
 
 /**
@@ -122,15 +131,12 @@ export type FunnelItem = {
 };
 
 export interface DefaultizedFunnelSeriesType
-  extends DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'> {
+  extends Omit<
+    DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'>,
+    'dataDirection'
+  > {
   dataPoints: FunnelDataPoints[][];
   data: Readonly<MakeRequired<FunnelValueType, 'id' | 'color'>[]>;
-  /**
-   * Denotes if the data is increasing, first data point is less than the last data point.
-   * While the data is decreasing if the first data point is greater than the last data point.
-   *
-   * This is used to determine the direction of the funnel.
-   */
   dataDirection: 'increasing' | 'decreasing';
 }
 

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -89,12 +89,12 @@ export interface FunnelSeriesType
    */
   variant?: 'filled' | 'outlined';
   /**
-   * Denotes if the data is increasing or decreasing.
+   * Denotes if the funnel is increasing or decreasing.
    * Only used in the `pyramid` and `step-pyramid` curves.
    *
-   * - `increasing`, first data point is smaller than the last data point.
-   * - `decreasing`, first data point is greater than the last data point.
-   * - `auto`, the data direction is determined automatically based on the first and last data points.
+   * - `increasing`, funnel is drawn with a point at the top and a wide base.
+   * - `decreasing`, funnel is drawn with a wide top and a point at the base.
+   * - `auto`, the direction is determined automatically based on the first and last data points.
    *
    * @default 'auto'
    */

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -90,6 +90,8 @@ export interface FunnelSeriesType
   variant?: 'filled' | 'outlined';
   /**
    * Denotes if the data is increasing or decreasing.
+   * Only used in the `pyramid` and `step-pyramid` curves.
+   *
    * - `increasing`, first data point is smaller than the last data point.
    * - `decreasing`, first data point is greater than the last data point.
    * - `auto`, the data direction is determined automatically based on the first and last data points.

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -89,13 +89,16 @@ export interface FunnelSeriesType
    */
   variant?: 'filled' | 'outlined';
   /**
-   * Toggles the direction the funnel is drawn.
+   * Denotes if the funnel is increasing or decreasing.
+   * Only used in the `pyramid` and `step-pyramid` curves.
    *
-   * - `decreasing`, funnel is drawn with a wide top and a point at the base.
    * - `increasing`, funnel is drawn with a point at the top and a wide base.
-   * @default 'decreasing'
+   * - `decreasing`, funnel is drawn with a wide top and a point at the base.
+   * - `auto`, the direction is determined automatically based on the first and last data points.
+   *
+   * @default 'auto'
    */
-  direction?: 'increasing' | 'decreasing';
+  funnelDirection?: 'increasing' | 'decreasing' | 'auto';
 }
 
 /**
@@ -130,9 +133,13 @@ export type FunnelItem = {
 };
 
 export interface DefaultizedFunnelSeriesType
-  extends DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'> {
+  extends Omit<
+    DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'>,
+    'funnelDirection'
+  > {
   dataPoints: FunnelDataPoints[][];
   data: Readonly<MakeRequired<FunnelValueType, 'id' | 'color'>[]>;
+  funnelDirection: 'increasing' | 'decreasing';
 }
 
 export type FunnelDataPoints = Record<'x' | 'y', number> & {

--- a/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnel.types.ts
@@ -98,7 +98,7 @@ export interface FunnelSeriesType
    *
    * @default 'auto'
    */
-  dataDirection?: 'increasing' | 'decreasing' | 'auto';
+  funnelDirection?: 'increasing' | 'decreasing' | 'auto';
 }
 
 /**
@@ -135,11 +135,11 @@ export type FunnelItem = {
 export interface DefaultizedFunnelSeriesType
   extends Omit<
     DefaultizedProps<FunnelSeriesType, CommonDefaultizedProps | 'layout'>,
-    'dataDirection'
+    'funnelDirection'
   > {
   dataPoints: FunnelDataPoints[][];
   data: Readonly<MakeRequired<FunnelValueType, 'id' | 'color'>[]>;
-  dataDirection: 'increasing' | 'decreasing';
+  funnelDirection: 'increasing' | 'decreasing';
 }
 
 export type FunnelDataPoints = Record<'x' | 'y', number> & {

--- a/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
@@ -1,5 +1,4 @@
 import { SeriesProcessor, ChartSeriesDefaultized } from '@mui/x-charts/internals';
-import type { FunnelCurveType } from '../curves';
 
 const createPoint = ({
   main,
@@ -18,25 +17,6 @@ const createPoint = ({
     ? { x: other, y: main, useBandWidth, stackOffset }
     : { x: main, y: other, useBandWidth, stackOffset };
 
-const getFunnelDirection = (
-  funnelDirection: 'increasing' | 'decreasing' | 'auto' | undefined,
-  curve: FunnelCurveType | undefined,
-  firstValue: number | undefined | null,
-  lastValue: number | undefined | null,
-): 'increasing' | 'decreasing' => {
-  if (
-    curve?.includes('pyramid') &&
-    (funnelDirection === 'increasing' || funnelDirection === 'decreasing')
-  ) {
-    return funnelDirection;
-  }
-
-  // Implicit check for null or undefined values
-  return firstValue != null && lastValue != null && firstValue < lastValue
-    ? 'increasing'
-    : 'decreasing';
-};
-
 const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
   const { seriesOrder, series } = params;
 
@@ -47,14 +27,7 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
   seriesOrder.forEach((seriesId) => {
     const currentSeries = series[seriesId];
 
-    const firstDataPoint = currentSeries.data.at(0);
-    const lastDataPoint = currentSeries.data.at(-1);
-    const funnelDirection = getFunnelDirection(
-      currentSeries.funnelDirection,
-      currentSeries.curve,
-      firstDataPoint?.value,
-      lastDataPoint?.value,
-    );
+    const direction = currentSeries.direction ?? 'decreasing';
 
     completedSeries[seriesId] = {
       labelMarkType: 'square',
@@ -65,7 +38,7 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
         id: `${seriesId}-funnel-item-${v.id ?? i}`,
         ...v,
       })),
-      funnelDirection,
+      direction,
       dataPoints: [],
     };
 
@@ -79,7 +52,7 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
         // Main = main axis, Other = other axis
         // For horizontal layout, main is y, other is x
         // For vertical layout, main is x, other is y
-        const isIncreasing = completedSeries[seriesId].funnelDirection === 'increasing';
+        const isIncreasing = completedSeries[seriesId].direction === 'increasing';
         const currentMaxMain = item.value;
         const getNextDataIndex = () => {
           if (isIncreasing) {

--- a/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
@@ -17,6 +17,21 @@ const createPoint = ({
     ? { x: other, y: main, useBandWidth, stackOffset }
     : { x: main, y: other, useBandWidth, stackOffset };
 
+const getDataDirection = (
+  dataDirection: 'increasing' | 'decreasing' | 'auto' | undefined,
+  firstValue: number | undefined | null,
+  lastValue: number | undefined | null,
+): 'increasing' | 'decreasing' => {
+  if (dataDirection === 'increasing' || dataDirection === 'decreasing') {
+    return dataDirection;
+  }
+
+  // Implicit check for null or undefined values
+  return firstValue != null && lastValue != null && firstValue < lastValue
+    ? 'increasing'
+    : 'decreasing';
+};
+
 const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
   const { seriesOrder, series } = params;
 
@@ -29,12 +44,11 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
 
     const firstDataPoint = currentSeries.data.at(0);
     const lastDataPoint = currentSeries.data.at(-1);
-    const dataDirection =
-      firstDataPoint !== undefined &&
-      lastDataPoint !== undefined &&
-      firstDataPoint.value < lastDataPoint.value
-        ? 'increasing'
-        : 'decreasing';
+    const dataDirection = getDataDirection(
+      currentSeries.dataDirection,
+      firstDataPoint?.value,
+      lastDataPoint?.value,
+    );
 
     completedSeries[seriesId] = {
       labelMarkType: 'square',

--- a/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
@@ -18,17 +18,17 @@ const createPoint = ({
     ? { x: other, y: main, useBandWidth, stackOffset }
     : { x: main, y: other, useBandWidth, stackOffset };
 
-const getDataDirection = (
-  dataDirection: 'increasing' | 'decreasing' | 'auto' | undefined,
+const getFunnelDirection = (
+  funnelDirection: 'increasing' | 'decreasing' | 'auto' | undefined,
   curve: FunnelCurveType | undefined,
   firstValue: number | undefined | null,
   lastValue: number | undefined | null,
 ): 'increasing' | 'decreasing' => {
   if (
     curve?.includes('pyramid') &&
-    (dataDirection === 'increasing' || dataDirection === 'decreasing')
+    (funnelDirection === 'increasing' || funnelDirection === 'decreasing')
   ) {
-    return dataDirection;
+    return funnelDirection;
   }
 
   // Implicit check for null or undefined values
@@ -49,8 +49,8 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
 
     const firstDataPoint = currentSeries.data.at(0);
     const lastDataPoint = currentSeries.data.at(-1);
-    const dataDirection = getDataDirection(
-      currentSeries.dataDirection,
+    const funnelDirection = getFunnelDirection(
+      currentSeries.funnelDirection,
       currentSeries.curve,
       firstDataPoint?.value,
       lastDataPoint?.value,
@@ -65,7 +65,7 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
         id: `${seriesId}-funnel-item-${v.id ?? i}`,
         ...v,
       })),
-      dataDirection,
+      funnelDirection,
       dataPoints: [],
     };
 
@@ -79,7 +79,7 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
         // Main = main axis, Other = other axis
         // For horizontal layout, main is y, other is x
         // For vertical layout, main is x, other is y
-        const isIncreasing = completedSeries[seriesId].dataDirection === 'increasing';
+        const isIncreasing = completedSeries[seriesId].funnelDirection === 'increasing';
         const currentMaxMain = item.value;
         const getNextDataIndex = () => {
           if (isIncreasing) {

--- a/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts-pro/src/FunnelChart/seriesConfig/seriesProcessor.ts
@@ -1,4 +1,5 @@
 import { SeriesProcessor, ChartSeriesDefaultized } from '@mui/x-charts/internals';
+import type { FunnelCurveType } from '../curves';
 
 const createPoint = ({
   main,
@@ -19,10 +20,14 @@ const createPoint = ({
 
 const getDataDirection = (
   dataDirection: 'increasing' | 'decreasing' | 'auto' | undefined,
+  curve: FunnelCurveType | undefined,
   firstValue: number | undefined | null,
   lastValue: number | undefined | null,
 ): 'increasing' | 'decreasing' => {
-  if (dataDirection === 'increasing' || dataDirection === 'decreasing') {
+  if (
+    curve?.includes('pyramid') &&
+    (dataDirection === 'increasing' || dataDirection === 'decreasing')
+  ) {
     return dataDirection;
   }
 
@@ -46,6 +51,7 @@ const seriesProcessor: SeriesProcessor<'funnel'> = (params) => {
     const lastDataPoint = currentSeries.data.at(-1);
     const dataDirection = getDataDirection(
       currentSeries.dataDirection,
+      currentSeries.curve,
       firstDataPoint?.value,
       lastDataPoint?.value,
     );


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18559

- Add `funnelDirection` to control pyramid direction

### Thoughts
- Not sure if we should use `increasing/decreasing` or `ascending/descending`
- We could go for `direction` too instead of `dataDirection`
- I didn't document it as it can be done in the pyramid PR, since it works for pyramid only.