### PR TITLE
[Data Grid] Fix tree data unable to deselect row for exclude model

### DIFF
--- a/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowSelection.DataGridPro.test.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { RefObject } from '@mui/x-internals/types';
-import { getCell, getColumnValues, getRows, includeRowSelection } from 'test/utils/helperFn';
+import {
+  getCell,
+  getColumnValues,
+  getRows,
+  includeRowSelection,
+  excludeRowSelection,
+} from 'test/utils/helperFn';
 import { createRenderer, screen, act, fireEvent } from '@mui/internal-test-utils';
 import {
   GridApi,
@@ -1280,6 +1286,25 @@ describe('<DataGridPro /> - Row selection', () => {
       );
       await act(async () => apiRef.current?.selectRowRange({ startId: 0, endId: 2 }, true));
       expect(getSelectedRowIds()).to.deep.equal([0, 2]);
+    });
+  });
+
+  describe('apiRef: getPropagatedRowSelectionModel', () => {
+    it.only('`getPropagatedRowSelectionModel` should return exclude models unchanged', () => {
+      render(<TreeDataGrid rowSelectionPropagation={{ descendants: true, parents: true }} />);
+
+      // Exclude models are not affected by propagation
+      const excludeModel = excludeRowSelection([1]);
+      const propagatedModel = apiRef.current?.getPropagatedRowSelectionModel(excludeModel);
+
+      expect(propagatedModel).to.equal(excludeModel); // same object
+
+      // Include models are affected by propagation
+      const includeModel = includeRowSelection([1]);
+      const propagatedIncludeModel = apiRef.current?.getPropagatedRowSelectionModel(includeModel);
+
+      expect(propagatedIncludeModel?.type).to.equal('include');
+      expect(propagatedIncludeModel?.ids).to.have.keys([1, 2, 3, 4, 5, 6, 7]);
     });
   });
 

--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -435,6 +435,7 @@ export const useGridRowSelection = (
       if (
         !isNestedData ||
         !applyAutoSelection ||
+        inputSelectionModel.type === 'exclude' ||
         (inputSelectionModel.ids.size === 0 && inputSelectionModel.type === 'include')
       ) {
         return inputSelectionModel;

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -199,3 +199,7 @@ export function getSelectByName(name: string) {
 export const includeRowSelection = (ids: GridRowId[]) => {
   return { type: 'include', ids: new Set(ids) } as const;
 };
+
+export const excludeRowSelection = (ids: GridRowId[]) => {
+  return { type: 'exclude', ids: new Set(ids) } as const;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Fixes #19046

## The Bug

When using a **controlled exclude model** with **tree data** and **row selection propagation**, the grid corrupts the model by treating excluded row IDs as selected row IDs.

### Step-by-Step Bug Flow

#### 1. User provides controlled exclude model

```typescript
<DataGridPro
  treeData
  rowSelectionModel={{ type: 'exclude', ids: new Set([1]) }}
  rowSelectionPropagation={{ descendants: true, parents: true }}
  onRowSelectionModelChange={handleChange}
/>
```

**Meaning**: "All rows selected EXCEPT row 1 (Thomas)"

#### 2. Grid calls `getPropagatedRowSelectionModel`

When the controlled prop is provided, `syncControlledState` (line 849) calls:

```typescript
const newSelectionModel = apiRef.current.getPropagatedRowSelectionModel(propRowSelectionModel);
```

#### 3. Bug: Function treats excluded IDs as selected IDs

**Before Fix** (lines 436-466):

```typescript
const getPropagatedRowSelectionModel = (inputSelectionModel) => {
  // No check for exclude model type! ❌
  if (!isNestedData || !applyAutoSelection || ...) {
    return inputSelectionModel;
  }

  const propagatedSelectionModel = {
    type: inputSelectionModel.type,  // 'exclude'
    ids: new Set(inputSelectionModel.ids),  // Set([1]) - EXCLUDED rows!
  };

  const selectionManager = createRowSelectionManager(propagatedSelectionModel);

  // Iterate over EXCLUDED row IDs ❌
  for (const id of inputSelectionModel.ids) {  // id = 1 (Thomas)
    findRowsToSelect(  // ❌ Wrong function for excluded rows!
      apiRef, tree, id,
      props.rowSelectionPropagation?.descendants,  // true
      props.rowSelectionPropagation?.parents,  // true
      (rowId) => selectionManager.select(rowId),  // ❌ Removes from exclude set!
    );
  }
};
```

#### 4. What happens inside the propagation

**Tree structure:**
```
Thomas (id: 1) - EXCLUDED
  ├─ Robert (id: 2)
  ├─ Karen (id: 3)
  └─ Nancy (id: 4)
```

**Propagation flow:**
1. `findRowsToSelect` is called with `id = 1` (Thomas - an EXCLUDED row)
2. It finds children: `[2, 3, 4]`
3. For each child, it calls: `selectionManager.select(childId)`

**What `select()` does for exclude models:**

```typescript
// In gridRowSelectionManager.ts
select(id) {
  if (this.model.type === 'exclude') {
    this.model.ids.delete(id);  // ❌ Removes from exclude set!
  }
}
```

#### 5. The corruption

**Starting model:**
```typescript
{ type: 'exclude', ids: Set([1]) }
// Meaning: "All selected except Thomas"
```

**After propagation:**
```typescript
{ type: 'exclude', ids: Set() }
// Meaning: "All rows selected!" ❌
```

**What happened:**
- Row 1 (Thomas) was in the exclude set
- `select()` was called on its children (2, 3, 4)
- Since they weren't in the exclude set, nothing was deleted
- But the semantic error is: we iterated over **excluded rows** and called **`findRowsToSelect`** on them!

## The Root Cause

**Semantic mismatch:**
- `findRowsToSelect` is designed for **SELECTION** propagation
- Exclude model IDs represent **UNSELECTED** rows
- Calling `findRowsToSelect` on unselected rows and using `select()` to "propagate" them corrupts the model

**Why exclude models don't need propagation:**

When a user actually deselects a row via UI interaction, propagation ALREADY happens correctly:

```typescript
// In selectRow (lines 294-302)
} else if (applyAutoSelection) {
  findRowsToDeselect(  // ✅ Correct function
    apiRef, tree, id,
    props.rowSelectionPropagation?.descendants,
    props.rowSelectionPropagation?.parents,
    (rowId) => selectionManager.unselect(rowId),  // ✅ Adds to exclude set
  );
}
```

**Result after UI deselection:**
```typescript
{ type: 'exclude', ids: Set([1, 2, 3, 4]) }  // ✅ Already complete!
```

The model is semantically complete - no "propagation reapplication" needed.

## The Solution

### Fix #3: Skip propagation for exclude models in `getPropagatedRowSelectionModel`

**Location:** `useGridRowSelection.ts:440`

**Change:**
```typescript
const getPropagatedRowSelectionModel = (inputSelectionModel) => {
  if (
    !isNestedData ||
    !applyAutoSelection ||
    inputSelectionModel.type === 'exclude' ||  // ← NEW: Skip for exclude models
    (inputSelectionModel.ids.size === 0 && inputSelectionModel.type === 'include')
  ) {
    return inputSelectionModel;  // Return unchanged
  }

  // Propagation logic below only runs for include models now
  // ...
};
```

## Test

Added a test to ensure that the exclude model is unchanged when getting from `getPropagatedRowSelectionModel`

---

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
