### PR TITLE
fix(filtering): avoid crash on undefined rowTree entry in tree level position selector

### DIFF
--- a/packages/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts
@@ -135,6 +135,10 @@ export const gridExpandedSortedRowTreeLevelPositionLookupSelector = createSelect
     return visibleSortedRowIds.reduce((acc: Record<GridRowId, number>, rowId) => {
       const rowNode = rowTree[rowId];
 
+      if (!rowNode) {
+        return acc;
+      }
+
       if (!depthPositionCounter[rowNode.depth]) {
         depthPositionCounter[rowNode.depth] = 0;
       }


### PR DESCRIPTION
Fixes #18645 

Steps to reproduce:

visit - https://mui.com/x/react-data-grid/server-side-data/row-grouping/

- You expand first row
- After, you expand second row
- After click the "regenarate data"

You will get this : "TypeError: Cannot read properties of undefined (reading 'depth')"

Expected behaviour: no error


https://github.com/user-attachments/assets/f0ffaab4-01e6-4fe0-88fb-b738b839a7e8

