### PR TITLE
[DataGrid] Fix resize loop with skeleton loader and horizontal scroll

### DIFF
--- a/packages/x-data-grid/src/components/base/GridOverlays.tsx
+++ b/packages/x-data-grid/src/components/base/GridOverlays.tsx
@@ -78,8 +78,7 @@ export function GridOverlayWrapper(props: React.PropsWithChildren<GridOverlaysPr
   let height: React.CSSProperties['height'] = Math.max(
     dimensions.viewportOuterSize.height -
       dimensions.topContainerHeight -
-      dimensions.bottomContainerHeight -
-      (dimensions.hasScrollX ? dimensions.scrollbarSize : 0),
+      dimensions.bottomContainerHeight,
     0,
   );
 


### PR DESCRIPTION
Closes #19260 

The spacing removed for the horizontal scrollbar creates a resize loop with the skeleton loader overlay.