### PR TITLE
[charts] Fix the highlight regression

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/FunnelSection.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelSection.tsx
@@ -42,7 +42,16 @@ const FunnelSection = consumeSlots(
       variant = 'filled',
       ...other
     } = props;
-    const interactionProps = useInteractionItemProps({ type: 'funnel', seriesId, dataIndex });
+
+    const funnelIdentifier = React.useMemo(
+      () => ({
+        type: 'funnel' as const,
+        seriesId,
+        dataIndex,
+      }),
+      [seriesId, dataIndex],
+    );
+    const interactionProps = useInteractionItemProps(funnelIdentifier);
     const { isFaded, isHighlighted } = useItemHighlighted({
       seriesId,
       dataIndex,

--- a/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
+++ b/packages/x-charts-pro/src/Heatmap/HeatmapItem.tsx
@@ -76,7 +76,15 @@ const useUtilityClasses = (ownerState: HeatmapItemOwnerState) => {
 function HeatmapItem(props: HeatmapItemProps) {
   const { seriesId, dataIndex, color, value, slotProps = {}, slots = {}, ...other } = props;
 
-  const interactionProps = useInteractionItemProps({ type: 'heatmap', seriesId, dataIndex });
+  const heatmapItemIdentifier = React.useMemo(
+    () => ({
+      type: 'heatmap' as const,
+      seriesId,
+      dataIndex,
+    }),
+    [seriesId, dataIndex],
+  );
+  const interactionProps = useInteractionItemProps(heatmapItemIdentifier);
   const { isFaded, isHighlighted } = useItemHighlighted({
     seriesId,
     dataIndex,

--- a/packages/x-charts-pro/src/SankeyChart/SankeyLinkElement.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyLinkElement.tsx
@@ -36,20 +36,23 @@ export const SankeyLinkElement = React.forwardRef<SVGPathElement, SankeyLinkElem
   function SankeyLinkElement(props, ref) {
     const { link, opacity = 0.4, onClick, seriesId } = props;
 
-    const identifier: SankeyLinkIdentifierWithData = {
-      type: 'sankey',
-      seriesId,
-      subType: 'link',
-      targetId: link.target.id,
-      sourceId: link.source.id,
-      link,
-    };
+    const sankeyLinkIdentifier: SankeyLinkIdentifierWithData = React.useMemo(
+      () => ({
+        type: 'sankey' as const,
+        seriesId,
+        subType: 'link',
+        targetId: link.target.id,
+        sourceId: link.source.id,
+        link,
+      }),
+      [seriesId, link],
+    );
 
     // Add interaction props for tooltips
-    const interactionProps = useInteractionItemProps(identifier);
+    const interactionProps = useInteractionItemProps(sankeyLinkIdentifier);
 
     const handleClick = useEventCallback((event: React.MouseEvent<SVGPathElement>) => {
-      onClick?.(event, identifier);
+      onClick?.(event, sankeyLinkIdentifier);
     });
 
     if (!link.path) {

--- a/packages/x-charts-pro/src/SankeyChart/SankeyNodeElement.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyNodeElement.tsx
@@ -54,19 +54,21 @@ export const SankeyNodeElement = React.forwardRef<SVGGElement, SankeyNodeElement
 
     const labelAnchor = node.depth === 0 ? 'start' : 'end';
 
-    const identifier: SankeyNodeIdentifierWithData = {
-      type: 'sankey',
-      seriesId,
-      subType: 'node',
-      nodeId: node.id,
-      node,
-    };
-
+    const sankeyNodeIdentifier: SankeyNodeIdentifierWithData = React.useMemo(
+      () => ({
+        type: 'sankey' as const,
+        seriesId,
+        subType: 'node',
+        nodeId: node.id,
+        node,
+      }),
+      [seriesId, node],
+    );
     // Add interaction props for tooltips
-    const interactionProps = useInteractionItemProps(identifier);
+    const interactionProps = useInteractionItemProps(sankeyNodeIdentifier);
 
     const handleClick = useEventCallback((event: React.MouseEvent<SVGRectElement>) => {
-      onClick?.(event, identifier);
+      onClick?.(event, sankeyNodeIdentifier);
     });
 
     return (

--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -62,7 +62,12 @@ function BarElement(props: BarElementProps) {
     height,
     ...other
   } = props;
-  const interactionProps = useInteractionItemProps({ type: 'bar', seriesId: id, dataIndex });
+
+  const barIdentifier = React.useMemo(
+    () => ({ type: 'bar' as const, seriesId: id, dataIndex }),
+    [id, dataIndex],
+  );
+  const interactionProps = useInteractionItemProps(barIdentifier);
   const { isFaded, isHighlighted } = useItemHighlighted({
     seriesId: id,
     dataIndex,

--- a/packages/x-charts/src/LineChart/AreaElement.tsx
+++ b/packages/x-charts/src/LineChart/AreaElement.tsx
@@ -107,7 +107,8 @@ function AreaElement(props: AreaElementProps) {
     ...other
   } = props;
 
-  const interactionProps = useInteractionItemProps({ type: 'line', seriesId: id });
+  const areaIdentifier = React.useMemo(() => ({ type: 'line' as const, seriesId: id }), [id]);
+  const interactionProps = useInteractionItemProps(areaIdentifier);
   const { isFaded, isHighlighted } = useItemHighlighted({
     seriesId: id,
   });

--- a/packages/x-charts/src/LineChart/CircleMarkElement.tsx
+++ b/packages/x-charts/src/LineChart/CircleMarkElement.tsx
@@ -65,7 +65,12 @@ function CircleMarkElement(props: CircleMarkElementProps) {
   } = props;
 
   const theme = useTheme();
-  const interactionProps = useInteractionItemProps({ type: 'line', seriesId: id, dataIndex });
+
+  const circleMarkIdentifier = React.useMemo(
+    () => ({ type: 'line' as const, seriesId: id, dataIndex }),
+    [id, dataIndex],
+  );
+  const interactionProps = useInteractionItemProps(circleMarkIdentifier);
 
   const ownerState = {
     id,

--- a/packages/x-charts/src/LineChart/LineElement.tsx
+++ b/packages/x-charts/src/LineChart/LineElement.tsx
@@ -106,7 +106,9 @@ function LineElement(props: LineElementProps) {
     onClick,
     ...other
   } = props;
-  const interactionProps = useInteractionItemProps({ type: 'line', seriesId: id });
+
+  const lineIdentifier = React.useMemo(() => ({ type: 'line' as const, seriesId: id }), [id]);
+  const interactionProps = useInteractionItemProps(lineIdentifier);
   const { isFaded, isHighlighted } = useItemHighlighted({
     seriesId: id,
   });

--- a/packages/x-charts/src/LineChart/MarkElement.tsx
+++ b/packages/x-charts/src/LineChart/MarkElement.tsx
@@ -75,7 +75,11 @@ function MarkElement(props: MarkElementProps) {
     ...other
   } = props;
 
-  const interactionProps = useInteractionItemProps({ type: 'line', seriesId: id, dataIndex });
+  const markIdentifier = React.useMemo(
+    () => ({ type: 'line' as const, seriesId: id, dataIndex }),
+    [id, dataIndex],
+  );
+  const interactionProps = useInteractionItemProps(markIdentifier);
 
   const ownerState = {
     id,

--- a/packages/x-charts/src/PieChart/PieArc.tsx
+++ b/packages/x-charts/src/PieChart/PieArc.tsx
@@ -115,7 +115,11 @@ const PieArc = React.forwardRef<SVGPathElement, PieArcProps>(function PieArc(pro
   };
   const classes = useUtilityClasses(ownerState);
 
-  const interactionProps = useInteractionItemProps({ type: 'pie', seriesId: id, dataIndex });
+  const pieArcIdentifier = React.useMemo(
+    () => ({ type: 'pie' as const, seriesId: id, dataIndex }),
+    [id, dataIndex],
+  );
+  const interactionProps = useInteractionItemProps(pieArcIdentifier);
   const animatedProps = useAnimatePieArc({
     cornerRadius,
     startAngle,


### PR DESCRIPTION
Fix #19433

The regression come from https://github.com/mui/mui-x/pull/19295/files in the `useInteractionItemProps.ts` file.

The following modification got required becaus ethe sankey does not have a `(type, seriesId, dataIndex)` identifier.

```diff
 const onPointerLeave = React.useCallback(() => {
    interactionActive.current = false;
-   instance.removeItemInteraction({
-      type: data.type,
-      seriesId: data.seriesId,
-      dataIndex: data.dataIndex,
-    } as SeriesItemIdentifier);
+   instance.removeItemInteraction(data);
    instance.clearHighlight();
-   }, [instance, data.type, data.seriesId, data.dataIndex]);
+  }, [instance, data]);
```

But with this modification we need to memoize the `data`. Otherwise the `useCallback` is useless, and it triggers the following `useEffect` all the time (causing the regression)

```js
  React.useEffect(() => {
    return () => {
      /* Clean up state if this item is unmounted while active. */
      if (interactionActive.current) {
        onPointerLeave();
      }
    };
  }, [onPointerLeave]);
```
