### PR TITLE
Added detail about updateRow return content

### DIFF
--- a/docs/data/data-grid/server-side-data/index.md
+++ b/docs/data/data-grid/server-side-data/index.md
@@ -256,6 +256,7 @@ To disable the Data Source cache, pass `null` to the `dataSourceCache` prop.
 The Data Source supports an optional `updateRow()` method for updating data on the server.
 
 This method returns a promise that resolves when the row is updated.
+The promise must contain a row. If the update is successful it shall be the updated row, else the previous row.
 If the promise resolves, the Grid updates the row and mutates the cache.
 If there's an error, `onDataSourceError()` is triggered with the error object containing the params described in the [Error handling section](#error-handling) that follows.
 


### PR DESCRIPTION
updateRow's returned promise must contain a row

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
