### PR TITLE
[DataGrid] Fix performance issue for root level "select all"

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -95,9 +95,12 @@ export const useGridRowSelection = (
     [props.rowSelection],
   );
 
+  const isNestedData = useGridSelector(apiRef, gridRowMaximumTreeDepthSelector) > 1;
+
   const applyAutoSelection =
     props.signature !== GridSignature.DataGrid &&
-    (props.rowSelectionPropagation?.parents || props.rowSelectionPropagation?.descendants);
+    (props.rowSelectionPropagation?.parents || props.rowSelectionPropagation?.descendants) &&
+    isNestedData;
 
   const propRowSelectionModel = React.useMemo(() => {
     return props.rowSelectionModel;
@@ -121,7 +124,6 @@ export const useGridRowSelection = (
 
   const canHaveMultipleSelection = isMultipleRowSelectionEnabled(props);
   const tree = useGridSelector(apiRef, gridRowTreeSelector);
-  const isNestedData = useGridSelector(apiRef, gridRowMaximumTreeDepthSelector) > 1;
 
   const expandMouseRowRangeSelection = React.useCallback(
     (id: GridRowId) => {

--- a/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts
@@ -206,6 +206,11 @@ export const findRowsToSelect = (
         }
       }
     };
+    // For root level rows, we don't need to traverse parents
+    const rowNode = tree[selectedRow];
+    if (!rowNode || rowNode.parent === GRID_ROOT_GROUP_ID) {
+      return;
+    }
     traverseParents(selectedRow);
   }
 };


### PR DESCRIPTION
Fixes #19001

Before: https://stackblitz.com/edit/ddumkzun-fz2hksdw
After: https://stackblitz.com/edit/ddumkzun-iv8mn7xq

## Changes done

This PR fix two things:

1. When the package is Pro or Premium but no nested data is available, row selection propagation was still running unnecessarily.
2. A redundant sibling search was occurring at the root level, even though it was already handled by the select all cell component.

## Follow up

A part of the performance issue still remains in this line:
https://github.com/mui/mui-x/blob/89fae6a191b0d19b6f240f50b8aa5087e0117200/packages/x-data-grid/src/hooks/features/rowSelection/utils.ts#L147

Specifically, the `.filter()` operation runs on all rows at a level, but now only for rows with `depth > 0`. In most cases, we can assume that the number of children (not descendents) under a given parent remains within a safe range (or else server-side data should be used).

However, we should still work on introducing partial dictionaries where possible to improve performance for these cases.