### PR TITLE
[charts] Definitions and guidelines docs

### DIFF
--- a/docs/data/charts/bars/bars.md
+++ b/docs/data/charts/bars/bars.md
@@ -8,6 +8,31 @@ components: BarChart, BarChartPro, BarElement, BarPlot, ChartsGrid, BarLabel
 
 <p class="description">Bar charts express quantities through a bar's length, using a common baseline.</p>
 
+## Guidelines
+
+Bar charts are ideal for comparing discrete categories or displaying changes over time with categorical data. They excel at showing:
+
+- **Categorical comparisons**: Perfect for comparing values across different categories (e.g., sales by product, population by country)
+- **Ranking and ordering**: Easy to identify which categories have the highest or lowest values
+- **Part-to-whole relationships**: When stacked, they show how individual parts contribute to a total
+- **Time series with discrete periods**: Monthly sales, yearly revenue, quarterly performance
+
+**When to use bar charts:**
+
+- You have categorical data with numerical values
+- You want to emphasize precise value comparisons
+- Your audience needs to quickly identify rankings or differences
+- You're displaying survey results, financial data, or performance metrics
+
+**Data requirements:**
+
+- One categorical dimension (x-axis for vertical bars, y-axis for horizontal bars)
+- One or more numerical dimensions for comparison
+- Works well with both positive and negative values
+- Optimal for 3-12 categories (too many categories can become cluttered)
+
+**Choose horizontal bars when:** category labels are long, you have many categories, or when the natural reading flow benefits from reading orientation.
+
 ## Basics
 
 Bar charts series should contain a `data` property containing an array of values.

--- a/docs/data/charts/funnel/funnel.md
+++ b/docs/data/charts/funnel/funnel.md
@@ -8,6 +8,35 @@ components: FunnelChart, FunnelPlot
 
 <p class="description">Funnel charts let you express quantity evolution along a process, such as audience engagement, population education levels, or yields of multiple processes.</p>
 
+## Guidelines
+
+Funnel charts are specifically designed to visualize sequential processes where quantities decrease at each stage, making them ideal for analyzing conversion rates, process efficiency, and identifying bottlenecks in workflows.
+
+- **Process visualization**: Perfect for showing how quantities flow through sequential stages
+- **Conversion analysis**: Identify where the biggest drop-offs occur in multi-step processes
+- **Bottleneck detection**: Quickly spot stages that need improvement or optimization
+- **Progress tracking**: Monitor how entities move through defined stages or levels
+
+**When to use funnel charts:**
+
+- You have sequential stages where quantities naturally decrease
+- You want to analyze conversion rates or process efficiency
+- You need to identify bottlenecks in workflows or user journeys
+- You're tracking progress through defined stages (sales pipeline, user onboarding)
+- The order of stages is meaningful and progressive
+
+**Data requirements:**
+
+- Sequential stages with logical order and progression
+- Positive numerical values that generally decrease through stages
+- Each stage should represent a subset of the previous stage
+- Works best with 3-8 stages (too many can become cluttered)
+- Clear, descriptive labels for each stage
+
+**Choose funnel charts when:** you're analyzing processes with natural drop-offs, tracking conversions through multiple steps, or when the "funnel" metaphor helps communicate your data story effectively.
+
+**Use pyramid variation** when values increase through stages, or when you want to emphasize growth rather than conversion. Consider **gap spacing** to highlight transition points between stages.
+
 ## Basics
 
 Funnel charts series must contain a `data` property containing an array of objects.

--- a/docs/data/charts/heatmap/heatmap.md
+++ b/docs/data/charts/heatmap/heatmap.md
@@ -8,6 +8,35 @@ components: Heatmap, HeatmapPlot, HeatmapTooltip, HeatmapTooltipContent
 
 <p class="description">Heatmap charts visually represents data with color variations to highlight patterns and trends across two dimensions.</p>
 
