### PR TITLE
[charts] Correct scale domain types

### DIFF
--- a/packages/x-charts/src/hooks/useScale.ts
+++ b/packages/x-charts/src/hooks/useScale.ts
@@ -9,7 +9,10 @@ import { useRadiusAxis, useRotationAxis, useXAxis, useYAxis } from './useAxis';
  * @param {D3Scale} scale The scale to use
  * @returns {(value: any) => number} A function that map value to their position
  */
-export function getValueToPositionMapper(scale: D3Scale): (value: any) => number {
+export function getValueToPositionMapper<
+  Domain extends { toString(): string } = { toString(): string },
+  Range = number,
+>(scale: D3Scale<Domain, Range>): (value: any) => number {
   if (isOrdinalScale(scale)) {
     return (value: any) => (scale(value) ?? 0) + scale.bandwidth() / 2;
   }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisScale.ts
@@ -1,4 +1,9 @@
-import { scaleBand, scalePoint, type ScaleSymLog } from '@mui/x-charts-vendor/d3-scale';
+import {
+  NumberValue,
+  scaleBand,
+  scalePoint,
+  type ScaleSymLog,
+} from '@mui/x-charts-vendor/d3-scale';
 import {
   AxisConfig,
   AxisId,
@@ -241,18 +246,18 @@ export function applyDomainLimit(
  * @param maxData Maximum value from the data.
  */
 export function getActualAxisExtrema(
-  axisExtrema: { min?: number | Date; max?: number | Date } | {},
-  minData: number,
-  maxData: number,
-): [number | Date, number | Date] {
-  let min: number | Date = minData;
-  let max: number | Date = maxData;
+  axisExtrema: { min?: NumberValue; max?: NumberValue } | {},
+  minData: NumberValue,
+  maxData: NumberValue,
+): [NumberValue, NumberValue] {
+  let min = minData;
+  let max = maxData;
 
-  if ('max' in axisExtrema && axisExtrema.max != null && axisExtrema.max.valueOf() < minData) {
+  if ('max' in axisExtrema && axisExtrema.max != null && axisExtrema.max < minData) {
     min = axisExtrema.max;
   }
 
-  if ('min' in axisExtrema && axisExtrema.min != null && axisExtrema.min.valueOf() > minData) {
+  if ('min' in axisExtrema && axisExtrema.min != null && axisExtrema.min > minData) {
     max = axisExtrema.min;
   }
 

--- a/packages/x-charts/src/internals/scaleGuards.ts
+++ b/packages/x-charts/src/internals/scaleGuards.ts
@@ -1,20 +1,26 @@
 import type { ScaleBand, ScalePoint } from '@mui/x-charts-vendor/d3-scale';
 import { D3OrdinalScale, D3Scale } from '../models/axis';
 
-export function isOrdinalScale<T extends { toString(): string }>(
-  scale: D3Scale<T>,
-): scale is D3OrdinalScale<T> {
-  return (scale as ScaleBand<T> | ScalePoint<T>).bandwidth !== undefined;
+export function isOrdinalScale<
+  Domain extends { toString(): string } = { toString(): string },
+  Range = number,
+  Output = number,
+>(scale: D3Scale<Domain, Range, Output>): scale is D3OrdinalScale<Domain> {
+  return (scale as ScaleBand<Domain> | ScalePoint<Domain>).bandwidth !== undefined;
 }
 
-export function isBandScale<T extends { toString(): string }>(
-  scale: D3Scale<T>,
-): scale is ScaleBand<T> {
-  return isOrdinalScale(scale) && (scale as ScaleBand<T>).paddingOuter !== undefined;
+export function isBandScale<
+  Domain extends { toString(): string } = { toString(): string },
+  Range = number,
+  Output = number,
+>(scale: D3Scale<Domain, Range, Output>): scale is ScaleBand<Domain> {
+  return isOrdinalScale(scale) && (scale as ScaleBand<Domain>).paddingOuter !== undefined;
 }
 
-export function isPointScale<T extends { toString(): string }>(
-  scale: D3Scale<T>,
-): scale is D3OrdinalScale<T> {
+export function isPointScale<
+  Domain extends { toString(): string } = { toString(): string },
+  Range = number,
+  Output = number,
+>(scale: D3Scale<Domain, Range, Output>): scale is D3OrdinalScale<Domain> {
   return isOrdinalScale(scale) && !('paddingOuter' in scale);
 }

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -22,7 +22,7 @@ import { ContinuousColorConfig, OrdinalColorConfig, PiecewiseColorConfig } from 
 export type AxisId = string | number;
 
 export type D3Scale<
-  Domain extends { toString(): string } = number | Date | string,
+  Domain extends { toString(): string } = { toString(): string },
   Range = number,
   Output = number,
 > =
@@ -41,7 +41,7 @@ export type D3ContinuousScale<Range = number, Output = number> =
   | ScaleTime<Range, Output>
   | ScaleLinear<Range, Output>;
 
-export type D3OrdinalScale<Domain extends { toString(): string } = number | Date | string> =
+export type D3OrdinalScale<Domain extends { toString(): string } = { toString(): string }> =
   | ScaleBand<Domain>
   | ScalePoint<Domain>;
 
@@ -266,7 +266,7 @@ export type AxisGroups = {
 export interface AxisScaleConfig {
   band: {
     scaleType: 'band';
-    scale: ScaleBand<number | Date | string>;
+    scale: ScaleBand<{ toString(): string }>;
     /**
      * The ratio between the space allocated for padding between two categories and the category width.
      * 0 means no gap, and 1 no data.
@@ -284,7 +284,7 @@ export interface AxisScaleConfig {
     Pick<TickParams, 'tickPlacement' | 'tickLabelPlacement'>;
   point: {
     scaleType: 'point';
-    scale: ScalePoint<number | Date | string>;
+    scale: ScalePoint<{ toString(): string }>;
     colorMap?: OrdinalColorConfig | ContinuousColorConfig | PiecewiseColorConfig;
   } & AxisGroups;
   log: {


### PR DESCRIPTION
Correct scale domain types. 

For continuous scales, in some places we accept `NumberValue`, in others `number | Date`. `NumberValue` is the type accepted by the continuous scales, so IMO we should accept those. 

For band scales, we accept `string | number | Date`, but the scale accepts `{ toString(): string }`.

