### PR TITLE
[charts] Fix undefined path when highlight empty line chart axis

### DIFF
--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue.test.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue.test.ts
@@ -1,0 +1,23 @@
+import { scaleBand, scaleLinear } from '@mui/x-charts-vendor/d3-scale';
+import { describe } from 'vitest';
+import { getAxisValue } from './getAxisValue';
+
+describe('getAxisValue', () => {
+  it('returns the inverted value when the scale is ordinal', () => {
+    const scale = scaleBand();
+
+    expect(getAxisValue(scale, ['A', 'B', 'C', 'D'], 600, 2)).to.eq('C');
+  });
+
+  it('returns the inverted value when the scale is continuous', () => {
+    const scale = scaleLinear([0, 100], [0, 1000]);
+
+    expect(getAxisValue(scale, [], 500, null)).to.eq(50);
+  });
+
+  it('returns `null` when the scale is continuous and its domain is not finite', () => {
+    const scale = scaleLinear([Infinity, -Infinity]);
+
+    expect(getAxisValue(scale, [], 500, null)).to.eq(null);
+  });
+});

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisValue.ts
@@ -1,5 +1,5 @@
 import { isOrdinalScale } from '../../../scaleGuards';
-import { ComputedAxis } from '../../../../models/axis';
+import { ComputedAxis, D3Scale } from '../../../../models/axis';
 
 function getAsANumber(value: number | Date) {
   return value instanceof Date ? value.getTime() : value;
@@ -60,16 +60,21 @@ export function getAxisIndex(axisConfig: ComputedAxis, pointerValue: number): nu
  * For a pointer coordinate, this function returns the value associated.
  * Returns `null` if the coordinate has no value associated.
  */
-export function getAxisValue(
-  axisConfig: ComputedAxis,
+export function getAxisValue<
+  Domain extends { toString(): string } = { toString(): string },
+  Range = number,
+  Output = number,
+>(
+  scale: D3Scale<Domain, Range, Output>,
+  axisData: readonly any[] | undefined,
   pointerValue: number,
   dataIndex: number | null,
 ): number | Date | null {
-  const { scale, data: axisData } = axisConfig;
-
   if (!isOrdinalScale(scale)) {
     if (dataIndex === null) {
-      return scale.invert(pointerValue);
+      const invertedValue = scale.invert(pointerValue);
+
+      return Number.isNaN(invertedValue) ? null : invertedValue;
     }
     return axisData![dataIndex];
   }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianInteraction.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianInteraction.selectors.ts
@@ -91,10 +91,17 @@ function valueGetter(
   ids: AxisId | AxisId[] = axes.axisIds[0],
 ): Value | Value[] {
   return Array.isArray(ids)
-    ? ids.map((id, axisIndex) =>
-        getAxisValue(axes.axis[id], value, (indexes as (number | null)[])[axisIndex]),
-      )
-    : getAxisValue(axes.axis[ids], value, indexes as number | null);
+    ? ids.map((id, axisIndex) => {
+        const axis = axes.axis[id];
+
+        return getAxisValue(
+          axis.scale,
+          axis.data,
+          value,
+          (indexes as (number | null)[])[axisIndex],
+        );
+      })
+    : getAxisValue(axes.axis[ids].scale, axes.axis[ids].data, value, indexes as number | null);
 }
 
 export const selectorChartsInteractionXAxisValue = createSelector(


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/19949. Alternative to https://github.com/mui/mui-x/pull/19962.

The issue is that `value` in the line below is `NaN`:

https://github.com/mui/mui-x/blob/1aa30bf070ffc7c77f102c69365b116050d1a60a/packages/x-charts/src/ChartsAxisHighlight/ChartsXAxisHighlight.tsx#L36

So, when calling `getXPosition(NaN)` we get `undefined`.

By updating `getAxisValue` to never return `NaN`, `selectAxisHighlightWithValue` will return an empty array, so `ChartsXHighlight` won't try to render any lines, fixing the issue.