### PR TITLE
[pickers] Fix usage not in main document

### DIFF
--- a/packages/x-date-pickers-pro/src/hooks/useMultiInputRangeField/useMultiInputRangeFieldRootProps.ts
+++ b/packages/x-date-pickers-pro/src/hooks/useMultiInputRangeField/useMultiInputRangeFieldRootProps.ts
@@ -22,8 +22,10 @@ export function useMultiInputRangeFieldRootProps<TForwardedProps extends { [key:
 
     executeInTheNextEventLoopTick(() => {
       if (
-        privatePickerContext.rootRefObject.current?.contains(getActiveElement(document)) ||
-        pickerContext.popupRef.current?.contains(getActiveElement(document))
+        privatePickerContext.rootRefObject.current?.contains(
+          getActiveElement(privatePickerContext.rootRefObject.current),
+        ) ||
+        pickerContext.popupRef.current?.contains(getActiveElement(pickerContext.popupRef.current))
       ) {
         return;
       }

--- a/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerPopper/PickerPopper.tsx
@@ -331,6 +331,7 @@ export function PickerPopper(inProps: PickerPopperProps) {
   const { children, placement = 'bottom-start', slots, slotProps, classes: classesProp } = props;
 
   const { open, popupRef, reduceAnimations } = usePickerContext();
+  const { ownerState: pickerOwnerState, rootRefObject } = usePickerPrivateContext();
   const { dismissViews, getCurrentViewMode, onPopperExited, triggerElement, viewContainerRole } =
     usePickerPrivateContext();
 
@@ -355,7 +356,7 @@ export function PickerPopper(inProps: PickerPopperProps) {
     }
 
     if (open) {
-      lastFocusedElementRef.current = getActiveElement(document);
+      lastFocusedElementRef.current = getActiveElement(rootRefObject.current);
     } else if (
       lastFocusedElementRef.current &&
       lastFocusedElementRef.current instanceof HTMLElement
@@ -368,17 +369,16 @@ export function PickerPopper(inProps: PickerPopperProps) {
         }
       });
     }
-  }, [open, viewContainerRole, getCurrentViewMode]);
+  }, [open, viewContainerRole, getCurrentViewMode, rootRefObject]);
 
   const classes = useUtilityClasses(classesProp);
