### PR TITLE
[docs] Improve bar chart demos on mobile

### DIFF
--- a/docs/data/charts/bars/BarAnimation.js
+++ b/docs/data/charts/bars/BarAnimation.js
@@ -32,6 +32,7 @@ export default function BarAnimation() {
           .slice(0, seriesNb)
           .map((s) => ({ ...s, data: s.data.slice(0, itemNb) }))}
         skipAnimation={skipAnimation}
+        margin={{ left: 0 }}
       />
       <FormControlLabel
         checked={skipAnimation}

--- a/docs/data/charts/bars/BarAnimation.tsx
+++ b/docs/data/charts/bars/BarAnimation.tsx
@@ -33,6 +33,7 @@ export default function BarAnimation() {
           .slice(0, seriesNb)
           .map((s) => ({ ...s, data: s.data.slice(0, itemNb) }))}
         skipAnimation={skipAnimation}
+        margin={{ left: 0 }}
       />
       <FormControlLabel
         checked={skipAnimation}

--- a/docs/data/charts/bars/BarClick.js
+++ b/docs/data/charts/bars/BarClick.js
@@ -40,6 +40,7 @@ const barChartsParams = {
   ],
   xAxis: [{ data: ['0', '3', '6', '9', '12'], id: 'axis1' }],
   height: 400,