+## Guidelines
+
+Heatmaps excel at revealing patterns, correlations, and anomalies in large datasets by using color intensity to represent values across a two-dimensional grid. They transform complex numerical data into intuitive visual patterns.
+
+- **Pattern recognition**: Perfect for identifying clusters, trends, and correlations in matrix-style data
+- **Large dataset visualization**: Handle thousands of data points effectively through color encoding
+- **Comparative analysis**: Compare values across two categorical dimensions simultaneously
+- **Density and intensity mapping**: Show concentration, frequency, or intensity across geographic or categorical spaces
+
+**When to use heatmaps:**
+
+- You have data that can be organized in a matrix format (rows and columns)
+- You want to show relationships between two categorical variables
+- You need to visualize large amounts of data at once
+- Pattern detection is more important than precise individual values
+- You're analyzing correlations, time-based patterns, or geographic distributions
+
+**Data requirements:**
+
+- Two categorical or ordinal dimensions (for x and y axes)
+- One continuous numerical dimension (for color intensity)
+- Data organized in a grid or matrix structure
+- Works well with normalized or standardized values
+- Benefits from consistent data density across the grid
+
+**Choose heatmaps when:** you have matrix-style data, need to spot patterns in large datasets, want to show correlations between categorical variables, or when color coding can reveal insights not obvious in numerical tables.
+
+**Common applications:** correlation matrices, time-series patterns (hour vs. day), geographic data, user behavior analysis, and performance metrics across categories.
+
 ## Basics
 
 Heatmap charts series must contain a `data` property containing an array of 3-tuples.

--- a/docs/data/charts/lines/lines.md
+++ b/docs/data/charts/lines/lines.md
@@ -8,6 +8,33 @@ components: LineChart, LineChartPro, LineElement, LineHighlightElement, LineHigh
 
 <p class="description">Line charts can express qualities about data, such as hierarchy, highlights, and comparisons.</p>
 
+## Guidelines
+
+Line charts are the go-to choice for visualizing trends and changes over continuous periods. They excel at revealing patterns in time-series data and showing relationships between variables. Key strengths include:
+
+- **Trend visualization**: Perfect for showing how values change over time (stock prices, website traffic, temperature)
+- **Pattern recognition**: Easy to spot trends, cycles, seasonality, and anomalies in data
+- **Multiple series comparison**: Compare trends across different categories or datasets simultaneously
+- **Continuous data**: Ideal for data points that have a natural progression or sequence
+
+**When to use line charts:**
+
+- You have time-series data or any continuous scale
+- The focus is on trends and changes rather than individual values
+- You want to show the relationship between two continuous variables
+- You need to display multiple data series for comparison
+- Your data points are connected in a meaningful sequence
+
+**Data requirements:**
+
+- At least one continuous dimension (typically time on x-axis)
+- One or more numerical dimensions for the y-axis
+- Data points should have a logical connection or sequence
+- Works best with evenly spaced intervals
+- Can handle missing data points with interpolation
+
+**Choose line charts over bars when:** continuity matters more than precise individual values, you're showing trends over time, or when you have many data points that would make bars cluttered.
+
 ## Basics
 
 ### Data format

--- a/docs/data/charts/pie/pie.md
+++ b/docs/data/charts/pie/pie.md
@@ -8,6 +8,34 @@ components: PieArc, PieArcLabel, PieArcLabelPlot, PieArcPlot, PieChart, PiePlot,
 
 <p class="description">Pie charts express portions of a whole, using arcs or angles within a circle.</p>
 
+## Guidelines
+
+Pie charts are specifically designed to show part-to-whole relationships, making proportions and percentages immediately visible. They work best when the focus is on how individual parts contribute to a complete dataset.
+
+- **Part-to-whole visualization**: Perfect for showing how individual components make up 100% of something
+- **Proportional comparison**: Easy to see which segments are larger or smaller relative to the whole
+- **Simple categorical breakdown**: Ideal for displaying survey results, market share, budget allocation
+- **At-a-glance understanding**: Quickly communicate the relative size of different categories
+
+**When to use pie charts:**
+
+- Your data represents parts of a whole that sum to 100%
+- You have 2-7 categories (too many slices become hard to distinguish)
+- The focus is on proportions rather than exact values
+- You want to emphasize the largest or smallest segments
+- Your audience needs to quickly grasp relative sizes
+
+**Data requirements:**
+
+- Categorical data with positive numerical values
+- Values should sum to a meaningful total (100%, total budget, etc.)
+- Each category should be mutually exclusive
+- Works best when differences between segments are substantial (>5%)
+
+**Avoid pie charts when:** you have many small categories, negative values, or when precise comparison of values is needed. Consider bar charts for better precision or when you have more than 7 categories.
+
+**Use donut charts** when you want to include additional information in the center or create a more modern aesthetic while maintaining the same data relationships.
+
 ## Basics
 
 Pie charts series must contain a `data` property containing an array of objects.

