### PR TITLE
[code-infra] Remove namespaces

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -411,7 +411,7 @@ export default defineConfig(
   },
 
   {
-    // TODO: typescript namespaces found to be harmful. Refactor to different patterns.
+    // TODO: typescript namespaces found to be harmful. Refactor to different patterns. More info: https://github.com/mui/mui-x/pull/19071
     ignores: ['packages/x-scheduler/**/*', 'packages/x-virtualizer/**/*'],
     rules: {
       '@typescript-eslint/no-namespace': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -409,4 +409,12 @@ export default defineConfig(
       'react-compiler/react-compiler': 'off',
     },
   },
+
+  {
+    // TODO: typescript namespaces found to be harmful. Refactor to different patterns.
+    ignores: ['packages/x-scheduler/**/*', 'packages/x-virtualizer/**/*'],
+    rules: {
+      '@typescript-eslint/no-namespace': 'error',
+    },
+  },
 );

--- a/packages/x-license/src/utils/licenseInfo.ts
+++ b/packages/x-license/src/utils/licenseInfo.ts
@@ -5,9 +5,9 @@ export interface MuiLicenseInfo {
   key: string | undefined;
 }
 
-declare namespace globalThis {
-  // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
-  let __MUI_LICENSE_INFO__: MuiLicenseInfo;
+declare global {
+  // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention, vars-on-top
+  var __MUI_LICENSE_INFO__: MuiLicenseInfo;
 }
 
 // Store the license information in a global, so it can be shared

--- a/packages/x-telemetry/src/runtime/config.ts
+++ b/packages/x-telemetry/src/runtime/config.ts
@@ -4,9 +4,9 @@ interface TelemetryEnvConfig {
   DEBUG: boolean;
 }
 
-declare namespace globalThis {
-  // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
-  let __MUI_X_TELEMETRY_DISABLED__: boolean | undefined;
+declare global {
+  // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention, vars-on-top
+  var __MUI_X_TELEMETRY_DISABLED__: boolean | undefined;
 }
 
 const envEnabledValues = ['1', 'true', 'yes', 'y'];

--- a/test/utils/addChaiAssertions.ts
+++ b/test/utils/addChaiAssertions.ts
@@ -6,6 +6,7 @@ chai.use(chaiPlugin);
 
 // https://stackoverflow.com/a/46755166/3406963
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Chai {
     interface Assertion {
       /**


### PR DESCRIPTION
Lint rule to disallow usage of typescript namespaces. We've seen at least two problems with them:

* Creates [non-portable types](https://github.com/mui/base-ui/pull/2324) in base ui.
* [This pattern](https://github.com/mui/mui-x/blob/1cf853ed45cf301211ece1c0ca21981ea208edfb/packages/x-virtualizer/src/models/core.ts#L4-L10) leads to broken bundling in [codesandbox](https://codesandbox.io/embed/kgylpd?module=/src/Demo.tsx&fontsize=12).

Gauging the ecosystem it also looks like support for namespaces in tooling is poor and tends to be treated as a deprecated feature. Propose to shy away from it to avoid other future problems.

* Leaving to the authors to refactor other usage
* The usage in chai is allowed, no other way to achieve this on legacy code.
* Will move this rule to code infra eventually