### PR TITLE
[charts] Use `hideLegend` prop in demo, instead of using css to hide legend

### DIFF
--- a/docs/data/charts/export/ExportChartOnBeforeExport.js
+++ b/docs/data/charts/export/ExportChartOnBeforeExport.js
@@ -86,7 +86,7 @@ export default function ExportChartOnBeforeExport() {
             imageExportOptions: [{ type: 'image/png', onBeforeExport }],
           },
         }}
-        sx={{ [`& .${legendClasses.root}`]: { display: 'none' } }}
+        hideLegend
       />
       <Typography variant="caption">Source: World Bank</Typography>
     </Stack>

--- a/docs/data/charts/export/ExportChartOnBeforeExport.tsx
+++ b/docs/data/charts/export/ExportChartOnBeforeExport.tsx
@@ -91,7 +91,7 @@ export default function ExportChartOnBeforeExport() {
             imageExportOptions: [{ type: 'image/png', onBeforeExport }],
           },
         }}
-        sx={{ [`& .${legendClasses.root}`]: { display: 'none' } }}
+        hideLegend
       />
       <Typography variant="caption">Source: World Bank</Typography>
     </Stack>

--- a/docs/data/charts/export/ExportChartOnBeforeExport.tsx.preview
+++ b/docs/data/charts/export/ExportChartOnBeforeExport.tsx.preview
@@ -10,6 +10,6 @@
       imageExportOptions: [{ type: 'image/png', onBeforeExport }],
     },
   }}
-  sx={{ [`& .${legendClasses.root}`]: { display: 'none' } }}
+  hideLegend
 />
 <Typography variant="caption">Source: World Bank</Typography>


### PR DESCRIPTION
while working on this issue, i noticed demo is using css to hide legend instead of using `hideLegend` prop