### PR TITLE
[code-infra] Attempt stabilizing `.toLocaleString`

### DIFF
--- a/test/regressions/index.tsx
+++ b/test/regressions/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider, Outlet, NavLink, useNavigate } from 'react-router';
 import { Globals } from '@react-spring/web';
+import * as sinon from 'sinon';
 import { setupFakeClock, restoreFakeClock } from '../utils/setupFakeClock'; // eslint-disable-line
 import { generateTestLicenseKey, setupTestLicenseKey } from '../utils/testLicense'; // eslint-disable-line
 import TestViewer from './TestViewer';
@@ -36,7 +37,17 @@ main();
 async function main() {
   setupFakeClock();
 
+  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
+  // The output of `toLocaleString` may be implementation dependent
+  const toLocaleStringStub = sinon
+    .stub(Date.prototype, 'toLocaleString')
+    .callsFake(function toLocaleString(this: Date) {
+      return this.toISOString();
+    });
+
   testsBySuite = (await import('./testsBySuite')).testsBySuite;
+
+  toLocaleStringStub.restore();
 
   restoreFakeClock();
 


### PR DESCRIPTION
Reading through [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString). toLocaleString  is also implementation specific:
> Note: Most of the time, the formatting returned by `toLocaleString()` is consistent. However, the output may vary between implementations, even within the same locale — output variations are by design and allowed by the specification. It may also not be what you expect. For example, the string may use non-breaking spaces or be surrounded by bidirectional control characters. You should not compare the results of `toLocaleString()` to hardcoded constants.

So [this flakyness](https://app.argos-ci.com/mui/mui-x/builds/41425/201313695) could be caused by the 'dateTime' formatter. Curious it's the only demo to have this, I presume other demos have these columns hidden behind overflow.