### PR TITLE
[scheduler] Add an option to not render the week number in the week day and month views

### DIFF
--- a/docs/data/scheduler/event-calendar/event-calendar.md
+++ b/docs/data/scheduler/event-calendar/event-calendar.md
@@ -199,8 +199,11 @@ You can customize the preferences menu using the `preferencesMenuConfig` prop:
 // will hide the menu
 preferencesMenuConfig={false}
 
-// will hide the menu item responsible for toggling the week-end visibility
+// will hide the menu item responsible for toggling the weekend visibility
 preferencesMenuConfig={{ toggleWeekendVisibility: false }}
+
+// will hide the menu item responsible for toggling the week number visibility
+preferencesMenuConfig={{ toggleWeekNumberVisibility: false }}
 ```
 
 {{"demo": "PreferencesMenu.js", "bg": "inline", "defaultCodeOpen": false}}

--- a/packages/x-scheduler/src/material/event-calendar/EventCalendar.test.tsx
+++ b/packages/x-scheduler/src/material/event-calendar/EventCalendar.test.tsx
@@ -3,7 +3,11 @@ import { DateTime } from 'luxon';
 import { screen } from '@mui/internal-test-utils';
 import { createSchedulerRenderer } from 'test/utils/scheduler';
 import { EventCalendar } from '@mui/x-scheduler/material/event-calendar';
-import { openPreferencesMenu, toggleHideWeekends } from '../internals/utils/test-utils';
+import {
+  openPreferencesMenu,
+  toggleHideWeekends,
+  toggleHideWeekNumber,
+} from '../internals/utils/test-utils';
 
 describe('EventCalendar', () => {
   const { render } = createSchedulerRenderer({ clockConfig: new Date('2025-05-26') });
@@ -102,6 +106,7 @@ describe('EventCalendar', () => {
     // Hide the weekends
     await openPreferencesMenu(user);
     await toggleHideWeekends(user);
+    await user.click(document.body);
 
     expect(screen.queryByRole('columnheader', { name: /Sunday 25/i })).to.equal(null);
     expect(screen.queryByRole('columnheader', { name: /Saturday 31/i })).to.equal(null);
@@ -109,6 +114,7 @@ describe('EventCalendar', () => {
     // Show the weekends again
     await openPreferencesMenu(user);
     await toggleHideWeekends(user);
+    await user.click(document.body);
 
     expect(screen.getByRole('columnheader', { name: /Sunday 25/i })).not.to.equal(null);
     expect(screen.getByRole('columnheader', { name: /Saturday 31/i })).not.to.equal(null);
@@ -124,6 +130,7 @@ describe('EventCalendar', () => {
     // Hide the weekends
     await openPreferencesMenu(user);
     await toggleHideWeekends(user);
+    await user.click(document.body);
 
     expect(screen.queryByRole('columnheader', { name: /Sunday/i })).to.equal(null);
     expect(screen.queryByRole('columnheader', { name: /Saturday/i })).to.equal(null);
@@ -131,6 +138,7 @@ describe('EventCalendar', () => {
     // Show the weekends again
     await openPreferencesMenu(user);
     await toggleHideWeekends(user);
+    await user.click(document.body);
 
     expect(screen.getByRole('columnheader', { name: /Sunday/i })).not.to.equal(null);
     expect(screen.getByRole('columnheader', { name: /Saturday/i })).not.to.equal(null);
@@ -146,6 +154,7 @@ describe('EventCalendar', () => {
     // Hide the weekends
     await openPreferencesMenu(user);
     await toggleHideWeekends(user);
+    await user.click(document.body);
 
     expect(screen.queryByLabelText(/Saturday 31/i)).to.equal(null);
     expect(screen.queryByLabelText(/Sunday 1/i)).to.equal(null);
@@ -153,8 +162,31 @@ describe('EventCalendar', () => {
     // Show the weekends again
     await openPreferencesMenu(user);
     await toggleHideWeekends(user);
+    await user.click(document.body);
 
     expect(screen.getByLabelText(/Saturday 31/i)).not.to.equal(null);
     expect(screen.getByLabelText(/Sunday 1/i)).not.to.equal(null);
+  });
+
+  it('should allow to show / hide the week number using the UI in the month view', async () => {
+    const { user } = render(<EventCalendar events={[]} defaultView="month" />);
+
+    // Week number should be visible by default
+    const findWeekHeaders = () => screen.queryAllByRole('rowheader', { name: /week/i });
+    expect(await findWeekHeaders()).to.have.lengthOf.above(0);
+
+    // Hide the week number
+    await openPreferencesMenu(user);
+    await toggleHideWeekNumber(user);
+    await user.click(document.body);
+
+    expect(await findWeekHeaders()).to.have.lengthOf(0);
+
+    // Show the week number again
+    await openPreferencesMenu(user);
+    await toggleHideWeekNumber(user);
+    await user.click(document.body);
+
+    expect(await findWeekHeaders()).to.have.lengthOf.above(0);
   });
 });

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.css
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.css
@@ -12,7 +12,7 @@
 }
 
 .PreferencesMenuPopup {
-  min-width: 170px;
+  min-width: 185px;
   padding: var(--space-2);
   border-radius: var(--radius-4);
   background-color: var(--surface);
@@ -48,16 +48,12 @@
   background: var(--interactive-active-bg);
 }
 
-/* Selected */
-.mui-x-scheduler .Button.PreferencesMenuButton[data-pressed],
-.PreferencesMenuCheckboxItem[data-checked] {
+.mui-x-scheduler .Button.PreferencesMenuButton[data-pressed] {
   background: var(--interactive-selected-bg);
   color: var(--interactive-selected-text);
 }
 
-/* Selected and hovered */
-.mui-x-scheduler .Button.PreferencesMenuButton[data-pressed]:hover,
-.PreferencesMenuCheckboxItem[data-checked]:hover {
+.mui-x-scheduler .Button.PreferencesMenuButton[data-pressed]:hover {
   background: var(--interactive-selected-hover-bg);
 }
 
@@ -75,15 +71,12 @@
   background: var(--interactive-focused-hover-bg);
 }
 
-/* Active and focused */
-.mui-x-scheduler .Button.PreferencesMenuButton:active:focus-visible,
-.PreferencesMenuCheckboxItem:active:focus-visible {
+.mui-x-scheduler .Button.PreferencesMenuButton:active:focus-visible {
   background: var(--interactive-active-focused-bg);
 }
 
 /* Selected and focused */
-.mui-x-scheduler .Button.PreferencesMenuButton[data-pressed]:focus-visible,
-.PreferencesMenuCheckboxItem[data-checked]:focus-visible {
+.mui-x-scheduler .Button.PreferencesMenuButton[data-pressed]:focus-visible {
   background: var(--interactive-selected-focused-bg);
   outline: var(--outline-focus);
   outline-offset: var(--outline-focus-offset);

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.test.tsx
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { createSchedulerRenderer } from 'test/utils/scheduler';
 import { StandaloneView } from '@mui/x-scheduler/material/standalone-view';
+import { screen } from '@mui/internal-test-utils';
 import { PreferencesMenu } from './PreferencesMenu';
-import { getPreferencesMenu } from '../../../utils/test-utils';
+import { getPreferencesMenu, openPreferencesMenu } from '../../../utils/test-utils';
 
 describe('<PreferencesMenu />', () => {
   const anchor = document.createElement('button');
@@ -54,5 +55,39 @@ describe('<PreferencesMenu />', () => {
     );
 
     expect(getPreferencesMenu()).to.equal(null);
+  });
+
+  it('should hide hideWeekends option when toggleWeekendVisibility is false', async () => {
+    const { user } = render(
+      <StandaloneView
+        events={[]}
+        preferencesMenuConfig={{ toggleWeekendVisibility: false, toggleWeekNumberVisibility: true }}
+      >
+        <PreferencesMenu />
+      </StandaloneView>,
+    );
+
+    await openPreferencesMenu(user);
+
+    expect(screen.queryByRole('menuitemcheckbox', { name: /hide weekends/i })).to.equal(null);
+    expect(screen.queryByRole('menuitemcheckbox', { name: /hide week number/i })).not.to.equal(
+      null,
+    );
+  });
+
+  it('should hide hideWeekNumber option when toggleWeekNumberVisibility is false', async () => {
+    const { user } = render(
+      <StandaloneView
+        events={[]}
+        preferencesMenuConfig={{ toggleWeekendVisibility: true, toggleWeekNumberVisibility: false }}
+      >
+        <PreferencesMenu />
+      </StandaloneView>,
+    );
+
+    await openPreferencesMenu(user);
+
+    expect(screen.queryByRole('menuitemcheckbox', { name: /hide weekends/i })).not.to.equal(null);
+    expect(screen.queryByRole('menuitemcheckbox', { name: /hide week number/i })).to.equal(null);
   });
 });

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.test.tsx
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.test.tsx
@@ -42,7 +42,13 @@ describe('<PreferencesMenu />', () => {
 
   it('should not render the menu when all the items are disabled', async () => {
     render(
-      <StandaloneView events={[]} preferencesMenuConfig={{ toggleWeekendVisibility: false }}>
+      <StandaloneView
+        events={[]}
+        preferencesMenuConfig={{
+          toggleWeekendVisibility: false,
+          toggleWeekNumberVisibility: false,
+        }}
+      >
         <PreferencesMenu />
       </StandaloneView>,
     );

--- a/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.tsx
+++ b/packages/x-scheduler/src/material/internals/components/header-toolbar/preferences-menu/PreferencesMenu.tsx
@@ -6,6 +6,10 @@ import { useStore } from '@base-ui-components/utils/store';
 import { CheckIcon, Settings } from 'lucide-react';
 import { Menu } from '@base-ui-components/react/menu';
 import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
+import {
+  CalendarPreferences,
+  CalendarPreferencesMenuConfig,
+} from '../../../../../primitives/models/preferences';
 import { useTranslations } from '../../../utils/TranslationsContext';
 import { useEventCalendarContext } from '../../../hooks/useEventCalendarContext';
 import { selectors } from '../../../../../primitives/use-event-calendar';
@@ -24,11 +28,38 @@ export const PreferencesMenu = React.forwardRef(function PreferencesMenu(
   const preferences = useStore(store, selectors.preferences);
   const preferencesMenuConfig = useStore(store, selectors.preferencesMenuConfig);
 
-  const handleHideWeekend = useEventCallback((checked: boolean, event: Event) => {
-    instance.setPreferences({ hideWeekends: checked }, event);
-  });
+  const handleToggle = useEventCallback(
+    (key: keyof CalendarPreferences, checked: boolean, event: Event) => {
+      instance.setPreferences({ [key]: checked }, event);
+    },
+  );
 
-  if (preferencesMenuConfig === false || !preferencesMenuConfig?.toggleWeekendVisibility) {
+  if (preferencesMenuConfig === false) {
+    return null;
+  }
+
+  const preferenceOptions: {
+    configKey: keyof CalendarPreferencesMenuConfig;
+    preferenceKey: keyof CalendarPreferences;
+    label: string;
+  }[] = [
+    {
+      configKey: 'toggleWeekendVisibility',
+      preferenceKey: 'hideWeekends',
+      label: translations.hideWeekends,
+    },
+    {
+      configKey: 'toggleWeekNumberVisibility',
+      preferenceKey: 'hideWeekNumber',
+      label: translations.hideWeekNumber,
+    },
+  ];
+
+  const visibleOptions = preferenceOptions.filter(
+    (option) => !!preferencesMenuConfig?.[option.configKey],
+  );
+
+  if (visibleOptions.length === 0) {
     return null;
   }
 
@@ -44,19 +75,21 @@ export const PreferencesMenu = React.forwardRef(function PreferencesMenu(
         <Menu.Portal container={containerRef}>
           <Menu.Positioner className="PreferencesMenuPositioner" sideOffset={4} align="end">
             <Menu.Popup className="PreferencesMenuPopup">
-              {preferencesMenuConfig.toggleWeekendVisibility && (
+              {visibleOptions.map((option) => (
                 <Menu.CheckboxItem
-                  checked={preferences.hideWeekends}
-                  onCheckedChange={handleHideWeekend}
-                  closeOnClick
+                  key={option.configKey}
+                  checked={preferences[option.preferenceKey]}
+                  onCheckedChange={(checked, event) =>
+                    handleToggle(option.preferenceKey, checked, event)
+                  }
                   className="PreferencesMenuCheckboxItem"
                 >
-                  <span>{translations.hideWeekends}</span>
+                  <span>{option.label}</span>
                   <Menu.CheckboxItemIndicator className="PreferencesMenuCheckboxIndicator">
                     <CheckIcon size={16} strokeWidth={1.5} />
                   </Menu.CheckboxItemIndicator>
                 </Menu.CheckboxItem>
-              )}
+              ))}
             </Menu.Popup>
           </Menu.Positioner>
         </Menu.Portal>

--- a/packages/x-scheduler/src/material/internals/utils/test-utils.ts
+++ b/packages/x-scheduler/src/material/internals/utils/test-utils.ts
@@ -15,3 +15,8 @@ export async function toggleHideWeekends(user) {
   const menuItem = await screen.findByRole('menuitemcheckbox', { name: /hide weekends/i });
   await user.click(menuItem);
 }
+
+export async function toggleHideWeekNumber(user) {
+  const menuItem = await screen.findByRole('menuitemcheckbox', { name: /hide week number/i });
+  await user.click(menuItem);
+}

--- a/packages/x-scheduler/src/material/models/translations.ts
+++ b/packages/x-scheduler/src/material/models/translations.ts
@@ -17,6 +17,7 @@ export interface SchedulerTranslations {
   // PreferencesMenu
   preferencesMenu: string;
   hideWeekends: string;
+  hideWeekNumber: string;
 
   // WeekView
   allDay: string;

--- a/packages/x-scheduler/src/material/month-view/MonthView.css
+++ b/packages/x-scheduler/src/material/month-view/MonthView.css
@@ -1,5 +1,6 @@
 .MonthViewContainer {
   --fixed-cell-width: 28px;
+  --grid-template-columns-month-view: repeat(auto-fit, minmax(0, 1fr));
 }
 
 .MonthViewContainer {
@@ -20,9 +21,16 @@
 }
 
 .MonthViewHeader {
-  display: grid;
-  grid-template-columns: var(--fixed-cell-width) repeat(auto-fit, minmax(0, 1fr));
   border-block-end: 1px solid var(--border-color);
+}
+
+.MonthViewRowGrid {
+  display: grid;
+  grid-template-columns: var(--grid-template-columns-month-view);
+}
+
+.MonthViewRowGrid.WithWeekNumber {
+  grid-template-columns: var(--fixed-cell-width) var(--grid-template-columns-month-view);
 }
 
 .MonthViewHeaderCell:not(:first-child) {

--- a/packages/x-scheduler/src/material/month-view/MonthView.tsx
+++ b/packages/x-scheduler/src/material/month-view/MonthView.tsx
@@ -75,8 +75,16 @@ export const MonthView = React.memo(
       >
         <EventPopoverProvider containerRef={containerRef}>
           <DayGrid.Root className="MonthViewRoot">
-            <div className="MonthViewHeader">
-              <div className="MonthViewWeekHeaderCell">{translations.weekAbbreviation}</div>
+            <div
+              className={clsx(
+                'MonthViewHeader',
+                'MonthViewRowGrid',
+                preferences.hideWeekNumber ? undefined : 'WithWeekNumber',
+              )}
+            >
+              {!preferences.hideWeekNumber && (
+                <div className="MonthViewWeekHeaderCell">{translations.weekAbbreviation}</div>
+              )}
               {getDayList({
                 date: weeks[0],
                 amount: 'week',

--- a/packages/x-scheduler/src/material/month-view/month-view-row/MonthViewWeekRow.css
+++ b/packages/x-scheduler/src/material/month-view/month-view-row/MonthViewWeekRow.css
@@ -1,8 +1,3 @@
-.MonthViewRow {
-  display: grid;
-  grid-template-columns: var(--fixed-cell-width) repeat(auto-fit, minmax(0, 1fr));
-}
-
 .MonthViewRow:not(:last-child) {
   border-block-end: 1px solid var(--border-color);
 }

--- a/packages/x-scheduler/src/material/month-view/month-view-row/MonthViewWeekRow.tsx
+++ b/packages/x-scheduler/src/material/month-view/month-view-row/MonthViewWeekRow.tsx
@@ -55,14 +55,23 @@ export default function MonthViewWeekRow(props: MonthViewWeekRowProps) {
   };
 
   return (
-    <DayGrid.Row key={weekNumber} className="MonthViewRow">
-      <div
-        className="MonthViewWeekNumberCell"
-        role="rowheader"
-        aria-label={translations.weekNumberAriaLabel(weekNumber)}
-      >
-        {weekNumber}
-      </div>
+    <DayGrid.Row
+      key={weekNumber}
+      className={clsx(
+        'MonthViewRow',
+        'MonthViewRowGrid',
+        preferences.hideWeekNumber ? undefined : 'WithWeekNumber',
+      )}
+    >
+      {!preferences.hideWeekNumber && (
+        <div
+          className="MonthViewWeekNumberCell"
+          role="rowheader"
+          aria-label={translations.weekNumberAriaLabel(weekNumber)}
+        >
+          {weekNumber}
+        </div>
+      )}
       {daysWithEvents.map(({ day, events, allDayEvents }, dayIdx) => {
         const isCurrentMonth = adapter.isSameMonth(day, visibleDate);
 

--- a/packages/x-scheduler/src/material/translations/enUS.ts
+++ b/packages/x-scheduler/src/material/translations/enUS.ts
@@ -17,6 +17,7 @@ export const enUS: SchedulerTranslations = {
   // Preferences menu
   preferencesMenu: 'Settings',
   hideWeekends: 'Hide weekends',
+  hideWeekNumber: 'Hide week number',
 
   // WeekView
   allDay: 'All day',

--- a/packages/x-scheduler/src/primitives/models/preferences.ts
+++ b/packages/x-scheduler/src/primitives/models/preferences.ts
@@ -4,6 +4,11 @@ export interface CalendarPreferences {
    * @default false
    */
   hideWeekends: boolean;
+  /**
+   * Whether the week number is hidden in the calendar.
+   * @default false
+   */
+  hideWeekNumber: boolean;
 }
 
 export interface CalendarPreferencesMenuConfig {
@@ -12,4 +17,9 @@ export interface CalendarPreferencesMenuConfig {
    * @default true
    */
   toggleWeekendVisibility: boolean;
+  /**
+   * Whether the menu item to toggle week number visibility is visible.
+   * @default true
+   */
+  toggleWeekNumberVisibility: boolean;
 }

--- a/packages/x-scheduler/src/primitives/use-event-calendar/EventCalendarInstance.ts
+++ b/packages/x-scheduler/src/primitives/use-event-calendar/EventCalendarInstance.ts
@@ -16,9 +16,10 @@ import { Adapter } from '../utils/adapter/types';
 
 const DEFAULT_VIEWS: CalendarView[] = ['week', 'day', 'month', 'agenda'];
 const DEFAULT_VIEW: CalendarView = 'week';
-const DEFAULT_PREFERENCES: CalendarPreferences = { hideWeekends: false };
+const DEFAULT_PREFERENCES: CalendarPreferences = { hideWeekends: false, hideWeekNumber: false };
 const DEFAULT_PREFERENCES_MENU_CONFIG: CalendarPreferencesMenuConfig = {
   toggleWeekendVisibility: true,
+  toggleWeekNumberVisibility: true,
 };
 const EMPTY_ARRAY: any[] = [];
 

--- a/packages/x-scheduler/src/primitives/use-event-calendar/useEventCalendar.types.ts
+++ b/packages/x-scheduler/src/primitives/use-event-calendar/useEventCalendar.types.ts
@@ -80,14 +80,14 @@ export interface EventCalendarParameters {
   showCurrentTimeIndicator?: boolean;
   /**
    * Preferences for the calendar.
-   * @default { hideWeekends: false }
+   * @default { hideWeekends: false, hideWeekNumber: false }
    */
   preferences?: Partial<CalendarPreferences>;
   /**
    * Config of the preferences menu.
    * Defines which options are visible in the menu.
    * If `false`, the menu will be entirely hidden.
-   * @default { toggleWeekendVisibility: true }
+   * @default { toggleWeekendVisibility: true, toggleWeekNumberVisibility: true }
    */
   preferencesMenuConfig?: Partial<CalendarPreferencesMenuConfig> | false;
 }


### PR DESCRIPTION
Issue #17717 

Add a boolean prop that adds the current week number in every view that renders one or several days.

In this PR:
- Added a boolean prop to the <EventCalendar /> component that renders the week number, the week number is only rendered when this prop is true (should be true by default).
- Added the option to the preference menu
- Added also one option on the preference config to hide the option.
- Added tests
- Added the prop to the docs (preferences config section)

Not in this PR:
- Support custom UIs to render the week number
- Allow to define this prop for each view

Note: For now, the week number is shown only in the `Month` view. We’ll add it to the other views once the designs are ready.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
