### PR TITLE
[tree view] Use aria-checked instead of aria-selected on items

### DIFF
--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.itemPlugin.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.itemPlugin.ts
@@ -64,10 +64,31 @@ export const useTreeViewSelectionItemPlugin: TreeViewItemPlugin = ({ props }) =>
 
   const isCheckboxSelectionEnabled = useStore(store, selectionSelectors.isCheckboxSelectionEnabled);
   const isItemSelectionEnabled = useStore(store, selectionSelectors.canItemBeSelected, itemId);
-  const checkboxSelectionStatus = useStore(store, selectorCheckboxSelectionStatus, itemId);
+  const selectionStatus = useStore(store, selectorCheckboxSelectionStatus, itemId);
+  const isSelectionEnabledForItem = useStore(store, selectionSelectors.canItemBeSelected, itemId);
 
   return {
     propsEnhancers: {
+      root: () => {
+        // https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
+        let ariaChecked: React.AriaAttributes['aria-checked'];
+        if (selectionStatus === 'checked') {
+          // - each selected node has aria-checked set to true.
+          ariaChecked = true;
+        } else if (selectionStatus === 'indeterminate') {
+          ariaChecked = 'mixed';
+        } else if (!isSelectionEnabledForItem) {
+          // - if the tree contains nodes that are not selectable, aria-checked is not present on those nodes.
+          ariaChecked = undefined;
+        } else {
+          // - all nodes that are selectable but not selected have aria-checked set to false.
+          ariaChecked = false;
+        }
+
+        return {
+          'aria-checked': ariaChecked,
+        };
+      },
       checkbox: ({
         externalEventHandlers,
         interactions,
@@ -92,8 +113,8 @@ export const useTreeViewSelectionItemPlugin: TreeViewItemPlugin = ({ props }) =>
           onChange: handleChange,
           visible: isCheckboxSelectionEnabled,
           disabled: !isItemSelectionEnabled,
-          checked: checkboxSelectionStatus === 'checked',
-          indeterminate: checkboxSelectionStatus === 'indeterminate',
+          checked: selectionStatus === 'checked',
+          indeterminate: selectionStatus === 'indeterminate',
         };
       },
     },

--- a/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.types.ts
+++ b/packages/x-tree-view/src/internals/plugins/useTreeViewSelection/useTreeViewSelection.types.ts
@@ -162,6 +162,10 @@ export type UseTreeViewSelectionSignature = TreeViewPluginSignature<{
   ];
 }>;
 
+export interface UseTreeItemRootSlotPropsFromSelection {
+  'aria-selected': React.AriaAttributes['aria-selected'];
+}
+
 export interface UseTreeItemCheckboxSlotPropsFromSelection {
   visible?: boolean;
   checked?: boolean;
@@ -172,5 +176,7 @@ export interface UseTreeItemCheckboxSlotPropsFromSelection {
 }
 
 declare module '@mui/x-tree-view/useTreeItem' {
+  interface UseTreeItemRootSlotOwnProps extends UseTreeItemRootSlotPropsFromSelection {}
+
   interface UseTreeItemCheckboxSlotOwnProps extends UseTreeItemCheckboxSlotPropsFromSelection {}
 }

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.ts
@@ -70,7 +70,6 @@ export const useTreeItem = <
   const checkboxRef = React.useRef<HTMLButtonElement>(null);
 
   const treeId = useStore(store, idSelectors.treeId);
-  const isSelectionEnabledForItem = useStore(store, selectionSelectors.canItemBeSelected, itemId);
   const isCheckboxSelectionEnabled = useStore(store, selectionSelectors.isCheckboxSelectionEnabled);
   const idAttribute = generateTreeItemIdAttribute({ itemId, treeId, id });
   const shouldBeAccessibleWithTab = useStore(
@@ -205,19 +204,6 @@ export const useTreeItem = <
       ...extractEventHandlers(externalProps),
     };
 
-    // https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
-    let ariaSelected: boolean | undefined;
-    if (status.selected) {
-      // - each selected node has aria-selected set to true.
-      ariaSelected = true;
-    } else if (!isSelectionEnabledForItem) {
-      // - if the tree contains nodes that are not selectable, aria-selected is not present on those nodes.
-      ariaSelected = undefined;
-    } else {
-      // - all nodes that are selectable but not selected have aria-selected set to false.
-      ariaSelected = false;
-    }
-
     const props: UseTreeItemRootSlotPropsFromUseTreeItem = {
       ...externalEventHandlers,
       ref: handleRootRef,
@@ -225,7 +211,6 @@ export const useTreeItem = <
       tabIndex: shouldBeAccessibleWithTab ? 0 : -1,
       id: idAttribute,
       'aria-expanded': status.expandable ? status.expanded : undefined,
-      'aria-selected': ariaSelected,
       'aria-disabled': status.disabled || undefined,
       ...externalProps,
       style: {

--- a/packages/x-tree-view/src/useTreeItem/useTreeItem.types.ts
+++ b/packages/x-tree-view/src/useTreeItem/useTreeItem.types.ts
@@ -45,7 +45,6 @@ export interface UseTreeItemRootSlotPropsFromUseTreeItem {
   tabIndex: 0 | -1;
   id: string;
   'aria-expanded': React.AriaAttributes['aria-expanded'];
-  'aria-selected': React.AriaAttributes['aria-selected'];
   'aria-disabled': React.AriaAttributes['aria-disabled'];
   onFocus: TreeViewCancellableEventHandler<React.FocusEvent<HTMLElement>>;
   onBlur: TreeViewCancellableEventHandler<React.FocusEvent<HTMLElement>>;


### PR DESCRIPTION
Closes #18740

I'm really not sure it's a good idea :grimacing: , because [the Mozilla doc](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/treeitem_role) and the [ARIA doc](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/) both only talks about true and false, never mixed for `role="treeitem"`...

<img width="810" height="114" alt="image" src="https://github.com/user-attachments/assets/5e4ca35f-c0fe-43b0-99be-1407d7ef98ab" />
