### PR TITLE
[charts] Add Future components link in the sidebar 

### DIFF
--- a/docs/data/charts/gantt/gantt.md
+++ b/docs/data/charts/gantt/gantt.md
@@ -3,7 +3,7 @@ title: React Gantt chart
 productId: x-charts
 ---
 
-# Charts - Gantt [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
+# Charts - Gantt [<span class="plan-premium"></span>](/x/introduction/licensing/#premium-plan 'Premium plan')🚧
 
 <p class="description">Gantt charts can illustrate a schedule and the relationships between its various activities.</p>
 

--- a/docs/data/charts/treemap/treemap.md
+++ b/docs/data/charts/treemap/treemap.md
@@ -3,7 +3,7 @@ title: React Treemap chart
 productId: x-charts
 ---
 
-# Charts - Treemap 🚧
+# Charts - Treemap [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan 'Pro plan')🚧
 
 <p class="description">Treemap allows to display data with a hierarchical structure.</p>
 

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -558,6 +558,7 @@ const pages: MuiPage[] = [
               { pathname: '/x/react-charts/pyramid', title: 'Pyramid demo' },
             ],
           },
+          { pathname: '/x/react-charts/#planned-charts', title: 'Future Components' },
           {
             pathname: '/x/react-charts/main-features',
             subheader: 'Main features',
@@ -619,15 +620,6 @@ const pages: MuiPage[] = [
                   },
                 ],
               },
-            ],
-          },
-          {
-            pathname: '/x/react-charts-future',
-            subheader: 'Future components',
-            children: [
-              { pathname: '/x/react-charts/treemap', title: 'Treemap', planned: true },
-              { pathname: '/x/react-charts/sankey', plan: 'pro', planned: true },
-              { pathname: '/x/react-charts/gantt', plan: 'pro', planned: true },
             ],
           },
         ],

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -558,7 +558,7 @@ const pages: MuiPage[] = [
               { pathname: '/x/react-charts/pyramid', title: 'Pyramid demo' },
             ],
           },
-          { pathname: '/x/react-charts/#planned-charts', title: 'Future Components' },
+          { pathname: '/x/react-charts/#planned-charts', title: 'Future Components', planned: true },
           {
             pathname: '/x/react-charts/main-features',
             subheader: 'Main features',

--- a/docs/data/pages.ts
+++ b/docs/data/pages.ts
@@ -558,7 +558,11 @@ const pages: MuiPage[] = [
               { pathname: '/x/react-charts/pyramid', title: 'Pyramid demo' },
             ],
           },
-          { pathname: '/x/react-charts/#planned-charts', title: 'Future Components', planned: true },
+          {
+            pathname: '/x/react-charts/#planned-charts',
+            title: 'Future Components',
+            planned: true,
+          },
           {
             pathname: '/x/react-charts/main-features',
             subheader: 'Main features',


### PR DESCRIPTION
Preview: https://deploy-preview-19140--material-ui-x.netlify.app/x/react-charts/#planned-charts
<img width="287" height="183" alt="Screenshot 2025-08-11 at 10 20 47 PM" src="https://github.com/user-attachments/assets/98fff697-0af1-408d-a1a6-1fff68fa7809" />
