### PR TITLE
[pickers] Ensure `slots` and `slotProps` are propagated to internal component

### DIFF
--- a/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateRangeField/SingleInputDateRangeField.tsx
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types';
 import { useThemeProps } from '@mui/material/styles';
 import refType from '@mui/utils/refType';
 import { DateRangeIcon } from '@mui/x-date-pickers/icons';
-import { PickerFieldUI, useFieldTextFieldProps } from '@mui/x-date-pickers/internals';
+import {
+  PickerFieldUI,
+  PickerFieldUIContextProvider,
+  useFieldTextFieldProps,
+} from '@mui/x-date-pickers/internals';
 import { SingleInputDateRangeFieldProps } from './SingleInputDateRangeField.types';
 import { useSingleInputDateRangeField } from './useSingleInputDateRangeField';
 import { FieldType } from '../models';
@@ -51,12 +55,9 @@ const SingleInputDateRangeField = React.forwardRef(function SingleInputDateRange
   >(textFieldProps);
 
   return (
-    <PickerFieldUI
-      slots={slots}
-      slotProps={slotProps}
-      fieldResponse={fieldResponse}
-      defaultOpenPickerIcon={DateRangeIcon}
-    />
+    <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={other.inputRef}>
+      <PickerFieldUI fieldResponse={fieldResponse} defaultOpenPickerIcon={DateRangeIcon} />
+    </PickerFieldUIContextProvider>
   );
 }) as DateRangeFieldComponent;
 

--- a/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputDateTimeRangeField/SingleInputDateTimeRangeField.tsx
@@ -2,7 +2,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { DateRangeIcon } from '@mui/x-date-pickers/icons';
-import { PickerFieldUI, useFieldTextFieldProps } from '@mui/x-date-pickers/internals';
+import {
+  PickerFieldUI,
+  PickerFieldUIContextProvider,
+  useFieldTextFieldProps,
+} from '@mui/x-date-pickers/internals';
 import { useThemeProps } from '@mui/material/styles';
 import refType from '@mui/utils/refType';
 import { SingleInputDateTimeRangeFieldProps } from './SingleInputDateTimeRangeField.types';
@@ -51,12 +55,9 @@ const SingleInputDateTimeRangeField = React.forwardRef(function SingleInputDateT
   >(textFieldProps);
 
   return (
-    <PickerFieldUI
-      slots={slots}
-      slotProps={slotProps}
-      fieldResponse={fieldResponse}
-      defaultOpenPickerIcon={DateRangeIcon}
-    />
+    <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={other.inputRef}>
+      <PickerFieldUI fieldResponse={fieldResponse} defaultOpenPickerIcon={DateRangeIcon} />
+    </PickerFieldUIContextProvider>
   );
 }) as DateRangeFieldComponent;
 

--- a/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
+++ b/packages/x-date-pickers-pro/src/SingleInputTimeRangeField/SingleInputTimeRangeField.tsx
@@ -2,7 +2,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { ClockIcon } from '@mui/x-date-pickers/icons';
-import { PickerFieldUI, useFieldTextFieldProps } from '@mui/x-date-pickers/internals';
+import {
+  PickerFieldUI,
+  PickerFieldUIContextProvider,
+  useFieldTextFieldProps,
+} from '@mui/x-date-pickers/internals';
 import { useThemeProps } from '@mui/material/styles';
 import refType from '@mui/utils/refType';
 import { SingleInputTimeRangeFieldProps } from './SingleInputTimeRangeField.types';
