### PR TITLE
[tree view] Fix scrolling bug when lazy loading and checkboxSelection are enabled

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
@@ -67,38 +67,6 @@ describeTreeView<
         expect(view.getAllTreeItemIds()).to.deep.equal(['1']);
       });
 
-      // it('should NOT publish removeItem event if items do not change', async () => {
-      //   const publishSpy = spy(publishTreeViewEvent);
-
-      //   const view = render({
-      //     items: [{ id: '1' }, { id: '2' }],
-      //   });
-
-      //   view.setItems([{ id: '1' }, { id: '2' }]);
-      //   expect(view.getAllTreeItemIds()).to.deep.equal(['1', '2']);
-
-      //   // Filtra solo las llamadas a 'removeItem'
-      //   const removeItemCalls = publishSpy
-      //     .getCalls()
-      //     .filter((call) => call.args[1] === 'removeItem');
-      //   expect(removeItemCalls.length).to.equal(0);
-      // });
-
-      // it('should publish removeItem event when an item is removed', async () => {
-      //   const publishSpy = spy(publishTreeViewEvent);
-      //   const view = render({
-      //     items: [{ id: '1' }, { id: '2' }],
-      //   });
-      //   view.setItems([]);
-
-      //   // expect(view.getAllTreeItemIds()).to.deep.equal(['1']);
-
-      //   const removeItemCalls = publishSpy
-      //     .getCalls()
-      //     .filter((call) => call.args[1] === 'removeItem');
-      //   expect(removeItemCalls.length).to.equal(1);
-      // });
-
       it('should support adding an item at the end', () => {
         const view = render({
           items: [{ id: '1' }],

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { act, fireEvent, reactMajor } from '@mui/internal-test-utils';
+import { act, fireEvent, reactMajor, waitFor } from '@mui/internal-test-utils';
 import { describeTreeView } from 'test/utils/tree-view/describeTreeView';
 import {
   UseTreeViewExpansionSignature,
@@ -66,6 +66,38 @@ describeTreeView<
         view.setItems([{ id: '1' }]);
         expect(view.getAllTreeItemIds()).to.deep.equal(['1']);
       });
+
+      // it('should NOT publish removeItem event if items do not change', async () => {
+      //   const publishSpy = spy(publishTreeViewEvent);
+
+      //   const view = render({
+      //     items: [{ id: '1' }, { id: '2' }],
+      //   });
+
+      //   view.setItems([{ id: '1' }, { id: '2' }]);
+      //   expect(view.getAllTreeItemIds()).to.deep.equal(['1', '2']);
+
+      //   // Filtra solo las llamadas a 'removeItem'
+      //   const removeItemCalls = publishSpy
+      //     .getCalls()
+      //     .filter((call) => call.args[1] === 'removeItem');
+      //   expect(removeItemCalls.length).to.equal(0);
+      // });
+
+      // it('should publish removeItem event when an item is removed', async () => {
+      //   const publishSpy = spy(publishTreeViewEvent);
+      //   const view = render({
+      //     items: [{ id: '1' }, { id: '2' }],
+      //   });
+      //   view.setItems([]);
+
+      //   // expect(view.getAllTreeItemIds()).to.deep.equal(['1']);
+
+      //   const removeItemCalls = publishSpy
+      //     .getCalls()
+      //     .filter((call) => call.args[1] === 'removeItem');
+      //   expect(removeItemCalls.length).to.equal(1);
+      // });
 
       it('should support adding an item at the end', () => {
         const view = render({
@@ -532,6 +564,61 @@ describeTreeView<
           expect(view.getItemRoot('1')).not.to.have.attribute('aria-disabled');
         });
       });
+    });
+
+    describe('lazy loading (dataSource)', () => {
+      it.skipIf(treeViewComponentName !== 'RichTreeViewPro')(
+        'should not reset focus after lazy loading children when checkboxSelection is enabled',
+        async () => {
+          function MyComponent() {
+            const items = [
+              { id: '1', label: 'Node 1' },
+              { id: '2', label: 'Node with children' },
+            ];
+
+            const getChildrenCount = (item) => {
+              if (item.subField === 'child') {
+                return 0;
+              }
+              return 1;
+            };
+
+            const getTreeItems = () => {
+              return [{ id: '2.1', label: 'Child', subField: 'child' }];
+            };
+
+            return (
+              <TreeViewComponent
+                items={items}
+                checkboxSelection
+                getItemChildren={(item) => item.children || []}
+                getItemId={(item) => item.id}
+                getItemLabel={(item) => item.label}
+                dataSource={{ getChildrenCount, getTreeItems }}
+                slotProps={{
+                  item: (ownerState) => ({ 'data-testid': ownerState.itemId }),
+                }}
+              />
+            );
+          }
+
+          const view = renderFromJSX(<MyComponent />);
+
+          fireEvent.focus(view.getItemRoot('2'));
+          expect(view.getFocusedItemId()).to.equal('2');
+
+          const expandIcon = view
+            .getItemRoot('2')
+            .querySelector('[data-testid="TreeViewExpandIconIcon"]')!;
+          fireEvent.click(expandIcon);
+          await waitFor(() => {
+            expect(view.isItemExpanded('2')).to.equal(true);
+          });
+
+          expect(!!view.getItemRoot('2.1')).to.equal(true);
+          expect(view.getFocusedItemId()).to.equal('2');
+        },
+      );
     });
   },
 );

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewItems/useTreeViewItems.tsx
@@ -282,7 +282,7 @@ export const useTreeViewItems: TreeViewPlugin<UseTreeViewItemsSignature> = ({
           };
         }
         Object.values(prevState.items.itemMetaLookup).forEach((item) => {
-          if (!newState.itemMetaLookup[item.id]) {
+          if (!newItems.itemMetaLookup[item.id]) {
             publishTreeViewEvent(instance, 'removeItem', { id: item.id });
           }
         });


### PR DESCRIPTION
Issue: #18689 

**Problem**
When using checkboxSelection with lazy loading, expanding a node triggered unnecessary `removeItem` event for items that were not actually removed (for all the items). This event is responsible for resetting the focus to the default focus (1) when it matches, resulting in the scroll position jumping to the top and a poor user experience.
<img width="1387" alt="Screenshot 2025-07-09 at 14 12 53" src="https://github.com/user-attachments/assets/3a5695b7-5c6e-4ca3-b83e-3043d330f176" />


**Solution**
The solution was to use **newItems**.itemMetaLookup for the comparison that decides when to trigger the event, this ensures that the diff checks against the merged lookup (which includes both previous and new nodes), so "removeItem" is only triggered for items that are truly removed from the tree, not for those that are still present after lazy loading.

**Demo**
https://github.com/user-attachments/assets/1170c21e-1618-4fdc-9b3e-efbc8aa50855


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
