### PR TITLE
[charts-pro] Fix `slotProps.tooltip.trigger` not respected in `ScatterChartPro` and `FunnelChart`

### DIFF
--- a/docs/translations/api-docs/charts/charts-tooltip-container/charts-tooltip-container.json
+++ b/docs/translations/api-docs/charts/charts-tooltip-container/charts-tooltip-container.json
@@ -42,7 +42,7 @@
       "description": "Help supporting a react-transition-group/Transition component."
     },
     "trigger": {
-      "description": "Select the kind of tooltip to display - &#39;item&#39;: Shows data about the item below the mouse. - &#39;axis&#39;: Shows values associated with the hovered x value - &#39;none&#39;: Does not display tooltip"
+      "description": "Select the kind of tooltip to display - &#39;item&#39;: Shows data about the item below the mouse; - &#39;axis&#39;: Shows values associated with the hovered x value; - &#39;none&#39;: Does not display tooltip."
     }
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/charts/charts-tooltip/charts-tooltip.json
+++ b/docs/translations/api-docs/charts/charts-tooltip/charts-tooltip.json
@@ -41,7 +41,7 @@
       "description": "Help supporting a react-transition-group/Transition component."
     },
     "trigger": {
-      "description": "Select the kind of tooltip to display - &#39;item&#39;: Shows data about the item below the mouse. - &#39;axis&#39;: Shows values associated with the hovered x value - &#39;none&#39;: Does not display tooltip"
+      "description": "Select the kind of tooltip to display - &#39;item&#39;: Shows data about the item below the mouse; - &#39;axis&#39;: Shows values associated with the hovered x value; - &#39;none&#39;: Does not display tooltip."
     }
   },
   "classDescriptions": {

--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -110,7 +110,7 @@ const FunnelChart = React.forwardRef(function FunnelChart(
           <ChartsAxis {...chartsAxisProps} />
           {children}
         </ChartsSurface>
-        {!themedProps.loading && <Tooltip {...themedProps.slotProps?.tooltip} trigger="item" />}
+        {!themedProps.loading && <Tooltip trigger="item" {...themedProps.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts-pro/src/FunnelChart/funnelSlots.types.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelSlots.types.ts
@@ -1,5 +1,9 @@
 import { ChartsOverlaySlotProps, ChartsOverlaySlots } from '@mui/x-charts/ChartsOverlay';
-import { ChartsTooltipSlotProps, ChartsTooltipSlots } from '@mui/x-charts/ChartsTooltip';
+import {
+  ChartsTooltipProps,
+  ChartsTooltipSlotProps,
+  ChartsTooltipSlots,
+} from '@mui/x-charts/ChartsTooltip';
 import {
   ChartsAxisSlotProps,
   ChartsAxisSlots,
@@ -23,11 +27,17 @@ export interface FunnelChartSlotProps
   extends ChartsAxisSlotProps,
     FunnelPlotSlotProps,
     ChartsLegendSlotProps,
-    ChartsTooltipSlotProps,
+    Omit<ChartsTooltipSlotProps, 'tooltip'>,
     ChartsOverlaySlotProps,
     ChartsAxisSlotProps,
     ChartsToolbarSlotProps,
-    Partial<ChartsSlotProps> {}
+    Partial<ChartsSlotProps> {
+  /**
+   * Slot props for the tooltip component.
+   * @default {}
+   */
+  tooltip?: Partial<ChartsTooltipProps<'item' | 'none'>>;
+}
 
 export interface FunnelChartSlotExtension {
   /**

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -14,7 +14,7 @@ import { ChartsGrid } from '@mui/x-charts/ChartsGrid';
 import { ChartsLegend } from '@mui/x-charts/ChartsLegend';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
 import { ChartsAxisHighlight } from '@mui/x-charts/ChartsAxisHighlight';
-import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
+import { ChartsTooltip, ChartsTooltipProps } from '@mui/x-charts/ChartsTooltip';
 import { useScatterChartProps } from '@mui/x-charts/internals';
 import { ChartsWrapper } from '@mui/x-charts/ChartsWrapper';
 import { ChartsSlotPropsPro, ChartsSlotsPro } from '../internals/material';
@@ -37,9 +37,15 @@ export interface ScatterChartProSlots
     ChartsToolbarProSlots,
     Partial<ChartsSlotsPro> {}
 export interface ScatterChartProSlotProps
-  extends Omit<ScatterChartSlotProps, 'toolbar'>,
+  extends Omit<ScatterChartSlotProps, 'toolbar' | 'tooltip'>,
     ChartsToolbarProSlotProps,
-    Partial<ChartsSlotPropsPro> {}
+    Partial<ChartsSlotPropsPro> {
+  /**
+   * Slot props for the tooltip component.
+   * @default {}
+   */
+  tooltip?: Partial<ChartsTooltipProps<'item' | 'none'>>;
+}
 
 export interface ScatterChartProProps
   extends Omit<ScatterChartProps, 'apiRef' | 'slots' | 'slotProps'>,

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -129,7 +129,7 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
           <ChartsAxisHighlight {...axisHighlightProps} />
           {children}
         </ChartsSurface>
-        {!props.loading && <Tooltip {...props?.slotProps?.tooltip} trigger="item" />}
+        {!props.loading && <Tooltip trigger="item" {...props?.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -266,9 +266,9 @@ ChartsTooltip.propTypes = {
   transition: PropTypes.bool,
   /**
    * Select the kind of tooltip to display
-   * - 'item': Shows data about the item below the mouse.
-   * - 'axis': Shows values associated with the hovered x value
-   * - 'none': Does not display tooltip
+   * - 'item': Shows data about the item below the mouse;
+   * - 'axis': Shows values associated with the hovered x value;
+   * - 'none': Does not display tooltip.
    * @default 'axis'
    */
   trigger: PropTypes.oneOf(['axis', 'item', 'none']),

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltip.tsx
@@ -6,8 +6,10 @@ import { ChartsItemTooltipContent } from './ChartsItemTooltipContent';
 import { ChartsAxisTooltipContent } from './ChartsAxisTooltipContent';
 import { ChartsTooltipContainer, ChartsTooltipContainerProps } from './ChartsTooltipContainer';
 import { useUtilityClasses } from './chartsTooltipClasses';
+import { TriggerOptions } from './utils';
 
-export interface ChartsTooltipProps extends Omit<ChartsTooltipContainerProps, 'children'> {}
+export interface ChartsTooltipProps<T extends TriggerOptions = TriggerOptions>
+  extends Omit<ChartsTooltipContainerProps<T>, 'children'> {}
 
 /**
  * Demos:

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -26,9 +26,9 @@ export interface ChartsTooltipContainerProps<T extends TriggerOptions = TriggerO
   extends Partial<PopperProps> {
   /**
    * Select the kind of tooltip to display
-   * - 'item': Shows data about the item below the mouse.
-   * - 'axis': Shows values associated with the hovered x value
-   * - 'none': Does not display tooltip
+   * - 'item': Shows data about the item below the mouse;
+   * - 'axis': Shows values associated with the hovered x value;
+   * - 'none': Does not display tooltip.
    * @default 'axis'
    */
   trigger?: T;
@@ -412,9 +412,9 @@ ChartsTooltipContainer.propTypes = {
   transition: PropTypes.bool,
   /**
    * Select the kind of tooltip to display
-   * - 'item': Shows data about the item below the mouse.
-   * - 'axis': Shows values associated with the hovered x value
-   * - 'none': Does not display tooltip
+   * - 'item': Shows data about the item below the mouse;
+   * - 'axis': Shows values associated with the hovered x value;
+   * - 'none': Does not display tooltip.
    * @default 'axis'
    */
   trigger: PropTypes.oneOf(['axis', 'item', 'none']),

--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -22,7 +22,8 @@ import { useSvgRef } from '../hooks';
 
 const noAxis = () => false;
 
-export interface ChartsTooltipContainerProps extends Partial<PopperProps> {
+export interface ChartsTooltipContainerProps<T extends TriggerOptions = TriggerOptions>
+  extends Partial<PopperProps> {
   /**
    * Select the kind of tooltip to display
    * - 'item': Shows data about the item below the mouse.
@@ -30,7 +31,7 @@ export interface ChartsTooltipContainerProps extends Partial<PopperProps> {
    * - 'none': Does not display tooltip
    * @default 'axis'
    */
-  trigger?: TriggerOptions;
+  trigger?: T;
   /**
    * Override or extend the styles applied to the component.
    */

--- a/packages/x-charts/src/ScatterChart/ScatterChart.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.tsx
@@ -14,7 +14,7 @@ import {
 import { ChartContainerProps } from '../ChartContainer';
 import { ChartsAxis, ChartsAxisProps } from '../ChartsAxis';
 import { ScatterSeriesType } from '../models/seriesType/scatter';
-import { ChartsTooltip } from '../ChartsTooltip';
+import { ChartsTooltip, ChartsTooltipProps } from '../ChartsTooltip';
 import { ChartsTooltipSlots, ChartsTooltipSlotProps } from '../ChartsTooltip/ChartTooltip.types';
 import { ChartsLegend, ChartsLegendSlotProps, ChartsLegendSlots } from '../ChartsLegend';
 import {
@@ -47,9 +47,15 @@ export interface ScatterChartSlotProps
     ScatterPlotSlotProps,
     ChartsLegendSlotProps,
     ChartsOverlaySlotProps,
-    ChartsTooltipSlotProps,
+    Omit<ChartsTooltipSlotProps, 'tooltip'>,
     ChartsToolbarSlotProps,
-    Partial<ChartsSlotProps> {}
+    Partial<ChartsSlotProps> {
+  /**
+   * Slot props for the tooltip component.
+   * @default {}
+   */
+  tooltip?: Partial<ChartsTooltipProps<'item' | 'none'>>;
+}
 
 export type ScatterSeries = MakeOptional<ScatterSeriesType, 'type'>;
 export interface ScatterChartProps


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18900.


## Before

See videos in https://github.com/mui/mui-x/issues/18900.

## After

### `ScatterChartPro`


https://github.com/user-attachments/assets/a2ef8426-df1c-4209-909e-c4245b98dfc4



### `FunnelChart`

https://github.com/user-attachments/assets/dbb520a4-70d0-4e59-a028-502826ea2490

