### PR TITLE
[fields] Remove redundant `id` and `aria-labelledby` attributes from spinbuttons

### DIFF
--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import useEventCallback from '@mui/utils/useEventCallback';
-import useId from '@mui/utils/useId';
 import { UseFieldStateReturnValue } from './useFieldState';
 import { FieldSection, MuiPickersAdapter, PickerManager } from '../../../models';
 import { UseFieldDOMGetters, UseFieldInternalProps } from './useField.types';
@@ -22,7 +21,7 @@ export function useFieldSectionContentProps(
 ): UseFieldSectionContentPropsReturnValue {
   const adapter = usePickerAdapter();
   const translations = usePickerTranslations();
-  const id = useId();
+  // const id = useId();
 
   const {
     focused,
@@ -176,7 +175,6 @@ export function useFieldSectionContentProps(
         onFocus: createFocusHandler(sectionIndex),
 
         // Aria attributes
-        'aria-labelledby': `${id}-${section.type}`,
         'aria-readonly': readOnly,
         'aria-valuenow': getSectionValueNow(section, adapter),
         'aria-valuemin': sectionBoundaries.minimum,
@@ -191,7 +189,6 @@ export function useFieldSectionContentProps(
         tabIndex: isContainerEditable || sectionIndex > 0 ? -1 : 0,
         contentEditable: !isContainerEditable && !disabled && !readOnly,
         role: 'spinbutton',
-        id: `${id}-${section.type}`,
         'data-range-position': (section as FieldRangeSection).dateName || undefined,
         spellCheck: isEditable ? false : undefined,
         autoCapitalize: isEditable ? 'off' : undefined,
@@ -202,7 +199,6 @@ export function useFieldSectionContentProps(
     },
     [
       sectionsValueBoundaries,
-      id,
       isContainerEditable,
       disabled,
       readOnly,

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldSectionContentProps.ts
@@ -21,7 +21,6 @@ export function useFieldSectionContentProps(
 ): UseFieldSectionContentPropsReturnValue {
   const adapter = usePickerAdapter();
   const translations = usePickerTranslations();
-  // const id = useId();
 
   const {
     focused,


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/19274.

The IDs did not serve any purpose.
- The SO behavior with `NVDA` on `Firefox` remains the same.
- This fixes the SO behavior with VoiceOver on MacOS, as it used to skip/miss the section `aria-label` given the existence of `aria-labelledby`, which pointed "nowhere". 🙈 