### PR TITLE
[charts] Render drawing area rect in cartesian charts

### DIFF
--- a/docs/data/charts/styling/BackgroundStyling.js
+++ b/docs/data/charts/styling/BackgroundStyling.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+import { cartesianDrawingAreaClasses } from '@mui/x-charts/ChartsCartesianDrawingArea';
+
+const labels = ['Group A', 'Group B', 'Group C', 'Group D', 'Group E'];
+const lData = [42, 24, 56, 45, 3];
+const rData = [57, 7, 19, 16, 22];
+
+const settings = {
+  xAxis: [{ data: labels }],
+  series: [
+    { data: lData, label: 'A', id: 'l_id' },
+    { data: rData, label: 'B', id: 'r_id' },
+  ],
+  height: 300,
+};
+
+export default function BackgroundStyling() {
+  return (
+    <BarChart
+      {...settings}
+      sx={(theme) => ({
+        [`.${cartesianDrawingAreaClasses.root}`]: {
+          fill: theme.palette.mode === 'dark' ? '#294036' : '#D0F0C0',
+        },
+      })}
+    />
+  );
+}

--- a/docs/data/charts/styling/BackgroundStyling.tsx
+++ b/docs/data/charts/styling/BackgroundStyling.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { BarChart, BarChartProps } from '@mui/x-charts/BarChart';
+import { cartesianDrawingAreaClasses } from '@mui/x-charts/ChartsCartesianDrawingArea';
+
+const labels: string[] = ['Group A', 'Group B', 'Group C', 'Group D', 'Group E'];
+const lData: number[] = [42, 24, 56, 45, 3];
+const rData: number[] = [57, 7, 19, 16, 22];
+
+const settings = {
+  xAxis: [{ data: labels }],
+  series: [
+    { data: lData, label: 'A', id: 'l_id' },
+    { data: rData, label: 'B', id: 'r_id' },
+  ],
+  height: 300,
+} satisfies BarChartProps;
+
+export default function BackgroundStyling(): React.JSX.Element {
+  return (
+    <BarChart
+      {...settings}
+      sx={(theme) => ({
+        [`.${cartesianDrawingAreaClasses.root}`]: {
+          fill: theme.palette.mode === 'dark' ? '#294036' : '#D0F0C0',
+        },
+      })}
+    />
+  );
+}

--- a/docs/data/charts/styling/BackgroundStyling.tsx.preview
+++ b/docs/data/charts/styling/BackgroundStyling.tsx.preview
@@ -1,0 +1,8 @@
+<BarChart
+  {...settings}
+  sx={(theme) => ({
+    [`.${cartesianDrawingAreaClasses.root}`]: {
+      fill: theme.palette.mode === 'dark' ? '#294036' : '#D0F0C0',
+    },
+  })}
+/>

--- a/docs/data/charts/styling/styling.md
+++ b/docs/data/charts/styling/styling.md
@@ -170,6 +170,12 @@ From here, you can target any subcomponents with its class name.
 
 {{"demo": "SxStyling.js"}}
 
+### Drawing area background
+
+Bar, line and scatter charts render a drawing area `<rect />` that can be used to set a background color for the chart.
+
+{{"demo": "BackgroundStyling.js"}}
+
 ### Gradients and patterns
 
 It is possible to use gradients and patterns to fill the charts.

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.tsx
@@ -12,6 +12,7 @@ import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
 import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
 import { useBarChartProps, ChartsWrapper } from '@mui/x-charts/internals';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
