### PR TITLE
[infra] Fix pnpm-lock.yaml broken lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15585,7 +15585,7 @@ snapshots:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      lru-cache: 11.2.1
+      lru-cache: 11.2.2
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
@@ -18094,7 +18094,7 @@ snapshots:
       '@npmcli/fs': 4.0.0
       fs-minipass: 3.0.3
       glob: 11.0.3
-      lru-cache: 11.2.1
+      lru-cache: 11.2.2
       minipass: 7.1.2
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
@@ -20238,7 +20238,7 @@ snapshots:
 
   hosted-git-info@9.0.0:
     dependencies:
-      lru-cache: 11.2.1
+      lru-cache: 11.2.2
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
Fixes failing CI actions in master, such as the ones from [this commit](https://github.com/mui/mui-x/commit/c32139bc5a20f22ef4a01c5c599471a1f183f7a9) and [this one](https://github.com/mui/mui-x/commit/261cc052ad7825ca0ae691da4623db40a5a632b6).

[This PR](https://github.com/mui/mui-x/pull/19748) added a dependency that depended on `lru-cache` v11.2.1, while [this one](https://github.com/mui/mui-x/pull/19737) upgraded `lru-cache` to v11.2.2.

Since a new dependency was added that depended on `lru-cache`, there was no conflict in the `pnpm-lock.yaml` file.

This PR just fixes that by ensuring we're using `lru-cache` v11.2.2 everywhere.