--- a/docs/data/charts/pyramid/pyramid.md
+++ b/docs/data/charts/pyramid/pyramid.md
@@ -8,6 +8,35 @@ components: FunnelChart, FunnelPlot
 
 <p class="description">The pyramid chart is a variation of the funnel chart.</p>
 
+## Guidelines
+
+Pyramid charts are ideal for visualizing hierarchical data or showing how quantities build up through progressive levels, making them perfect for displaying demographic data, organizational structures, or any data that naturally forms a pyramid shape.
+
+- **Hierarchical visualization**: Perfect for showing data with natural hierarchical relationships
+- **Population analysis**: Ideal for age demographics, organizational levels, or skill distributions
+- **Foundation-to-peak progression**: Show how smaller segments build toward a larger base or peak
+- **Comparative hierarchy**: Compare different pyramid structures side by side
+
+**When to use pyramid charts:**
+
+- Your data has a natural hierarchical or layered structure
+- You want to show how smaller categories contribute to larger ones
+- You're displaying demographic data (age pyramids, population distribution)
+- You need to visualize organizational hierarchies or skill levels
+- The pyramid metaphor helps communicate your data story
+
+**Data requirements:**
+
+- Hierarchical or layered categorical data
+- Positive numerical values with meaningful relationships between levels
+- Natural ordering from base to peak (or vice versa)
+- Works best with 3-7 levels for clarity
+- Clear labels that convey the hierarchical relationship
+
+**Choose pyramid charts when:** your data naturally forms a pyramid structure, you're showing demographic distributions, organizational hierarchies, or when the pyramid shape adds meaning to your data presentation.
+
+**Direction matters:** Use ascending pyramids for growth/building concepts, descending for filtering/reduction concepts. Consider **proportional segments** when relative sizes within levels are important.
+
 ## Pyramid Chart
 
 To create a pyramid chart, set the `curve` property to `pyramid` in the series.

--- a/docs/data/charts/radar/radar.md
+++ b/docs/data/charts/radar/radar.md
@@ -8,6 +8,35 @@ components: RadarChart, RadarChartPro, RadarGrid, RadarSeriesArea, RadarSeriesMa
 
 <p class="description">Radar lets you compare multivariate data in a 2D chart.</p>
 
+## Guidelines
+
+Radar charts (also known as spider or web charts) are designed for comparing multiple variables across different entities, making them ideal for multivariate analysis where you need to see patterns across several dimensions simultaneously.
+
+- **Multivariate comparison**: Perfect for comparing performance across multiple metrics (skills, ratings, characteristics)
+- **Profile visualization**: Show complete profiles or "fingerprints" of entities across various dimensions
+- **Strengths and weaknesses**: Quickly identify where entities excel or underperform across different criteria
+- **Balanced assessment**: Ideal for displaying survey results, performance evaluations, or competitive analysis
+
+**When to use radar charts:**
+
+- You have 3-8 variables to compare across different entities
+- All variables are on similar scales or can be normalized
+- You want to show overall patterns rather than precise values
+- You're comparing profiles, ratings, or performance metrics
+- The focus is on relative performance across multiple dimensions
+
+**Data requirements:**
+
+- Multiple numerical variables (metrics) for comparison
+- Variables should be on comparable scales or normalized (0-100%, 1-10 rating, etc.)
+- Works best with 3-8 metrics (too few or too many become hard to interpret)
+- Each entity should have values for all or most metrics
+- Positive values work best (negative values can be confusing on radar charts)
+
+**Choose radar charts when:** you need to compare overall profiles rather than individual metrics, you want to show balanced performance across multiple areas, or when the "shape" of the data profile is meaningful.
+
+**Avoid radar charts** for precise value comparison, when metrics have very different scales, or when you have many missing data points. Consider parallel coordinates or grouped bar charts for better precision.
+
 ## Basics
 
 Radar charts series should contain a `data` property containing an array of values.

--- a/docs/data/charts/sankey/sankey.md
+++ b/docs/data/charts/sankey/sankey.md
@@ -8,6 +8,35 @@ components: SankeyChart, SankeyPlot, SankeyTooltip, SankeyTooltipContent
 
 <p class="description">Sankey charts are great for visualizing flows between different elements.</p>
 
