### PR TITLE
[charts] Fix type assertion in axis highlight components

### DIFF
--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsXAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsXAxisHighlight.tsx
@@ -29,7 +29,6 @@ export default function ChartsXHighlight(props: {
   const axisXValues = useSelector(store, selectorChartsHighlightXAxisValue);
   const xAxes = useSelector(store, selectorChartXAxis);
 
-
   if (axisXValues.length === 0) {
     return null;
   }

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsXAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsXAxisHighlight.tsx
@@ -29,6 +29,7 @@ export default function ChartsXHighlight(props: {
   const axisXValues = useSelector(store, selectorChartsHighlightXAxisValue);
   const xAxes = useSelector(store, selectorChartXAxis);
 
+
   if (axisXValues.length === 0) {
     return null;
   }
@@ -59,8 +60,7 @@ export default function ChartsXHighlight(props: {
       <React.Fragment key={`${axisId}-${value}`}>
         {isBandScaleX && xScale(value) !== undefined && (
           <ChartsAxisHighlightPath
-            // @ts-expect-error, xScale value is checked in the statement above
-            d={`M ${xScale(value) - (xScale.step() - xScale.bandwidth()) / 2} ${
+            d={`M ${xScale(value)! - (xScale.step() - xScale.bandwidth()) / 2} ${
               top
             } l ${xScale.step()} 0 l 0 ${height} l ${-xScale.step()} 0 Z`}
             className={classes.root}

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsYAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsYAxisHighlight.tsx
@@ -29,6 +29,7 @@ export default function ChartsYHighlight(props: {
   const axisYValues = useSelector(store, selectorChartsHighlightYAxisValue);
   const yAxes = useSelector(store, selectorChartYAxis);
 
+
   if (axisYValues.length === 0) {
     return null;
   }
@@ -54,13 +55,13 @@ export default function ChartsYHighlight(props: {
       }
     }
 
+
     return (
       <React.Fragment key={`${axisId}-${value}`}>
         {isBandScaleY && yScale(value) !== undefined && (
           <ChartsAxisHighlightPath
             d={`M ${left} ${
-              // @ts-expect-error, yScale value is checked in the statement above
-              yScale(value) - (yScale.step() - yScale.bandwidth()) / 2
+              yScale(value)! - (yScale.step() - yScale.bandwidth()) / 2
             } l 0 ${yScale.step()} l ${width} 0 l 0 ${-yScale.step()} Z`}
             className={classes.root}
             ownerState={{ axisHighlight: 'band' }}

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsYAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsYAxisHighlight.tsx
@@ -29,7 +29,6 @@ export default function ChartsYHighlight(props: {
   const axisYValues = useSelector(store, selectorChartsHighlightYAxisValue);
   const yAxes = useSelector(store, selectorChartYAxis);
 
-
   if (axisYValues.length === 0) {
     return null;
   }

--- a/packages/x-charts/src/ChartsAxisHighlight/ChartsYAxisHighlight.tsx
+++ b/packages/x-charts/src/ChartsAxisHighlight/ChartsYAxisHighlight.tsx
@@ -54,7 +54,6 @@ export default function ChartsYHighlight(props: {
       }
     }
 
-
     return (
       <React.Fragment key={`${axisId}-${value}`}>
         {isBandScaleY && yScale(value) !== undefined && (


### PR DESCRIPTION
This PR removes unnecessary `@ts-expect-error` checks