### PR TITLE
[charts-pro] Allow customizing scatter preview marker size

### DIFF
--- a/docs/data/charts/zoom-and-pan/ZoomSliderPreview.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderPreview.js
@@ -100,13 +100,7 @@ const scatterXAxis = {
   valueFormatter: (v) => gdpPerCapitaFormatter.format(v),
 };
 const scatterSettings = {
-  yAxis: [
-    {
-      id: 'y',
-      width: 44,
-      min: 0,
-    },
-  ],
+  yAxis: [{ id: 'y', width: 16, min: 0 }],
   series: continents.map((continent) => ({
     label: continent,
     data: countriesInContinent[continent]

--- a/docs/data/charts/zoom-and-pan/ZoomSliderPreview.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderPreview.tsx
@@ -104,13 +104,7 @@ const scatterXAxis = {
   valueFormatter: (v: number | null) => gdpPerCapitaFormatter.format(v!),
 };
 const scatterSettings = {
-  yAxis: [
-    {
-      id: 'y',
-      width: 44,
-      min: 0,
-    },
-  ],
+  yAxis: [{ id: 'y', width: 16, min: 0 }],
   series: continents.map((continent) => ({
     label: continent,
     data: countriesInContinent[continent]

--- a/docs/data/charts/zoom-and-pan/ZoomSliderPreviewCustomMarkerSize.js
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderPreviewCustomMarkerSize.js
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import { ScatterChartPro } from '@mui/x-charts-pro/ScatterChartPro';
+import Slider from '@mui/material/Slider';
+import { globalGdpPerCapita } from '../dataset/globalGdpPerCapita';
+import { globalBirthPerWoman } from '../dataset/globalBirthsPerWoman';
+import {
+  continents,
+  countriesInContinent,
+  countryData,
+} from '../dataset/countryData';
+
+const gdpPerCapitaFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  notation: 'compact',
+});
+
+const scatterXAxis = {
+  valueFormatter: (v) => gdpPerCapitaFormatter.format(v),
+};
+
+const dataPerContinent = continents.map((continent) =>
+  countriesInContinent[continent]
+    .map((code) => ({
+      id: code,
+      x: globalGdpPerCapita.find((d) => d.code === code)?.gdpPerCapita,
+      y: globalBirthPerWoman.find((d) => d.code === code)?.rate,
+    }))
+    .filter((d) => d.x !== undefined && d.y !== undefined),
+);
+
+const scatterSettings = {
+  yAxis: [{ id: 'y', width: 16, min: 0 }],
+  height: 300,
+};
+
+export default function ZoomSliderPreviewCustomMarkerSize() {
+  const [markerSize, setMarkerSize] = React.useState(2);
+  const series = continents.map((continent, continentIndex) => ({
+    label: continent,
+    data: dataPerContinent[continentIndex],
+    preview: { markerSize },
+    valueFormatter: (value) =>
+      `${countryData[value.id].country} - Birth rate: ${value.y} - GDP per capita: ${gdpPerCapitaFormatter.format(value.x)}`,
+  }));
+
+  return (
+    <Stack
+      width="100%"
+      gap={2}
+      direction="row"
+      justifyContent="center"
+      flexWrap={{ xs: 'wrap-reverse', sm: 'nowrap' }}
+    >
+      <Stack width="100%" gap={2}>
+        <Typography variant="h6" sx={{ alignSelf: 'center' }}>
+          Births per woman vs GDP per capita (USD, 2023)
+        </Typography>
+        <ScatterChartPro
+          {...scatterSettings}
+          xAxis={[
+            { ...scatterXAxis, zoom: { slider: { enabled: true, preview: true } } },
+          ]}
+          series={series}
+        />
+        <Typography variant="caption">
+          GDP per capita is expressed in international dollars at 2021 prices. <br />
+          Source: Our World in Data. Updated: 2023.
+        </Typography>
+      </Stack>
+
+      <Stack
+        minWidth="120px"
+        justifyContent="center"
+        alignItems="center"
+        alignSelf="center"
+      >
+        <Typography id="marker-size-slider" gutterBottom>
+          Marker Size: {markerSize}
+        </Typography>
+        <Slider
+          size="small"
+          min={1}
+          max={10}
+          aria-labelledby="marker-size-slider"
+          onChange={(event, value) => setMarkerSize(value)}
+          value={markerSize}
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/charts/zoom-and-pan/ZoomSliderPreviewCustomMarkerSize.tsx
+++ b/docs/data/charts/zoom-and-pan/ZoomSliderPreviewCustomMarkerSize.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { ScatterValueType } from '@mui/x-charts/models';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import {
+  ScatterChartPro,
+  ScatterChartProProps,
+} from '@mui/x-charts-pro/ScatterChartPro';
+import Slider from '@mui/material/Slider';
+import { globalGdpPerCapita } from '../dataset/globalGdpPerCapita';
+import { globalBirthPerWoman } from '../dataset/globalBirthsPerWoman';
+import {
+  continents,
+  countriesInContinent,
+  countryData,
+} from '../dataset/countryData';
+
+const gdpPerCapitaFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  notation: 'compact',
+});
+
+const scatterXAxis = {
+  valueFormatter: (v: number | null) => gdpPerCapitaFormatter.format(v!),
+};
+
+const dataPerContinent = continents.map((continent) =>
+  countriesInContinent[continent]
+    .map((code) => ({
+      id: code,
+      x: globalGdpPerCapita.find((d) => d.code === code)?.gdpPerCapita,
+      y: globalBirthPerWoman.find((d) => d.code === code)?.rate,
+    }))
+    .filter(
+      (d): d is { id: string; x: number; y: number } =>
+        d.x !== undefined && d.y !== undefined,
+    ),
+);
+
+const scatterSettings = {
+  yAxis: [{ id: 'y', width: 16, min: 0 }],
+  height: 300,
+} satisfies Partial<ScatterChartProProps>;
+
+export default function ZoomSliderPreviewCustomMarkerSize() {
+  const [markerSize, setMarkerSize] = React.useState(2);
+  const series = continents.map((continent, continentIndex) => ({
+    label: continent,
+    data: dataPerContinent[continentIndex],
+    preview: { markerSize },
+    valueFormatter: (value: ScatterValueType | null) =>
+      `${countryData[value!.id as keyof typeof countryData].country} - Birth rate: ${value!.y} - GDP per capita: ${gdpPerCapitaFormatter.format(value!.x)}`,
+  }));
+
+  return (
+    <Stack
+      width="100%"
+      gap={2}
+      direction="row"
+      justifyContent="center"
+      flexWrap={{ xs: 'wrap-reverse', sm: 'nowrap' }}
+    >
+      <Stack width="100%" gap={2}>
+        <Typography variant="h6" sx={{ alignSelf: 'center' }}>
+          Births per woman vs GDP per capita (USD, 2023)
+        </Typography>
+        <ScatterChartPro
+          {...scatterSettings}
+          xAxis={[
+            { ...scatterXAxis, zoom: { slider: { enabled: true, preview: true } } },
+          ]}
+          series={series}
+        />
+        <Typography variant="caption">
+          GDP per capita is expressed in international dollars at 2021 prices. <br />
+          Source: Our World in Data. Updated: 2023.
+        </Typography>
+      </Stack>
+
+      <Stack
+        minWidth="120px"
+        justifyContent="center"
+        alignItems="center"
+        alignSelf="center"
+      >
+        <Typography id="marker-size-slider" gutterBottom>
+          Marker Size: {markerSize}
+        </Typography>
+        <Slider
+          size="small"
+          min={1}
+          max={10}
+          aria-labelledby="marker-size-slider"
+          onChange={(event, value) => setMarkerSize(value)}
+          value={markerSize}
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/docs/data/charts/zoom-and-pan/zoom-and-pan.md
+++ b/docs/data/charts/zoom-and-pan/zoom-and-pan.md
@@ -92,17 +92,28 @@ The zoom slider uses the same limits as the zooming options. You can set the `mi
 
 The zoom slider does not display values outside the range delimited by `minStart` and `maxEnd`.
 
-### Preview
-
-When the zoom slider is enabled, you can preview the zoomed area by enabling the `zoom.slider.preview` property on the axis config.
-
-{{"demo": "ZoomSliderPreview.js"}}
-
 ### Composition
 
 When using composition, you can render the axes' sliders by rendering the `ChartZoomSlider` component.
 
 {{"demo": "ZoomSliderComposition.js"}}
+
+## Preview 🧪
+
+:::info
+This feature is in preview. It is ready for production use, but its API, visuals and behavior may change in future minor or patch releases.
+:::
+
+When the zoom slider is enabled, you can preview the zoomed area by enabling the `zoom.slider.preview` property on the axis config.
+
+{{"demo": "ZoomSliderPreview.js"}}
+
+### Scatter marker size
+
+The size of the preview marker in scatter charts is 1px by default.
+You can customize it by setting the `zoom.slider.preview.markerSize` property on the series configuration object.
+
+{{"demo": "ZoomSliderPreviewCustomMarkerSize.js"}}
 
 ## Zoom management
 

--- a/docs/pages/x/api/charts/scatter-series-type.json
+++ b/docs/pages/x/api/charts/scatter-series-type.json
@@ -21,6 +21,11 @@
     },
     "labelMarkType": { "type": { "description": "ChartsLabelMarkProps['type']" } },
     "markerSize": { "type": { "description": "number" } },
+    "preview": {
+      "type": {
+        "description": "{<br />  /**<br />   * The size of the preview marker.<br />   * @default 1<br />   */<br />  markerSize?: number<br />}"
+      }
+    },
     "valueFormatter": { "type": { "description": "SeriesValueFormatter&lt;TValue&gt;" } },
     "xAxisId": { "type": { "description": "string" } },
     "yAxisId": { "type": { "description": "string" } },

--- a/docs/translations/api-docs/charts/scatter-series-type.json
+++ b/docs/translations/api-docs/charts/scatter-series-type.json
@@ -19,6 +19,7 @@
       "description": "Defines the mark type for the series.<br /><br />There is a default mark type for each series type."
     },
     "markerSize": { "description": "" },
+    "preview": { "description": "" },
     "valueFormatter": {
       "description": "Formatter used to render values in tooltip or other data display."
     },

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/previews/ScatterPreviewPlot.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/previews/ScatterPreviewPlot.tsx
@@ -82,8 +82,6 @@ interface ScatterPreviewItemsProps {
   width: number;
 }
 
-const DEFAULT_MARKER_SIZE = 1;
-
 function ScatterPreviewItems(props: ScatterPreviewItemsProps) {
   const { series, xScale, yScale, color, colorGetter, x, y, width, height } = props;
 
@@ -105,7 +103,7 @@ function ScatterPreviewItems(props: ScatterPreviewItemsProps) {
             x={dataPoint.x}
             y={dataPoint.y}
             seriesId={series.id}
-            size={DEFAULT_MARKER_SIZE}
+            size={series.preview.markerSize}
             isHighlighted={false}
             isFaded={false}
           />

--- a/packages/x-charts/src/ScatterChart/seriesConfig/seriesProcessor.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/seriesProcessor.ts
@@ -36,6 +36,10 @@ const seriesProcessor: SeriesProcessor<'scatter'> = ({ series, seriesOrder }, da
           labelMarkType: 'circle' as const,
           markerSize: 4,
           ...seriesData,
+          preview: {
+            markerSize: 1,
+            ...seriesData?.preview,
+          },
           data,
           valueFormatter: seriesData.valueFormatter ?? ((v) => v && `(${v.x}, ${v.y})`),
         },

--- a/packages/x-charts/src/models/seriesType/scatter.ts
+++ b/packages/x-charts/src/models/seriesType/scatter.ts
@@ -1,4 +1,4 @@
-import { DefaultizedProps } from '@mui/x-internals/types';
+import { DefaultizedProps, MakeRequired } from '@mui/x-internals/types';
 import { CartesianSeriesType, CommonDefaultizedProps, CommonSeriesType, SeriesId } from './common';
 
 export type ScatterValueType = {
@@ -55,6 +55,13 @@ export interface ScatterSeriesType
      */
     id?: string;
   };
+  preview?: {
+    /**
+     * The size of the preview marker.
+     * @default 1
+     */
+    markerSize?: number;
+  };
 }
 
 /**
@@ -68,4 +75,6 @@ export type ScatterItemIdentifier = {
 };
 
 export interface DefaultizedScatterSeriesType
-  extends DefaultizedProps<ScatterSeriesType, CommonDefaultizedProps | 'color' | 'markerSize'> {}
+  extends DefaultizedProps<ScatterSeriesType, CommonDefaultizedProps | 'color' | 'markerSize'> {
+  preview: MakeRequired<NonNullable<ScatterSeriesType['preview']>, 'markerSize'>;
+}


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/18267#issuecomment-3026951980.

Allow customizing scatter preview marker size.


https://github.com/user-attachments/assets/005f1824-c67c-4ba0-a1c4-bee6ddb33d1c

