### PR TITLE
[code-infra] Fix renovate PR titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":semanticCommitsDisabled"],
   "automerge": false,
   "commitMessageAction": "Bump",
   "commitMessageExtra": "to {{newValue}}",


### PR DESCRIPTION
The PR titles are wrong: 

<img width="647" height="341" alt="SCR-20250713-opac" src="https://github.com/user-attachments/assets/cafdc483-acc2-41c4-bb6b-2e65a483e106" />

[Screenshot source](https://github.com/mui/mui-x/pulls?q=is%3Apr+label%3Adependencies+is%3Aclosed). Details in https://github.com/renovatebot/renovate/discussions/36568.

It's annoying, I initially noticed it in https://github.com/mui/mui-x/releases/tag/v8.5.1 because the changelog would list those PR (fix since by using GitHub Labels, rather than title). It's also annoying because it would get in the way of https://github.com/mui/mui-public/issues/239.

---

If it works, we should deploy this everywhere, like we have already in the Toolpad repository.