### PR TITLE
[DataGridPro] Set correct parent paths when tree is refreshed with data source tree data and row grouping

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
-import {
-  GridRowId,
-  gridRowTreeSelector,
-  gridColumnLookupSelector,
-  GridDataSourceGroupNode,
-} from '@mui/x-data-grid-pro';
+import { GridRowId, gridRowTreeSelector, gridColumnLookupSelector } from '@mui/x-data-grid-pro';
 import {
   GridStrategyProcessor,
   useGridRegisterStrategyProcessor,
@@ -15,7 +10,7 @@ import {
   skipSorting,
   skipFiltering,
   GridRowsPartialUpdates,
-  GridRowTreeCreationParams,
+  getParentPath,
 } from '@mui/x-data-grid-pro/internals';
 import { DataGridPremiumProcessedProps } from '../../../models/dataGridPremiumProps';
 import { getGroupingRules, RowGroupingStrategy } from './gridRowGroupingUtils';
@@ -125,16 +120,3 @@ export const useGridDataSourceRowGroupingPreProcessors = (
     getVisibleRowsLookup,
   );
 };
-
-function getParentPath(rowId: GridRowId, treeCreationParams: GridRowTreeCreationParams): string[] {
-  if (
-    treeCreationParams.updates.type !== 'full' ||
-    !treeCreationParams.previousTree?.[rowId] ||
-    treeCreationParams.previousTree[rowId].depth < 1 ||
-    !('path' in treeCreationParams.previousTree[rowId])
-  ) {
-    return [];
-  }
-
-  return (treeCreationParams.previousTree[rowId] as GridDataSourceGroupNode).path || [];
-}

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/useGridDataSourceTreeDataPreProcessors.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/useGridDataSourceTreeDataPreProcessors.tsx
@@ -22,7 +22,7 @@ import {
   GRID_TREE_DATA_GROUPING_COL_DEF_FORCED_PROPERTIES,
 } from '../treeData/gridTreeDataGroupColDef';
 import { DataGridProProcessedProps } from '../../../models/dataGridProProps';
