### PR TITLE
[charts] Refactor `getAxisExtremum`

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/computeAxisValue.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/computeAxisValue.ts
@@ -10,7 +10,7 @@ import {
   DefaultedXAxis,
   DefaultedAxis,
   CartesianChartSeriesType,
-  getAxisExtremum,
+  getAxisExtrema,
   isBandScaleConfig,
   getScale,
   getColorScale,
@@ -112,7 +112,7 @@ export function computeAxisValue({
     const axis = eachAxis as Readonly<DefaultedAxis<ScaleName, any, Readonly<ChartsAxisProps>>>;
     let range = getRange(drawingArea, axisDirection, axis);
 
-    const [minData, maxData] = getAxisExtremum(
+    const [minData, maxData] = getAxisExtrema(
       axis,
       axisDirection,
       seriesConfig as ChartSeriesConfig<CartesianChartSeriesType>,

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -67,7 +67,7 @@ export * from './scaleGuards';
 export * from './findMinMax';
 
 // contexts
-export { getAxisExtremum } from './plugins/featurePlugins/useChartCartesianAxis/getAxisExtremum';
+export { getAxisExtrema } from './plugins/featurePlugins/useChartCartesianAxis/getAxisExtrema';
 export * from '../context/ChartProvider';
 export * from '../context/ChartsSlotsContext';
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/computeAxisValue.ts
@@ -18,7 +18,7 @@ import { getColorScale, getOrdinalColorScale, getSequentialColorScale } from '..
 import { scaleTickNumberByRange } from '../../../ticks';
 import { getScale } from '../../../getScale';
 import { isDateData, createDateFormatter } from '../../../dateHelpers';
-import { getAxisExtremum } from './getAxisExtremum';
+import { getAxisExtrema } from './getAxisExtrema';
 import type { ChartDrawingArea } from '../../../../hooks';
 import { ChartSeriesConfig } from '../../models/seriesConfig';
 import { ComputedAxisConfig, DefaultizedZoomOptions } from './useChartCartesianAxis.types';
@@ -183,7 +183,7 @@ export function computeAxisValue<T extends ChartSeriesType>({
 
     const filter = zoom === undefined && !zoomOption ? getFilters : undefined; // Do not apply filtering if zoom is already defined.
     if (filter) {
-      const [minData, maxData] = getAxisExtremum(
+      const [minData, maxData] = getAxisExtrema(
         axis,
         axisDirection,
         seriesConfig as ChartSeriesConfig<CartesianChartSeriesType>,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
@@ -21,7 +21,7 @@ import { zoomScaleRange } from './zoom';
 import { getAxisDomainLimit } from './getAxisDomainLimit';
 import { getTickNumber } from '../../../ticks';
 import { getScale } from '../../../getScale';
-import { getAxisExtremum } from './getAxisExtremum';
+import { getAxisExtrema } from './getAxisExtrema';
 import { ChartDrawingArea } from '../../../../hooks/useDrawingArea';
 
 const DEFAULT_CATEGORY_GAP_RATIO = 0.2;
@@ -152,7 +152,7 @@ function getAxisScale<T extends ChartSeriesType>(
   const zoomRange: [number, number] = zoom ? [zoom.start, zoom.end] : [0, 100];
   const range = getRange(drawingArea, axisDirection, axis);
 
-  const [minData, maxData] = getAxisExtremum(
+  const [minData, maxData] = getAxisExtrema(
     axis,
     axisDirection,
     seriesConfig as ChartSeriesConfig<CartesianChartSeriesType>,


### PR DESCRIPTION
Refactor `getAxisExtremum`. Applied several small changes:

- Rename to `getAxisExtrema`
- Move the logic for deciding the min/max to `getAxisExtrema` instead of `axisExtremumCallback`
- Change it to a named function so that it shows up in performance traces

