### PR TITLE
[docs] Generate `llms.txt` for X and their products

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(pnpm tsx:*)",
+      "Bash(node:*)",
+      "Bash(grep:*)",
+      "Bash(pnpm run docs:llms:build:*)",
+      "Bash(find:*)",
+      "Bash(git add:*)",
+      "Bash(pnpm docs:llms:build:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __diff_output__
 !/docs/pages/playground/tsconfig.json
 /docs/.env.local
 /docs/export
+/docs/public/x/
 /test/regressions/screenshots
 build
 dist

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs:api": "NODE_OPTIONS=--max-old-space-size=4096 pnpm docs:api:build && pnpm docs:api:buildX",
     "docs:api:build": "tsx ./scripts/buildApiDocs/index.ts",
     "docs:api:buildX": "tsx ./docs/scripts/api/buildApi.ts",
+    "docs:llms:build": "rimraf --glob ./docs/public/x/ && tsx ./scripts/buildLlmsDocs/index.ts --projectSettings scripts/buildApiDocs/projectSettings.ts",
     "docs:link-check": "tsx ./docs/scripts/reportBrokenLinks.js",
     "docs:build": "pnpm run release:build && pnpm --filter docs build",
     "docs:typescript:formatted": "pnpm --filter docs typescript:transpile",

