### PR TITLE
[docs] Reduce image size in the inventory grid demo

### DIFF
--- a/docs/src/modules/components/demos/data-grid/Inventory/InventoryDashboard.tsx
+++ b/docs/src/modules/components/demos/data-grid/Inventory/InventoryDashboard.tsx
@@ -11,6 +11,7 @@ import {
   GridDetailPanelToggleCell,
   GRID_DETAIL_PANEL_TOGGLE_COL_DEF,
   isGroupingColumn,
+  GridRowParams,
 } from '@mui/x-data-grid-premium';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -217,6 +218,13 @@ const profitAggregation: GridAggregationFunction<
   },
 };
 
+const aggregationFunctions = { ...GRID_AGGREGATION_FUNCTIONS, profit: profitAggregation };
+
+const getDetailPanelContent = (params: GridRowParams<Product>) => (
+  <ProductDetailPanel row={params.row} />
+);
+const getDetailPanelHeight = () => 115;
+
 function InventoryDashboard() {
   const apiRef = useGridApiRef();
 
@@ -225,11 +233,6 @@ function InventoryDashboard() {
       apiRef.current?.toggleDetailPanel(params.id);
     },
     [apiRef],
-  );
-
-  const aggregationFunctions = React.useMemo(
-    () => ({ ...GRID_AGGREGATION_FUNCTIONS, profit: profitAggregation }),
-    [],
   );
 
   return (
@@ -273,8 +276,8 @@ function InventoryDashboard() {
                   },
                 }}
                 disableRowSelectionOnClick
