### PR TITLE
[support-infra] Remove default issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -1,6 +1,6 @@
 name: Bug report 🐛
 description: Create a bug report for MUI X.
-labels: ['status: waiting for maintainer', 'type: bug']
+labels: ['status: waiting for maintainer']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -1,6 +1,6 @@
 name: Feature request 💄
 description: Suggest a new idea for MUI X.
-labels: ['status: waiting for maintainer', 'type: new feature']
+labels: ['status: waiting for maintainer']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Context, I have spent some time to dive into the product backlog labeling health:

1. I create filters that allows us to find all the issues without a product scope label: https://www.notion.so/mui-org/product-GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca?source=copy_link#24bcbfe7b66080f19ad0d207c9e5ce1a. Then fixed them to get to zero.
But I gave up on covering material-ui repo, it would have taken a whole day 😀.
2. I fixed all the issues with more than one label type. From which, it seems clear that `expected behavior` and `duplicate` label should be ["type" labels](https://www.notion.so/mui-org/GitHub-issues-Product-backlog-c1d7072e0c2545b0beb43b115f6030f6?source=copy_link#1e3cbfe7b660801e8af6eed5b0d0ce68) because they are mutually exclusive with the other type labels. And with this larger diversity of types labels, adding the `type:` prefix now feels like a clear win.

However, it feels like there are too many of them that have the wrong type, e.g.:

- #18431
- #18847
- #18404

So I think we should normalize back to what the other repositories do. We tried with mui/mui-x, but it looks like the probabilities are something like this:

- user developers apply the right label: 40%
- maintainer see that they needs to apply the right label when there is one applied by default 50%
- maintainer see that they needs to apply the right label when there is none applied by default 95%
- maintainer apply the right label: 95%

Then we can apply the math with ⬆️ values:

1. Label by default, probability to get the right label = 0.40 * 0.50 + 0.40 * 0.50 * 0.95 + 0.60 * 0.50 * 0.95 = 0.68
2. No labels by default, probability to get the right label = 0.95 * 0.95 = 0.90 🏆