### PR TITLE
[charts] Simplify radar internal hooks

### DIFF
--- a/packages/x-charts/src/RadarChart/RadarAxisHighlight/RadarAxisHighlight.tsx
+++ b/packages/x-charts/src/RadarChart/RadarAxisHighlight/RadarAxisHighlight.tsx
@@ -65,13 +65,13 @@ function RadarAxisHighlight(props: RadarAxisHighlightProps) {
         pointerEvents="none"
         strokeDasharray="4 4"
       />
-      {points.map(({ highlighted }, seriesIndex) => {
+      {points.map((point, seriesIndex) => {
         return (
           <circle
             key={series[seriesIndex].id}
             fill={series[seriesIndex].color}
-            cx={highlighted.x}
-            cy={highlighted.y}
+            cx={point.x}
+            cy={point.y}
             className={classes.dot}
             pointerEvents="none"
             {...(series[seriesIndex].hideMark ? highlightMark : highlightMarkShadow)}

--- a/packages/x-charts/src/RadarChart/RadarAxisHighlight/useRadarAxisHighlight.ts
+++ b/packages/x-charts/src/RadarChart/RadarAxisHighlight/useRadarAxisHighlight.ts
@@ -16,13 +16,6 @@ import {
   selectorChartsInteractionRotationAxisValue,
 } from '../../internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarInteraction.selectors';
 
-interface UseRadarAxisHighlightParams {
-  /**
-   * If true, coordinates of the previous/next point will be added.
-   */
-  includesNeighbors?: boolean;
-}
-
 interface UseRadarAxisHighlightReturnValue {
   /**
    * The radar center.
@@ -52,7 +45,7 @@ interface UseRadarAxisHighlightReturnValue {
    * The { x, y, value } values for the highlighted points in the same order as the `series` array.
    * If `includesNeighbors` is set to `true` it also contains the information for `previous` and `next` data point.
    */
-  points: Points[];
+  points: Point[];
   /**
    * Charts instances giving access to `polar2svg` and `svg2polar` helpers.
    */
@@ -67,17 +60,7 @@ interface Point {
   value: number;
 }
 
-interface Points {
-  highlighted: Point;
-  previous?: Point;
-  next?: Point;
-}
-
-export function useRadarAxisHighlight(
-  params?: UseRadarAxisHighlightParams,
-): UseRadarAxisHighlightReturnValue | null {
-  const { includesNeighbors = false } = params ?? {};
-
+export function useRadarAxisHighlight(): UseRadarAxisHighlightReturnValue | null {
   const radarSeries = useRadarSeries();
 
   const rotationScale = useRotationScale<'point'>();
@@ -124,55 +107,15 @@ export function useRadarAxisHighlight(
       const r = radiusScale(value)!;
       const [x, y] = instance.polar2svg(r, angle);
 
-      const retrunedValue: Points = {
-        highlighted: {
-          x,
-          y,
-          r,
-          angle,
-          value,
-        },
+      const returnedValue: Point = {
+        x,
+        y,
+        r,
+        angle,
+        value,
       };
-      if (!includesNeighbors) {
-        return retrunedValue;
-      }
 
-      const dataLength = series.data.length;
-
-      const prevIndex = (dataLength + highlightedIndex - 1) % dataLength;
-      const nextIndex = (highlightedIndex + 1) % dataLength;
-
-      const prevValue = series.data[prevIndex];
-      const nextValue = series.data[nextIndex];
-
-      if (prevValue != null) {
-        const prevR = radiusAxis[radiusAxisIds[prevIndex]].scale(prevValue)!;
-        const prevAngle = rotationScale(rotationScale.domain()[prevIndex])!;
-        const [px, py] = instance.polar2svg(prevR, prevAngle);
-
-        retrunedValue.previous = {
-          x: px,
-          y: py,
-          r: prevR,
-          angle: prevAngle,
-          value: prevValue,
-        };
-      }
-
-      if (nextValue != null) {
-        const nextR = radiusAxis[radiusAxisIds[nextIndex]].scale(nextValue)!;
-        const nextAngle = rotationScale(rotationScale.domain()[nextIndex])!;
-        const [nx, ny] = instance.polar2svg(nextR, nextAngle);
-
-        retrunedValue.next = {
-          x: nx,
-          y: ny,
-          r: nextR,
-          angle: nextAngle,
-          value: nextValue,
-        };
-      }
-      return retrunedValue;
+      return returnedValue;
     }),
   };
 }


### PR DESCRIPTION
While working on the radar, I noticed

1. A typo (my bad)
2. The radar axis highlight is returning an array of objects with coordinates of the highlighted points, **and** the previous/next points. I remove this option

The previouse/next point was initially computed to enable the following shape: A slice of the radar (the green area).

The design solution got abandoned so this is just dead code

<img width="1784" height="1828" alt="image" src="https://github.com/user-attachments/assets/7f6e8d5a-7345-44b3-87db-cec21b5bd4f0" />