@@ -51,12 +55,9 @@ const SingleInputTimeRangeField = React.forwardRef(function SingleInputTimeRange
   >(textFieldProps);
 
   return (
-    <PickerFieldUI
-      slots={slots}
-      slotProps={slotProps}
-      fieldResponse={fieldResponse}
-      defaultOpenPickerIcon={ClockIcon}
-    />
+    <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={other.inputRef}>
+      <PickerFieldUI fieldResponse={fieldResponse} defaultOpenPickerIcon={ClockIcon} />
+    </PickerFieldUIContextProvider>
   );
 }) as DateRangeFieldComponent;
 

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -9,7 +9,6 @@ import {
   DateOrTimeViewWithMeridiem,
   PickerProvider,
   PickerRangeValue,
-  PickerFieldUIContextProvider,
 } from '@mui/x-date-pickers/internals';
 import {
   UseDesktopRangePickerParams,
@@ -39,7 +38,8 @@ export const useDesktopRangePicker = <
   const { slots, slotProps, inputRef, localeText } = props;
 
   const fieldType = getRangeFieldType(slots.field);
-  const viewContainerRole = fieldType === 'single-input' ? 'dialog' : 'tooltip';
+  const isSingleInput = fieldType === 'single-input';
+  const viewContainerRole = isSingleInput ? 'dialog' : 'tooltip';
   const rangePositionResponse = useRangePosition(props);
 
   const getStepNavigation = createRangePickerStepNavigation({
@@ -81,16 +81,21 @@ export const useDesktopRangePicker = <
 
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
-      <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={inputRef}>
-        <PickerRangePositionContext.Provider value={rangePositionResponse}>
-          <Field {...fieldProps} />
-          <PickerPopper slots={slots} slotProps={slotProps}>
-            <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
-              {renderCurrentView()}
-            </Layout>
-          </PickerPopper>
-        </PickerRangePositionContext.Provider>
-      </PickerFieldUIContextProvider>
+      <PickerRangePositionContext.Provider value={rangePositionResponse}>
+        <Field
+          slots={slots}
+          slotProps={slotProps}
+          {...(isSingleInput && {
+            inputRef,
+          })}
+          {...fieldProps}
+        />
+        <PickerPopper slots={slots} slotProps={slotProps}>
+          <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
+            {renderCurrentView()}
+          </Layout>
+        </PickerPopper>
+      </PickerRangePositionContext.Provider>
     </PickerProvider>
   );
 

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -11,7 +11,6 @@ import {
   DateOrTimeViewWithMeridiem,
   PickerProvider,
   PickerRangeValue,
-  PickerFieldUIContextProvider,
 } from '@mui/x-date-pickers/internals';
 import { usePickerTranslations } from '@mui/x-date-pickers/hooks';
 import { FieldOwnerState } from '@mui/x-date-pickers/models';
@@ -43,6 +42,7 @@ export const useMobileRangePicker = <
   const { slots, slotProps: innerSlotProps, label, inputRef, localeText } = props;
 
   const fieldType = getRangeFieldType(slots.field);
+  const isSingleInput = fieldType === 'single-input';
   const rangePositionResponse = useRangePosition(props);
   const contextTranslations = usePickerTranslations();
 
@@ -76,7 +76,7 @@ export const useMobileRangePicker = <
     elementType: Field,
     externalSlotProps: innerSlotProps?.field,
     additionalProps: {
-      ...(fieldType === 'single-input' &&
+      ...(isSingleInput &&
         isToolbarHidden && {
           id: labelId,
         }),
@@ -131,16 +131,21 @@ export const useMobileRangePicker = <
 
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
-      <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={inputRef}>
-        <PickerRangePositionContext.Provider value={rangePositionResponse}>
-          <Field {...fieldProps} />
-          <PickersModalDialog slots={slots} slotProps={slotProps}>
-            <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
-              {renderCurrentView()}
-            </Layout>
-          </PickersModalDialog>
-        </PickerRangePositionContext.Provider>
-      </PickerFieldUIContextProvider>
+      <PickerRangePositionContext.Provider value={rangePositionResponse}>
+        <Field
+          slots={slots}
+          slotProps={slotProps}
+          {...(isSingleInput && {
+            inputRef,
+          })}
+          {...fieldProps}
+        />
+        <PickersModalDialog slots={slots} slotProps={slotProps}>
+          <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
+            {renderCurrentView()}
+          </Layout>
+        </PickersModalDialog>
+      </PickerRangePositionContext.Provider>
     </PickerProvider>
   );
 

--- a/packages/x-date-pickers/src/DateField/DateField.tsx
+++ b/packages/x-date-pickers/src/DateField/DateField.tsx
@@ -5,7 +5,11 @@ import { useThemeProps } from '@mui/material/styles';
 import refType from '@mui/utils/refType';
 import { DateFieldProps } from './DateField.types';
 import { useDateField } from './useDateField';
-import { PickerFieldUI, useFieldTextFieldProps } from '../internals/components/PickerFieldUI';
+import {
+  PickerFieldUI,
+  PickerFieldUIContextProvider,
+  useFieldTextFieldProps,
+} from '../internals/components/PickerFieldUI';
 import { CalendarIcon } from '../icons';
 
 type DateFieldComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
@@ -45,12 +49,9 @@ const DateField = React.forwardRef(function DateField<
   );
 
   return (
-    <PickerFieldUI
-      slots={slots}
-      slotProps={slotProps}
-      fieldResponse={fieldResponse}
-      defaultOpenPickerIcon={CalendarIcon}
-    />
+    <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={other.inputRef}>
+      <PickerFieldUI fieldResponse={fieldResponse} defaultOpenPickerIcon={CalendarIcon} />
+    </PickerFieldUIContextProvider>
   );
 }) as DateFieldComponent;
 

--- a/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
+++ b/packages/x-date-pickers/src/DateTimeField/DateTimeField.tsx
@@ -5,7 +5,11 @@ import { useThemeProps } from '@mui/material/styles';
 import refType from '@mui/utils/refType';
 import { DateTimeFieldProps } from './DateTimeField.types';
 import { useDateTimeField } from './useDateTimeField';
-import { PickerFieldUI, useFieldTextFieldProps } from '../internals/components/PickerFieldUI';
+import {
+  PickerFieldUI,
+  PickerFieldUIContextProvider,
+  useFieldTextFieldProps,
+} from '../internals/components/PickerFieldUI';
 import { CalendarIcon } from '../icons';
 
 type DateTimeFieldComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
@@ -49,12 +53,9 @@ const DateTimeField = React.forwardRef(function DateTimeField<
   );
 
   return (
-    <PickerFieldUI
-      slots={slots}
-      slotProps={slotProps}
-      fieldResponse={fieldResponse}
-      defaultOpenPickerIcon={CalendarIcon}
-    />
+    <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={other.inputRef}>
+      <PickerFieldUI fieldResponse={fieldResponse} defaultOpenPickerIcon={CalendarIcon} />
+    </PickerFieldUIContextProvider>
   );
 }) as DateTimeFieldComponent;
 

