### PR TITLE
[code-infra] Ensure `material-ui/disallow-react-api-in-server-components` ESLint rule is applied

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -263,7 +263,7 @@ module.exports = {
     },
     {
       files: ['packages/*/src/**/*.?(c|m)[jt]s?(x)'],
-      excludedFiles: ['*.d.ts', '*.spec.*'],
+      excludedFiles: ['*.d.ts', '*.spec.*', '*.test.*'],
       rules: {
         'material-ui/mui-name-matches-component-name': [
           'error',
@@ -283,6 +283,7 @@ module.exports = {
             ],
           },
         ],
+        'material-ui/disallow-react-api-in-server-components': 'error',
       },
     },
     {

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { styled } from '@mui/material/styles';
 import {
   AxisId,

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import {
   AxisId,

--- a/packages/x-charts/src/context/ChartProvider/ChartContext.tsx
+++ b/packages/x-charts/src/context/ChartProvider/ChartContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import type { ChartContextValue } from './ChartProvider.types';
 

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartId/useChartId.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartId/useChartId.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { ChartPlugin } from '../../models';
 import { UseChartIdSignature } from './useChartId.types';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartVoronoi/useChartVoronoi.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartVoronoi/useChartVoronoi.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid-premium/src/components/aiAssistantPanel/GridAiAssistantPanelConversation.tsx
+++ b/packages/x-data-grid-premium/src/components/aiAssistantPanel/GridAiAssistantPanelConversation.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { getDataGridUtilityClass, GridShadowScrollArea } from '@mui/x-data-grid-pro';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid-premium/src/components/aiAssistantPanel/GridAiAssistantPanelConversationsMenu.tsx
+++ b/packages/x-data-grid-premium/src/components/aiAssistantPanel/GridAiAssistantPanelConversationsMenu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { GridMenu, useGridSelector } from '@mui/x-data-grid-pro';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid-premium/src/components/collapsible/Collapsible.tsx
+++ b/packages/x-data-grid-premium/src/components/collapsible/Collapsible.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { styled } from '@mui/system';
 import { vars } from '@mui/x-data-grid-pro/internals';

--- a/packages/x-data-grid-premium/src/components/collapsible/CollapsibleContext.tsx
+++ b/packages/x-data-grid-premium/src/components/collapsible/CollapsibleContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface CollapsibleContextValue {

--- a/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanel.tsx
+++ b/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanel.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { GridPivotPanelHeader } from './GridPivotPanelHeader';
 import { GridPivotPanelBody } from './GridPivotPanelBody';

--- a/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelBody.tsx
+++ b/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelBody.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { styled } from '@mui/system';
 import {

--- a/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelField.tsx
+++ b/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelField.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { styled } from '@mui/system';
 import {

--- a/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelFieldMenu.tsx
+++ b/packages/x-data-grid-premium/src/components/pivotPanel/GridPivotPanelFieldMenu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { GridMenu, useGridSelector } from '@mui/x-data-grid-pro';

--- a/packages/x-data-grid-premium/src/components/prompt/GridPrompt.tsx
+++ b/packages/x-data-grid-premium/src/components/prompt/GridPrompt.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import {
   getDataGridUtilityClass,

--- a/packages/x-data-grid-premium/src/components/promptField/PromptField.tsx
+++ b/packages/x-data-grid-premium/src/components/promptField/PromptField.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { RenderProp } from '@mui/x-data-grid';

--- a/packages/x-data-grid-premium/src/components/promptField/PromptFieldContext.tsx
+++ b/packages/x-data-grid-premium/src/components/promptField/PromptFieldContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface PromptFieldState {

--- a/packages/x-data-grid-premium/src/components/resizablePanel/ResizablePanelContext.tsx
+++ b/packages/x-data-grid-premium/src/components/resizablePanel/ResizablePanelContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface ResizablePanelContextValue {

--- a/packages/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/aggregation/useGridAggregation.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { gridColumnLookupSelector, useGridEvent, useGridApiMethod } from '@mui/x-data-grid-pro';

--- a/packages/x-data-grid-premium/src/hooks/features/aiAssistant/useGridAiAssistant.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/aiAssistant/useGridAiAssistant.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/cellSelection/useGridCellSelection.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import ownerDocument from '@mui/utils/ownerDocument';

--- a/packages/x-data-grid-premium/src/hooks/features/dataSource/useGridDataSourcePremium.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/dataSource/useGridDataSourcePremium.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGrouping.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGroupingPreProcessors.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridRowGroupingPreProcessors.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-premium/src/hooks/utils/useKeepGroupedColumnsHidden.ts
+++ b/packages/x-data-grid-premium/src/hooks/utils/useKeepGroupedColumnsHidden.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-premium/src/hooks/utils/useResize.ts
+++ b/packages/x-data-grid-premium/src/hooks/utils/useResize.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export type ResizeDirection = 'horizontal' | 'vertical';

--- a/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterCell.tsx
+++ b/packages/x-data-grid-pro/src/components/headerFiltering/GridHeaderFilterCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/columnPinning/useGridColumnPinning.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourceBasePro.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { isDeepEqual } from '@mui/x-internals/isDeepEqual';

--- a/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourcePro.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/dataSource/useGridDataSourcePro.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/detailPanel/useGridDetailPanel.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-pro/src/hooks/features/rowPinning/useGridRowPinning.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/rowPinning/useGridRowPinning.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useGridApiMethod } from '@mui/x-data-grid';

--- a/packages/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/rowReorder/useGridRowReorder.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridDataSourceLazyLoader.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { throttle } from '@mui/x-internals/throttle';

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridInfiniteLoadingIntersection.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideLazyLoader/useGridInfiniteLoadingIntersection.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useGridSelector, useGridApiMethod, gridDimensionsSelector } from '@mui/x-data-grid';

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/useGridDataSourceTreeDataPreProcessors.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/useGridDataSourceTreeDataPreProcessors.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid-pro/src/hooks/features/treeData/useGridTreeDataPreProcessors.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/treeData/useGridTreeDataPreProcessors.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import {

--- a/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridActionsCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useRtl } from '@mui/system/RtlProvider';

--- a/packages/x-data-grid/src/components/cell/GridCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid/src/components/cell/GridEditBooleanCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditBooleanCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid/src/components/cell/GridEditDateCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditDateCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid/src/components/cell/GridEditInputCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditInputCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
+++ b/packages/x-data-grid/src/components/cell/GridEditSingleSelectCell.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnGroupHeader.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useId from '@mui/utils/useId';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridColumnHeaderTitle.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
+++ b/packages/x-data-grid/src/components/columnHeaders/GridGenericColumnHeaderItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import clsx from 'clsx';
 import useForkRef from '@mui/utils/useForkRef';

--- a/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
+++ b/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import composeClasses from '@mui/utils/composeClasses';

--- a/packages/x-data-grid/src/components/menu/GridMenu.tsx
+++ b/packages/x-data-grid/src/components/menu/GridMenu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid/src/components/panel/GridPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanel.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/x-data-grid/src/components/panel/GridPanelContext.tsx
+++ b/packages/x-data-grid/src/components/panel/GridPanelContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface GridPanelContextValue {

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputBoolean.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import refType from '@mui/utils/refType';

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputDate.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputMultipleValue.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterInputValue.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
+++ b/packages/x-data-grid/src/components/panel/filterPanel/GridFilterPanel.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { SxProps, Theme } from '@mui/material/styles';

--- a/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
+++ b/packages/x-data-grid/src/components/quickFilter/QuickFilter.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import debounce from '@mui/utils/debounce';

--- a/packages/x-data-grid/src/components/quickFilter/QuickFilterContext.tsx
+++ b/packages/x-data-grid/src/components/quickFilter/QuickFilterContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface QuickFilterState {

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarDensitySelector.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
+++ b/packages/x-data-grid/src/components/toolbar/GridToolbarExportContainer.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid/src/components/toolbarV8/GridToolbar.tsx
+++ b/packages/x-data-grid/src/components/toolbarV8/GridToolbar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useId from '@mui/utils/useId';

--- a/packages/x-data-grid/src/components/toolbarV8/Toolbar.tsx
+++ b/packages/x-data-grid/src/components/toolbarV8/Toolbar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/system';

--- a/packages/x-data-grid/src/components/toolbarV8/ToolbarButton.tsx
+++ b/packages/x-data-grid/src/components/toolbarV8/ToolbarButton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import useForkRef from '@mui/utils/useForkRef';

--- a/packages/x-data-grid/src/components/toolbarV8/ToolbarContext.tsx
+++ b/packages/x-data-grid/src/components/toolbarV8/ToolbarContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface ToolbarContextValue {

--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollbar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { styled } from '@mui/system';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridRegisterPipeApplier.ts
+++ b/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridRegisterPipeApplier.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useFirstRender } from '../../utils/useFirstRender';

--- a/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridRegisterPipeProcessor.ts
+++ b/packages/x-data-grid/src/hooks/core/pipeProcessing/useGridRegisterPipeProcessor.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useFirstRender } from '../../utils/useFirstRender';

--- a/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridRegisterStrategyProcessor.ts
+++ b/packages/x-data-grid/src/hooks/core/strategyProcessing/useGridRegisterStrategyProcessor.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useFirstRender } from '../../utils/useFirstRender';

--- a/packages/x-data-grid/src/hooks/core/useGridApiInitialization.ts
+++ b/packages/x-data-grid/src/hooks/core/useGridApiInitialization.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { EventManager } from '@mui/x-internals/EventManager';

--- a/packages/x-data-grid/src/hooks/core/useGridIsRtl.tsx
+++ b/packages/x-data-grid/src/hooks/core/useGridIsRtl.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useRtl } from '@mui/system/RtlProvider';

--- a/packages/x-data-grid/src/hooks/core/useGridProps.ts
+++ b/packages/x-data-grid/src/hooks/core/useGridProps.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import type { RefObject } from '@mui/x-internals/types';
 import type { DataGridProps } from '../../models/props/DataGridProps';

--- a/packages/x-data-grid/src/hooks/features/columnGrouping/useGridColumnGrouping.ts
+++ b/packages/x-data-grid/src/hooks/features/columnGrouping/useGridColumnGrouping.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';

--- a/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnHeaders/useGridColumnHeaders.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import clsx from 'clsx';
 import { styled } from '@mui/material/styles';

--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
+++ b/packages/x-data-grid/src/hooks/features/columns/useGridColumns.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridEventListener } from '../../../models/events';

--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSource.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSource.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';

--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useLazyRef from '@mui/utils/useLazyRef';

--- a/packages/x-data-grid/src/hooks/features/density/useGridDensity.tsx
+++ b/packages/x-data-grid/src/hooks/features/density/useGridDensity.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/x-data-grid/src/hooks/features/dimensions/useGridDimensions.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridCellEditing.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { warnOnce } from '@mui/x-internals/warning';

--- a/packages/x-data-grid/src/hooks/features/editing/useGridEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridEditing.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';

--- a/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
+++ b/packages/x-data-grid/src/hooks/features/editing/useGridRowEditing.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
+++ b/packages/x-data-grid/src/hooks/features/export/useGridPrintExport.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import ownerDocument from '@mui/utils/ownerDocument';

--- a/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
+++ b/packages/x-data-grid/src/hooks/features/focus/useGridFocus.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/features/headerFiltering/useGridHeaderFiltering.ts
+++ b/packages/x-data-grid/src/hooks/features/headerFiltering/useGridHeaderFiltering.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';

--- a/packages/x-data-grid/src/hooks/features/listView/useGridListView.tsx
+++ b/packages/x-data-grid/src/hooks/features/listView/useGridListView.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import { RefObject } from '@mui/x-internals/types';

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationMeta.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationMeta.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridPrivateApiCommunity } from '../../../models/api/gridApiCommunity';

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridPaginationModel.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { isDeepEqual } from '@mui/x-internals/isDeepEqual';

--- a/packages/x-data-grid/src/hooks/features/pagination/useGridRowCount.ts
+++ b/packages/x-data-grid/src/hooks/features/pagination/useGridRowCount.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useLazyRef from '@mui/utils/useLazyRef';

--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-data-grid/src/hooks/features/rows/useGridRowSpanning.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRowSpanning.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useLazyRef from '@mui/utils/useLazyRef';

--- a/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
+++ b/packages/x-data-grid/src/hooks/features/rows/useGridRows.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import useLazyRef from '@mui/utils/useLazyRef';

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { RefObject } from '@mui/x-internals/types';

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualization.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualization.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridRenderContext } from '../../../models';

--- a/packages/x-data-grid/src/hooks/utils/useGridEvent.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridEvent.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { EventListenerOptions } from '@mui/x-internals/EventManager';

--- a/packages/x-data-grid/src/hooks/utils/useGridPrivateApiContext.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridPrivateApiContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { GridPrivateApiCommon } from '../../models/api/gridApiCommon';

--- a/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridSelector.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
 import { fastObjectShallowCompare } from '@mui/x-internals/fastObjectShallowCompare';

--- a/packages/x-data-grid/src/internals/demo/TailwindDemoContainer.tsx
+++ b/packages/x-data-grid/src/internals/demo/TailwindDemoContainer.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';

--- a/packages/x-data-grid/src/utils/css/context.tsx
+++ b/packages/x-data-grid/src/utils/css/context.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { useGridConfiguration } from '../../hooks/utils/useGridConfiguration';

--- a/packages/x-date-pickers-pro/src/hooks/useMultiInputRangeField/useMultiInputRangeFieldSelectedSections.ts
+++ b/packages/x-date-pickers-pro/src/hooks/useMultiInputRangeField/useMultiInputRangeFieldSelectedSections.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useForkRef from '@mui/utils/useForkRef';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-date-pickers-pro/src/hooks/useMultiInputRangeField/useTextFieldProps.ts
+++ b/packages/x-date-pickers-pro/src/hooks/useMultiInputRangeField/useTextFieldProps.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import { useDateManager, useDateTimeManager, useTimeManager } from '@mui/x-date-pickers/managers';

--- a/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
+++ b/packages/x-date-pickers/src/PickersTextField/PickersInputBase/PickersInputBase.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useFormControl } from '@mui/material/FormControl';

--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useForkRef from '@mui/utils/useForkRef';

--- a/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useSlotProps from '@mui/utils/useSlotProps';
 import Grow from '@mui/material/Grow';

--- a/packages/x-date-pickers/src/internals/components/PickerProvider.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerProvider.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material/styles';

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useControlled from '@mui/utils/useControlled';
 import useTimeout from '@mui/utils/useTimeout';

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { useRtl } from '@mui/system/RtlProvider';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useForkRef from '@mui/utils/useForkRef';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-date-pickers/src/internals/hooks/useNullableFieldPrivateContext.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useNullableFieldPrivateContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import type { UseFieldInternalProps } from './useField';
 import { FieldRef } from '../../models';

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useOrientation.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useOrientation.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import { DateOrTimeViewWithMeridiem, PickerOrientation } from '../../../models';

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useValueAndOpenStates.ts
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/hooks/useValueAndOpenStates.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { warnOnce } from '@mui/x-internals/warning';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/usePicker/usePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-date-pickers/src/internals/hooks/useViews.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useViews.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useControlled from '@mui/utils/useControlled';

--- a/packages/x-scheduler/src/joy/internals/hooks/useEventCalendarStore.ts
+++ b/packages/x-scheduler/src/joy/internals/hooks/useEventCalendarStore.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { Store } from '../../../base-ui-copy/utils/store';
 import { State } from '../../event-calendar/store';

--- a/packages/x-scheduler/src/joy/internals/utils/EventPopoverProvider.tsx
+++ b/packages/x-scheduler/src/joy/internals/utils/EventPopoverProvider.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { Popover } from '@base-ui-components/react/popover';
 import { CalendarEvent } from '../../models/events';

--- a/packages/x-scheduler/src/primitives/time-grid/column/TimeGridColumnContext.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/column/TimeGridColumnContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { SchedulerValidDate } from '../../models';
 

--- a/packages/x-scheduler/src/primitives/time-grid/root/TimeGridRootContext.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/root/TimeGridRootContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 export interface TimeGridRootContext {}

--- a/packages/x-scheduler/src/primitives/utils/useEvent.ts
+++ b/packages/x-scheduler/src/primitives/utils/useEvent.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { getAdapter } from './adapter/getAdapter';
 import { useOnEveryMinuteStart } from './useOnEveryMinuteStart';

--- a/packages/x-scheduler/src/primitives/utils/useOnEveryMinuteStart.ts
+++ b/packages/x-scheduler/src/primitives/utils/useOnEveryMinuteStart.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { useEffectEvent } from '@floating-ui/react/utils';
 import { useTimeout } from '../../base-ui-copy/utils/useTimeout';

--- a/packages/x-tree-view-pro/src/internals/plugins/useTreeViewLazyLoading/useTreeViewLazyLoading.ts
+++ b/packages/x-tree-view-pro/src/internals/plugins/useTreeViewLazyLoading/useTreeViewLazyLoading.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useLazyRef from '@mui/utils/useLazyRef';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-tree-view/src/internals/TreeViewItemDepthContext/TreeViewItemDepthContext.ts
+++ b/packages/x-tree-view/src/internals/TreeViewItemDepthContext/TreeViewItemDepthContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { TreeViewItemId } from '../../models';
 import { TreeViewState } from '../models';

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewChildrenItemProvider.tsx
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewChildrenItemProvider.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useTreeViewContext } from './TreeViewContext';

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewContext.ts
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { TreeViewAnyPluginSignature } from '../models';
 import { TreeViewContextValue } from './TreeViewProvider.types';

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewStyleContext.ts
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewStyleContext.ts
@@ -1,3 +1,4 @@
+'use client';
 import { SlotComponentProps } from '@mui/utils/types';
 import * as React from 'react';
 

--- a/packages/x-tree-view/src/internals/components/RichTreeViewItems.tsx
+++ b/packages/x-tree-view/src/internals/components/RichTreeViewItems.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useSlotProps from '@mui/utils/useSlotProps';
 import { SlotComponentProps } from '@mui/utils/types';

--- a/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.ts
+++ b/packages/x-tree-view/src/internals/corePlugins/useTreeViewId/useTreeViewId.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { TreeViewPlugin } from '../../models';
 import { UseTreeViewIdSignature } from './useTreeViewId.types';

--- a/packages/x-tree-view/src/internals/corePlugins/useTreeViewInstanceEvents/useTreeViewInstanceEvents.ts
+++ b/packages/x-tree-view/src/internals/corePlugins/useTreeViewInstanceEvents/useTreeViewInstanceEvents.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { EventManager } from '@mui/x-internals/EventManager';
 import type { TreeViewPlugin } from '../../models';

--- a/packages/x-tree-view/src/internals/hooks/useInstanceEventHandler.ts
+++ b/packages/x-tree-view/src/internals/hooks/useInstanceEventHandler.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { UnregisterToken, CleanupTracking } from '../utils/cleanupTracking/CleanupTracking';
 import { TimerBasedCleanupTracking } from '../utils/cleanupTracking/TimerBasedCleanupTracking';

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import { TreeViewPlugin } from '../../models';

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewJSXItems/useTreeViewJSXItems.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewJSXItems/useTreeViewJSXItems.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
 import useForkRef from '@mui/utils/useForkRef';

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewKeyboardNavigation/useTreeViewKeyboardNavigation.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { useRtl } from '@mui/system/RtlProvider';
 import useEventCallback from '@mui/utils/useEventCallback';

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.itemPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewLabel/useTreeViewLabel.itemPlugin.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { useTreeViewContext } from '../../TreeViewProvider';
 import { TreeViewCancellableEvent } from '../../../models';


### PR DESCRIPTION
Discovered this "can-of-worms" while checking https://github.com/mui/mui-x/pull/18562.

Due to legacy ESLint config overriding rules applied on the same `files`, this rule was being overridden and didn't take effect. 🙈 
Previously, we had a `build:rsc` script taking care of adding `use client;` at the top of the file, but https://github.com/mui/mui-x/pull/16273 removed it in favor of this ESLint rule... 🙈 

cc @brijeshb42