### PR TITLE
[docs] Add a linear gauge demo

### DIFF
--- a/docs/data/charts/bar-demo/LinearGauge.js
+++ b/docs/data/charts/bar-demo/LinearGauge.js
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { BarChart } from '@mui/x-charts/BarChart';
+// import { ChartsTooltip } from '@mui/x-charts/ChartsTooltip';
+
+const dataset = [
+  { feature: 'Progress', completed: 60, inProgress: 25, pending: 15 },
+];
+
+const chartSetting = {
+  height: 200,
+  sx: (theme) => ({
+    '& .MuiBarElement-root': {
+      outline: `2px solid ${theme.palette.background.paper}`,
+    },
+  }),
+};
+
+const valueFormatter = (value) => (value === null ? '' : `${value}%`);
+
+export default function LinearGauge() {
+  return (
+    <BarChart
+      dataset={dataset}
+      yAxis={[
+        {
+          scaleType: 'band',
+          dataKey: 'feature',
+          width: 60,
+        },
+      ]}
+      xAxis={[{ valueFormatter }]}
+      series={[
+        { dataKey: 'completed', label: 'Completed', valueFormatter, stack: 'total' },
+        {
+          dataKey: 'inProgress',
+          label: 'In Progress',
+          valueFormatter,
+          stack: 'total',
+        },
+        { dataKey: 'pending', label: 'Pending', valueFormatter, stack: 'total' },
+      ].map((series) => ({
+        ...series,
+        highlightScope: {
+          highlighted: 'item',
+          faded: 'global',
+        },
+      }))}
+      layout="horizontal"
+      grid={{ vertical: true }}
+      {...chartSetting}
+      slotProps={{ tooltip: { trigger: 'item' } }}
+      borderRadius={4}
+    />
+  );
+}

--- a/docs/data/charts/bar-demo/bar-demo.md
+++ b/docs/data/charts/bar-demo/bar-demo.md
@@ -39,3 +39,7 @@ components: BarChart, BarElement, BarPlot
 ## Population pyramid
 
 {{"demo": "PopulationPyramidBarChart.js"}}
+
+## LinearGauge
+
+{{"demo": "LinearGauge.js"}}


### PR DESCRIPTION
Note: We have an open issue for this component, I wanted to try it using a bar chart. Through this PR I'm exploring if we it's worth adding it as a demo on the docs.

 - [ ] Typescript to be added


<img width="875" height="392" alt="Screenshot 2025-10-06 at 3 10 26 PM" src="https://github.com/user-attachments/assets/c7a1064e-85ff-4a22-8efd-1c4351f050c4" />