--- a/packages/x-date-pickers/src/TimeField/TimeField.tsx
+++ b/packages/x-date-pickers/src/TimeField/TimeField.tsx
@@ -5,7 +5,11 @@ import { useThemeProps } from '@mui/material/styles';
 import refType from '@mui/utils/refType';
 import { TimeFieldProps } from './TimeField.types';
 import { useTimeField } from './useTimeField';
-import { PickerFieldUI, useFieldTextFieldProps } from '../internals/components/PickerFieldUI';
+import {
+  PickerFieldUI,
+  PickerFieldUIContextProvider,
+  useFieldTextFieldProps,
+} from '../internals/components/PickerFieldUI';
 import { ClockIcon } from '../icons';
 
 type TimeFieldComponent = (<TEnableAccessibleFieldDOMStructure extends boolean = true>(
@@ -45,12 +49,9 @@ const TimeField = React.forwardRef(function TimeField<
   );
 
   return (
-    <PickerFieldUI
-      slots={slots}
-      slotProps={slotProps}
-      fieldResponse={fieldResponse}
-      defaultOpenPickerIcon={ClockIcon}
-    />
+    <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={other.inputRef}>
+      <PickerFieldUI fieldResponse={fieldResponse} defaultOpenPickerIcon={ClockIcon} />
+    </PickerFieldUIContextProvider>
   );
 }) as TimeFieldComponent;
 

