### PR TITLE
[scheduler][primitives] Allow to expand / shrink an event duration using drag & drop in the Time Grid

### DIFF
--- a/docs/pages/x/react-scheduler/full-screen-event-calendar.js
+++ b/docs/pages/x/react-scheduler/full-screen-event-calendar.js
@@ -13,6 +13,7 @@ export default function FullEventCalendar() {
       defaultVisibleDate={events[0].start}
       onEventsChange={setEvents}
       areEventsDraggable
+      areEventsResizable
     />
   );
 }

--- a/packages/x-scheduler/src/joy/event-calendar/EventCalendar.tsx
+++ b/packages/x-scheduler/src/joy/event-calendar/EventCalendar.tsx
@@ -31,6 +31,7 @@ export const EventCalendar = React.forwardRef(function EventCalendar(
     defaultVisibleDate,
     onVisibleDateChange,
     areEventsDraggable,
+    areEventsResizable,
     translations,
     className,
     ...other
@@ -46,6 +47,7 @@ export const EventCalendar = React.forwardRef(function EventCalendar(
     defaultVisibleDate,
     onVisibleDateChange,
     areEventsDraggable,
+    areEventsResizable,
   });
 
   const view = useSelector(store, selectors.view);

--- a/packages/x-scheduler/src/joy/event-calendar/EventCalendar.types.ts
+++ b/packages/x-scheduler/src/joy/event-calendar/EventCalendar.types.ts
@@ -59,7 +59,7 @@ export interface UseEventCalendarParameters {
    */
   areEventsDraggable?: boolean;
   /**
-   * Whether the event start or end can be dragged to change its duration without changing this other date.
+   * Whether the event start or end can be dragged to change its duration without changing its other date.
    * @default false
    */
   areEventsResizable?: boolean;

--- a/packages/x-scheduler/src/joy/event-calendar/EventCalendar.types.ts
+++ b/packages/x-scheduler/src/joy/event-calendar/EventCalendar.types.ts
@@ -54,10 +54,15 @@ export interface UseEventCalendarParameters {
    */
   onVisibleDateChange?: (visibleDate: SchedulerValidDate, event: React.UIEvent) => void;
   /**
-   * Whether the items in the calendar are draggable to change their start and end dates without changing the duration.
+   * Whether the event can be dragged to change its start and end dates without changing the duration.
    * @default false
    */
   areEventsDraggable?: boolean;
+  /**
+   * Whether the event start or end can be dragged to change its duration without changing this other date.
+   * @default false
+   */
+  areEventsResizable?: boolean;
 }
 
 export interface EventCalendarInstance {

--- a/packages/x-scheduler/src/joy/event-calendar/store.ts
+++ b/packages/x-scheduler/src/joy/event-calendar/store.ts
@@ -19,9 +19,13 @@ export type State = {
    */
   visibleResources: Map<CalendarResourceId, boolean>;
   /**
-   * Whether the items in the calendar are draggable to change their start and end dates without changing the duration.
+   * Whether the event can be dragged to change its start and end dates without changing the duration.
    */
   areEventsDraggable: boolean;
+  /**
+   * Whether the event start or end can be dragged to change its duration without changing this other date.
+   */
+  areEventsResizable: boolean;
 };
 
 export type EventCalendarStore = Store<State>;
@@ -82,5 +86,8 @@ export const selectors = {
   ),
   isEventDraggable: createSelector((state: State, { readOnly }: { readOnly?: boolean }) => {
     return !readOnly && state.areEventsDraggable;
+  }),
+  isEventResizable: createSelector((state: State, { readOnly }: { readOnly?: boolean }) => {
+    return !readOnly && state.areEventsResizable;
   }),
 };

--- a/packages/x-scheduler/src/joy/event-calendar/store.ts
+++ b/packages/x-scheduler/src/joy/event-calendar/store.ts
@@ -23,7 +23,7 @@ export type State = {
    */
   areEventsDraggable: boolean;
   /**
-   * Whether the event start or end can be dragged to change its duration without changing this other date.
+   * Whether the event start or end can be dragged to change its duration without changing its other date.
    */
   areEventsResizable: boolean;
 };

--- a/packages/x-scheduler/src/joy/event-calendar/useEventCalendar.ts
+++ b/packages/x-scheduler/src/joy/event-calendar/useEventCalendar.ts
@@ -28,6 +28,7 @@ export function useEventCalendar(parameters: UseEventCalendarParameters) {
     defaultVisibleDate = defaultVisibleDateFallback,
     onVisibleDateChange,
     areEventsDraggable = false,
+    areEventsResizable = false,
   } = parameters;
 
   useAssertModelConsistency({
@@ -54,6 +55,7 @@ export function useEventCalendar(parameters: UseEventCalendarParameters) {
         view: viewProp ?? defaultView,
         views: ['week', 'day', 'month', 'agenda'],
         areEventsDraggable,
+        areEventsResizable,
       }),
   ).current;
 

--- a/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.css
+++ b/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.css
@@ -3,12 +3,13 @@
   background-color: var(--event-background);
   position: relative;
 
-  &[data-dragging] {
+  &[data-dragging],
+  &[data-resizing] {
     opacity: 0.5;
   }
 
   &:hover .EventResizeHandler {
-    display: initial;
+    opacity: 1;
   }
 }
 
@@ -95,7 +96,7 @@
   right: 0;
   z-index: 3;
   cursor: ns-resize;
-  display: none;
+  opacity: 0;
 
   &[data-start] {
     top: 0;

--- a/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.css
+++ b/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.css
@@ -1,9 +1,14 @@
 .EventCard {
   border-radius: var(--radius-4);
   background-color: var(--event-background);
+  position: relative;
 
-  &[data-moving] {
+  &[data-dragging] {
     opacity: 0.5;
+  }
+
+  &:hover .EventResizeHandler {
+    display: initial;
   }
 }
 
@@ -81,4 +86,22 @@
   border-radius: var(--radius-1);
   background: var(--regular-line-bg);
   pointer-events: none;
+}
+
+.EventResizeHandler {
+  position: absolute;
+  height: 4px;
+  left: 0;
+  right: 0;
+  z-index: 3;
+  cursor: ns-resize;
+  display: none;
+
+  &[data-start] {
+    top: 0;
+  }
+
+  &[data-end] {
+    bottom: 0;
+  }
 }

--- a/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.tsx
+++ b/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.tsx
@@ -32,6 +32,7 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
   const id = useId(idProp);
   const { store } = useEventCalendarContext();
   const isDraggable = useSelector(store, selectors.isEventDraggable, { readOnly });
+  const isResizable = useSelector(store, selectors.isEventResizable, { readOnly });
 
   const durationMs =
     adapter.toJsDate(eventProp.end).getTime() - adapter.toJsDate(eventProp.start).getTime();
@@ -102,7 +103,11 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
       end={eventProp.end}
       {...other}
     >
+      {isResizable && (
+        <TimeGrid.EventResizeHandler position="start" className="EventResizeHandler" />
+      )}
       {content}
+      {isResizable && <TimeGrid.EventResizeHandler position="end" className="EventResizeHandler" />}
     </TimeGrid.Event>
   );
 });

--- a/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.tsx
+++ b/packages/x-scheduler/src/joy/internals/components/event/time-grid-event/TimeGridEvent.tsx
@@ -103,11 +103,9 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
       end={eventProp.end}
       {...other}
     >
-      {isResizable && (
-        <TimeGrid.EventResizeHandler position="start" className="EventResizeHandler" />
-      )}
+      {isResizable && <TimeGrid.EventResizeHandler side="start" className="EventResizeHandler" />}
       {content}
-      {isResizable && <TimeGrid.EventResizeHandler position="end" className="EventResizeHandler" />}
+      {isResizable && <TimeGrid.EventResizeHandler side="end" className="EventResizeHandler" />}
     </TimeGrid.Event>
   );
 });

