### PR TITLE
[chart] Fix incorrect code in line chart preview

### DIFF
--- a/docs/data/charts/lines/ColorScale.js
+++ b/docs/data/charts/lines/ColorScale.js
@@ -10,7 +10,7 @@ import Checkbox from '@mui/material/Checkbox';
 export default function ColorScale() {
   const [colorX, setColorX] = React.useState('None');
   const [colorY, setColorY] = React.useState('piecewise');
-  const [colorArea, setColorArea] = React.useState(false);
+  const [colorArea, setColorArea] = React.useState(true);
 
   return (
     <Stack direction="column" spacing={1} sx={{ width: '100%', maxWidth: 600 }}>

--- a/docs/data/charts/lines/ColorScale.tsx
+++ b/docs/data/charts/lines/ColorScale.tsx
@@ -14,7 +14,7 @@ export default function ColorScale() {
   const [colorY, setColorY] = React.useState<'None' | 'piecewise' | 'continuous'>(
     'piecewise',
   );
-  const [colorArea, setColorArea] = React.useState(false);
+  const [colorArea, setColorArea] = React.useState(true);
 
   return (
     <Stack direction="column" spacing={1} sx={{ width: '100%', maxWidth: 600 }}>


### PR DESCRIPTION
Fixes #18943 

### Changes
This PR fixes the following:

1. In https://mui.com/x/react-charts/lines/#color-scale the preview code was using `ScatterChart` instead of `LineChart`.
2. At the same place chart area was shown which is now changed to be configurable using a checkbox.

Screenshot of the change:
<img width="812" height="774" alt="image" src="https://github.com/user-attachments/assets/0f6bc7fa-1a2b-4422-af8b-6223036c19c5" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