-import { skipFiltering, skipSorting } from './utils';
+import { getParentPath, skipFiltering, skipSorting } from './utils';
 import { GridPrivateApiPro } from '../../../models/gridApiPro';
 import {
   GridGroupingColDefOverride,
@@ -138,9 +138,9 @@ export const useGridDataSourceTreeDataPreProcessors = (
         throw new Error('MUI X: No `getChildrenCount` method provided with the dataSource.');
       }
 
-      const parentPath = (params.updates as GridRowsPartialUpdates).groupKeys ?? [];
-
       const getRowTreeBuilderNode = (rowId: GridRowId) => {
+        const parentPath =
+          (params.updates as GridRowsPartialUpdates).groupKeys ?? getParentPath(rowId, params);
         const count = getChildrenCount(params.dataRowIdToModelLookup[rowId]);
         return {
           id: rowId,

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
@@ -31,9 +31,9 @@ export function skipSorting(rowTree: GridRowTreeConfig) {
 }
 
 /**
-* Retrieves the parent path for a row from the previous tree state.
-* Used during full tree updates to maintain correct hierarchy.
-*/
+ * Retrieves the parent path for a row from the previous tree state.
+ * Used during full tree updates to maintain correct hierarchy.
+ */
 export function getParentPath(
   rowId: GridRowId,
   treeCreationParams: GridRowTreeCreationParams,

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
@@ -30,6 +30,10 @@ export function skipSorting(rowTree: GridRowTreeConfig) {
   return getTreeNodeDescendants(rowTree, GRID_ROOT_GROUP_ID, false);
 }
 
+/**
+* Retrieves the parent path for a row from the previous tree state.
+* Used during full tree updates to maintain correct hierarchy.
+*/
 export function getParentPath(
   rowId: GridRowId,
   treeCreationParams: GridRowTreeCreationParams,

--- a/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
+++ b/packages/x-data-grid-pro/src/hooks/features/serverSideTreeData/utils.ts
@@ -1,5 +1,14 @@
-import { GridRowId, GridRowTreeConfig, GRID_ROOT_GROUP_ID } from '@mui/x-data-grid';
-import { defaultGridFilterLookup, getTreeNodeDescendants } from '@mui/x-data-grid/internals';
+import {
+  GridRowId,
+  GridRowTreeConfig,
+  GRID_ROOT_GROUP_ID,
+  GridDataSourceGroupNode,
+} from '@mui/x-data-grid';
+import {
+  defaultGridFilterLookup,
+  getTreeNodeDescendants,
+  GridRowTreeCreationParams,
+} from '@mui/x-data-grid/internals';
 
 export function skipFiltering(rowTree: GridRowTreeConfig) {
   const filteredChildrenCountLookup: Record<GridRowId, number> = {};
@@ -19,4 +28,20 @@ export function skipFiltering(rowTree: GridRowTreeConfig) {
 
 export function skipSorting(rowTree: GridRowTreeConfig) {
   return getTreeNodeDescendants(rowTree, GRID_ROOT_GROUP_ID, false);
+}
+
+export function getParentPath(
+  rowId: GridRowId,
+  treeCreationParams: GridRowTreeCreationParams,
+): string[] {
+  if (
+    treeCreationParams.updates.type !== 'full' ||
+    !treeCreationParams.previousTree?.[rowId] ||
+    treeCreationParams.previousTree[rowId].depth < 1 ||
+    !('path' in treeCreationParams.previousTree[rowId])
+  ) {
+    return [];
+  }
+
+  return (treeCreationParams.previousTree[rowId] as GridDataSourceGroupNode).path || [];
 }

--- a/packages/x-data-grid-pro/src/internals/index.ts
+++ b/packages/x-data-grid-pro/src/internals/index.ts
@@ -66,6 +66,10 @@ export { sortRowTree } from '../utils/tree/sortRowTree';
 export { insertNodeInTree, removeNodeFromTree, getVisibleRowsLookup } from '../utils/tree/utils';
 export type { RowTreeBuilderGroupingCriterion } from '../utils/tree/models';
 
-export { skipSorting, skipFiltering } from '../hooks/features/serverSideTreeData/utils';
+export {
+  skipSorting,
+  skipFiltering,
+  getParentPath,
+} from '../hooks/features/serverSideTreeData/utils';
 
 export * from './propValidation';


### PR DESCRIPTION
After fix: https://deploy-preview-18715--material-ui-x.netlify.app/x/react-data-grid/server-side-data/row-grouping/

Fixes the root cause of https://github.com/mui/mui-x/issues/18645

Closes https://github.com/mui/mui-x/pull/18647 as it only handles the symptom.

Root cause of the error is a (by the grid's tree builder) perceived duplicate group/tree key on a full tree refresh.
It is only visible if the whole tree is regenerated and some of the subgroups have the same value under different parents.
This is the case in our [demo](https://mui.com/x/react-data-grid/server-side-data/row-grouping/), where the status is being repeated for each parent. Also, this is why the error will not happen if less than 2 subgroups are expanded, because there are no duplicates in that scenario.

Note:
I will link data source row grouping lines of code, but the same applies to the data source tree data.

On initial load, the data is processed by the row tree creation pre processor and a [full tree](https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts#L64) is being created

If a group is expanded, we use the group key as a param and return the children of that group
Children are added through the tree update and new nodes are [inserted to the tree](https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts#L73)

If the data is regenerated, pre processor again wants to generate the [full tree](https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts#L64), but the [`getRowTreeBuilderNode`](https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts#L66) does not have [`groupKeys`](https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid-premium/src/hooks/features/rowGrouping/useGridDataSourceRowGroupingPreProcessors.ts#L51) this time, because we are not making a request for a specific parent.

This results in status field getting the same path, since `parentPath = []` and down the line https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid-pro/src/utils/tree/insertDataRowInTree.ts#L72 will remove the "duplicates" from the tree.
This will create a state in which these two selectors
https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid/src/hooks/features/rows/gridRowsSelector.ts#L27
https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid/src/hooks/features/rows/gridRowsSelector.ts#L37
have different amount of records which eventually leads to
https://github.com/mui/mui-x/blob/v8.7.0/packages/x-data-grid/src/hooks/features/filter/gridFilterSelector.ts#L136
not being found.

This update uses previous tree to rebuild correct parent paths which keeps the tree and lookup state in sync and prevents the initially reported error