### PR TITLE
[scheduler] Fix resource item hover

### DIFF
--- a/packages/x-scheduler/src/joy/internals/components/resource-legend/ResourceLegend.css
+++ b/packages/x-scheduler/src/joy/internals/components/resource-legend/ResourceLegend.css
@@ -1,14 +1,21 @@
 .ResourceLegendContainer {
   display: flex;
   flex-direction: column;
-  padding: var(--space-2);
-  gap: var(--space-2);
+  /* padding: var(--space-2);
+  gap: var(--space-2); */
 }
 
 .ResourceLegendItem {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-3);
+  cursor: pointer;
+}
+
+.ResourceLegendItem:hover {
+  background-color: var(--interactive-hover-bg);
 }
 
 .ResourceLegendColor {
@@ -27,4 +34,8 @@
 .joy .Button.ResourceLegendButton {
   padding: var(--space-1);
   margin-inline-start: auto;
+}
+
+.joy .Button.ResourceLegendButton:hover {
+  background-color: var(--interactive-hover-bg);
 }

--- a/packages/x-scheduler/src/joy/internals/components/resource-legend/ResourceLegend.css
+++ b/packages/x-scheduler/src/joy/internals/components/resource-legend/ResourceLegend.css
@@ -1,8 +1,6 @@
 .ResourceLegendContainer {
   display: flex;
   flex-direction: column;
-  /* padding: var(--space-2);
-  gap: var(--space-2); */
 }
 
 .ResourceLegendItem {

--- a/packages/x-scheduler/src/joy/internals/components/resource-legend/ResourceLegend.tsx
+++ b/packages/x-scheduler/src/joy/internals/components/resource-legend/ResourceLegend.tsx
@@ -26,8 +26,8 @@ function ResourceLegendItem(props: { resource: CalendarResource }) {
         className={clsx('NeutralTextButton', 'Button', 'ResourceLegendButton')}
         value={resource.id}
         render={(rootProps, state) => (
-          // eslint-disable-next-line react/button-has-type
           <button
+            type="button"
             aria-label={
               state.checked
                 ? translations.hideEventsLabel(resource.name)


### PR DESCRIPTION
Issue #18937 

We need to add a hover effect for the entire item instead of just the icon
Current hover effect:
https://github.com/user-attachments/assets/ae0843bf-8d62-4e1b-979a-2f429e68a3bd
<img width="287" height="234" alt="Screenshot 2025-07-28 at 12 29 55" src="https://github.com/user-attachments/assets/d7251bed-85d4-4b45-82cf-0d386fb8e805" />

Fixed hover effect:
https://github.com/user-attachments/assets/e3020262-ca25-4e3b-8857-b6f50383143a
<img width="272" height="232" alt="Screenshot 2025-07-28 at 12 30 39" src="https://github.com/user-attachments/assets/2b46651c-b38b-4556-a324-03b685dac36f" />


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
