### PR TITLE
[date-pickers] Update Korean (ko-KR) locale

### DIFF
--- a/packages/x-date-pickers/src/locales/koKR.ts
+++ b/packages/x-date-pickers/src/locales/koKR.ts
@@ -42,7 +42,7 @@ const koKRPickers: Partial<PickersLocaleText> = {
   dateTimePickerToolbarTitle: '날짜 & 시간 선택하기',
   timePickerToolbarTitle: '시간 선택하기',
   dateRangePickerToolbarTitle: '날짜 범위 선택하기',
-  // timeRangePickerToolbarTitle: 'Select time range',
+  timeRangePickerToolbarTitle: '시간 범위 선택하기',
 
   // Clock labels
   clockLabelText: (view, formattedTime) =>
@@ -69,7 +69,10 @@ const koKRPickers: Partial<PickersLocaleText> = {
     formattedTime
       ? `시간을 선택하세요. 현재 선택된 시간은 ${formattedTime}입니다.`
       : '시간을 선택하세요',
-  // openRangePickerDialogue: formattedRange => formattedRange ? `Choose range, selected range is ${formattedRange}` : 'Choose range',
+  openRangePickerDialogue: (formattedRange) =>
+    formattedRange
+      ? `범위를 선택하세요. 현재 선택된 범위는 ${formattedRange}입니다.`
+      : '범위를 선택하세요',
   fieldClearLabel: '지우기',
 
   // Table labels
@@ -94,7 +97,7 @@ const koKRPickers: Partial<PickersLocaleText> = {
   hours: '시간',
   minutes: '분',
   seconds: '초',
-  // meridiem: 'Meridiem',
+  meridiem: '오전/오후',
 
   // Common
   empty: '공란',


### PR DESCRIPTION
This PR updates the **Korean locale** for `date-pickers` to provide more accurate and natural translations for Korean users.  
The changes are based on the supported locales list from the [official MUI documentation](https://mui.com/x/react-date-pickers/localization/#supported-locales) and issue #3211.

With this update, the Korean localization for `date-pickers` will be fully complete.
Additionally, the components mentioned in issue #3211 → `DataGrid, DataGridPro, DataGridPremium (5 remaining)` appear to have already been completed.

Thank you.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
