### PR TITLE
[charts] Increase data points in chart benchmarks

### DIFF
--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -23,7 +23,7 @@ describe('BarChart', () => {
         <BarChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,
       );
 
-      await findByText('926', { ignore: 'span' });
+      await findByText(dataLength.toLocaleString(), { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('BarChart', () => {
-  const dataLength = 1000;
+  const dataLength = 800;
   const data = Array.from({ length: dataLength + 1 }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -17,7 +17,7 @@ describe('BarChart', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    `BarChart rendering ${dataLength} data points`,
+    'BarChart with big data amount',
     async () => {
       const { findByText } = render(
         <BarChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -23,7 +23,7 @@ describe('BarChart', () => {
         <BarChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,
       );
 
-      await findByText(dataLength.toLocaleString(), { ignore: 'span' });
+      await findByText('926', { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('BarChart', () => {
-  const dataLength = 150;
+  const dataLength = 1000;
   const data = Array.from({ length: dataLength + 1 }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -17,7 +17,7 @@ describe('BarChart', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    'BarChart with big data amount',
+    `BarChart rendering ${dataLength} data points`,
     async () => {
       const { findByText } = render(
         <BarChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,

--- a/test/performance-charts/tests/BarChart.bench.tsx
+++ b/test/performance-charts/tests/BarChart.bench.tsx
@@ -23,7 +23,7 @@ describe('BarChart', () => {
         <BarChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,
       );
 
-      await findByText(dataLength.toLocaleString(), { ignore: 'span' });
+      await findByText(dataLength.toString(), { ignore: 'span' });
 
       cleanup();
     },

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('BarChartPro', () => {
-  const dataLength = 1000;
+  const dataLength = 800;
   const data = Array.from({ length: dataLength + 1 }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -17,7 +17,7 @@ describe('BarChartPro', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    `BarChartPro rendering ${dataLength} data points`,
+    'BarChartPro with big data amount',
     async () => {
       const { findByText } = render(
         <BarChartPro

--- a/test/performance-charts/tests/BarChartPro.bench.tsx
+++ b/test/performance-charts/tests/BarChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('BarChartPro', () => {
-  const dataLength = 400;
+  const dataLength = 1000;
   const data = Array.from({ length: dataLength + 1 }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -17,7 +17,7 @@ describe('BarChartPro', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    'BarChartPro with big data amount',
+    `BarChartPro rendering ${dataLength} data points`,
     async () => {
       const { findByText } = render(
         <BarChartPro

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChart', () => {
-  const dataLength = 2_000;
+  const dataLength = 1_400;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -17,10 +17,15 @@ describe('LineChart', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    `LineChart with marks rendering ${dataLength} data points`,
+    'LineChart with big data amount (with marks)',
     async () => {
       const { findByText } = render(
-        <LineChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,
+        <LineChart
+          xAxis={[{ data: xData }]}
+          series={[{ data: yData, showMark: true }]}
+          width={500}
+          height={300}
+        />,
       );
 
       await findByText(dataLength.toLocaleString(), { ignore: 'span' });
@@ -31,12 +36,12 @@ describe('LineChart', () => {
   );
 
   bench(
-    `Area chart rendering ${dataLength} data points (no marks)`,
+    'Area chart with big data amount (no marks)',
     async () => {
       const { findByText } = render(
         <LineChart
           xAxis={[{ data: xData }]}
-          series={[{ area: true, data: yData }]}
+          series={[{ area: true, data: yData, showMark: false }]}
           width={500}
           height={300}
         />,

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChart', () => {
-  const dataLength = 200;
+  const dataLength = 10_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChart', () => {
-  const dataLength = 5_000;
+  const dataLength = 2_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChart', () => {
-  const dataLength = 10_000;
+  const dataLength = 5_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/LineChart.bench.tsx
+++ b/test/performance-charts/tests/LineChart.bench.tsx
@@ -17,16 +17,26 @@ describe('LineChart', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    'LineChart with big data amount',
+    `LineChart with marks rendering ${dataLength} data points`,
+    async () => {
+      const { findByText } = render(
+        <LineChart xAxis={[{ data: xData }]} series={[{ data: yData }]} width={500} height={300} />,
+      );
+
+      await findByText(dataLength.toLocaleString(), { ignore: 'span' });
+
+      cleanup();
+    },
+    options,
+  );
+
+  bench(
+    `Area chart rendering ${dataLength} data points (no marks)`,
     async () => {
       const { findByText } = render(
         <LineChart
           xAxis={[{ data: xData }]}
-          series={[
-            {
-              data: yData,
-            },
-          ]}
+          series={[{ area: true, data: yData }]}
           width={500}
           height={300}
         />,

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -17,17 +17,13 @@ describe('LineChartPro', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    'LineChartPro with big data amount',
+    `LineChartPro with marks rendering ${dataLength} data points`,
     async () => {
       const { findByText } = render(
         <LineChartPro
           xAxis={[{ id: 'x', data: xData, zoom: { filterMode: 'discard' } }]}
           initialZoom={[{ axisId: 'x', start: 50, end: 75 }]}
-          series={[
-            {
-              data: yData,
-            },
-          ]}
+          series={[{ data: yData }]}
           width={500}
           height={300}
         />,

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChartPro', () => {
-  const dataLength = 10_000;
+  const dataLength = 5_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChartPro', () => {
-  const dataLength = 2_000;
+  const dataLength = 1_400;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -17,13 +17,13 @@ describe('LineChartPro', () => {
   const yData = data.map((d) => d.y);
 
   bench(
-    `LineChartPro with marks rendering ${dataLength} data points`,
+    'LineChartPro with big data amount and zoomed in (with marks)',
     async () => {
       const { findByText } = render(
         <LineChartPro
           xAxis={[{ id: 'x', data: xData, zoom: { filterMode: 'discard' } }]}
           initialZoom={[{ axisId: 'x', start: 50, end: 75 }]}
-          series={[{ data: yData }]}
+          series={[{ data: yData, showMark: true }]}
           width={500}
           height={300}
         />,

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChartPro', () => {
-  const dataLength = 200;
+  const dataLength = 10_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/LineChartPro.bench.tsx
+++ b/test/performance-charts/tests/LineChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('LineChartPro', () => {
-  const dataLength = 5_000;
+  const dataLength = 2_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChart', () => {
-  const dataLength = 10_000;
+  const dataLength = 5_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -21,11 +21,7 @@ describe('ScatterChart', () => {
       const { findByText } = render(
         <ScatterChart
           xAxis={[{ data: xData, valueFormatter: (v: number) => v.toLocaleString('en-US') }]}
-          series={[
-            {
-              data,
-            },
-          ]}
+          series={[{ data }]}
           width={500}
           height={300}
         />,

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChart', () => {
-  const dataLength = 5_000;
+  const dataLength = 2_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChart', () => {
-  const dataLength = 2_000;
+  const dataLength = 1_400;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -16,7 +16,7 @@ describe('ScatterChart', () => {
   const xData = data.map((d) => d.x);
 
   bench(
-    `ScatterChart rendering ${dataLength} data points`,
+    'ScatterChart with big data amount',
     async () => {
       const { findByText } = render(
         <ScatterChart

--- a/test/performance-charts/tests/ScatterChart.bench.tsx
+++ b/test/performance-charts/tests/ScatterChart.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChart', () => {
-  const dataLength = 800;
+  const dataLength = 10_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -16,7 +16,7 @@ describe('ScatterChart', () => {
   const xData = data.map((d) => d.x);
 
   bench(
-    'ScatterChart with big data amount',
+    `ScatterChart rendering ${dataLength} data points`,
     async () => {
       const { findByText } = render(
         <ScatterChart

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChartPro', () => {
-  const dataLength = 50;
+  const dataLength = 10_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -16,7 +16,7 @@ describe('ScatterChartPro', () => {
   const xData = data.map((d) => d.x);
 
   bench(
-    'ScatterChartPro with big data amount',
+    `ScatterChartPro rendering ${dataLength} data points`,
     async () => {
       const { findByText } = render(
         <ScatterChartPro
@@ -29,11 +29,7 @@ describe('ScatterChartPro', () => {
             },
           ]}
           initialZoom={[{ axisId: 'x', start: 20, end: 70 }]}
-          series={[
-            {
-              data,
-            },
-          ]}
+          series={[{ data }]}
           width={500}
           height={300}
         />,
@@ -47,7 +43,7 @@ describe('ScatterChartPro', () => {
   );
 
   bench(
-    'ScatterChartPro with big data amount and zoomed in',
+    `Zoomed in ScatterChartPro rendering ${dataLength} data points`,
     async () => {
       const { findByText } = render(
         <ScatterChartPro

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChartPro', () => {
-  const dataLength = 2_000;
+  const dataLength = 1_400;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,
@@ -16,7 +16,7 @@ describe('ScatterChartPro', () => {
   const xData = data.map((d) => d.x);
 
   bench(
-    `ScatterChartPro rendering ${dataLength} data points`,
+    'ScatterChartPro with big data amount',
     async () => {
       const { findByText } = render(
         <ScatterChartPro
@@ -43,7 +43,7 @@ describe('ScatterChartPro', () => {
   );
 
   bench(
-    `Zoomed in ScatterChartPro rendering ${dataLength} data points`,
+    'ScatterChartPro with big data amount and zoomed in',
     async () => {
       const { findByText } = render(
         <ScatterChartPro

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChartPro', () => {
-  const dataLength = 10_000;
+  const dataLength = 5_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,

--- a/test/performance-charts/tests/ScatterChartPro.bench.tsx
+++ b/test/performance-charts/tests/ScatterChartPro.bench.tsx
@@ -7,7 +7,7 @@ import { options } from '../utils/options';
 import { bench } from '../utils/bench';
 
 describe('ScatterChartPro', () => {
-  const dataLength = 5_000;
+  const dataLength = 2_000;
   const data = Array.from({ length: dataLength }).map((_, i) => ({
     x: i,
     y: 50 + Math.sin(i / 5) * 25,


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/issues/12960.

Increase data points in bar, line and scatter chart benchmarks, so we can better see how performance scales with greater number of data points. 

Also added area chart benchmark to ensure we benchmark that use case as well. 