### PR TITLE
[pickers] MuiPickersLayout-toolbar is overlapping the Calendar in RTL MobileDatePicker variant

### DIFF
--- a/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
+++ b/packages/x-date-pickers/src/PickersLayout/PickersLayout.tsx
@@ -47,14 +47,6 @@ export const PickersLayoutRoot = styled('div', {
       },
     },
     {
-      props: { pickerOrientation: 'landscape', layoutDirection: 'rtl' },
-      style: {
-        [`& .${pickersLayoutClasses.toolbar}`]: {
-          gridColumn: 3,
-        },
-      },
-    },
-    {
       props: { pickerOrientation: 'portrait' },
       style: {
         [`& .${pickersLayoutClasses.toolbar}`]: { gridColumn: '2 / 4', gridRow: 1 },


### PR DESCRIPTION
Issue #18972 

Remove redundant RTL-specific layout override for pickers

This PR removes a custom style override for isRtl: true. It was causing layout issues in RTL mode, and is not needed, the default layout behaves correctly under dir="rtl" without extra overrides.

Tested in both RTL and LTR: layout now renders as expected.

Demo
https://github.com/user-attachments/assets/81cc08cd-b570-4aef-bc90-ac778f08b2ec

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
