### PR TITLE
[charts] Ignore empty tick labels in label overlap computation

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/getVisibleLabels.tsx
+++ b/packages/x-charts/src/ChartsXAxis/getVisibleLabels.tsx
@@ -49,7 +49,7 @@ export function getVisibleLabels<T extends TickItemType>(
       if (formattedValue === '') {
         return false;
       }
-      
+
       const textPosition = offset + labelOffset;
 
       if (


### PR DESCRIPTION
The issue is that `previousTextLimit` was updated even is their is no text to display. So frequently for log scale axis, the 90k tick which is very close to the 100k tick update the `previousTextLimit` and prevent the 100k tick to render.

Before/after

<img width="551" height="317" alt="image" src="https://github.com/user-attachments/assets/50c7b1d1-a50c-4267-9343-8ed99ff1c73a" />
<img width="551" height="317" alt="image" src="https://github.com/user-attachments/assets/22df68ce-56d4-4851-b8a5-8f6095e74b49" />
