### PR TITLE
[DateField] Prevent blur event propagation on individual Sections

### DIFF
--- a/packages/x-date-pickers/src/PickersSectionList/PickersSectionList.tsx
+++ b/packages/x-date-pickers/src/PickersSectionList/PickersSectionList.tsx
@@ -94,10 +94,28 @@ function PickersSection(props: PickersSectionProps) {
     ownerState: { ...ownerState, separatorPosition: 'after' },
   });
 
+  // Only propagate blur when focus leaves the SectionContent entirely.
+  const sectionContentRef = React.useRef<HTMLSpanElement>(null);
+  const handleSectionContentRef = useForkRef((sectionContentProps as any).ref, sectionContentRef);
+
   return (
     <Section {...sectionProps}>
       <SectionSeparator {...sectionSeparatorBeforeProps} />
-      <SectionContent {...sectionContentProps} />
+      <SectionContent
+        {...sectionContentProps}
+        ref={handleSectionContentRef}
+        onBlur={(event) => {
+          const next = (event.relatedTarget as Node | null);
+          // If the next focused element stays within the whole field (root),
+          // do not propagate blur. We only want blur when leaving the field entirely.
+          const root = (event.currentTarget as HTMLElement).closest(`.${pickersSectionListClasses.root}`);
+          if (root && next instanceof Node && root.contains(next)) {
+            event.stopPropagation();
+            return;
+          }
+          // Otherwise, focus left the whole field; allow propagation.
+        }}
+      />
       <SectionSeparator {...sectionSeparatorAfterProps} />
     </Section>
   );


### PR DESCRIPTION
Fix for #19604 

This will prevent propagating the `blur` event during transition between the individual `Section`s. 