### PR TITLE
[charts] Simplify params in `getRange` and `createDateFormatter`

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/computeAxisValue.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/computeAxisValue.ts
@@ -152,7 +152,7 @@ export function computeAxisValue({
       };
 
       if (isDateData(axis.data)) {
-        const dateFormatter = createDateFormatter(axis, scaleRange);
+        const dateFormatter = createDateFormatter(axis.data, scaleRange, axis.tickNumber);
         completeAxis[axis.id].valueFormatter = axis.valueFormatter ?? dateFormatter;
       }
     }

--- a/packages/x-charts/src/internals/dateHelpers.ts
+++ b/packages/x-charts/src/internals/dateHelpers.ts
@@ -1,4 +1,4 @@
-import { scaleTime } from '@mui/x-charts-vendor/d3-scale';
+import { NumberValue, scaleTime } from '@mui/x-charts-vendor/d3-scale';
 import { AxisConfig } from '../models';
 import { ChartsAxisProps } from '../models/axis';
 
@@ -11,16 +11,18 @@ export const isDateData = (data?: readonly any[]): data is Date[] => data?.[0] i
 
 /**
  * Creates a formatter function for date values.
- * @param axis The axis configuration.
+ * @param data The data array containing Date or NumberValue objects.
  * @param range The range for the time scale.
+ * @param tickNumber (Optional) The number of ticks for formatting.
  * @returns A formatter function for date values.
  */
 export function createDateFormatter(
-  axis: AxisConfig<'band' | 'point', any, ChartsAxisProps>,
+  data: Iterable<Date | NumberValue>,
   range: number[],
+  tickNumber?: number,
 ): AxisConfig<'band' | 'point', any, ChartsAxisProps>['valueFormatter'] {
-  const timeScale = scaleTime(axis.data!, range);
+  const timeScale = scaleTime(data, range);
 
   return (v, { location }) =>
-    location === 'tick' ? timeScale.tickFormat(axis.tickNumber)(v) : `${v.toLocaleString()}`;
+    location === 'tick' ? timeScale.tickFormat(tickNumber)(v) : `${v.toLocaleString()}`;
 }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -1,6 +1,6 @@
 import { scaleBand, scalePoint, ScaleSymLog } from '@mui/x-charts-vendor/d3-scale';
 import { createScalarFormatter } from '../../../defaultValueFormatters';
-import { AxisConfig, ScaleName } from '../../../../models';
+import { ScaleName } from '../../../../models';
 import {
   ChartsXAxisProps,
   ChartsAxisProps,
@@ -32,14 +32,14 @@ import { getAxisDomainLimit } from './getAxisDomainLimit';
 function getRange(
   drawingArea: ChartDrawingArea,
   axisDirection: 'x' | 'y', // | 'rotation' | 'radius',
-  axis: AxisConfig<ScaleName, any, ChartsAxisProps>,
+  reverse: boolean,
 ): [number, number] {
   const range: [number, number] =
     axisDirection === 'x'
       ? [drawingArea.left, drawingArea.left + drawingArea.width]
       : [drawingArea.top + drawingArea.height, drawingArea.top];
 
-  return axis.reverse ? [range[1], range[0]] : range;
+  return reverse ? [range[1], range[0]] : range;
 }
 
 const DEFAULT_CATEGORY_GAP_RATIO = 0.2;
@@ -109,7 +109,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
     const zoomOption = zoomOptions?.[axis.id];
     const zoom = zoomMap?.get(axis.id);
     const zoomRange: [number, number] = zoom ? [zoom.start, zoom.end] : [0, 100];
-    const range = getRange(drawingArea, axisDirection, axis);
+    const range = getRange(drawingArea, axisDirection, axis.reverse ?? false);
 
     const [minData, maxData] = getAxisExtremum(
       axis,
@@ -151,7 +151,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
       };
 
       if (isDateData(axis.data)) {
-        const dateFormatter = createDateFormatter(axis, scaleRange);
+        const dateFormatter = createDateFormatter(axis.data, scaleRange, axis.tickNumber);
         completeAxis[axis.id].valueFormatter = axis.valueFormatter ?? dateFormatter;
       }
     }
@@ -175,7 +175,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
       };
 
       if (isDateData(axis.data)) {
-        const dateFormatter = createDateFormatter(axis, scaleRange);
+        const dateFormatter = createDateFormatter(axis.data, scaleRange, axis.tickNumber);
         completeAxis[axis.id].valueFormatter = axis.valueFormatter ?? dateFormatter;
       }
     }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/computeAxisValue.ts
@@ -146,7 +146,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
       };
 
       if (isDateData(axis.data)) {
-        const dateFormatter = createDateFormatter(axis, range);
+        const dateFormatter = createDateFormatter(axis.data, range, axis.tickNumber);
         completeAxis[axis.id].valueFormatter = axis.valueFormatter ?? dateFormatter;
       }
     }
@@ -166,7 +166,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
       };
 
       if (isDateData(axis.data)) {
-        const dateFormatter = createDateFormatter(axis, range);
+        const dateFormatter = createDateFormatter(axis.data, range, axis.tickNumber);
         completeAxis[axis.id].valueFormatter = axis.valueFormatter ?? dateFormatter;
       }
     }


### PR DESCRIPTION
Simplify params in `getRange` and `createDateFormatter`. 