### PR TITLE
[code-infra] Update renovate, exclude infra packages from MUI group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,10 +30,6 @@
       "schedule": "* * 1 1,7 *"
     },
     {
-      "groupName": "Material UI",
-      "matchPackageNames": ["@mui/*", "!@mui/internal-*", "!@mui/docs"]
-    },
-    {
       "groupName": "date-fns-v2",
       "matchPackageNames": ["date-fns-v2"],
       "allowedVersions": "< 3.0.0"


### PR DESCRIPTION
Rely on [mui groups](https://github.com/mui/mui-public/blob/a6f0bf1d38a4303edfc0b3b0a94e57807a95c399/renovate/default.json#L30-L39) coming from code-infra