### PR TITLE
[charts] Allow gestures to require a key to be pressed

### DIFF
--- a/packages/x-internal-gestures/src/core/Gesture.ts
+++ b/packages/x-internal-gestures/src/core/Gesture.ts
@@ -74,6 +74,9 @@ export type GestureOptions<GestureName extends string> = {
    * Array of keyboard keys that must be pressed for the gesture to be recognized.
    * If not provided or empty, no keyboard key requirement is applied.
    *
+   * A special identifier `ControlOrMeta` can be used to match either Control or Meta keys,
+   * which is useful for cross-platform compatibility.
+   *
    * @example ['Shift', 'Alt']
    * @default [] (no key requirement)
    */

--- a/packages/x-internal-gestures/src/core/Gesture.ts
+++ b/packages/x-internal-gestures/src/core/Gesture.ts
@@ -77,7 +77,7 @@ export type GestureOptions<GestureName extends string> = {
    * @example ['Shift', 'Alt']
    * @default [] (no key requirement)
    */
-  keys?: KeyboardKey[];
+  requiredKeys?: KeyboardKey[];
 };
 
 // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
@@ -139,7 +139,7 @@ export abstract class Gesture<GestureName extends string> {
   /**
    * Array of keyboard keys that must be pressed for the gesture to be recognized.
    */
-  protected keys?: KeyboardKey[];
+  protected requiredKeys?: KeyboardKey[];
 
   /**
    * KeyboardManager instance for tracking key presses
@@ -198,7 +198,7 @@ export abstract class Gesture<GestureName extends string> {
     this.preventDefault = options.preventDefault ?? false;
     this.stopPropagation = options.stopPropagation ?? false;
     this.preventIf = options.preventIf ?? [];
-    this.keys = options.keys;
+    this.requiredKeys = options.requiredKeys;
   }
 
   /**
@@ -248,7 +248,7 @@ export abstract class Gesture<GestureName extends string> {
     this.preventDefault = options.preventDefault ?? this.preventDefault;
     this.stopPropagation = options.stopPropagation ?? this.stopPropagation;
     this.preventIf = options.preventIf ?? this.preventIf;
-    this.keys = options.keys ?? this.keys;
+    this.requiredKeys = options.requiredKeys ?? this.requiredKeys;
   }
 
   /**
@@ -318,8 +318,8 @@ export abstract class Gesture<GestureName extends string> {
    */
   protected shouldPreventGesture(element: TargetElement): boolean {
     // First check if required keyboard keys are pressed
-    if (this.keys && this.keys.length > 0) {
-      if (!this.keyboardManager.areKeysPressed(this.keys)) {
+    if (this.requiredKeys && this.requiredKeys.length > 0) {
+      if (!this.keyboardManager.areKeysPressed(this.requiredKeys)) {
         return true; // Prevent the gesture if required keys are not pressed
       }
     }

--- a/packages/x-internal-gestures/src/core/Gesture.ts
+++ b/packages/x-internal-gestures/src/core/Gesture.ts
@@ -142,7 +142,7 @@ export abstract class Gesture<GestureName extends string> {
   /**
    * Array of keyboard keys that must be pressed for the gesture to be recognized.
    */
-  protected requiredKeys?: KeyboardKey[];
+  protected requiredKeys: KeyboardKey[];
 
   /**
    * KeyboardManager instance for tracking key presses
@@ -201,7 +201,7 @@ export abstract class Gesture<GestureName extends string> {
     this.preventDefault = options.preventDefault ?? false;
     this.stopPropagation = options.stopPropagation ?? false;
     this.preventIf = options.preventIf ?? [];
-    this.requiredKeys = options.requiredKeys;
+    this.requiredKeys = options.requiredKeys ?? [];
   }
 
   /**

--- a/packages/x-internal-gestures/src/core/GestureManager.ts
+++ b/packages/x-internal-gestures/src/core/GestureManager.ts
@@ -145,7 +145,7 @@ export class GestureManager<
 
   private pointerManager: PointerManager;
 
-  private keyboardManager: KeyboardManager = KeyboardManager.getInstance();
+  private keyboardManager: KeyboardManager = new KeyboardManager();
 
   /**
    * Create a new GestureManager instance to coordinate gesture recognition

--- a/packages/x-internal-gestures/src/core/GestureManager.ts
+++ b/packages/x-internal-gestures/src/core/GestureManager.ts
@@ -145,7 +145,7 @@ export class GestureManager<
 
   private pointerManager: PointerManager;
 
-  private keyboardManager: KeyboardManager = new KeyboardManager();
+  private keyboardManager: KeyboardManager = KeyboardManager.getInstance();
 
   /**
    * Create a new GestureManager instance to coordinate gesture recognition

--- a/packages/x-internal-gestures/src/core/GestureManager.ts
+++ b/packages/x-internal-gestures/src/core/GestureManager.ts
@@ -1,5 +1,6 @@
 import { ActiveGesturesRegistry } from './ActiveGesturesRegistry';
 import { Gesture } from './Gesture';
+import { KeyboardManager } from './KeyboardManager';
 import { PointerManager, PointerManagerOptions } from './PointerManager';
 import { GestureElement } from './types/GestureElement';
 import { MergeUnions } from './types/MergeUnions';
@@ -143,6 +144,8 @@ export class GestureManager<
     new ActiveGesturesRegistry();
 
   private pointerManager: PointerManager;
+
+  private keyboardManager: KeyboardManager = new KeyboardManager();
 
   /**
    * Create a new GestureManager instance to coordinate gesture recognition
@@ -345,7 +348,12 @@ export class GestureManager<
     // Clone the gesture template and create a new instance with optional overrides
     // This allows each element to have its own state, event listeners, and configuration
     const gestureInstance = gestureTemplate.clone(options);
-    gestureInstance.init(element, this.pointerManager, this.activeGesturesRegistry);
+    gestureInstance.init(
+      element,
+      this.pointerManager,
+      this.activeGesturesRegistry,
+      this.keyboardManager,
+    );
 
     // Store the gesture in the element's gesture map
     elementGestures.set(gestureName, gestureInstance);
@@ -417,5 +425,6 @@ export class GestureManager<
     this.gestureTemplates.clear();
     this.elementGestureMap.clear();
     this.activeGesturesRegistry.destroy();
+    this.keyboardManager.destroy();
   }
 }

--- a/packages/x-internal-gestures/src/core/KeyboardManager.dynamic-key-filter.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.dynamic-key-filter.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mouseGesture } from '../testing';
+import { GestureManager } from './GestureManager';
+import { TapGesture } from './gestures/TapGesture';
+
+describe('Gesture Keyboard Filter Dynamic Updates', () => {
+  let container: HTMLElement;
+  let target: HTMLElement;
+  let gestureManager: GestureManager<'dynamicTap', TapGesture<'dynamicTap'>>;
+  let events: string[];
+
+  beforeEach(() => {
+    events = [];
+
+    // Set up DOM
+    container = document.createElement('div');
+    container.style.width = '200px';
+    container.style.height = '200px';
+    document.body.appendChild(container);
+
+    // Set up gesture manager with a tap gesture that has no initial key requirements
+    gestureManager = new GestureManager({
+      gestures: [
+        new TapGesture({
+          name: 'dynamicTap',
+          // No keys requirement initially
+        }),
+      ],
+    });
+
+    // Set up target element
+    target = document.createElement('div');
+    target.style.width = '100px';
+    target.style.height = '100px';
+    container.appendChild(target);
+
+    // Register the gesture on the target
+    const gestureTarget = gestureManager.registerElement('dynamicTap', target);
+
+    // Add event listener
+    gestureTarget.addEventListener('dynamicTap', () => {
+      events.push('dynamicTap');
+    });
+  });
+
+  afterEach(() => {
+    gestureManager.destroy();
+    container.remove();
+    events = [];
+  });
+
+  it('should initially trigger the gesture without any keys pressed', async () => {
+    // Perform a tap with no keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger the gesture
+    expect(events).toEqual(['dynamicTap']);
+  });
+
+  it('should respect dynamically updated key requirements', async () => {
+    // Update the gesture to require Shift key
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      keys: ['Shift'],
+    });
+
+    // Perform a tap with no keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should not trigger the gesture
+    expect(events).toEqual([]);
+
+    // Press Shift key
+    const keydownEvent = new KeyboardEvent('keydown', { key: 'Shift' });
+    window.dispatchEvent(keydownEvent);
+
+    // Perform a tap with Shift key pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger the gesture
+    expect(events).toEqual(['dynamicTap']);
+
+    // Release Shift key
+    const keyupEvent = new KeyboardEvent('keyup', { key: 'Shift' });
+    window.dispatchEvent(keyupEvent);
+  });
+
+  it('should support removing key requirements dynamically', async () => {
+    // First add a key requirement
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      keys: ['Control'],
+    });
+
+    // Perform a tap with no keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should not trigger the gesture
+    expect(events).toEqual([]);
+
+    // Now remove the key requirement
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      keys: [], // Empty array removes the requirement
+    });
+
+    // Perform a tap with no keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger the gesture
+    expect(events).toEqual(['dynamicTap']);
+  });
+
+  it('should support changing key requirements dynamically', async () => {
+    // First require Control key
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      keys: ['Control'],
+    });
+
+    // Press Control key
+    const keydownCtrl = new KeyboardEvent('keydown', { key: 'Control' });
+    window.dispatchEvent(keydownCtrl);
+
+    // Perform a tap with Control key pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger the gesture
+    expect(events).toEqual(['dynamicTap']);
+    events = []; // Clear events
+
+    // Change to require Shift key instead
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      keys: ['Shift'],
+    });
+
+    // Perform a tap with Control key still pressed (but now Shift is required)
+    await mouseGesture.tap({ target });
+
+    // Should not trigger the gesture
+    expect(events).toEqual([]);
+
+    // Press Shift key
+    const keydownShift = new KeyboardEvent('keydown', { key: 'Shift' });
+    window.dispatchEvent(keydownShift);
+
+    // Perform a tap with both Control and Shift keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger the gesture
+    expect(events).toEqual(['dynamicTap']);
+
+    // Release keys
+    const keyupCtrl = new KeyboardEvent('keyup', { key: 'Control' });
+    const keyupShift = new KeyboardEvent('keyup', { key: 'Shift' });
+    window.dispatchEvent(keyupCtrl);
+    window.dispatchEvent(keyupShift);
+  });
+});

--- a/packages/x-internal-gestures/src/core/KeyboardManager.dynamic-key-filter.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.dynamic-key-filter.test.ts
@@ -60,7 +60,7 @@ describe('Gesture Keyboard Filter Dynamic Updates', () => {
   it('should respect dynamically updated key requirements', async () => {
     // Update the gesture to require Shift key
     gestureManager.setGestureOptions('dynamicTap', target, {
-      keys: ['Shift'],
+      requiredKeys: ['Shift'],
     });
 
     // Perform a tap with no keys pressed
@@ -87,7 +87,7 @@ describe('Gesture Keyboard Filter Dynamic Updates', () => {
   it('should support removing key requirements dynamically', async () => {
     // First add a key requirement
     gestureManager.setGestureOptions('dynamicTap', target, {
-      keys: ['Control'],
+      requiredKeys: ['Control'],
     });
 
     // Perform a tap with no keys pressed
@@ -98,7 +98,7 @@ describe('Gesture Keyboard Filter Dynamic Updates', () => {
 
     // Now remove the key requirement
     gestureManager.setGestureOptions('dynamicTap', target, {
-      keys: [], // Empty array removes the requirement
+      requiredKeys: [], // Empty array removes the requirement
     });
 
     // Perform a tap with no keys pressed
@@ -111,7 +111,7 @@ describe('Gesture Keyboard Filter Dynamic Updates', () => {
   it('should support changing key requirements dynamically', async () => {
     // First require Control key
     gestureManager.setGestureOptions('dynamicTap', target, {
-      keys: ['Control'],
+      requiredKeys: ['Control'],
     });
 
     // Press Control key
@@ -127,7 +127,7 @@ describe('Gesture Keyboard Filter Dynamic Updates', () => {
 
     // Change to require Shift key instead
     gestureManager.setGestureOptions('dynamicTap', target, {
-      keys: ['Shift'],
+      requiredKeys: ['Shift'],
     });
 
     // Perform a tap with Control key still pressed (but now Shift is required)

--- a/packages/x-internal-gestures/src/core/KeyboardManager.key-filter.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.key-filter.test.ts
@@ -31,7 +31,7 @@ describe('Gesture Keyboard Filter', () => {
         }),
         new TapGesture({
           name: 'shiftTap',
-          keys: ['Shift'], // This gesture requires Shift key to be pressed
+          requiredKeys: ['Shift'], // This gesture requires Shift key to be pressed
         }),
       ],
     });

--- a/packages/x-internal-gestures/src/core/KeyboardManager.key-filter.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.key-filter.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mouseGesture } from '../testing';
+import { GestureManager } from './GestureManager';
+import { TapGesture } from './gestures/TapGesture';
+
+describe('Gesture Keyboard Filter', () => {
+  let container: HTMLElement;
+  let target: HTMLElement;
+  let gestureManager: GestureManager<
+    'tap' | 'shiftTap',
+    TapGesture<'tap'> | TapGesture<'shiftTap'>
+  >;
+  let events: string[];
+
+  beforeEach(() => {
+    events = [];
+
+    // Set up DOM
+    container = document.createElement('div');
+    container.style.width = '200px';
+    container.style.height = '200px';
+    document.body.appendChild(container);
+
+    // Set up gesture manager with two tap gestures:
+    // 1. Regular tap with no key requirements
+    // 2. Shift tap that requires the Shift key to be pressed
+    gestureManager = new GestureManager({
+      gestures: [
+        new TapGesture({
+          name: 'tap',
+        }),
+        new TapGesture({
+          name: 'shiftTap',
+          keys: ['Shift'], // This gesture requires Shift key to be pressed
+        }),
+      ],
+    });
+
+    // Set up target element
+    target = document.createElement('div');
+    target.style.width = '100px';
+    target.style.height = '100px';
+    container.appendChild(target);
+
+    // Register both gestures on the same target
+    const gestureTarget = gestureManager.registerElement(['tap', 'shiftTap'], target);
+
+    // Add event listeners for both gestures
+    gestureTarget.addEventListener('tap', () => events.push('tap'));
+
+    gestureTarget.addEventListener('shiftTap', () => events.push('shiftTap'));
+  });
+
+  afterEach(() => {
+    gestureManager.destroy();
+    container.remove();
+    events = [];
+  });
+
+  it('should trigger regular tap gesture without any keys pressed', async () => {
+    // Perform a tap with no keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger only the regular tap
+    expect(events).toEqual(['tap']);
+    expect(events).not.toContain('shiftTap');
+  });
+
+  it('should trigger both regular tap and shift-tap gestures when Shift key is pressed', async () => {
+    // Simulate Shift key press
+    const keydownEvent = new KeyboardEvent('keydown', { key: 'Shift' });
+    window.dispatchEvent(keydownEvent);
+
+    // Perform a tap with Shift key pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger both gestures
+    expect(events).toStrictEqual(['tap', 'shiftTap']);
+  });
+
+  it('should not trigger shift-tap gesture after Shift key is released', async () => {
+    // Simulate Shift key press then release
+    const keydownEvent = new KeyboardEvent('keydown', { key: 'Shift' });
+    window.dispatchEvent(keydownEvent);
+    const keyupEvent = new KeyboardEvent('keyup', { key: 'Shift' });
+    window.dispatchEvent(keyupEvent);
+
+    // Perform a tap with no keys pressed
+    await mouseGesture.tap({ target });
+
+    // Should trigger only the regular tap
+    expect(events).toEqual(['tap']);
+    expect(events).not.toContain('shiftTap');
+  });
+});

--- a/packages/x-internal-gestures/src/core/KeyboardManager.multi-key-filter.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.multi-key-filter.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mouseGesture } from '../testing';
+import { GestureManager } from './GestureManager';
+import { PanGesture } from './gestures/PanGesture';
+
+describe('Gesture Multiple Key Filter', () => {
+  let container: HTMLElement;
+  let target: HTMLElement;
+  let gestureManager: GestureManager<
+    'pan' | 'ctrlPan' | 'ctrlAltPan',
+    PanGesture<'pan'> | PanGesture<'ctrlPan'> | PanGesture<'ctrlAltPan'>
+  >;
+  let events: string[];
+
+  beforeEach(() => {
+    events = [];
+
+    // Set up DOM
+    container = document.createElement('div');
+    container.style.width = '200px';
+    container.style.height = '200px';
+    document.body.appendChild(container);
+
+    // Set up gesture manager with three pan gestures:
+    // 1. Regular pan with no key requirements
+    // 2. Ctrl pan that requires the Control key to be pressed
+    // 3. Ctrl+Alt pan that requires both Control and Alt keys to be pressed
+    gestureManager = new GestureManager({
+      gestures: [
+        new PanGesture({
+          name: 'pan',
+          threshold: 0,
+        }),
+        new PanGesture({
+          name: 'ctrlPan',
+          threshold: 0,
+          keys: ['Control'], // This gesture requires Control key to be pressed
+        }),
+        new PanGesture({
+          name: 'ctrlAltPan',
+          threshold: 0,
+          keys: ['Control', 'Alt'], // This gesture requires both Control and Alt keys
+        }),
+      ],
+    });
+
+    // Set up target element
+    target = document.createElement('div');
+    target.style.width = '100px';
+    target.style.height = '100px';
+    container.appendChild(target);
+
+    // Register all gestures on the same target
+    const gestureTarget = gestureManager.registerElement(['pan', 'ctrlPan', 'ctrlAltPan'], target);
+
+    // Add event listeners for all gestures
+    gestureTarget.addEventListener('panStart', () => events.push('panStart'));
+    gestureTarget.addEventListener('pan', () => events.push('pan'));
+    gestureTarget.addEventListener('ctrlPanStart', () => events.push('ctrlPanStart'));
+    gestureTarget.addEventListener('ctrlPan', () => events.push('ctrlPan'));
+    gestureTarget.addEventListener('ctrlAltPanStart', () => events.push('ctrlAltPanStart'));
+    gestureTarget.addEventListener('ctrlAltPan', () => events.push('ctrlAltPan'));
+  });
+
+  afterEach(() => {
+    gestureManager.destroy();
+    container.remove();
+    events = [];
+  });
+
+  it('should trigger only regular pan with no keys pressed', async () => {
+    // Perform a pan with no keys pressed
+    await mouseGesture.pan({
+      target,
+      distance: 50,
+      angle: 0, // horizontal movement
+    });
+
+    // Should trigger only the regular pan
+    expect(events).toContain('panStart');
+    expect(events).toContain('pan');
+    expect(events).not.toContain('ctrlPanStart');
+    expect(events).not.toContain('ctrlPan');
+    expect(events).not.toContain('ctrlAltPanStart');
+    expect(events).not.toContain('ctrlAltPan');
+  });
+
+  it('should trigger regular pan and ctrl-pan when Control key is pressed', async () => {
+    // Simulate Control key press
+    const keydownEvent = new KeyboardEvent('keydown', { key: 'Control' });
+    window.dispatchEvent(keydownEvent);
+
+    // Perform a pan with Control key pressed
+    await mouseGesture.pan({
+      target,
+      distance: 50,
+      angle: 0, // horizontal movement
+    });
+
+    // Should trigger regular pan and ctrl-pan
+    expect(events).toContain('panStart');
+    expect(events).toContain('pan');
+    expect(events).toContain('ctrlPanStart');
+    expect(events).toContain('ctrlPan');
+    expect(events).not.toContain('ctrlAltPanStart');
+    expect(events).not.toContain('ctrlAltPan');
+
+    // Clean up key press
+    const keyupEvent = new KeyboardEvent('keyup', { key: 'Control' });
+    window.dispatchEvent(keyupEvent);
+  });
+
+  it('should trigger all pans when Control and Alt keys are pressed', async () => {
+    // Simulate Control+Alt key presses
+    const keydownCtrl = new KeyboardEvent('keydown', { key: 'Control' });
+    const keydownAlt = new KeyboardEvent('keydown', { key: 'Alt' });
+    window.dispatchEvent(keydownCtrl);
+    window.dispatchEvent(keydownAlt);
+
+    // Perform a pan with Control+Alt keys pressed
+    await mouseGesture.pan({
+      target,
+      distance: 50,
+      angle: 0, // horizontal movement
+    });
+
+    // Should trigger all pans
+    expect(events).toContain('panStart');
+    expect(events).toContain('pan');
+    expect(events).toContain('ctrlPanStart');
+    expect(events).toContain('ctrlPan');
+    expect(events).toContain('ctrlAltPanStart');
+    expect(events).toContain('ctrlAltPan');
+
+    // Clean up key presses
+    const keyupCtrl = new KeyboardEvent('keyup', { key: 'Control' });
+    const keyupAlt = new KeyboardEvent('keyup', { key: 'Alt' });
+    window.dispatchEvent(keyupCtrl);
+    window.dispatchEvent(keyupAlt);
+  });
+
+  it('should not trigger ctrl-alt-pan if only one key of the combination is pressed', async () => {
+    // Simulate only Alt key press
+    const keydownAlt = new KeyboardEvent('keydown', { key: 'Alt' });
+    window.dispatchEvent(keydownAlt);
+
+    // Perform a pan with only Alt key pressed
+    await mouseGesture.pan({
+      target,
+      distance: 50,
+      angle: 0, // horizontal movement
+    });
+
+    // Should trigger only regular pan
+    expect(events).toContain('panStart');
+    expect(events).toContain('pan');
+    expect(events).not.toContain('ctrlPanStart');
+    expect(events).not.toContain('ctrlPan');
+    expect(events).not.toContain('ctrlAltPanStart');
+    expect(events).not.toContain('ctrlAltPan');
+
+    // Clean up key press
+    const keyupAlt = new KeyboardEvent('keyup', { key: 'Alt' });
+    window.dispatchEvent(keyupAlt);
+  });
+});

--- a/packages/x-internal-gestures/src/core/KeyboardManager.multi-key-filter.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.multi-key-filter.test.ts
@@ -34,12 +34,12 @@ describe('Gesture Multiple Key Filter', () => {
         new PanGesture({
           name: 'ctrlPan',
           threshold: 0,
-          keys: ['Control'], // This gesture requires Control key to be pressed
+          requiredKeys: ['Control'], // This gesture requires Control key to be pressed
         }),
         new PanGesture({
           name: 'ctrlAltPan',
           threshold: 0,
-          keys: ['Control', 'Alt'], // This gesture requires both Control and Alt keys
+          requiredKeys: ['Control', 'Alt'], // This gesture requires both Control and Alt keys
         }),
       ],
     });

--- a/packages/x-internal-gestures/src/core/KeyboardManager.test.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { KeyboardManager } from './KeyboardManager';
+
+describe('KeyboardManager', () => {
+  let keyboardManager: KeyboardManager;
+  let addEventListenerSpy: MockInstance;
+  let removeEventListenerSpy: MockInstance;
+
+  beforeEach(() => {
+    // Spy on window event listener methods
+    addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    // Get a fresh instance of KeyboardManager
+    keyboardManager = new KeyboardManager();
+  });
+
+  afterEach(() => {
+    keyboardManager.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('should add event listeners on initialization', () => {
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    expect(addEventListenerSpy).toHaveBeenCalledWith('keyup', expect.any(Function));
+    expect(addEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+  });
+
+  it('should remove event listeners on destroy', () => {
+    keyboardManager.destroy();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keyup', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+  });
+
+  it('should track pressed keys', () => {
+    // Simulate key press events
+    const keydownEvent = new KeyboardEvent('keydown', { key: 'Shift' });
+    window.dispatchEvent(keydownEvent);
+
+    expect(keyboardManager.areKeysPressed(['Shift'])).toBe(true);
+    expect(keyboardManager.areKeysPressed(['Alt'])).toBe(false);
+    expect(keyboardManager.areKeysPressed(['Shift', 'Alt'])).toBe(false);
+
+    // Simulate another key press
+    const keydownEvent2 = new KeyboardEvent('keydown', { key: 'Alt' });
+    window.dispatchEvent(keydownEvent2);
+
+    expect(keyboardManager.areKeysPressed(['Shift'])).toBe(true);
+    expect(keyboardManager.areKeysPressed(['Alt'])).toBe(true);
+    expect(keyboardManager.areKeysPressed(['Shift', 'Alt'])).toBe(true);
+  });
+
+  it('should track key releases', () => {
+    // Press keys
+    const keydownEvent1 = new KeyboardEvent('keydown', { key: 'Shift' });
+    const keydownEvent2 = new KeyboardEvent('keydown', { key: 'Alt' });
+    window.dispatchEvent(keydownEvent1);
+    window.dispatchEvent(keydownEvent2);
+
+    expect(keyboardManager.areKeysPressed(['Shift', 'Alt'])).toBe(true);
+
+    // Release a key
+    const keyupEvent = new KeyboardEvent('keyup', { key: 'Shift' });
+    window.dispatchEvent(keyupEvent);
+
+    expect(keyboardManager.areKeysPressed(['Shift'])).toBe(false);
+    expect(keyboardManager.areKeysPressed(['Alt'])).toBe(true);
+    expect(keyboardManager.areKeysPressed(['Shift', 'Alt'])).toBe(false);
+  });
+
+  it('should clear all keys on window blur', () => {
+    // Press keys
+    const keydownEvent1 = new KeyboardEvent('keydown', { key: 'Shift' });
+    const keydownEvent2 = new KeyboardEvent('keydown', { key: 'Alt' });
+    window.dispatchEvent(keydownEvent1);
+    window.dispatchEvent(keydownEvent2);
+
+    expect(keyboardManager.areKeysPressed(['Shift', 'Alt'])).toBe(true);
+
+    // Trigger window blur
+    const blurEvent = new Event('blur');
+    window.dispatchEvent(blurEvent);
+
+    expect(keyboardManager.areKeysPressed(['Shift'])).toBe(false);
+    expect(keyboardManager.areKeysPressed(['Alt'])).toBe(false);
+  });
+
+  it('should handle undefined or empty key arrays', () => {
+    expect(keyboardManager.areKeysPressed()).toBe(true);
+    expect(keyboardManager.areKeysPressed([])).toBe(true);
+  });
+});

--- a/packages/x-internal-gestures/src/core/KeyboardManager.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.ts
@@ -1,0 +1,87 @@
+/**
+ * KeyboardManager - Manager for keyboard events in the gesture recognition system
+ *
+ * This class tracks keyboard state:
+ * 1. Capturing and tracking all pressed keys
+ * 2. Providing methods to check if specific keys are pressed
+ */
+
+/**
+ * Type definition for keyboard keys
+ */
+export type KeyboardKey = string;
+
+/**
+ * Class responsible for tracking keyboard state
+ */
+export class KeyboardManager {
+  private pressedKeys: Set<KeyboardKey> = new Set();
+
+  /**
+   * Create a new KeyboardManager instance
+   */
+  constructor() {
+    this.initialize();
+  }
+
+  /**
+   * Initialize the keyboard event listeners
+   */
+  private initialize(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    // Add keyboard event listeners
+    window.addEventListener('keydown', this.handleKeyDown);
+    window.addEventListener('keyup', this.handleKeyUp);
+    // Reset keys when window loses focus
+    window.addEventListener('blur', this.clearKeys);
+  }
+
+  /**
+   * Handle keydown events
+   */
+  private handleKeyDown = (event: KeyboardEvent): void => {
+    this.pressedKeys.add(event.key);
+  };
+
+  /**
+   * Handle keyup events
+   */
+  private handleKeyUp = (event: KeyboardEvent): void => {
+    this.pressedKeys.delete(event.key);
+  };
+
+  /**
+   * Clear all pressed keys
+   */
+  private clearKeys = (): void => {
+    this.pressedKeys.clear();
+  };
+
+  /**
+   * Check if a set of keys are all currently pressed
+   * @param keys The keys to check
+   * @returns True if all specified keys are pressed, false otherwise
+   */
+  public areKeysPressed(keys?: KeyboardKey[]): boolean {
+    if (!keys || keys.length === 0) {
+      return true; // No keys required means the condition is satisfied
+    }
+
+    return keys.every((key) => this.pressedKeys.has(key));
+  }
+
+  /**
+   * Cleanup method to remove event listeners
+   */
+  public destroy(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', this.handleKeyDown);
+      window.removeEventListener('keyup', this.handleKeyUp);
+      window.removeEventListener('blur', this.clearKeys);
+    }
+    this.clearKeys();
+  }
+}

--- a/packages/x-internal-gestures/src/core/KeyboardManager.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.ts
@@ -1,9 +1,11 @@
 /**
- * KeyboardManager - Manager for keyboard events in the gesture recognition system
+ * KeyboardManager - Centralized manager for keyboard events in the gesture recognition system
  *
- * This class tracks keyboard state:
+ * This singleton class tracks keyboard state across the application:
  * 1. Capturing and tracking all pressed keys
  * 2. Providing methods to check if specific keys are pressed
+ *
+ * This is a singleton class since it is designed to manage global keyboard state, and has no need for multiple instances.
  */
 
 /**
@@ -12,23 +14,37 @@
 export type KeyboardKey = string;
 
 /**
- * Class responsible for tracking keyboard state
+ * Class responsible for tracking keyboard state across the application
  */
 export class KeyboardManager {
+  private static instance: KeyboardManager;
+
   private pressedKeys: Set<KeyboardKey> = new Set();
 
+  private keyboardListenersAdded = false;
+
   /**
-   * Create a new KeyboardManager instance
+   * Create a new KeyboardManager instance or return the existing one
    */
-  constructor() {
+  private constructor() {
     this.initialize();
+  }
+
+  /**
+   * Get the singleton instance of KeyboardManager
+   */
+  public static getInstance(): KeyboardManager {
+    if (!KeyboardManager.instance) {
+      KeyboardManager.instance = new KeyboardManager();
+    }
+    return KeyboardManager.instance;
   }
 
   /**
    * Initialize the keyboard event listeners
    */
   private initialize(): void {
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || this.keyboardListenersAdded) {
       return;
     }
 
@@ -37,6 +53,8 @@ export class KeyboardManager {
     window.addEventListener('keyup', this.handleKeyUp);
     // Reset keys when window loses focus
     window.addEventListener('blur', this.clearKeys);
+
+    this.keyboardListenersAdded = true;
   }
 
   /**
@@ -77,10 +95,11 @@ export class KeyboardManager {
    * Cleanup method to remove event listeners
    */
   public destroy(): void {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && this.keyboardListenersAdded) {
       window.removeEventListener('keydown', this.handleKeyDown);
       window.removeEventListener('keyup', this.handleKeyUp);
       window.removeEventListener('blur', this.clearKeys);
+      this.keyboardListenersAdded = false;
     }
     this.clearKeys();
   }

--- a/packages/x-internal-gestures/src/core/KeyboardManager.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.ts
@@ -1,11 +1,9 @@
 /**
- * KeyboardManager - Centralized manager for keyboard events in the gesture recognition system
+ * KeyboardManager - Manager for keyboard events in the gesture recognition system
  *
- * This singleton class tracks keyboard state across the application:
+ * This class tracks keyboard state:
  * 1. Capturing and tracking all pressed keys
  * 2. Providing methods to check if specific keys are pressed
- *
- * This is a singleton class since it is designed to manage global keyboard state, and has no need for multiple instances.
  */
 
 /**
@@ -14,37 +12,23 @@
 export type KeyboardKey = string;
 
 /**
- * Class responsible for tracking keyboard state across the application
+ * Class responsible for tracking keyboard state
  */
 export class KeyboardManager {
-  private static instance: KeyboardManager;
-
   private pressedKeys: Set<KeyboardKey> = new Set();
 
-  private keyboardListenersAdded = false;
-
   /**
-   * Create a new KeyboardManager instance or return the existing one
+   * Create a new KeyboardManager instance
    */
-  private constructor() {
+  constructor() {
     this.initialize();
-  }
-
-  /**
-   * Get the singleton instance of KeyboardManager
-   */
-  public static getInstance(): KeyboardManager {
-    if (!KeyboardManager.instance) {
-      KeyboardManager.instance = new KeyboardManager();
-    }
-    return KeyboardManager.instance;
   }
 
   /**
    * Initialize the keyboard event listeners
    */
   private initialize(): void {
-    if (typeof window === 'undefined' || this.keyboardListenersAdded) {
+    if (typeof window === 'undefined') {
       return;
     }
 
@@ -53,8 +37,6 @@ export class KeyboardManager {
     window.addEventListener('keyup', this.handleKeyUp);
     // Reset keys when window loses focus
     window.addEventListener('blur', this.clearKeys);
-
-    this.keyboardListenersAdded = true;
   }
 
   /**
@@ -95,11 +77,10 @@ export class KeyboardManager {
    * Cleanup method to remove event listeners
    */
   public destroy(): void {
-    if (typeof window !== 'undefined' && this.keyboardListenersAdded) {
+    if (typeof window !== 'undefined') {
       window.removeEventListener('keydown', this.handleKeyDown);
       window.removeEventListener('keyup', this.handleKeyUp);
       window.removeEventListener('blur', this.clearKeys);
-      this.keyboardListenersAdded = false;
     }
     this.clearKeys();
   }

--- a/packages/x-internal-gestures/src/core/KeyboardManager.ts
+++ b/packages/x-internal-gestures/src/core/KeyboardManager.ts
@@ -9,7 +9,38 @@
 /**
  * Type definition for keyboard keys
  */
-export type KeyboardKey = string;
+export type KeyboardKey = AllKeys | (string & {});
+
+type AllNumbers = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+type AllLetters =
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | 'j'
+  | 'k'
+  | 'l'
+  | 'm'
+  | 'n'
+  | 'o'
+  | 'p'
+  | 'q'
+  | 'r'
+  | 's'
+  | 't'
+  | 'u'
+  | 'v'
+  | 'w'
+  | 'x'
+  | 'y'
+  | 'z';
+type AllMeta = 'Shift' | 'Control' | 'Alt' | 'Meta' | 'ControlOrMeta';
+type AllKeys = AllMeta | AllLetters | AllNumbers;
 
 /**
  * Class responsible for tracking keyboard state
@@ -70,7 +101,12 @@ export class KeyboardManager {
       return true; // No keys required means the condition is satisfied
     }
 
-    return keys.every((key) => this.pressedKeys.has(key));
+    return keys.every((key) => {
+      if (key === 'ControlOrMeta') {
+        return this.pressedKeys.has('Control') || this.pressedKeys.has('Meta');
+      }
+      return this.pressedKeys.has(key);
+    });
   }
 
   /**

--- a/packages/x-internal-gestures/src/core/PointerGesture.ts
+++ b/packages/x-internal-gestures/src/core/PointerGesture.ts
@@ -1,5 +1,6 @@
 import { ActiveGesturesRegistry } from './ActiveGesturesRegistry';
 import { Gesture, GestureEventData, GestureOptions } from './Gesture';
+import type { KeyboardManager } from './KeyboardManager';
 import { PointerData, PointerManager } from './PointerManager';
 import { TargetElement } from './types/TargetElement';
 
@@ -102,8 +103,9 @@ export abstract class PointerGesture<GestureName extends string> extends Gesture
     element: TargetElement,
     pointerManager: PointerManager,
     gestureRegistry: ActiveGesturesRegistry<GestureName>,
+    keyboardManager: KeyboardManager,
   ): void {
-    super.init(element, pointerManager, gestureRegistry);
+    super.init(element, pointerManager, gestureRegistry, keyboardManager);
 
     this.unregisterHandler = this.pointerManager!.registerGestureHandler((pointers, event) =>
       this.handlePointerEvent(pointers, event),

--- a/packages/x-internal-gestures/src/core/gestures/MoveGesture.test.ts
+++ b/packages/x-internal-gestures/src/core/gestures/MoveGesture.test.ts
@@ -159,6 +159,7 @@ describe('Move Gesture', () => {
       target,
       Reflect.get(gestureManager, 'pointerManager'),
       Reflect.get(gestureManager, 'activeGesturesRegistry'),
+      Reflect.get(gestureManager, 'keyboardManager'),
     );
 
     // Create a pointer move event with touch type

--- a/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
@@ -110,7 +110,7 @@ export class MoveGesture<GestureName extends string> extends PointerGesture<Gest
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
@@ -14,6 +14,7 @@
 
 import { ActiveGesturesRegistry } from '../ActiveGesturesRegistry';
 import { GesturePhase, GestureState } from '../Gesture';
+import type { KeyboardManager } from '../KeyboardManager';
 import { PointerGesture, PointerGestureEventData, PointerGestureOptions } from '../PointerGesture';
 import { PointerData, PointerManager } from '../PointerManager';
 import { TargetElement } from '../types/TargetElement';
@@ -109,6 +110,7 @@ export class MoveGesture<GestureName extends string> extends PointerGesture<Gest
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,
@@ -119,8 +121,9 @@ export class MoveGesture<GestureName extends string> extends PointerGesture<Gest
     element: TargetElement,
     pointerManager: PointerManager,
     gestureRegistry: ActiveGesturesRegistry<GestureName>,
+    keyboardManager: KeyboardManager,
   ): void {
-    super.init(element, pointerManager, gestureRegistry);
+    super.init(element, pointerManager, gestureRegistry, keyboardManager);
 
     // Add event listeners for entering and leaving elements
     // These are different from pointer events handled by PointerManager

--- a/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
@@ -110,7 +110,7 @@ export class MoveGesture<GestureName extends string> extends PointerGesture<Gest
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
@@ -182,7 +182,7 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
       direction: [...this.direction],
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
@@ -182,6 +182,7 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
       direction: [...this.direction],
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
@@ -182,7 +182,7 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
       direction: [...this.direction],
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
@@ -145,6 +145,7 @@ export class PinchGesture<GestureName extends string> extends PointerGesture<Ges
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
@@ -145,7 +145,7 @@ export class PinchGesture<GestureName extends string> extends PointerGesture<Ges
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
@@ -145,7 +145,7 @@ export class PinchGesture<GestureName extends string> extends PointerGesture<Ges
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
@@ -126,7 +126,7 @@ export class PressGesture<GestureName extends string> extends PointerGesture<Ges
       maxPointers: this.maxPointers,
       duration: this.duration,
       maxDistance: this.maxDistance,
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
@@ -126,7 +126,7 @@ export class PressGesture<GestureName extends string> extends PointerGesture<Ges
       maxPointers: this.maxPointers,
       duration: this.duration,
       maxDistance: this.maxDistance,
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
@@ -126,6 +126,7 @@ export class PressGesture<GestureName extends string> extends PointerGesture<Ges
       maxPointers: this.maxPointers,
       duration: this.duration,
       maxDistance: this.maxDistance,
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
@@ -103,7 +103,7 @@ export class RotateGesture<GestureName extends string> extends PointerGesture<Ge
       stopPropagation: this.stopPropagation,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
@@ -103,7 +103,7 @@ export class RotateGesture<GestureName extends string> extends PointerGesture<Ge
       stopPropagation: this.stopPropagation,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
@@ -103,6 +103,7 @@ export class RotateGesture<GestureName extends string> extends PointerGesture<Ge
       stopPropagation: this.stopPropagation,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
@@ -114,7 +114,7 @@ export class TapGesture<GestureName extends string> extends PointerGesture<Gestu
       maxPointers: this.maxPointers,
       maxDistance: this.maxDistance,
       taps: this.taps,
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
@@ -114,6 +114,7 @@ export class TapGesture<GestureName extends string> extends PointerGesture<Gestu
       maxPointers: this.maxPointers,
       maxDistance: this.maxDistance,
       taps: this.taps,
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
@@ -114,7 +114,7 @@ export class TapGesture<GestureName extends string> extends PointerGesture<Gestu
       maxPointers: this.maxPointers,
       maxDistance: this.maxDistance,
       taps: this.taps,
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -186,7 +186,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
       min: this.min,
       initialDelta: this.initialDelta,
       invert: this.invert,
-      keys: this.keys,
+      requiredKeys: this.requiredKeys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -186,7 +186,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
       min: this.min,
       initialDelta: this.initialDelta,
       invert: this.invert,
-      requiredKeys: this.requiredKeys,
+      requiredKeys: [...this.requiredKeys],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -10,6 +10,7 @@
 
 import { ActiveGesturesRegistry } from '../ActiveGesturesRegistry';
 import { Gesture, GestureEventData, GestureOptions, GestureState } from '../Gesture';
+import type { KeyboardManager } from '../KeyboardManager';
 import { PointerData, PointerManager } from '../PointerManager';
 import { TargetElement } from '../types/TargetElement';
 import { calculateCentroid, createEventName } from '../utils';
@@ -185,6 +186,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
       min: this.min,
       initialDelta: this.initialDelta,
       invert: this.invert,
+      keys: this.keys,
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,
@@ -195,8 +197,9 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
     element: TargetElement,
     pointerManager: PointerManager,
     gestureRegistry: ActiveGesturesRegistry<GestureName>,
+    keyboardManager: KeyboardManager,
   ): void {
-    super.init(element, pointerManager, gestureRegistry);
+    super.init(element, pointerManager, gestureRegistry, keyboardManager);
 
     // Add event listener directly to the element
     // @ts-expect-error, WheelEvent is correct.

--- a/packages/x-internal-gestures/src/core/index.ts
+++ b/packages/x-internal-gestures/src/core/index.ts
@@ -7,6 +7,7 @@
 // Export core classes
 export { Gesture } from './Gesture';
 export { GestureManager } from './GestureManager';
+export { KeyboardManager, type KeyboardKey } from './KeyboardManager';
 export { PointerGesture } from './PointerGesture';
 export { PointerManager } from './PointerManager';
 

--- a/packages/x-internal-gestures/src/matchers/matchers/toUpdateOptions.ts
+++ b/packages/x-internal-gestures/src/matchers/matchers/toUpdateOptions.ts
@@ -1,4 +1,4 @@
-import { Gesture, PointerManager } from '../../core';
+import { Gesture, KeyboardManager, PointerManager } from '../../core';
 import { ActiveGesturesRegistry } from '../../core/ActiveGesturesRegistry';
 import { AnyGesture } from '../AnyGesture';
 import { MatcherState, SyncMatcherFn } from '../Matcher.types';
@@ -73,9 +73,10 @@ export const toUpdateOptions: SyncMatcherFn = function toUpdateOptions(
 
   const pointerManager = new PointerManager({});
   const gestureRegistry = new ActiveGesturesRegistry();
+  const keyboardManager = new KeyboardManager();
 
   // Setup the environment for testing
-  clone.init(target, pointerManager, gestureRegistry);
+  clone.init(target, pointerManager, gestureRegistry, keyboardManager);
 
   // Create and dispatch the change options event
   const changeOptionsEvent = new CustomEvent(`${clone.name}ChangeOptions`, {

--- a/packages/x-internal-gestures/src/matchers/matchers/toUpdateState.ts
+++ b/packages/x-internal-gestures/src/matchers/matchers/toUpdateState.ts
@@ -1,4 +1,4 @@
-import { Gesture, PointerManager } from '../../core';
+import { Gesture, KeyboardManager, PointerManager } from '../../core';
 import { ActiveGesturesRegistry } from '../../core/ActiveGesturesRegistry';
 import { AnyGesture } from '../AnyGesture';
 import { MatcherState, SyncMatcherFn } from '../Matcher.types';
@@ -75,9 +75,10 @@ export const toUpdateState: SyncMatcherFn = function toUpdateState(
 
   const pointerManager = new PointerManager({});
   const gestureRegistry = new ActiveGesturesRegistry();
+  const keyboardManager = new KeyboardManager();
 
   // Setup the environment for testing
-  clone.init(target, pointerManager, gestureRegistry);
+  clone.init(target, pointerManager, gestureRegistry, keyboardManager);
 
   // Create and dispatch the change state event
   const changeStateEvent = new CustomEvent(`${clone.name}ChangeState`, {

--- a/packages/x-internal-gestures/src/testing/MouseUserGesture.ts
+++ b/packages/x-internal-gestures/src/testing/MouseUserGesture.ts
@@ -1,5 +1,7 @@
 import { move } from './gestures/MoveUserGesture';
 import { MoveUserGestureOptions, MoveUserGestureRoot } from './gestures/MoveUserGesture.types';
+import { pan } from './gestures/PanUserGesture';
+import type { PanUserGestureOptions, PanUserGestureRoot } from './gestures/PanUserGesture.types';
 import { press } from './gestures/PressUserGesture';
 import { PressUserGestureOptions, PressUserGestureRoot } from './gestures/PressUserGesture.types';
 import { tap } from './gestures/TapUserGesture';
@@ -26,6 +28,7 @@ export type MouseUserGestureRoot = {
 } & TapUserGestureRoot<'mouse'> &
   PressUserGestureRoot<'mouse'> &
   MoveUserGestureRoot &
+  PanUserGestureRoot<'mouse'> &
   TurnWheelUserGestureRoot &
   MouseUserGestureRootExtension;
 
@@ -52,6 +55,10 @@ class MouseUserGesture extends UserGesture implements MouseUserGestureRoot {
 
   async turnWheel(options: TurnWheelUserGestureOptions): Promise<void> {
     return turnWheel(this.pointerManager, options, this.advanceTimers);
+  }
+
+  async pan(options: PanUserGestureOptions<'mouse'>): Promise<void> {
+    return pan(this.pointerManager, options, this.advanceTimers);
   }
 }
 

--- a/packages/x-internal-gestures/src/testing/TouchUserGesture.ts
+++ b/packages/x-internal-gestures/src/testing/TouchUserGesture.ts
@@ -28,7 +28,7 @@ export type TouchUserGestureRoot = {
 } & TapUserGestureRoot<'touch'> &
   PressUserGestureRoot<'touch'> &
   PinchUserGestureRoot &
-  PanUserGestureRoot &
+  PanUserGestureRoot<'touch'> &
   RotateUserGestureRoot &
   TouchUserGestureRootExtension;
 
@@ -49,7 +49,7 @@ class TouchUserGesture extends UserGesture implements TouchUserGestureRoot {
     return pinch(this.pointerManager, options, this.advanceTimers);
   }
 
-  async pan(options: PanUserGestureOptions): Promise<void> {
+  async pan(options: PanUserGestureOptions<'touch'>): Promise<void> {
     return pan(this.pointerManager, options, this.advanceTimers);
   }
 

--- a/packages/x-internal-gestures/src/testing/gestures/PanUserGesture.types.ts
+++ b/packages/x-internal-gestures/src/testing/gestures/PanUserGesture.types.ts
@@ -1,6 +1,6 @@
-import { Pointers } from '../types/Pointers';
+import { Pointers, type MousePointer, type PointerType } from '../types/Pointers';
 
-export type PanUserGestureOptions = {
+export type PanUserGestureOptions<P extends PointerType> = {
   /**
    * The target element to start the pan on.
    */
@@ -60,14 +60,31 @@ export type PanUserGestureOptions = {
    * @default true
    */
   releasePointers?: boolean | number[];
-};
+} & (P extends 'mouse'
+  ? {
+      /**
+       * The pointer configuration to be used.
+       */
+      pointer?: MousePointer;
+    }
+  : {
+      /**
+       * The pointers configuration to be used.
+       *
+       * It can be an object with the amount and distance properties, or an array of pointers.
+       *
+       * @default
+       * { amount: 1, distance: 50 }
+       */
+      pointers?: Pointers;
+    });
 
-export type PanUserGestureRoot = {
+export type PanUserGestureRoot<P extends PointerType> = {
   /**
    * Sets up the pan gesture with the given options.
    *
    * @param {PanUserGestureOptions} options - Configuration for the pan gesture
    * @returns {Promise<void>} A promise that resolves when the gesture is complete
    */
-  pan: (options: PanUserGestureOptions) => Promise<void>;
+  pan: (options: PanUserGestureOptions<P>) => Promise<void>;
 };


### PR DESCRIPTION
* Added `requiredKeys` to `GestureOptions`, allowing gestures to specify keyboard keys that must be pressed for the gesture to be recognised.