### PR TITLE
[support-infra] Add `synchronize` to workflow triggers

### DIFF
--- a/.github/workflows/check-if-pr-has-type-label.yml
+++ b/.github/workflows/check-if-pr-has-type-label.yml
@@ -2,7 +2,8 @@ name: Check PR type label
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled]
+    # Adding `synchronize` to handle workflow runs when the PR's branch is updated
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions: {}
 


### PR DESCRIPTION
The check type label workflow did not get triggered on updates to the PR HEAD, so it was stuck in an unresolved state.

This should fix it.