### PR TITLE
[tree view] Do not forward the `ownerState` to the icon

### DIFF
--- a/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.tsx
+++ b/packages/x-tree-view/src/TreeItemIcon/TreeItemIcon.tsx
@@ -54,7 +54,7 @@ function TreeItemIcon(props: TreeItemIconProps) {
   }
 
   const Icon = slots[iconName];
-  const iconProps = useSlotProps({
+  const { ownerState, ...iconProps } = useSlotProps({
     elementType: Icon as NonNullable<typeof Icon>,
     externalSlotProps: (tempOwnerState: any) => ({
       ...resolveComponentProps(


### PR DESCRIPTION
Fixes #16954