### PR TITLE
[docs] Fix font size in axis reference line demo

### DIFF
--- a/docs/data/charts/axis/ReferenceLine.js
+++ b/docs/data/charts/axis/ReferenceLine.js
@@ -53,7 +53,7 @@ export default function ReferenceLine() {
         <ChartsReferenceLine
           x={new Date(2023, 8, 2, 9)}
           lineStyle={{ strokeDasharray: '10 5' }}
-          labelStyle={{ fontSize: '10', lineHeight: 1.2 }}
+          labelStyle={{ fontSize: 10, lineHeight: 1.2 }}
           label={`Wake up\n9AM`}
           labelAlign="start"
         />

--- a/docs/data/charts/axis/ReferenceLine.tsx
+++ b/docs/data/charts/axis/ReferenceLine.tsx
@@ -53,7 +53,7 @@ export default function ReferenceLine() {
         <ChartsReferenceLine
           x={new Date(2023, 8, 2, 9)}
           lineStyle={{ strokeDasharray: '10 5' }}
-          labelStyle={{ fontSize: '10', lineHeight: 1.2 }}
+          labelStyle={{ fontSize: 10, lineHeight: 1.2 }}
           label={`Wake up\n9AM`}
           labelAlign="start"
         />

--- a/docs/data/charts/axis/ReferenceLine.tsx.preview
+++ b/docs/data/charts/axis/ReferenceLine.tsx.preview
@@ -3,7 +3,7 @@
   <ChartsReferenceLine
     x={new Date(2023, 8, 2, 9)}
     lineStyle={{ strokeDasharray: '10 5' }}
-    labelStyle={{ fontSize: '10', lineHeight: 1.2 }}
+    labelStyle={{ fontSize: 10, lineHeight: 1.2 }}
     label={`Wake up\n9AM`}
     labelAlign="start"
   />


### PR DESCRIPTION
The `fontSize` property should either be a number or a string with a unit. A unitless string doesn't work.

<img width="809" height="317" alt="image" src="https://github.com/user-attachments/assets/58ed7b96-e1aa-447d-aba1-2adc66e40156" />


[Reproduction](https://stackblitz.com/edit/react-9oaydnjo?file=src%2FApp.js)

