### PR TITLE
[code-infra] upgrade form-data to >=4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,8 @@
     "yargs": "catalog:"
   },
   "resolutions": {
-    "ast-types": "^0.14.2"
+    "ast-types": "^0.14.2",
+    "form-data": ">=4.0.4"
   },
   "packageManager": "pnpm@10.13.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,7 @@ catalogs:
 
 overrides:
   ast-types: ^0.14.2
+  form-data: '>=4.0.4'
 
 importers:
 
@@ -8169,8 +8170,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   format-util@1.0.5:
@@ -13971,7 +13972,7 @@ snapshots:
     dependencies:
       axios: 1.10.0(debug@4.4.1)
       find-up: 6.3.0
-      form-data: 4.0.3
+      form-data: 4.0.4
       node-gyp-build: 4.8.4
     transitivePeerDependencies:
       - debug
@@ -16042,7 +16043,7 @@ snapshots:
       '@types/retry': 0.12.0
       axios: 1.10.0(debug@4.4.1)
       eventemitter3: 5.0.1
-      form-data: 4.0.3
+      form-data: 4.0.4
       is-electron: 2.2.2
       is-stream: 2.0.1
       p-queue: 6.6.2
@@ -17657,7 +17658,7 @@ snapshots:
   axios@1.10.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.1)
-      form-data: 4.0.3
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -19711,7 +19712,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.3:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
Fixes [this alert](https://github.com/mui/mui-x/security/dependabot/173).

I don't think the alert applies to our codebase since only dev dependencies transitively depend on the affected `form-data` version, but might as well upgrade it. 