### PR TITLE
[scheduler] Fix Scheduler dark mode

### DIFF
--- a/packages/x-scheduler/src/joy/styles/tokens.css
+++ b/packages/x-scheduler/src/joy/styles/tokens.css
@@ -321,7 +321,7 @@
   --shadow-tint: 215 22% 17%;
 }
 
-.mode-dark {
+.mode-dark .joy {
   --mauve-1: #121113;
   --mauve-2: #1a191b;
   --mauve-2-rgb: 26, 25, 27;
@@ -415,6 +415,6 @@
   --border-color: var(--mauve-4);
 }
 
-body {
+body .joy {
   background-color: var(--surface);
 }


### PR DESCRIPTION
Minor adjustment to resolve a dark mode issue caused by CSS specificity.

<img width="1513" alt="Screenshot 2025-07-01 at 13 43 55" src="https://github.com/user-attachments/assets/76ca5aae-066f-491b-9a71-63a1710e9884" />
<img width="1513" alt="Screenshot 2025-07-01 at 13 43 50" src="https://github.com/user-attachments/assets/17bd413f-424d-4d6f-b55e-1252b793a2ad" />

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
