### PR TITLE
[code-infra] Remove remaining usages of `lodash`

### DIFF
--- a/docs/scripts/api/buildApi.ts
+++ b/docs/scripts/api/buildApi.ts
@@ -4,7 +4,7 @@ import { hideBin } from 'yargs/helpers';
 import path from 'path';
 import fs from 'fs';
 import * as prettier from 'prettier';
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'es-toolkit/string';
 import {
   buildApiInterfacesJson,
   buildInterfacesDocumentationPage,

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "globby": "^14.1.0",
     "jsdom": "26.1.0",
     "lerna": "^9.0.0",
-    "lodash": "^4.17.21",
     "magic-string": "^0.30.19",
     "markdownlint-cli2": "^0.18.1",
     "moment": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,9 +401,6 @@ importers:
       lerna:
         specifier: ^9.0.0
         version: 9.0.0(@swc/core@1.13.5)(@types/node@22.18.8)(babel-plugin-macros@3.1.0)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       magic-string:
         specifier: ^0.30.19
         version: 0.30.19

--- a/scripts/buildApiDocs/chartsSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/chartsSettings/getComponentInfo.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'es-toolkit/string';
 import { getHeaders, getTitle, renderMarkdown } from '@mui/internal-markdown';
 import {
   ComponentInfo,

--- a/scripts/buildApiDocs/gridSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/gridSettings/getComponentInfo.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'es-toolkit/string';
 import { getHeaders, getTitle, renderMarkdown } from '@mui/internal-markdown';
 import {
   ComponentInfo,

--- a/scripts/buildApiDocs/pickersSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/pickersSettings/getComponentInfo.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'es-toolkit/string';
 import { getHeaders, getTitle, renderMarkdown } from '@mui/internal-markdown';
 import {
   ComponentInfo,

--- a/scripts/buildApiDocs/treeViewSettings/getComponentInfo.ts
+++ b/scripts/buildApiDocs/treeViewSettings/getComponentInfo.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'es-toolkit/string';
 import { getHeaders, getTitle, renderMarkdown } from '@mui/internal-markdown';
 import {
   ComponentInfo,

--- a/test/e2e-website/data-grid.spec.ts
+++ b/test/e2e-website/data-grid.spec.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from '@playwright/test';
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'es-toolkit/string';
 import { TestFixture } from './playwright.config';
 
 const test = base.extend<TestFixture>({});


### PR DESCRIPTION
Related to https://github.com/mui/mui-public/issues/740. 

Removes the remaining usages of `lodash` that were left in https://github.com/mui/mui-x/pull/19853.

