### PR TITLE
[charts] Add support for filtering gestures based on pointer types

### DIFF
--- a/packages/x-internal-gestures/src/core/Gesture.ts
+++ b/packages/x-internal-gestures/src/core/Gesture.ts
@@ -45,6 +45,11 @@ export type GestureEventData<CustomData extends Record<string, unknown> = Record
   };
 
 /**
+ * Defines the types of pointers that can trigger a gesture.
+ */
+export type PointerMode = 'mouse' | 'touch' | 'pen';
+
+/**
  * Configuration options for creating a gesture instance.
  */
 export type GestureOptions<GestureName extends string> = {
@@ -69,6 +74,14 @@ export type GestureOptions<GestureName extends string> = {
    * @default [] (no prevented gestures)
    */
   preventIf?: string[];
+  /**
+   * List of pointer types that can trigger this gesture.
+   * If provided, only the specified pointer types will be able to activate the gesture.
+   *
+   * @example ['mouse', 'touch']
+   * @default [] (all pointer types allowed)
+   */
+  pointerMode?: PointerMode[];
 };
 
 // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
@@ -128,6 +141,12 @@ export abstract class Gesture<GestureName extends string> {
   protected preventIf: string[];
 
   /**
+   * List of pointer types that can trigger this gesture.
+   * If undefined, all pointer types are allowed.
+   */
+  protected pointerMode: PointerMode[];
+
+  /**
    * User-mutable data object for sharing state between gesture events
    * This object is included in all events emitted by this gesture
    */
@@ -179,6 +198,7 @@ export abstract class Gesture<GestureName extends string> {
     this.preventDefault = options.preventDefault ?? false;
     this.stopPropagation = options.stopPropagation ?? false;
     this.preventIf = options.preventIf ?? [];
+    this.pointerMode = options.pointerMode ?? [];
   }
 
   /**
@@ -226,6 +246,7 @@ export abstract class Gesture<GestureName extends string> {
     this.preventDefault = options.preventDefault ?? this.preventDefault;
     this.stopPropagation = options.stopPropagation ?? this.stopPropagation;
     this.preventIf = options.preventIf ?? this.preventIf;
+    this.pointerMode = options.pointerMode ?? this.pointerMode;
   }
 
   /**
@@ -302,6 +323,22 @@ export abstract class Gesture<GestureName extends string> {
 
     // Check if any of the gestures that would prevent this one are active
     return this.preventIf.some((gestureName) => activeGestures[gestureName]);
+  }
+
+  /**
+   * Checks if the given pointer type is allowed for this gesture based on the pointerMode setting.
+   *
+   * @param pointerType - The type of pointer to check.
+   * @returns true if the pointer type is allowed, false otherwise.
+   */
+  protected isPointerTypeAllowed(pointerType: string): boolean {
+    // If no pointer mode is specified, all pointer types are allowed
+    if (!this.pointerMode || this.pointerMode.length === 0) {
+      return true;
+    }
+
+    // Check if the pointer type is in the allowed types list
+    return this.pointerMode.includes(pointerType as PointerMode);
   }
 
   /**

--- a/packages/x-internal-gestures/src/core/PointerGesture.ts
+++ b/packages/x-internal-gestures/src/core/PointerGesture.ts
@@ -145,10 +145,11 @@ export abstract class PointerGesture<GestureName extends string> extends Gesture
   ): PointerData[] {
     return pointers.filter(
       (pointer) =>
-        calculatedTarget === pointer.target ||
+        (calculatedTarget === pointer.target ||
         calculatedTarget.contains(pointer.target as Node) ||
         pointer.target === this.originalTarget ||
-        calculatedTarget === this.originalTarget,
+        calculatedTarget === this.originalTarget) &&
+        this.isPointerTypeAllowed(pointer.pointerType)
     );
   }
 

--- a/packages/x-internal-gestures/src/core/PointerMode.test.ts
+++ b/packages/x-internal-gestures/src/core/PointerMode.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mouseGesture, touchGesture } from '../testing';
+import { GestureManager } from './GestureManager';
+import { TapGesture } from './gestures/TapGesture';
+
+describe('Pointer Mode Filter', () => {
+  let container: HTMLElement;
+  let target: HTMLElement;
+  let events: string[];
+  let gestureManager: GestureManager<any, any>;
+
+  beforeEach(() => {
+    events = [];
+
+    // Set up DOM
+    container = document.createElement('div');
+    container.style.width = '200px';
+    container.style.height = '200px';
+    document.body.appendChild(container);
+
+    // Set up target element
+    target = document.createElement('div');
+    target.style.width = '100px';
+    target.style.height = '100px';
+    container.appendChild(target);
+  });
+
+  afterEach(() => {
+    // Clean up
+    gestureManager.destroy();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('should only trigger gestures for specified pointer types', async () => {
+    // Set up gesture manager with three tap gestures:
+    // 1. mouseTap: only triggered by mouse events
+    // 2. touchTap: only triggered by touch events
+    // 3. anyTap: triggered by any pointer type
+    gestureManager = new GestureManager({
+      gestures: [
+        new TapGesture({
+          name: 'mouseTap',
+          pointerMode: ['mouse'],
+        }),
+        new TapGesture({
+          name: 'touchTap',
+          pointerMode: ['touch'],
+        }),
+        new TapGesture({
+          name: 'anyTap',
+          // No pointerMode specified, accepts all pointer types
+        }),
+      ],
+    });
+
+    // Register gestures on the element
+    const gestureTarget = gestureManager.registerElement(
+      ['mouseTap', 'touchTap', 'anyTap'],
+      target,
+    );
+
+    // Add event listeners for all gesture types
+    gestureTarget.addEventListener('mouseTap', () => events.push('mouseTap'));
+    gestureTarget.addEventListener('touchTap', () => events.push('touchTap'));
+    gestureTarget.addEventListener('anyTap', () => events.push('anyTap'));
+
+    // Test 1: Mouse gesture (move) should trigger mouseTap and anyTap gestures but not touchTap
+    await mouseGesture.tap({ target });
+
+    expect(events).toContain('mouseTap');
+    expect(events).not.toContain('touchTap');
+    expect(events).toContain('anyTap');
+
+    // Reset events arrays
+    events = [];
+
+    // Test 2: Touch gesture (tap) should trigger touchTap and anyTap gestures but not mouseTap
+    await touchGesture.tap({ target });
+
+    expect(events).not.toContain('mouseTap');
+    expect(events).toContain('touchTap');
+    expect(events).toContain('anyTap');
+  });
+
+  it('should update pointerMode at runtime via setGestureOptions', async () => {
+    // Set up gesture manager with a single tap gesture that initially accepts all pointer types
+    gestureManager = new GestureManager({
+      gestures: [
+        new TapGesture({
+          name: 'dynamicTap',
+          // No pointerMode initially, accepts all pointer types
+        }),
+      ],
+    });
+
+    // Register the gesture on the element
+    const gestureTarget = gestureManager.registerElement('dynamicTap', target);
+
+    // Add event listeners
+    gestureTarget.addEventListener('dynamicTap', () => events.push('dynamicTap'));
+
+    // Test 1: Initially, both touch and mouse gestures should trigger events
+    await touchGesture.tap({ target });
+
+    expect(events).toContain('dynamicTap');
+
+    // Reset events
+    events = [];
+
+    await mouseGesture.tap({ target });
+
+    expect(events).toContain('dynamicTap');
+
+    // Reset events
+    events = [];
+
+    // Test 2: Update to only allow touch gestures
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      pointerMode: ['touch'],
+    });
+
+    // Touch gesture should still work
+    await touchGesture.tap({ target });
+
+    expect(events).toContain('dynamicTap');
+
+    // Reset events
+    events = [];
+
+    // Mouse gesture should no longer work
+    await mouseGesture.tap({ target });
+
+    expect(events).toStrictEqual([]); // No events should be triggered for mouse
+
+    // Test 3: Update to only allow mouse gestures
+    gestureManager.setGestureOptions('dynamicTap', target, {
+      pointerMode: ['mouse'],
+    });
+
+    // Reset events
+    events = [];
+
+    // Touch gesture should no longer work
+    await touchGesture.tap({ target });
+
+    expect(events).toStrictEqual([]); // No events should be triggered for touch
+
+    // Mouse gesture should work again
+    await mouseGesture.tap({ target });
+
+    expect(events).toContain('dynamicTap');
+  });
+
+  it('should support multiple pointer types in pointerMode array', async () => {
+    // Set up gesture manager with a tap gesture that accepts both mouse and touch
+    gestureManager = new GestureManager({
+      gestures: [
+        new TapGesture({
+          name: 'multiTap',
+          pointerMode: ['mouse', 'touch'], // Accept both mouse and touch
+        }),
+      ],
+    });
+
+    // Register the gesture on the element
+    const gestureTarget = gestureManager.registerElement('multiTap', target);
+
+    // Add event listeners
+    gestureTarget.addEventListener('multiTap', () => events.push('multiTap'));
+
+    // Test 1: Mouse gesture should work
+    await mouseGesture.tap({ target });
+
+    expect(events).toContain('multiTap');
+
+    // Reset events
+    events = [];
+
+    // Test 2: Touch gesture should also work
+    await touchGesture.tap({ target });
+
+    expect(events).toContain('multiTap');
+  });
+});

--- a/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/MoveGesture.ts
@@ -109,6 +109,7 @@ export class MoveGesture<GestureName extends string> extends PointerGesture<Gest
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PanGesture.ts
@@ -182,6 +182,7 @@ export class PanGesture<GestureName extends string> extends PointerGesture<Gestu
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
       direction: [...this.direction],
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PinchGesture.ts
@@ -145,6 +145,7 @@ export class PinchGesture<GestureName extends string> extends PointerGesture<Ges
       threshold: this.threshold,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/PressGesture.ts
@@ -126,6 +126,7 @@ export class PressGesture<GestureName extends string> extends PointerGesture<Ges
       maxPointers: this.maxPointers,
       duration: this.duration,
       maxDistance: this.maxDistance,
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/RotateGesture.ts
@@ -103,6 +103,7 @@ export class RotateGesture<GestureName extends string> extends PointerGesture<Ge
       stopPropagation: this.stopPropagation,
       minPointers: this.minPointers,
       maxPointers: this.maxPointers,
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TapGesture.ts
@@ -114,6 +114,7 @@ export class TapGesture<GestureName extends string> extends PointerGesture<Gestu
       maxPointers: this.maxPointers,
       maxDistance: this.maxDistance,
       taps: this.taps,
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,

--- a/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
+++ b/packages/x-internal-gestures/src/core/gestures/TurnWheelGesture.ts
@@ -185,6 +185,7 @@ export class TurnWheelGesture<GestureName extends string> extends Gesture<Gestur
       min: this.min,
       initialDelta: this.initialDelta,
       invert: this.invert,
+      pointerMode: [...this.pointerMode],
       preventIf: [...this.preventIf],
       // Apply any overrides passed to the method
       ...overrides,


### PR DESCRIPTION
- Introduced the `pointerMode` option in `GestureOptions` and updated the `Gesture` class to support filtering gestures based on pointer types.