### PR TITLE
[code-infra] Support custom npm dist tags during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: true
       dist-tag:
-        description: 'NPM dist tag to publish to'
+        description: 'npm dist tag to publish to'
         required: false
         type: string
         default: 'latest'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: true
+      dist-tag:
+        description: 'NPM dist tag to publish to'
+        required: false
+        type: string
+        default: 'latest'
 
 permissions: {}
 
@@ -47,6 +52,9 @@ jobs:
           fi
           if [ "${{ inputs.github-release }}" = "true" ]; then
             ARGS="$ARGS --github-release"
+          fi
+          if [ -n "${{ inputs.dist-tag }}" ]; then
+            ARGS="$ARGS --tag ${{ inputs.dist-tag }}"
           fi
 
           pnpm code-infra publish $ARGS

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build:clean": "rimraf .next && pnpm build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "cross-env-shell 'next dev --port ${PORT:-3001}'",
-    "deploy": "git push -f upstream master:docs-v8",
+    "deploy": "git fetch upstream master && git push -f upstream FETCH_HEAD:docs-v8",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "serve": "serve ./export -l 3010",
     "create-playground": "node ./scripts/createPlayground.js",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@inquirer/prompts": "^7.8.6",
     "@mui/internal-babel-plugin-display-name": "^1.0.4-canary.7",
     "@mui/internal-bundle-size-checker": "^1.0.9-canary.46",
-    "@mui/internal-code-infra": "^0.0.3-canary.17",
+    "@mui/internal-code-infra": "^0.0.3-canary.19",
     "@mui/internal-markdown": "^2.0.6",
     "@mui/internal-test-utils": "catalog:",
     "@mui/material": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^1.0.9-canary.46
         version: 1.0.9-canary.46(@types/node@22.18.8)(rollup@4.50.1)(terser@5.43.1)(tsx@4.20.6)(yaml@2.8.1)
       '@mui/internal-code-infra':
-        specifier: ^0.0.3-canary.17
-        version: 0.0.3-canary.17(@typescript-eslint/parser@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0))(eslint@9.36.0)(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)
+        specifier: ^0.0.3-canary.19
+        version: 0.0.3-canary.19(@typescript-eslint/parser@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0))(eslint@9.36.0)(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)
       '@mui/internal-markdown':
         specifier: ^2.0.6
         version: 2.0.9
@@ -4026,8 +4026,8 @@ packages:
     resolution: {integrity: sha512-KyKMYVpN8ScUkhgmo6LwXoaVf5c49c2qNeX39s/xLALrmFycOqd2q+ElN6wXLrYT7VkgJQhMHj77PcKhoBpm4A==}
     hasBin: true
 
-  '@mui/internal-code-infra@0.0.3-canary.17':
-    resolution: {integrity: sha512-+9R21uphQTbFQIVmjMz+SqioYjGs6N7fgLaLgCdUykmqUFsLp/MeJuv+91l94MFAt7TYUrOD/3OzK4mCq4BcaQ==}
+  '@mui/internal-code-infra@0.0.3-canary.19':
+    resolution: {integrity: sha512-LMQAy+0XWTaXTbMtacB2QaQPqFhKwJnfIZ0k0yUBXdHizfKKAobJyifBS+YBErGNrkoW9GOMrJcuLM3h92gPcA==}
     hasBin: true
     peerDependencies:
       eslint: ^9.0.0
@@ -14617,7 +14617,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@mui/internal-code-infra@0.0.3-canary.17(@typescript-eslint/parser@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0))(eslint@9.36.0)(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)':
+  '@mui/internal-code-infra@0.0.3-canary.19(@typescript-eslint/parser@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.10)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.44.1(eslint@9.36.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.36.0))(eslint@9.36.0)(postcss@8.5.6)(prettier@3.6.2)(stylelint@16.24.0(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
       '@argos-ci/core': 4.1.5
       '@babel/cli': 7.28.3(@babel/core@7.28.4)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,11 +92,11 @@ In case of a problem, another method to generate the changelog is available at t
 1. Go to the [publish action](https://github.com/mui/mui-x/actions/workflows/publish.yml).
 2. Choose "Run workflow" dropdown
 
-> - **Branch:** master
-> - **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
-> - **Run in dry-run mode:** Used for debugging.
-> - **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
-> - **NPM dist tag to publish to** Use to publish legacy or canary versions
+   > - **Branch:** master
+   > - **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
+   > - **Run in dry-run mode:** Used for debugging.
+   > - **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
+   > - **NPM dist tag to publish to** Use to publish legacy or canary versions.
 
 3. Click "Run workflow"
 4. Optional: A maintainer may have to approve the workflow run.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,7 +96,7 @@ In case of a problem, another method to generate the changelog is available at t
    > - **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
    > - **Run in dry-run mode:** Used for debugging.
    > - **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
-   > - **NPM dist tag to publish to** Use to publish legacy or canary versions.
+   > - **npm dist tag to publish to** Use to publish legacy or canary versions.
 
 3. Click "Run workflow"
 4. Optional: A maintainer may have to approve the workflow run.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,10 +92,11 @@ In case of a problem, another method to generate the changelog is available at t
 1. Go to the [publish action](https://github.com/mui/mui-x/actions/workflows/publish.yml).
 2. Choose "Run workflow" dropdown
 
-> **Branch:** master
-> **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
-> **Run in dry-run mode:** Used for debugging.
-> **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
+> - **Branch:** master
+> - **Commit SHA to release from:** the commit that contains the merged release on master. This commit is linked to the GitHub release.
+> - **Run in dry-run mode:** Used for debugging.
+> - **Create GitHub release:** Keep selected if you want a GitHub release to be automatically created from the changelog.
+> - **NPM dist tag to publish to** Use to publish legacy or canary versions
 
 3. Click "Run workflow"
 4. Optional: A maintainer may have to approve the workflow run.


### PR DESCRIPTION
* Allow publishing to different dist tag than "latest"
* Tweak docs deploy to fetch latest master first, like https://github.com/mui/material-ui/pull/47018/