### PR TITLE
[charts] Refactor optional chaining for props in PieChart, PieChartPro, and ScatterChartPro components

### DIFF
--- a/packages/x-charts-pro/src/PieChartPro/PieChartPro.tsx
+++ b/packages/x-charts-pro/src/PieChartPro/PieChartPro.tsx
@@ -98,13 +98,13 @@ const PieChartPro = React.forwardRef<SVGSVGElement, PieChartProProps>(
       <ChartDataProviderPro<'pie', PieChartProPluginSignatures> {...chartDataProviderProProps}>
         <ChartsWrapper
           legendPosition={props.slotProps?.legend?.position}
-          legendDirection={props?.slotProps?.legend?.direction ?? 'vertical'}
+          legendDirection={props.slotProps?.legend?.direction ?? 'vertical'}
           sx={sx}
         >
           {showToolbar ? <Toolbar /> : null}
           {!hideLegend && (
             <ChartsLegend
-              direction={props?.slotProps?.legend?.direction ?? 'vertical'}
+              direction={props.slotProps?.legend?.direction ?? 'vertical'}
               slots={slots}
               slotProps={slotProps}
             />

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.tsx
@@ -135,7 +135,7 @@ const ScatterChartPro = React.forwardRef(function ScatterChartPro(
           <ChartsAxisHighlight {...axisHighlightProps} />
           {children}
         </ChartsSurface>
-        {!props.loading && <Tooltip trigger="item" {...props?.slotProps?.tooltip} />}
+        {!props.loading && <Tooltip trigger="item" {...props.slotProps?.tooltip} />}
       </ChartsWrapper>
     </ChartDataProviderPro>
   );

--- a/packages/x-charts/src/PieChart/PieChart.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.tsx
@@ -144,13 +144,13 @@ const PieChart = React.forwardRef(function PieChart(
     <ChartDataProvider<'pie', PieChartPluginSignatures> {...chartDataProviderProps}>
       <ChartsWrapper
         legendPosition={props.slotProps?.legend?.position}
-        legendDirection={props?.slotProps?.legend?.direction ?? 'vertical'}
+        legendDirection={props.slotProps?.legend?.direction ?? 'vertical'}
         sx={sx}
       >
         {showToolbar && Toolbar ? <Toolbar {...props.slotProps?.toolbar} /> : null}
         {!hideLegend && (
           <ChartsLegend
-            direction={props?.slotProps?.legend?.direction ?? 'vertical'}
+            direction={props.slotProps?.legend?.direction ?? 'vertical'}
             slots={slots}
             slotProps={slotProps}
           />

--- a/packages/x-charts/src/hooks/animation/useAnimatePieArcLabel.ts
+++ b/packages/x-charts/src/hooks/animation/useAnimatePieArcLabel.ts
@@ -71,8 +71,8 @@ export function useAnimatePieArcLabel(
     {
       startAngle: props.startAngle,
       endAngle: props.endAngle,
-      innerRadius: props?.arcLabelRadius ?? props.innerRadius,
-      outerRadius: props?.arcLabelRadius ?? props.outerRadius,
+      innerRadius: props.arcLabelRadius ?? props.innerRadius,
+      outerRadius: props.arcLabelRadius ?? props.outerRadius,
       paddingAngle: props.paddingAngle,
       cornerRadius: props.cornerRadius,
     },


### PR DESCRIPTION
While working on https://github.com/mui/mui-x/pull/19257 i noticed, `?.` is used for `props` where `props` will always be defined. created PR to remove these instances