+  margin: { left: 0 },
 };
 
 export default function BarClick() {

--- a/docs/data/charts/bars/BarClick.tsx
+++ b/docs/data/charts/bars/BarClick.tsx
@@ -41,6 +41,7 @@ const barChartsParams = {
   ],
   xAxis: [{ data: ['0', '3', '6', '9', '12'], id: 'axis1' }],
   height: 400,
+  margin: { left: 0 },
 } as const;
 
 export default function BarClick() {

--- a/docs/data/charts/bars/BarGap.js
+++ b/docs/data/charts/bars/BarGap.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import Typography from '@mui/material/Typography';
 import ChartsUsageDemo from 'docsx/src/modules/components/ChartsUsageDemo';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { balanceSheet, addLabels } from './netflixsBalanceSheet';
-import Typography from '@mui/material/Typography';
 
 const series = addLabels([
   { dataKey: 'totAss' },

--- a/docs/data/charts/bars/BarGap.js
+++ b/docs/data/charts/bars/BarGap.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ChartsUsageDemo from 'docsx/src/modules/components/ChartsUsageDemo';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { balanceSheet, addLabels } from './netflixsBalanceSheet';
+import Typography from '@mui/material/Typography';
 
 const series = addLabels([
   { dataKey: 'totAss' },
@@ -30,20 +31,23 @@ export default function BarGap() {
         },
       }}
       renderDemo={(props) => (
-        <BarChart
-          dataset={balanceSheet}
-          series={series}
-          height={300}
-          xAxis={[
-            {
-              dataKey: 'year',
-              categoryGapRatio: props.categoryGapRatio,
-              barGapRatio: props.barGapRatio,
-            },
-          ]}
-          yAxis={[{ valueFormatter: (v) => `$ ${v / 1000000}B` }]}
-          hideLegend
-        />
+        <div style={{ width: '100%' }}>
+          <Typography>Netflix balance sheet</Typography>
+          <BarChart
+            dataset={balanceSheet}
+            series={series}
+            height={300}
+            xAxis={[
+              {
+                dataKey: 'year',
+                categoryGapRatio: props.categoryGapRatio,
+                barGapRatio: props.barGapRatio,
+              },
+            ]}
+            yAxis={[{ valueFormatter: (v) => `$ ${v / 1000000}B` }]}
+            hideLegend
+          />
+        </div>
       )}
       getCode={({ props }) => {
         return `import { BarChart } from '@mui/x-charts/BarChart';

--- a/docs/data/charts/bars/BarGap.tsx
+++ b/docs/data/charts/bars/BarGap.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ChartsUsageDemo from 'docsx/src/modules/components/ChartsUsageDemo';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { balanceSheet, addLabels } from './netflixsBalanceSheet';
+import Typography from '@mui/material/Typography';
 
 const series = addLabels([
   { dataKey: 'totAss' },
@@ -30,20 +31,23 @@ export default function BarGap() {
         },
       }}
       renderDemo={(props) => (
-        <BarChart
-          dataset={balanceSheet}
-          series={series}
-          height={300}
-          xAxis={[
-            {
-              dataKey: 'year',
-              categoryGapRatio: props.categoryGapRatio,
-              barGapRatio: props.barGapRatio,
-            },
-          ]}
-          yAxis={[{ valueFormatter: (v: number) => `$ ${v / 1000000}B` }]}
-          hideLegend
-        />
+        <div style={{ width: '100%' }}>
+          <Typography>Netflix balance sheet</Typography>
+          <BarChart
+            dataset={balanceSheet}
+            series={series}
+            height={300}
+            xAxis={[
+              {
+                dataKey: 'year',
+                categoryGapRatio: props.categoryGapRatio,
+                barGapRatio: props.barGapRatio,
+              },
+            ]}
+            yAxis={[{ valueFormatter: (v: number) => `$ ${v / 1000000}B` }]}
+            hideLegend
+          />
+        </div>
       )}
       getCode={({ props }) => {
         return `import { BarChart } from '@mui/x-charts/BarChart';

--- a/docs/data/charts/bars/BarGap.tsx
+++ b/docs/data/charts/bars/BarGap.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import Typography from '@mui/material/Typography';
 import ChartsUsageDemo from 'docsx/src/modules/components/ChartsUsageDemo';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { balanceSheet, addLabels } from './netflixsBalanceSheet';
-import Typography from '@mui/material/Typography';
 
 const series = addLabels([
   { dataKey: 'totAss' },

--- a/docs/data/charts/bars/BarGradient.js
+++ b/docs/data/charts/bars/BarGradient.js
@@ -15,6 +15,7 @@ const settings = {
   ],
   height: 300,
   barLabel: 'value',
+  margin: { left: 0 },
 };
 
 export default function BarGradient() {

--- a/docs/data/charts/bars/BarGradient.tsx
+++ b/docs/data/charts/bars/BarGradient.tsx
@@ -15,6 +15,7 @@ const settings = {
   ],
   height: 300,
   barLabel: 'value',
+  margin: { left: 0 },
 } as const;
 
 export default function BarGradient() {

--- a/docs/data/charts/bars/BarLabel.js
+++ b/docs/data/charts/bars/BarLabel.js
@@ -8,6 +8,8 @@ export default function BarLabel() {
       series={[{ data: [4, 3, 5] }, { data: [1, 6, 3] }, { data: [2, 5, 6] }]}
       height={300}
       barLabel="value"
+      margin={{ left: 0 }}
+      yAxis={[{ width: 30 }]}
     />
   );
 }

--- a/docs/data/charts/bars/BarLabel.tsx
+++ b/docs/data/charts/bars/BarLabel.tsx
@@ -8,6 +8,8 @@ export default function BarLabel() {
       series={[{ data: [4, 3, 5] }, { data: [1, 6, 3] }, { data: [2, 5, 6] }]}
       height={300}
       barLabel="value"
+      margin={{ left: 0 }}
+      yAxis={[{ width: 30 }]}
     />
   );
 }

--- a/docs/data/charts/bars/BarLabel.tsx.preview
+++ b/docs/data/charts/bars/BarLabel.tsx.preview
@@ -3,4 +3,6 @@
   series={[{ data: [4, 3, 5] }, { data: [1, 6, 3] }, { data: [2, 5, 6] }]}
   height={300}
   barLabel="value"
+  margin={{ left: 0 }}
+  yAxis={[{ width: 30 }]}
 />

--- a/docs/data/charts/bars/BorderRadius.js
+++ b/docs/data/charts/bars/BorderRadius.js
@@ -41,6 +41,7 @@ export default function BorderRadius() {
           { dataKey: 'high', label: 'High', layout, stack: 'stack' },
           { dataKey: 'low', label: 'Low', layout, stack: 'stack' },
         ]}
+        margin={{ left: 0 }}
         {...(layout === 'vertical' ? chartSettingsV : chartSettingsH)}
         borderRadius={radius}
       />

--- a/docs/data/charts/bars/BorderRadius.tsx
+++ b/docs/data/charts/bars/BorderRadius.tsx
@@ -43,6 +43,7 @@ export default function BorderRadius() {
           { dataKey: 'high', label: 'High', layout, stack: 'stack' },
           { dataKey: 'low', label: 'Low', layout, stack: 'stack' },
         ]}
+        margin={{ left: 0 }}
         {...(layout === 'vertical' ? chartSettingsV : chartSettingsH)}
         borderRadius={radius}
       />

--- a/docs/data/charts/bars/ColorScale.js
+++ b/docs/data/charts/bars/ColorScale.js
@@ -97,10 +97,11 @@ export default function ColorScale() {
               undefined,
           },
         ]}
+        margin={{ left: 0 }}
       />
       <HighlightedCode
         code={[
-          `<ScatterChart`,
+          `<BarChart`,
           '  /* ... */',
           // ColorX
           ...(colorX === 'None' ? ['  xAxis={[{}]}'] : []),

--- a/docs/data/charts/bars/ColorScale.tsx
+++ b/docs/data/charts/bars/ColorScale.tsx
@@ -107,10 +107,11 @@ export default function ColorScale() {
               undefined,
           },
         ]}
+        margin={{ left: 0 }}
       />
       <HighlightedCode
         code={[
-          `<ScatterChart`,
+          `<BarChart`,
           '  /* ... */',
           // ColorX
           ...(colorX === 'None' ? ['  xAxis={[{}]}'] : []),

--- a/docs/data/charts/bars/CustomLabels.js
+++ b/docs/data/charts/bars/CustomLabels.js
@@ -16,6 +16,7 @@ export default function CustomLabels() {
         return context.bar.height < 60 ? null : item.value?.toString();
       }}
       height={350}
+      margin={{ left: 0 }}
     />
   );
 }

