### PR TITLE
[charts] Fix crash when rendering large scatter dataset

### DIFF
--- a/packages/x-charts/src/BarChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/extremums.ts
@@ -16,9 +16,21 @@ const getBaseExtremum: CartesianExtremumGetter<'bar'> = (params) => {
   });
 
   const data = filter ? axis.data?.filter((_, i) => filter({ x: null, y: null }, i)) : axis.data;
-  const minX = Math.min(...(data ?? []));
-  const maxX = Math.max(...(data ?? []));
-  return [minX, maxX];
+
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const value of data ?? []) {
+    if (value < min) {
+      min = value;
+    }
+
+    if (value > max) {
+      max = value;
+    }
+  }
+
+  return [min, max];
 };
 
 const getValueExtremum =

--- a/packages/x-charts/src/BarChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/extremums.ts
@@ -1,4 +1,5 @@
 import { CartesianExtremumGetter } from '../../internals/plugins/models/seriesConfig';
+import { findMinMax } from '../../internals/findMinMax';
 
 const createResult = (data: any, direction: 'x' | 'y') => {
   if (direction === 'x') {
@@ -17,20 +18,7 @@ const getBaseExtremum: CartesianExtremumGetter<'bar'> = (params) => {
 
   const data = filter ? axis.data?.filter((_, i) => filter({ x: null, y: null }, i)) : axis.data;
 
-  let min = Infinity;
-  let max = -Infinity;
-
-  for (const value of data ?? []) {
-    if (value < min) {
-      min = value;
-    }
-
-    if (value > max) {
-      max = value;
-    }
-  }
-
-  return [min, max];
+  return findMinMax(data ?? []);
 };
 
 const getValueExtremum =

--- a/packages/x-charts/src/LineChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/extremums.ts
@@ -6,9 +6,20 @@ import {
 export const getExtremumX: CartesianExtremumGetter<'line'> = (params) => {
   const { axis } = params;
 
-  const minX = Math.min(...(axis.data ?? []));
-  const maxX = Math.max(...(axis.data ?? []));
-  return [minX, maxX];
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const value of axis.data ?? []) {
+    if (value < min) {
+      min = value;
+    }
+
+    if (value > max) {
+      max = value;
+    }
+  }
+
+  return [min, max];
 };
 
 type GetValues = (d: [number, number]) => [number, number];

--- a/packages/x-charts/src/LineChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/extremums.ts
@@ -2,24 +2,12 @@ import {
   CartesianExtremumFilter,
   CartesianExtremumGetter,
 } from '../../internals/plugins/models/seriesConfig';
+import { findMinMax } from '../../internals/findMinMax';
 
 export const getExtremumX: CartesianExtremumGetter<'line'> = (params) => {
   const { axis } = params;
 
-  let min = Infinity;
-  let max = -Infinity;
-
-  for (const value of axis.data ?? []) {
-    if (value < min) {
-      min = value;
-    }
-
-    if (value > max) {
-      max = value;
-    }
-  }
-
-  return [min, max];
+  return findMinMax(axis.data ?? []);
 };
 
 type GetValues = (d: [number, number]) => [number, number];

--- a/packages/x-charts/src/ScatterChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/extremums.ts
@@ -16,63 +16,91 @@ const mergeMinMax = (
 export const getExtremumX: CartesianExtremumGetter<'scatter'> = (params) => {
   const { series, axis, isDefaultAxis, getFilters } = params;
 
-  return Object.keys(series)
-    .filter((seriesId) => {
-      const axisId = series[seriesId].xAxisId;
-      return axisId === axis.id || (axisId === undefined && isDefaultAxis);
-    })
-    .reduce(
-      (acc, seriesId) => {
-        const filter = getFilters?.({
-          currentAxisId: axis.id,
-          isDefaultAxis,
-          seriesXAxisId: series[seriesId].xAxisId,
-          seriesYAxisId: series[seriesId].yAxisId,
-        });
+  let min = Infinity;
+  let max = -Infinity;
 
-        const seriesMinMax = series[seriesId].data?.reduce<CartesianExtremumGetterResult>(
-          (accSeries, d, dataIndex) => {
-            if (filter && !filter(d, dataIndex)) {
-              return accSeries;
-            }
-            return mergeMinMax(accSeries, [d.x, d.x]);
-          },
-          [Infinity, -Infinity],
-        );
-        return mergeMinMax(acc, seriesMinMax ?? [Infinity, -Infinity]);
-      },
-      [Infinity, -Infinity],
-    );
+  for (const seriesId in series) {
+    if (!Object.prototype.hasOwnProperty.call(series, seriesId)) {
+      continue;
+    }
+
+    const axisId = series[seriesId].xAxisId;
+    if (!(axisId === axis.id || (axisId === undefined && isDefaultAxis))) {
+      continue;
+    }
+
+    const filter = getFilters?.({
+      currentAxisId: axis.id,
+      isDefaultAxis,
+      seriesXAxisId: series[seriesId].xAxisId,
+      seriesYAxisId: series[seriesId].yAxisId,
+    });
+
+    const seriesData = series[seriesId].data ?? [];
+
+    for (let i = 0; i < seriesData.length; i += 1) {
+      const d = seriesData[i];
+
+      if (filter && !filter(d, i)) {
+        continue;
+      }
+
+      if (d.x !== null) {
+        if (d.x < min) {
+          min = d.x;
+        }
+        if (d.x > max) {
+          max = d.x;
+        }
+      }
+    }
+  }
+
+  return [min, max];
 };
 
 export const getExtremumY: CartesianExtremumGetter<'scatter'> = (params) => {
   const { series, axis, isDefaultAxis, getFilters } = params;
 
-  return Object.keys(series)
-    .filter((seriesId) => {
-      const axisId = series[seriesId].yAxisId;
-      return axisId === axis.id || (axisId === undefined && isDefaultAxis);
-    })
-    .reduce(
-      (acc, seriesId) => {
-        const filter = getFilters?.({
-          currentAxisId: axis.id,
-          isDefaultAxis,
-          seriesXAxisId: series[seriesId].xAxisId,
-          seriesYAxisId: series[seriesId].yAxisId,
-        });
+  let min = Infinity;
+  let max = -Infinity;
 
-        const seriesMinMax = series[seriesId].data?.reduce<CartesianExtremumGetterResult>(
-          (accSeries, d, dataIndex) => {
-            if (filter && !filter(d, dataIndex)) {
-              return accSeries;
-            }
-            return mergeMinMax(accSeries, [d.y, d.y]);
-          },
-          [Infinity, -Infinity],
-        );
-        return mergeMinMax(acc, seriesMinMax ?? [Infinity, -Infinity]);
-      },
-      [Infinity, -Infinity],
-    );
+  for (const seriesId in series) {
+    if (!Object.prototype.hasOwnProperty.call(series, seriesId)) {
+      continue;
+    }
+
+    const axisId = series[seriesId].yAxisId;
+    if (!(axisId === axis.id || (axisId === undefined && isDefaultAxis))) {
+      continue;
+    }
+
+    const filter = getFilters?.({
+      currentAxisId: axis.id,
+      isDefaultAxis,
+      seriesXAxisId: series[seriesId].xAxisId,
+      seriesYAxisId: series[seriesId].yAxisId,
+    });
+
+    const seriesData = series[seriesId].data ?? [];
+
+    for (let i = 0; i < seriesData.length; i += 1) {
+      const d = seriesData[i];
+
+      if (filter && !filter(d, i)) {
+        continue;
+      }
+
+      if (d.y !== null) {
+        if (d.y < min) {
+          min = d.y;
+        }
+        if (d.y > max) {
+          max = d.y;
+        }
+      }
+    }
+  }
+
+  return [min, max];
 };

--- a/packages/x-charts/src/ScatterChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/extremums.ts
@@ -1,17 +1,4 @@
-import {
-  CartesianExtremumGetter,
-  CartesianExtremumGetterResult,
-} from '../../internals/plugins/models/seriesConfig';
-
-const mergeMinMax = (
-  acc: CartesianExtremumGetterResult,
-  val: CartesianExtremumGetterResult,
-): CartesianExtremumGetterResult => {
-  return [
-    val[0] === null ? acc[0] : Math.min(acc[0], val[0]),
-    val[1] === null ? acc[1] : Math.max(acc[1], val[1]),
-  ];
-};
+import { CartesianExtremumGetter } from '../../internals/plugins/models/seriesConfig';
 
 export const getExtremumX: CartesianExtremumGetter<'scatter'> = (params) => {
   const { series, axis, isDefaultAxis, getFilters } = params;

--- a/packages/x-charts/src/ScatterChart/seriesConfig/extremums.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/extremums.ts
@@ -7,7 +7,7 @@ export const getExtremumX: CartesianExtremumGetter<'scatter'> = (params) => {
   let max = -Infinity;
 
   for (const seriesId in series) {
-    if (!Object.prototype.hasOwnProperty.call(series, seriesId)) {
+    if (!Object.hasOwn(series, seriesId)) {
       continue;
     }
 
@@ -53,7 +53,7 @@ export const getExtremumY: CartesianExtremumGetter<'scatter'> = (params) => {
   let max = -Infinity;
 
   for (const seriesId in series) {
-    if (!Object.prototype.hasOwnProperty.call(series, seriesId)) {
+    if (!Object.hasOwn(series, seriesId)) {
       continue;
     }
 

--- a/packages/x-charts/src/internals/findMinMax.test.ts
+++ b/packages/x-charts/src/internals/findMinMax.test.ts
@@ -1,0 +1,32 @@
+import { findMinMax } from './findMinMax';
+
+describe('findMinMax', () => {
+  it('should find min and max in a simple array', () => {
+    expect(findMinMax([1, 2, 3, 4, 5])).to.deep.equal([1, 5]);
+  });
+
+  it('should handle negative numbers', () => {
+    expect(findMinMax([-5, -2, 0, 3, 8])).to.deep.equal([-5, 8]);
+  });
+
+  it('should handle array with same numbers', () => {
+    expect(findMinMax([2, 2, 2, 2])).to.deep.equal([2, 2]);
+  });
+
+  it('should handle single element array', () => {
+    expect(findMinMax([1])).to.deep.equal([1, 1]);
+  });
+
+  it('should handle empty array', () => {
+    expect(findMinMax([])).to.deep.equal([Infinity, -Infinity]);
+  });
+
+  it('should handle decimal numbers', () => {
+    expect(findMinMax([1.5, 2.7, -3.2, 0.1])).to.deep.equal([-3.2, 2.7]);
+  });
+
+  it('should handle one million elements', () => {
+    const largeArray = Array.from({ length: 1_000_000 }, (_, i) => i - 5000); // [-500, -499, ..., 499]
+    expect(findMinMax(largeArray)).to.deep.equal([-5000, 994999]);
+  });
+});

--- a/packages/x-charts/src/internals/findMinMax.ts
+++ b/packages/x-charts/src/internals/findMinMax.ts
@@ -1,0 +1,16 @@
+export function findMinMax(data: readonly number[]): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const value of data ?? []) {
+    if (value < min) {
+      min = value;
+    }
+
+    if (value > max) {
+      max = value;
+    }
+  }
+
+  return [min, max];
+}

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -65,6 +65,7 @@ export * from './ticks';
 export * from './dateHelpers';
 export * from './invertScale';
 export * from './isBandScale';
+export * from './findMinMax';
 
 // contexts
 export { getAxisExtremum } from './plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum';

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum.ts
@@ -46,14 +46,9 @@ export const getAxisExtremum = <T extends CartesianChartSeriesType>(
   formattedSeries: ProcessedSeries<T>,
   getFilters?: GetZoomAxisFilters,
 ) => {
-  const seriesTypes: T[] = [];
-  for (const seriesType in seriesConfig) {
-    if (isCartesianSeriesType(seriesType) && seriesType in formattedSeries) {
-      seriesTypes.push(seriesType);
-    }
-  }
+  const charTypes = Object.keys(seriesConfig).filter(isCartesianSeriesType);
 
-  const extremums = seriesTypes.reduce<CartesianExtremumGetterResult>(
+  const extremums = charTypes.reduce<CartesianExtremumGetterResult>(
     (acc, charType) =>
       axisExtremumCallback(
         acc,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum.ts
@@ -46,7 +46,9 @@ export const getAxisExtremum = <T extends CartesianChartSeriesType>(
   formattedSeries: ProcessedSeries<T>,
   getFilters?: GetZoomAxisFilters,
 ) => {
-  const charTypes = Object.keys(seriesConfig).filter(isCartesianSeriesType);
+  const charTypes = Object.keys(seriesConfig)
+    .filter(isCartesianSeriesType)
+    .filter((t) => Object.keys(formattedSeries).includes(t));
 
   const extremums = charTypes.reduce<CartesianExtremumGetterResult>(
     (acc, charType) =>

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum.ts
@@ -46,11 +46,14 @@ export const getAxisExtremum = <T extends CartesianChartSeriesType>(
   formattedSeries: ProcessedSeries<T>,
   getFilters?: GetZoomAxisFilters,
 ) => {
-  const charTypes = Object.keys(seriesConfig)
-    .filter(isCartesianSeriesType)
-    .filter((t) => Object.keys(formattedSeries).includes(t));
+  const seriesTypes: T[] = [];
+  for (const seriesType in seriesConfig) {
+    if (isCartesianSeriesType(seriesType) && seriesType in formattedSeries) {
+      seriesTypes.push(seriesType);
+    }
+  }
 
-  const extremums = charTypes.reduce<CartesianExtremumGetterResult>(
+  const extremums = seriesTypes.reduce<CartesianExtremumGetterResult>(
     (acc, charType) =>
       axisExtremumCallback(
         acc,


### PR DESCRIPTION
Part of https://github.com/mui/mui-x/issues/12960.

Fix an issue where scatter charts with 1 million data points would crash with "Maximum call stack size exceeded". 