-  const { ownerState: pickerOwnerState, rootRefObject } = usePickerPrivateContext();
 
   const handleClickAway: OnClickAway = useEventCallback(() => {
     if (viewContainerRole === 'tooltip') {
       executeInTheNextEventLoopTick(() => {
         if (
-          rootRefObject.current?.contains(getActiveElement(document)) ||
-          popupRef.current?.contains(getActiveElement(document))
+          rootRefObject.current?.contains(getActiveElement(rootRefObject.current)) ||
+          popupRef.current?.contains(getActiveElement(popupRef.current))
         ) {
           return;
         }

--- a/packages/x-date-pickers/src/internals/hooks/useField/syncSelectionToDOM.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/syncSelectionToDOM.ts
@@ -1,3 +1,4 @@
+import ownerDocument from '@mui/utils/ownerDocument';
 import { PickerValidValue } from '../../models';
 import { getActiveElement } from '../../utils/utils';
 import { UseFieldDOMGetters } from './useField.types';
@@ -20,7 +21,7 @@ export function syncSelectionToDOM<TValue extends PickerValidValue>(
     return;
   }
 
-  const selection = document.getSelection();
+  const selection = ownerDocument(domGetters.getRoot()).getSelection();
   if (!selection) {
     return;
   }
@@ -41,7 +42,7 @@ export function syncSelectionToDOM<TValue extends PickerValidValue>(
   }
 
   // On multi input range pickers we want to update selection range only for the active input
-  if (!domGetters.getRoot().contains(getActiveElement(document))) {
+  if (!domGetters.getRoot().contains(getActiveElement(domGetters.getRoot()))) {
     return;
   }
 

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldRootProps.ts
@@ -139,7 +139,7 @@ export function useFieldRootProps(
       return;
     }
 
-    const activeElement = getActiveElement(document);
+    const activeElement = getActiveElement(domGetters.getRoot());
 
     setFocused(true);
 
@@ -155,7 +155,7 @@ export function useFieldRootProps(
         return;
       }
 
-      const activeElement = getActiveElement(document);
+      const activeElement = getActiveElement(domGetters.getRoot());
       const shouldBlur = !domGetters.getRoot().contains(activeElement);
       if (shouldBlur) {
         setFocused(false);

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV6TextField.ts
@@ -168,7 +168,7 @@ export const useFieldV6TextField = <
   }
 
   function focusField(newSelectedSection: number | FieldSectionType = 0) {
-    if (getActiveElement(document) === inputRef.current) {
+    if (getActiveElement(inputRef.current) === inputRef.current) {
       return;
     }
     inputRef.current?.focus();
@@ -400,7 +400,7 @@ export const useFieldV6TextField = <
 
   React.useEffect(() => {
     // Select all the sections when focused on mount (`autoFocus = true` on the input)
-    if (inputRef.current && inputRef.current === getActiveElement(document)) {
+    if (inputRef.current && inputRef.current === getActiveElement(inputRef.current)) {
       setSelectedSections('all');
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -424,7 +424,7 @@ export const useFieldV6TextField = <
       // On multi input range pickers we want to update selection range only for the active input
       // This helps to avoid the focus jumping on Safari https://github.com/mui/mui-x/issues/9003
       // because WebKit implements the `setSelectionRange` based on the spec: https://bugs.webkit.org/show_bug.cgi?id=224425
-      if (inputRef.current !== getActiveElement(document)) {
+      if (inputRef.current !== getActiveElement(inputRef.current)) {
         return;
       }
 
@@ -448,7 +448,7 @@ export const useFieldV6TextField = <
           selectionStart !== inputRef.current.selectionStart ||
           selectionEnd !== inputRef.current.selectionEnd
         ) {
-          if (inputRef.current === getActiveElement(document)) {
+          if (inputRef.current === getActiveElement(inputRef.current)) {
             inputRef.current.setSelectionRange(selectionStart, selectionEnd);
           }
         }
@@ -457,7 +457,7 @@ export const useFieldV6TextField = <
           // could happen on Android
           if (
             inputRef.current &&
-            inputRef.current === getActiveElement(document) &&
+            inputRef.current === getActiveElement(inputRef.current) &&
             // The section might loose all selection, where `selectionStart === selectionEnd`
             // https://github.com/mui/mui-x/pull/13652
             inputRef.current.selectionStart === inputRef.current.selectionEnd &&
@@ -488,7 +488,7 @@ export const useFieldV6TextField = <
     return 'numeric';
   }, [activeSectionIndex, state.sections]);
 
-  const inputHasFocus = inputRef.current && inputRef.current === getActiveElement(document);
+  const inputHasFocus = inputRef.current && inputRef.current === getActiveElement(inputRef.current);
   const shouldShowPlaceholder = !inputHasFocus && areAllSectionsEmpty;
 
   React.useImperativeHandle(unstableFieldRef, () => ({
@@ -542,7 +542,7 @@ export const useFieldV6TextField = <
 };
 
 function isFieldFocused(inputRef: React.RefObject<HTMLInputElement | null>) {
-  return inputRef.current === getActiveElement(document);
+  return inputRef.current === getActiveElement(inputRef.current);
 }
 
 type FieldSectionWithPositions<TValue extends PickerValidValue> = InferFieldSection<TValue> & {

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldV7TextField.ts
@@ -302,7 +302,7 @@ export const useFieldV7TextField = <
 };
 
 function getActiveSectionIndex(sectionListRef: React.RefObject<PickersSectionListRef | null>) {
-  const activeElement = getActiveElement(document) as HTMLElement | undefined;
+  const activeElement = getActiveElement(sectionListRef.current?.getRoot());
   if (
     !activeElement ||
     !sectionListRef.current ||
@@ -315,6 +315,6 @@ function getActiveSectionIndex(sectionListRef: React.RefObject<PickersSectionLis
 }
 
 function isFieldFocused(sectionListRef: React.RefObject<PickersSectionListRef | null>) {
-  const activeElement = getActiveElement(document);
+  const activeElement = getActiveElement(sectionListRef.current?.getRoot());
   return !!sectionListRef.current && sectionListRef.current.getRoot().contains(activeElement);
 }

--- a/packages/x-date-pickers/src/internals/utils/utils.ts
+++ b/packages/x-date-pickers/src/internals/utils/utils.ts
@@ -1,5 +1,6 @@
 import { Theme } from '@mui/material/styles';
 import { SxProps, SystemStyleObject } from '@mui/system';
+import ownerDocument from '@mui/utils/ownerDocument';
 import * as React from 'react';
 
 /* Use it instead of .includes method for IE support */
@@ -35,7 +36,7 @@ export const executeInTheNextEventLoopTick = (fn: () => void) => {
 };
 
 // https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
-export const getActiveElement = (root: Document | ShadowRoot = document): Element | null => {
+const getActiveElementInternal = (root: Document | ShadowRoot = document): Element | null => {
   const activeEl = root.activeElement;
 
   if (!activeEl) {
@@ -43,10 +44,20 @@ export const getActiveElement = (root: Document | ShadowRoot = document): Elemen
   }
 
   if (activeEl.shadowRoot) {
-    return getActiveElement(activeEl.shadowRoot);
+    return getActiveElementInternal(activeEl.shadowRoot);
   }
 
   return activeEl;
+};
+
+/**
+ * Gets the currently active element within a given node's document.
+ * This function traverses shadow DOM if necessary.
+ * @param node - The node from which to get the active element.
+ * @returns The currently active element, or null if none is found.
+ */
+export const getActiveElement = (node: Node | null | undefined): Element | null => {
+  return getActiveElementInternal(ownerDocument(node));
 };
 
 /**
@@ -57,7 +68,7 @@ export const getActiveElement = (root: Document | ShadowRoot = document): Elemen
  */
 export const getFocusedListItemIndex = (listElement: HTMLUListElement): number => {
   const children = Array.from(listElement.children);
-  return children.indexOf(getActiveElement(document)!);
+  return children.indexOf(getActiveElement(listElement)!);
 };
 
 export const DEFAULT_DESKTOP_MODE_MEDIA_QUERY = '@media (pointer: fine)';


### PR DESCRIPTION
Recreate https://github.com/mui/mui-x/pull/10847 with a global solution.

> Fixes a bug where MUI datepickers would not accept keyboard interaction when loaded in a popup via React Portal. See bug reproduction code here: https://codesandbox.io/s/mui-datepickers-in-popup-window-via-react-portal-dx83lg?file=/src/App.js:0-3486

> Instead of using the global document, instead use the inputRef.current's ownerDocument which accurately reflects the document the input is mounted on. This should have no effect to the "normal" usecase, as then inputRef.current.ownerDocument === document

___
Updated [CodeSandbox](https://codesandbox.io/p/sandbox/mui-datepickers-in-popup-window-via-react-portal-forked-3dw266) showcasing problems with the input and accessible DOM structure behaviors as well as a Date Range Picker.


### Before

https://github.com/user-attachments/assets/79e05bfd-2ba1-44a4-a181-5cd01043ba77

### After

https://github.com/user-attachments/assets/ca271d9c-6ea0-444b-a171-561c04e004b5

