### PR TITLE
[DataGrid] Fix scroll issue in R17

### DIFF
--- a/packages/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
+++ b/packages/x-data-grid/src/components/virtualization/GridVirtualScrollerRenderZone.tsx
@@ -3,10 +3,7 @@ import clsx from 'clsx';
 import { styled, SxProps, Theme } from '@mui/system';
 import composeClasses from '@mui/utils/composeClasses';
 import { forwardRef } from '@mui/x-internals/forwardRef';
-import { useGridApiContext } from '../../hooks/utils/useGridApiContext';
-import { useGridSelector } from '../../hooks/utils/useGridSelector';
-import { gridRowsMetaSelector } from '../../hooks/features/rows';
-import { gridRenderContextSelector } from '../../hooks/features/virtualization';
+import { useGridPrivateApiContext } from '../../hooks/utils/useGridPrivateApiContext';
 import { useGridRootProps } from '../../hooks/utils/useGridRootProps';
 import { getDataGridUtilityClass } from '../../constants/gridClasses';
 import { DataGridProcessedProps } from '../../models/props/DataGridProps';
@@ -37,14 +34,10 @@ const GridVirtualScrollerRenderZone = forwardRef<
   React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> }
 >(function GridVirtualScrollerRenderZone(props, ref) {
   const { className, ...other } = props;
-  const apiRef = useGridApiContext();
+  const apiRef = useGridPrivateApiContext();
   const rootProps = useGridRootProps();
   const classes = useUtilityClasses(rootProps);
-  const offsetTop = useGridSelector(apiRef, () => {
-    const renderContext = gridRenderContextSelector(apiRef);
-    const rowsMeta = gridRowsMetaSelector(apiRef);
-    return rowsMeta.positions[renderContext.firstRowIndex] ?? 0;
-  });
+  const offsetTop = apiRef.current.virtualizer.api.useVirtualization().getters.getOffsetTop();
 
   return (
     <VirtualScrollerRenderZoneRoot

--- a/packages/x-virtualizer/src/features/virtualization.ts
+++ b/packages/x-virtualizer/src/features/virtualization.ts
@@ -146,6 +146,7 @@ function useVirtualization(store: Store<BaseState>, params: VirtualizerParams, a
   const renderContext = useStore(store, selectors.renderContext);
   const enabledForRows = useStore(store, selectors.enabledForRows);
   const enabledForColumns = useStore(store, selectors.enabledForColumns);
+  const rowsMeta = useStore(store, Dimensions.selectors.rowsMeta);
 
   const contentHeight = useStore(store, Dimensions.selectors.contentHeight);
 
@@ -315,6 +316,10 @@ function useVirtualization(store: Store<BaseState>, params: VirtualizerParams, a
       onScrollChange?.(scrollPosition.current, nextRenderContext);
     }
   });
+
+  const getOffsetTop = () => {
+    return rowsMeta.positions[renderContext.firstRowIndex] ?? 0;
+  };
 
   /**
    * HACK: unstable_rowTree fixes the issue described below, but does it by tightly coupling this
@@ -610,6 +615,7 @@ function useVirtualization(store: Store<BaseState>, params: VirtualizerParams, a
 
   const getters = {
     setPanels,
+    getOffsetTop,
     getRows,
     getContainerProps: () => ({
       ref: refSetter('container'),


### PR DESCRIPTION
Closes #19101 

The `useSyncExternalStore` shim updates in multiple render calls in R17, which makes the `offsetTop` be de-sync'ed from the rendered rows. This PR makes it that both of those values are fetched the same way. This will be refactored away eventually.