### PR TITLE
[DataGrid] Hide column separator of non-resizable pinned column

### DIFF
--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -469,6 +469,12 @@ export const GridRootStyles = styled('div', {
         opacity: 0.5,
       },
     },
+    // Hide the column separator when the column is the first pinned column and it is not resizable
+    // In this case, this column separator blocks interaction with the separator from the previous column since it has a higher z-index
+    [`& .${c['columnHeader--withLeftBorder']} .${c['columnSeparator--sideLeft']}:not(.${c['columnSeparator--resizable']}), & .${c['columnHeader--withRightBorder']} .${c['columnSeparator--sideRight']}:not(.${c['columnSeparator--resizable']})`]:
+      {
+        display: 'none',
+      },
     [`& .${c['columnSeparator--sideLeft']}`]: {
       left: columnSeparatorOffset,
     },

--- a/packages/x-data-grid/src/components/containers/GridRootStyles.ts
+++ b/packages/x-data-grid/src/components/containers/GridRootStyles.ts
@@ -469,8 +469,8 @@ export const GridRootStyles = styled('div', {
         opacity: 0.5,
       },
     },
-    // Hide the column separator when the column is the first pinned column and it is not resizable
-    // In this case, this column separator blocks interaction with the separator from the previous column since it has a higher z-index
+    // Hide the column separator when the column has border and it is not resizable
+    // In this case, this column separator may block interaction with the separator from the adjacent column that is resizable
     [`& .${c['columnHeader--withLeftBorder']} .${c['columnSeparator--sideLeft']}:not(.${c['columnSeparator--resizable']}), & .${c['columnHeader--withRightBorder']} .${c['columnSeparator--sideRight']}:not(.${c['columnSeparator--resizable']})`]:
       {
         display: 'none',


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/19238

(try resizing `email` column)
Before: https://stackblitz.com/edit/kqpvdt5d-nvpznub8?file=src%2FDemo.tsx
After: https://stackblitz.com/edit/avd95mh8?file=src%2FDemo.tsx

In the situation where a pinned, non-resizable column is coming after a flex column, the column separators overlap each other. Since the pinned column is not resizable, the interactions on the separator are disabled, which also prevents interactions with the separator of the flex column.

The update hides the separator of the first pinned column (since it already has a border) and allows easier access to the separators of the flex column.
