### PR TITLE
[DataGrid] Fix indeterminate select all state with exclude model

### DIFF
--- a/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/x-data-grid/src/components/columnSelection/GridHeaderCheckbox.tsx
@@ -121,7 +121,7 @@ const GridHeaderCheckbox = forwardRef<HTMLButtonElement, GridColumnHeaderParams>
     }, [filteredSelection, selectionCandidates]);
 
     const isIndeterminate = React.useMemo(() => {
-      if (filteredSelection.ids.size === 0) {
+      if (currentSelectionSize === 0) {
         return false;
       }
       const selectionManager = createRowSelectionManager(filteredSelection);
@@ -131,7 +131,7 @@ const GridHeaderCheckbox = forwardRef<HTMLButtonElement, GridColumnHeaderParams>
         }
       }
       return false;
-    }, [filteredSelection, selectionCandidates]);
+    }, [currentSelectionSize, filteredSelection, selectionCandidates]);
 
     const isChecked = currentSelectionSize > 0;
 


### PR DESCRIPTION
Fixes #19434 

`filteredSelection.ids` contains the ids in the model irrespective of `exclude` or `include` selection type, which causes issues when in `exclude` mode.