--- a/docs/data/charts/bars/CustomLabels.tsx
+++ b/docs/data/charts/bars/CustomLabels.tsx
@@ -16,6 +16,7 @@ export default function CustomLabels() {
         return context.bar.height < 60 ? null : item.value?.toString();
       }}
       height={350}
+      margin={{ left: 0 }}
     />
   );
 }

--- a/docs/data/charts/bars/CustomLabels.tsx.preview
+++ b/docs/data/charts/bars/CustomLabels.tsx.preview
@@ -11,4 +11,5 @@
     return context.bar.height < 60 ? null : item.value?.toString();
   }}
   height={350}
+  margin={{ left: 0 }}
 />

--- a/docs/data/charts/bars/GridDemo.js
+++ b/docs/data/charts/bars/GridDemo.js
@@ -3,12 +3,9 @@ import { BarChart } from '@mui/x-charts/BarChart';
 import { dataset, valueFormatter } from '../dataset/weather';
 
 const chartSetting = {
-  xAxis: [
-    {
-      label: 'rainfall (mm)',
-    },
-  ],
+  xAxis: [{ label: 'rainfall (mm)' }],
   height: 400,
+  margin: { left: 0 },
 };
 
 export default function GridDemo() {

--- a/docs/data/charts/bars/GridDemo.tsx
+++ b/docs/data/charts/bars/GridDemo.tsx
@@ -3,12 +3,9 @@ import { BarChart } from '@mui/x-charts/BarChart';
 import { dataset, valueFormatter } from '../dataset/weather';
 
 const chartSetting = {
-  xAxis: [
-    {
-      label: 'rainfall (mm)',
-    },
-  ],
+  xAxis: [{ label: 'rainfall (mm)' }],
   height: 400,
+  margin: { left: 0 },
 };
 
 export default function GridDemo() {

--- a/docs/data/charts/bars/HorizontalBars.js
+++ b/docs/data/charts/bars/HorizontalBars.js
@@ -9,6 +9,7 @@ const chartSetting = {
     },
   ],
   height: 400,
+  margin: { left: 0 },
 };
 
 export default function HorizontalBars() {

--- a/docs/data/charts/bars/HorizontalBars.tsx
+++ b/docs/data/charts/bars/HorizontalBars.tsx
@@ -9,6 +9,7 @@ const chartSetting = {
     },
   ],
   height: 400,
