### PR TITLE
[scheduler] Improve performances of `buildOccurrenceConflicts`

### DIFF
--- a/packages/x-scheduler/src/primitives/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
+++ b/packages/x-scheduler/src/primitives/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
@@ -60,6 +60,10 @@ export namespace useEventOccurrencesWithTimelinePosition {
   }
 }
 
+/**
+ * Looks for conflicts between occurrences and build a list of conflicts for each occurrence.
+ * The provided occurrences need to be sorted by starting date-time.
+ */
 function buildOccurrenceConflicts(
   adapter: Adapter,
   occurrences: CalendarEventOccurrence[],
@@ -70,6 +74,8 @@ function buildOccurrenceConflicts(
   let currentBlock: OccurrenceBlock = getEmptyBlock();
   let lastEndTimestamp = 0;
 
+  // Group occurrences in non-overlapping blocks to reduce the number of comparisons when looking for conflicts.
+  // Computes the properties needed for each occurrence.
   for (const occurrence of occurrences) {
     // TODO: Avoid JS Date conversion
     const startTimestamp = adapter.toJsDate(occurrence.start).getTime();
@@ -78,7 +84,7 @@ function buildOccurrenceConflicts(
 
     if (startTimestamp >= lastEndTimestamp) {
       if (currentBlock.occurrences.length > 0) {
-          occurrencesBlocks.push(currentBlock);
+        occurrencesBlocks.push(currentBlock);
       }
       currentBlock = getEmptyBlock();
       lastEndTimestamp = 0;
@@ -103,8 +109,8 @@ function buildOccurrenceConflicts(
     occurrencesBlocks.push(currentBlock);
   }
 
+  // For each block, looks for conflicts between occurrences to build the conflicts list.
   const conflicts: OccurrenceConflicts[] = [];
-
   for (const block of occurrencesBlocks) {
     for (let i = 0; i < block.occurrences.length; i += 1) {
       const occurrence = block.occurrences[i];

--- a/packages/x-scheduler/src/primitives/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
+++ b/packages/x-scheduler/src/primitives/use-event-occurrences-with-timeline-position/useEventOccurrencesWithTimelinePosition.ts
@@ -77,7 +77,9 @@ function buildOccurrenceConflicts(
     const occurrenceDurationMs = endTimestamp - startTimestamp;
 
     if (startTimestamp >= lastEndTimestamp) {
-      occurrencesBlocks.push(currentBlock);
+      if (currentBlock.occurrences.length > 0) {
+          occurrencesBlocks.push(currentBlock);
+      }
       currentBlock = getEmptyBlock();
       lastEndTimestamp = 0;
     }


### PR DESCRIPTION
The idea is simple, if the occurrences can be splitted in two blocks of occurrences that don't overlap at all, then I can build the conflicts of each group independently. So if one group has a high `longestDurationMs`, the other groups don't pay this higher computation cost.

This doesn't add significant benefits for the Time Grid.
But for the Timeline, it will allow to avoid high computation costs for all the events when only some portion of the timeline contain long events.

Other improvement:  since we are already computing the timestamp of every event, I'm using it to do all the comparison instead of using `isAfter` and `isBefore`.