### PR TITLE
[charts][docs] Fix broken link to D3

### DIFF
--- a/docs/data/charts/stacking/stacking.md
+++ b/docs/data/charts/stacking/stacking.md
@@ -17,7 +17,7 @@ Series with the same `stack` value will get stacked together.
 
 ## Stacking strategy
 
-Based on D3 [stack orders](https://github.com/d3/d3-shape#stack-orders) and [stack offsets](https://github.com/d3/d3-shape#stack-offsets) you can modify how series are stacked.
+Based on D3 [stack orders](https://d3js.org/d3-shape/stack#stack_order) and [stack offsets](https://d3js.org/d3-shape/stack#stack_offset) you can modify how series are stacked.
 
 To pass those attributes, use series properties `stackOffset` (default `'diverging'` for bar and `'none'` for line) and `stackOrder` (default `'none'`).
 You can define them for only one of the series of a stack group.


### PR DESCRIPTION
This used to work, proof: https://github.com/d3/d3-shape/tree/v2.0.0?tab=readme-ov-file#stack-orders, but the docs got moved afterward.

Preview: https://deploy-preview-19020--material-ui-x.netlify.app/x/react-charts/stacking/#stacking-strategy

---

**Off-topic**. I landed here trying to use the stacking feature with an LLM. (v0, MUI Chat, Bolt, Lovable, etc).

- HeroUI: https://heroui.chat/chat/74d1de8f-5b73-44fa-a6c9-6dd9536fed27. It doesn't want to use any other dependencies but Hero UI ❌.
- Lovable: https://lovable.dev/projects/d3a84641-f6a7-4307-8f4a-7ed3deefc165. It crashes, it can't render emotion. ❌
- v0: https://v0.dev/chat/render-mui-chart-example-vkc0OgRcjpH. It tried to use the recharts' API and failed. ❌
- Bolt: https://bolt.new/~/sb1-wlxeucqd. It tried to use the recharts' API and failed. ❌
- GitHub Copilot. It tried to use the recharts' API and failed. Even when I tell him to access the MUI docs, it fails ❌
- Windsurf. Tries to do crazy stuff, failed. ❌
- Cursor. It tried to use the recharts' API and failed. ❌
- Replit: https://replit.com/@OlivierTassina1/ChartDisplay. It's super slow, but it managed to do it by doing a web search, and then crawling our docs (so has no notion of versioning) 🐢✅. 
- MUI Chat: https://chat.mui.com/chat/edit-lGsn4WKWV4sVbej3tpbw. It works and fast ✅.
But, if you add some level of confusion in the request, it fails ❌: https://chat.mui.com/chat/edit-07wYP8b4BFjdCDg56cfU. It's like it struggles to turn https://deploy-preview-19020--material-ui-x.netlify.app/x/react-charts/stacking/#stack-offset into code. I think this emphasizes how important https://www.notion.so/mui-org/docs-infra-Meeting-2025-08-01-242cbfe7b6608078ad3adcfa5cdc2412?source=copy_link#242cbfe7b66080c48257f51086a36c6d is. I myself struggle to make sense of the docs, I need to read the demo's source carefully to understand, it feels like there are too many hops, so should have simpler code examples, for humans and LLMs. cc @mapache-salvaje for context.