### PR TITLE
[scheduler] Fix `useButton()` usage

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
@@ -6,7 +6,7 @@ import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
 import { useStore } from '@base-ui-components/utils/store/useStore';
 import { useButton } from '../../base-ui-copy/utils/useButton';
 import { useRenderElement } from '../../base-ui-copy/utils/useRenderElement';
-import { BaseUIComponentProps } from '../../base-ui-copy/utils/types';
+import { BaseUIComponentProps, NonNativeButtonProps } from '../../base-ui-copy/utils/types';
 import { useEvent } from '../../utils/useEvent';
 import { CalendarEvent, CalendarEventId, SchedulerValidDate } from '../../models';
 import { useAdapter, diffIn } from '../../use-adapter';
@@ -31,6 +31,7 @@ export const CalendarGridDayEvent = React.forwardRef(function CalendarGridDayEve
     eventId,
     occurrenceKey,
     isDraggable = false,
+    nativeButton = false,
     // Props forwarded to the DOM element
     ...elementProps
   } = componentProps;
@@ -41,7 +42,10 @@ export const CalendarGridDayEvent = React.forwardRef(function CalendarGridDayEve
 
   const adapter = useAdapter();
   const ref = React.useRef<HTMLDivElement>(null);
-  const { getButtonProps, buttonRef } = useButton({ disabled: !isInteractive });
+  const { getButtonProps, buttonRef } = useButton({
+    disabled: !isInteractive,
+    native: nativeButton,
+  });
   const { start: rowStart, end: rowEnd } = useCalendarGridDayRowContext();
   const { state: eventState } = useEvent({ start, end });
   const store = useEventCalendarStoreContext();
@@ -146,7 +150,10 @@ export namespace CalendarGridDayEvent {
     resizing: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State>, useEvent.Parameters {
+  export interface Props
+    extends BaseUIComponentProps<'div', State>,
+      NonNativeButtonProps,
+      useEvent.Parameters {
     /**
      * The unique identifier of the event.
      */

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.tsx
@@ -6,7 +6,7 @@ import { useEventCallback } from '@base-ui-components/utils/useEventCallback';
 import { useStore } from '@base-ui-components/utils/store';
 import { useButton } from '../../base-ui-copy/utils/useButton';
 import { useRenderElement } from '../../base-ui-copy/utils/useRenderElement';
-import { BaseUIComponentProps } from '../../base-ui-copy/utils/types';
+import { BaseUIComponentProps, NonNativeButtonProps } from '../../base-ui-copy/utils/types';
 import { CalendarGridTimeEventCssVars } from './CalendarGridTimeEventCssVars';
 import { useCalendarGridTimeColumnContext } from '../time-column/CalendarGridTimeColumnContext';
 import { useEvent } from '../../utils/useEvent';
@@ -31,6 +31,7 @@ export const CalendarGridTimeEvent = React.forwardRef(function CalendarGridTimeE
     eventId,
     occurrenceKey,
     isDraggable = false,
+    nativeButton = false,
     // Props forwarded to the DOM element
     ...elementProps
   } = componentProps;
@@ -44,7 +45,10 @@ export const CalendarGridTimeEvent = React.forwardRef(function CalendarGridTimeE
   const store = useEventCalendarStoreContext();
   const isDragging = useStore(store, selectors.isOccurrenceMatchingThePlaceholder, occurrenceKey);
   const [isResizing, setIsResizing] = React.useState(false);
-  const { getButtonProps, buttonRef } = useButton({ disabled: !isInteractive });
+  const { getButtonProps, buttonRef } = useButton({
+    disabled: !isInteractive,
+    native: nativeButton,
+  });
 
   const {
     start: columnStart,
@@ -159,7 +163,10 @@ export namespace CalendarGridTimeEvent {
     resizing: boolean;
   }
 
-  export interface Props extends BaseUIComponentProps<'div', State>, useEvent.Parameters {
+  export interface Props
+    extends BaseUIComponentProps<'div', State>,
+      NonNativeButtonProps,
+      useEvent.Parameters {
     /**
      * The unique identifier of the event.
      */

--- a/packages/x-scheduler-headless/src/timeline/event/TimelineEvent.tsx
+++ b/packages/x-scheduler-headless/src/timeline/event/TimelineEvent.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useRenderElement } from '../../base-ui-copy/utils/useRenderElement';
-import { BaseUIComponentProps } from '../../base-ui-copy/utils/types';
+import { BaseUIComponentProps, NonNativeButtonProps } from '../../base-ui-copy/utils/types';
 import { useButton } from '../../base-ui-copy/utils/useButton';
 import { useTimelineEventRowContext } from '../event-row/TimelineEventRowContext';
 import { useEvent } from '../../utils/useEvent';
@@ -19,6 +19,7 @@ export const TimelineEvent = React.forwardRef(function TimelineEvent(
     // Internal props
     start,
     end,
+    nativeButton = false,
     // Props forwarded to the DOM element
     ...elementProps
   } = componentProps;
@@ -27,7 +28,10 @@ export const TimelineEvent = React.forwardRef(function TimelineEvent(
   // to control whether the event should behave like a button
   const isInteractive = true;
 
-  const { getButtonProps, buttonRef } = useButton({ disabled: !isInteractive });
+  const { getButtonProps, buttonRef } = useButton({
+    disabled: !isInteractive,
+    native: nativeButton,
+  });
 
   const { start: rowStart, end: rowEnd } = useTimelineEventRowContext();
 
@@ -61,5 +65,8 @@ export const TimelineEvent = React.forwardRef(function TimelineEvent(
 export namespace TimelineEvent {
   export interface State extends useEvent.State {}
 
-  export interface Props extends BaseUIComponentProps<'div', State>, useEvent.Parameters {}
+  export interface Props
+    extends BaseUIComponentProps<'div', State>,
+      NonNativeButtonProps,
+      useEvent.Parameters {}
 }


### PR DESCRIPTION
Follow up on #19855 

We had a new warning in dev because the `nativeButton` is now used by the `useButton()` hook to fire a warning when using a non-native button (a div with aria attributes) without passing `nativeButton: false` to it.

I kept a non native button as the default to avoid any change on the DOM structure so this PR is purely a bug fix :+1: 