### PR TITLE
[infra] Fix `fs-extra` removal from `formattedTSDemos` script

### DIFF
--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -11,6 +11,7 @@
  */
 const ignoreList = ['/pages.ts', 'styling.ts', 'styling.tsx', 'types.ts'];
 
+const fse = require('fs-extra');
 const fs = require('fs');
 const path = require('path');
 const babel = require('@babel/core');
@@ -90,7 +91,7 @@ const previewOverride = {
 async function transpileFile(tsxPath, program, ignoreCache = false) {
   const jsPath = tsxPath.replace(/\.tsx?$/, '.js');
   try {
-    if (!ignoreCache && (await fs.promises.exists(jsPath))) {
+    if (!ignoreCache && (await fse.exists(jsPath))) {
       const [jsStat, tsxStat] = await Promise.all([
         fs.promises.stat(jsPath),
         fs.promises.stat(tsxPath),


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/mui/mui-x/pull/19127.

`fs.exists` is valid, but `fs.promises.exists` doesn't exist since `fs.exists` is deprecated.

Reverting to `fs-extra`'s version for now. I'll look into removing it later. 