### PR TITLE
[scheduler] Refactor - use `original` when checking the source of truth before applying changes 

### DIFF
--- a/packages/x-scheduler/src/primitives/utils/SchedulerStore/SchedulerStore.ts
+++ b/packages/x-scheduler/src/primitives/utils/SchedulerStore/SchedulerStore.ts
@@ -266,19 +266,19 @@ export class SchedulerStore<
       return undefined;
     }
 
-    const modelBefore = selectors.event(this.state, eventId);
-    if (!modelBefore) {
+    const original = selectors.event(this.state, eventId);
+    if (!original) {
       throw new Error(`Scheduler: the original event was not found (id="${eventId}").`);
     }
 
     const changes: RecurringEventUpdatedProperties = { start, end };
-    if (surfaceType === 'time-grid' && modelBefore.allDay) {
+    if (surfaceType === 'time-grid' && original.allDay) {
       changes.allDay = false;
-    } else if (surfaceType === 'day-grid' && !modelBefore.allDay) {
+    } else if (surfaceType === 'day-grid' && !original.allDay) {
       changes.allDay = true;
     }
 
-    if (modelBefore.rrule) {
+    if (original.rrule) {
       let scope: RecurringUpdateEventScope;
       if (chooseRecurringEventScope) {
         // TODO: Issue #19440 + #19441 - Allow to edit all events or only this event.


### PR DESCRIPTION
Naming convention proposal:
- Use **`original`** when updating an entity (the source of truth before applying changes).
- Use **`previous`** when comparing state values (UI flags, placeholders, etc.).
- Use **`existing`** when validating duplicates during creation.

This way the naming stays consistent and makes the intent clear in each context.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