--- a/packages/x-scheduler/src/primitives/time-grid/column/TimeGridColumn.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/column/TimeGridColumn.tsx
@@ -15,6 +15,7 @@ import {
   EVENT_DRAG_PRECISION_MINUTE,
   getCursorPositionRelativeToElement,
   isDraggingTimeGridEvent,
+  isDraggingTimeGridEventResizeHandler,
 } from '../../utils/drag-utils';
 
 export const TimeGridColumn = React.forwardRef(function TimeGridColumn(
@@ -81,10 +82,7 @@ export const TimeGridColumn = React.forwardRef(function TimeGridColumn(
 
   const props = React.useMemo(() => ({ role: 'gridcell' }), []);
 
-  const state: TimeGridColumn.State = React.useMemo(() => ({}), []);
-
   const element = useRenderElement('div', componentProps, {
-    state,
     ref: [forwardedRef, ref],
     props: [props, elementProps],
   });
@@ -127,10 +125,11 @@ export const TimeGridColumn = React.forwardRef(function TimeGridColumn(
 
     return dropTargetForElements({
       element: domElement,
-      canDrop: (arg) => isDraggingTimeGridEvent(arg.source.data),
-      getData: () => ({ type: 'column' }),
+      canDrop: (arg) =>
+        isDraggingTimeGridEvent(arg.source.data) ||
+        isDraggingTimeGridEventResizeHandler(arg.source.data),
       onDrag: ({ source: { data }, location }) => {
-        if (!isDraggingTimeGridEvent(data)) {
+        if (!isDraggingTimeGridEvent(data) && !isDraggingTimeGridEventResizeHandler(data)) {
           return;
         }
 
@@ -142,7 +141,7 @@ export const TimeGridColumn = React.forwardRef(function TimeGridColumn(
         setPlaceholder(newPlaceholder);
       },
       onDrop: ({ source: { data }, location }) => {
-        if (!isDraggingTimeGridEvent(data)) {
+        if (!isDraggingTimeGridEvent(data) && !isDraggingTimeGridEventResizeHandler(data)) {
           return;
         }
 

--- a/packages/x-scheduler/src/primitives/time-grid/column/TimeGridColumn.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/column/TimeGridColumn.tsx
@@ -178,6 +178,11 @@ export const TimeGridColumn = React.forwardRef(function TimeGridColumn(
           setPlaceholder(newPlaceholder);
         }
       },
+      onDragStart: ({ source: { data } }) => {
+        if (isDraggingTimeGridEvent(data) || isDraggingTimeGridEventResizeHandler(data)) {
+          setPlaceholder({ id: data.id, start: data.start, end: data.end });
+        }
+      },
       onDrop: ({ source: { data }, location }) => {
         const newEvent = getEventDropData({
           data,

--- a/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/TimeGridEventResizeHandler.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/TimeGridEventResizeHandler.tsx
@@ -1,0 +1,86 @@
+'use client';
+import * as React from 'react';
+import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { disableNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/disable-native-drag-preview';
+import { useRenderElement } from '../../../base-ui-copy/utils/useRenderElement';
+import { BaseUIComponentProps } from '../../../base-ui-copy/utils/types';
+import { useTimeGridEventContext } from '../event/TimeGridEventContext';
+
+export const TimeGridEventResizeHandler = React.forwardRef(function TimeGridEventResizeHandler(
+  componentProps: TimeGridEventResizeHandler.Props,
+  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    // Rendering props
+    className,
+    render,
+    // Internal props
+    position,
+    // Props forwarded to the DOM element
+    ...elementProps
+  } = componentProps;
+
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const { eventId, start: eventStart, end: eventEnd } = useTimeGridEventContext();
+
+  const props = React.useMemo(() => ({}), []);
+
+  const state: TimeGridEventResizeHandler.State = React.useMemo(
+    () => ({ start: position === 'start', end: position === 'end', dragging: isDragging }),
+    [position, isDragging],
+  );
+
+  React.useEffect(() => {
+    const domElement = ref.current;
+    if (!domElement) {
+      return () => {};
+    }
+
+    return draggable({
+      element: domElement,
+      getInitialData: ({ input }) => ({
+        source: 'TimeGridEventResizeHandler',
+        id: eventId,
+        start: eventStart,
+        end: eventEnd,
+        // position: getCursorPositionRelativeToElement({ ref, input }),
+      }),
+      onGenerateDragPreview: ({ nativeSetDragImage }) => {
+        disableNativeDragPreview({ nativeSetDragImage });
+      },
+      onDragStart: () => setIsDragging(true),
+      onDrop: () => setIsDragging(false),
+    });
+  }, [eventStart, eventEnd, eventId]);
+
+  return useRenderElement('div', componentProps, {
+    state,
+    ref: [forwardedRef, ref],
+    props: [props, elementProps],
+  });
+});
+
+export namespace TimeGridEventResizeHandler {
+  export interface State {
+    /**
+     * Whether the resize handler is targeting the start date of the event.
+     */
+    start: boolean;
+    /**
+     * Whether the resize handler is targeting the end date of the event.
+     */
+    end: boolean;
+    /**
+     * Whether the resize handler is being dragged.
+     */
+    dragging: boolean;
+  }
+
+  export interface Props extends BaseUIComponentProps<'div', State> {
+    /**
+     * The date to edit when dragging the resize handler.
+     */
+    position: 'start' | 'end';
+  }
+}

--- a/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/TimeGridEventResizeHandler.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/TimeGridEventResizeHandler.tsx
@@ -5,6 +5,8 @@ import { disableNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/elem
 import { useRenderElement } from '../../../base-ui-copy/utils/useRenderElement';
 import { BaseUIComponentProps } from '../../../base-ui-copy/utils/types';
 import { useTimeGridEventContext } from '../event/TimeGridEventContext';
+import { SchedulerValidDate } from '../../models';
+import { getCursorPositionRelativeToElement } from '../../utils/drag-utils';
 
 export const TimeGridEventResizeHandler = React.forwardRef(function TimeGridEventResizeHandler(
   componentProps: TimeGridEventResizeHandler.Props,
@@ -15,7 +17,7 @@ export const TimeGridEventResizeHandler = React.forwardRef(function TimeGridEven
     className,
     render,
     // Internal props
-    position,
+    side: position,
     // Props forwarded to the DOM element
     ...elementProps
   } = componentProps;
@@ -44,7 +46,7 @@ export const TimeGridEventResizeHandler = React.forwardRef(function TimeGridEven
         id: eventId,
         start: eventStart,
         end: eventEnd,
-        // position: getCursorPositionRelativeToElement({ ref, input }),
+        position: getCursorPositionRelativeToElement({ ref, input }),
       }),
       onGenerateDragPreview: ({ nativeSetDragImage }) => {
         disableNativeDragPreview({ nativeSetDragImage });
@@ -81,6 +83,15 @@ export namespace TimeGridEventResizeHandler {
     /**
      * The date to edit when dragging the resize handler.
      */
-    position: 'start' | 'end';
+    side: 'start' | 'end';
+  }
+
+  export interface DragData {
+    source: 'TimeGridEventResizeHandler';
+    id: string | number;
+    start: SchedulerValidDate;
+    end: SchedulerValidDate;
+    side: 'start' | 'end';
+    position: { y: number };
   }
 }

--- a/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/TimeGridEventResizeHandler.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/TimeGridEventResizeHandler.tsx
@@ -17,20 +17,19 @@ export const TimeGridEventResizeHandler = React.forwardRef(function TimeGridEven
     className,
     render,
     // Internal props
-    side: position,
+    side,
     // Props forwarded to the DOM element
     ...elementProps
   } = componentProps;
 
   const ref = React.useRef<HTMLDivElement>(null);
-  const [isDragging, setIsDragging] = React.useState(false);
-  const { eventId, start: eventStart, end: eventEnd } = useTimeGridEventContext();
+  const { eventId, setIsResizing, start: eventStart, end: eventEnd } = useTimeGridEventContext();
 
   const props = React.useMemo(() => ({}), []);
 
   const state: TimeGridEventResizeHandler.State = React.useMemo(
-    () => ({ start: position === 'start', end: position === 'end', dragging: isDragging }),
-    [position, isDragging],
+    () => ({ start: side === 'start', end: side === 'end' }),
+    [side],
   );
 
   React.useEffect(() => {
@@ -46,15 +45,16 @@ export const TimeGridEventResizeHandler = React.forwardRef(function TimeGridEven
         id: eventId,
         start: eventStart,
         end: eventEnd,
+        side,
         position: getCursorPositionRelativeToElement({ ref, input }),
       }),
       onGenerateDragPreview: ({ nativeSetDragImage }) => {
         disableNativeDragPreview({ nativeSetDragImage });
       },
-      onDragStart: () => setIsDragging(true),
-      onDrop: () => setIsDragging(false),
+      onDragStart: () => setIsResizing(true),
+      onDrop: () => setIsResizing(false),
     });
-  }, [eventStart, eventEnd, eventId]);
+  }, [eventStart, eventEnd, eventId, side, setIsResizing]);
 
   return useRenderElement('div', componentProps, {
     state,
@@ -73,10 +73,6 @@ export namespace TimeGridEventResizeHandler {
      * Whether the resize handler is targeting the end date of the event.
      */
     end: boolean;
-    /**
-     * Whether the resize handler is being dragged.
-     */
-    dragging: boolean;
   }
 
   export interface Props extends BaseUIComponentProps<'div', State> {

--- a/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/index.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/event-resize-handler/index.ts
@@ -1,0 +1,1 @@
+export * from './TimeGridEventResizeHandler';

--- a/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEvent.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEvent.tsx
@@ -38,6 +38,7 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
 
   const ref = React.useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = React.useState(false);
+  const [isResizing, setIsResizing] = React.useState(false);
   const { getButtonProps, buttonRef } = useButton({ disabled: !isInteractive });
 
   const { start: columnStart, end: columnEnd } = useTimeGridColumnContext();
@@ -72,8 +73,8 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
   const { state: eventState, props: eventProps } = useEvent({ start, end });
 
   const state: TimeGridEvent.State = React.useMemo(
-    () => ({ ...eventState, dragging: isDragging }),
-    [eventState, isDragging],
+    () => ({ ...eventState, dragging: isDragging, resizing: isResizing }),
+    [eventState, isDragging, isResizing],
   );
 
   const contextValue: TimeGridEventContext = React.useMemo(
@@ -81,6 +82,7 @@ export const TimeGridEvent = React.forwardRef(function TimeGridEvent(
       eventId,
       start,
       end,
+      setIsResizing,
     }),
     [eventId, start, end],
   );
@@ -126,6 +128,10 @@ export namespace TimeGridEvent {
      * Whether the event is being dragged.
      */
     dragging: boolean;
+    /**
+     * Whether the event is being resized.
+     */
+    resizing: boolean;
   }
 
   export interface Props extends BaseUIComponentProps<'div', State>, useEvent.Parameters {
@@ -145,7 +151,6 @@ export namespace TimeGridEvent {
   }
 
   export interface DragData {
-    type: 'event';
     source: 'TimeGridEvent';
     id: string | number;
     start: SchedulerValidDate;

--- a/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEvent.tsx
+++ b/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEvent.tsx
@@ -144,7 +144,7 @@ export namespace TimeGridEvent {
     isResizable?: boolean;
   }
 
-  export interface EventDragData {
+  export interface DragData {
     type: 'event';
     source: 'TimeGridEvent';
     id: string | number;

--- a/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEventContext.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEventContext.ts
@@ -15,6 +15,10 @@ export interface TimeGridEventContext {
    * The end date and time of the event
    */
   end: SchedulerValidDate;
+  /**
+   * Sets whether the event is being resized.
+   */
+  setIsResizing: (isResizing: boolean) => void;
 }
 
 export const TimeGridEventContext = React.createContext<TimeGridEventContext | undefined>(

--- a/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEventContext.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEventContext.ts
@@ -1,0 +1,32 @@
+'use client';
+import * as React from 'react';
+import { SchedulerValidDate } from '../../models';
+
+export interface TimeGridEventContext {
+  /**
+   * The unique identifier of the event.
+   */
+  eventId: string | number;
+  /**
+   * The start date and time of the event
+   */
+  start: SchedulerValidDate;
+  /**
+   * The end date and time of the event
+   */
+  end: SchedulerValidDate;
+}
+
+export const TimeGridEventContext = React.createContext<TimeGridEventContext | undefined>(
+  undefined,
+);
+
+export function useTimeGridEventContext() {
+  const context = React.useContext(TimeGridEventContext);
+  if (context === undefined) {
+    throw new Error(
+      'Scheduler: `TimeGridEventContext` is missing. TimeGrid Event parts must be placed within <TimeGrid.Event />.',
+    );
+  }
+  return context;
+}

--- a/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEventDataAttributes.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/event/TimeGridEventDataAttributes.ts
@@ -7,4 +7,12 @@ export enum TimeGridEventDataAttributes {
    * Present when the event end date is in the past.
    */
   ended = 'data-ended',
+  /**
+   * Present when the event is being dragged.
+   */
+  dragging = 'data-dragging',
+  /**
+   * Present when the event is being resized.
+   */
+  resizing = 'data-resizing',
 }

--- a/packages/x-scheduler/src/primitives/time-grid/index.parts.ts
+++ b/packages/x-scheduler/src/primitives/time-grid/index.parts.ts
@@ -2,5 +2,6 @@ export { TimeGridRoot as Root } from './root/TimeGridRoot';
 export { TimeGridScrollableContent as ScrollableContent } from './scrollable-content/TimeGridScrollableContent';
 export { TimeGridColumn as Column } from './column/TimeGridColumn';
 export { TimeGridEvent as Event } from './event/TimeGridEvent';
+export { TimeGridEventResizeHandler as EventResizeHandler } from './event-resize-handler/TimeGridEventResizeHandler';
 
 export { useTimeGridColumnPlaceholder as useColumnPlaceholder } from './use-column-placeholder/useTimeGridColumnPlaceholder';

--- a/packages/x-scheduler/src/primitives/utils/drag-utils.ts
+++ b/packages/x-scheduler/src/primitives/utils/drag-utils.ts
@@ -1,4 +1,5 @@
 import type { TimeGridEvent } from '../time-grid/event';
+import type { TimeGridEventResizeHandler } from '../time-grid/event-resize-handler';
 
 export const EVENT_DRAG_PRECISION_MINUTE = 15;
 
@@ -20,12 +21,12 @@ export function getCursorPositionRelativeToElement({
   return { y };
 }
 
-export function isDraggingTimeGridEvent(data: any): data is TimeGridEvent.EventDragData {
+export function isDraggingTimeGridEvent(data: any): data is TimeGridEvent.DragData {
   return data.source === 'TimeGridEvent';
 }
 
 export function isDraggingTimeGridEventResizeHandler(
   data: any,
-): data is TimeGridEvent.EventDragData {
+): data is TimeGridEventResizeHandler.DragData {
   return data.source === 'TimeGridEventResizeHandler';
 }

--- a/packages/x-scheduler/src/primitives/utils/drag-utils.ts
+++ b/packages/x-scheduler/src/primitives/utils/drag-utils.ts
@@ -21,5 +21,11 @@ export function getCursorPositionRelativeToElement({
 }
 
 export function isDraggingTimeGridEvent(data: any): data is TimeGridEvent.EventDragData {
-  return data.type === 'event' && data.source === 'TimeGridEvent';
+  return data.source === 'TimeGridEvent';
+}
+
+export function isDraggingTimeGridEventResizeHandler(
+  data: any,
+): data is TimeGridEvent.EventDragData {
+  return data.source === 'TimeGridEventResizeHandler';
 }

--- a/packages/x-scheduler/src/primitives/utils/drag-utils.ts
+++ b/packages/x-scheduler/src/primitives/utils/drag-utils.ts
@@ -1,7 +1,11 @@
+import { SchedulerValidDate } from '../models';
 import type { TimeGridEvent } from '../time-grid/event';
 import type { TimeGridEventResizeHandler } from '../time-grid/event-resize-handler';
+import { Adapter } from './adapter/types';
 
 export const EVENT_DRAG_PRECISION_MINUTE = 15;
+
+export const EVENT_DRAG_PRECISION_MS = EVENT_DRAG_PRECISION_MINUTE * 60 * 1000;
 
 export function getCursorPositionRelativeToElement({
   ref,
@@ -29,4 +33,35 @@ export function isDraggingTimeGridEventResizeHandler(
   data: any,
 ): data is TimeGridEventResizeHandler.DragData {
   return data.source === 'TimeGridEventResizeHandler';
+}
+
+export function createDateFromPositionInCollection(
+  parameters: CreateDateFromPositionInCollectionParameters,
+): SchedulerValidDate {
+  const { adapter, collectionStart, collectionEnd, position } = parameters;
+
+  // TODO: Avoid JS date conversion
+  const getTimestamp = (date: SchedulerValidDate) => adapter.toJsDate(date).getTime();
+
+  const collectionStartTimestamp = getTimestamp(collectionStart);
+  const collectionEndTimestamp = getTimestamp(collectionEnd);
+  const collectionDurationMs = collectionEndTimestamp - collectionStartTimestamp;
+
+  const positionInCollectionMs = collectionDurationMs * position;
+  const roundedPositionInCollectionMs =
+    Math.round(positionInCollectionMs / EVENT_DRAG_PRECISION_MS) * EVENT_DRAG_PRECISION_MS;
+
+  // TODO: Use "addMilliseconds" instead of "addSeconds" when available in the adapter
+  return adapter.addSeconds(collectionStart, roundedPositionInCollectionMs / 1000);
+}
+
+interface CreateDateFromPositionInCollectionParameters {
+  adapter: Adapter;
+  collectionStart: SchedulerValidDate;
+  collectionEnd: SchedulerValidDate;
+  /**
+   * Position to convert relative to the collection.
+   * Must be a value between 0 and 1, where 0 is the start of the collection and 1 is the end.
+   */
+  position: number;
 }


### PR DESCRIPTION
Closes #17692

- [x] Allow to change the start date
- [x] Allow to change the end date
- [x] Make sure the resulting event always have start date < end date and a duration of at least 15mn

Follow up
- Clean multi days resizing (right now it's broken, but the rendering of multi days event is broken anyway)