### PR TITLE
[internal] Add comment for Codspeed triggers

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -8,6 +8,13 @@ on:
     paths:
       - 'packages/x-charts*/**'
   pull_request:
+    types:
+      # Default
+      - opened
+      - synchronize
+      - reopened
+      # To run when the right labels are applied
+      - labeled
     branches:
       - master
       - next

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,19 +3,14 @@ name: Benchmarks
 on:
   push:
     branches:
-      - 'master'
-      - 'next'
+      - master
+      - next
     paths:
       - 'packages/x-charts*/**'
   pull_request:
-    types:
-      - labeled
-      - opened
-      - synchronize
-      - reopened
     branches:
-      - 'master'
-      - 'next'
+      - master
+      - next
 
 permissions: {}
 


### PR DESCRIPTION
~By default, the pull_request type has `opened`, `synchronize`, `reopened` https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target. It seems to be all we need. I was surprised to see this action trigger when a label was applied. It was added in #13952. https://codspeed.io/docs/integrations/ci/github-actions says nothing about it either.~

Add comments to clarify why.