### PR TITLE
[infra] Remove "main" fields from publishable packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@mui/icons-material": "catalog:",
     "@mui/internal-bundle-size-checker": "^1.0.9-canary.38",
     "@mui/internal-babel-plugin-display-name": "^1.0.4-canary.6",
-    "@mui/internal-code-infra": "^0.0.3-canary.0",
+    "@mui/internal-code-infra": "^0.0.3-canary.1",
     "@mui/internal-markdown": "^2.0.6",
     "@mui/internal-test-utils": "catalog:",
     "@mui/material": "catalog:",

--- a/packages/x-charts-premium/package.json
+++ b/packages/x-charts-premium/package.json
@@ -3,7 +3,6 @@
   "version": "8.5.1",
   "author": "MUI Team",
   "description": "The Premium plan edition of the MUI X Charts components.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-charts-pro/package.json
+++ b/packages/x-charts-pro/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The Pro plan edition of the MUI X Charts components.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-charts/package.json
+++ b/packages/x-charts/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The community edition of MUI X Charts components.",
-  "main": "src/index.js",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-data-grid-generator/package.json
+++ b/packages/x-data-grid-generator/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "Generate fake data for demo purposes only.",
-  "main": "src/index.ts",
   "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-data-grid-premium/package.json
+++ b/packages/x-data-grid-premium/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The Premium plan edition of the MUI X Data Grid Components.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-data-grid-pro/package.json
+++ b/packages/x-data-grid-pro/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The Pro plan edition of the MUI X Data Grid components.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-data-grid/package.json
+++ b/packages/x-data-grid/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The Community plan edition of the MUI X Data Grid components.",
-  "main": "src/index.ts",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-date-pickers-pro/package.json
+++ b/packages/x-date-pickers-pro/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The Pro plan edition of the MUI X Date and Time Picker components.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-date-pickers/package.json
+++ b/packages/x-date-pickers/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The community edition of the MUI X Date and Time Picker components.",
-  "main": "src/index.ts",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "MUI X License verification.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-scheduler/package.json
+++ b/packages/x-scheduler/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "The community edition of the Scheduler component (MUI X).",
   "author": "MUI Team",
-  "main": "src/index.ts",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-telemetry/package.json
+++ b/packages/x-telemetry/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "MUI X Telemetry.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-tree-view-pro/package.json
+++ b/packages/x-tree-view-pro/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The Pro plan edition of the MUI X Tree View components.",
-  "main": "src/index.ts",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/packages/x-tree-view/package.json
+++ b/packages/x-tree-view/package.json
@@ -3,7 +3,6 @@
   "version": "8.11.0",
   "author": "MUI Team",
   "description": "The community edition of the MUI X Tree View components.",
-  "main": "src/index.ts",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mui/mui-x/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,8 +285,8 @@ importers:
         specifier: ^1.0.9-canary.38
         version: 1.0.9-canary.38(@types/node@24.3.0)(rollup@4.46.2)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
       '@mui/internal-code-infra':
-        specifier: ^0.0.3-canary.0
-        version: 0.0.3-canary.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0))(eslint@9.34.0)(prettier@3.6.2)(typescript@5.9.2)
+        specifier: ^0.0.3-canary.1
+        version: 0.0.3-canary.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0))(eslint@9.34.0)(prettier@3.6.2)(typescript@5.9.2)
       '@mui/internal-markdown':
         specifier: ^2.0.6
         version: 2.0.9
@@ -4191,8 +4191,8 @@ packages:
     resolution: {integrity: sha512-9hqDvOezGxIztw/9FdWmg+M+jzM8fspsR/MqssBUHYUvLxYUy3P0MO3iTy/GJHkZvvL53hJTI3XD6NjSuaeIgw==}
     hasBin: true
 
-  '@mui/internal-code-infra@0.0.3-canary.0':
-    resolution: {integrity: sha512-UrRxmcpUtIw6URCwUkCVqVoihnEEbyeyWH5rqqiffKdO9miiPI0HSZE+dz/D+f7hzOy1IEnj/TStuvKO0avSGQ==}
+  '@mui/internal-code-infra@0.0.3-canary.1':
+    resolution: {integrity: sha512-gr0dPyqDjI3oek/UA4fWYtLZgfHWsQ2rnJ8/1TM2m5PjdOU7QjOYt3cC11K+1e61cWI7oyzBSmKAO6Ci+1tH6A==}
     hasBin: true
     peerDependencies:
       eslint: ^9.0.0
@@ -14791,7 +14791,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.3-canary.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0))(eslint@9.34.0)(prettier@3.6.2)(typescript@5.9.2)':
+  '@mui/internal-code-infra@0.0.3-canary.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.41.0(eslint@9.34.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0))(eslint@9.34.0)(prettier@3.6.2)(typescript@5.9.2)':
     dependencies:
       '@argos-ci/core': 4.1.1
       '@babel/cli': 7.28.3(@babel/core@7.28.3)


### PR DESCRIPTION
Since it is automatically added by the build cli. The equivalent is adding the same path to `exports["."]` which'll then get added as `main`/`module` to the built package.json

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
