### PR TITLE
[pickers] Merge slotProps for input adornment in PickerFieldUI component

### DIFF
--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -142,7 +142,10 @@ export function PickerFieldUI<
   });
   const { ownerState: endInputAdornmentOwnerState, ...endInputAdornmentProps } = useSlotProps({
     elementType: InputAdornment,
-    externalSlotProps: slotProps?.inputAdornment,
+    externalSlotProps: mergeSlotProps(
+      pickerFieldUIContext.slotProps.inputAdornment,
+      slotProps?.inputAdornment,
+    ),
     additionalProps: {
       position: 'end' as const,
     },


### PR DESCRIPTION
closes https://github.com/mui/mui-x/issues/19391

Working preview: https://deploy-preview-19399--material-ui-x.netlify.app/x/react-date-pickers/custom-opening-button/#add-an-icon-next-to-the-opening-button

Argos failing is expected