### PR TITLE
[charts] Batch string measurements

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/getVisibleLabels.tsx
+++ b/packages/x-charts/src/ChartsXAxis/getVisibleLabels.tsx
@@ -2,8 +2,8 @@
 import { TickItemType } from '../hooks/useTicks';
 import { ChartsXAxisProps, ComputedXAxis } from '../models/axis';
 import { getMinXTranslation } from '../internals/geometry';
-import { getWordsByLines } from '../internals/getWordsByLines';
-import { warmUpStringSizeCache } from '../internals/domUtils';
+import { ChartsTextStyle } from '../internals/getWordsByLines';
+import { batchMeasureStrings } from '../internals/domUtils';
 
 /* Returns a set of indices of the tick labels that should be visible.  */
 export function getVisibleLabels<T extends TickItemType>(
@@ -22,19 +22,6 @@ export function getVisibleLabels<T extends TickItemType>(
       isXInside: (x: number) => boolean;
     },
 ): Set<T> {
-  const getTickLabelSize = (tick: T) => {
-    if (!isMounted || tick.formattedValue === undefined) {
-      return { width: 0, height: 0 };
-    }
-
-    const tickSizes = getWordsByLines({ style, needsComputation: true, text: tick.formattedValue });
-
-    return {
-      width: Math.max(...tickSizes.map((size) => size.width)),
-      height: Math.max(tickSizes.length * tickSizes[0].height),
-    };
-  };
-
   if (typeof tickLabelInterval === 'function') {
     return new Set(xTicks.filter((item, index) => tickLabelInterval(item.value, index)));
   }
@@ -55,10 +42,7 @@ export function getVisibleLabels<T extends TickItemType>(
     return isXInside(textPosition);
   });
 
-  warmUpStringSizeCache(
-    candidateTickLabels.map((t) => t.formattedValue ?? ''),
-    style,
-  );
+  const sizeMap = measureTickLabels(candidateTickLabels, style);
 
   return new Set(
     candidateTickLabels.filter((item, labelIndex) => {
@@ -74,7 +58,9 @@ export function getVisibleLabels<T extends TickItemType>(
       }
 
       /* Measuring text width is expensive, so we need to delay it as much as possible to improve performance. */
-      const { width, height } = getTickLabelSize(item);
+      const { width, height } = isMounted
+        ? getTickLabelSize(sizeMap, item)
+        : { width: 0, height: 0 };
 
       const distance = getMinXTranslation(width, height, style?.angle);
 
@@ -92,4 +78,38 @@ export function getVisibleLabels<T extends TickItemType>(
       return true;
     }),
   );
+}
+
+function getTickLabelSize<T extends TickItemType>(
+  sizeMap: Map<string | number, { width: number; height: number }>,
+  tick: T,
+) {
+  if (tick.formattedValue === undefined) {
+    return { width: 0, height: 0 };
+  }
+
+  let width = 0;
+  let height = 0;
+
+  for (const line of tick.formattedValue.split('\n')) {
+    const lineSize = sizeMap.get(line);
+    if (lineSize) {
+      width = Math.max(width, lineSize.width);
+      height += lineSize.height;
+    }
+  }
+
+  return { width, height };
+}
+
+function measureTickLabels<T extends TickItemType>(ticks: T[], style: ChartsTextStyle | undefined) {
+  const strings = new Set<string>();
+
+  for (const tick of ticks) {
+    if (tick.formattedValue) {
+      tick.formattedValue.split('\n').forEach((line) => strings.add(line));
+    }
+  }
+
+  return batchMeasureStrings(strings, style);
 }


### PR DESCRIPTION
Batch string measurements when getting a string's size. Most of the current slowdown is due to forced reflow. If we render a bunch of spans at once and measure them all, then we'll just have a single reflow. The trade-off is that we're rendering many more elements, but from preliminary results, the trade-off is worth it.  

The total render time of the example below **shows a 1.8x speed-up when rendering** (1.26s, down from 2.27s). The layout phase is 3.7x faster (132.9ms, down from 494.6ms) and time spent recalculating styles was reduced by 2.2 times (89.6ms, down from 199.7ms).

### Results

Still preliminary, but I'm seeing a big improvement. The results below were obtained using 4x CPU throttling.
I increased the cache to 10k in both cases to create a fair comparison.

<img width="634" height="419" alt="image" src="https://github.com/user-attachments/assets/0c09e9d5-e67d-441e-8a68-a8b278e9917a" />

<details>

<summary>Code</summary>

```tsx
import * as React from "react";
import Paper from "@mui/material/Paper";
import Box from "@mui/material/Box";
import { ChartContainer } from "@mui/x-charts/ChartContainer";
import { BarPlot } from "@mui/x-charts/BarChart";
import { LinePlot, MarkPlot } from "@mui/x-charts/LineChart";
import { ChartsXAxis } from "@mui/x-charts/ChartsXAxis";

const lineData: number[] = [];
const barData: number[] = [];
const xAxis: number[] = [];

const pointsPerSerie = 3600;

for (let i = 0; i < pointsPerSerie; i++) {
  lineData.push(i);
  barData.push(pointsPerSerie - i);
  xAxis.push(i);
}

export default function CompositionBench() {
  console.log("Component run");

  return (
    <Box sx={{ width: "100%", overflow: "auto" }}>
      <Paper sx={{ margin: 1, height: 300, width: 600 }} elevation={3}>
        <ChartContainer
          series={[
            {
              type: "bar",
              data: barData,
            },
            {
              type: "line",
              data: lineData,
              showMark: false,
            },
          ]}
          xAxis={[
            {
              data: xAxis,
              scaleType: "band",
              id: "x-axis-id",
              height: 45,
            },
          ]}
        >
          <BarPlot />
          <LinePlot />
          <MarkPlot />
          <ChartsXAxis label="X axis" axisId="x-axis-id" />
        </ChartContainer>
      </Paper>
    </Box>
  );
}
```

</details>

**Before (total time)**

Total render time: 2.27s

Breakdown:
- Layout: 494.6ms
- Recalculate style: 199.7ms
- `getStringSize`: 1222ms



<img width="824" height="1302" alt="image" src="https://github.com/user-attachments/assets/dba88641-12a3-4cae-97cb-c387c7853133" />


**After (total time)**

Total render time: 1.26s

Breakdown:
- Layout: 132.9ms
- Recalculate style: 89.6ms
- `getStringSize`: 92.2ms
- `batchMeasureStrings`: 148.2ms


<img width="826" height="1300" alt="image" src="https://github.com/user-attachments/assets/17f35b82-3733-449d-b780-3ad08d7c6be8" />
