### PR TITLE
[charts] Fix piecewise scale causing wrong colors in axis with min/max

### DIFF
--- a/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.js
+++ b/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
 import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 
 const data = [
   { x: -6, y: 14, id: 0 },
@@ -18,7 +19,7 @@ const data = [
 
 export default function PiecewiseRestrictedAxis() {
   return (
-    <React.Fragment>
+    <Stack maxWidth={500}>
       <ScatterChart
         xAxis={[{ min: -25, max: 23 }]}
         yAxis={[
@@ -41,6 +42,6 @@ export default function PiecewiseRestrictedAxis() {
         All blue points should be above the blue line, all green points above the
         green line.
       </Typography>
-    </React.Fragment>
+    </Stack>
   );
 }

--- a/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.js
+++ b/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.js
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
+import Typography from '@mui/material/Typography';
+
+const data = [
+  { x: -6, y: 14, id: 0 },
+  { x: 24, y: -16, id: 1 },
+  { x: 12, y: 14, id: 2 },
+  { x: 5, y: 5, id: 3 },
+  { x: -18, y: -3, id: 4 },
+  { x: -17, y: -21, id: 5 },
+  { x: -22, y: -2, id: 6 },
+  { x: 18, y: -8, id: 7 },
+  { x: 5, y: -17, id: 8 },
+  { x: 10, y: 7, id: 9 },
+];
+
+export default function PiecewiseRestrictedAxis() {
+  return (
+    <React.Fragment>
+      <ScatterChart
+        xAxis={[{ min: -25, max: 23 }]}
+        yAxis={[
+          {
+            colorMap: {
+              type: 'piecewise',
+              thresholds: [-20, 0],
+              colors: ['red', 'blue', 'green'],
+            },
+          },
+        ]}
+        series={[{ data }]}
+        height={300}
+        width={500}
+      >
+        <ChartsReferenceLine y={-20} lineStyle={{ stroke: 'blue' }} />
+        <ChartsReferenceLine y={0} lineStyle={{ stroke: 'green' }} />
+      </ScatterChart>
+      <Typography>
+        All blue points should be above the blue line, all green points above the
+        green line.
+      </Typography>
+    </React.Fragment>
+  );
+}

--- a/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
+++ b/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
 import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 
 const data = [
   { x: -6, y: 14, id: 0 },
@@ -18,7 +19,7 @@ const data = [
 
 export default function PiecewiseRestrictedAxis() {
   return (
-    <React.Fragment>
+    <Stack maxWidth={500}>
       <ScatterChart
         xAxis={[{ min: -25, max: 23 }]}
         yAxis={[
@@ -41,6 +42,6 @@ export default function PiecewiseRestrictedAxis() {
         All blue points should be above the blue line, all green points above the
         green line.
       </Typography>
-    </React.Fragment>
+    </Stack>
   );
 }

--- a/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
+++ b/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
+import Typography from '@mui/material/Typography';
 
 const data = [
   { x: -6, y: 14, id: 0 },
@@ -17,23 +18,29 @@ const data = [
 
 export default function MinMaxExample() {
   return (
-    <ScatterChart
-      xAxis={[{ min: -25, max: 23 }]}
-      yAxis={[
-        {
-          colorMap: {
-            type: 'piecewise',
-            thresholds: [-20, 0],
-            colors: ['red', 'blue', 'green'],
+    <React.Fragment>
+      <ScatterChart
+        xAxis={[{ min: -25, max: 23 }]}
+        yAxis={[
+          {
+            colorMap: {
+              type: 'piecewise',
+              thresholds: [-20, 0],
+              colors: ['red', 'blue', 'green'],
+            },
           },
-        },
-      ]}
-      series={[{ data }]}
-      height={300}
-      width={500}
-    >
-      <ChartsReferenceLine y={-20} lineStyle={{ stroke: 'blue' }} />
-      <ChartsReferenceLine y={0} lineStyle={{ stroke: 'green' }} />
-    </ScatterChart>
+        ]}
+        series={[{ data }]}
+        height={300}
+        width={500}
+      >
+        <ChartsReferenceLine y={-20} lineStyle={{ stroke: 'blue' }} />
+        <ChartsReferenceLine y={0} lineStyle={{ stroke: 'green' }} />
+      </ScatterChart>
+      <Typography>
+        All blue points should be above the blue line, all green points above the
+        green line.
+      </Typography>
+    </React.Fragment>
   );
 }

--- a/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
+++ b/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
@@ -16,7 +16,7 @@ const data = [
   { x: 10, y: 7, id: 9 },
 ];
 
-export default function MinMaxExample() {
+export default function PiecewiseRestrictedAxis() {
   return (
     <React.Fragment>
       <ScatterChart

--- a/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
+++ b/docs/data/visual-regression-tests/PiecewiseRestrictedAxis.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { ScatterChart } from '@mui/x-charts/ScatterChart';
+import { ChartsReferenceLine } from '@mui/x-charts/ChartsReferenceLine';
+
+const data = [
+  { x: -6, y: 14, id: 0 },
+  { x: 24, y: -16, id: 1 },
+  { x: 12, y: 14, id: 2 },
+  { x: 5, y: 5, id: 3 },
+  { x: -18, y: -3, id: 4 },
+  { x: -17, y: -21, id: 5 },
+  { x: -22, y: -2, id: 6 },
+  { x: 18, y: -8, id: 7 },
+  { x: 5, y: -17, id: 8 },
+  { x: 10, y: 7, id: 9 },
+];
+
+export default function MinMaxExample() {
+  return (
+    <ScatterChart
+      xAxis={[{ min: -25, max: 23 }]}
+      yAxis={[
+        {
+          colorMap: {
+            type: 'piecewise',
+            thresholds: [-20, 0],
+            colors: ['red', 'blue', 'green'],
+          },
+        },
+      ]}
+      series={[{ data }]}
+      height={300}
+      width={500}
+    >
+      <ChartsReferenceLine y={-20} lineStyle={{ stroke: 'blue' }} />
+      <ChartsReferenceLine y={0} lineStyle={{ stroke: 'green' }} />
+    </ScatterChart>
+  );
+}

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -101,7 +101,7 @@ function Scatter(props: ScatterProps) {
           <Marker
             key={dataPoint.id ?? dataPoint.dataIndex}
             dataIndex={dataPoint.dataIndex}
-            color={colorGetter ? colorGetter(i) : color}
+            color={colorGetter ? colorGetter(dataPoint.dataIndex) : color}
             isHighlighted={isItemHighlighted}
             isFaded={isItemFaded}
             x={dataPoint.x}

--- a/packages/x-charts/src/ScatterChart/Scatter.tsx
+++ b/packages/x-charts/src/ScatterChart/Scatter.tsx
@@ -93,7 +93,7 @@ function Scatter(props: ScatterProps) {
 
   return (
     <g data-series={series.id} className={classes.root}>
-      {scatterPlotData.map((dataPoint, i) => {
+      {scatterPlotData.map((dataPoint) => {
         const isItemHighlighted = isHighlighted(dataPoint);
         const isItemFaded = !isItemHighlighted && isFaded(dataPoint);
 


### PR DESCRIPTION
Fixes #19594.

The issue was that `i` from `scatterPlotData` doesn't match the original `dataIndex`, which caused the markers to get the color from another data point. To fix it, we need to use `dataPoint.dataIndex`. This issue only happened in the individual scatter; the batch scatter is unaffected.

Added visual regression test. 

Before:

<img width="485" height="317" alt="image" src="https://github.com/user-attachments/assets/f96c6320-d7a7-455b-be14-9d3ffd07ecdd" />


After:

<img width="499" height="316" alt="image" src="https://github.com/user-attachments/assets/f4ec6713-6f36-4075-85c1-3147b2aa22f8" />
