### PR TITLE
[support-infra] Improve GitHub Action that check PRs labels

### DIFF
--- a/.github/workflows/check-if-pr-has-type-label.yml
+++ b/.github/workflows/check-if-pr-has-type-label.yml
@@ -1,7 +1,7 @@
 name: Check PR type label
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, labeled, unlabeled]
 
 permissions: {}
@@ -9,9 +9,7 @@ permissions: {}
 jobs:
   check-label:
     name: check PR labels
+    permissions:
+      pull-requests: read
     # no need for a check if the PR is merged. That is done inside the reusable workflow
     uses: mui/mui-public/.github/workflows/prs_check-if-pr-has-type-label.yml@master
-    permissions:
-      issues: write
-      pull-requests: write
-      contents: write


### PR DESCRIPTION
A few enhancements:

- Restrict the permissions; we only need read access
- Run the action from the PR, not from the target, so we can more easily iterate on this logic. As long as it has no write permissions, we are good.
- Sort keys to match the other actions

Context: I was cleaning up a bit the issue description of https://github.com/mui/mui-public/issues/206, I read this file, and it seemed strange.