### PR TITLE
[code-infra] Accept `PORT` env on `docs:dev` script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
     "build": "rimraf ./export && cross-env NODE_ENV=production next build && pnpm build-sw",
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "next dev --port 3001",
+    "dev": "next dev --port ${PORT:-3001}",
     "deploy": "git push -f upstream master:docs-v8",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "serve": "serve ./export -l 3010",


### PR DESCRIPTION
This allows me to automate different ports for multiple copies of the repo.

Original behaviour should stay the same, unless you set PORT in your env for some other reason, which you probably shouldn't 🫠 