### PR TITLE
[code-infra] Fix `fs.promises.watchFile`

### DIFF
--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -202,7 +202,7 @@ async function main(argv) {
   }
 
   tsxFiles.forEach((filePath) => {
-    fs.promises.watchFile(filePath, { interval: 500 }, async () => {
+    fs.watchFile(filePath, { interval: 500 }, async () => {
       if ((await transpileFile(filePath, program, true)) === 0) {
         console.log('Success - %s', filePath);
       }


### PR DESCRIPTION
In https://github.com/mui/mui-x/pull/19127 I converted `fse.watchFile` to `fs.promises.watchFile`, which apparently doesn't exist. 

Revert to using the synchronous `fs.watchFile` to fix this issue, although we should probably be using [`fs.promises.watch`](https://nodejs.org/api/fs.html#fspromiseswatchfilename-options):

> Using [fs.watch()](https://nodejs.org/api/fs.html#fswatchfilename-options-listener) is more efficient than fs.watchFile and fs.unwatchFile. fs.watch should be used instead of fs.watchFile and fs.unwatchFile when possible.

I'll move this to `fs.watch` in a follow-up PR.
