### PR TITLE
[pickers] Preserve time format when using single column layout on TimeRangePicker

### DIFF
--- a/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/DesktopTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/DesktopTimeRangePicker/DesktopTimeRangePicker.tsx
@@ -115,7 +115,10 @@ const DesktopTimeRangePicker = React.forwardRef(function DesktopTimeRangePicker<
     views,
     viewRenderers,
     ampmInClock: true,
-    format: resolveTimeFormat(adapter, defaultizedProps),
+    format: resolveTimeFormat(adapter, {
+      ...defaultizedProps,
+      views: defaultizedProps.viewsForFormatting,
+    }),
     slots: {
       field: SingleInputTimeRangeField,
       ...defaultizedProps.slots,

--- a/packages/x-date-pickers-pro/src/MobileTimeRangePicker/MobileTimeRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/MobileTimeRangePicker/MobileTimeRangePicker.tsx
@@ -110,7 +110,10 @@ const MobileTimeRangePicker = React.forwardRef(function MobileTimeRangePicker<
     ...defaultizedProps,
     ampmInClock: true,
     viewRenderers,
-    format: resolveTimeFormat(adapter, defaultizedProps),
+    format: resolveTimeFormat(adapter, {
+      ...defaultizedProps,
+      views: defaultizedProps.viewsForFormatting,
+    }),
     slots: {
       field: SingleInputTimeRangeField,
       ...defaultizedProps.slots,

--- a/packages/x-date-pickers-pro/src/TimeRangePicker/shared.tsx
+++ b/packages/x-date-pickers-pro/src/TimeRangePicker/shared.tsx
@@ -121,6 +121,7 @@ type UseTimeRangePickerDefaultizedProps<Props extends BaseTimeRangePickerProps> 
   > & {
     shouldRenderTimeInASingleColumn: boolean;
     views: readonly TimeViewWithMeridiem[];
+    viewsForFormatting: readonly TimeViewWithMeridiem[];
   };
 
 export function useTimeRangePickerDefaultizedProps<Props extends BaseTimeRangePickerProps>(
@@ -166,6 +167,11 @@ export function useTimeRangePickerDefaultizedProps<Props extends BaseTimeRangePi
     views: defaultViews,
   });
 
+  // Keep the original views for format calculation (before filtering)
+  const viewsForFormatting: readonly TimeViewWithMeridiem[] = ampm
+    ? [...defaultViews, 'meridiem']
+    : defaultViews;
+
   return {
     ...themeProps,
     ...validationProps,
@@ -175,6 +181,7 @@ export function useTimeRangePickerDefaultizedProps<Props extends BaseTimeRangePi
     shouldRenderTimeInASingleColumn,
     thresholdToRenderTimeInASingleColumn,
     views,
+    viewsForFormatting,
     ampm,
     slots: {
       tabs: TimeRangePickerTabs,


### PR DESCRIPTION

Same issue (https://github.com/mui/mui-x/issues/19405) which was happening in DateTimePicker and DateTimeRangePicker, is happening in TimeRangePicker as well.  

Preview: https://deploy-preview-19626--material-ui-x.netlify.app/x/react-date-pickers/time-range-picker/#basic-usage

### Before
<img width="501" height="198" alt="image" src="https://github.com/user-attachments/assets/1cd4d251-2637-407e-a593-b3f13dae7083" />


### After

<img width="482" height="194" alt="image" src="https://github.com/user-attachments/assets/ed33117d-9960-4956-8b15-249783289d20" />


I have checked `TimePicker`, I can't see issue there

<img width="469" height="185" alt="image" src="https://github.com/user-attachments/assets/6b304505-df1a-4835-af1f-32e2dde69bba" />

