### PR TITLE
[x-telemetry] Avoid global CJS require

### DIFF
--- a/packages/x-telemetry/src/runtime/config.import-meta.ts
+++ b/packages/x-telemetry/src/runtime/config.import-meta.ts
@@ -1,3 +1,0 @@
-const importMetaEnv: Record<string, string> | undefined = import.meta.env;
-
-export { importMetaEnv };

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -10,7 +10,7 @@ declare namespace globalThis {
 }
 
 interface LocalImportMetaEnv {
-  [key: string]: any;
+  [key: string]: string;
 }
 
 interface LocalImportMeta {

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'module';
+
 interface TelemetryEnvConfig {
   NODE_ENV: string | '<unknown>';
   IS_COLLECTING: boolean | undefined;
@@ -66,7 +68,7 @@ function getIsTelemetryCollecting(): boolean | undefined {
 
   try {
     // e.g. Vite.js
-    // eslint-disable-next-line global-require
+    const require = createRequire(import.meta.url);
     const { importMetaEnv } = require('./config.import-meta');
     if (importMetaEnv) {
       const result = getBooleanEnvFromEnvObject('MUI_X_TELEMETRY_DISABLED', importMetaEnv);
@@ -131,7 +133,7 @@ function getIsDebugModeEnabled(): boolean {
 
   try {
     // e.g. Vite.js
-    // eslint-disable-next-line global-require
+    const require = createRequire(import.meta.url);
     const { importMetaEnv } = require('./config.import-meta');
     if (importMetaEnv) {
       const result = getBooleanEnvFromEnvObject('MUI_X_TELEMETRY_DEBUG', importMetaEnv);

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -14,7 +14,7 @@ interface LocalImportMetaEnv {
 }
 
 interface LocalImportMeta {
-  env: LocalImportMetaEnv;
+  env?: LocalImportMetaEnv;
 }
 
 const envEnabledValues = ['1', 'true', 'yes', 'y'];

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -1,5 +1,3 @@
-import { createRequire } from 'module';
-
 interface TelemetryEnvConfig {
   NODE_ENV: string | '<unknown>';
   IS_COLLECTING: boolean | undefined;
@@ -43,7 +41,7 @@ function getBooleanEnvFromEnvObject(envKey: string, envObj: Record<string, any>)
   return undefined;
 }
 
-function getIsTelemetryCollecting(): boolean | undefined {
+function getIsTelemetryCollecting() {
   // Check global variable
   // eslint-disable-next-line no-underscore-dangle
   const globalValue = globalThis.__MUI_X_TELEMETRY_DISABLED__;
@@ -68,8 +66,7 @@ function getIsTelemetryCollecting(): boolean | undefined {
 
   try {
     // e.g. Vite.js
-    const require = createRequire(import.meta.url);
-    const { importMetaEnv } = require('./config.import-meta');
+    const importMetaEnv = import.meta.env;
     if (importMetaEnv) {
       const result = getBooleanEnvFromEnvObject('MUI_X_TELEMETRY_DISABLED', importMetaEnv);
       if (typeof result === 'boolean') {
@@ -104,7 +101,7 @@ function getIsTelemetryCollecting(): boolean | undefined {
   return undefined;
 }
 
-function getIsDebugModeEnabled(): boolean {
+function getIsDebugModeEnabled() {
   try {
     // Check global variable
     // eslint-disable-next-line no-underscore-dangle
@@ -133,8 +130,7 @@ function getIsDebugModeEnabled(): boolean {
 
   try {
     // e.g. Vite.js
-    const require = createRequire(import.meta.url);
-    const { importMetaEnv } = require('./config.import-meta');
+    const importMetaEnv = import.meta.env;
     if (importMetaEnv) {
       const result = getBooleanEnvFromEnvObject('MUI_X_TELEMETRY_DEBUG', importMetaEnv);
       if (typeof result === 'boolean') {
@@ -174,7 +170,7 @@ function getNodeEnv(): string {
 
 let cachedEnv: TelemetryEnvConfig | null = null;
 
-export function getTelemetryEnvConfig(skipCache: boolean = false): TelemetryEnvConfig {
+export function getTelemetryEnvConfig(skipCache: boolean = false) {
   if (skipCache || !cachedEnv) {
     cachedEnv = {
       NODE_ENV: getNodeEnv(),

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -9,6 +9,14 @@ declare namespace globalThis {
   let __MUI_X_TELEMETRY_DISABLED__: boolean | undefined;
 }
 
+interface LocalImportMetaEnv {
+  [key: string]: any;
+}
+
+interface LocalImportMeta {
+  env: LocalImportMetaEnv;
+}
+
 const envEnabledValues = ['1', 'true', 'yes', 'y'];
 const envDisabledValues = ['0', 'false', 'no', 'n'];
 
@@ -66,7 +74,7 @@ function getIsTelemetryCollecting() {
 
   try {
     // e.g. Vite.js
-    const importMetaEnv = import.meta.env;
+    const importMetaEnv = (import.meta as unknown as LocalImportMeta).env;
     if (importMetaEnv) {
       const result = getBooleanEnvFromEnvObject('MUI_X_TELEMETRY_DISABLED', importMetaEnv);
       if (typeof result === 'boolean') {
@@ -130,7 +138,7 @@ function getIsDebugModeEnabled() {
 
   try {
     // e.g. Vite.js
-    const importMetaEnv = import.meta.env;
+    const importMetaEnv = (import.meta as unknown as LocalImportMeta).env;
     if (importMetaEnv) {
       const result = getBooleanEnvFromEnvObject('MUI_X_TELEMETRY_DEBUG', importMetaEnv);
       if (typeof result === 'boolean') {


### PR DESCRIPTION
Fix https://github.com/mui/mui-x/issues/18558.
~Try this idea: https://stackoverflow.com/a/74370910.~
Scratch this.☝️`module` is Node API, we need this to work on the browser.
___
What was the reason for externalizing `import.meta.env` into a separate file?
Was it for avoiding TS issues in our repo as well as the end user end?
Maybe a "faked" local type hack would be sufficient to circumvent it? 🤔 