### PR TITLE
[ai-assistant] Make it clear that the API key must be private

### DIFF
--- a/docs/data/data-grid/ai-assistant/ai-assistant.md
+++ b/docs/data/data-grid/ai-assistant/ai-assistant.md
@@ -66,7 +66,7 @@ The Data Grid provides all the necessary elements for integration with MUI's ser
 1. Contact [sales@mui.com](mailto:sales@mui.com) to get an API key for our processing service.
 
    :::warning
-   Avoid exposing the API key to the client by using a proxy server that receives prompt processing requests, adds the `x-api-key` header, and passes the request on to MUI's service.
+   Do not expose the API key to the public. Instead, keep it private, use a proxy server that receives prompt processing requests, adds the `x-api-key` header, and passes the request on to MUI's service.
 
    This is an example of a [Fastify proxy](https://www.npmjs.com/package/@fastify/http-proxy) for the prompt requests.
 


### PR DESCRIPTION
The key is used directly for billing; if it's public, people can grab a random one and use it on their own server. Until we fix https://github.com/mui/mui-private/issues/1057. I believe we can't, in the docs, tell people to "avoid", it should be "don't. I have been wanting to fix this for a long time, #19142 gave more importance to it.