-                getDetailPanelContent={({ row }) => <ProductDetailPanel row={row} />}
-                getDetailPanelHeight={() => 115}
+                getDetailPanelContent={getDetailPanelContent}
+                getDetailPanelHeight={getDetailPanelHeight}
                 rowHeight={80}
                 onRowClick={onRowClick}
                 slots={{

--- a/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
+++ b/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
@@ -33,7 +33,7 @@ export const products: Product[] = [
     incoming: 30,
     colors: ['Black', 'Silver'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 2,
@@ -49,7 +49,7 @@ export const products: Product[] = [
     totalSold: 180,
     incoming: 25,
     colors: ['Platinum Silver', 'Frost White'],
-    image: 'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=120&h=120&fit=crop',
   },
   {
     id: 3,
@@ -65,7 +65,7 @@ export const products: Product[] = [
     totalSold: 120,
     incoming: 15,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop',
   },
   {
     id: 4,
@@ -82,7 +82,7 @@ export const products: Product[] = [
     incoming: 40,
     colors: ['Black', 'White', 'Blue'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 5,
@@ -98,7 +98,7 @@ export const products: Product[] = [
     totalSold: 400,
     incoming: 50,
     colors: ['Black', 'Silver'],
-    image: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=120&h=120&fit=crop',
   },
   {
     id: 6,
@@ -114,7 +114,7 @@ export const products: Product[] = [
     totalSold: 474,
     incoming: 24,
     colors: ['Space Gray', 'Silver'],
-    image: 'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=120&h=120&fit=crop',
   },
   {
     id: 7,
@@ -130,7 +130,7 @@ export const products: Product[] = [
     totalSold: 423,
     incoming: 32,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL80_UY500_CR0,,500,500.jpg',
+    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL80_UY500_CR0,,120,120.jpg',
   },
   {
     id: 8,
@@ -146,7 +146,7 @@ export const products: Product[] = [
     totalSold: 320,
     incoming: 20,
     colors: ['Graphite', 'Pale Gray'],
-    image: 'https://images.pexels.com/photos/392018/pexels-photo-392018.jpeg?w=500&h=500&fit=crop',
+    image: 'https://images.pexels.com/photos/392018/pexels-photo-392018.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 9,
@@ -163,7 +163,7 @@ export const products: Product[] = [
     incoming: 12,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 10,
@@ -180,7 +180,7 @@ export const products: Product[] = [
     incoming: 54,
     colors: ['Black', 'White', 'Pink'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 11,
@@ -197,7 +197,7 @@ export const products: Product[] = [
     incoming: 18,
     colors: ['Gray'],
     image:
-      'https://images.pexels.com/photos/30708285/pexels-photo-30708285.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/30708285/pexels-photo-30708285.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 12,
@@ -213,7 +213,7 @@ export const products: Product[] = [
     totalSold: 195,
     incoming: 10,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop',
   },
   {
     id: 13,
@@ -230,7 +230,7 @@ export const products: Product[] = [
     incoming: 30,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 14,
@@ -247,7 +247,7 @@ export const products: Product[] = [
     incoming: 16,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 15,
@@ -263,7 +263,7 @@ export const products: Product[] = [
     totalSold: 375,
     incoming: 22,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1614588876378-b2ffa4520c22??w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1614588876378-b2ffa4520c22??w=120&h=120&fit=crop',
   },
   {
     id: 16,
@@ -280,7 +280,7 @@ export const products: Product[] = [
     incoming: 20,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 17,
@@ -296,7 +296,7 @@ export const products: Product[] = [
     totalSold: 165,
     incoming: 8,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=500&h=500&fit=crop',
+    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop',
   },
   {
     id: 18,
@@ -313,7 +313,7 @@ export const products: Product[] = [
     incoming: 12,
     colors: ['White', 'Fog', 'Linen'],
     image:
-      'https://georgiapowermarketplace.com/dw/image/v2/BDDP_PRD/on/demandware.static/-/Sites-masterCatalog/default/dw4a7b3d7f/Products/I-GOOWIFPRO-01-SNOW-XXXX-V1.jpg?sw=500&sh=500',
+      'https://georgiapowermarketplace.com/dw/image/v2/BDDP_PRD/on/demandware.static/-/Sites-masterCatalog/default/dw4a7b3d7f/Products/I-GOOWIFPRO-01-SNOW-XXXX-V1.jpg?sw=120&sh=120',
   },
   {
     id: 19,
@@ -330,7 +330,7 @@ export const products: Product[] = [
     incoming: 18,
     colors: ['Space Gray', 'Silver'],
     image:
-      'https://images.pexels.com/photos/2351844/pexels-photo-2351844.jpeg?w=500&h=500&fit=crop',
+      'https://images.pexels.com/photos/2351844/pexels-photo-2351844.jpeg?w=120&h=120&fit=crop',
   },
   {
     id: 20,
@@ -346,6 +346,6 @@ export const products: Product[] = [
     totalSold: 140,
     incoming: 10,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/6120ERqr3xL._UF500,500_QL80_.jpg',
+    image: 'https://m.media-amazon.com/images/I/6120ERqr3xL._UF120,120_QL80_.jpg',
   },
 ];

--- a/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
+++ b/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
@@ -130,7 +130,7 @@ export const products: Product[] = [
     totalSold: 423,
     incoming: 32,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL80_UY500_CR0,,120,120.jpg',
+    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL80_UY120_CR0,,120,120.jpg',
   },
   {
     id: 8,

--- a/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
+++ b/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
@@ -33,7 +33,7 @@ export const products: Product[] = [
     incoming: 30,
     colors: ['Black', 'Silver'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?_gl=1*bf4yfr*_ga*OTUxMzk3MTE0LjE3NTAxOTYyMTM.*_ga_8JE65Q40S6*czE3NTAxOTYyMTMkbzEkZzEkdDE3NTAxOTYyMjgkajQ1JGwwJGgw',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 2,
@@ -81,7 +81,8 @@ export const products: Product[] = [
     totalSold: 300,
     incoming: 40,
     colors: ['Black', 'White', 'Blue'],
-    image: 'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg',
+    image:
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 5,
@@ -129,7 +130,7 @@ export const products: Product[] = [
     totalSold: 423,
     incoming: 32,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg',
+    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL80_UY500_CR0,,500,500.jpg',
   },
   {
     id: 8,
@@ -145,7 +146,7 @@ export const products: Product[] = [
     totalSold: 320,
     incoming: 20,
     colors: ['Graphite', 'Pale Gray'],
-    image: 'https://images.pexels.com/photos/392018/pexels-photo-392018.jpeg',
+    image: 'https://images.pexels.com/photos/392018/pexels-photo-392018.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 9,
@@ -162,7 +163,7 @@ export const products: Product[] = [
     incoming: 12,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?_gl=1*bf4yfr*_ga*OTUxMzk3MTE0LjE3NTAxOTYyMTM.*_ga_8JE65Q40S6*czE3NTAxOTYyMTMkbzEkZzEkdDE3NTAxOTYyMjgkajQ1JGwwJGgw',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 10,
@@ -178,7 +179,8 @@ export const products: Product[] = [
     totalSold: 174,
     incoming: 54,
     colors: ['Black', 'White', 'Pink'],
-    image: 'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg',
+    image:
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 11,
@@ -194,7 +196,8 @@ export const products: Product[] = [
     totalSold: 305,
     incoming: 18,
     colors: ['Gray'],
-    image: 'https://media.startech.com/cms/products/gallery_large/5g4ab-usb-c-hub._main.jpg',
+    image:
+      'https://images.pexels.com/photos/30708285/pexels-photo-30708285.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 12,
@@ -226,7 +229,8 @@ export const products: Product[] = [
     totalSold: 412,
     incoming: 30,
     colors: ['Black'],
-    image: 'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg',
+    image:
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 14,
@@ -243,7 +247,7 @@ export const products: Product[] = [
     incoming: 16,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?_gl=1*bf4yfr*_ga*OTUxMzk3MTE0LjE3NTAxOTYyMTM.*_ga_8JE65Q40S6*czE3NTAxOTYyMTMkbzEkZzEkdDE3NTAxOTYyMjgkajQ1JGwwJGgw',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 15,
@@ -259,8 +263,7 @@ export const products: Product[] = [
     totalSold: 375,
     incoming: 22,
     colors: ['Black'],
-    image:
-      'https://images.unsplash.com/photo-1614588876378-b2ffa4520c22?q=80&w=1720&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    image: 'https://images.unsplash.com/photo-1614588876378-b2ffa4520c22??w=500&h=500&fit=crop',
   },
   {
     id: 16,
@@ -276,7 +279,8 @@ export const products: Product[] = [
     totalSold: 310,
     incoming: 20,
     colors: ['Black'],
-    image: 'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg',
+    image:
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 17,
@@ -309,7 +313,7 @@ export const products: Product[] = [
     incoming: 12,
     colors: ['White', 'Fog', 'Linen'],
     image:
-      'https://georgiapowermarketplace.com/dw/image/v2/BDDP_PRD/on/demandware.static/-/Sites-masterCatalog/default/dw4a7b3d7f/Products/I-GOOWIFPRO-01-SNOW-XXXX-V1.jpg?sw=800&sh=800',
+      'https://georgiapowermarketplace.com/dw/image/v2/BDDP_PRD/on/demandware.static/-/Sites-masterCatalog/default/dw4a7b3d7f/Products/I-GOOWIFPRO-01-SNOW-XXXX-V1.jpg?sw=500&sh=500',
   },
   {
     id: 19,
@@ -325,7 +329,8 @@ export const products: Product[] = [
     totalSold: 282,
     incoming: 18,
     colors: ['Space Gray', 'Silver'],
-    image: 'https://images.pexels.com/photos/2351844/pexels-photo-2351844.jpeg',
+    image:
+      'https://images.pexels.com/photos/2351844/pexels-photo-2351844.jpeg?w=500&h=500&fit=crop',
   },
   {
     id: 20,
@@ -341,6 +346,6 @@ export const products: Product[] = [
     totalSold: 140,
     incoming: 10,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/6120ERqr3xL._UF894,1000_QL80_.jpg',
+    image: 'https://m.media-amazon.com/images/I/6120ERqr3xL._UF500,500_QL80_.jpg',
   },
 ];

--- a/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
+++ b/docs/src/modules/components/demos/data-grid/Inventory/data/products.ts
@@ -33,7 +33,7 @@ export const products: Product[] = [
     incoming: 30,
     colors: ['Black', 'Silver'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 2,
@@ -49,7 +49,8 @@ export const products: Product[] = [
     totalSold: 180,
     incoming: 25,
     colors: ['Platinum Silver', 'Frost White'],
-    image: 'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 3,
@@ -65,7 +66,8 @@ export const products: Product[] = [
     totalSold: 120,
     incoming: 15,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 4,
@@ -82,7 +84,7 @@ export const products: Product[] = [
     incoming: 40,
     colors: ['Black', 'White', 'Blue'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 5,
@@ -98,7 +100,8 @@ export const products: Product[] = [
     totalSold: 400,
     incoming: 50,
     colors: ['Black', 'Silver'],
-    image: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 6,
@@ -114,7 +117,8 @@ export const products: Product[] = [
     totalSold: 474,
     incoming: 24,
     colors: ['Space Gray', 'Silver'],
-    image: 'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1593642632823-8f785ba67e45?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 7,
@@ -130,7 +134,7 @@ export const products: Product[] = [
     totalSold: 423,
     incoming: 32,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL80_UY120_CR0,,120,120.jpg',
+    image: 'https://m.media-amazon.com/images/I/81xN-mI5KBL.jpg@._V1_QL100_UY120_CR0,,120,120.jpg',
   },
   {
     id: 8,
@@ -146,7 +150,8 @@ export const products: Product[] = [
     totalSold: 320,
     incoming: 20,
     colors: ['Graphite', 'Pale Gray'],
-    image: 'https://images.pexels.com/photos/392018/pexels-photo-392018.jpeg?w=120&h=120&fit=crop',
+    image:
+      'https://images.pexels.com/photos/392018/pexels-photo-392018.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 9,
@@ -163,7 +168,7 @@ export const products: Product[] = [
     incoming: 12,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 10,
@@ -180,7 +185,7 @@ export const products: Product[] = [
     incoming: 54,
     colors: ['Black', 'White', 'Pink'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 11,
@@ -197,7 +202,7 @@ export const products: Product[] = [
     incoming: 18,
     colors: ['Gray'],
     image:
-      'https://images.pexels.com/photos/30708285/pexels-photo-30708285.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/30708285/pexels-photo-30708285.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 12,
@@ -213,7 +218,8 @@ export const products: Product[] = [
     totalSold: 195,
     incoming: 10,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 13,
@@ -230,7 +236,7 @@ export const products: Product[] = [
     incoming: 30,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 14,
@@ -247,7 +253,7 @@ export const products: Product[] = [
     incoming: 16,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1983037/pexels-photo-1983037.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 15,
@@ -263,7 +269,8 @@ export const products: Product[] = [
     totalSold: 375,
     incoming: 22,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1614588876378-b2ffa4520c22??w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1614588876378-b2ffa4520c22??w=120&h=120&fit=crop&q=100',
   },
   {
     id: 16,
@@ -280,7 +287,7 @@ export const products: Product[] = [
     incoming: 20,
     colors: ['Black'],
     image:
-      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/1054713/pexels-photo-1054713.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 17,
@@ -296,7 +303,8 @@ export const products: Product[] = [
     totalSold: 165,
     incoming: 8,
     colors: ['Black'],
-    image: 'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop',
+    image:
+      'https://images.unsplash.com/photo-1527443224154-c4a3942d3acf?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 18,
@@ -330,7 +338,7 @@ export const products: Product[] = [
     incoming: 18,
     colors: ['Space Gray', 'Silver'],
     image:
-      'https://images.pexels.com/photos/2351844/pexels-photo-2351844.jpeg?w=120&h=120&fit=crop',
+      'https://images.pexels.com/photos/2351844/pexels-photo-2351844.jpeg?w=120&h=120&fit=crop&q=100',
   },
   {
     id: 20,
@@ -346,6 +354,6 @@ export const products: Product[] = [
     totalSold: 140,
     incoming: 10,
     colors: ['Black'],
-    image: 'https://m.media-amazon.com/images/I/6120ERqr3xL._UF120,120_QL80_.jpg',
+    image: 'https://m.media-amazon.com/images/I/6120ERqr3xL._UF120,120_QL100_.jpg',
   },
 ];


### PR DESCRIPTION
Reduces total download for all images in the demo from ~5MB to ~90kB.

I have resized the images down to 120x120 - double than the image size from styles - because of retina displays

I have also made master/detail props static, as it is suggested in https://mui.com/x/react-data-grid/master-detail

Preview
https://deploy-preview-19004--material-ui-x.netlify.app/x/react-data-grid/demos/inventory/
