### PR TITLE
[pickers] Export the resolveDateFormat utility function

### DIFF
--- a/packages/x-date-pickers/src/internals/index.ts
+++ b/packages/x-date-pickers/src/internals/index.ts
@@ -167,6 +167,7 @@ export {
   isDatePickerView,
   mergeDateAndTime,
   formatMeridiem,
+  resolveDateFormat,
   DATE_VIEWS,
 } from './utils/date-utils';
 export { getDefaultReferenceDate } from './utils/getDefaultReferenceDate';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The function `resolveDateTimeFormat` and `resolveTimeFormat` are already exposed. `resolveDateFormat` is not. It would be convenient to have access to the default format that the picker component uses.

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).