### PR TITLE
[tree view] Allow to pass null to the icon slots

### DIFF
--- a/packages/x-tree-view/src/TreeItem/TreeItem.tsx
+++ b/packages/x-tree-view/src/TreeItem/TreeItem.tsx
@@ -379,7 +379,6 @@ export const TreeItem = React.forwardRef(function TreeItem(
         <Content {...contentProps}>
           <IconContainer {...iconContainerProps}>
             {status.error && <ErrorIcon {...errorContainerProps} />}
-
             {status.loading ? (
               <LoadingIcon {...loadingContainerProps} />
             ) : (

--- a/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.tsx
+++ b/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.tsx
@@ -7,16 +7,36 @@ import { TreeItemIconProps } from './TreeItemIcon.types';
 import { useTreeViewStyleContext } from '../internals/TreeViewProvider/TreeViewStyleContext';
 import { TreeViewCollapseIcon, TreeViewExpandIcon } from '../icons';
 
+function pickIcon(
+  treeItemIcon: React.ElementType | null | undefined,
+  treeViewIcon: React.ElementType | null | undefined,
+  fallback?: React.ElementType,
+) {
+  if (treeItemIcon !== undefined) {
+    return treeItemIcon;
+  }
+  if (treeViewIcon !== undefined) {
+    return treeViewIcon;
+  }
+  return fallback;
+}
+
 function TreeItemIcon(props: TreeItemIconProps) {
   const { slots: slotsFromTreeItem, slotProps: slotPropsFromTreeItem, status } = props;
-
   const { slots: slotsFromTreeView, slotProps: slotPropsFromTreeView } = useTreeViewStyleContext();
 
   const slots = {
-    collapseIcon:
-      slotsFromTreeItem?.collapseIcon ?? slotsFromTreeView.collapseIcon ?? TreeViewCollapseIcon,
-    expandIcon: slotsFromTreeItem?.expandIcon ?? slotsFromTreeView.expandIcon ?? TreeViewExpandIcon,
-    endIcon: slotsFromTreeItem?.endIcon ?? slotsFromTreeView.endIcon,
+    collapseIcon: pickIcon(
+      slotsFromTreeItem?.collapseIcon,
+      slotsFromTreeView.collapseIcon,
+      TreeViewCollapseIcon,
+    ),
+    expandIcon: pickIcon(
+      slotsFromTreeItem?.expandIcon,
+      slotsFromTreeView.expandIcon,
+      TreeViewExpandIcon,
+    ),
+    endIcon: pickIcon(slotsFromTreeItem?.endIcon, slotsFromTreeView.endIcon),
     icon: slotsFromTreeItem?.icon,
   };
 
@@ -35,7 +55,7 @@ function TreeItemIcon(props: TreeItemIconProps) {
 
   const Icon = slots[iconName];
   const iconProps = useSlotProps({
-    elementType: Icon,
+    elementType: Icon as React.ElementType,
     externalSlotProps: (tempOwnerState: any) => ({
       ...resolveComponentProps(
         slotPropsFromTreeView[iconName as keyof typeof slotPropsFromTreeView],

--- a/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.types.ts
+++ b/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.types.ts
@@ -6,19 +6,19 @@ export interface TreeItemIconSlots {
   /**
    * The icon used to collapse the item.
    */
-  collapseIcon?: React.ElementType;
+  collapseIcon?: React.ElementType | null;
   /**
    * The icon used to expand the item.
    */
-  expandIcon?: React.ElementType;
+  expandIcon?: React.ElementType | null;
   /**
    * The icon displayed next to an end item.
    */
-  endIcon?: React.ElementType;
+  endIcon?: React.ElementType | null;
   /**
    * The icon to display next to the Tree Item's label.
    */
-  icon?: React.ElementType;
+  icon?: React.ElementType | null;
 }
 
 export interface TreeItemIconSlotProps {

--- a/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewStyleContext.ts
+++ b/packages/x-tree-view/src/internals/TreeViewProvider/TreeViewStyleContext.ts
@@ -31,16 +31,16 @@ export interface TreeViewSlots {
   /**
    * The default icon used to collapse the item.
    */
-  collapseIcon?: React.ElementType;
+  collapseIcon?: React.ElementType | null;
   /**
    * The default icon used to expand the item.
    */
-  expandIcon?: React.ElementType;
+  expandIcon?: React.ElementType | null;
   /**
    * The default icon displayed next to an end item.
    * This is applied to all Tree Items and can be overridden by the TreeItem `icon` slot prop.
    */
-  endIcon?: React.ElementType;
+  endIcon?: React.ElementType | null;
 }
 
 export interface TreeViewSlotProps {


### PR DESCRIPTION
Closes [#12548](https://github.com/mui/mui-x/issues/12548)

Not sure if we want the div wrapping the icon to keep its width when it has no icon inside it.
For now I did not change that :+1: 