### PR TITLE
[code-infra] Remove unnecessary triggers from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,6 @@
 name: Publish packages
 
-# single workflow for both canary and stable as we can only specify a single
-# workflow file for trusted publishing
-
 on:
-  push:
-    branches:
-      - master
-  schedule:
-    - cron: '0 0 * * *' # Daily at midnight UTC
   workflow_dispatch:
     inputs:
       sha:


### PR DESCRIPTION
Accidentally copied over from [`mui-public`](https://github.com/mui/mui-public/blob/master/.github/workflows/publish.yml). X doesn't have canary publishing.
