### PR TITLE
[code-infra] Turn on all testing-library eslint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,9 +188,6 @@ export default defineConfig(
     ],
     extends: createTestConfig({ useMocha: false }),
     ignores: ['test/e2e/**/*', 'test/regressions/**/*'],
-    rules: {
-      'testing-library/no-container': 'off',
-    },
   },
   baseSpecRules,
 

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.zoom.test.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.zoom.test.tsx
@@ -57,6 +57,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const svg = container.querySelector('svg')!;
 
     await user.pointer([
@@ -116,6 +117,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
       expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
+      // eslint-disable-next-line testing-library/no-container
       const svg = container.querySelector('svg')!;
 
       // we drag one position so C should be visible
@@ -187,6 +189,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const target = container.querySelector('.MuiAreaElement-root')!;
 
     // We drag from right to left to pan the view
@@ -245,6 +248,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const svg = container.querySelector('svg')!;
 
     await user.pointer([
@@ -300,6 +304,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const svg = container.querySelector('svg')!;
 
     // Perform tap and drag gesture - tap once, then drag vertically up to zoom in
@@ -351,6 +356,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const svg = container.querySelector('svg')!;
 
     // Simulate the problematic scenario:
@@ -436,6 +442,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const svg = container.querySelector('svg')!;
 
     await user.pointer([
@@ -483,6 +490,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
+    // eslint-disable-next-line testing-library/no-container
     const svg = container.querySelector('svg')!;
 
     // we drag one position so C should be visible

--- a/packages/x-charts/src/ChartsLabel/ChartsLabelGradient.test.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelGradient.test.tsx
@@ -46,18 +46,21 @@ describe('<ChartsLabelGradient />', () => {
     describe('horizontal', () => {
       it('should render a gradient in the correct orientation', () => {
         const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" />);
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(0);
       });
 
       it('should reverse the gradient', () => {
         const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" reverse />);
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(180);
       });
 
       it('should rotate the gradient', () => {
         const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" rotate />);
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(90);
       });
@@ -66,6 +69,7 @@ describe('<ChartsLabelGradient />', () => {
         const { container } = render(
           <ChartsLabelGradient gradientId="gradient.test-id" reverse rotate />,
         );
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(-90);
       });
@@ -76,6 +80,7 @@ describe('<ChartsLabelGradient />', () => {
         const { container } = render(
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" />,
         );
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(-90);
       });
@@ -84,6 +89,7 @@ describe('<ChartsLabelGradient />', () => {
         const { container } = render(
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" reverse />,
         );
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(90);
       });
@@ -92,6 +98,7 @@ describe('<ChartsLabelGradient />', () => {
         const { container } = render(
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" rotate />,
         );
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(0);
       });
@@ -100,6 +107,7 @@ describe('<ChartsLabelGradient />', () => {
         const { container } = render(
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" reverse rotate />,
         );
+        // eslint-disable-next-line testing-library/no-container
         const svg = container.querySelector('svg');
         expect(matrixToRotation(svg)).to.equal(180);
       });
@@ -111,6 +119,7 @@ describe('<ChartsLabelGradient />', () => {
           const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" />, {
             wrapper: RtlWrapper,
           });
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           // Technically it is -180, but the browser will normalize it to 180
           expect(matrixToRotation(svg)).to.equal(180);
@@ -121,6 +130,7 @@ describe('<ChartsLabelGradient />', () => {
             <ChartsLabelGradient gradientId="gradient.test-id" reverse />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(0);
         });
@@ -130,6 +140,7 @@ describe('<ChartsLabelGradient />', () => {
             <ChartsLabelGradient gradientId="gradient.test-id" rotate />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(-90);
         });
@@ -139,6 +150,7 @@ describe('<ChartsLabelGradient />', () => {
             <ChartsLabelGradient gradientId="gradient.test-id" reverse rotate />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(90);
         });
@@ -150,6 +162,7 @@ describe('<ChartsLabelGradient />', () => {
             <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(-90);
         });
@@ -159,6 +172,7 @@ describe('<ChartsLabelGradient />', () => {
             <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" reverse />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(90);
         });
@@ -168,6 +182,7 @@ describe('<ChartsLabelGradient />', () => {
             <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" rotate />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(0);
         });
@@ -182,6 +197,7 @@ describe('<ChartsLabelGradient />', () => {
             />,
             { wrapper: RtlWrapper },
           );
+          // eslint-disable-next-line testing-library/no-container
           const svg = container.querySelector('svg');
           expect(matrixToRotation(svg)).to.equal(180);
         });

--- a/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.test.tsx
+++ b/packages/x-charts/src/ChartsLegend/PiecewiseColorLegend.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui/internal-test-utils';
+import { createRenderer, describeConformance, screen } from '@mui/internal-test-utils';
 import { PiecewiseColorLegend, piecewiseColorLegendClasses } from '@mui/x-charts/ChartsLegend';
 import { ChartDataProvider } from '@mui/x-charts/ChartDataProvider';
 import { ChartsSurface } from '@mui/x-charts/ChartsSurface';
@@ -51,7 +51,7 @@ describe('<PiecewiseColorLegend />', () => {
   }));
 
   it('should apply inline-start class when labelPosition="inline-start"', () => {
-    const { container } = render(
+    render(
       <ChartDataProvider
         height={50}
         width={50}
@@ -77,13 +77,11 @@ describe('<PiecewiseColorLegend />', () => {
       </ChartDataProvider>,
     );
 
-    expect(container.querySelector(`.${piecewiseColorLegendClasses.inlineStart}`)).not.to.equal(
-      null,
-    );
+    expect(screen.getByRole('list').className).contains(piecewiseColorLegendClasses.inlineStart);
   });
 
   it('should apply inline-end class when labelPosition="inline-end"', () => {
-    const { container } = render(
+    render(
       <ChartDataProvider
         height={50}
         width={50}
@@ -109,6 +107,6 @@ describe('<PiecewiseColorLegend />', () => {
       </ChartDataProvider>,
     );
 
-    expect(container.querySelector(`.${piecewiseColorLegendClasses.inlineEnd}`)).not.to.equal(null);
+    expect(screen.getByRole('list').className).contains(piecewiseColorLegendClasses.inlineEnd);
   });
 });

--- a/packages/x-charts/src/PieChart/PieChart.test.tsx
+++ b/packages/x-charts/src/PieChart/PieChart.test.tsx
@@ -96,6 +96,7 @@ describe('<PieChart />', () => {
     );
 
     // by default does not show focus indicator
+    /* eslint-disable testing-library/no-container */
     expect(container.querySelector(`.${pieArcClasses.focusIndicator}`)).not.toBeTruthy();
 
     // focus the chart
@@ -112,5 +113,6 @@ describe('<PieChart />', () => {
     expect(
       container.querySelector(`.${pieArcClasses.focusIndicator}.MuiPieArc-data-index-1`),
     ).toBeTruthy();
+    /* eslint-enable testing-library/no-container */
   });
 });

--- a/packages/x-charts/src/PieChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/PieChart/checkClickEvent.test.tsx
@@ -30,6 +30,7 @@ describe('PieChart - click event', () => {
           onItemClick={() => {}}
         />,
       );
+      // eslint-disable-next-line testing-library/no-container
       const slices = container.querySelectorAll<HTMLElement>('path.MuiPieArc-root');
 
       expect(Array.from(slices).map((slice) => slice.getAttribute('cursor'))).to.deep.equal([

--- a/packages/x-data-grid-pro/src/tests/infiniteLoader.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/infiniteLoader.DataGridPro.test.tsx
@@ -37,6 +37,7 @@ describe('<DataGridPro /> - Infinite loader', () => {
         );
       }
       const { container, setProps } = render(<TestCase rows={baseRows} />);
+      // eslint-disable-next-line testing-library/no-container
       const virtualScroller = container.querySelector('.MuiDataGrid-virtualScroller')!;
 
       // arbitrary number to make sure that the bottom of the grid window is reached.
@@ -183,6 +184,7 @@ describe('<DataGridPro /> - Infinite loader', () => {
         );
       }
       const { container } = render(<TestCase rows={baseRows} pinnedRows={basePinnedRows} />);
+      // eslint-disable-next-line testing-library/no-container
       const virtualScroller = container.querySelector('.MuiDataGrid-virtualScroller')!;
       // on the initial render, last row is not visible and the `observe` method is not called
       expect(observe.callCount).to.equal(0);

--- a/packages/x-data-grid-pro/src/tests/rowReorder.DataGridPro.test.tsx
+++ b/packages/x-data-grid-pro/src/tests/rowReorder.DataGridPro.test.tsx
@@ -306,6 +306,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Row reorder', () => {
     const { container } = render(<Test />);
 
     // Initially, no scroll areas should be visible
+    /* eslint-disable testing-library/no-container */
     expect(container.querySelectorAll(`.${gridClasses.scrollArea}`)).to.have.length(0);
 
     // Start dragging a row at the top (scroll = 0)
@@ -352,6 +353,7 @@ describe.skipIf(isJSDOM)('<DataGridPro /> - Row reorder', () => {
 
     // Scroll areas should be hidden again
     expect(container.querySelectorAll(`.${gridClasses.scrollArea}`)).to.have.length(0);
+    /* eslint-enable testing-library/no-container */
   });
 
   it('should allow row reordering when dragging from any cell during active reorder', () => {

--- a/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -96,15 +96,21 @@ describe('<DataGrid /> - Layout & warnings', () => {
         );
       }
 
-      const { container, setProps } = render(<TestCase width={300} />);
+      const { setProps } = render(<TestCase width={300} />);
       let rect;
-      rect = container.querySelector('[role="row"][data-rowindex="0"]')!.getBoundingClientRect();
+      rect = screen
+        .getAllByRole('row')
+        .find((el) => el.dataset.rowindex === '0')!
+        .getBoundingClientRect();
       expect(rect.width).to.equal(300 - 2);
 
       setProps({ width: 400 });
 
       await waitFor(() => {
-        rect = container.querySelector('[role="row"][data-rowindex="0"]')!.getBoundingClientRect();
+        rect = screen
+          .getAllByRole('row')
+          .find((el) => el.dataset.rowindex === '0')!
+          .getBoundingClientRect();
         expect(rect.width).to.equal(400 - 2);
       });
     });

--- a/packages/x-scheduler/src/internals/components/header-toolbar/HeaderToolbar.test.tsx
+++ b/packages/x-scheduler/src/internals/components/header-toolbar/HeaderToolbar.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createSchedulerRenderer } from 'test/utils/scheduler';
+import { screen } from '@mui/internal-test-utils';
 import { StandaloneView } from '@mui/x-scheduler/standalone-view';
+import { createSchedulerRenderer } from 'test/utils/scheduler';
 import { HeaderToolbar } from './HeaderToolbar';
 
 describe('<ViewSwitcher />', () => {
@@ -13,59 +14,71 @@ describe('<ViewSwitcher />', () => {
 
   // Rendering the HeaderToolbar instead of the ViewSwitcher directly - ViewSwitcher takes views as a prop from toolbar
   it('should render the first three views + Arrow down for the default set of views', () => {
-    const { container } = render(
+    render(
       <StandaloneView {...standaloneDefaults}>
         <HeaderToolbar />
       </StandaloneView>,
     );
 
-    const buttons = container.querySelectorAll('.MainItem');
-    expect(buttons).toHaveLength(4);
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.className.includes('MainItem'));
+
+    expect(buttons).toHaveLength(3);
     expect(buttons[0]).to.have.text('Week');
     expect(buttons[1]).to.have.text('Day');
     expect(buttons[2]).to.have.text('Month');
-    expect(buttons[3]).to.have.attribute('aria-label', 'Show more views');
+
+    expect(screen.getByRole('menuitem')).to.have.attribute('aria-label', 'Show more views');
   });
 
   it('should render the first three views + Arrow down for a custom set of views (with more than 3 views)', () => {
-    const { container } = render(
+    render(
       <StandaloneView {...standaloneDefaults} views={['agenda', 'week', 'day', 'month']}>
         <HeaderToolbar />
       </StandaloneView>,
     );
 
-    const buttons = container.querySelectorAll('.MainItem');
-    expect(buttons).toHaveLength(4);
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.className.includes('MainItem'));
+    expect(buttons).toHaveLength(3);
     expect(buttons[0]).to.have.text('Agenda');
     expect(buttons[1]).to.have.text('Week');
     expect(buttons[2]).to.have.text('Day');
-    expect(buttons[3]).to.have.attribute('aria-label', 'Show more views');
+    expect(screen.getByRole('menuitem')).to.have.attribute('aria-label', 'Show more views');
   });
 
   it('should render the first three views + the selected view for a custom set of views (with more than 3 views)', () => {
-    const { container } = render(
+    render(
       <StandaloneView {...standaloneDefaults} view="day" views={['agenda', 'week', 'day', 'month']}>
         <HeaderToolbar />
       </StandaloneView>,
     );
 
-    const buttons = container.querySelectorAll('.MainItem');
-    expect(buttons).toHaveLength(4);
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.className.includes('MainItem'));
+    expect(buttons).toHaveLength(3);
     expect(buttons[0]).to.have.text('Agenda');
     expect(buttons[1]).to.have.text('Week');
     expect(buttons[2]).to.have.text('Day');
-    expect(buttons[3]).to.have.attribute('aria-label', 'Show more views');
     expect(buttons[2]).to.have.attribute('data-pressed', 'true');
+
+    const menuButton = screen.getByRole('menuitem');
+    expect(menuButton).to.have.attribute('aria-label', 'Show more views');
   });
 
   it('should render the three first views for a custom set of views (with exactly 3 views)', () => {
-    const { container } = render(
+    render(
       <StandaloneView {...standaloneDefaults} views={['agenda', 'week', 'day']}>
         <HeaderToolbar />
       </StandaloneView>,
     );
 
-    const buttons = container.querySelectorAll('.MainItem');
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.className.includes('MainItem'));
     expect(buttons).toHaveLength(3);
     expect(buttons[0]).to.have.text('Agenda');
     expect(buttons[1]).to.have.text('Week');
@@ -73,13 +86,15 @@ describe('<ViewSwitcher />', () => {
   });
 
   it('should render the two first views for a custom set of views (with exactly 2 views)', () => {
-    const { container } = render(
+    render(
       <StandaloneView {...standaloneDefaults} views={['agenda', 'week']}>
         <HeaderToolbar />
       </StandaloneView>,
     );
 
-    const buttons = container.querySelectorAll('.MainItem');
+    const buttons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.className.includes('MainItem'));
     expect(buttons).toHaveLength(2);
     expect(buttons[0]).to.have.text('Agenda');
     expect(buttons[1]).to.have.text('Week');

--- a/packages/x-scheduler/src/timeline/Timeline.test.tsx
+++ b/packages/x-scheduler/src/timeline/Timeline.test.tsx
@@ -245,29 +245,27 @@ describe('<Timeline />', () => {
 
   describe('views', () => {
     it('should render the correct header and updates CSS variable when switching views', async () => {
-      const { container: firstContainer } = renderTimeline({
+      renderTimeline({
         view: 'time',
         views: ['days', 'time'],
       });
 
-      const rootElement = firstContainer.querySelector('.TimelineRoot') as HTMLElement;
-      expect(firstContainer.querySelector('.TimeHeader')).not.to.equal(null);
+      let rootElement = screen.getByRole('grid');
+      expect(rootElement.querySelector('.TimeHeader')).not.to.equal(null);
 
       expect(rootElement.style.getPropertyValue('--unit-width')).to.contain('time-cell-width');
 
       const daysSwitchControl = screen.getByRole('button', { name: /days/i });
       expect(daysSwitchControl).not.to.equal(null);
 
-      const { container: secondContainer } = renderTimeline({
+      renderTimeline({
         view: 'days',
         views: ['days', 'time'],
       });
 
-      const updatedRootElement = secondContainer.querySelector('.TimelineRoot') as HTMLElement;
-      expect(secondContainer.querySelector('.DaysHeader')).not.to.equal(null);
-      expect(updatedRootElement.style.getPropertyValue('--unit-width')).to.contain(
-        'days-cell-width',
-      );
+      rootElement = screen.getAllByRole('grid').at(-1) as HTMLElement;
+      expect(rootElement.querySelector('.DaysHeader')).not.to.equal(null);
+      expect(rootElement.style.getPropertyValue('--unit-width')).to.contain('days-cell-width');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

Mostly ignores the `testing-library/no-container` rule in some specific places where there is no other way to query the desired element.
To do this properly, it might require code changes in the component, ie, querying `svg` that has no other attributes.

Part of - https://github.com/mui/mui-public/issues/173

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
