### PR TITLE
[pickers] Fix `slotProps.textField.slotProps.htmlInput` resolution

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/DateField.test.tsx
@@ -45,6 +45,32 @@ describe('<DateField />', () => {
 
       expect(screen.getByRole('textbox', { description: 'field-helper' })).not.to.equal(null);
     });
+
+    it('should respect the `slotProps.textField.slotProps.htmlInput` on accessible DOM structure', () => {
+      render(
+        <DateField
+          enableAccessibleFieldDOMStructure
+          slotProps={{
+            textField: { slotProps: { htmlInput: { 'data-testid': 'test-html-input' } } },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('test-html-input')).not.to.equal(null);
+    });
+
+    it('should respect the `slotProps.textField.slotProps.htmlInput` on non-accessible DOM structure', () => {
+      render(
+        <DateField
+          enableAccessibleFieldDOMStructure={false}
+          slotProps={{
+            textField: { slotProps: { htmlInput: { 'data-testid': 'test-html-input' } } },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('test-html-input')).not.to.equal(null);
+    });
   });
 
   describe('slotProps.inputAdornment behavior', () => {

--- a/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
+++ b/packages/x-date-pickers/src/DesktopDatePicker/tests/DesktopDatePicker.test.tsx
@@ -485,6 +485,32 @@ describe('<DesktopDatePicker />', () => {
 
       expect(screen.getByRole('textbox')).attribute('name').to.equal('test-field');
     });
+
+    it('should respect the `slotProps.textField.slotProps.htmlInput` on accessible DOM structure', () => {
+      render(
+        <DesktopDatePicker
+          enableAccessibleFieldDOMStructure
+          slotProps={{
+            textField: { slotProps: { htmlInput: { 'data-testid': 'test-html-input' } } },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('test-html-input')).not.to.equal(null);
+    });
+
+    it('should respect the `slotProps.textField.slotProps.htmlInput` on non-accessible DOM structure', () => {
+      render(
+        <DesktopDatePicker
+          enableAccessibleFieldDOMStructure={false}
+          slotProps={{
+            textField: { slotProps: { htmlInput: { 'data-testid': 'test-html-input' } } },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId('test-html-input')).not.to.equal(null);
+    });
   });
 
   describe('slotProps.inputAdornment behavior', () => {

--- a/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
+++ b/packages/x-date-pickers/src/internals/components/PickerFieldUI.tsx
@@ -339,6 +339,15 @@ export function PickerFieldUI<
           ...additionalTextFieldInputProps,
         };
 
+  // We need to resolve the `inputProps` since we are messing with those props in this component.
+  textFieldProps.inputProps =
+    materialMajor >= 6 && (textFieldProps as TextFieldProps)?.slotProps?.htmlInput
+      ? resolveComponentProps(
+          (textFieldProps as TextFieldProps).slotProps!.htmlInput as any,
+          ownerState,
+        )
+      : textFieldProps.inputProps;
+
   // Remove the `input` slotProps to avoid them overriding the manually resolved `InputProps`.
   // Relevant on `materialMajor >= 6` since `slotProps` would take precedence.
   delete (textFieldProps as TextFieldProps)?.slotProps?.input;


### PR DESCRIPTION
Fix: https://github.com/mui/mui-x/issues/14684#issuecomment-3325498780

Confirmed locally that it fixes the issue showcased in the example.

After the change, `slotProps.textField.slotProps.htmlInput` was not being resolved, causing a slight regression in some usage configurations.