### PR TITLE
[DataGrid] Fix flex column width diff calculation while resizing

### DIFF
--- a/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/x-data-grid/src/hooks/features/columnResize/useGridColumnResize.tsx
@@ -91,7 +91,7 @@ function computeNewWidth(
   } else {
     newWidth += columnBounds.right - clickX;
   }
-  return newWidth;
+  return Math.round(newWidth);
 }
 
 function computeOffsetToSeparator(
@@ -826,5 +826,5 @@ function updateProperty(
   if (!element) {
     return;
   }
-  element.style[property] = `${parseInt(element.style[property], 10) + delta}px`;
+  element.style[property] = `${Math.round(parseFloat(element.style[property])) + delta}px`;
 }


### PR DESCRIPTION
Context https://github.com/mui/mui-x/issues/19597#issuecomment-3322863595

Demo
https://stackblitz.com/edit/rxkvvwe7?file=src%2FDemo.tsx
Bug is not visible in the preview panel, but it is in the preview app
https://rxkvvwe7-nszy--5173--96435430.local-credentialless.webcontainer.io/

Resizing pinned columns makes the filler border go away from the column borders.

This is due to the rounding errors for the flex columns, which this PR fixes.