### PR TITLE
[infra] Create renovate group for Next.js and eslint-plugin-next

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,10 @@
       "groupName": "conf",
       "matchPackageNames": ["conf"],
       "allowedVersions": "< 12.0.0"
+    },
+    {
+      "groupName": "next",
+      "matchPackageNames": ["next", "@next/eslint-plugin-next"]
     }
   ]
 }


### PR DESCRIPTION
Create renovate group for Next.js and eslint-plugin-next since they are released together.

See source commit in provenance:
- [`next`](https://www.npmjs.com/package/next)
- [`@next/eslint-plugin-next`](https://www.npmjs.com/package/@next/eslint-plugin-next)