### PR TITLE
[code-infra] Remove log when restarting dev server

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -207,8 +207,6 @@ export default withDocsInfra({
       console.log('Considering only English for SSR');
       traverse(pages, 'en');
     } else {
-      // eslint-disable-next-line no-console
-      console.log('Considering various locales for SSR');
       LANGUAGES_SSR.forEach((userLanguage) => {
         traverse(pages, userLanguage);
       });


### PR DESCRIPTION
This log doesn't seem to be adding much. The default case is considering various locales and we're already logging when we aren't following the default case. 

On the other hand, it occupies some space in the terminal for no benefit, so I'd like to know your thoughts on removing it. 

<img width="906" height="1040" alt="image" src="https://github.com/user-attachments/assets/f7823be0-325e-4100-a6dd-bff7195084ba" />
