### PR TITLE
[data grid] filterFormProps - columnInputProps only accept variant 'outlined'

### DIFF
--- a/packages/x-data-grid/src/material/index.tsx
+++ b/packages/x-data-grid/src/material/index.tsx
@@ -159,8 +159,8 @@ const BaseSelect = forwardRef<any, P['baseSelect']>(function BaseSelect(props, r
         label={label}
         displayEmpty
         onChange={onChange as any}
-        {...rest}
         variant="outlined"
+        {...rest}
         notched
         inputProps={slotProps?.htmlInput}
         onOpen={onOpen}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/mui-x/issues/18912

## Changelog

Simply moves the spread operator below the variant prop.