+## Guidelines
+
+Sankey charts excel at visualizing flows, transfers, and connections between different entities, making complex relationships and resource movements easy to understand through proportional link widths.
+
+- **Flow visualization**: Perfect for showing how quantities move between different states, categories, or entities
+- **Resource tracking**: Ideal for energy flows, budget allocations, migration patterns, or supply chains
+- **Network analysis**: Visualize connections and transfers in complex systems
+- **Proportional relationships**: Link thickness represents quantity, making relative flows immediately apparent
+
+**When to use Sankey charts:**
+
+- You have data representing flows or transfers between entities
+- You want to show how quantities are distributed across different paths
+- You need to visualize complex networks with weighted connections
+- You're analyzing resource allocation, process flows, or migration patterns
+- The thickness of connections meaningfully represents quantity or importance
+
+**Data requirements:**
+
+- Source-target relationships with associated quantities
+- Clear entity definitions (nodes) that can send/receive flows
+- Positive numerical values representing flow quantities
+- Logical flow direction (from sources to targets)
+- Works best when total inflows equal total outflows for balanced visualization
+
+**Choose Sankey charts when:** you need to show how things flow through a system, visualize resource allocation or redistribution, track multi-step processes, or when the proportional thickness of connections adds insight to your data story.
+
+**Common applications:** energy flows, financial transfers, user journey analysis, supply chain visualization, and demographic migrations.
+
 :::info
 This feature is in preview. It is ready for production use, but its API, visuals and behavior may change in future minor or patch releases.
 :::

--- a/docs/data/charts/scatter/scatter.md
+++ b/docs/data/charts/scatter/scatter.md
@@ -8,6 +8,35 @@ components: ScatterChart, ScatterChartPro, ScatterPlot, ChartsGrid, ChartsWrappe
 
 <p class="description">Scatter charts express the relation between two variables, using points in a surface.</p>
 
+## Guidelines
+
+Scatter charts are the ideal choice for exploring relationships between two continuous variables and identifying patterns, correlations, or outliers in your data. They excel at revealing insights that other chart types might miss.
+
+- **Correlation analysis**: Perfect for showing positive, negative, or no correlation between two variables
+- **Pattern discovery**: Identify clusters, trends, and outliers in multi-dimensional data
+- **Distribution visualization**: See how data points are spread across two dimensions
+- **Outlier detection**: Easily spot data points that don't follow the general pattern
+
+**When to use scatter charts:**
+
+- You want to explore the relationship between two continuous variables
+- You're looking for correlations, patterns, or trends in your data
+- You need to identify outliers or anomalies
+- You want to show the distribution of data points across two dimensions
+- You're conducting statistical analysis or data exploration
+
+**Data requirements:**
+
+- Two continuous numerical variables (x and y coordinates)
+- Optional third variable for color coding or sizing points
+- Works well with any number of data points (from dozens to thousands)
+- Each point represents a single observation or entity
+- No requirement for data to be sorted or sequential
+
+**Choose scatter charts when:** the relationship between variables is more important than individual values, you're doing exploratory data analysis, or when you want to identify patterns that might not be obvious in other chart formats.
+
+**Add trend lines** to highlight correlations, use **color coding** to show additional dimensions, or vary **point sizes** to represent a third variable for richer data storytelling.
+
 ## Basics
 
 Scatter chart series should contain a `data` property containing an array of objects.


### PR DESCRIPTION
Added initial definition and guidelines for each of the main chart types.

## Questions

### Question # 1
The current "guidelines" section, is too much "in the face" of the user. What would be the best approach?

**Ideas**
- Move it to the bottom of their respective pages
- Move it below an initial description and chart example
- Move it to a different subpage of the main component `> Bars > Definition`

### Question # 2

Should we provide links referring to further readings in external websites and references for the content shown?

Eg:

```md
#### Further Reading

For more in-depth guidance on bar chart best practices and design principles:

- **[Data-to-Viz: Bar Chart](link)** - Comprehensive guide on when and how to use bar charts effectively
```

### Question # 3

Should we use bullet points and short text (current approach). 
Or long text with some sporadic bullet points, like (https://www.data-to-viz.com/graph/barplot.html)