--- a/scripts/buildApiDocs/chartsSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/chartsSettings/getComponentInfo.ts
@@ -46,6 +46,7 @@ export function getComponentInfo(filename: string): ComponentInfo {
         .filter((page) => page.pathname.startsWith('/charts') && page.components.includes(name))
         .map((page) => {
           return {
+            filePath: page.filename,
             demoPageTitle: renderMarkdown(getTitle(page.markdownContent)),
             demoPathname: `${page.pathname.replace('/charts', '/x/react-charts')}/`,
           };

--- a/scripts/buildApiDocs/chartsSettings/index.ts
+++ b/scripts/buildApiDocs/chartsSettings/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import { LANGUAGES } from 'docs/config';
 import { ProjectSettings, ComponentReactApi, HookReactApi } from '@mui-internal/api-docs-builder';
 import findApiPages from '@mui-internal/api-docs-builder/utils/findApiPages';
@@ -6,6 +7,20 @@ import generateUtilityClass, { isGlobalState } from '@mui/utils/generateUtilityC
 import { getComponentImports, getComponentInfo } from './getComponentInfo';
 
 type PageType = { pathname: string; title: string; plan?: 'community' | 'pro' | 'premium' };
+
+function getNonComponentFolders(): string[] {
+  try {
+    return fs
+      .readdirSync(path.join(process.cwd(), 'docs/data/charts'), { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory() && dirent.name !== 'components')
+      .map((dirent) => `charts/${dirent.name}`)
+      .sort();
+  } catch (error) {
+    // Fallback to empty array if directory doesn't exist
+    console.warn('Could not read the directories:', error);
+    return [];
+  }
+}
 
 export const projectChartsSettings: ProjectSettings = {
   output: {
@@ -91,4 +106,9 @@ export default chartsApiPages;
   },
   generateClassName: generateUtilityClass,
   isGlobalClassName: isGlobalState,
+  nonComponentFolders: [
+    ...getNonComponentFolders(),
+    'migration/migration-charts-v7',
+    'migration/migration-charts-v6',
+  ],
 };

--- a/scripts/buildApiDocs/gridSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/gridSettings/getComponentInfo.ts
@@ -66,7 +66,7 @@ export function getComponentInfo(filename: string): ComponentInfo {
         {
           demoPathname: '/x/react-data-grid/#mit-version-free-forever',
           demoPageTitle: 'DataGrid',
-          filePath: '',
+          filePath: path.join(process.cwd(), 'docs/data/data-grid/components/usage.md'),
         },
         {
           demoPathname: '/x/react-data-grid/#pro-version',

--- a/scripts/buildApiDocs/gridSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/gridSettings/getComponentInfo.ts
@@ -52,6 +52,7 @@ export function getComponentInfo(filename: string): ComponentInfo {
         const componentDemos = allMarkdowns
           .filter((page) => page.components?.includes(name))
           .map((page) => ({
+            filePath: page.filename,
             demoPageTitle: renderMarkdown(getTitle(page.markdownContent)),
             demoPathname: `/x/react-data-grid/components/${path.basename(page.pathname)}`,
           }));
@@ -62,9 +63,21 @@ export function getComponentInfo(filename: string): ComponentInfo {
       }
 
       return [
-        { demoPathname: '/x/react-data-grid/#mit-version-free-forever', demoPageTitle: 'DataGrid' },
-        { demoPathname: '/x/react-data-grid/#pro-version', demoPageTitle: 'DataGridPro' },
-        { demoPathname: '/x/react-data-grid/#premium-version', demoPageTitle: 'DataGridPremium' },
+        {
+          demoPathname: '/x/react-data-grid/#mit-version-free-forever',
+          demoPageTitle: 'DataGrid',
+          filePath: '',
+        },
+        {
+          demoPathname: '/x/react-data-grid/#pro-version',
+          demoPageTitle: 'DataGridPro',
+          filePath: '',
+        },
+        {
+          demoPathname: '/x/react-data-grid/#premium-version',
+          demoPageTitle: 'DataGridPremium',
+          filePath: '',
+        },
       ];
     },
     layoutConfigPath: 'docsx/src/modules/utils/dataGridLayoutConfig',

--- a/scripts/buildApiDocs/gridSettings/index.ts
+++ b/scripts/buildApiDocs/gridSettings/index.ts
@@ -113,6 +113,7 @@ export default dataGridApiPages;
   isGlobalClassName: isGlobalState,
   nonComponentFolders: [
     ...getNonComponentFolders(),
+    'data-grid/components/usage.md',
     'migration/migration-data-grid-v7',
     'migration/migration-data-grid-v6',
     'migration/migration-data-grid-v5',

--- a/scripts/buildApiDocs/gridSettings/index.ts
+++ b/scripts/buildApiDocs/gridSettings/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import { LANGUAGES } from 'docs/config';
 import { ProjectSettings, ComponentReactApi, HookReactApi } from '@mui-internal/api-docs-builder';
 import findApiPages from '@mui-internal/api-docs-builder/utils/findApiPages';
@@ -6,6 +7,20 @@ import generateUtilityClass, { isGlobalState } from '@mui/utils/generateUtilityC
 import { getComponentImports, getComponentInfo } from './getComponentInfo';
 
 type PageType = { pathname: string; title: string; plan?: 'community' | 'pro' | 'premium' };
+
+function getNonComponentFolders(): string[] {
+  try {
+    return fs
+      .readdirSync(path.join(process.cwd(), 'docs/data/data-grid'), { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory() && dirent.name !== 'components')
+      .map((dirent) => `data-grid/${dirent.name}`)
+      .sort();
+  } catch (error) {
+    // Fallback to empty array if directory doesn't exist
+    console.warn('Could not read the directories:', error);
+    return [];
+  }
+}
 
 const COMPONENT_API_PAGES = [
   'src/DataGridPremium/DataGridPremium.tsx',
@@ -96,4 +111,11 @@ export default dataGridApiPages;
   },
   generateClassName: generateUtilityClass,
   isGlobalClassName: isGlobalState,
+  nonComponentFolders: [
+    ...getNonComponentFolders(),
+    'migration/migration-data-grid-v7',
+    'migration/migration-data-grid-v6',
+    'migration/migration-data-grid-v5',
+    'migration/migration-data-grid-v4',
+  ],
 };

--- a/scripts/buildApiDocs/index.ts
+++ b/scripts/buildApiDocs/index.ts
@@ -1,17 +1,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { ProjectSettings, buildApi } from '@mui-internal/api-docs-builder';
-import { projectPickersSettings } from './pickersSettings';
-import { projectChartsSettings } from './chartsSettings';
-import { projectGridSettings } from './gridSettings';
-import { projectTreeSettings } from './treeViewSettings';
-
-const projectSettings: ProjectSettings[] = [
-  projectPickersSettings,
-  projectChartsSettings,
-  projectTreeSettings,
-  projectGridSettings,
-];
+import { buildApi } from '@mui-internal/api-docs-builder';
+import { projectSettings } from './projectSettings';
 
 type CommandOptions = { grep?: string };
 

--- a/scripts/buildApiDocs/pickersSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/pickersSettings/getComponentInfo.ts
@@ -48,6 +48,7 @@ export function getComponentInfo(filename: string): ComponentInfo {
         )
         .map((page) => {
           return {
+            filePath: page.filename,
             demoPageTitle: renderMarkdown(getTitle(page.markdownContent)),
             demoPathname: `${page.pathname.replace('/date-pickers', '/x/react-date-pickers')}/`,
           };

--- a/scripts/buildApiDocs/pickersSettings/index.ts
+++ b/scripts/buildApiDocs/pickersSettings/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import { LANGUAGES } from 'docs/config';
 import { ProjectSettings, ComponentReactApi, HookReactApi } from '@mui-internal/api-docs-builder';
 import findApiPages from '@mui-internal/api-docs-builder/utils/findApiPages';
@@ -6,6 +7,20 @@ import generateUtilityClass, { isGlobalState } from '@mui/utils/generateUtilityC
 import { getComponentImports, getComponentInfo } from './getComponentInfo';
 
 type PageType = { pathname: string; title: string; plan?: 'community' | 'pro' | 'premium' };
+
+function getNonComponentFolders(): string[] {
+  try {
+    return fs
+      .readdirSync(path.join(process.cwd(), 'docs/data/date-pickers'), { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory() && dirent.name !== 'components')
+      .map((dirent) => `date-pickers/${dirent.name}`)
+      .sort();
+  } catch (error) {
+    // Fallback to empty array if directory doesn't exist
+    console.warn('Could not read the directories:', error);
+    return [];
+  }
+}
 
 export const projectPickersSettings: ProjectSettings = {
   output: {
@@ -76,4 +91,11 @@ export default datePickersApiPages;
   },
   generateClassName: generateUtilityClass,
   isGlobalClassName: isGlobalState,
+  nonComponentFolders: [
+    ...getNonComponentFolders(),
+    'migration/migration-date-pickers-v7',
+    'migration/migration-date-pickers-v6',
+    'migration/migration-date-pickers-v5',
+    'migration/migration-date-pickers-lab',
+  ],
 };

--- a/scripts/buildApiDocs/projectSettings.ts
+++ b/scripts/buildApiDocs/projectSettings.ts
@@ -5,8 +5,8 @@ import { projectGridSettings } from './gridSettings';
 import { projectTreeSettings } from './treeViewSettings';
 
 export const projectSettings: ProjectSettings[] = [
-  // projectPickersSettings,
-  // projectChartsSettings,
-  // projectTreeSettings,
+  projectPickersSettings,
+  projectChartsSettings,
+  projectTreeSettings,
   projectGridSettings,
 ];

--- a/scripts/buildApiDocs/projectSettings.ts
+++ b/scripts/buildApiDocs/projectSettings.ts
@@ -1,0 +1,12 @@
+import { ProjectSettings } from '@mui-internal/api-docs-builder';
+import { projectPickersSettings } from './pickersSettings';
+import { projectChartsSettings } from './chartsSettings';
+import { projectGridSettings } from './gridSettings';
+import { projectTreeSettings } from './treeViewSettings';
+
+export const projectSettings: ProjectSettings[] = [
+  // projectPickersSettings,
+  // projectChartsSettings,
+  // projectTreeSettings,
+  projectGridSettings,
+];

--- a/scripts/buildApiDocs/projectSettings.ts
+++ b/scripts/buildApiDocs/projectSettings.ts
@@ -6,7 +6,7 @@ import { projectTreeSettings } from './treeViewSettings';
 
 export const projectSettings: ProjectSettings[] = [
   projectPickersSettings,
-  // projectChartsSettings,
-  // projectTreeSettings,
-  // projectGridSettings,
+  projectChartsSettings,
+  projectTreeSettings,
+  projectGridSettings,
 ];

--- a/scripts/buildApiDocs/projectSettings.ts
+++ b/scripts/buildApiDocs/projectSettings.ts
@@ -6,7 +6,7 @@ import { projectTreeSettings } from './treeViewSettings';
 
 export const projectSettings: ProjectSettings[] = [
   projectPickersSettings,
-  projectChartsSettings,
-  projectTreeSettings,
-  projectGridSettings,
+  // projectChartsSettings,
+  // projectTreeSettings,
+  // projectGridSettings,
 ];

--- a/scripts/buildApiDocs/treeViewSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/treeViewSettings/getComponentInfo.ts
@@ -46,6 +46,7 @@ export function getComponentInfo(filename: string): ComponentInfo {
         .filter((page) => page.pathname.startsWith('/tree-view') && page.components.includes(name))
         .map((page) => {
           return {
+            filePath: page.filename,
             demoPageTitle: renderMarkdown(getTitle(page.markdownContent)),
             demoPathname: `${page.pathname.replace('/tree-view', '/x/react-tree-view')}/`,
           };

--- a/scripts/buildApiDocs/treeViewSettings/index.ts
+++ b/scripts/buildApiDocs/treeViewSettings/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import { LANGUAGES } from 'docs/config';
 import { ProjectSettings, ComponentReactApi, HookReactApi } from '@mui-internal/api-docs-builder';
 import findApiPages from '@mui-internal/api-docs-builder/utils/findApiPages';
@@ -6,6 +7,20 @@ import generateUtilityClass, { isGlobalState } from '@mui/utils/generateUtilityC
 import { getComponentImports, getComponentInfo } from './getComponentInfo';
 
 type PageType = { pathname: string; title: string; plan?: 'community' | 'pro' | 'premium' };
+
+function getNonComponentFolders(): string[] {
+  try {
+    return fs
+      .readdirSync(path.join(process.cwd(), 'docs/data/tree-view'), { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory() && dirent.name !== 'components')
+      .map((dirent) => `tree-view/${dirent.name}`)
+      .sort();
+  } catch (error) {
+    // Fallback to empty array if directory doesn't exist
+    console.warn('Could not read the directories:', error);
+    return [];
+  }
+}
 
 export const projectTreeSettings: ProjectSettings = {
   output: {
@@ -64,4 +79,10 @@ export default treeViewApiPages;
   },
   generateClassName: generateUtilityClass,
   isGlobalClassName: isGlobalState,
+  nonComponentFolders: [
+    ...getNonComponentFolders(),
+    'migration/migration-tree-view-v7',
+    'migration/migration-tree-view-v6',
+    'migration/migration-tree-view-lab',
+  ],
 };

--- a/scripts/buildLlmsDocs/index.ts
+++ b/scripts/buildLlmsDocs/index.ts
@@ -435,7 +435,12 @@ async function processApiSection(
 
       // Try both JSON patterns: direct and double lastSegment
       const jsonFilePath = path.join(process.cwd(), 'docs/pages', apiItem.pathname + '.json');
-      const jsonFilePathDouble = path.join(process.cwd(), 'docs/pages', apiItem.pathname, lastSegment + '.json');
+      const jsonFilePathDouble = path.join(
+        process.cwd(),
+        'docs/pages',
+        apiItem.pathname,
+        lastSegment + '.json',
+      );
 
       // Try both markdown patterns: docs/data and docs/pages with double lastSegment
       const markdownFilePath = path.join(
@@ -445,7 +450,12 @@ async function processApiSection(
         lastSegment,
         lastSegment + '.md',
       );
-      const markdownFilePathPages = path.join(process.cwd(), 'docs/pages', apiItem.pathname, lastSegment + '.md');
+      const markdownFilePathPages = path.join(
+        process.cwd(),
+        'docs/pages',
+        apiItem.pathname,
+        lastSegment + '.md',
+      );
 
       let apiMarkdown: string;
 
@@ -500,6 +510,26 @@ async function processApiSection(
   }
 
   return generatedFiles;
+}
+
+/**
+ * Recursively find children of an item with the specified subheader
+ */
+function findChildrenBySubheader(page: MuiPage, targetSubheader: string): MuiPage[] {
+  if (page.subheader === targetSubheader && page.children) {
+    return page.children;
+  }
+  
+  if (page.children) {
+    for (const child of page.children) {
+      const result = findChildrenBySubheader(child, targetSubheader);
+      if (result.length > 0) {
+        return result;
+      }
+    }
+  }
+  
+  return [];
 }
 
 /**
@@ -945,9 +975,11 @@ async function buildLlmsDocs(argv: ArgumentsCamelCase<CommandOptions>): Promise<
     })();
 
     const pagesSection = findProjectPagesSection(projectKey);
-    if (pagesSection && pagesSection.children) {
+    if (pagesSection) {
+      // Find children of an item with subheader "Resources"
+      const resourcesChildren = findChildrenBySubheader(pagesSection, "Resources");
       // Find API sections in the project pages
-      for (const child of pagesSection.children) {
+      for (const child of resourcesChildren) {
         if (child.pathname.includes('/api/')) {
           try {
             const projectName = getProjectNameFromSettings(currentProjectSettings);

--- a/scripts/buildLlmsDocs/index.ts
+++ b/scripts/buildLlmsDocs/index.ts
@@ -1,0 +1,596 @@
+/**
+ * LLM Documentation Generator
+ *
+ * This script generates LLM-optimized documentation by processing MUI component markdown files
+ * and non-component documentation files to create comprehensive, standalone documentation.
+ *
+ * ## Main Workflow:
+ *
+ * 1. **Component Processing**:
+ *    - Discovers all components using the API docs builder infrastructure
+ *    - For each component, finds its markdown documentation and API JSON
+ *    - Processes markdown by replacing `{{"demo": "filename.js"}}` syntax with actual code snippets
+ *    - Appends API documentation (props, slots, CSS classes) to the markdown
+ *    - Outputs to files like `material-ui/react-accordion.md`
+ *
+ * 2. **Non-Component Processing** (optional):
+ *    - Processes markdown files from specified folders (e.g., `system`, `material/customization`)
+ *    - Applies the same demo replacement logic
+ *    - Uses URL transformation logic to maintain consistent paths with components
+ *    - Outputs to files like `system/borders.md`, `material-ui/customization/color.md`
+ *
+ * 3. **Index Generation** (llms.txt):
+ *    - Generates `llms.txt` index files for each top-level directory
+ *    - Groups files by category (components, customization, getting-started, etc.)
+ *    - Creates markdown-formatted lists with relative paths and descriptions
+ *    - Outputs to files like `material-ui/llms.txt`, `system/llms.txt`
+ *
+ * ## Key Features:
+ *
+ * - **Demo Replacement**: Converts `{{"demo": "filename.js"}}` to actual JSX/TSX code snippets
+ * - **API Integration**: Automatically includes component API documentation (props, slots, CSS)
+ * - **Reusable**: Accepts project settings via CLI to work across different repositories
+ * - **Filtering**: Supports grep patterns to process specific components/files
+ * - **Path Consistency**: Uses existing URL transformation logic for consistent output structure
+ * - **Auto-indexing**: Generates llms.txt files with categorized documentation listings
+ *
+ * ## Usage Examples:
+ *
+ * ```bash
+ * # Process all Material UI components
+ * pnpm tsx scripts/buildLlmsDocs/index.ts --projectSettings ./packages/api-docs-builder-core/materialUi/projectSettings.ts
+ *
+ * # Process specific components with non-component docs
+ * pnpm tsx scripts/buildLlmsDocs/index.ts \
+ *   --projectSettings ./packages/api-docs-builder-core/materialUi/projectSettings.ts \
+ *   --nonComponentFolders system material/customization \
+ *   --grep "Button|borders"
+ * ```
+ *
+ * ## Output Structure:
+ *
+ * - **Components**: `material-ui/react-{component}.md` (e.g., `material-ui/react-button.md`)
+ * - **Customization**: `material-ui/customization/{topic}.md` (e.g., `material-ui/customization/color.md`)
+ * - **Getting Started**: `material-ui/getting-started/{topic}.md` (e.g., `material-ui/getting-started/installation.md`)
+ * - **Index Files**: `{directory}/llms.txt` (e.g., `material-ui/llms.txt`, `system/llms.txt`)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import yargs, { ArgumentsCamelCase } from 'yargs';
+import kebabCase from 'lodash/kebabCase';
+import { processMarkdownFile, processApiFile } from '@mui-internal-scripts/generate-llms-txt';
+import { ComponentInfo, ProjectSettings } from '@mui-internal/api-docs-builder';
+import { getHeaders } from '@mui/internal-markdown';
+import { fixPathname } from '@mui-internal/api-docs-builder/buildApiUtils';
+import replaceUrl from '@mui-internal/api-docs-builder/utils/replaceUrl';
+import findComponents from '@mui-internal/api-docs-builder/utils/findComponents';
+import findPagesMarkdown from '@mui-internal/api-docs-builder/utils/findPagesMarkdown';
+
+interface ComponentDocInfo {
+  name: string;
+  componentInfo: ComponentInfo;
+  demos: Array<{ demoPageTitle: string; demoPathname: string }>;
+  markdownPath?: string;
+  apiJsonPath?: string;
+}
+
+interface GeneratedFile {
+  outputPath: string;
+  title: string;
+  description: string;
+  originalMarkdownPath: string;
+  category: string;
+  orderIndex?: number; // Track the order for non-component folders
+}
+
+type CommandOptions = {
+  grep?: string;
+  outputDir?: string;
+  projectSettings?: string;
+};
+
+/**
+ * Find all components using the API docs builder infrastructure
+ */
+async function findComponentsToProcess(
+  projectSettings: ProjectSettings,
+  grep: RegExp | null,
+): Promise<ComponentDocInfo[]> {
+  const components: ComponentDocInfo[] = [];
+
+  // Iterate through TypeScript projects, using the same logic as buildApi.ts
+  for (const project of projectSettings.typeScriptProjects) {
+    const projectComponents = findComponents(path.join(project.rootPath, 'src')).filter(
+      (component) => {
+        if (projectSettings.skipComponent(component.filename)) {
+          return false;
+        }
+
+        if (grep === null) {
+          return true;
+        }
+
+        return grep.test(component.filename);
+      },
+    );
+
+    for (const component of projectComponents) {
+      try {
+        // Get component info using the API docs builder
+        const componentInfo = projectSettings.getComponentInfo(component.filename);
+
+        // Skip if component should be skipped (internal, etc.)
+        const fileInfo = componentInfo.readFile();
+        if (fileInfo.shouldSkip) {
+          continue;
+        }
+
+        // Get demos for this component
+        const demos = componentInfo.getDemos();
+
+        // Skip if no demos found (likely not a public component)
+        if (demos.length === 0) {
+          continue;
+        }
+
+        // Get the markdown file path from the first demo
+        const firstDemo = demos[0];
+        const markdownPath = firstDemo ? firstDemo.filePath : undefined;
+
+        // Get API JSON path
+        const apiJsonPath = path.join(
+          componentInfo.apiPagesDirectory,
+          `${path.basename(componentInfo.apiPathname)}.json`,
+        );
+
+        components.push({
+          name: componentInfo.name,
+          componentInfo,
+          demos,
+          markdownPath,
+          apiJsonPath: fs.existsSync(apiJsonPath) ? apiJsonPath : undefined,
+        });
+      } catch (error) {
+        // Skip components that can't be processed
+        continue;
+      }
+    }
+  }
+
+  return components;
+}
+
+/**
+ * Extract title and description from markdown content
+ */
+function extractMarkdownInfo(markdownPath: string): { title: string; description: string } {
+  try {
+    const content = fs.readFileSync(markdownPath, 'utf-8');
+    const headers = getHeaders(content);
+
+    // Get title from frontmatter or first h1
+    const title =
+      headers.title || content.match(/^# (.+)$/m)?.[1] || path.basename(markdownPath, '.md');
+
+    // Extract description from the first paragraph with class="description"
+    const descriptionMatch = content.match(/<p class="description">([^<]+)<\/p>/);
+    let description = '';
+
+    if (descriptionMatch) {
+      description = descriptionMatch[1].trim();
+    } else {
+      // Fallback: get first paragraph after title (excluding headers)
+      const paragraphMatch = content.match(/^# .+\n\n(?!#)(.+?)(?:\n\n|$)/m);
+      if (paragraphMatch && !paragraphMatch[1].startsWith('#')) {
+        description = paragraphMatch[1].trim();
+      }
+    }
+
+    return { title, description };
+  } catch (error) {
+    return {
+      title: path.basename(markdownPath, '.md'),
+      description: '',
+    };
+  }
+}
+
+/**
+ * Find all non-component markdown files from specified folders
+ */
+function findNonComponentMarkdownFiles(
+  folders: string[],
+  grep: RegExp | null,
+): Array<{ markdownPath: string; outputPath: string }> {
+  // Get all markdown files using the existing findPagesMarkdown utility
+  const allMarkdownFiles = findPagesMarkdown();
+
+  const files: Array<{ markdownPath: string; outputPath: string }> = [];
+
+  for (const page of allMarkdownFiles) {
+    // Check if the page belongs to one of the specified folders
+    const belongsToFolder = folders.some((folder) => page.pathname.startsWith(`/${folder}`));
+    if (!belongsToFolder) {
+      continue;
+    }
+
+    // Apply grep filter if specified
+    if (grep) {
+      const fileName = path.basename(page.filename);
+      if (!grep.test(fileName) && !grep.test(page.pathname)) {
+        continue;
+      }
+    }
+
+    // Apply fixPathname first, then replaceUrl to get the proper output structure (like components)
+    const afterFixPathname = fixPathname(page.pathname);
+    const fixedPathname = replaceUrl(afterFixPathname, '/material-ui/');
+    const outputPath = `${fixedPathname.replace(/^\//, '').replace(/\/$/, '')}.md`;
+
+    files.push({
+      markdownPath: page.filename,
+      outputPath,
+    });
+  }
+
+  return files;
+}
+
+/**
+ * Process a single component
+ */
+function processComponent(component: ComponentDocInfo): string | null {
+  // Processing component: ${component.name}
+
+  // Skip if no markdown file found
+  if (!component.markdownPath) {
+    console.error(`Warning: No markdown file found for component: ${component.name}`);
+    return null;
+  }
+
+  // Process the markdown file with demo replacement
+  let processedMarkdown = processMarkdownFile(component.markdownPath);
+
+  // Read the frontmatter to get all components listed in this markdown file
+  const markdownContent = fs.readFileSync(component.markdownPath, 'utf-8');
+  const headers = getHeaders(markdownContent);
+  const componentsInPage = headers.components || [];
+
+  // Add API sections for all components listed in the frontmatter
+  if (componentsInPage.length > 0) {
+    for (const componentName of componentsInPage) {
+      // Construct the API JSON path based on the project settings
+      const apiJsonPath = path.join(
+        component.componentInfo.apiPagesDirectory,
+        `${kebabCase(componentName)}.json`,
+      );
+
+      if (fs.existsSync(apiJsonPath)) {
+        try {
+          const apiMarkdown = processApiFile(apiJsonPath);
+          processedMarkdown += `\n\n${apiMarkdown}`;
+        } catch (error) {
+          console.error(`Warning: Could not process API for ${componentName}:`, error);
+        }
+      } else {
+        console.warn(`Warning: API JSON file not found for ${componentName}: ${apiJsonPath}`);
+      }
+    }
+  } else if (component.apiJsonPath) {
+    // Fallback: Add API section for the primary component if no frontmatter components found
+    try {
+      const apiMarkdown = processApiFile(component.apiJsonPath);
+      processedMarkdown += `\n\n${apiMarkdown}`;
+    } catch (error) {
+      console.error(`Warning: Could not process API for ${component.name}:`, error);
+    }
+  }
+
+  return processedMarkdown;
+}
+
+/**
+ * Convert kebab-case to Title Case
+ */
+function toTitleCase(kebabCaseStr: string): string {
+  return kebabCaseStr
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Generate llms.txt content for a specific directory
+ */
+function generateLlmsTxt(
+  generatedFiles: GeneratedFile[],
+  projectName: string,
+  baseDir: string,
+): string {
+  // Group files by category
+  const groupedByCategory: Record<string, GeneratedFile[]> = {};
+
+  for (const file of generatedFiles) {
+    const category = file.category;
+    if (!groupedByCategory[category]) {
+      groupedByCategory[category] = [];
+    }
+    groupedByCategory[category].push(file);
+  }
+
+  // Generate content
+  let content = `# ${projectName}\n\n`;
+  content += `This is the documentation for the ${projectName} package.\n`;
+  content += `It contains comprehensive guides, components, and utilities for building user interfaces.\n\n`;
+
+  // Add sections for each category
+  // Sort categories to ensure components appear first, then by orderIndex for non-component folders
+  const sortedCategories = Object.keys(groupedByCategory).sort((a, b) => {
+    if (a === 'components') {
+      return -1;
+    }
+    if (b === 'components') {
+      return 1;
+    }
+
+    // For non-component categories, check if they have orderIndex
+    const filesA = groupedByCategory[a];
+    const filesB = groupedByCategory[b];
+    const orderIndexA = filesA[0]?.orderIndex ?? Number.MAX_SAFE_INTEGER;
+    const orderIndexB = filesB[0]?.orderIndex ?? Number.MAX_SAFE_INTEGER;
+
+    if (orderIndexA !== orderIndexB) {
+      return orderIndexA - orderIndexB;
+    }
+
+    return a.localeCompare(b);
+  });
+
+  for (const category of sortedCategories) {
+    const files = groupedByCategory[category];
+    if (files.length === 0) {
+      continue;
+    }
+
+    const sectionTitle = toTitleCase(category);
+    content += `## ${sectionTitle}\n\n`;
+
+    // Sort files by title (components) or maintain original order (non-components)
+    if (category === 'components') {
+      files.sort((a, b) => a.title.localeCompare(b.title));
+    }
+    // Non-component files are already in the order they were discovered
+
+    for (const file of files) {
+      // Calculate relative path from the baseDir to the file
+      const relativePath = file.outputPath.startsWith(`${baseDir}/`)
+        ? `/${baseDir}/${file.outputPath.substring(baseDir.length + 1)}`
+        : `/${file.outputPath}`;
+      content += `- [${file.title}](${relativePath})`;
+      if (file.description) {
+        content += `: ${file.description}`;
+      }
+      content += '\n';
+    }
+    content += '\n';
+  }
+
+  return content.trim();
+}
+
+/**
+ * Main build function
+ */
+async function buildLlmsDocs(argv: ArgumentsCamelCase<CommandOptions>): Promise<void> {
+  const grep = argv.grep ? new RegExp(argv.grep) : null;
+  const outputDir = argv.outputDir || path.join(process.cwd(), 'docs/public');
+
+  // Load project settings from the specified path
+  if (!argv.projectSettings) {
+    throw new Error('--projectSettings is required');
+  }
+
+  let projectSettings: ProjectSettings[];
+  try {
+    const settingsPath = path.resolve(argv.projectSettings);
+    const settingsModule = await import(settingsPath);
+    const imported = settingsModule.projectSettings || settingsModule.default || settingsModule;
+    projectSettings = Array.isArray(imported) ? imported : [imported];
+  } catch (error) {
+    throw new Error(`Failed to load project settings from ${argv.projectSettings}: ${error}`);
+  }
+
+  // Track generated files for llms.txt
+  const generatedFiles: GeneratedFile[] = [];
+  let processedCount = 0;
+
+  // Process each project settings individually
+  for (const currentProjectSettings of projectSettings) {
+    // Find all components for this project
+    const components = await findComponentsToProcess(currentProjectSettings, grep);
+
+    // Found ${components.length} components to process for this project
+
+    // Find non-component markdown files if specified in this project settings
+    let nonComponentFiles: Array<{ markdownPath: string; outputPath: string }> = [];
+    const nonComponentFolders = (currentProjectSettings as any).nonComponentFolders;
+    if (nonComponentFolders && nonComponentFolders.length > 0) {
+      nonComponentFiles = findNonComponentMarkdownFiles(nonComponentFolders, grep);
+      // Found ${nonComponentFiles.length} non-component markdown files to process for this project
+    }
+
+    // Process each component
+    for (const component of components) {
+      try {
+        const processedMarkdown = processComponent(component);
+
+        if (!processedMarkdown) {
+          continue;
+        }
+
+        // Use the component's demo pathname to create the output structure
+        // e.g., /material-ui/react-accordion/ -> material-ui/react-accordion.md
+        const outputFileName = component.demos[0]
+          ? `${component.demos[0].demoPathname.replace(/^\//, '').replace(/\/$/, '')}.md`
+          : `${component.componentInfo.apiPathname.replace(/^\//, '').replace(/\/$/, '')}.md`;
+
+        const outputPath = path.join(outputDir, outputFileName);
+
+        // Check if this file has already been generated (avoid duplicates for components that share the same markdown file)
+        const existingFile = generatedFiles.find((f) => f.outputPath === outputFileName);
+        if (!existingFile) {
+          // Ensure the directory exists
+          const outputDirPath = path.dirname(outputPath);
+          if (!fs.existsSync(outputDirPath)) {
+            fs.mkdirSync(outputDirPath, { recursive: true });
+          }
+
+          fs.writeFileSync(outputPath, processedMarkdown, 'utf-8');
+          // ✓ Generated: ${outputFileName}
+          processedCount += 1;
+
+          // Track this file for llms.txt
+          if (component.markdownPath) {
+            const { title, description } = extractMarkdownInfo(component.markdownPath);
+            generatedFiles.push({
+              outputPath: outputFileName,
+              title,
+              description,
+              originalMarkdownPath: component.markdownPath,
+              category: 'components',
+            });
+          }
+        }
+      } catch (error) {
+        console.error(`✗ Error processing ${component.name}:`, error);
+      }
+    }
+
+    // Process non-component markdown files for this project
+    for (const file of nonComponentFiles) {
+      try {
+        // Processing non-component file: ${path.relative(process.cwd(), file.markdownPath)}
+
+        // Process the markdown file with demo replacement
+        const processedMarkdown = processMarkdownFile(file.markdownPath);
+
+        const outputPath = path.join(outputDir, file.outputPath);
+
+        // Ensure the directory exists
+        const outputDirPath = path.dirname(outputPath);
+        if (!fs.existsSync(outputDirPath)) {
+          fs.mkdirSync(outputDirPath, { recursive: true });
+        }
+
+        fs.writeFileSync(outputPath, processedMarkdown, 'utf-8');
+        // ✓ Generated: ${file.outputPath}
+        processedCount += 1;
+
+        // Track this file for llms.txt
+        const { title, description } = extractMarkdownInfo(file.markdownPath);
+
+        // Extract category from the file path
+        // e.g., "material-ui/customization/color.md" -> "customization"
+        // e.g., "getting-started/installation.md" -> "getting-started"
+        const pathParts = file.outputPath.split('/');
+        const category = pathParts.reverse()[1];
+
+        // Find the order index based on which folder this file belongs to
+        let orderIndex = -1;
+        if (nonComponentFolders) {
+          for (let i = 0; i < nonComponentFolders.length; i += 1) {
+            if (file.markdownPath.includes(`/${nonComponentFolders[i]}/`)) {
+              orderIndex = i;
+              break;
+            }
+          }
+        }
+
+        generatedFiles.push({
+          outputPath: file.outputPath,
+          title,
+          description,
+          originalMarkdownPath: file.markdownPath,
+          category,
+          orderIndex,
+        });
+      } catch (error) {
+        console.error(`✗ Error processing ${file.markdownPath}:`, error);
+      }
+    }
+  }
+
+  // Generate llms.txt files
+  if (generatedFiles.length > 0) {
+    const groupedByFirstDir: Record<string, GeneratedFile[]> = {};
+
+    for (const file of generatedFiles) {
+      const firstDir = file.outputPath.split('/')[0];
+      if (!groupedByFirstDir[firstDir]) {
+        groupedByFirstDir[firstDir] = [];
+      }
+      groupedByFirstDir[firstDir].push(file);
+    }
+
+    for (const [dirName, files] of Object.entries(groupedByFirstDir)) {
+      let projectName;
+      if (dirName === 'material-ui') {
+        projectName = 'Material UI';
+      } else if (dirName === 'system') {
+        projectName = 'MUI System';
+      } else {
+        projectName = dirName.charAt(0).toUpperCase() + dirName.slice(1);
+      }
+
+      const llmsContent = generateLlmsTxt(files, projectName, dirName);
+      const llmsPath = path.join(outputDir, dirName, 'llms.txt');
+
+      // Ensure directory exists
+      const llmsDirPath = path.dirname(llmsPath);
+      if (!fs.existsSync(llmsDirPath)) {
+        fs.mkdirSync(llmsDirPath, { recursive: true });
+      }
+
+      fs.writeFileSync(llmsPath, llmsContent, 'utf-8');
+      // ✓ Generated: ${dirName}/llms.txt
+      processedCount += 1;
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`\nCompleted! Generated ${processedCount} files in ${outputDir}`);
+}
+
+/**
+ * CLI setup
+ */
+yargs(process.argv.slice(2))
+  .command({
+    command: '$0',
+    describe: 'Generates LLM-optimized documentation for MUI components.',
+    builder: (command: any) => {
+      return command
+        .option('grep', {
+          description:
+            'Only generate files for components matching the pattern. The string is treated as a RegExp.',
+          type: 'string',
+        })
+        .option('outputDir', {
+          description: 'Output directory for generated markdown files.',
+          type: 'string',
+          default: './docs/public',
+        })
+        .option('projectSettings', {
+          description:
+            'Path to the project settings module that exports ProjectSettings interface.',
+          type: 'string',
+          demandOption: true,
+        });
+    },
+    handler: buildLlmsDocs,
+  })
+  .help()
+  .strict(true)
+  .version(false)
+  .parse();

--- a/scripts/buildLlmsDocs/index.ts
+++ b/scripts/buildLlmsDocs/index.ts
@@ -431,9 +431,23 @@ async function buildLlmsDocs(argv: ArgumentsCamelCase<CommandOptions>): Promise<
 
         // Use the component's demo pathname to create the output structure
         // e.g., /material-ui/react-accordion/ -> material-ui/react-accordion.md
-        const outputFileName = component.demos[0]
-          ? `${component.demos[0].demoPathname.replace(/^\//, '').replace(/\/$/, '')}.md`
-          : `${component.componentInfo.apiPathname.replace(/^\//, '').replace(/\/$/, '')}.md`;
+        // Replace paths containing # in the last segment with /usage.md
+        let outputFileName;
+        if (component.demos[0]) {
+          let pathname = component.demos[0].demoPathname.replace(/^\//, '').replace(/\/$/, '');
+          const pathParts = pathname.split('/');
+          const lastPart = pathParts[pathParts.length - 1];
+          
+          if (lastPart.includes('#')) {
+            // Replace the last segment with 'usage' if it contains #
+            pathParts[pathParts.length - 1] = 'usage';
+            pathname = pathParts.join('/');
+          }
+          
+          outputFileName = `${pathname}.md`;
+        } else {
+          outputFileName = `${component.componentInfo.apiPathname.replace(/^\//, '').replace(/\/$/, '')}.md`;
+        }
 
         const outputPath = path.join(outputDir, outputFileName);
 

--- a/scripts/buildLlmsDocs/index.ts
+++ b/scripts/buildLlmsDocs/index.ts
@@ -302,7 +302,6 @@ function findNonComponentMarkdownFiles(
  * Process a single component by combining its markdown and API documentation
  */
 function processComponent(component: ComponentDocInfo): string | null {
-
   // Skip if no markdown file found
   if (!component.markdownPath) {
     console.error(`Warning: No markdown file found for component: ${component.name}`);
@@ -381,12 +380,18 @@ async function formatMarkdown(content: string): Promise<string> {
 }
 
 /**
- * Increase header levels by one (add one # to each header)
+ * Increase header levels by one (add one # to each header) and remove project prefixes from titles
  */
 function increaseHeaderLevels(content: string): string {
   // Replace headers with one additional #
   // # becomes ##, ## becomes ###, ### becomes ####, etc.
-  return content.replace(/^(#{1,5})\s/gm, '#$1 ');
+  let processedContent = content.replace(/^(#{1,5})\s/gm, '#$1 ');
+
+  // Remove project prefixes from markdown link titles for root llms.txt
+  // e.g., "Date and Time Pickers - Custom layout" -> "Custom layout"
+  processedContent = processedContent.replace(/\[([^[\]]*?)\s*-\s*([^[\]]*?)\]/g, '[$2]');
+
+  return processedContent;
 }
 
 /**
@@ -852,7 +857,6 @@ async function buildLlmsDocs(argv: ArgumentsCamelCase<CommandOptions>): Promise<
     // Process non-component markdown files for this project
     for (const file of nonComponentFiles) {
       try {
-
         // Process the markdown file with demo replacement
         const processedMarkdown = processMarkdownFile(file.markdownPath);
 

--- a/scripts/buildLlmsDocs/tsconfig.json
+++ b/scripts/buildLlmsDocs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./index.ts"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,12 @@
       "@mui-internal/api-docs-builder/*": [
         "./node_modules/@mui/monorepo/packages/api-docs-builder/*"
       ],
+      "@mui-internal-scripts/generate-llms-txt": [
+        "./node_modules/@mui/monorepo/packages-internal/scripts/generate-llms-txt/src"
+      ],
+      "@mui-internal-scripts/generate-llms-txt/*": [
+        "./node_modules/@mui/monorepo/packages-internal/scripts/generate-llms-txt/src/*"
+      ],
       "test/*": ["./test/*"],
       "docs/*": ["./node_modules/@mui/monorepo/docs/*"],
       "docsx/*": ["./docs/*"]


### PR DESCRIPTION


## Preview

This PR updates the LLM documentation generation to create better organized and more comprehensive documentation files:

**Root Index:**
- `docs/public/x/llms.txt` - Main index with clean titles (no project prefixes)

**Project Indexes:**
- `docs/public/x/react-date-pickers/llms.txt` - Date and Time Pickers with API documentation
- `docs/public/x/react-charts/llms.txt` - Charts with API documentation  
- `docs/public/x/react-tree-view/llms.txt` - Tree View with API documentation
- `docs/public/x/react-data-grid/llms.txt` - Data Grid with API documentation

## Summary

This PR enhances the LLM documentation generator to properly include API documentation in project indexes and improves the overall organization of generated documentation files.

The generated `llms.txt` has the same structure as the docs sidebar.

## How to run/test

To test the changes and generate the updated documentation:

```bash
# Generate LLM documentation for all projects
pnpm tsx scripts/buildLlmsDocs/index.ts --projectSettings ./scripts/buildApiDocs/projectSettings.ts

# Generate for specific projects only
pnpm tsx scripts/buildLlmsDocs/index.ts --projectSettings ./scripts/buildApiDocs/projectSettings.ts --grep "charts|pickers"

# Verify the output files
ls -la docs/public/x/
ls -la docs/public/x/react-charts/
ls -la docs/public/x/react-date-pickers/
```

**Expected results:**
- Root `docs/public/x/llms.txt` should show clean titles without project prefixes
- Each project's `llms.txt` should include API documentation in the Resources section
- API files should be properly organized under `docs/public/x/api/{project}/`

## Review Notes

### 🔍 **Key Areas to Review**

1. **API Integration Logic** (lines 922-937): Check how the regex pattern finds API sections and processes them
2. **File Processing Simplification** (lines 1009-1050): Verify the removal of complex grouping logic works correctly
3. **Title Prefix Removal** (lines 393-395): Ensure the regex correctly strips project prefixes without affecting other content

### 📁 **Output Structure**
```
docs/public/x/
├── llms.txt                    # Root index with clean titles
├── react-charts/
│   └── llms.txt               # Includes API files in Resources section
├── react-data-grid/
│   └── llms.txt               # Includes API files in Resources section
└── api/
    ├── charts/
    │   ├── bar-chart.md
    │   └── line-chart.md
    └── data-grid/
        └── grid-api.md
```

## Breaking Changes
None - this is purely an enhancement to the documentation generation process.