### PR TITLE
[scheduler] Use a hook instead of a selector for `eventsToRenderGroupedByDay`

### DIFF
--- a/packages/x-scheduler/src/material/agenda-view/AgendaView.tsx
+++ b/packages/x-scheduler/src/material/agenda-view/AgendaView.tsx
@@ -6,7 +6,7 @@ import { useStore } from '@base-ui-components/utils/store';
 import { getAdapter } from '../../primitives/utils/adapter/getAdapter';
 import { AgendaViewProps } from './AgendaView.types';
 import { useDayList } from '../../primitives/use-day-list/useDayList';
-import { useEventCalendarContext } from '../internals/hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../primitives/utils/useEventCalendarContext';
 import { AGENDA_VIEW_DAYS_AMOUNT, selectors } from '../../primitives/use-event-calendar';
 import { EventPopoverProvider, EventPopoverTrigger } from '../internals/components/event-popover';
 import { DayGridEvent } from '../internals/components/event/day-grid-event/DayGridEvent';

--- a/packages/x-scheduler/src/material/day-view/DayView.tsx
+++ b/packages/x-scheduler/src/material/day-view/DayView.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useStore } from '@base-ui-components/utils/store';
 import { DayViewProps } from './DayView.types';
 import { DayTimeGrid } from '../internals/components/day-time-grid/DayTimeGrid';
-import { useEventCalendarContext } from '../internals/hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../primitives/use-event-calendar';
 
 export const DayView = React.memo(

--- a/packages/x-scheduler/src/material/event-calendar/EventCalendar.tsx
+++ b/packages/x-scheduler/src/material/event-calendar/EventCalendar.tsx
@@ -7,7 +7,7 @@ import { WeekView } from '../week-view/WeekView';
 import { AgendaView } from '../agenda-view';
 import { DayView } from '../day-view/DayView';
 import { TranslationsProvider } from '../internals/utils/TranslationsContext';
-import { EventCalendarContext } from '../internals/hooks/useEventCalendarContext';
+import { EventCalendarContext } from '../../primitives/utils/useEventCalendarContext';
 import { MonthView } from '../month-view';
 import { HeaderToolbar } from '../internals/components/header-toolbar';
 import { DateNavigator } from '../internals/components/date-navigator';

--- a/packages/x-scheduler/src/material/internals/components/date-navigator/DateNavigator.tsx
+++ b/packages/x-scheduler/src/material/internals/components/date-navigator/DateNavigator.tsx
@@ -6,7 +6,7 @@ import { useStore } from '@base-ui-components/utils/store';
 import { DateNavigatorProps } from './DateNavigator.types';
 import { getAdapter } from '../../../../primitives/utils/adapter/getAdapter';
 import { useTranslations } from '../../utils/TranslationsContext';
-import { useEventCalendarContext } from '../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../../../primitives/use-event-calendar';
 import './DateNavigator.css';
 

--- a/packages/x-scheduler/src/material/internals/components/day-time-grid/DayTimeGrid.tsx
+++ b/packages/x-scheduler/src/material/internals/components/day-time-grid/DayTimeGrid.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useMergedRefs } from '@base-ui-components/utils/useMergedRefs';
 import { useIsoLayoutEffect } from '@base-ui-components/utils/useIsoLayoutEffect';
 import { useStore } from '@base-ui-components/utils/store';
+import { useDayGridRowEventOccurrences } from '../../../../primitives/use-day-grid-row-event-occurrences';
 import { SchedulerValidDate, CalendarEvent } from '../../../../primitives/models';
 import { getEventWithLargestRowIndex } from '../../../../primitives/utils/event-utils';
 import { getAdapter } from '../../../../primitives/utils/adapter/getAdapter';
@@ -13,7 +14,7 @@ import { DayTimeGridProps } from './DayTimeGrid.types';
 import { TimeGridEvent } from '../event/time-grid-event/TimeGridEvent';
 import { diffIn, isWeekend } from '../../../../primitives/utils/date-utils';
 import { useTranslations } from '../../utils/TranslationsContext';
