### PR TITLE
[scheduler] Remove direct Luxon usages in tests

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/current-time-indicator/CalendarGridCurrentTimeIndicator.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/current-time-indicator/CalendarGridCurrentTimeIndicator.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 
 describe('<CalendarGrid.CurrentTimeIndicator />', () => {
   const { render } = createSchedulerRenderer();
 
-  const day = DateTime.now();
+  const day = adapter.date();
 
   describeConformance(<CalendarGrid.CurrentTimeIndicator />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.DayCell />', () => {
   const { render } = createSchedulerRenderer();
 
-  const day = DateTime.now();
+  const day = adapter.date();
 
   describeConformance(<CalendarGrid.DayCell value={day} />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/calendar-grid/day-event-placeholder/CalendarGridDayEventPlaceholder.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event-placeholder/CalendarGridDayEventPlaceholder.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.DayEventPlaceholder />', () => {
   const { render } = createSchedulerRenderer();
 
-  const eventStart = DateTime.now();
-  const eventEnd = eventStart.plus({ hours: 1 });
+  const eventStart = adapter.date();
+  const eventEnd = adapter.addHours(eventStart, 1);
 
   describeConformance(<CalendarGrid.DayEventPlaceholder />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/calendar-grid/day-event-resize-handler/CalendarGridDayEventResizeHandler.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event-resize-handler/CalendarGridDayEventResizeHandler.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.DayEventResizeHandler />', () => {
   const { render } = createSchedulerRenderer();
 
-  const eventStart = DateTime.now();
-  const eventEnd = eventStart.plus({ hours: 1 });
+  const eventStart = adapter.date();
+  const eventEnd = adapter.addHours(eventStart, 1);
 
   describeConformance(<CalendarGrid.DayEventResizeHandler side="start" />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 
 describe('<CalendarGrid.DayEvent />', () => {
   const { render } = createSchedulerRenderer();
 
-  const eventStart = DateTime.now();
-  const eventEnd = eventStart.plus({ hours: 1 });
+  const eventStart = adapter.date();
+  const eventEnd = adapter.addHours(eventStart, 1);
 
   describeConformance(
     <CalendarGrid.DayEvent

--- a/packages/x-scheduler-headless/src/calendar-grid/day-row/CalendarGridDayRow.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-row/CalendarGridDayRow.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.DayRow />', () => {
   const { render } = createSchedulerRenderer();
 
-  const day = DateTime.now();
+  const day = adapter.date();
 
   describeConformance(
     <CalendarGrid.DayRow start={day.startOf('day')} end={day.endOf('day')} />,

--- a/packages/x-scheduler-headless/src/calendar-grid/time-column/CalendarGridTimeColumn.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-column/CalendarGridTimeColumn.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 
 describe('<CalendarGrid.TimeColumn />', () => {
   const { render } = createSchedulerRenderer();
 
-  const day = DateTime.now();
+  const day = adapter.date();
 
   describeConformance(
     <CalendarGrid.TimeColumn start={day.startOf('day')} end={day.endOf('day')} />,

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event-placeholder/CalendarGridTimeEventPlaceholder.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event-placeholder/CalendarGridTimeEventPlaceholder.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.TimeEventPlaceholder />', () => {
   const { render } = createSchedulerRenderer();
 
-  const eventStart = DateTime.now();
-  const eventEnd = eventStart.plus({ hours: 1 });
+  const eventStart = adapter.date();
+  const eventEnd = adapter.addHours(eventStart, 1);
 
   describeConformance(
     <CalendarGrid.TimeEventPlaceholder start={eventStart} end={eventEnd} />,

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event-resize-handler/CalendarGridTimeEventResizeHandler.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event-resize-handler/CalendarGridTimeEventResizeHandler.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.TimeEventResizeHandler />', () => {
   const { render } = createSchedulerRenderer();
 
-  const eventStart = DateTime.now();
-  const eventEnd = eventStart.plus({ hours: 1 });
+  const eventStart = adapter.date();
+  const eventEnd = adapter.addHours(eventStart, 1);
 
   describeConformance(<CalendarGrid.TimeEventResizeHandler side="start" />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.test.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { CalendarGrid } from '@mui/x-scheduler-headless/calendar-grid';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 import { EventCalendarProvider } from '@mui/x-scheduler-headless/event-calendar-provider';
 
 describe('<CalendarGrid.TimeEvent />', () => {
   const { render } = createSchedulerRenderer();
 
-  const eventStart = DateTime.now();
-  const eventEnd = eventStart.plus({ hours: 1 });
+  const eventStart = adapter.date();
+  const eventEnd = adapter.addHours(eventStart, 1);
 
   describeConformance(
     <CalendarGrid.TimeEvent

--- a/packages/x-scheduler-headless/src/timeline/event-row/TimelineEventRow.test.tsx
+++ b/packages/x-scheduler-headless/src/timeline/event-row/TimelineEventRow.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { Timeline } from '@mui/x-scheduler-headless/timeline';
 import { TimelineProvider } from '@mui/x-scheduler-headless/timeline-provider';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
-import { DateTime } from 'luxon';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 
 describe('<Timeline.EventRow />', () => {
   const { render } = createSchedulerRenderer();
 
-  const start = DateTime.now().startOf('day');
-  const end = DateTime.now().endOf('day');
+  const start = adapter.startOfDay(adapter.date());
+  const end = adapter.endOfDay(adapter.date());
 
   describeConformance(<Timeline.EventRow start={start} end={end} />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/timeline/event/TimelineEvent.test.tsx
+++ b/packages/x-scheduler-headless/src/timeline/event/TimelineEvent.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { Timeline } from '@mui/x-scheduler-headless/timeline';
 import { TimelineProvider } from '@mui/x-scheduler-headless/timeline-provider';
-import { createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
-import { DateTime } from 'luxon';
+import { adapter, createSchedulerRenderer, describeConformance } from 'test/utils/scheduler';
 
 describe('<Timeline.Event />', () => {
   const { render } = createSchedulerRenderer();
 
-  const start = DateTime.now().startOf('day');
-  const end = DateTime.now().endOf('day');
+  const start = adapter.startOfDay(adapter.date());
+  const end = adapter.endOfDay(adapter.date());
 
   describeConformance(<Timeline.Event start={start} end={end} />, () => ({
     refInstanceof: window.HTMLDivElement,

--- a/packages/x-scheduler-headless/src/use-adapter/useAdapter.test.ts
+++ b/packages/x-scheduler-headless/src/use-adapter/useAdapter.test.ts
@@ -1,19 +1,18 @@
-import { DateTime } from 'luxon';
 import { adapter } from 'test/utils/scheduler';
 import { diffIn, isWeekend } from './useAdapter';
 
 describe('date-utils', () => {
   describe('isWeekend', () => {
     it('returns false for weekday (e.g. Wednesday)', () => {
-      const wed = DateTime.fromISO('2025-01-08T12:00:00Z');
+      const wed = adapter.date('2025-01-08T12:00:00Z');
       expect(isWeekend(adapter, wed)).to.equal(false);
     });
 
     it('returns true for Saturday or Sunday', () => {
-      const sat = DateTime.fromISO('2025-01-11T12:00:00Z');
+      const sat = adapter.date('2025-01-11T12:00:00Z');
       expect(isWeekend(adapter, sat)).to.equal(true);
 
-      const sun = DateTime.fromISO('2025-01-12T12:00:00Z');
+      const sun = adapter.date('2025-01-12T12:00:00Z');
       expect(isWeekend(adapter, sun)).to.equal(true);
     });
   });
@@ -21,104 +20,104 @@ describe('date-utils', () => {
   describe('diffIn', () => {
     describe('minutes', () => {
       it('returns whole-minute difference for same-hour timestamps (floored)', () => {
-        const later = DateTime.fromISO('2025-04-10T10:45:30Z');
-        const earlier = DateTime.fromISO('2025-04-10T10:00:10Z');
+        const later = adapter.date('2025-04-10T10:45:30Z');
+        const earlier = adapter.date('2025-04-10T10:00:10Z');
         // 45m 20s -> 45
         expect(diffIn(adapter, later, earlier, 'minutes')).to.equal(45);
       });
 
       it('returns negative value when first date is earlier than second', () => {
-        const earlier = DateTime.fromISO('2025-04-10T10:00:10Z');
-        const later = DateTime.fromISO('2025-04-10T10:45:30Z');
+        const earlier = adapter.date('2025-04-10T10:00:10Z');
+        const later = adapter.date('2025-04-10T10:45:30Z');
         // -45m 20s -> -46 after floor
         expect(diffIn(adapter, earlier, later, 'minutes')).to.equal(-46);
       });
 
       it('returns 0 when both instants are identical', () => {
-        const t = DateTime.fromISO('2025-04-10T10:45:30Z');
+        const t = adapter.date('2025-04-10T10:45:30Z');
         expect(diffIn(adapter, t, t, 'minutes')).to.equal(0);
       });
     });
 
     describe('days', () => {
       it('ignores time-of-day and compares calendar dates only (end of day vs start of day)', () => {
-        const endOf = DateTime.fromISO('2025-02-15T23:59:59Z');
-        const startOf = DateTime.fromISO('2025-02-10T00:00:01Z');
+        const endOf = adapter.date('2025-02-15T23:59:59Z');
+        const startOf = adapter.date('2025-02-10T00:00:01Z');
         // Calendar span: 10 -> 15 = 5 days
         expect(diffIn(adapter, endOf, startOf, 'days')).to.equal(5);
       });
 
       it('handles month boundary correctly (Feb to Mar)', () => {
-        const a = DateTime.fromISO('2025-03-02T05:00:00Z');
-        const b = DateTime.fromISO('2025-02-27T18:00:00Z');
+        const a = adapter.date('2025-03-02T05:00:00Z');
+        const b = adapter.date('2025-02-27T18:00:00Z');
         // 27 -> 28 -> 1 -> 2 = 3
         expect(diffIn(adapter, a, b, 'days')).to.equal(3);
       });
 
       it('returns negative days when order is reversed', () => {
-        const earlier = DateTime.fromISO('2025-03-02T12:00:00Z');
-        const later = DateTime.fromISO('2025-03-05T01:00:00Z');
+        const earlier = adapter.date('2025-03-02T12:00:00Z');
+        const later = adapter.date('2025-03-05T01:00:00Z');
         expect(diffIn(adapter, earlier, later, 'days')).to.equal(-3);
       });
     });
 
     describe('weeks', () => {
       it('computes whole-week difference based on startOfWeek alignment', () => {
-        const week3 = DateTime.fromISO('2025-01-18T09:00:00Z');
-        const week1 = DateTime.fromISO('2025-01-03T09:00:00Z');
+        const week3 = adapter.date('2025-01-18T09:00:00Z');
+        const week1 = adapter.date('2025-01-03T09:00:00Z');
         expect(diffIn(adapter, week3, week1, 'weeks')).to.equal(2);
       });
 
       it('returns 0 for dates inside the same calendar week', () => {
-        const monday = DateTime.fromISO('2025-01-06T08:00:00Z');
-        const friday = DateTime.fromISO('2025-01-10T18:00:00Z');
+        const monday = adapter.date('2025-01-06T08:00:00Z');
+        const friday = adapter.date('2025-01-10T18:00:00Z');
         expect(diffIn(adapter, friday, monday, 'weeks')).to.equal(0);
       });
 
       it('returns negative when first date is in an earlier week', () => {
-        const earlierWeek = DateTime.fromISO('2025-01-06T12:00:00Z');
-        const laterWeek = DateTime.fromISO('2025-01-27T12:00:00Z');
+        const earlierWeek = adapter.date('2025-01-06T12:00:00Z');
+        const laterWeek = adapter.date('2025-01-27T12:00:00Z');
         expect(diffIn(adapter, earlierWeek, laterWeek, 'weeks')).to.equal(-3);
       });
     });
 
     describe('months', () => {
       it('computes difference across year boundary', () => {
-        const a = DateTime.fromISO('2026-03-10T00:00:00Z');
-        const b = DateTime.fromISO('2025-12-10T00:00:00Z');
+        const a = adapter.date('2026-03-10T00:00:00Z');
+        const b = adapter.date('2025-12-10T00:00:00Z');
         // Dec(2025) -> Mar(2026) = 3
         expect(diffIn(adapter, a, b, 'months')).to.equal(3);
       });
 
       it('returns negative for earlier month', () => {
-        const earlierMonth = DateTime.fromISO('2025-05-01T00:00:00Z');
-        const laterMonth = DateTime.fromISO('2025-07-01T00:00:00Z');
+        const earlierMonth = adapter.date('2025-05-01T00:00:00Z');
+        const laterMonth = adapter.date('2025-07-01T00:00:00Z');
         expect(diffIn(adapter, earlierMonth, laterMonth, 'months')).to.equal(-2);
       });
 
       it('returns 0 for same month regardless of day/time', () => {
-        const a = DateTime.fromISO('2025-07-31T23:59:59Z');
-        const b = DateTime.fromISO('2025-07-01T00:00:00Z');
+        const a = adapter.date('2025-07-31T23:59:59Z');
+        const b = adapter.date('2025-07-01T00:00:00Z');
         expect(diffIn(adapter, a, b, 'months')).to.equal(0);
       });
     });
 
     describe('years', () => {
       it('returns positive difference across multiple years', () => {
-        const a = DateTime.fromISO('2030-05-01T00:00:00Z');
-        const b = DateTime.fromISO('2025-05-01T00:00:00Z');
+        const a = adapter.date('2030-05-01T00:00:00Z');
+        const b = adapter.date('2025-05-01T00:00:00Z');
         expect(diffIn(adapter, a, b, 'years')).to.equal(5);
       });
 
       it('returns negative difference when first date is earlier', () => {
-        const a = DateTime.fromISO('2022-12-31T23:59:59Z');
-        const b = DateTime.fromISO('2025-01-01T00:00:00Z');
+        const a = adapter.date('2022-12-31T23:59:59Z');
+        const b = adapter.date('2025-01-01T00:00:00Z');
         expect(diffIn(adapter, a, b, 'years')).to.equal(-3);
       });
 
       it('returns 0 for dates within the same calendar year', () => {
-        const a = DateTime.fromISO('2025-12-31T23:59:59Z');
-        const b = DateTime.fromISO('2025-01-01T00:00:00Z');
+        const a = adapter.date('2025-12-31T23:59:59Z');
+        const b = adapter.date('2025-01-01T00:00:00Z');
         expect(diffIn(adapter, a, b, 'years')).to.equal(0);
       });
     });

--- a/packages/x-scheduler-headless/src/use-adapter/useAdapter.ts
+++ b/packages/x-scheduler-headless/src/use-adapter/useAdapter.ts
@@ -4,6 +4,8 @@ import { Adapter } from './useAdapter.types';
 
 export const DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS = new AdapterLuxon();
 
+export const DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS_FR = new AdapterLuxon({ locale: 'fr' });
+
 // TODO: Replace with Base UI adapter when available.
 export function useAdapter() {
   return DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS;

--- a/packages/x-scheduler-headless/src/utils/date-utils.test.ts
+++ b/packages/x-scheduler-headless/src/utils/date-utils.test.ts
@@ -1,12 +1,11 @@
-import { DateTime } from 'luxon';
 import { adapter } from 'test/utils/scheduler';
 import { mergeDateAndTime } from './date-utils';
 
 describe('date-utils', () => {
   describe('mergeDateAndTime', () => {
     it('merges hour/minute/second/ms from timeParam into dateParam', () => {
-      const date = DateTime.fromISO('2025-03-10T00:00:00Z');
-      const time = DateTime.fromISO('2024-12-25T13:45:27.123Z');
+      const date = adapter.date('2025-03-10T00:00:00Z');
+      const time = adapter.date('2024-12-25T13:45:27.123Z');
       const merged = mergeDateAndTime(adapter, date, time);
       expect(adapter.getYear(merged)).to.equal(2025);
       expect(adapter.getMonth(merged)).to.equal(2);

--- a/packages/x-scheduler-headless/src/utils/recurrence-utils.test.ts
+++ b/packages/x-scheduler-headless/src/utils/recurrence-utils.test.ts
@@ -1,5 +1,4 @@
-import { DateTime } from 'luxon';
-import { adapter } from 'test/utils/scheduler';
+import { adapter, adapterFr } from 'test/utils/scheduler';
 import {
   ByDayCode,
   ByDayValue,
@@ -26,29 +25,12 @@ import {
   applyRecurringUpdateAll,
 } from './recurrence-utils';
 import { diffIn } from '../use-adapter';
-import { Adapter } from '../use-adapter/useAdapter.types';
 
 describe('recurrence-utils', () => {
   describe('getByDayMaps', () => {
-    type MiniAdapter = Pick<Adapter<any>, 'date' | 'addDays' | 'getDayOfWeek'>;
-
-    const ISO_ADAPTER = {
-      date: (value?: string | null) => adapter.date(value as string),
-      addDays: adapter.addDays,
-      // TODO: Do not use Luxon APIs directly
-      getDayOfWeek: (d: DateTime) => d.weekday,
-    } as unknown as MiniAdapter;
-
-    const SUNDAY_FIRST_ADAPTER = {
-      date: (value?: string | null) => adapter.date(value as string),
-      addDays: adapter.addDays,
-      // TODO: Do not use Luxon APIs directly
-      getDayOfWeek: (d: DateTime) => (d.weekday === 7 ? 1 : d.weekday + 1),
-    } as unknown as MiniAdapter;
-
     const ALL_CODES: ByDayCode[] = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
-    it('respects ISO Mon=1 numbering', () => {
-      const { byDayToNum, numToByDay } = getByDayMaps(ISO_ADAPTER as Adapter);
+    it('respects fr locale Mon=1 numbering', () => {
+      const { byDayToNum, numToByDay } = getByDayMaps(adapterFr);
 
       expect(byDayToNum.MO).to.equal(1);
       expect(byDayToNum.SU).to.equal(7);
@@ -59,8 +41,8 @@ describe('recurrence-utils', () => {
       });
     });
 
-    it('respects Sunday=1 numbering', () => {
-      const { byDayToNum, numToByDay } = getByDayMaps(SUNDAY_FIRST_ADAPTER as Adapter);
+    it('respects enUS locale Sunday=1 numbering', () => {
+      const { byDayToNum, numToByDay } = getByDayMaps(adapter);
 
       expect(byDayToNum.SU).to.equal(1);
       expect(byDayToNum.MO).to.equal(2);

--- a/packages/x-scheduler/src/agenda-view/AgendaView.test.tsx
+++ b/packages/x-scheduler/src/agenda-view/AgendaView.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
-import { DateTime } from 'luxon';
 import { spy } from 'sinon';
 import { adapter, createSchedulerRenderer } from 'test/utils/scheduler';
 import { EventCalendar } from '@mui/x-scheduler/event-calendar';
@@ -11,7 +10,7 @@ describe('<AgendaView />', () => {
   describe('time navigation', () => {
     it('should go to previous agenda period (12 days) when clicking on the Previous Agenda button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z');
 
       const { user } = render(
         <EventCalendar
@@ -30,7 +29,7 @@ describe('<AgendaView />', () => {
 
     it('should go to next agenda period (12 days) when clicking on the Next Agenda button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z');
 
       const { user } = render(
         <EventCalendar

--- a/packages/x-scheduler/src/day-view/DayView.test.tsx
+++ b/packages/x-scheduler/src/day-view/DayView.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
-import { DateTime } from 'luxon';
 import { spy } from 'sinon';
 import { adapter, createSchedulerRenderer } from 'test/utils/scheduler';
 import { EventCalendar } from '@mui/x-scheduler/event-calendar';
@@ -11,7 +10,7 @@ describe('<DayView />', () => {
   describe('time navigation', () => {
     it('should go to start of previous day when clicking on the Previous Day button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z');
 
       const { user } = render(
         <EventCalendar
@@ -30,7 +29,7 @@ describe('<DayView />', () => {
 
     it('should go to start of next day when clicking on the Next Day button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z');
 
       const { user } = render(
         <EventCalendar

--- a/packages/x-scheduler/src/event-calendar/EventCalendar.test.tsx
+++ b/packages/x-scheduler/src/event-calendar/EventCalendar.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { screen } from '@mui/internal-test-utils';
-import { createSchedulerRenderer } from 'test/utils/scheduler';
+import { adapter, createSchedulerRenderer } from 'test/utils/scheduler';
 import { EventCalendar } from '@mui/x-scheduler/event-calendar';
 import {
   changeTo24HoursFormat,
@@ -21,14 +20,14 @@ describe('EventCalendar', () => {
         events={[
           {
             id: '1',
-            start: DateTime.fromISO('2025-05-26T07:30:00'),
-            end: DateTime.fromISO('2025-05-26T08:15:00'),
+            start: adapter.date('2025-05-26T07:30:00'),
+            end: adapter.date('2025-05-26T08:15:00'),
             title: 'Running',
           },
           {
             id: '2',
-            start: DateTime.fromISO('2025-05-27T16:00:00'),
-            end: DateTime.fromISO('2025-05-27T17:00:00'),
+            start: adapter.date('2025-05-27T16:00:00'),
+            end: adapter.date('2025-05-27T17:00:00'),
             title: 'Weekly',
           },
         ]}
@@ -57,15 +56,15 @@ describe('EventCalendar', () => {
         events={[
           {
             id: '1',
-            start: DateTime.fromISO('2025-05-26T07:30:00'),
-            end: DateTime.fromISO('2025-05-26T08:15:00'),
+            start: adapter.date('2025-05-26T07:30:00'),
+            end: adapter.date('2025-05-26T08:15:00'),
             title: 'Running',
             resource: '1',
           },
           {
             id: '2',
-            start: DateTime.fromISO('2025-05-27T16:00:00'),
-            end: DateTime.fromISO('2025-05-27T17:00:00'),
+            start: adapter.date('2025-05-27T16:00:00'),
+            end: adapter.date('2025-05-27T17:00:00'),
             title: 'Weekly',
             resource: '2',
           },
@@ -220,8 +219,8 @@ describe('EventCalendar', () => {
           events={[
             {
               id: '1',
-              start: DateTime.fromISO('2025-05-26T07:30:00'),
-              end: DateTime.fromISO('2025-05-26T08:15:00'),
+              start: adapter.date('2025-05-26T07:30:00'),
+              end: adapter.date('2025-05-26T08:15:00'),
               title: 'Running',
             },
           ]}
@@ -253,8 +252,8 @@ describe('EventCalendar', () => {
           events={[
             {
               id: '1',
-              start: DateTime.fromISO('2025-05-26T07:30:00'),
-              end: DateTime.fromISO('2025-05-26T08:15:00'),
+              start: adapter.date('2025-05-26T07:30:00'),
+              end: adapter.date('2025-05-26T08:15:00'),
               title: 'Running',
             },
           ]}

--- a/packages/x-scheduler/src/month-view/MonthView.test.tsx
+++ b/packages/x-scheduler/src/month-view/MonthView.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { adapter, createSchedulerRenderer } from 'test/utils/scheduler';
 import { screen, within } from '@mui/internal-test-utils';
 import { CalendarEvent } from '@mui/x-scheduler-headless/models';
@@ -11,14 +10,14 @@ import { EventCalendar } from '../event-calendar';
 const events: CalendarEvent[] = [
   {
     id: '1',
-    start: DateTime.fromISO('2025-05-01T09:00:00'),
-    end: DateTime.fromISO('2025-05-01T10:00:00'),
+    start: adapter.date('2025-05-01T09:00:00'),
+    end: adapter.date('2025-05-01T10:00:00'),
     title: 'Meeting',
   },
   {
     id: '2',
-    start: DateTime.fromISO('2025-05-15T14:00:00'),
-    end: DateTime.fromISO('2025-05-15T15:00:00'),
+    start: adapter.date('2025-05-15T14:00:00'),
+    end: adapter.date('2025-05-15T15:00:00'),
     title: 'Doctor Appointment',
   },
 ];
@@ -26,36 +25,36 @@ const events: CalendarEvent[] = [
 const allDayEvents: CalendarEvent[] = [
   {
     id: 'all-day-1',
-    start: DateTime.fromISO('2025-05-05T00:00:00'),
-    end: DateTime.fromISO('2025-05-07T23:59:59'),
+    start: adapter.date('2025-05-05T00:00:00'),
+    end: adapter.date('2025-05-07T23:59:59'),
     title: 'Multi-day Conference',
     allDay: true,
   },
   {
     id: 'all-day-2',
-    start: DateTime.fromISO('2025-04-28T00:00:00'), // Previous week
-    end: DateTime.fromISO('2025-05-06T23:59:59'), // Current week
+    start: adapter.date('2025-04-28T00:00:00'), // Previous week
+    end: adapter.date('2025-05-06T23:59:59'), // Current week
     title: 'Long Event',
     allDay: true,
   },
   {
     id: 'all-day-3',
-    start: DateTime.fromISO('2025-05-12T00:00:00'),
-    end: DateTime.fromISO('2025-05-14T23:59:59'),
+    start: adapter.date('2025-05-12T00:00:00'),
+    end: adapter.date('2025-05-14T23:59:59'),
     title: 'Grid Row Test',
     allDay: true,
   },
   {
     id: 'all-day-4',
-    start: DateTime.fromISO('2025-05-14T00:00:00'),
-    end: DateTime.fromISO('2025-05-16T23:59:59'),
+    start: adapter.date('2025-05-14T00:00:00'),
+    end: adapter.date('2025-05-16T23:59:59'),
     title: 'Three Day Event',
     allDay: true,
   },
   {
     id: 'all-day-5',
-    start: DateTime.fromISO('2025-05-06T00:00:00'),
-    end: DateTime.fromISO('2025-05-16T23:59:59'),
+    start: adapter.date('2025-05-06T00:00:00'),
+    end: adapter.date('2025-05-16T23:59:59'),
     title: 'Multiple week event',
     allDay: true,
   },
@@ -117,7 +116,7 @@ describe('<MonthView />', () => {
     expect(handleViewChange.firstCall.firstArg).to.equal('day');
     expect(handleVisibleDateChange.calledOnce).to.equal(true);
     expect(handleVisibleDateChange.firstCall.firstArg).toEqualDateTime(
-      DateTime.fromISO('2025-05-15T00:00:00'),
+      adapter.date('2025-05-15T00:00:00'),
     );
   });
 
@@ -135,32 +134,32 @@ describe('<MonthView />', () => {
     const manyEvents = [
       {
         id: '1',
-        start: DateTime.fromISO('2025-05-01T08:00:00'),
-        end: DateTime.fromISO('2025-05-01T09:00:00'),
+        start: adapter.date('2025-05-01T08:00:00'),
+        end: adapter.date('2025-05-01T09:00:00'),
         title: 'Breakfast',
       },
       {
         id: '2',
-        start: DateTime.fromISO('2025-05-01T09:30:00'),
-        end: DateTime.fromISO('2025-05-01T10:30:00'),
+        start: adapter.date('2025-05-01T09:30:00'),
+        end: adapter.date('2025-05-01T10:30:00'),
         title: 'Team Standup',
       },
       {
         id: '3',
-        start: DateTime.fromISO('2025-05-01T11:00:00'),
-        end: DateTime.fromISO('2025-05-01T12:00:00'),
+        start: adapter.date('2025-05-01T11:00:00'),
+        end: adapter.date('2025-05-01T12:00:00'),
         title: 'Client Call',
       },
       {
         id: '4',
-        start: DateTime.fromISO('2025-05-01T13:00:00'),
-        end: DateTime.fromISO('2025-05-01T14:00:00'),
+        start: adapter.date('2025-05-01T13:00:00'),
+        end: adapter.date('2025-05-01T14:00:00'),
         title: 'Lunch',
       },
       {
         id: '5',
-        start: DateTime.fromISO('2025-05-01T15:00:00'),
-        end: DateTime.fromISO('2025-05-01T16:00:00'),
+        start: adapter.date('2025-05-01T15:00:00'),
+        end: adapter.date('2025-05-01T16:00:00'),
         title: 'Design Review',
       },
     ];
@@ -245,22 +244,22 @@ describe('<MonthView />', () => {
       const overlappingEvents = [
         {
           id: 'event-1',
-          start: DateTime.fromISO('2025-05-12T00:00:00'),
-          end: DateTime.fromISO('2025-05-14T23:59:59'),
+          start: adapter.date('2025-05-12T00:00:00'),
+          end: adapter.date('2025-05-14T23:59:59'),
           title: 'Event 1',
           allDay: true,
         },
         {
           id: 'event-2',
-          start: DateTime.fromISO('2025-05-13T00:00:00'),
-          end: DateTime.fromISO('2025-05-15T23:59:59'),
+          start: adapter.date('2025-05-13T00:00:00'),
+          end: adapter.date('2025-05-15T23:59:59'),
           title: 'Event 2',
           allDay: true,
         },
         {
           id: 'event-3',
-          start: DateTime.fromISO('2025-05-16T00:00:00'),
-          end: DateTime.fromISO('2025-05-17T23:59:59'),
+          start: adapter.date('2025-05-16T00:00:00'),
+          end: adapter.date('2025-05-17T23:59:59'),
           title: 'Event 3',
           allDay: true,
         },
@@ -330,7 +329,7 @@ describe('<MonthView />', () => {
   describe('time navigation', () => {
     it('should go to start of previous month when clicking on the Previous Month button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z');
 
       const { user } = render(
         <EventCalendar
@@ -349,7 +348,7 @@ describe('<MonthView />', () => {
 
     it('should go to start of next month when clicking on the Next Month button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z');
 
       const { user } = render(
         <EventCalendar

--- a/packages/x-scheduler/src/timeline/Timeline.test.tsx
+++ b/packages/x-scheduler/src/timeline/Timeline.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { screen } from '@mui/internal-test-utils';
 import { diffIn } from '@mui/x-scheduler-headless/use-adapter';
 import { Timeline } from '@mui/x-scheduler/timeline';
@@ -15,22 +14,22 @@ const baseEvents: CalendarEvent[] = [
   {
     id: 'event-1',
     title: 'Spec Review',
-    start: DateTime.fromISO('2025-07-03T09:00:00Z'),
-    end: DateTime.fromISO('2025-07-03T10:00:00Z'),
+    start: adapter.date('2025-07-03T09:00:00Z'),
+    end: adapter.date('2025-07-03T10:00:00Z'),
     resource: 'resource-1',
   },
   {
     id: 'event-2',
     title: 'UX Sync',
-    start: DateTime.fromISO('2025-07-03T11:00:00Z'),
-    end: DateTime.fromISO('2025-07-06T12:00:00Z'),
+    start: adapter.date('2025-07-03T11:00:00Z'),
+    end: adapter.date('2025-07-06T12:00:00Z'),
     resource: 'resource-2',
   },
   {
     id: 'event-3',
     title: 'Architecture Session',
-    start: DateTime.fromISO('2025-07-04T13:00:00Z'),
-    end: DateTime.fromISO('2025-08-04T14:30:00Z'),
+    start: adapter.date('2025-07-04T13:00:00Z'),
+    end: adapter.date('2025-08-04T14:30:00Z'),
     resource: 'resource-1',
   },
 ];
@@ -40,7 +39,7 @@ describe('<Timeline />', () => {
     clockConfig: new Date('2025-07-03T00:00:00Z'),
   });
 
-  const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z');
+  const visibleDate = adapter.date('2025-07-03T00:00:00Z');
   function renderTimeline(options?: {
     resources?: CalendarResource[];
     events?: CalendarEvent[];
@@ -94,8 +93,8 @@ describe('<Timeline />', () => {
         {
           id: 'event-4',
           title: 'Out of range',
-          start: DateTime.fromISO('2050-07-04T13:00:00Z'),
-          end: DateTime.fromISO('2050-08-04T14:30:00Z'),
+          start: adapter.date('2050-07-04T13:00:00Z'),
+          end: adapter.date('2050-08-04T14:30:00Z'),
           resource: 'resource-1',
         },
       ];
@@ -178,8 +177,8 @@ describe('<Timeline />', () => {
         {
           id: 'event-4',
           title: 'Next month',
-          start: DateTime.fromISO('2025-08-04T13:00:00Z'),
-          end: DateTime.fromISO('2025-09-04T14:30:00Z'),
+          start: adapter.date('2025-08-04T13:00:00Z'),
+          end: adapter.date('2025-09-04T14:30:00Z'),
           resource: 'resource-1',
         },
       ];
@@ -209,15 +208,15 @@ describe('<Timeline />', () => {
         {
           id: 'event-1',
           title: 'This year',
-          start: DateTime.fromISO('2025-08-03T13:00:00Z'),
-          end: DateTime.fromISO('2025-09-04T14:30:00Z'),
+          start: adapter.date('2025-08-03T13:00:00Z'),
+          end: adapter.date('2025-09-04T14:30:00Z'),
           resource: 'resource-1',
         },
         {
           id: 'event-2',
           title: 'Next year',
-          start: DateTime.fromISO('2026-08-03T13:00:00Z'),
-          end: DateTime.fromISO('2026-09-04T14:30:00Z'),
+          start: adapter.date('2026-08-03T13:00:00Z'),
+          end: adapter.date('2026-09-04T14:30:00Z'),
           resource: 'resource-1',
         },
       ];

--- a/packages/x-scheduler/src/week-view/WeekView.test.tsx
+++ b/packages/x-scheduler/src/week-view/WeekView.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { DateTime } from 'luxon';
 import { spy } from 'sinon';
 import { adapter, createSchedulerRenderer } from 'test/utils/scheduler';
 import { screen, within } from '@mui/internal-test-utils';
@@ -10,22 +9,22 @@ import { StandaloneView } from '@mui/x-scheduler/standalone-view';
 const allDayEvents = [
   {
     id: 'all-day-1',
-    start: DateTime.fromISO('2025-05-05T00:00:00'),
-    end: DateTime.fromISO('2025-05-07T23:59:59'),
+    start: adapter.date('2025-05-05T00:00:00'),
+    end: adapter.date('2025-05-07T23:59:59'),
     title: 'Multi-day Conference',
     allDay: true,
   },
   {
     id: 'all-day-2',
-    start: DateTime.fromISO('2025-04-28T00:00:00'), // Previous week
-    end: DateTime.fromISO('2025-05-06T23:59:59'), // Current week
+    start: adapter.date('2025-04-28T00:00:00'), // Previous week
+    end: adapter.date('2025-05-06T23:59:59'), // Current week
     title: 'Long Event',
     allDay: true,
   },
   {
     id: 'all-day-3',
-    start: DateTime.fromISO('2025-05-04T00:00:00'),
-    end: DateTime.fromISO('2025-05-07T23:59:59'),
+    start: adapter.date('2025-05-04T00:00:00'),
+    end: adapter.date('2025-05-07T23:59:59'),
     title: 'Four day event',
     allDay: true,
   },
@@ -107,22 +106,22 @@ describe('<WeekView />', () => {
       const overlappingEvents = [
         {
           id: 'event-1',
-          start: DateTime.fromISO('2025-05-04T00:00:00'),
-          end: DateTime.fromISO('2025-05-06T23:59:59'),
+          start: adapter.date('2025-05-04T00:00:00'),
+          end: adapter.date('2025-05-06T23:59:59'),
           title: 'Event 1',
           allDay: true,
         },
         {
           id: 'event-2',
-          start: DateTime.fromISO('2025-05-05T00:00:00'),
-          end: DateTime.fromISO('2025-05-07T23:59:59'),
+          start: adapter.date('2025-05-05T00:00:00'),
+          end: adapter.date('2025-05-07T23:59:59'),
           title: 'Event 2',
           allDay: true,
         },
         {
           id: 'event-3',
-          start: DateTime.fromISO('2025-05-08T00:00:00'),
-          end: DateTime.fromISO('2025-05-09T23:59:59'),
+          start: adapter.date('2025-05-08T00:00:00'),
+          end: adapter.date('2025-05-09T23:59:59'),
           title: 'Event 3',
           allDay: true,
         },
@@ -180,7 +179,7 @@ describe('<WeekView />', () => {
   describe('time navigation', () => {
     it('should go to start of previous week when clicking on the Previous Week button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z'); // Thursday
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z'); // Thursday
 
       const { user } = render(
         <EventCalendar
@@ -199,7 +198,7 @@ describe('<WeekView />', () => {
 
     it('should go to start of next week when clicking on the Next Week button', async () => {
       const onVisibleDateChange = spy();
-      const visibleDate = DateTime.fromISO('2025-07-03T00:00:00Z'); // Thursday
+      const visibleDate = adapter.date('2025-07-03T00:00:00Z'); // Thursday
 
       const { user } = render(
         <EventCalendar

--- a/test/utils/scheduler/adapters.ts
+++ b/test/utils/scheduler/adapters.ts
@@ -1,4 +1,9 @@
-import { DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS } from '@mui/x-scheduler-headless/use-adapter';
+import {
+  DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS,
+  DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS_FR,
+} from '@mui/x-scheduler-headless/use-adapter';
 
 // TODO: Replace with Base UI adapter when available.
 export const adapter = DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS;
+
+export const adapterFr = DO_NOT_USE_THIS_VARIABLE_ADAPTER_CLASS_FR;


### PR DESCRIPTION
Will make the migration to Date Fns easier when the Base UI adapters are available