### PR TITLE
[core] Fix licensing model name

### DIFF
--- a/packages/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
+++ b/packages/x-data-grid-premium/src/tests/license.DataGridPremium.test.tsx
@@ -11,7 +11,7 @@ describe('<DataGridPremium /> - License', () => {
     LicenseInfo.setLicenseKey(
       generateLicense({
         expiryDate: addYears(new Date(), 1),
-        orderNumber: 'Test',
+        orderNumber: '123',
         licenseModel: 'subscription',
         planScope: 'pro',
         planVersion: 'initial',

--- a/packages/x-license/src/generateLicense/generateLicense.test.ts
+++ b/packages/x-license/src/generateLicense/generateLicense.test.ts
@@ -5,13 +5,13 @@ describe('License: generateLicense', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'subscription',
         planVersion: 'initial',
       }),
     ).to.equal(
-      'e8fad422a82720084ec67dd693f08056Tz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXBybyxMTT1zdWJzY3JpcHRpb24sUFY9aW5pdGlhbCxLVj0y',
+      'dcb6ef99ea44c162494608dd6c3b43eaTz0xMjMsRT0xNTkxNzIzODc5MDYyLFM9cHJvLExNPXN1YnNjcmlwdGlvbixQVj1pbml0aWFsLEtWPTI=',
     );
   });
 
@@ -19,13 +19,13 @@ describe('License: generateLicense', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'premium',
         licenseModel: 'subscription',
         planVersion: 'initial',
       }),
     ).to.equal(
-      '8ca0384bfb92ec214d4cd72483f5110bTz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXByZW1pdW0sTE09c3Vic2NyaXB0aW9uLFBWPWluaXRpYWwsS1Y9Mg==',
+      '5f42b577a8a4875dada84e712bf0e1eaTz0xMjMsRT0xNTkxNzIzODc5MDYyLFM9cHJlbWl1bSxMTT1zdWJzY3JpcHRpb24sUFY9aW5pdGlhbCxLVj0y',
     );
   });
 
@@ -33,13 +33,13 @@ describe('License: generateLicense', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'subscription',
         planVersion: 'initial',
       }),
     ).to.equal(
-      'e8fad422a82720084ec67dd693f08056Tz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXBybyxMTT1zdWJzY3JpcHRpb24sUFY9aW5pdGlhbCxLVj0y',
+      'dcb6ef99ea44c162494608dd6c3b43eaTz0xMjMsRT0xNTkxNzIzODc5MDYyLFM9cHJvLExNPXN1YnNjcmlwdGlvbixQVj1pbml0aWFsLEtWPTI=',
     );
   });
 
@@ -47,13 +47,13 @@ describe('License: generateLicense', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'perpetual',
         planVersion: 'initial',
       }),
     ).to.equal(
-      'aaf2e3c60b06199962fbbab985843d97Tz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXBybyxMTT1wZXJwZXR1YWwsUFY9aW5pdGlhbCxLVj0y',
+      '1930a9d5475565836e69ea1ac98208eeTz0xMjMsRT0xNTkxNzIzODc5MDYyLFM9cHJvLExNPXBlcnBldHVhbCxQVj1pbml0aWFsLEtWPTI=',
     );
   });
 
@@ -61,13 +61,13 @@ describe('License: generateLicense', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'subscription',
         planVersion: 'Q3-2024',
       }),
     ).to.equal(
-      '4adf08e54d606215809064d1d31b6b39Tz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXBybyxMTT1zdWJzY3JpcHRpb24sUFY9UTMtMjAyNCxLVj0y',
+      'a43dfef1c82eb79935c6cd38272b8fdeTz0xMjMsRT0xNTkxNzIzODc5MDYyLFM9cHJvLExNPXN1YnNjcmlwdGlvbixQVj1RMy0yMDI0LEtWPTI=',
     );
   });
 