+import { ChartsCartesianDrawingArea } from '@mui/x-charts/ChartsCartesianDrawingArea';
 import {
   ChartsToolbarProSlotProps,
   ChartsToolbarProSlots,
@@ -106,6 +107,7 @@ const BarChartPro = React.forwardRef(function BarChartPro(
         {showToolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsSurface {...chartsSurfaceProps}>
+          <ChartsCartesianDrawingArea />
           <ChartsGrid {...gridProps} />
           <g {...clipPathGroupProps}>
             <BarPlot {...barPlotProps} />

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.tsx
@@ -20,6 +20,7 @@ import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
 import { ChartsClipPath } from '@mui/x-charts/ChartsClipPath';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { useLineChartProps, ChartsWrapper } from '@mui/x-charts/internals';
+import { ChartsCartesianDrawingArea } from '@mui/x-charts/ChartsCartesianDrawingArea';
 import {
   ChartsToolbarProSlotProps,
   ChartsToolbarProSlots,
@@ -115,6 +116,7 @@ const LineChartPro = React.forwardRef(function LineChartPro(
         {showToolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsSurface {...chartsSurfaceProps}>
+          <ChartsCartesianDrawingArea />
           <ChartsGrid {...gridProps} />
           <g {...clipPathGroupProps}>
             <AreaPlot {...areaPlotProps} />

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -16,6 +16,7 @@ import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsAxisHighlight } from '@mui/x-charts/ChartsAxisHighlight';
 import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
 import { useScatterChartProps, ChartsWrapper } from '@mui/x-charts/internals';
+import { ChartsCartesianDrawingArea } from '@mui/x-charts/ChartsCartesianDrawingArea';
 import { ChartsSlotPropsPro, ChartsSlotsPro } from '../internals/material';
 import { ChartZoomSlider } from '../ChartZoomSlider';
 import { ChartsToolbarPro } from '../ChartsToolbarPro';
@@ -117,6 +118,7 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
         {showToolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsSurface {...chartsSurfaceProps}>
+          <ChartsCartesianDrawingArea />
           <ChartsAxis {...chartsAxisProps} />
           <ChartZoomSlider />
           <ChartsGrid {...gridProps} />

--- a/packages/x-charts/src/BarChart/BarChart.tsx
+++ b/packages/x-charts/src/BarChart/BarChart.tsx
@@ -28,6 +28,7 @@ import { ChartsSurface } from '../ChartsSurface';
 import { useChartContainerProps } from '../ChartContainer/useChartContainerProps';
 import { ChartsWrapper } from '../internals/components/ChartsWrapper';
 import { BarChartPluginsSignatures } from './BarChart.plugins';
+import { ChartsCartesianDrawingArea } from '../ChartsCartesianDrawingArea/ChartsCartesianDrawingArea';
 
 export interface BarChartSlots
   extends ChartsAxisSlots,
@@ -140,6 +141,7 @@ const BarChart = React.forwardRef(function BarChart(
         {props.showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsSurface {...chartsSurfaceProps}>
+          <ChartsCartesianDrawingArea />
           <ChartsGrid {...gridProps} />
           <g {...clipPathGroupProps}>
             <BarPlot {...barPlotProps} />

--- a/packages/x-charts/src/ChartsCartesianDrawingArea/ChartsCartesianDrawingArea.tsx
+++ b/packages/x-charts/src/ChartsCartesianDrawingArea/ChartsCartesianDrawingArea.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useDrawingArea } from '../hooks';
+import { useUtilityClasses } from './cartesianDrawingAreaClasses';
+
+export function ChartsCartesianDrawingArea() {
+  const { left, top, width, height } = useDrawingArea();
+  const classes = useUtilityClasses();
+
+  return (
+    <rect className={classes.root} fill="none" x={left} y={top} width={width} height={height} />
+  );
+}

--- a/packages/x-charts/src/ChartsCartesianDrawingArea/cartesianDrawingAreaClasses.ts
+++ b/packages/x-charts/src/ChartsCartesianDrawingArea/cartesianDrawingAreaClasses.ts
@@ -1,0 +1,26 @@
+import composeClasses from '@mui/utils/composeClasses';
+
+export interface CartesianDrawingAreaClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type CartesianDrawingAreaClassKey = keyof CartesianDrawingAreaClasses;
+
+export function getCartesianDrawingAreaUtilityClass(slot: string): string {
+  return `MuiChartsCartesianDrawingArea-${slot}`;
+}
+
+export const cartesianDrawingAreaClasses: CartesianDrawingAreaClasses = {
+  root: getCartesianDrawingAreaUtilityClass('root'),
+};
+
+export const useUtilityClasses = (
+  classes?: Partial<CartesianDrawingAreaClasses>,
+): CartesianDrawingAreaClasses => {
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getCartesianDrawingAreaUtilityClass, classes);
+};

--- a/packages/x-charts/src/ChartsCartesianDrawingArea/index.ts
+++ b/packages/x-charts/src/ChartsCartesianDrawingArea/index.ts
@@ -1,0 +1,6 @@
+export * from './ChartsCartesianDrawingArea';
+export {
+  cartesianDrawingAreaClasses,
+  type CartesianDrawingAreaClasses,
+  type CartesianDrawingAreaClassKey,
+} from './cartesianDrawingAreaClasses';

--- a/packages/x-charts/src/LineChart/LineChart.tsx
+++ b/packages/x-charts/src/LineChart/LineChart.tsx
@@ -35,6 +35,7 @@ import { ChartsSurface } from '../ChartsSurface';
 import { ChartsWrapper } from '../internals/components/ChartsWrapper';
 import { LineChartPluginsSignatures } from './LineChart.plugins';
 import { ChartsToolbarSlots, ChartsToolbarSlotProps } from '../Toolbar';
+import { ChartsCartesianDrawingArea } from '../ChartsCartesianDrawingArea/ChartsCartesianDrawingArea';
 
 export interface LineChartSlots
   extends ChartsAxisSlots,
@@ -168,6 +169,7 @@ const LineChart = React.forwardRef(function LineChart(
         {props.showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsSurface {...chartsSurfaceProps}>
+          <ChartsCartesianDrawingArea />
           <ChartsGrid {...gridProps} />
           <g {...clipPathGroupProps}>
             <AreaPlot {...areaPlotProps} />

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -33,6 +33,7 @@ import { ChartsSurface } from '../ChartsSurface';
 import { ChartsWrapper } from '../internals/components/ChartsWrapper';
 import { UseChartVoronoiSignature } from '../internals/plugins/featurePlugins/useChartVoronoi';
 import { ScatterChartPluginsSignatures } from './ScatterChart.plugins';
+import { ChartsCartesianDrawingArea } from '../ChartsCartesianDrawingArea/ChartsCartesianDrawingArea';
 
 export interface ScatterChartSlots
   extends ChartsAxisSlots,
@@ -150,6 +151,7 @@ const ScatterChart = React.forwardRef(function ScatterChart(
         {props.showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!props.hideLegend && <ChartsLegend {...legendProps} />}
         <ChartsSurface {...chartsSurfaceProps}>
+          <ChartsCartesianDrawingArea />
           <ChartsAxis {...chartsAxisProps} />
           <ChartsGrid {...gridProps} />
           <g data-drawing-container>

--- a/packages/x-charts/src/index.ts
+++ b/packages/x-charts/src/index.ts
@@ -15,6 +15,7 @@ export * from './ChartsLabel';
 export * from './ChartsLegend';
 export * from './ChartsLocalizationProvider';
 export * from './ChartsAxisHighlight';
+export * from './ChartsCartesianDrawingArea';
 export * from './BarChart';
 export * from './LineChart';
 export * from './PieChart';


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18754.

Adds a `<rect/>` with the size of the drawing area rect for bar, line and scatter charts.


https://github.com/user-attachments/assets/e08a0d12-8719-49d3-8ee8-f4a4ac73ec85

