### PR TITLE
[DataGrid] Fix styled API arguments error

### DIFF
--- a/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
+++ b/packages/x-data-grid/src/components/columnsManagement/GridColumnsManagement.tsx
@@ -460,6 +460,6 @@ const GridColumnsManagementEmptyText = styled('div', {
 const GridColumnsManagementRow = styled(NotRendered<GridSlotProps['baseCheckbox']>, {
   name: 'MuiDataGrid',
   slot: 'ColumnsManagementRow',
-})();
+})({});
 
 export { GridColumnsManagement };


### PR DESCRIPTION
Fixes #19456 

The PR #19097 added this slot, it seems, styled API requires to pass an empty object even if there are no actual styles.