### PR TITLE
[scheduler] Group the hooks in the biggest components

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
@@ -45,22 +45,31 @@ export const CalendarGridDayEvent = React.forwardRef(function CalendarGridDayEve
   // to control whether the event should behave like a button
   const isInteractive = true;
 
+  // Context hooks
   const adapter = useAdapter();
   const store = useEventCalendarStoreContext();
   const { id: rootId } = useCalendarGridRootContext();
   const { start: rowStart, end: rowEnd } = useCalendarGridDayRowContext();
   const { index: cellIndex } = useCalendarGridDayCellContext();
 
+  // Ref hooks
   const ref = React.useRef<HTMLDivElement>(null);
+
+  // Selector hooks
+  const hasPlaceholder = useStore(store, selectors.hasOccurrencePlaceholder);
+  const isDragging = useStore(store, selectors.isOccurrenceMatchingThePlaceholder, occurrenceKey);
+
+  // State hooks
+  const [isResizing, setIsResizing] = React.useState(false);
+  const id = useId(idProp);
+
+  // Feature hooks
   const { getButtonProps, buttonRef } = useButton({
     disabled: !isInteractive,
     native: nativeButton,
   });
+
   const { state: eventState } = useEvent({ start, end });
-  const hasPlaceholder = useStore(store, selectors.hasOccurrencePlaceholder);
-  const isDragging = useStore(store, selectors.isOccurrenceMatchingThePlaceholder, occurrenceKey);
-  const [isResizing, setIsResizing] = React.useState(false);
-  const id = useId(idProp);
 
   const columnHeaderId = getCalendarGridHeaderCellId(rootId, cellIndex);
 

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.tsx
@@ -44,24 +44,32 @@ export const CalendarGridTimeEvent = React.forwardRef(function CalendarGridTimeE
   // to control whether the event should behave like a button
   const isInteractive = true;
 
+  // Context hooks
   const adapter = useAdapter();
-  const ref = React.useRef<HTMLDivElement>(null);
   const store = useEventCalendarStoreContext();
   const { id: rootId } = useCalendarGridRootContext();
-  const isDragging = useStore(store, selectors.isOccurrenceMatchingThePlaceholder, occurrenceKey);
-  const [isResizing, setIsResizing] = React.useState(false);
-  const { getButtonProps, buttonRef } = useButton({
-    disabled: !isInteractive,
-    native: nativeButton,
-  });
-  const id = useId(idProp);
-
   const {
     start: columnStart,
     end: columnEnd,
     index: columnIndex,
     getCursorPositionInElementMs,
   } = useCalendarGridTimeColumnContext();
+
+  // Ref hooks
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  // Selector hooks
+  const isDragging = useStore(store, selectors.isOccurrenceMatchingThePlaceholder, occurrenceKey);
+
+  // State hooks
+  const [isResizing, setIsResizing] = React.useState(false);
+  const id = useId(idProp);
+
+  // Feature hooks
+  const { getButtonProps, buttonRef } = useButton({
+    disabled: !isInteractive,
+    native: nativeButton,
+  });
 
   const { position, duration } = useElementPositionInCollection({
     start,

--- a/packages/x-scheduler/src/internals/components/date-navigator/DateNavigator.tsx
+++ b/packages/x-scheduler/src/internals/components/date-navigator/DateNavigator.tsx
@@ -16,9 +16,12 @@ export const DateNavigator = React.forwardRef(function DateNavigator(
 ) {
   const { className, ...other } = props;
 
+  // Context hooks
   const adapter = useAdapter();
   const store = useEventCalendarStoreContext();
   const translations = useTranslations();
+
+  // Selector hooks
   const view = useStore(store, selectors.view);
   const visibleDate = useStore(store, selectors.visibleDate);
   const isSidePanelOpen = useStore(store, selectors.preferences).isSidePanelOpen;

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayGridCell.tsx
@@ -14,11 +14,19 @@ import { useEventPopoverContext } from '../event-popover/EventPopoverContext';
 
 export function DayGridCell(props: DayGridCellProps) {
   const { day, row } = props;
+
+  // Context hooks
   const adapter = useAdapter();
-  const placeholder = CalendarGrid.usePlaceholderInDay(day.value, row);
   const store = useEventCalendarStoreContext();
+
+  // Ref hooks
   const cellRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Selector hooks
   const isCreation = useStore(store, selectors.isCreatingNewEventInDayCell, day.value);
+
+  // Feature hooks
+  const placeholder = CalendarGrid.usePlaceholderInDay(day.value, row);
 
   const { startEditing } = useEventPopoverContext();
 

--- a/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
+++ b/packages/x-scheduler/src/internals/components/day-time-grid/DayTimeGrid.tsx
@@ -24,28 +24,34 @@ export const DayTimeGrid = React.forwardRef(function DayTimeGrid(
 ) {
   const { days, className, ...other } = props;
 
+  // Context hooks
   const adapter = useAdapter();
   const translations = useTranslations();
+  const store = useEventCalendarStoreContext();
+
+  // Ref hooks
   const bodyRef = React.useRef<HTMLDivElement>(null);
   const allDayHeaderWrapperRef = React.useRef<HTMLDivElement>(null);
   const containerRef = React.useRef<HTMLElement | null>(null);
   const handleRef = useMergedRefs(forwardedRef, containerRef);
 
-  const store = useEventCalendarStoreContext();
+  // Selector hooks
   const visibleDate = useStore(store, selectors.visibleDate);
   const hasDayView = useStore(store, selectors.hasDayView);
   const now = useStore(store, selectors.nowUpdatedEveryMinute);
   const isMultiDayEvent = useStore(store, selectors.isMultiDayEvent);
   const ampm = useStore(store, selectors.ampm);
   const showCurrentTimeIndicator = useStore(store, selectors.showCurrentTimeIndicator);
-  const timeFormat = ampm ? 'hoursMinutes12h' : 'hoursMinutes24h';
 
+  // Feature hooks
   const occurrencesMap = useEventOccurrencesGroupedByDay({ days, renderEventIn: 'every-day' });
   const occurrences = useEventOccurrencesWithDayGridPosition({
     days,
     occurrencesMap,
     shouldAddPosition: isMultiDayEvent,
   });
+
+  const timeFormat = ampm ? 'hoursMinutes12h' : 'hoursMinutes24h';
 
   const { start, end } = React.useMemo(
     () => ({

--- a/packages/x-scheduler/src/internals/components/event-popover/EventPopover.tsx
+++ b/packages/x-scheduler/src/internals/components/event-popover/EventPopover.tsx
@@ -42,26 +42,32 @@ export const EventPopover = React.forwardRef(function EventPopover(
 ) {
   const { className, style, container, anchor, occurrence, onClose, ...other } = props;
 
+  // Context hooks
   const adapter = useAdapter();
   const translations = useTranslations();
   const store = useEventCalendarStoreContext();
+
+  // Selector hooks
   const isEventReadOnly = useStore(store, selectors.isEventReadOnly, occurrence.id);
   const resources = useStore(store, selectors.resources);
   const color = useStore(store, selectors.eventColor, occurrence.id);
   const rawPlaceholder = useStore(store, selectors.occurrencePlaceholder);
   const recurrencePresets = useStore(store, selectors.recurrencePresets, occurrence.start);
 
-  const fmtDate = (d: SchedulerValidDate) => adapter.formatByString(d, 'yyyy-MM-dd');
-  const fmtTime = (d: SchedulerValidDate) => adapter.formatByString(d, 'HH:mm');
-
+  // State hooks
   const [errors, setErrors] = React.useState<Form.Props['errors']>({});
   const [isAllDay, setIsAllDay] = React.useState<boolean>(Boolean(occurrence.allDay));
-  const [when, setWhen] = React.useState(() => ({
-    startDate: fmtDate(occurrence.start),
-    endDate: fmtDate(occurrence.end),
-    startTime: fmtTime(occurrence.start),
-    endTime: fmtTime(occurrence.end),
-  }));
+  const [when, setWhen] = React.useState(() => {
+    const fmtDate = (d: SchedulerValidDate) => adapter.formatByString(d, 'yyyy-MM-dd');
+    const fmtTime = (d: SchedulerValidDate) => adapter.formatByString(d, 'HH:mm');
+
+    return {
+      startDate: fmtDate(occurrence.start),
+      endDate: fmtDate(occurrence.end),
+      startTime: fmtTime(occurrence.start),
+      endTime: fmtTime(occurrence.end),
+    };
+  });
 
   function computeRange(next: typeof when, nextIsAllDay = isAllDay) {
     if (nextIsAllDay) {


### PR DESCRIPTION
We have a few files that start to be less readable because they have A LOT of contexts, ref and selectors.
WDYT about this small improvement? :eyes: 