### PR TITLE
[DataGridPremium] Disable aggregation on the grouping column by default

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/createGroupingColDef.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/createGroupingColDef.tsx
@@ -35,6 +35,7 @@ const GROUPING_COL_DEF_DEFAULT_PROPERTIES: Omit<GridColDef, 'field'> = {
   type: 'custom',
   disableReorder: true,
   chartable: false,
+  aggregable: false,
 };
 
 const GROUPING_COL_DEF_FORCED_PROPERTIES_DEFAULT: Pick<


### PR DESCRIPTION
Team decision after https://github.com/mui/mui-x/issues/19018 has been reported.
The actual problem is fixed in https://github.com/mui/mui-x/pull/19690

Preview: https://deploy-preview-19692--material-ui-x.netlify.app/x/react-data-grid/row-grouping/