### PR TITLE
[code-infra] Remove renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,6 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
       "groupName": "D3",
       "matchPackageNames": ["d3-*", "@types/d3-*"]
     },


### PR DESCRIPTION
* devDependencies are now grouped by default
* Avoid `autoMerge` to mitigate against supply chain attacks.