### PR TITLE
[DataGridPro] Keep the drop effect if `keepColumnPositionIfDraggedOutside` is enabled

### DIFF
--- a/packages/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx
+++ b/packages/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx
@@ -359,9 +359,13 @@ export const useGridColumnReorder = (
   );
 
   React.useEffect(() => {
+    if (!props.keepColumnPositionIfDraggedOutside) {
+      return () => {};
+    }
+
     const doc = ownerDocument(apiRef.current.rootElementRef!.current);
     const listener = (event: DragEvent) => {
-      if (props.keepColumnPositionIfDraggedOutside && event.dataTransfer) {
+      if (event.dataTransfer) {
         // keep the drop effect if we are keeping the column position if dragged outside
         // https://github.com/mui/mui-x/issues/19183#issuecomment-3202307783
         event.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/19183#issuecomment-3202307783

The problem occurs when the column is dragged outside of the drop zone. Other elements change the `dropEffect` to `none`, which makes the animation go back to the initial position.

Before: https://stackblitz.com/edit/dxwxkwjy?file=src%2FDemo.tsx

To test, use the first example at
https://deploy-preview-19372--material-ui-x.netlify.app/x/react-data-grid/column-ordering/
and add `keepColumnPositionIfDraggedOutside`