### PR TITLE
[infra] Set nodejs versions of various CIs to 22.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ default-job: &default-job
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
   working_directory: /tmp/mui
   docker:
-    - image: cimg/node:22.16
+    - image: cimg/node:22.18
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
     name: Continuous releases
     uses: mui/mui-public/.github/workflows/ci-base.yml@master
     with:
-      node-version: '22'
+      node-version: '22.18.0'

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "pnpm docs:build"
 
 [build.environment]
-  NODE_VERSION = "22"
+  NODE_VERSION = "22.18"
   PNPM_FLAGS = "--frozen-lockfile"
   NODE_OPTIONS = "--max-old-space-size=4096"
 

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   },
   "packageManager": "pnpm@10.15.1",
   "engines": {
-    "pnpm": "10.15.1"
+    "pnpm": "10.15.1",
+    "node": ">=22.18"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,3 +93,5 @@ onlyBuiltDependencies:
   - nx
   - sharp
   - unrs-resolver
+
+engineStrict: true


### PR DESCRIPTION
Also make the engine requirement strict (node >=22.18) for local dev

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
