### PR TITLE
[pickers] Fix input `autoCapitalize` value for Firefox compatibility.

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
@@ -194,7 +194,9 @@ export function useFieldSectionContentProps(
         id: `${id}-${section.type}`,
         'data-range-position': (section as FieldRangeSection).dateName || undefined,
         spellCheck: isEditable ? false : undefined,
-        autoCapitalize: isEditable ? 'off' : undefined,
+        // Firefox hydrates this as `'none`' instead of `'off'`. No problems in chromium with both values.
+        // For reference https://github.com/mui/mui-x/issues/19012
+        autoCapitalize: isEditable ? 'none' : undefined,
         autoCorrect: isEditable ? 'off' : undefined,
         children: section.value || section.placeholder,
         inputMode: section.contentType === 'letter' ? 'text' : 'numeric',


### PR DESCRIPTION
There was a hydration issue in Firefox about this property.
setting it to `'none'` fixes that and does not break it in chromium.

Fixes #19012 