### PR TITLE
[charts-pro] Fix zoom preview having wrong domain in some cases

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/computeAxisValue.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/computeAxisValue.ts
@@ -20,6 +20,7 @@ import {
   getCartesianAxisTriggerTooltip,
   isDateData,
   createDateFormatter,
+  getDefaultTickNumber,
 } from '@mui/x-charts/internals';
 import { AxisConfig, ChartsXAxisProps, ChartsYAxisProps, ScaleName } from '@mui/x-charts/models';
 
@@ -190,7 +191,11 @@ export function computeAxisValue({
       axisExtremums[1] = max;
     }
 
-    const rawTickNumber = getTickNumber({ ...axis, range, domain: axisExtremums });
+    const rawTickNumber = getTickNumber(
+      axis,
+      axisExtremums,
+      getDefaultTickNumber(Math.abs(range[1] - range[0])),
+    );
     const tickNumber = scaleTickNumberByRange(rawTickNumber, range);
 
     const scale = getScale(scaleType, axisExtremums, range);

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
@@ -34,6 +34,7 @@ type GetAxesScalesParams<T extends ChartSeriesType = ChartSeriesType> = {
    * @deprecated To remove in v9. This is an experimental feature to avoid breaking change.
    */
   preferStrictDomainInLineCharts?: boolean;
+  defaultTickNumber: number;
 };
 
 function getRange(
@@ -56,6 +57,7 @@ export function getXAxesScales<T extends ChartSeriesType>({
   seriesConfig,
   zoomMap,
   preferStrictDomainInLineCharts,
+  defaultTickNumber,
 }: GetAxesScalesParams<T> & {
   axis?: DefaultedAxis[];
 }) {
@@ -74,6 +76,7 @@ export function getXAxesScales<T extends ChartSeriesType>({
       axisIndex,
       formattedSeries,
       preferStrictDomainInLineCharts,
+      defaultTickNumber,
     );
   });
 
@@ -87,6 +90,7 @@ export function getYAxesScales<T extends ChartSeriesType>({
   seriesConfig,
   zoomMap,
   preferStrictDomainInLineCharts,
+  defaultTickNumber,
 }: GetAxesScalesParams<T> & {
   axis?: DefaultedAxis[];
 }) {
@@ -105,6 +109,7 @@ export function getYAxesScales<T extends ChartSeriesType>({
       axisIndex,
       formattedSeries,
       preferStrictDomainInLineCharts,
+      defaultTickNumber,
     );
   });
 
@@ -133,6 +138,7 @@ function getAxisScale<T extends ChartSeriesType>(
    * @deprecated To remove in v9. This is an experimental feature to avoid breaking change.
    */
   preferStrictDomainInLineCharts: boolean | undefined,
+  defaultTickNumber: number,
 ): ScaleDefinition {
   const zoomRange: [number, number] = zoom ? [zoom.start, zoom.end] : [0, 100];
   const range = getRange(drawingArea, axisDirection, axis);
@@ -182,7 +188,7 @@ function getAxisScale<T extends ChartSeriesType>(
     axisExtrema[1] = max;
   }
 
-  const rawTickNumber = getTickNumber({ ...axis, range, domain: axisExtrema });
+  const rawTickNumber = getTickNumber(axis, axisExtrema, defaultTickNumber);
 
   const zoomedRange = zoomScaleRange(range, zoomRange);
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPreview.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPreview.selectors.ts
@@ -12,6 +12,8 @@ import { computeAxisValue } from './computeAxisValue';
 import {
   selectorChartZoomAxisFilters,
   selectorChartZoomOptionsLookup,
+  selectorDefaultXAxisTickNumber,
+  selectorDefaultYAxisTickNumber,
 } from './useChartCartesianAxisRendering.selectors';
 import { AxisId } from '../../../../models/axis';
 import { ZoomData } from './zoom.types';
@@ -51,6 +53,7 @@ export const selectorChartPreviewXScales = createSelector(
     selectorChartSeriesConfig,
     selectorChartZoomOptionsLookup,
     selectorPreferStrictDomainInLineCharts,
+    selectorDefaultXAxisTickNumber,
     (_, axisId: AxisId) => axisId,
   ],
   function selectorChartPreviewXScales(
@@ -60,6 +63,7 @@ export const selectorChartPreviewXScales = createSelector(
     seriesConfig,
     zoomOptions,
     preferStrictDomainInLineCharts,
+    defaultTickNumber,
     axisId,
   ) {
     const hasAxis = xAxes?.some((axis) => axis.id === axisId);
@@ -77,6 +81,7 @@ export const selectorChartPreviewXScales = createSelector(
       seriesConfig,
       zoomMap,
       preferStrictDomainInLineCharts,
+      defaultTickNumber,
     });
   },
 );
@@ -142,6 +147,7 @@ export const selectorChartPreviewYScales = createSelector(
     selectorChartSeriesConfig,
     selectorChartZoomOptionsLookup,
     selectorPreferStrictDomainInLineCharts,
+    selectorDefaultYAxisTickNumber,
     (_, axisId: AxisId) => axisId,
   ],
   function selectorChartPreviewYScales(
@@ -151,6 +157,7 @@ export const selectorChartPreviewYScales = createSelector(
     seriesConfig,
     zoomOptions,
     preferStrictDomainInLineCharts,
+    defaultTickNumber,
     axisId,
   ) {
     const hasAxis = yAxes?.some((axis) => axis.id === axisId);
@@ -168,6 +175,7 @@ export const selectorChartPreviewYScales = createSelector(
       seriesConfig,
       zoomMap,
       preferStrictDomainInLineCharts,
+      defaultTickNumber,
     });
   },
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
@@ -17,6 +17,7 @@ import {
 } from './useChartCartesianAxisLayout.selectors';
 import { selectorPreferStrictDomainInLineCharts } from '../../corePlugins/useChartExperimentalFeature';
 import { getXAxesScales, getYAxesScales } from './getAxisScale';
+import { getDefaultTickNumber } from '../../../ticks';
 
 export const createZoomMap = (zoom: readonly ZoomData[]) => {
   const zoomItemMap = new Map<AxisId, ZoomData>();
@@ -68,6 +69,20 @@ const selectorChartYFilter = createSelector(
     zoomMap && zoomOptions && createAxisFilterMapper(zoomMap, zoomOptions, 'y'),
 );
 
+export const selectorDefaultXAxisTickNumber = createSelector(
+  [selectorChartDrawingArea],
+  function selectorDefaultXAxisTickNumber(drawingArea) {
+    return getDefaultTickNumber(drawingArea.width);
+  },
+);
+
+export const selectorDefaultYAxisTickNumber = createSelector(
+  [selectorChartDrawingArea],
+  function selectorDefaultYAxisTickNumber(drawingArea) {
+    return getDefaultTickNumber(drawingArea.height);
+  },
+);
+
 export const selectorChartXScales = createSelector(
   [
     selectorChartRawXAxis,
@@ -76,6 +91,7 @@ export const selectorChartXScales = createSelector(
     selectorChartSeriesConfig,
     selectorChartZoomMap,
     selectorPreferStrictDomainInLineCharts,
+    selectorDefaultXAxisTickNumber,
   ],
   function selectorChartXScales(
     axis,
@@ -84,6 +100,7 @@ export const selectorChartXScales = createSelector(
     seriesConfig,
     zoomMap,
     preferStrictDomainInLineCharts,
+    defaultTickNumber,
   ) {
     return getXAxesScales({
       drawingArea,
@@ -92,6 +109,7 @@ export const selectorChartXScales = createSelector(
       seriesConfig,
       zoomMap,
       preferStrictDomainInLineCharts,
+      defaultTickNumber,
     });
   },
 );
@@ -104,6 +122,7 @@ export const selectorChartYScales = createSelector(
     selectorChartSeriesConfig,
     selectorChartZoomMap,
     selectorPreferStrictDomainInLineCharts,
+    selectorDefaultYAxisTickNumber,
   ],
   function selectorChartYScales(
     axis,
@@ -112,6 +131,7 @@ export const selectorChartYScales = createSelector(
     seriesConfig,
     zoomMap,
     preferStrictDomainInLineCharts,
+    defaultTickNumber,
   ) {
     return getYAxesScales({
       drawingArea,
@@ -120,6 +140,7 @@ export const selectorChartYScales = createSelector(
       seriesConfig,
       zoomMap,
       preferStrictDomainInLineCharts,
+      defaultTickNumber,
     });
   },
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/computeAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/computeAxisValue.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../../models/axis';
 import { ChartSeriesType, PolarChartSeriesType } from '../../../../models/seriesType/config';
 import { getColorScale, getOrdinalColorScale } from '../../../colorScale';
-import { getTickNumber, scaleTickNumberByRange } from '../../../ticks';
+import { getDefaultTickNumber, getTickNumber, scaleTickNumberByRange } from '../../../ticks';
 import { getScale } from '../../../getScale';
 import { isDateData, createDateFormatter } from '../../../dateHelpers';
 import { getAxisExtremum } from './getAxisExtremum';
@@ -188,7 +188,11 @@ export function computeAxisValue<T extends ChartSeriesType>({
       axisExtremums[1] = max;
     }
 
-    const rawTickNumber = getTickNumber({ ...axis, range, domain: axisExtremums });
+    const rawTickNumber = getTickNumber(
+      axis,
+      axisExtremums,
+      getDefaultTickNumber(Math.abs(range[1] - range[0])),
+    );
     const tickNumber = scaleTickNumberByRange(rawTickNumber, range);
 
     const scale = getScale(scaleType, axisExtremums, range);

--- a/packages/x-charts/src/internals/ticks.ts
+++ b/packages/x-charts/src/internals/ticks.ts
@@ -1,19 +1,14 @@
 import type { TickParams } from '../hooks/useTicks';
 
-export function getTickNumber(
-  params: TickParams & {
-    range: number[];
-    domain: any[];
-  },
-) {
-  const { tickMaxStep, tickMinStep, tickNumber, range, domain } = params;
+export function getTickNumber(params: TickParams, domain: any[], defaultTickNumber: number) {
+  const { tickMaxStep, tickMinStep, tickNumber } = params;
 
   const maxTicks =
     tickMinStep === undefined ? 999 : Math.floor(Math.abs(domain[1] - domain[0]) / tickMinStep);
   const minTicks =
     tickMaxStep === undefined ? 2 : Math.ceil(Math.abs(domain[1] - domain[0]) / tickMaxStep);
 
-  const defaultizedTickNumber = tickNumber ?? Math.floor(Math.abs(range[1] - range[0]) / 50);
+  const defaultizedTickNumber = tickNumber ?? defaultTickNumber;
 
   return Math.min(maxTicks, Math.max(minTicks, defaultizedTickNumber));
 }
@@ -27,4 +22,8 @@ export function scaleTickNumberByRange(tickNumber: number, range: number[]) {
   }
 
   return tickNumber / ((range[1] - range[0]) / 100);
+}
+
+export function getDefaultTickNumber(dimension: number) {
+  return Math.floor(Math.abs(dimension) / 50);
 }


### PR DESCRIPTION
This happened because we were calculating the ticks based on the preview drawing area, which isn't the same as the chart drawing area. This caused different results when calling `scale.nice(tickNumber)` since `tickNumber` was different.

In [this example](https://mui.com/x/react-charts/zoom-and-pan/#preview), the domain of the preview is `[0, 1]` while the domain of the chart is `[0, 0.8]`. This happens because the preview is calling `nice()` with two ticks and the chart is calling it with four.