@@ -75,13 +75,13 @@ describe('License: generateLicense', () => {
     expect(
       generateLicense({
         expiryDate: new Date(1591723879062),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'premium',
         licenseModel: 'subscription',
         planVersion: 'Q3-2024',
       }),
     ).to.equal(
-      'b76c2067275b3b566fcae1d28ad23c91Tz1NVUktMTIzLEU9MTU5MTcyMzg3OTA2MixTPXByZW1pdW0sTE09c3Vic2NyaXB0aW9uLFBWPVEzLTIwMjQsS1Y9Mg==',
+      '21b1d706d059d60add6dd17e3b28e2b8Tz0xMjMsRT0xNTkxNzIzODc5MDYyLFM9cHJlbWl1bSxMTT1zdWJzY3JpcHRpb24sUFY9UTMtMjAyNCxLVj0y',
     );
   });
 });

--- a/packages/x-license/src/useLicenseVerifier/useLicenseVerifier.test.tsx
+++ b/packages/x-license/src/useLicenseVerifier/useLicenseVerifier.test.tsx
@@ -55,7 +55,7 @@ describe.skipIf(!isJSDOM)('useLicenseVerifier', () => {
       const key = generateLicense({
         expiryDate: new Date(3001, 0, 0, 0, 0, 0, 0),
         licenseModel: 'perpetual',
-        orderNumber: '12345',
+        orderNumber: '123',
         planScope: 'pro',
         planVersion: 'initial',
       });
@@ -80,7 +80,7 @@ describe.skipIf(!isJSDOM)('useLicenseVerifier', () => {
 
       const expiredLicenseKey = generateLicense({
         expiryDate: new Date(new Date().getTime() - oneDayInMS * 30),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'subscription',
         planVersion: 'initial',
@@ -110,7 +110,7 @@ describe.skipIf(!isJSDOM)('useLicenseVerifier', () => {
 
       const licenseKey = generateLicense({
         expiryDate: new Date(3001, 0, 0, 0, 0, 0, 0),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'subscription',
         planVersion: 'initial',
@@ -136,7 +136,7 @@ describe.skipIf(!isJSDOM)('useLicenseVerifier', () => {
 
       const licenseKey = generateLicense({
         expiryDate: new Date(3001, 0, 0, 0, 0, 0, 0),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'pro',
         licenseModel: 'subscription',
         planVersion: 'Q3-2024',
@@ -160,7 +160,7 @@ describe.skipIf(!isJSDOM)('useLicenseVerifier', () => {
 
       const licenseKey = generateLicense({
         expiryDate: new Date(3001, 0, 0, 0, 0, 0, 0),
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planScope: 'premium',
         licenseModel: 'subscription',
         planVersion: 'Q3-2024',

--- a/packages/x-license/src/verifyLicense/verifyLicense.test.ts
+++ b/packages/x-license/src/verifyLicense/verifyLicense.test.ts
@@ -22,7 +22,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
 
   describe('key version: 1', () => {
     const licenseKey =
-      '0f94d8b65161817ca5d7f7af8ac2f042T1JERVI6TVVJLVN0b3J5Ym9vayxFWFBJUlk9MTY1NDg1ODc1MzU1MCxLRVlWRVJTSU9OPTE=';
+      '65897de688b8bed993b1d6ddd0e1d548T1JERVI6MTIzLEVYUElSWT0xNzg1ODc0MDEwNzA4LEtFWVZFUlNJT049MQ==';
 
     it('should log an error when ReleaseInfo is not valid', () => {
       process.env.NODE_ENV = 'production';
@@ -53,7 +53,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
         expiryDate: new Date(releaseDate.getTime() - oneDayInMS),
         planScope: 'pro',
         licenseModel: 'perpetual',
-        orderNumber: 'MUI-123',
+        orderNumber: '123',
         planVersion: 'initial',
       });
 
@@ -82,7 +82,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
   describe('key version: 2', () => {
     const licenseKeyPro = generateLicense({
       expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-      orderNumber: 'MUI-123',
+      orderNumber: '123',
       planScope: 'pro',
       licenseModel: 'subscription',
       planVersion: 'initial',
@@ -90,7 +90,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
 
     const licenseKeyPremium = generateLicense({
       expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-      orderNumber: 'MUI-123',
+      orderNumber: '123',
       planScope: 'premium',
       licenseModel: 'subscription',
       planVersion: 'initial',
@@ -148,7 +148,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
         process.env.NODE_ENV = 'production';
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-          orderNumber: 'MUI-123',
+          orderNumber: '123',
           planScope: 'pro',
           licenseModel: 'subscription',
           planVersion: 'initial',
@@ -166,7 +166,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
       it('should not validate subscription license in dev if current date is after expiry date but release date is before expiry date', () => {
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(new Date().getTime() - oneDayInMS),
-          orderNumber: 'MUI-123',
+          orderNumber: '123',
           planScope: 'pro',
           licenseModel: 'subscription',
           planVersion: 'initial',
@@ -185,7 +185,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
         process.env.NODE_ENV = 'development';
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(new Date().getTime() - oneDayInMS * 30),
-          orderNumber: 'MUI-123',
+          orderNumber: '123',
           planScope: 'pro',
           licenseModel: 'subscription',
           planVersion: 'initial',
@@ -203,7 +203,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
       it('should validate perpetual license in dev if current date is after expiry date but release date is before expiry date', () => {
         const expiredLicenseKey = generateLicense({
           expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-          orderNumber: 'MUI-123',
+          orderNumber: '123',
           planScope: 'pro',
           licenseModel: 'perpetual',
           planVersion: 'initial',
@@ -235,7 +235,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
   describe('key version: 2.1', () => {
     const licenseKeyPro = generateLicense({
       expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-      orderNumber: 'MUI-123',
+      orderNumber: '123',
       planScope: 'pro',
       licenseModel: 'annual',
       planVersion: 'initial',
@@ -256,7 +256,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
   describe('key version: 2.2', () => {
     const proLicenseKeyInitial = generateLicense({
       expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-      orderNumber: 'MUI-123',
+      orderNumber: '123',
       planScope: 'pro',
       licenseModel: 'annual',
       planVersion: 'initial',
@@ -264,7 +264,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
 
     const premiumLicenseKeyInitial = generateLicense({
       expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-      orderNumber: 'MUI-123',
+      orderNumber: '123',
       planScope: 'premium',
       licenseModel: 'annual',
       planVersion: 'initial',
@@ -272,7 +272,7 @@ describe.skipIf(!isJSDOM)('License: verifyLicense', () => {
 
     const proLicenseKeyQ32024 = generateLicense({
       expiryDate: new Date(releaseDate.getTime() + oneDayInMS),
-      orderNumber: 'MUI-123',
+      orderNumber: '123',
       planScope: 'pro',
       licenseModel: 'annual',
       planVersion: 'Q3-2024',

--- a/test/performance-charts/setup.ts
+++ b/test/performance-charts/setup.ts
@@ -4,7 +4,7 @@ import { generateLicense, LicenseInfo } from '@mui/x-license';
 beforeAll(() => {
   const licenseKey = generateLicense({
     expiryDate: new Date(3001, 0, 0, 0, 0, 0, 0),
-    orderNumber: 'MUI-123',
+    orderNumber: '123',
     planScope: 'pro',
     licenseModel: 'subscription',
     planVersion: 'Q3-2024',

--- a/test/utils/testLicense.js
+++ b/test/utils/testLicense.js
@@ -7,7 +7,7 @@ export function generateTestLicenseKey(expiryDate = new Date()) {
   return generateLicense({
     licenseModel: 'subscription',
     planScope: 'premium',
-    orderNumber: 'MUI X tests',
+    orderNumber: '123',
     expiryDate,
     planVersion: 'Q3-2024',
   });


### PR DESCRIPTION
The initial goal was to finish the renaming of "licensing model" to "license model", where it got missed. At the same time I did:

- Align the license decode method with the source, to prepare for https://github.com/mui/mui-x/issues/19024.