### PR TITLE
[charts] Remove unused code path from `getAxisScale`

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
@@ -15,7 +15,7 @@ import {
 import { CartesianChartSeriesType, ChartSeriesType } from '../../../../models/seriesType/config';
 import { ProcessedSeries } from '../../corePlugins/useChartSeries';
 import { ChartSeriesConfig } from '../../models';
-import { GetZoomAxisFilters, ZoomData } from './zoom.types';
+import { ZoomData } from './zoom.types';
 import { DefaultizedZoomOptions } from './useChartCartesianAxis.types';
 import { zoomScaleRange } from './zoom';
 import { getAxisDomainLimit } from './getAxisDomainLimit';
@@ -32,7 +32,6 @@ type ComputeCommonParams<T extends ChartSeriesType = ChartSeriesType> = {
   seriesConfig: ChartSeriesConfig<T>;
   zoomMap?: Map<AxisId, ZoomData>;
   zoomOptions?: Record<AxisId, DefaultizedZoomOptions>;
-  getFilters?: GetZoomAxisFilters;
   /**
    * @deprecated To remove in v9. This is an experimental feature to avoid breaking change.
    */
@@ -59,7 +58,6 @@ export function getXAxesScales<T extends ChartSeriesType>({
   seriesConfig,
   zoomMap,
   zoomOptions,
-  getFilters,
   preferStrictDomainInLineCharts,
 }: ComputeCommonParams<T> & {
   axis?: DefaultedAxis[];
@@ -81,7 +79,6 @@ export function getXAxesScales<T extends ChartSeriesType>({
       axisIndex,
       formattedSeries,
       preferStrictDomainInLineCharts,
-      getFilters,
     );
   });
 
@@ -95,7 +92,6 @@ export function getYAxesScales<T extends ChartSeriesType>({
   seriesConfig,
   zoomMap,
   zoomOptions,
-  getFilters,
   preferStrictDomainInLineCharts,
 }: ComputeCommonParams<T> & {
   axis?: DefaultedAxis[];
@@ -117,7 +113,6 @@ export function getYAxesScales<T extends ChartSeriesType>({
       axisIndex,
       formattedSeries,
       preferStrictDomainInLineCharts,
-      getFilters,
     );
   });
 
@@ -147,19 +142,9 @@ function getAxisScale<T extends ChartSeriesType>(
    * @deprecated To remove in v9. This is an experimental feature to avoid breaking change.
    */
   preferStrictDomainInLineCharts: boolean | undefined,
-  getFilters?: GetZoomAxisFilters,
 ): ScaleDefinition {
   const zoomRange: [number, number] = zoom ? [zoom.start, zoom.end] : [0, 100];
   const range = getRange(drawingArea, axisDirection, axis);
-
-  const [minData, maxData] = getAxisExtrema(
-    axis,
-    axisDirection,
-    seriesConfig as ChartSeriesConfig<CartesianChartSeriesType>,
-    axisIndex,
-    formattedSeries,
-    zoom === undefined && !zoomOption ? getFilters : undefined, // Do not apply filtering if zoom is already defined.
-  );
 
   if (isBandScaleConfig(axis)) {
     const categoryGapRatio = axis.categoryGapRatio ?? DEFAULT_CATEGORY_GAP_RATIO;
@@ -191,6 +176,13 @@ function getAxisScale<T extends ChartSeriesType>(
     preferStrictDomainInLineCharts,
   );
 
+  const [minData, maxData] = getAxisExtrema(
+    axis,
+    axisDirection,
+    seriesConfig as ChartSeriesConfig<CartesianChartSeriesType>,
+    axisIndex,
+    formattedSeries,
+  );
   const axisExtrema = getActualAxisExtrema(axis, minData, maxData);
 
   if (typeof domainLimit === 'function') {

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
@@ -16,7 +16,6 @@ import { CartesianChartSeriesType, ChartSeriesType } from '../../../../models/se
 import { ProcessedSeries } from '../../corePlugins/useChartSeries';
 import { ChartSeriesConfig } from '../../models';
 import { ZoomData } from './zoom.types';
-import { DefaultizedZoomOptions } from './useChartCartesianAxis.types';
 import { zoomScaleRange } from './zoom';
 import { getAxisDomainLimit } from './getAxisDomainLimit';
 import { getTickNumber } from '../../../ticks';
@@ -26,12 +25,11 @@ import { ChartDrawingArea } from '../../../../hooks/useDrawingArea';
 
 const DEFAULT_CATEGORY_GAP_RATIO = 0.2;
 
-type ComputeCommonParams<T extends ChartSeriesType = ChartSeriesType> = {
+type GetAxesScalesParams<T extends ChartSeriesType = ChartSeriesType> = {
   drawingArea: ChartDrawingArea;
   formattedSeries: ProcessedSeries<T>;
   seriesConfig: ChartSeriesConfig<T>;
   zoomMap?: Map<AxisId, ZoomData>;
-  zoomOptions?: Record<AxisId, DefaultizedZoomOptions>;
   /**
    * @deprecated To remove in v9. This is an experimental feature to avoid breaking change.
    */
@@ -57,22 +55,19 @@ export function getXAxesScales<T extends ChartSeriesType>({
   axis: axes = [],
   seriesConfig,
   zoomMap,
-  zoomOptions,
   preferStrictDomainInLineCharts,
-}: ComputeCommonParams<T> & {
+}: GetAxesScalesParams<T> & {
   axis?: DefaultedAxis[];
 }) {
   const scales: Record<AxisId, ScaleDefinition> = {};
 
   axes.forEach((eachAxis, axisIndex) => {
     const axis = eachAxis as Readonly<DefaultedAxis<ScaleName, any, Readonly<ChartsAxisProps>>>;
-    const zoomOption = zoomOptions?.[axis.id];
     const zoom = zoomMap?.get(axis.id);
 
     scales[axis.id] = getAxisScale(
       axis,
       'x',
-      zoomOption,
       zoom,
       drawingArea,
       seriesConfig,
@@ -91,22 +86,19 @@ export function getYAxesScales<T extends ChartSeriesType>({
   axis: axes = [],
   seriesConfig,
   zoomMap,
-  zoomOptions,
   preferStrictDomainInLineCharts,
-}: ComputeCommonParams<T> & {
+}: GetAxesScalesParams<T> & {
   axis?: DefaultedAxis[];
 }) {
   const scales: Record<AxisId, ScaleDefinition> = {};
 
   axes.forEach((eachAxis, axisIndex) => {
     const axis = eachAxis as Readonly<DefaultedAxis<ScaleName, any, Readonly<ChartsAxisProps>>>;
-    const zoomOption = zoomOptions?.[axis.id];
     const zoom = zoomMap?.get(axis.id);
 
     scales[axis.id] = getAxisScale(
       axis,
       'y',
-      zoomOption,
       zoom,
       drawingArea,
       seriesConfig,
@@ -132,7 +124,6 @@ export type ScaleDefinition =
 function getAxisScale<T extends ChartSeriesType>(
   axis: Readonly<DefaultedAxis<ScaleName, any, Readonly<ChartsAxisProps>>>,
   axisDirection: 'x' | 'y',
-  zoomOption: DefaultizedZoomOptions | undefined,
   zoom: ZoomData | undefined,
   drawingArea: ChartDrawingArea,
   seriesConfig: ChartSeriesConfig<T>,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPreview.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPreview.selectors.ts
@@ -76,7 +76,6 @@ export const selectorChartPreviewXScales = createSelector(
       axis: xAxes,
       seriesConfig,
       zoomMap,
-      zoomOptions,
       preferStrictDomainInLineCharts,
     });
   },
@@ -168,7 +167,6 @@ export const selectorChartPreviewYScales = createSelector(
       axis: yAxes,
       seriesConfig,
       zoomMap,
-      zoomOptions,
       preferStrictDomainInLineCharts,
     });
   },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
@@ -75,7 +75,6 @@ export const selectorChartXScales = createSelector(
     selectorChartSeriesProcessed,
     selectorChartSeriesConfig,
     selectorChartZoomMap,
-    selectorChartZoomOptionsLookup,
     selectorPreferStrictDomainInLineCharts,
   ],
   function selectorChartXScales(
@@ -84,7 +83,6 @@ export const selectorChartXScales = createSelector(
     formattedSeries,
     seriesConfig,
     zoomMap,
-    zoomOptions,
     preferStrictDomainInLineCharts,
   ) {
     return getXAxesScales({
@@ -93,7 +91,6 @@ export const selectorChartXScales = createSelector(
       axis,
       seriesConfig,
       zoomMap,
-      zoomOptions,
       preferStrictDomainInLineCharts,
     });
   },
@@ -106,7 +103,6 @@ export const selectorChartYScales = createSelector(
     selectorChartSeriesProcessed,
     selectorChartSeriesConfig,
     selectorChartZoomMap,
-    selectorChartZoomOptionsLookup,
     selectorPreferStrictDomainInLineCharts,
   ],
   function selectorChartYScales(
@@ -115,7 +111,6 @@ export const selectorChartYScales = createSelector(
     formattedSeries,
     seriesConfig,
     zoomMap,
-    zoomOptions,
     preferStrictDomainInLineCharts,
   ) {
     return getYAxesScales({
@@ -124,7 +119,6 @@ export const selectorChartYScales = createSelector(
       axis,
       seriesConfig,
       zoomMap,
-      zoomOptions,
       preferStrictDomainInLineCharts,
     });
   },


### PR DESCRIPTION
`getAxisScale` was never being called with `getFilters`, and `zoomOption` was unnecessary.

Also moved `getAxisExtrema` below the checks for ordinal scales because it isn't necessary before and it should save some unnecessary computation.