### PR TITLE
[infra] Update `findLatestTaggedVersion` to filter tags based on major version

### DIFF
--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -124,7 +124,7 @@ async function findLatestTaggedVersionForMajor(major) {
     throw new Error('No tags found in repository');
   }
 
-  if (major !== undefined && major !== null) {
+  if (major != null) {
     const majorStr = String(major);
     const filteredTags = tags.filter((tag) => tag.name && tag.name.startsWith(`v${majorStr}.`));
     if (filteredTags.length > 0) {

--- a/scripts/changelogUtils.mjs
+++ b/scripts/changelogUtils.mjs
@@ -117,6 +117,7 @@ async function findLatestTaggedVersionForMajor(major) {
   const { data: tags } = await octokit.rest.repos.listTags({
     owner: ORG,
     repo: REPO,
+    per_page: 100,
   });
   if (major) {
     const filteredTags = tags.filter((tag) => tag.name.startsWith(`v${major}.`));

--- a/scripts/createReleasePR.mjs
+++ b/scripts/createReleasePR.mjs
@@ -859,7 +859,7 @@ async function main({ githubToken }) {
       auth: githubToken,
     });
 
-    const { findLatestTaggedVersion, generateChangelog: generator } = getChangelogUtils(octokit);
+    const { findLatestTaggedVersionForMajor, generateChangelog: generator } = getChangelogUtils(octokit);
 
     // Find the upstream remote
     const upstreamRemote = await findMuiXRemote();
@@ -891,7 +891,7 @@ async function main({ githubToken }) {
     // Always prompt for major version first
     const majorVersion = await selectMajorVersion(latestMajorVersion);
 
-    const latestTag = await findLatestTaggedVersion();
+    const latestTag = await findLatestTaggedVersionForMajor(majorVersion);
     const previousVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
     console.log(`Latest tag for major version ${majorVersion}: ${previousVersion}`);
 


### PR DESCRIPTION
fixes a problem with the changelog generation script