-import { useEventCalendarContext } from '../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../../../primitives/use-event-calendar';
 import { EventPopoverProvider, EventPopoverTrigger } from '../event-popover';
 import './DayTimeGrid.css';
@@ -38,7 +39,7 @@ export const DayTimeGrid = React.forwardRef(function DayTimeGrid(
   const resourcesByIdMap = useStore(store, selectors.resourcesByIdMap);
   const visibleDate = useStore(store, selectors.visibleDate);
   const hasDayView = useStore(store, selectors.hasDayView);
-  const daysWithEvents = useStore(store, selectors.eventsToRenderGroupedByDay, {
+  const daysWithEvents = useDayGridRowEventOccurrences({
     days,
     shouldOnlyRenderEventInOneCell: false,
   });

--- a/packages/x-scheduler/src/material/internals/components/event-popover/EventPopover.tsx
+++ b/packages/x-scheduler/src/material/internals/components/event-popover/EventPopover.tsx
@@ -22,7 +22,7 @@ import { getColorClassName } from '../../utils/color-utils';
 import { useTranslations } from '../../utils/TranslationsContext';
 import { CalendarEvent } from '../../../../primitives/models';
 import { selectors } from '../../../../primitives/use-event-calendar';
-import { useEventCalendarContext } from '../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../primitives/utils/useEventCalendarContext';
 import './EventPopover.css';
 import {
   buildRecurrencePresets,

--- a/packages/x-scheduler/src/material/internals/components/event/day-grid-event/DayGridEvent.tsx
+++ b/packages/x-scheduler/src/material/internals/components/event/day-grid-event/DayGridEvent.tsx
@@ -10,7 +10,7 @@ import { DayGridEventProps } from './DayGridEvent.types';
 import { getColorClassName } from '../../../utils/color-utils';
 import { useTranslations } from '../../../utils/TranslationsContext';
 import { selectors } from '../../../../../primitives/use-event-calendar';
-import { useEventCalendarContext } from '../../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../../primitives/utils/useEventCalendarContext';
 import './DayGridEvent.css';
 import '../index.css';
 

--- a/packages/x-scheduler/src/material/internals/components/event/time-grid-event/TimeGridEvent.tsx
+++ b/packages/x-scheduler/src/material/internals/components/event/time-grid-event/TimeGridEvent.tsx
@@ -9,7 +9,7 @@ import { getAdapter } from '../../../../../primitives/utils/adapter/getAdapter';
 import { TimeGrid } from '../../../../../primitives/time-grid';
 import { getColorClassName } from '../../../utils/color-utils';
 import { selectors } from '../../../../../primitives/use-event-calendar';
-import { useEventCalendarContext } from '../../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../../primitives/utils/useEventCalendarContext';
 import './TimeGridEvent.css';
 import '../index.css';
 

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/HeaderToolbar.tsx
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/HeaderToolbar.tsx
@@ -5,7 +5,7 @@ import { useStore } from '@base-ui-components/utils/store';
 import { HeaderToolbarProps } from './HeaderToolbar.types';
 import { ViewSwitcher } from './view-switcher';
 import { useTranslations } from '../../utils/TranslationsContext';
-import { useEventCalendarContext } from '../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../../../primitives/use-event-calendar';
 import { SettingsMenu } from './settings-menu';
 import './HeaderToolbar.css';

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/settings-menu/SettingsMenu.tsx
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/settings-menu/SettingsMenu.tsx
@@ -7,7 +7,7 @@ import { CheckIcon, Settings } from 'lucide-react';
 import { Menu } from '@base-ui-components/react/menu';
 import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
 import { useTranslations } from '../../../utils/TranslationsContext';
-import { useEventCalendarContext } from '../../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../../../../primitives/use-event-calendar';
 import './SettingsMenu.css';
 

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/view-switcher/ViewSwitcher.tsx
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/view-switcher/ViewSwitcher.tsx
@@ -8,7 +8,7 @@ import { ChevronDown } from 'lucide-react';
 import { Menubar } from '@base-ui-components/react/menubar';
 import { CalendarView } from '../../../../../primitives/models';
 import { useTranslations } from '../../../utils/TranslationsContext';
-import { useEventCalendarContext } from '../../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../../../../primitives/use-event-calendar';
 import './ViewSwitcher.css';
 

--- a/packages/x-scheduler/src/material/internals/components/resource-legend/ResourceLegend.tsx
+++ b/packages/x-scheduler/src/material/internals/components/resource-legend/ResourceLegend.tsx
@@ -9,7 +9,7 @@ import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
 import { ResourceLegendProps } from './ResourceLegend.types';
 import { useTranslations } from '../../utils/TranslationsContext';
 import { getColorClassName } from '../../utils/color-utils';
-import { useEventCalendarContext } from '../../hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../../../primitives/use-event-calendar';
 import { CalendarResource } from '../../../../primitives/models';
 import './ResourceLegend.css';

--- a/packages/x-scheduler/src/material/month-view/MonthView.tsx
+++ b/packages/x-scheduler/src/material/month-view/MonthView.tsx
@@ -7,7 +7,7 @@ import { useResizeObserver } from '@mui/x-internals/useResizeObserver';
 import { useDayList } from '../../primitives/use-day-list/useDayList';
 import { getAdapter } from '../../primitives/utils/adapter/getAdapter';
 import { MonthViewProps } from './MonthView.types';
-import { useEventCalendarContext } from '../internals/hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../primitives/use-event-calendar';
 import { useWeekList } from '../../primitives/use-week-list/useWeekList';
 import { DayGrid } from '../../primitives/day-grid';

--- a/packages/x-scheduler/src/material/month-view/month-view-row/MonthViewWeekRow.tsx
+++ b/packages/x-scheduler/src/material/month-view/month-view-row/MonthViewWeekRow.tsx
@@ -2,11 +2,12 @@
 import * as React from 'react';
 import clsx from 'clsx';
 import { useStore } from '@base-ui-components/utils/store';
+import { useDayGridRowEventOccurrences } from '../../../primitives/use-day-grid-row-event-occurrences';
 import { SchedulerValidDate } from '../../../primitives/models';
 import { getAdapter } from '../../../primitives/utils/adapter/getAdapter';
 import { DayGrid } from '../../../primitives/day-grid';
 import { useDayList } from '../../../primitives/use-day-list/useDayList';
-import { useEventCalendarContext } from '../../internals/hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../../primitives/utils/useEventCalendarContext';
 import { DayGridEvent } from '../../internals/components/event/day-grid-event/DayGridEvent';
 import { diffIn, isWeekend } from '../../../primitives/utils/date-utils';
 import { getEventWithLargestRowIndex } from '../../../primitives/utils/event-utils';
@@ -36,7 +37,7 @@ export default function MonthViewWeekRow(props: MonthViewWeekRowProps) {
     [getDayList, week, settings.hideWeekends],
   );
 
-  const daysWithEvents = useStore(store, selectors.eventsToRenderGroupedByDay, {
+  const daysWithEvents = useDayGridRowEventOccurrences({
     days,
     shouldOnlyRenderEventInOneCell: false,
   });

--- a/packages/x-scheduler/src/material/standalone-view/StandaloneView.tsx
+++ b/packages/x-scheduler/src/material/standalone-view/StandaloneView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EventCalendarContext } from '../internals/hooks/useEventCalendarContext';
+import { EventCalendarContext } from '../../primitives/utils/useEventCalendarContext';
 import { useEventCalendar } from '../../primitives/use-event-calendar';
 
 /**

--- a/packages/x-scheduler/src/material/week-view/WeekView.tsx
+++ b/packages/x-scheduler/src/material/week-view/WeekView.tsx
@@ -5,7 +5,7 @@ import { useDayList } from '../../primitives/use-day-list/useDayList';
 import { WeekViewProps } from './WeekView.types';
 import { getAdapter } from '../../primitives/utils/adapter/getAdapter';
 import { DayTimeGrid } from '../internals/components/day-time-grid/DayTimeGrid';
-import { useEventCalendarContext } from '../internals/hooks/useEventCalendarContext';
+import { useEventCalendarContext } from '../../primitives/utils/useEventCalendarContext';
 import { selectors } from '../../primitives/use-event-calendar';
 
 const adapter = getAdapter();

--- a/packages/x-scheduler/src/primitives/models/event.ts
+++ b/packages/x-scheduler/src/primitives/models/event.ts
@@ -84,8 +84,10 @@ export interface CalendarEventOccurrence extends CalendarEvent {
   key: string;
 }
 
-/** Extension of an occurrence with layout information for all-day rows. */
-export interface CalendarEventOccurrenceWithPosition extends CalendarEventOccurrence {
+/**
+ * Extension of an occurrence with layout information for all-day rows.
+ */
+export interface CalendarEventOccurrencesWithRowIndex extends CalendarEventOccurrence {
   eventRowIndex?: number;
 }
 

--- a/packages/x-scheduler/src/primitives/use-day-grid-row-event-occurrences/index.ts
+++ b/packages/x-scheduler/src/primitives/use-day-grid-row-event-occurrences/index.ts
@@ -1,0 +1,1 @@
+export * from './useDayGridRowEventOccurrences';

--- a/packages/x-scheduler/src/primitives/use-day-grid-row-event-occurrences/useDayGridRowEventOccurrences.ts
+++ b/packages/x-scheduler/src/primitives/use-day-grid-row-event-occurrences/useDayGridRowEventOccurrences.ts
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { useStore } from '@base-ui-components/utils/store';
+import {
+  CalendarEventOccurrence,
+  CalendarEventOccurrencesWithRowIndex,
+  SchedulerValidDate,
+} from '../models';
+import { getEventDays, getEventRowIndex } from '../utils/event-utils';
+import { useAdapter } from '../utils/adapter/useAdapter';
+import { getRecurringEventOccurrencesForVisibleDays } from '../utils/recurrence-utils';
+import { useEventCalendarContext } from '../utils/useEventCalendarContext';
+import { selectors } from '../use-event-calendar';
+
+export function useDayGridRowEventOccurrences(
+  parameters: useDayGridRowEventOccurrences.Parameters,
+): useDayGridRowEventOccurrences.ReturnValue {
+  const { days, shouldOnlyRenderEventInOneCell } = parameters;
+  const adapter = useAdapter();
+  const { store } = useEventCalendarContext();
+  const events = useStore(store, selectors.events);
+  const visibleResources = useStore(store, selectors.visibleResourcesMap);
+
+  return React.useMemo(() => {
+    const daysMap = new Map<
+      string,
+      { events: CalendarEventOccurrence[]; allDayEvents: CalendarEventOccurrencesWithRowIndex[] }
+    >();
+    for (const day of days) {
+      const dayKey = adapter.format(day, 'keyboardDate');
+      daysMap.set(dayKey, { events: [], allDayEvents: [] });
+    }
+
+    // Collect ALL event occurrences (both recurring and non-recurring)
+    const visibleOccurrences: CalendarEventOccurrence[] = [];
+
+    for (const event of events) {
+      // STEP 1: Skip events from resources that are not visible
+      if (event.resource && visibleResources.get(event.resource) === false) {
+        continue;
+      }
+
+      // STEP 2-A: Recurrent event processing, if it is recurrent expand it for the visible days
+      if (event.rrule) {
+        const occurrences = getRecurringEventOccurrencesForVisibleDays(event, days, adapter);
+        visibleOccurrences.push(...occurrences);
+        continue;
+      }
+
+      // STEP 2-B: Non-recurring event processing, check if the event is within the visible days
+      const eventFirstDay = adapter.startOfDay(event.start);
+      const eventLastDay = adapter.endOfDay(event.end);
+      if (
+        adapter.isAfter(eventFirstDay, days[days.length - 1]) ||
+        adapter.isBefore(eventLastDay, days[0])
+      ) {
+        continue; // Skip events that are not in the visible days
+      }
+
+      visibleOccurrences.push({ ...event, key: String(event.id) });
+    }
+
+    // STEP 3: Sort by the actual start date of each occurrence
+    // We sort here so that events are processed in the correct order, ensuring consistent row index assignment for all-day events
+    const sortedOccurrences = visibleOccurrences
+      // TODO: Avoid JS Date conversion
+      .map((occurrence) => ({
+        occurrence,
+        timestamp: adapter.toJsDate(occurrence.start).getTime(),
+      }))
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .map((item) => item.occurrence);
+
+    // STEP 4: Add the occurrence to the days map
+    for (const occurrence of sortedOccurrences) {
+      const eventDays: SchedulerValidDate[] = getEventDays(
+        occurrence,
+        days,
+        adapter,
+        shouldOnlyRenderEventInOneCell,
+      );
+
+      for (const day of eventDays) {
+        const dayKey = adapter.format(day, 'keyboardDate');
+        if (!daysMap.has(dayKey)) {
+          daysMap.set(dayKey, { events: [], allDayEvents: [] });
+        }
+
+        // STEP 4.1: Process all-day events and get their position in the row
+        if (occurrence.allDay) {
+          const eventRowIndex = getEventRowIndex(occurrence, day, days, daysMap, adapter);
+
+          daysMap.get(dayKey)!.allDayEvents.push({
+            ...occurrence,
+            eventRowIndex,
+          });
+        } else {
+          daysMap.get(dayKey)!.events.push(occurrence);
+        }
+      }
+    }
+
+    return days.map((day) => {
+      const dayKey = adapter.format(day, 'keyboardDate');
+      return {
+        day,
+        events: daysMap.get(dayKey)?.events || [],
+        allDayEvents: daysMap.get(dayKey)?.allDayEvents || [],
+      };
+    });
+  }, [adapter, visibleResources, events, days, shouldOnlyRenderEventInOneCell]);
+}
+
+export namespace useDayGridRowEventOccurrences {
+  export interface Parameters {
+    days: SchedulerValidDate[];
+    shouldOnlyRenderEventInOneCell: boolean;
+  }
+
+  export type ReturnValue = {
+    day: SchedulerValidDate;
+    events: CalendarEventOccurrence[];
+    allDayEvents: CalendarEventOccurrencesWithRowIndex[];
+  }[];
+}

--- a/packages/x-scheduler/src/primitives/use-event-calendar/store.ts
+++ b/packages/x-scheduler/src/primitives/use-event-calendar/store.ts
@@ -7,12 +7,8 @@ import {
   CalendarResourceId,
   CalendarView,
   CalendarSettings,
-  CalendarEventOccurrence,
-  CalendarEventOccurrenceWithPosition,
 } from '../models';
 import { Adapter } from '../utils/adapter/types';
-import { getEventDays, getEventRowIndex } from '../utils/event-utils';
-import { getRecurringEventOccurrencesForVisibleDays } from '../utils/recurrence-utils';
 
 export type State = {
   /**
@@ -77,6 +73,8 @@ export const selectors = {
   settings: createSelector((state: State) => state.settings),
   hasDayView: createSelector((state: State) => state.views.includes('day')),
   resources: createSelector((state: State) => state.resources),
+  events: createSelector((state: State) => state.events),
+  visibleResourcesMap: createSelector((state: State) => state.visibleResources),
   visibleResourcesList: createSelectorMemoized(
     (state: State) => state.resources,
     (state: State) => state.visibleResources,
@@ -96,103 +94,6 @@ export const selectors = {
         map.set(resource.id, resource);
       }
       return map;
-    },
-  ),
-  eventsToRenderGroupedByDay: createSelector(
-    (state: State) => state.events,
-    (state: State) => state.visibleResources,
-    (state: State) => state.adapter,
-    (
-      _state: State,
-      parameters: { days: SchedulerValidDate[]; shouldOnlyRenderEventInOneCell: boolean },
-    ) => parameters,
-    (events, visibleResources, adapter, { days, shouldOnlyRenderEventInOneCell }) => {
-      const daysMap = new Map<
-        string,
-        { events: CalendarEventOccurrence[]; allDayEvents: CalendarEventOccurrenceWithPosition[] }
-      >();
-      for (const day of days) {
-        const dayKey = adapter.format(day, 'keyboardDate');
-        daysMap.set(dayKey, { events: [], allDayEvents: [] });
-      }
-
-      // Collect ALL event occurrences (both recurring and non-recurring)
-      const visibleOccurrences: CalendarEventOccurrence[] = [];
-
-      for (const event of events) {
-        // STEP 1: Skip events from resources that are not visible
-        if (event.resource && visibleResources.get(event.resource) === false) {
-          continue;
-        }
-
-        // STEP 2-A: Recurrent event processing, if it is recurrent expand it for the visible days
-        if (event.rrule) {
-          const occurrences = getRecurringEventOccurrencesForVisibleDays(event, days, adapter);
-          visibleOccurrences.push(...occurrences);
-          continue;
-        }
-
-        // STEP 2-B: Non-recurring event processing, check if the event is within the visible days
-        const eventFirstDay = adapter.startOfDay(event.start);
-        const eventLastDay = adapter.endOfDay(event.end);
-        if (
-          adapter.isAfter(eventFirstDay, days[days.length - 1]) ||
-          adapter.isBefore(eventLastDay, days[0])
-        ) {
-          continue; // Skip events that are not in the visible days
-        }
-
-        visibleOccurrences.push({ ...event, key: String(event.id) });
-      }
-
-      // STEP 3: Sort by the actual start date of each occurrence
-      // We sort here so that events are processed in the correct order, ensuring consistent row index assignment for all-day events
-      const sortedOccurrences = visibleOccurrences
-        // TODO: Avoid JS Date conversion
-        .map((occurrence) => ({
-          occurrence,
-          timestamp: adapter.toJsDate(occurrence.start).getTime(),
-        }))
-        .sort((a, b) => a.timestamp - b.timestamp)
-        .map((item) => item.occurrence);
-
-      // STEP 4: Add the occurrence to the days map
-      for (const occurrence of sortedOccurrences) {
-        const eventDays: SchedulerValidDate[] = getEventDays(
-          occurrence,
-          days,
-          adapter,
-          shouldOnlyRenderEventInOneCell,
-        );
-
-        for (const day of eventDays) {
-          const dayKey = adapter.format(day, 'keyboardDate');
-          if (!daysMap.has(dayKey)) {
-            daysMap.set(dayKey, { events: [], allDayEvents: [] });
-          }
-
-          // STEP 4.1: Process all-day events and get their position in the row
-          if (occurrence.allDay) {
-            const eventRowIndex = getEventRowIndex(occurrence, day, days, daysMap, adapter);
-
-            daysMap.get(dayKey)!.allDayEvents.push({
-              ...occurrence,
-              eventRowIndex,
-            });
-          } else {
-            daysMap.get(dayKey)!.events.push(occurrence);
-          }
-        }
-      }
-
-      return days.map((day) => {
-        const dayKey = adapter.format(day, 'keyboardDate');
-        return {
-          day,
-          events: daysMap.get(dayKey)?.events || [],
-          allDayEvents: daysMap.get(dayKey)?.allDayEvents || [],
-        };
-      });
     },
   ),
   // TODO: Add a new data structure (Map?) to avoid linear complexity here.

--- a/packages/x-scheduler/src/primitives/utils/event-utils.test.ts
+++ b/packages/x-scheduler/src/primitives/utils/event-utils.test.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { CalendarEventOccurrenceWithPosition } from '@mui/x-scheduler/primitives/models';
+import { CalendarEventOccurrencesWithRowIndex } from '@mui/x-scheduler/primitives/models';
 import {
   getEventDays,
   getEventRowIndex,
@@ -14,7 +14,7 @@ describe('event-utils', () => {
     id: string,
     start: string,
     end: string,
-  ): CalendarEventOccurrenceWithPosition => ({
+  ): CalendarEventOccurrencesWithRowIndex => ({
     id,
     key: id,
     start: adapter.date(start),
@@ -25,7 +25,7 @@ describe('event-utils', () => {
 
   describe('getEventWithLargestRowIndex', () => {
     it('should return the largest row index from events', () => {
-      const events: CalendarEventOccurrenceWithPosition[] = [
+      const events: CalendarEventOccurrencesWithRowIndex[] = [
         {
           id: '1',
           key: '1',
@@ -60,7 +60,7 @@ describe('event-utils', () => {
     });
 
     it('should return 0 when events array is empty', () => {
-      const events: CalendarEventOccurrenceWithPosition[] = [];
+      const events: CalendarEventOccurrencesWithRowIndex[] = [];
 
       const result = getEventWithLargestRowIndex(events);
 
@@ -68,7 +68,7 @@ describe('event-utils', () => {
     });
 
     it('should return 0 when all events have undefined eventRowIndex', () => {
-      const eventsWithUndefinedRowIndex: CalendarEventOccurrenceWithPosition[] = [
+      const eventsWithUndefinedRowIndex: CalendarEventOccurrencesWithRowIndex[] = [
         {
           id: '1',
           key: '1',
@@ -95,7 +95,7 @@ describe('event-utils', () => {
     });
 
     it('should handle mix of defined and undefined eventRowIndex values', () => {
-      const events: CalendarEventOccurrenceWithPosition[] = [
+      const events: CalendarEventOccurrencesWithRowIndex[] = [
         {
           id: '1',
           key: '1',
@@ -181,7 +181,7 @@ describe('event-utils', () => {
       start: string,
       end: string,
       eventRowIndex: number,
-    ): CalendarEventOccurrenceWithPosition => ({
+    ): CalendarEventOccurrencesWithRowIndex => ({
       ...createEvent(id, start, end),
       eventRowIndex,
     });

--- a/packages/x-scheduler/src/primitives/utils/event-utils.ts
+++ b/packages/x-scheduler/src/primitives/utils/event-utils.ts
@@ -1,7 +1,7 @@
 import {
   SchedulerValidDate,
   CalendarEvent,
-  CalendarEventOccurrenceWithPosition,
+  CalendarEventOccurrencesWithRowIndex,
   CalendarEventOccurrence,
 } from '../models';
 import { Adapter } from './adapter/types';
@@ -11,12 +11,12 @@ import { Adapter } from './adapter/types';
  *  Useful to know how many stacked rows are already used for a given day.
  *  @returns Highest row index found, or 0 if none.
  */
-export function getEventWithLargestRowIndex(events: CalendarEventOccurrenceWithPosition[]) {
+export function getEventWithLargestRowIndex(events: CalendarEventOccurrencesWithRowIndex[]) {
   return (
     events.reduce(
       (maxEvent, event) =>
         (event?.eventRowIndex ?? 0) > (maxEvent.eventRowIndex ?? 0) ? event : maxEvent,
-      { eventRowIndex: 0 } as CalendarEventOccurrenceWithPosition,
+      { eventRowIndex: 0 } as CalendarEventOccurrencesWithRowIndex,
     ).eventRowIndex || 0
   );
 }
@@ -44,7 +44,7 @@ export function getEventRowIndex(
   event: CalendarEventOccurrence,
   day: SchedulerValidDate,
   days: SchedulerValidDate[],
-  daysMap: Map<string, { allDayEvents: CalendarEventOccurrenceWithPosition[] }>,
+  daysMap: Map<string, { allDayEvents: CalendarEventOccurrencesWithRowIndex[] }>,
   adapter: Adapter,
 ): number {
   const dayKey = adapter.format(day, 'keyboardDate');

--- a/packages/x-scheduler/src/primitives/utils/useEventCalendarContext.ts
+++ b/packages/x-scheduler/src/primitives/utils/useEventCalendarContext.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import type { useEventCalendar } from '../../../primitives/use-event-calendar';
+import type { useEventCalendar } from '../use-event-calendar';
 
 export const EventCalendarContext = React.createContext<useEventCalendar.ReturnValue | null>(null);
 


### PR DESCRIPTION
The selector doesn't bring additional value here.
And having a hook will make the code a lot more flexible.