### PR TITLE
[charts-pro] Fix geometry not handling gestures in specific scenarios

### DIFF
--- a/packages/x-charts/src/BarChart/BarPlot.tsx
+++ b/packages/x-charts/src/BarChart/BarPlot.tsx
@@ -81,7 +81,7 @@ function BarPlot(props: BarPlotProps) {
   const classes = useUtilityClasses();
 
   return (
-    <BarPlotRoot className={classes.root}>
+    <BarPlotRoot data-chart-element-inside className={classes.root}>
       {!withoutBorderRadius &&
         masksData.map(({ id, x, y, width, height, hasPositive, hasNegative, layout }) => {
           return (

--- a/packages/x-charts/src/LineChart/AreaPlot.tsx
+++ b/packages/x-charts/src/LineChart/AreaPlot.tsx
@@ -68,7 +68,7 @@ function AreaPlot(props: AreaPlotProps) {
   const completedData = useAggregatedData();
 
   return (
-    <AreaPlotRoot {...other}>
+    <AreaPlotRoot data-chart-element-inside {...other}>
       {completedData.map(
         ({ d, seriesId, color, area, gradientId }) =>
           !!area && (

--- a/packages/x-charts/src/LineChart/LinePlot.tsx
+++ b/packages/x-charts/src/LineChart/LinePlot.tsx
@@ -66,7 +66,7 @@ function LinePlot(props: LinePlotProps) {
 
   const completedData = useAggregatedData();
   return (
-    <LinePlotRoot {...other}>
+    <LinePlotRoot data-chart-element-inside {...other}>
       {completedData.map(({ d, seriesId, color, gradientId }) => {
         return (
           <LineElement

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.ts
@@ -218,8 +218,12 @@ export const useChartDimensions: ChartPlugin<UseChartDimensionsSignature> = ({
       if (!element || !(element instanceof Element) || !svgElement) {
         return false;
       }
-      // For element allowed to overflow, wrapping them in <g data-drawing-container /> make them fully part of the drawing area.
-      if (element.closest('[data-drawing-container]')) {
+      if (
+        // For element allowed to overflow, wrapping them in <g data-drawing-container /> make them fully part of the drawing area.
+        // For element allowed handle interaction, wrapping them in <g data-chart-element-inside /> mark them as being inside the drawing area.
+        // Closest uses a css selector. A comma `,` is read as an "or" operator.
+        element.closest('[data-drawing-container],[data-chart-element-inside]')
+      ) {
         return true;
       }
 


### PR DESCRIPTION
The boundaries of some elements were outside of the drawing area, which made the `isElementInside` consider them outside. 

I didn't re-use `data-drawing-container` as that currently has other meanings as well