### PR TITLE
[DataGrid] Allow to skip cache in `fetchRows()` API method

### DIFF
--- a/packages/x-data-grid/src/hooks/features/dataSource/models.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/models.ts
@@ -6,15 +6,25 @@ import type {
 import type { GridRowId, GridRowModel } from '../../../models/gridRows';
 import type { GridDataSourceCacheDefaultConfig } from './cache';
 
+/**
+ * The parameters for the `fetchRows` method.
+ */
+interface GridFetchRowsParams extends Partial<GridGetRowsParams> {
+  /**
+   * If `true`, bypasses the cache and forces a refetch of the rows from the server.
+   */
+  skipCache?: boolean;
+}
+
 export interface GridDataSourceApiBase {
   /**
    * Fetches the rows from the server.
    * If no `parentId` option is provided, it fetches the root rows.
    * Any missing parameter from `params` will be filled from the state (sorting, filtering, etc.).
    * @param {GridRowId} parentId The id of the parent node (default: `GRID_ROOT_GROUP_ID`).
-   * @param {Partial<GridGetRowsParams>} params Request parameters override.
+   * @param {GridFetchRowsParams} params Request parameters override.
    */
-  fetchRows: (parentId?: GridRowId, params?: Partial<GridGetRowsParams>) => void;
+  fetchRows: (parentId?: GridRowId, params?: GridFetchRowsParams) => void;
   /**
    * The data source cache object.
    */

--- a/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
+++ b/packages/x-data-grid/src/hooks/features/dataSource/useGridDataSourceBase.ts
@@ -97,16 +97,18 @@ export const useGridDataSourceBase = <Api extends GridPrivateApiCommunity>(
 
       options.clearDataSourceState?.();
 
+      const { skipCache, ...getRowsParams } = params || {};
+
       const fetchParams = {
         ...gridGetRowsParamsSelector(apiRef),
         ...apiRef.current.unstable_applyPipeProcessors('getRowsParams', {}),
-        ...params,
+        ...getRowsParams,
       };
 
       const cacheKeys = cacheChunkManager.getCacheKeys(fetchParams);
       const responses = cacheKeys.map((cacheKey) => cache.get(cacheKey));
 
-      if (responses.every((response) => response !== undefined)) {
+      if (!skipCache && responses.every((response) => response !== undefined)) {
         apiRef.current.applyStrategyProcessor('dataSourceRowsUpdate', {
           response: CacheChunkManager.mergeResponses(responses as GridGetRowsResponse[]),
           fetchParams,

--- a/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/dataSource.DataGrid.test.tsx
@@ -270,6 +270,38 @@ describe.skipIf(isJSDOM)('<DataGrid /> - Data source', () => {
       });
       expect(pageChangeSpy.callCount).to.equal(2);
     });
+
+    it('should bypass cache when forceRefetch is true', async () => {
+      const testCache = new TestCache();
+      render(<TestDataSource dataSourceCache={testCache} />);
+
+      // Wait for initial fetch
+      await waitFor(() => {
+        expect(fetchRowsSpy.callCount).to.equal(1);
+      });
+      expect(testCache.size()).to.equal(1);
+
+      // Fetch same data again with skipCache = true
+      act(() => {
+        apiRef.current?.dataSource.fetchRows(undefined, { skipCache: true });
+      });
+
+      await waitFor(() => {
+        expect(fetchRowsSpy.callCount).to.equal(2);
+      });
+      // Cache should still be updated with new data
+      expect(testCache.size()).to.equal(1);
+
+      // Fetch same data again without skipCache (should use cache)
+      act(() => {
+        apiRef.current?.dataSource.fetchRows();
+      });
+
+      // Should not trigger another fetch since data is cached
+      await waitFor(() => {
+        expect(fetchRowsSpy.callCount).to.equal(2);
+      });
+    });
   });
 
   describe('Error handling', () => {


### PR DESCRIPTION
Fixes #18767