### PR TITLE
[tree view] Allow to skip the event param on the `focusItem()` api method

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.ts
@@ -45,7 +45,7 @@ export const useTreeViewFocus: TreeViewPlugin<UseTreeViewFocusSignature> = ({
     }
   };
 
-  const focusItem = useEventCallback((event: React.SyntheticEvent, itemId: string) => {
+  const focusItem = useEventCallback((event: React.SyntheticEvent | null, itemId: string) => {
     // If we receive an itemId, and it is visible, the focus will be set to it
     if (isItemVisible(itemId)) {
       innerFocusItem(event, itemId);

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewFocus/useTreeViewFocus.types.ts
@@ -10,10 +10,10 @@ export interface UseTreeViewFocusPublicAPI {
    *
    * If the item is the child of a collapsed item, then this method will do nothing.
    * Make sure to expand the ancestors of the item before calling this method if needed.
-   * @param {React.SyntheticEvent} event The DOM event that triggered the change.
+   * @param {React.SyntheticEvent | null} event The DOM event that triggered the change.
    * @param {TreeViewItemId} itemId The id of the item to focus.
    */
-  focusItem: (event: React.SyntheticEvent, itemId: string) => void;
+  focusItem: (event: React.SyntheticEvent | null, itemId: string) => void;
 }
 
 export interface UseTreeViewFocusInstance extends UseTreeViewFocusPublicAPI {


### PR DESCRIPTION
Closes #19652