### PR TITLE
[data grid] Move list view column logic into visible column selector

### DIFF
--- a/docs/data/data-grid/list-view/ListView.js
+++ b/docs/data/data-grid/list-view/ListView.js
@@ -118,7 +118,7 @@ export default function ListView() {
   const rowHeight = isListView ? 64 : 52;
 
   return (
-    <div style={{ maxWidth: 360, height: 600 }}>
+    <div style={{ width: '100%', maxWidth: 360, height: 600 }}>
       <DataGridPro
         {...data}
         loading={loading}

--- a/docs/data/data-grid/list-view/ListView.tsx
+++ b/docs/data/data-grid/list-view/ListView.tsx
@@ -137,7 +137,7 @@ export default function ListView() {
   const rowHeight = isListView ? 64 : 52;
 
   return (
-    <div style={{ maxWidth: 360, height: 600 }}>
+    <div style={{ width: '100%', maxWidth: 360, height: 600 }}>
       <DataGridPro
         {...data}
         loading={loading}

--- a/docs/data/data-grid/list-view/ListViewEdit.js
+++ b/docs/data/data-grid/list-view/ListViewEdit.js
@@ -211,6 +211,7 @@ export default function ListViewEdit() {
       style={{
         display: 'flex',
         flexDirection: 'column',
+        width: '100%',
         maxWidth: 360,
         height: 400,
       }}

--- a/docs/data/data-grid/list-view/ListViewEdit.tsx
+++ b/docs/data/data-grid/list-view/ListViewEdit.tsx
@@ -219,6 +219,7 @@ export default function ListViewEdit() {
       style={{
         display: 'flex',
         flexDirection: 'column',
+        width: '100%',
         maxWidth: 360,
         height: 400,
       }}

--- a/docs/pages/x/api/data-grid/selectors.json
+++ b/docs/pages/x/api/data-grid/selectors.json
@@ -391,7 +391,7 @@
   },
   {
     "name": "gridVisibleColumnDefinitionsSelector",
-    "returnType": "GridStateColDef[]",
+    "returnType": "(GridListViewColDef & { computedWidth: number })[]",
     "category": "Visible Columns",
     "description": "Get the visible columns as a lookup (an object containing the field for keys and the definition for values)."
   },
@@ -403,7 +403,7 @@
   },
   {
     "name": "gridVisiblePinnedColumnDefinitionsSelector",
-    "returnType": "{ left: GridStateColDef[]; right: GridStateColDef[] }",
+    "returnType": "GridPinnedColumns",
     "category": "Visible Columns",
     "description": "Get the visible pinned columns."
   },

--- a/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
+++ b/packages/x-data-grid/src/hooks/features/columns/gridColumnsSelector.ts
@@ -8,8 +8,10 @@ import {
   GridColumnLookup,
   GridPinnedColumnFields,
   EMPTY_PINNED_COLUMN_FIELDS,
+  GridPinnedColumns,
 } from './gridColumnsInterfaces';
 import { gridIsRtlSelector } from '../../core/gridCoreSelector';
+import { gridListColumnSelector, gridListViewSelector } from '../listView';
 
 /**
  * Get the columns state
@@ -75,8 +77,12 @@ export const gridInitialColumnVisibilityModelSelector = createSelector(
 export const gridVisibleColumnDefinitionsSelector = createSelectorMemoized(
   gridColumnDefinitionsSelector,
   gridColumnVisibilityModelSelector,
-  (columns, columnVisibilityModel) =>
-    columns.filter((column) => columnVisibilityModel[column.field] !== false),
+  gridListViewSelector,
+  gridListColumnSelector,
+  (columns, columnVisibilityModel, listView, listColumn) =>
+    listView && listColumn
+      ? [listColumn]
+      : columns.filter((column) => columnVisibilityModel[column.field] !== false),
 );
 
 /**
@@ -117,7 +123,11 @@ export const gridVisiblePinnedColumnDefinitionsSelector = createSelectorMemoized
   gridPinnedColumnsSelector,
   gridVisibleColumnFieldsSelector,
   gridIsRtlSelector,
-  (columnsState, model, visibleColumnFields, isRtl) => {
+  gridListViewSelector,
+  (columnsState, model, visibleColumnFields, isRtl, listView) => {
+    if (listView) {
+      return EMPTY_PINNED_COLUMN_FIELDS as unknown as GridPinnedColumns;
+    }
     const visiblePinnedFields = filterMissingColumns(model, visibleColumnFields, isRtl);
     const visiblePinnedColumns = {
       left: visiblePinnedFields.left.map((field) => columnsState.lookup[field]),

--- a/packages/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/x-data-grid/src/hooks/features/keyboardNavigation/useGridKeyboardNavigation.ts
@@ -31,7 +31,6 @@ import {
 import { GridPipeProcessor, useGridRegisterPipeProcessor } from '../../core/pipeProcessing';
 import { isEventTargetInPortal } from '../../../utils/domUtils';
 import { getLeftColumnIndex, getRightColumnIndex, findNonRowSpannedCell } from './utils';
-import { gridListColumnSelector } from '../listView/gridListViewSelectors';
 import { createSelectorMemoized } from '../../../utils/createSelector';
 import { gridVisibleRowsSelector } from '../pagination';
 import { gridPinnedRowsSelector } from '../rows/gridRowsSelector';
@@ -62,7 +61,6 @@ export const useGridKeyboardNavigation = (
 ): void => {
   const logger = useGridLogger(apiRef, 'useGridKeyboardNavigation');
   const isRtl = useRtl();
-  const listView = props.listView;
 
   const getCurrentPageRows = React.useCallback(() => {
     return gridVisibleRowsWithPinnedRowsSelector(apiRef);
@@ -93,9 +91,7 @@ export const useGridKeyboardNavigation = (
           colIndex = nextCellColSpanInfo.rightVisibleCellIndex;
         }
       }
-      const field = listView
-        ? gridListColumnSelector(apiRef)!.field
-        : gridVisibleColumnFieldsSelector(apiRef)[colIndex];
+      const field = gridVisibleColumnFieldsSelector(apiRef)[colIndex];
       const nonRowSpannedRowId = findNonRowSpannedCell(apiRef, rowId, field, rowSpanScanDirection);
       // `scrollToIndexes` requires a rowIndex relative to all visible rows.
       // Those rows do not include pinned rows, but pinned rows do not need scroll anyway.
@@ -109,7 +105,7 @@ export const useGridKeyboardNavigation = (
       });
       apiRef.current.setCellFocus(nonRowSpannedRowId, field);
     },
-    [apiRef, logger, listView],
+    [apiRef, logger],
   );
 
   const goToHeader = React.useCallback(
@@ -501,7 +497,7 @@ export const useGridKeyboardNavigation = (
 
       const viewportPageSize = apiRef.current.getViewportPageSize();
 
-      const getColumnIndexFn = listView ? () => 0 : apiRef.current.getColumnIndex;
+      const getColumnIndexFn = props.listView ? () => 0 : apiRef.current.getColumnIndex;
       const colIndexBefore = (params as GridCellParams).field
         ? getColumnIndexFn((params as GridCellParams).field)
         : 0;
@@ -509,10 +505,7 @@ export const useGridKeyboardNavigation = (
       const firstRowIndexInPage = 0;
       const lastRowIndexInPage = currentPageRows.length - 1;
       const firstColIndex = 0;
-      const visibleColumns = listView
-        ? [gridListColumnSelector(apiRef)]
-        : gridVisibleColumnDefinitionsSelector(apiRef);
-      const lastColIndex = visibleColumns.length - 1;
+      const lastColIndex = gridVisibleColumnDefinitionsSelector(apiRef).length - 1;
       let shouldPreventDefault = true;
 
       switch (event.key) {
@@ -654,7 +647,7 @@ export const useGridKeyboardNavigation = (
       headerFilteringEnabled,
       goToHeaderFilter,
       goToHeader,
-      listView,
+      props.listView,
     ],
   );
 

--- a/packages/x-data-grid/src/hooks/features/listView/gridListViewSelectors.ts
+++ b/packages/x-data-grid/src/hooks/features/listView/gridListViewSelectors.ts
@@ -2,6 +2,15 @@ import { createRootSelector } from '../../../utils/createSelector';
 import { GridStateCommunity } from '../../../models/gridStateCommunity';
 
 /**
+ * Get the list view state
+ * @category List View
+ * @ignore - Do not document
+ */
+export const gridListViewSelector = createRootSelector(
+  (state: GridStateCommunity) => state.listView,
+);
+
+/**
  * Get the list column definition
  * @category List View
  * @ignore - Do not document

--- a/packages/x-data-grid/src/hooks/features/listView/useGridListView.tsx
+++ b/packages/x-data-grid/src/hooks/features/listView/useGridListView.tsx
@@ -14,9 +14,10 @@ import { useGridEvent } from '../../utils/useGridEvent';
 export type GridListViewState = (GridListViewColDef & { computedWidth: number }) | undefined;
 
 export const listViewStateInitializer: GridStateInitializer<
-  Pick<DataGridProcessedProps, 'listViewColumn'>
+  Pick<DataGridProcessedProps, 'listView' | 'listViewColumn'>
 > = (state, props, apiRef) => ({
   ...state,
+  listView: props.listView ?? false,
   listViewColumn: props.listViewColumn
     ? { ...props.listViewColumn, computedWidth: getListColumnWidth(apiRef) }
     : undefined,
@@ -74,6 +75,13 @@ export function useGridListView(
       });
     }
   }, [apiRef, props.listViewColumn]);
+
+  useEnhancedEffect(() => {
+    apiRef.current.setState((state) => ({
+      ...state,
+      listView: props.listView ?? false,
+    }));
+  }, [apiRef, props.listView]);
 
   React.useEffect(() => {
     if (props.listView && !props.listViewColumn) {

--- a/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
+++ b/packages/x-data-grid/src/hooks/features/scroll/useGridScroll.ts
@@ -18,7 +18,6 @@ import { GridScrollApi } from '../../../models/api/gridScrollApi';
 import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { gridExpandedSortedRowEntriesSelector } from '../filter/gridFilterSelector';
 import { gridDimensionsSelector } from '../dimensions';
-import { gridListColumnSelector } from '../listView/gridListViewSelectors';
 
 // Logic copied from https://www.w3.org/TR/wai-aria-practices/examples/listbox/js/listbox.js
 // Similar to https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
@@ -55,7 +54,7 @@ function scrollIntoView(dimensions: {
  */
 export const useGridScroll = (
   apiRef: RefObject<GridPrivateApiCommunity>,
-  props: Pick<DataGridProcessedProps, 'pagination' | 'listView'>,
+  props: Pick<DataGridProcessedProps, 'pagination'>,
 ): void => {
   const isRtl = useRtl();
   const logger = useGridLogger(apiRef, 'useGridScroll');
@@ -67,9 +66,7 @@ export const useGridScroll = (
     (params: Partial<GridCellIndexCoordinates>) => {
       const dimensions = gridDimensionsSelector(apiRef);
       const totalRowCount = gridRowCountSelector(apiRef);
-      const visibleColumns = props.listView
-        ? [gridListColumnSelector(apiRef)!]
-        : gridVisibleColumnDefinitionsSelector(apiRef);
+      const visibleColumns = gridVisibleColumnDefinitionsSelector(apiRef);
       const scrollToHeader = params.rowIndex == null;
       if ((!scrollToHeader && totalRowCount === 0) || visibleColumns.length === 0) {
         return false;
@@ -143,7 +140,7 @@ export const useGridScroll = (
 
       return false;
     },
-    [logger, apiRef, virtualScrollerRef, props.pagination, visibleSortedRows, props.listView],
+    [logger, apiRef, virtualScrollerRef, props.pagination, visibleSortedRows],
   );
 
   const scroll = React.useCallback<GridScrollApi['scroll']>(

--- a/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/x-data-grid/src/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -50,9 +50,7 @@ import {
 } from './gridVirtualizationSelectors';
 import { EMPTY_RENDER_CONTEXT } from './useGridVirtualization';
 import { gridRowSpanningHiddenCellsOriginMapSelector } from '../rows/gridRowSpanningSelectors';
-import { gridListColumnSelector } from '../listView/gridListViewSelectors';
 import { minimalContentHeight } from '../rows/gridRowsUtils';
-import { EMPTY_PINNED_COLUMN_FIELDS, GridPinnedColumns } from '../columns';
 import { gridFocusedVirtualCellSelector } from './gridFocusedVirtualCellSelector';
 import { roundToDecimalPlaces } from '../../../utils/roundToDecimalPlaces';
 import { isJSDOM } from '../../../utils/isJSDOM';
@@ -103,18 +101,13 @@ export const useGridVirtualScroller = () => {
   const apiRef = useGridPrivateApiContext() as RefObject<PrivateApiWithInfiniteLoader>;
   const rootProps = useGridRootProps();
   const { listView } = rootProps;
-  const visibleColumns = useGridSelector(apiRef, () =>
-    listView ? [gridListColumnSelector(apiRef)!] : gridVisibleColumnDefinitionsSelector(apiRef),
-  );
+  const visibleColumns = useGridSelector(apiRef, gridVisibleColumnDefinitionsSelector);
   const enabledForRows = useGridSelector(apiRef, gridVirtualizationRowEnabledSelector) && !isJSDOM;
   const enabledForColumns =
     useGridSelector(apiRef, gridVirtualizationColumnEnabledSelector) && !isJSDOM;
 
   const pinnedRows = useGridSelector(apiRef, gridPinnedRowsSelector);
-  const pinnedColumnDefinitions = gridVisiblePinnedColumnDefinitionsSelector(apiRef);
-  const pinnedColumns = listView
-    ? (EMPTY_PINNED_COLUMN_FIELDS as unknown as GridPinnedColumns)
-    : pinnedColumnDefinitions;
+  const pinnedColumns = gridVisiblePinnedColumnDefinitionsSelector(apiRef);
   const hasBottomPinnedRows = pinnedRows.bottom.length > 0;
   const [panels, setPanels] = React.useState(EMPTY_DETAIL_PANELS);
 
@@ -784,9 +777,7 @@ function inputsSelector(
 ): RenderContextInputs {
   const dimensions = gridDimensionsSelector(apiRef);
   const currentPage = getVisibleRows(apiRef, rootProps);
-  const visibleColumns = rootProps.listView
-    ? [gridListColumnSelector(apiRef)!]
-    : gridVisibleColumnDefinitionsSelector(apiRef);
+  const visibleColumns = gridVisibleColumnDefinitionsSelector(apiRef);
   const hiddenCellsOriginMap = gridRowSpanningHiddenCellsOriginMapSelector(apiRef);
   const lastRowId = apiRef.current.state.rows.dataRowIds.at(-1);
   const lastColumn = visibleColumns.at(-1);

--- a/packages/x-data-grid/src/models/gridStateCommunity.ts
+++ b/packages/x-data-grid/src/models/gridStateCommunity.ts
@@ -62,6 +62,7 @@ export interface GridStateCommunity {
   virtualization: GridVirtualizationState;
   columnResize: GridColumnResizeState;
   rowSpanning: GridRowSpanningState;
+  listView: boolean;
   listViewColumn: GridListViewState;
 }
 

--- a/scripts/x-data-grid-premium.exports.json
+++ b/scripts/x-data-grid-premium.exports.json
@@ -439,6 +439,7 @@
   { "name": "GridLeafNode", "kind": "Interface" },
   { "name": "gridListColumnSelector", "kind": "Variable" },
   { "name": "GridListViewColDef", "kind": "TypeAlias" },
+  { "name": "gridListViewSelector", "kind": "Variable" },
   { "name": "GridLoadIcon", "kind": "Variable" },
   { "name": "GridLoadingOverlay", "kind": "Variable" },
   { "name": "GridLoadingOverlayProps", "kind": "Interface" },

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -389,6 +389,7 @@
   { "name": "GridLeafNode", "kind": "Interface" },
   { "name": "gridListColumnSelector", "kind": "Variable" },
   { "name": "GridListViewColDef", "kind": "TypeAlias" },
+  { "name": "gridListViewSelector", "kind": "Variable" },
   { "name": "GridLoadIcon", "kind": "Variable" },
   { "name": "GridLoadingOverlay", "kind": "Variable" },
   { "name": "GridLoadingOverlayProps", "kind": "Interface" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -359,6 +359,7 @@
   { "name": "GridLeafNode", "kind": "Interface" },
   { "name": "gridListColumnSelector", "kind": "Variable" },
   { "name": "GridListViewColDef", "kind": "TypeAlias" },
+  { "name": "gridListViewSelector", "kind": "Variable" },
   { "name": "GridLoadIcon", "kind": "Variable" },
   { "name": "GridLoadingOverlay", "kind": "Variable" },
   { "name": "GridLoadingOverlayProps", "kind": "Interface" },


### PR DESCRIPTION
Part of #14997

Moves list view conditional column rendering logic to the visible column selector.