### PR TITLE
[infra] Re-add `fs-extra` to fix Netlify deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "eslint-plugin-mui-x": "workspace:^",
     "fast-glob": "catalog:",
     "format-util": "^1.0.5",
+    "fs-extra": "^11.3.1",
     "glob-gitignore": "^1.0.15",
     "globby": "^14.1.0",
     "html-webpack-plugin": "^5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       format-util:
         specifier: ^1.0.5
         version: 1.0.5
+      fs-extra:
+        specifier: ^11.3.1
+        version: 11.3.1
       glob-gitignore:
         specifier: ^1.0.15
         version: 1.0.15


### PR DESCRIPTION
Fixes failing Netlify deploys. E.g., [1](https://app.netlify.com/projects/material-ui-x/deploys/689ca428b6728a0007f895e7), [2](https://app.netlify.com/projects/material-ui-x/deploys/689c9eb01125be000815cd29). 

This is intended as a quick fix while I'm investigating the root cause. 