### PR TITLE
[pickers] Fix digital clock column width CSS

### DIFF
--- a/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
+++ b/packages/x-date-pickers/src/MultiSectionDigitalClock/MultiSectionDigitalClockSection.tsx
@@ -65,7 +65,8 @@ const MultiSectionDigitalClockSectionRoot = styled(MenuList, {
   slot: 'Root',
 })<{ ownerState: MultiSectionDigitalClockSectionOwnerState }>(({ theme }) => ({
   maxHeight: DIGITAL_CLOCK_VIEW_HEIGHT,
-  width: 56,
+  minWidth: 56,
+  flexGrow: 1,
   padding: 0,
   overflow: 'hidden',
   scrollbarWidth: 'thin',
@@ -107,7 +108,7 @@ const MultiSectionDigitalClockSectionItem = styled(MenuItem, {
 })(({ theme }) => ({
   padding: 8,
   margin: '2px 4px',
-  width: MULTI_SECTION_CLOCK_SECTION_WIDTH,
+  minWidth: MULTI_SECTION_CLOCK_SECTION_WIDTH,
   justifyContent: 'center',
   '&:first-of-type': {
     marginTop: 4,

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -79,7 +79,7 @@ export const PickersLayoutContentWrapper = styled('div', {
   name: 'MuiPickersLayout',
   slot: 'ContentWrapper',
 })<{ ownerState: PickerLayoutOwnerState }>({
-  gridColumn: '1 / 4',
+  gridColumn: '2 / 4',
   gridRow: 2,
   display: 'flex',
   flexDirection: 'column',

--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -32,7 +32,7 @@ export const PickersLayoutRoot = styled('div', {
   slot: 'Root',
 })<{ ownerState: PickerLayoutOwnerState }>({
   display: 'grid',
-  gridAutoColumns: 'max-content auto max-content',
+  gridAutoColumns: 'max-content 1fr max-content',
   gridAutoRows: 'max-content auto max-content',
   [`& .${pickersLayoutClasses.actionBar}`]: { gridColumn: '1 / 4', gridRow: 3 },
   variants: [
@@ -79,7 +79,7 @@ export const PickersLayoutContentWrapper = styled('div', {
   name: 'MuiPickersLayout',
   slot: 'ContentWrapper',
 })<{ ownerState: PickerLayoutOwnerState }>({
-  gridColumn: '2 / 4',
+  gridColumn: '1 / 4',
   gridRow: 2,
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/mui-x/issues/18818


Before:
<img width="374" height="801" alt="image" src="https://github.com/user-attachments/assets/4b41d846-630c-41de-b9fe-9e20c4d49684" />


After:
<img width="373" height="667" alt="image" src="https://github.com/user-attachments/assets/b14e19d8-2a9a-4a7b-8bbe-7eb6169fde4e" />