+  margin: { left: 0 },
 };
 
 export default function HorizontalBars() {

--- a/docs/data/charts/bars/LabelsAboveBars.js
+++ b/docs/data/charts/bars/LabelsAboveBars.js
@@ -11,15 +11,10 @@ export default function LabelsAboveBars() {
   return (
     <ChartContainer
       xAxis={[{ scaleType: 'band', data: ['A', 'B', 'C'] }]}
-      series={[
-        {
-          type: 'bar',
-          id: 'base',
-          data: [5, 17, 11],
-        },
-      ]}
-      width={300}
+      series={[{ type: 'bar', id: 'base', data: [5, 17, 11] }]}
       height={400}
+      yAxis={[{ width: 30 }]}
+      margin={{ left: 0, right: 10 }}
     >
       <BarPlot barLabel="value" slots={{ barLabel: BarLabel }} />
       <ChartsXAxis />

--- a/docs/data/charts/bars/LabelsAboveBars.tsx
+++ b/docs/data/charts/bars/LabelsAboveBars.tsx
@@ -11,15 +11,10 @@ export default function LabelsAboveBars() {
   return (
     <ChartContainer
       xAxis={[{ scaleType: 'band', data: ['A', 'B', 'C'] }]}
-      series={[
-        {
-          type: 'bar',
-          id: 'base',
-          data: [5, 17, 11],
-        },
-      ]}
-      width={300}
+      series={[{ type: 'bar', id: 'base', data: [5, 17, 11] }]}
       height={400}
+      yAxis={[{ width: 30 }]}
+      margin={{ left: 0, right: 10 }}
     >
       <BarPlot barLabel="value" slots={{ barLabel: BarLabel }} />
       <ChartsXAxis />

--- a/docs/data/charts/bars/LabelsAboveBars.tsx.preview
+++ b/docs/data/charts/bars/LabelsAboveBars.tsx.preview
@@ -1,14 +1,9 @@
 <ChartContainer
   xAxis={[{ scaleType: 'band', data: ['A', 'B', 'C'] }]}
-  series={[
-    {
-      type: 'bar',
-      id: 'base',
-      data: [5, 17, 11],
-    },
-  ]}
-  width={300}
+  series={[{ type: 'bar', id: 'base', data: [5, 17, 11] }]}
   height={400}
+  yAxis={[{ width: 30 }]}
+  margin={{ left: 0, right: 10 }}
 >
   <BarPlot barLabel="value" slots={{ barLabel: BarLabel }} />
   <ChartsXAxis />

--- a/docs/data/charts/bars/StackBars.js
+++ b/docs/data/charts/bars/StackBars.js
@@ -1,29 +1,33 @@
 import * as React from 'react';
+import Typography from '@mui/material/Typography';
 import { BarChart } from '@mui/x-charts/BarChart';
-import { addLabels, balanceSheet } from './netflixsBalanceSheet';
+import { addLabels, balanceSheet, valueFormatter } from './netflixsBalanceSheet';
 
 export default function StackBars() {
   return (
-    <BarChart
-      dataset={balanceSheet}
-      series={addLabels([
-        { dataKey: 'currAss', stack: 'assets' },
-        { dataKey: 'nCurrAss', stack: 'assets' },
-        { dataKey: 'curLia', stack: 'liability' },
-        { dataKey: 'nCurLia', stack: 'liability' },
-        { dataKey: 'capStock', stack: 'equity' },
-        { dataKey: 'retEarn', stack: 'equity' },
-        { dataKey: 'treas', stack: 'equity' },
-      ])}
-      xAxis={[{ dataKey: 'year' }]}
-      yAxis={[{ width: 80 }]}
-      {...config}
-    />
+    <div style={{ width: '100%' }}>
+      <Typography>Netflix balance sheet</Typography>
+      <BarChart
+        dataset={balanceSheet}
+        series={addLabels([
+          { dataKey: 'currAss', stack: 'assets' },
+          { dataKey: 'nCurrAss', stack: 'assets' },
+          { dataKey: 'curLia', stack: 'liability' },
+          { dataKey: 'nCurLia', stack: 'liability' },
+          { dataKey: 'capStock', stack: 'equity' },
+          { dataKey: 'retEarn', stack: 'equity' },
+          { dataKey: 'treas', stack: 'equity' },
+        ])}
+        xAxis={[{ dataKey: 'year' }]}
+        {...config}
+      />
+    </div>
   );
 }
 
 const config = {
   height: 350,
-  margin: { left: 40 },
+  margin: { left: 0 },
+  yAxis: [{ width: 50, valueFormatter }],
   hideLegend: true,
 };

--- a/docs/data/charts/bars/StackBars.tsx
+++ b/docs/data/charts/bars/StackBars.tsx
@@ -1,23 +1,27 @@
 import * as React from 'react';
+import Typography from '@mui/material/Typography';
 import { BarChart, BarChartProps } from '@mui/x-charts/BarChart';
 import { addLabels, balanceSheet, valueFormatter } from './netflixsBalanceSheet';
 
 export default function StackBars() {
   return (
-    <BarChart
-      dataset={balanceSheet}
-      series={addLabels([
-        { dataKey: 'currAss', stack: 'assets' },
-        { dataKey: 'nCurrAss', stack: 'assets' },
-        { dataKey: 'curLia', stack: 'liability' },
-        { dataKey: 'nCurLia', stack: 'liability' },
-        { dataKey: 'capStock', stack: 'equity' },
-        { dataKey: 'retEarn', stack: 'equity' },
-        { dataKey: 'treas', stack: 'equity' },
-      ])}
-      xAxis={[{ dataKey: 'year' }]}
-      {...config}
-    />
+    <div style={{ width: '100%' }}>
+      <Typography>Netflix balance sheet</Typography>
+      <BarChart
+        dataset={balanceSheet}
+        series={addLabels([
+          { dataKey: 'currAss', stack: 'assets' },
+          { dataKey: 'nCurrAss', stack: 'assets' },
+          { dataKey: 'curLia', stack: 'liability' },
+          { dataKey: 'nCurLia', stack: 'liability' },
+          { dataKey: 'capStock', stack: 'equity' },
+          { dataKey: 'retEarn', stack: 'equity' },
+          { dataKey: 'treas', stack: 'equity' },
+        ])}
+        xAxis={[{ dataKey: 'year' }]}
+        {...config}
+      />
+    </div>
   );
 }
 

--- a/docs/data/charts/bars/StackBars.tsx
+++ b/docs/data/charts/bars/StackBars.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BarChart, BarChartProps } from '@mui/x-charts/BarChart';
-import { addLabels, balanceSheet } from './netflixsBalanceSheet';
+import { addLabels, balanceSheet, valueFormatter } from './netflixsBalanceSheet';
 
 export default function StackBars() {
   return (
@@ -16,7 +16,6 @@ export default function StackBars() {
         { dataKey: 'treas', stack: 'equity' },
       ])}
       xAxis={[{ dataKey: 'year' }]}
-      yAxis={[{ width: 80 }]}
       {...config}
     />
   );
@@ -24,6 +23,7 @@ export default function StackBars() {
 
 const config: Partial<BarChartProps> = {
   height: 350,
-  margin: { left: 40 },
+  margin: { left: 0 },
+  yAxis: [{ width: 50, valueFormatter }],
   hideLegend: true,
 };

--- a/docs/data/charts/bars/StackBars.tsx.preview
+++ b/docs/data/charts/bars/StackBars.tsx.preview
@@ -1,3 +1,4 @@
+<Typography>Netflix balance sheet</Typography>
 <BarChart
   dataset={balanceSheet}
   series={addLabels([
@@ -10,6 +11,5 @@
     { dataKey: 'treas', stack: 'equity' },
   ])}
   xAxis={[{ dataKey: 'year' }]}
-  yAxis={[{ width: 80 }]}
   {...config}
 />

--- a/docs/data/charts/bars/TickPlacementBars.js
+++ b/docs/data/charts/bars/TickPlacementBars.js
@@ -65,6 +65,7 @@ const chartSetting = {
   ],
   series: [{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }],
   height: 300,
+  margin: { left: 0 },
 };
 
 export default function TickPlacementBars() {

--- a/docs/data/charts/bars/TickPlacementBars.tsx
+++ b/docs/data/charts/bars/TickPlacementBars.tsx
@@ -80,6 +80,7 @@ const chartSetting = {
   ],
   series: [{ dataKey: 'seoul', label: 'Seoul rainfall', valueFormatter }],
   height: 300,
+  margin: { left: 0 },
 };
 
 export default function TickPlacementBars() {

--- a/docs/data/charts/bars/netflixsBalanceSheet.js
+++ b/docs/data/charts/bars/netflixsBalanceSheet.js
@@ -14,11 +14,17 @@ const translations = {
   nonAffect: 'non Affected',
 };
 
+export const valueFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  style: 'currency',
+  currency: 'USD',
+}).format;
+
 export function addLabels(series) {
   return series.map((item) => ({
     ...item,
     label: translations[item.dataKey],
-    valueFormatter: (v) => (v ? `$ ${v.toLocaleString()}k` : '-'),
+    valueFormatter: (v) => (v ? valueFormatter(v) : '-'),
   }));
 }
 

--- a/docs/data/charts/bars/netflixsBalanceSheet.ts
+++ b/docs/data/charts/bars/netflixsBalanceSheet.ts
@@ -14,11 +14,17 @@ const translations = {
   nonAffect: 'non Affected',
 } as const;
 
+export const valueFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  style: 'currency',
+  currency: 'USD',
+}).format;
+
 export function addLabels<T extends { dataKey: keyof typeof translations }>(series: T[]) {
   return series.map((item) => ({
     ...item,
     label: translations[item.dataKey],
-    valueFormatter: (v: number | null) => (v ? `$ ${v.toLocaleString()}k` : '-'),
+    valueFormatter: (v: number | null) => (v ? valueFormatter(v) : '-'),
   }));
 }
 

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -774,6 +774,7 @@ export const GridRootStyles = styled('div', {
       [`&.${c['scrollbarFiller--pinnedRight']}`]: {
         backgroundColor: vars.cell.background.pinned,
         position: 'sticky',
+        zIndex: 40, // Should be above the column separator
         right: 0,
       },
     },


### PR DESCRIPTION
The Bar chart left margin is not that much of an issue on desktop. But on mobile it's a lot of lost space.

For example the [stacking](https://mui.com/x/react-charts/bars/#stacking) before/after


![image](https://github.com/user-attachments/assets/33b6153a-eb13-434d-b5e4-b28465932a7a)
![image](https://github.com/user-attachments/assets/7fb3935d-cca1-4211-80b3-aa26853a5e43)
