### PR TITLE
[charts] Fix tooltip position when scrolling

### DIFF
--- a/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
+++ b/packages/x-charts/src/ChartsTooltip/ChartsTooltipContainer.tsx
@@ -99,10 +99,12 @@ function ChartsTooltipContainer(inProps: ChartsTooltipContainerProps) {
 
     element.addEventListener('pointerdown', handlePointerEvent);
     element.addEventListener('pointermove', handlePointerEvent);
+    element.addEventListener('pointerenter', handlePointerEvent);
 
     return () => {
       element.removeEventListener('pointerdown', handlePointerEvent);
       element.removeEventListener('pointermove', handlePointerEvent);
+      element.removeEventListener('pointerenter', handlePointerEvent);
       update.clear();
     };
   }, [svgRef, positionRef]);


### PR DESCRIPTION
Fix https://mui-org.slack.com/archives/C011VC970AW/p1759490601723559?thread_ts=1759406724.281789&cid=C011VC970AW

When you enter by scrolling the tooltip get data thanks to the `pointerenter` event, but no coordinate because none of `pointermove` or `pointerdown` got trigger. So in this PR I propose to add another listener to get pointer coordinate