### PR TITLE
[data grid] Fix use use-sync-external-store shim

### DIFF
--- a/packages/x-internals/src/store/useStore.ts
+++ b/packages/x-internals/src/store/useStore.ts
@@ -1,4 +1,6 @@
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
+/* We need to import the shim because React 17 does not support the `useSyncExternalStore` API.
+ * More info: https://github.com/mui/mui-x/issues/18303#issuecomment-2958392341 */
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import type { Store } from './Store';
 
 export function useStore<State, Value>(


### PR DESCRIPTION
Closes #19057

Same resolution as  https://github.com/mui/mui-x/issues/18303