### PR TITLE
[code-infra] Update DEFAULT_TIMESTAMP format to ISO 8601

### DIFF
--- a/test/utils/setupFakeClock.ts
+++ b/test/utils/setupFakeClock.ts
@@ -7,7 +7,7 @@ declare global {
 }
 
 // Use a "real timestamp" so that we see a useful date instead of "00:00"
-const DEFAULT_TIMESTAMP = 'Mon Aug 18 14:11:54 2014 -0500';
+const DEFAULT_TIMESTAMP = '2014-08-18T14:11:54-05:00';
 
 // eslint-disable-next-line import/no-mutable-exports
 export let fakeClock: ReturnType<typeof useFakeTimers> | undefined;


### PR DESCRIPTION
Avoid any potential ambiguity in parsing this date.

This should help fix flaky visual tests https://mui-org.slack.com/archives/C05SBSU8NPR/p1758264088856169?thread_ts=1758264088.856169&cid=C05SBSU8NPR. 