### PR TITLE
[charts] Make new hideLegend prop on ChartWrapper optional

### DIFF
--- a/docs/pages/x/api/charts/charts-wrapper.json
+++ b/docs/pages/x/api/charts/charts-wrapper.json
@@ -1,10 +1,10 @@
 {
   "props": {
-    "hideLegend": { "type": { "name": "bool" }, "required": true },
     "extendVertically": {
       "type": { "name": "bool" },
       "default": "`false` if the `height` prop is set. And `true` otherwise."
     },
+    "hideLegend": { "type": { "name": "bool" }, "default": "false" },
     "legendDirection": {
       "type": { "name": "enum", "description": "'horizontal'<br>&#124;&nbsp;'vertical'" },
       "default": "'horizontal'"

--- a/packages/x-charts/src/ChartsWrapper/ChartsWrapper.tsx
+++ b/packages/x-charts/src/ChartsWrapper/ChartsWrapper.tsx
@@ -25,9 +25,10 @@ export interface ChartsWrapperProps {
   legendDirection?: Direction;
   /**
    * If `true`, the legend is not rendered.
+   * @default false
    */
   // eslint-disable-next-line react/no-unused-prop-types
-  hideLegend: boolean;
+  hideLegend?: boolean;
   /**
    * If `true`, the chart wrapper set `height: 100%`.
    * @default `false` if the `height` prop is set. And `true` otherwise.
@@ -58,7 +59,7 @@ const getAlignItems = (position: Position | undefined) => {
 };
 
 const getGridTemplateAreas = (
-  hideLegend: boolean,
+  hideLegend: boolean | undefined,
   direction: Direction | undefined,
   position: Position | undefined,
 ) => {
@@ -81,7 +82,7 @@ const getGridTemplateAreas = (
 };
 
 const getTemplateColumns = (
-  hideLegend: boolean,
+  hideLegend: boolean = false,
   direction: Direction = 'horizontal',
   horizontalPosition: Position['horizontal'] = 'end',
   width: number | undefined = undefined,
@@ -98,7 +99,7 @@ const getTemplateColumns = (
 };
 
 const getTemplateRows = (
-  hideLegend: boolean,
+  hideLegend: boolean = false,
   direction: Direction = 'horizontal',
   verticalPosition: Position['vertical'] = 'top',
 ) => {
@@ -208,8 +209,9 @@ ChartsWrapper.propTypes = {
   extendVertically: PropTypes.bool,
   /**
    * If `true`, the legend is not rendered.
+   * @default false
    */
-  hideLegend: PropTypes.bool.isRequired,
+  hideLegend: PropTypes.bool,
   /**
    * The direction of the legend.
    * @default 'horizontal'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
I am using composition for some of our more complicated charts and #19257 introduced a new required prop on `ChartWrapper ` which broke our build. I have made this optional with a false default, which seems reasonable to me?

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
