### PR TITLE
[scheduler] Improve internals to get which days an event should be visible on

### DIFF
--- a/packages/x-scheduler/src/primitives/use-event-occurrences-grouped-by-day/useEventOccurrencesGroupedByDay.ts
+++ b/packages/x-scheduler/src/primitives/use-event-occurrences-grouped-by-day/useEventOccurrencesGroupedByDay.ts
@@ -77,15 +77,8 @@ export function innerGetEventOccurrencesGroupedByDay(
   const occurrences = getOccurrencesFromEvents({ adapter, start, end, events, visibleResources });
 
   for (const occurrence of occurrences) {
-    const eventDays: SchedulerValidDate[] = getDaysTheOccurrenceIsVisibleOn(
-      occurrence,
-      days,
-      adapter,
-      renderEventIn,
-    );
-
-    for (const day of eventDays) {
-      const dayKey = getDateKey(day, adapter);
+    const eventDays = getDaysTheOccurrenceIsVisibleOn(occurrence, days, adapter, renderEventIn);
+    for (const dayKey of eventDays) {
       const occurrenceType = occurrence.allDay ? 'allDay' : 'nonAllDay';
       occurrencesGroupedByDay.get(dayKey)![occurrenceType].push(occurrence);
     }

--- a/packages/x-scheduler/src/primitives/utils/event-utils.test.ts
+++ b/packages/x-scheduler/src/primitives/utils/event-utils.test.ts
@@ -17,50 +17,6 @@ describe('event-utils', () => {
     allDay: true,
   });
 
-  describe('isDayWithinRange', () => {
-    const eventFirstDay = adapter.date('2024-01-15');
-    const eventLastDay = adapter.date('2024-01-17');
-    it('should return true when day is same as event first day', () => {
-      const day = adapter.date('2024-01-15');
-
-      const result = isDayWithinRange(day, eventFirstDay, eventLastDay, adapter);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return true when day is same as event last day', () => {
-      const day = adapter.date('2024-01-17');
-
-      const result = isDayWithinRange(day, eventFirstDay, eventLastDay, adapter);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return true when day is between event first and last day', () => {
-      const day = adapter.date('2024-01-16');
-
-      const result = isDayWithinRange(day, eventFirstDay, eventLastDay, adapter);
-
-      expect(result).toBe(true);
-    });
-
-    it('should return false when day is before event first day', () => {
-      const day = adapter.date('2024-01-14');
-
-      const result = isDayWithinRange(day, eventFirstDay, eventLastDay, adapter);
-
-      expect(result).toBe(false);
-    });
-
-    it('should return false when day is after event last day', () => {
-      const day = adapter.date('2024-01-18');
-
-      const result = isDayWithinRange(day, eventFirstDay, eventLastDay, adapter);
-
-      expect(result).toBe(false);
-    });
-  });
-
   describe('getDaysTheOccurrenceIsVisibleOn', () => {
     const days = [
       processDate(adapter.date('2024-01-14'), adapter),

--- a/packages/x-scheduler/src/primitives/utils/event-utils.ts
+++ b/packages/x-scheduler/src/primitives/utils/event-utils.ts
@@ -7,21 +7,8 @@ import {
 import { Adapter } from './adapter/types';
 import { getRecurringEventOccurrencesForVisibleDays } from './recurrence-utils';
 
-export function isDayWithinRange(
-  day: SchedulerValidDate,
-  eventFirstDay: SchedulerValidDate,
-  eventLastDay: SchedulerValidDate,
-  adapter: Adapter,
-) {
-  return (
-    adapter.isSameDay(day, eventFirstDay) ||
-    adapter.isSameDay(day, eventLastDay) ||
-    (adapter.isAfter(day, eventFirstDay) && adapter.isBefore(day, eventLastDay))
-  );
-}
-
 /**
- *  Returns the list of days an event occurrence should be visible on.
+ *  Returns the key of the days an event occurrence should be visible on.
  */
 export function getDaysTheOccurrenceIsVisibleOn(
   event: CalendarEvent,
@@ -29,18 +16,25 @@ export function getDaysTheOccurrenceIsVisibleOn(
   adapter: Adapter,
   renderEventIn: 'first-day' | 'every-day',
 ) {
-  const eventFirstDay = adapter.startOfDay(event.start);
-  if (renderEventIn === 'first-day') {
-    if (adapter.isBefore(eventFirstDay, days[0].value)) {
-      return [days[0].value];
+  const dayKeys: string[] = [];
+  for (const day of days) {
+    // If the day is before the event start, skip to the next day
+    if (adapter.isBeforeDay(day.value, event.start)) {
+      continue;
     }
-    return [eventFirstDay];
-  }
 
-  const eventLastDay = adapter.endOfDay(event.end);
-  return days
-    .filter((day) => isDayWithinRange(day.value, eventFirstDay, eventLastDay, adapter))
-    .map((day) => day.value);
+    // If the day is after the event end, break as the days are sorted by start date
+    if (adapter.isAfterDay(day.value, event.end)) {
+      break;
+    }
+    dayKeys.push(day.key);
+
+    // If the event should only be rendered on its first day, break after the first match
+    if (renderEventIn === 'first-day') {
+      break;
+    }
+  }
+  return dayKeys;
 }
 
 /**


### PR DESCRIPTION
- [x] Update the signature of `getDaysTheOccurrenceIsVisibleOn` to return the key instead of the value (we were re-creating the key from the value)
- [x] Make sure `getDaysTheOccurrenceIsVisibleOn` cannot return a date that is not in the days (`return [eventFirstDay];` can be risky if tomorrow we allow people to render 2 weeks and hide the week end, it would try to push events starting during the week end in a non existing map key)
- [x] Do not loop upon the entire list of days when we know all the remaining days are after the event's end date