--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -98,7 +98,7 @@ export function PickerFieldUI<
   TEnableAccessibleFieldDOMStructure extends boolean,
   TProps extends UseFieldProps<TEnableAccessibleFieldDOMStructure>,
 >(props: PickerFieldUIProps<TEnableAccessibleFieldDOMStructure, TProps>) {
-  const { slots, slotProps, fieldResponse, defaultOpenPickerIcon } = props;
+  const { fieldResponse, defaultOpenPickerIcon } = props;
 
   const translations = usePickerTranslations();
   const pickerContext = useNullablePickerContext();
@@ -123,18 +123,13 @@ export function PickerFieldUI<
   const openPickerButtonPosition = triggerStatus !== 'hidden' ? openPickerButtonPositionProp : null;
 
   const TextField =
-    slots?.textField ??
     pickerFieldUIContext.slots.textField ??
     (fieldResponse.enableAccessibleFieldDOMStructure === false ? MuiTextField : PickersTextField);
 
-  const InputAdornment =
-    slots?.inputAdornment ?? pickerFieldUIContext.slots.inputAdornment ?? MuiInputAdornment;
+  const InputAdornment = pickerFieldUIContext.slots.inputAdornment ?? MuiInputAdornment;
   const { ownerState: startInputAdornmentOwnerState, ...startInputAdornmentProps } = useSlotProps({
     elementType: InputAdornment,
-    externalSlotProps: mergeSlotProps(
-      pickerFieldUIContext.slotProps.inputAdornment,
-      slotProps?.inputAdornment,
-    ),
+    externalSlotProps: pickerFieldUIContext.slotProps.inputAdornment,
     additionalProps: {
       position: 'start' as const,
     },
@@ -142,7 +137,7 @@ export function PickerFieldUI<
   });
   const { ownerState: endInputAdornmentOwnerState, ...endInputAdornmentProps } = useSlotProps({
     elementType: InputAdornment,
-    externalSlotProps: slotProps?.inputAdornment,
+    externalSlotProps: pickerFieldUIContext.slotProps.inputAdornment,
     additionalProps: {
       position: 'end' as const,
     },
@@ -175,14 +170,11 @@ export function PickerFieldUI<
     ownerState,
   });
 
-  const ClearButton = slots?.clearButton ?? pickerFieldUIContext.slots.clearButton ?? MuiIconButton;
+  const ClearButton = pickerFieldUIContext.slots.clearButton ?? MuiIconButton;
   // We don't want to forward the `ownerState` to the `<IconButton />` component, see mui/material-ui#34056
   const { ownerState: clearButtonOwnerState, ...clearButtonProps } = useSlotProps({
     elementType: ClearButton,
-    externalSlotProps: mergeSlotProps(
-      pickerFieldUIContext.slotProps.clearButton,
-      slotProps?.clearButton,
-    ),
+    externalSlotProps: pickerFieldUIContext.slotProps.clearButton,
     className: 'clearButton',
     additionalProps: {
       title: translations.fieldClearLabel,
@@ -198,13 +190,10 @@ export function PickerFieldUI<
     ownerState,
   });
 
-  const ClearIcon = slots?.clearIcon ?? pickerFieldUIContext.slots.clearIcon ?? MuiClearIcon;
+  const ClearIcon = pickerFieldUIContext.slots.clearIcon ?? MuiClearIcon;
   const clearIconProps = useSlotProps({
     elementType: ClearIcon,
-    externalSlotProps: mergeSlotProps(
-      pickerFieldUIContext.slotProps.clearIcon,
-      slotProps?.clearIcon,
-    ),
+    externalSlotProps: pickerFieldUIContext.slotProps.clearIcon,
     additionalProps: {
       fontSize: 'small',
     },
@@ -260,6 +249,14 @@ export function PickerFieldUI<
       </InputAdornment>
     );
   }
+  // handle the case of showing custom `inputAdornment` for Field components
+  if (
+    !textFieldProps.InputProps?.endAdornment &&
+    !textFieldProps.InputProps?.startAdornment &&
+    pickerFieldUIContext.slots.inputAdornment
+  ) {
+    textFieldProps.InputProps.endAdornment = <InputAdornment {...endInputAdornmentProps} />;
+  }
 
   if (clearButtonPosition != null) {
     textFieldProps.sx = [
@@ -313,16 +310,6 @@ export interface PickerFieldUIProps<
   TEnableAccessibleFieldDOMStructure extends boolean,
   TProps extends UseFieldProps<TEnableAccessibleFieldDOMStructure>,
 > {
-  /**
-   * Overridable component slots.
-   * @default {}
-   */
-  slots?: PickerFieldUISlots;
-  /**
-   * The props used for each component slot.
-   * @default {}
-   */
-  slotProps?: PickerFieldUISlotProps;
   /**
    * Object returned by the `useField` hook or one of its wrapper (for example `useDateField`).
    */

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -6,7 +6,6 @@ import { usePicker } from '../usePicker';
 import { PickersLayout } from '../../../PickersLayout';
 import { DateOrTimeViewWithMeridiem, PickerValue } from '../../models';
 import { PickerProvider } from '../../components/PickerProvider';
-import { PickerFieldUIContextProvider } from '../../components/PickerFieldUI';
 import { createNonRangePickerStepNavigation } from '../../utils/createNonRangePickerStepNavigation';
 
 /**
@@ -85,14 +84,12 @@ export const useDesktopPicker = <
 
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
-      <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={inputRef}>
-        <Field {...fieldProps} />
-        <PickerPopper slots={slots} slotProps={slotProps}>
-          <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
-            {renderCurrentView()}
-          </Layout>
-        </PickerPopper>
-      </PickerFieldUIContextProvider>
+      <Field slots={slots} slotProps={slotProps} inputRef={inputRef} {...fieldProps} />
+      <PickerPopper slots={slots} slotProps={slotProps}>
+        <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
+          {renderCurrentView()}
+        </Layout>
+      </PickerPopper>
     </PickerProvider>
   );
 

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -6,7 +6,6 @@ import { usePicker } from '../usePicker';
 import { PickersLayout } from '../../../PickersLayout';
 import { DateOrTimeViewWithMeridiem, PickerValue } from '../../models';
 import { PickerProvider } from '../../components/PickerProvider';
-import { PickerFieldUIContextProvider } from '../../components/PickerFieldUI';
 import { createNonRangePickerStepNavigation } from '../../utils/createNonRangePickerStepNavigation';
 
 /**
@@ -85,14 +84,12 @@ export const useMobilePicker = <
 
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
-      <PickerFieldUIContextProvider slots={slots} slotProps={slotProps} inputRef={inputRef}>
-        <Field {...fieldProps} />
-        <PickersModalDialog slots={slots} slotProps={slotProps}>
-          <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
-            {renderCurrentView()}
-          </Layout>
-        </PickersModalDialog>
-      </PickerFieldUIContextProvider>
+      <Field slots={slots} slotProps={slotProps} inputRef={inputRef} {...fieldProps} />
+      <PickersModalDialog slots={slots} slotProps={slotProps}>
+        <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
+          {renderCurrentView()}
+        </Layout>
+      </PickersModalDialog>
     </PickerProvider>
   );
 


### PR DESCRIPTION
Noticed a problem with `inputAdornment` resolution while checking https://mui.com/x/react-date-pickers/custom-opening-button/#add-an-icon-next-to-the-opening-button
<img width="870" height="1119" alt="Screenshot 2025-07-21 at 17 30 39" src="https://github.com/user-attachments/assets/c537adb3-a87a-48d5-8b25-a59bd574cf05" />


The problem is on this line:
https://github.com/mui/mui-x/blob/be7b78c4b14cfabbeb3afde462c46977783c9ddb/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx#L143-L145
A forgotten case to handle `?? pickerFieldUIContext.slots.inputAdornment`.
This felt too fragile to me, given that we've already made a mistake here without noticing. 🙈 
___
I refactored how `slots` and `slotProps` are propagated to avoid the need to target `slotProps ?? context.slotProps`.