### PR TITLE
[infra] Run prettier on `createReleasePR.mjs`

### DIFF
--- a/scripts/createReleasePR.mjs
+++ b/scripts/createReleasePR.mjs
@@ -859,7 +859,8 @@ async function main({ githubToken }) {
       auth: githubToken,
     });
 
-    const { findLatestTaggedVersionForMajor, generateChangelog: generator } = getChangelogUtils(octokit);
+    const { findLatestTaggedVersionForMajor, generateChangelog: generator } =
+      getChangelogUtils(octokit);
 
     // Find the upstream remote
     const upstreamRemote = await findMuiXRemote();


### PR DESCRIPTION
It was causing the `test_static` to fail on PRs. [Example](https://app.circleci.com/pipelines/github/mui/mui-x/104287/workflows/6b96815b-7090-403a-ac71-0899f7dbfdb3/jobs/632488)