### PR TITLE
[charts] Measure string sizes using SVG elements

### DIFF
--- a/docs/data/charts/axis/TicksWithoutLabels.js
+++ b/docs/data/charts/axis/TicksWithoutLabels.js
@@ -56,7 +56,7 @@ export default function TicksWithoutLabels() {
               scaleType: 'log',
               valueFormatter: tickFormatter,
               label: 'Number of events (Log scale)',
-              width: 48,
+              width: 50,
             },
           ]}
           series={[{ data }]}

--- a/docs/data/charts/axis/TicksWithoutLabels.tsx
+++ b/docs/data/charts/axis/TicksWithoutLabels.tsx
@@ -59,7 +59,7 @@ export default function TicksWithoutLabels() {
               scaleType: 'log',
               valueFormatter: tickFormatter,
               label: 'Number of events (Log scale)',
-              width: 48,
+              width: 50,
             },
           ]}
           series={[{ data }]}

--- a/docs/data/charts/dataset/countryData.js
+++ b/docs/data/charts/dataset/countryData.js
@@ -174,7 +174,7 @@ export const countryData = {
   PYF: { country: 'French Polynesia', continent: 'Oceania' },
   QAT: { country: 'Qatar', continent: 'Asia' },
   ROU: { country: 'Romania', continent: 'Europe' },
-  RUS: { country: 'Russian Federation', continent: 'Europe' },
+  RUS: { country: 'Russia', continent: 'Europe' },
   RWA: { country: 'Rwanda', continent: 'Africa' },
   SAU: { country: 'Saudi Arabia', continent: 'Asia' },
   SDN: { country: 'Sudan', continent: 'Africa' },

--- a/docs/data/charts/dataset/countryData.ts
+++ b/docs/data/charts/dataset/countryData.ts
@@ -174,7 +174,7 @@ export const countryData = {
   PYF: { country: 'French Polynesia', continent: 'Oceania' },
   QAT: { country: 'Qatar', continent: 'Asia' },
   ROU: { country: 'Romania', continent: 'Europe' },
-  RUS: { country: 'Russian Federation', continent: 'Europe' },
+  RUS: { country: 'Russia', continent: 'Europe' },
   RWA: { country: 'Rwanda', continent: 'Africa' },
   SAU: { country: 'Saudi Arabia', continent: 'Asia' },
   SDN: { country: 'Sudan', continent: 'Africa' },

--- a/packages/x-charts-pro/src/BarChartPro/BarChartPro.zoom.test.tsx
+++ b/packages/x-charts-pro/src/BarChartPro/BarChartPro.zoom.test.tsx
@@ -4,6 +4,7 @@ import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
 import * as sinon from 'sinon';
 import { BarChartPro } from './BarChartPro';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const getAxisTickValues = (axis: 'x' | 'y'): string[] => {
   const axisData = Array.from(
@@ -59,7 +60,7 @@ describe.skipIf(isJSDOM)('<BarChartPro /> - Zoom', () => {
     );
     expect(getAxisTickValues('x')).to.deep.equal(['A', 'B', 'C', 'D']);
 
-    const svg = document.querySelector('svg')!;
+    const svg = document.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -97,7 +98,7 @@ describe.skipIf(isJSDOM)('<BarChartPro /> - Zoom', () => {
 
       expect(getAxisTickValues('x')).to.deep.equal(['D']);
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector(CHART_SELECTOR)!;
 
       // we drag one position so C should be visible
       await user.pointer([
@@ -158,7 +159,7 @@ describe.skipIf(isJSDOM)('<BarChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x')).to.deep.equal(['A', 'B', 'C', 'D']);
 
-    const svg = document.querySelector('svg')!;
+    const svg = document.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -213,7 +214,7 @@ describe.skipIf(isJSDOM)('<BarChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x')).to.deep.equal(['A', 'B', 'C', 'D']);
 
-    const svg = document.querySelector('svg')!;
+    const svg = document.querySelector(CHART_SELECTOR)!;
 
     // Perform tap and drag gesture - tap once, then drag vertically up to zoom in
     await user.pointer([

--- a/packages/x-charts-pro/src/FunnelChart/checkClickEvent.test.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/checkClickEvent.test.tsx
@@ -3,6 +3,7 @@ import { createRenderer } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import { FunnelChart } from '@mui/x-charts-pro/FunnelChart';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const config = {
   series: [
@@ -61,7 +62,7 @@ describe('FunnelChart - click event', () => {
           <FunnelChart {...config} onAxisClick={onAxisClick} />
         </div>,
       );
-      const svg = document.querySelector<HTMLElement>('svg')!;
+      const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
       await user.pointer([
         {
@@ -111,7 +112,7 @@ describe('FunnelChart - click event', () => {
             />
           </div>,
         );
-        const svg = document.querySelector<HTMLElement>('svg')!;
+        const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
         await user.pointer([
           {
@@ -162,7 +163,7 @@ describe('FunnelChart - click event', () => {
             />
           </div>,
         );
-        const svg = document.querySelector<HTMLElement>('svg')!;
+        const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
         await user.pointer([
           {

--- a/packages/x-charts-pro/src/LineChartPro/LineChartPro.zoom.test.tsx
+++ b/packages/x-charts-pro/src/LineChartPro/LineChartPro.zoom.test.tsx
@@ -4,6 +4,7 @@ import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
 import * as sinon from 'sinon';
 import { LineChartPro } from './LineChartPro';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const getAxisTickValues = (axis: 'x' | 'y', container: HTMLElement): string[] => {
   const axisData = Array.from(
@@ -58,7 +59,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
     // eslint-disable-next-line testing-library/no-container
-    const svg = container.querySelector('svg')!;
+    const svg = container.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -118,7 +119,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
       expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
       // eslint-disable-next-line testing-library/no-container
-      const svg = container.querySelector('svg')!;
+      const svg = container.querySelector(CHART_SELECTOR)!;
 
       // we drag one position so C should be visible
       await user.pointer([
@@ -249,7 +250,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
     // eslint-disable-next-line testing-library/no-container
-    const svg = container.querySelector('svg')!;
+    const svg = container.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -305,7 +306,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
     // eslint-disable-next-line testing-library/no-container
-    const svg = container.querySelector('svg')!;
+    const svg = container.querySelector(CHART_SELECTOR)!;
 
     // Perform tap and drag gesture - tap once, then drag vertically up to zoom in
     await user.pointer([
@@ -357,7 +358,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x', container)).to.deep.equal(['A', 'B', 'C', 'D']);
 
     // eslint-disable-next-line testing-library/no-container
-    const svg = container.querySelector('svg')!;
+    const svg = container.querySelector(CHART_SELECTOR)!;
 
     // Simulate the problematic scenario:
     // 1. Small drag down (positive deltaY) - this should zoom out slightly
@@ -443,7 +444,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
     // eslint-disable-next-line testing-library/no-container
-    const svg = container.querySelector('svg')!;
+    const svg = container.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -491,7 +492,7 @@ describe.skipIf(isJSDOM)('<LineChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x', container)).to.deep.equal(['D']);
 
     // eslint-disable-next-line testing-library/no-container
-    const svg = container.querySelector('svg')!;
+    const svg = container.querySelector(CHART_SELECTOR)!;
 
     // we drag one position so C should be visible
     await user.pointer([

--- a/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.zoom.test.tsx
+++ b/packages/x-charts-pro/src/ScatterChartPro/ScatterChartPro.zoom.test.tsx
@@ -4,6 +4,7 @@ import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
 import * as sinon from 'sinon';
 import { ScatterChartPro } from './ScatterChartPro';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const getAxisTickValues = (axis: 'x' | 'y'): string[] => {
   const axisData = Array.from(
@@ -84,7 +85,7 @@ describe.skipIf(isJSDOM)('<ScatterChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x')).to.deep.equal(['1', '2', '3']);
     expect(getAxisTickValues('y')).to.deep.equal(['10', '20', '30']);
 
-    const svg = document.querySelector('svg')!;
+    const svg = document.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -126,7 +127,7 @@ describe.skipIf(isJSDOM)('<ScatterChartPro /> - Zoom', () => {
         options,
       );
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector(CHART_SELECTOR)!;
 
       expect(getAxisTickValues('x')).to.deep.equal(['2.6', '2.8', '3.0']);
       expect(getAxisTickValues('y')).to.deep.equal(['26', '28', '30']);
@@ -193,7 +194,7 @@ describe.skipIf(isJSDOM)('<ScatterChartPro /> - Zoom', () => {
     expect(getAxisTickValues('x')).to.deep.equal(['1', '2', '3']);
     expect(getAxisTickValues('y')).to.deep.equal(['10', '20', '30']);
 
-    const svg = document.querySelector('svg')!;
+    const svg = document.querySelector(CHART_SELECTOR)!;
 
     await user.pointer([
       {
@@ -249,7 +250,7 @@ describe.skipIf(isJSDOM)('<ScatterChartPro /> - Zoom', () => {
 
     expect(getAxisTickValues('x')).to.deep.equal(['1', '2', '3']);
 
-    const svg = document.querySelector('svg')!;
+    const svg = document.querySelector(CHART_SELECTOR)!;
 
     // Perform tap and drag gesture - tap once, then drag vertically up to zoom in
     await user.pointer([

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/ZoomInteractionConfig.test.tsx
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/ZoomInteractionConfig.test.tsx
@@ -5,6 +5,7 @@ import { createRenderer, fireEvent, act } from '@mui/internal-test-utils';
 import { isJSDOM } from 'test/utils/skipIf';
 import * as sinon from 'sinon';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
+import { CHART_SELECTOR } from '../../../tests/constants';
 
 describe.skipIf(isJSDOM)('ZoomInteractionConfig Keys and Modes', () => {
   const { render } = createRenderer();
@@ -64,7 +65,7 @@ describe.skipIf(isJSDOM)('ZoomInteractionConfig Keys and Modes', () => {
 
       expect(getAxisTickValues('x')).to.deep.equal(['A', 'B', 'C', 'D']);
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector(CHART_SELECTOR)!;
 
       await user.pointer([
         {
@@ -111,7 +112,7 @@ describe.skipIf(isJSDOM)('ZoomInteractionConfig Keys and Modes', () => {
 
       expect(getAxisTickValues('x')).to.deep.equal(['D']);
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector(CHART_SELECTOR)!;
 
       // Drag without Alt key - should not pan
       await user.pointer([
@@ -177,7 +178,7 @@ describe.skipIf(isJSDOM)('ZoomInteractionConfig Keys and Modes', () => {
 
       expect(getAxisTickValues('x')).to.deep.equal(['D']);
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector(CHART_SELECTOR)!;
 
       // Drag with only Shift key - should not pan
       await user.keyboard('{Shift>}');
@@ -247,7 +248,7 @@ describe.skipIf(isJSDOM)('ZoomInteractionConfig Keys and Modes', () => {
 
       expect(getAxisTickValues('x')).to.deep.equal(['D']);
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector(CHART_SELECTOR)!;
 
       // Mouse drag - should pan
       await user.pointer([
@@ -311,7 +312,7 @@ describe.skipIf(isJSDOM)('ZoomInteractionConfig Keys and Modes', () => {
 
       expect(getAxisTickValues('x')).to.deep.equal(['A', 'B', 'C', 'D']);
 
-      const svg = document.querySelector('svg')!;
+      const svg = document.querySelector('svg:not([aria-hidden="true"])')!;
 
       // Wheel - should not zoom since only pinch is enabled
       for (let i = 0; i < 30; i += 1) {

--- a/packages/x-charts-pro/src/tests/constants.ts
+++ b/packages/x-charts-pro/src/tests/constants.ts
@@ -1,0 +1,1 @@
+export const CHART_SELECTOR = 'svg:not([aria-hidden="true"])';

--- a/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/BarChart/checkClickEvent.test.tsx
@@ -3,6 +3,7 @@ import { createRenderer } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const config = {
   dataset: [
@@ -49,7 +50,7 @@ describe('BarChart - click event', () => {
           />
         </div>,
       );
-      const svg = document.querySelector<HTMLElement>('svg')!;
+      const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
       await user.pointer([
         {
@@ -104,7 +105,7 @@ describe('BarChart - click event', () => {
             />
           </div>,
         );
-        const svg = document.querySelector<HTMLElement>('svg')!;
+        const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
         await user.pointer([
           {

--- a/packages/x-charts/src/ChartsLabel/ChartsLabelGradient.test.tsx
+++ b/packages/x-charts/src/ChartsLabel/ChartsLabelGradient.test.tsx
@@ -7,6 +7,7 @@ import { isJSDOM } from 'test/utils/skipIf';
 import RtlProvider from '@mui/system/RtlProvider';
 // It's not publicly exported, so, using a relative import
 import { ChartsLabelGradient } from './ChartsLabelGradient';
+import { CHART_SELECTOR } from '../tests/constants';
 
 describe('<ChartsLabelGradient />', () => {
   const { render } = createRenderer();
@@ -34,8 +35,8 @@ describe('<ChartsLabelGradient />', () => {
 
   // JSDOM does not support SVGMatrix
   describe.skipIf(isJSDOM)('rotation', () => {
-    const matrixToRotation = (element: SVGSVGElement | null) => {
-      if (!element) {
+    const matrixToRotation = (element: Element | null) => {
+      if (!element || !(element instanceof SVGElement)) {
         throw new Error('Svg element not found');
       }
 
@@ -47,21 +48,21 @@ describe('<ChartsLabelGradient />', () => {
       it('should render a gradient in the correct orientation', () => {
         const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" />);
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(0);
       });
 
       it('should reverse the gradient', () => {
         const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" reverse />);
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(180);
       });
 
       it('should rotate the gradient', () => {
         const { container } = render(<ChartsLabelGradient gradientId="gradient.test-id" rotate />);
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(90);
       });
 
@@ -70,7 +71,7 @@ describe('<ChartsLabelGradient />', () => {
           <ChartsLabelGradient gradientId="gradient.test-id" reverse rotate />,
         );
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(-90);
       });
     });
@@ -81,7 +82,7 @@ describe('<ChartsLabelGradient />', () => {
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" />,
         );
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(-90);
       });
 
@@ -90,7 +91,7 @@ describe('<ChartsLabelGradient />', () => {
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" reverse />,
         );
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(90);
       });
 
@@ -99,7 +100,7 @@ describe('<ChartsLabelGradient />', () => {
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" rotate />,
         );
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(0);
       });
 
@@ -108,7 +109,7 @@ describe('<ChartsLabelGradient />', () => {
           <ChartsLabelGradient gradientId="gradient.test-id" direction="vertical" reverse rotate />,
         );
         // eslint-disable-next-line testing-library/no-container
-        const svg = container.querySelector('svg');
+        const svg = container.querySelector(CHART_SELECTOR);
         expect(matrixToRotation(svg)).to.equal(180);
       });
     });
@@ -120,7 +121,7 @@ describe('<ChartsLabelGradient />', () => {
             wrapper: RtlWrapper,
           });
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           // Technically it is -180, but the browser will normalize it to 180
           expect(matrixToRotation(svg)).to.equal(180);
         });
@@ -131,7 +132,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(0);
         });
 
@@ -141,7 +142,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(-90);
         });
 
@@ -151,7 +152,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(90);
         });
       });
@@ -163,7 +164,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(-90);
         });
 
@@ -173,7 +174,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(90);
         });
 
@@ -183,7 +184,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(0);
         });
 
@@ -198,7 +199,7 @@ describe('<ChartsLabelGradient />', () => {
             { wrapper: RtlWrapper },
           );
           // eslint-disable-next-line testing-library/no-container
-          const svg = container.querySelector('svg');
+          const svg = container.querySelector(CHART_SELECTOR);
           expect(matrixToRotation(svg)).to.equal(180);
         });
       });

--- a/packages/x-charts/src/LineChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/LineChart/checkClickEvent.test.tsx
@@ -3,6 +3,7 @@ import { createRenderer } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const config = {
   dataset: [
@@ -43,7 +44,7 @@ describe('LineChart - click event', () => {
           />
         </div>,
       );
-      const svg = document.querySelector<HTMLElement>('svg')!;
+      const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
       await user.pointer([
         {

--- a/packages/x-charts/src/RadarChart/RadarChart.test.tsx
+++ b/packages/x-charts/src/RadarChart/RadarChart.test.tsx
@@ -4,6 +4,7 @@ import { describeConformance } from 'test/utils/describeConformance';
 import { Unstable_RadarChart as RadarChart, RadarChartProps } from '@mui/x-charts/RadarChart';
 import { spy } from 'sinon';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const radarConfig: RadarChartProps = {
   height: 100,
@@ -66,7 +67,7 @@ describe('<RadarChart />', () => {
       </div>,
     );
 
-    const svg = document.querySelector<HTMLElement>('svg')!;
+    const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
     await user.pointer([{ target: svg, coords: { clientX: 45, clientY: 45 } }]);
 
     expect(document.querySelector<HTMLElement>('svg .MuiRadarAxisHighlight-root')!).toBeVisible();

--- a/packages/x-charts/src/RadarChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/RadarChart/checkClickEvent.test.tsx
@@ -3,6 +3,7 @@ import { createRenderer } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import { RadarChart, RadarChartProps } from '@mui/x-charts/RadarChart';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const config: RadarChartProps = {
   series: [
@@ -34,7 +35,7 @@ describe('RadarChart - click event', () => {
           <RadarChart {...config} onAxisClick={onAxisClick} />
         </div>,
       );
-      const svg = document.querySelector<HTMLElement>('svg')!;
+      const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
       await user.pointer([
         {
@@ -84,7 +85,7 @@ describe('RadarChart - click event', () => {
             />
           </div>,
         );
-        const svg = document.querySelector<HTMLElement>('svg')!;
+        const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
         await user.pointer([
           {

--- a/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterChart.test.tsx
@@ -3,6 +3,7 @@ import { createRenderer, screen } from '@mui/internal-test-utils/createRenderer'
 import { describeConformance } from 'test/utils/describeConformance';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const cellSelector = '.MuiChartsTooltip-root td, .MuiChartsTooltip-root th';
 
@@ -75,7 +76,7 @@ describe('<ScatterChart />', () => {
         />
       </div>,
     );
-    const svg = document.querySelector<HTMLElement>('svg')!;
+    const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
     await user.pointer([
       // Set tooltip position voronoi value
       { target: svg, coords: { clientX: 10, clientY: 10 } },

--- a/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
+++ b/packages/x-charts/src/ScatterChart/checkClickEvent.test.tsx
@@ -3,6 +3,7 @@ import { createRenderer } from '@mui/internal-test-utils';
 import { spy } from 'sinon';
 import { ScatterChart } from '@mui/x-charts/ScatterChart';
 import { isJSDOM } from 'test/utils/skipIf';
+import { CHART_SELECTOR } from '../tests/constants';
 
 const config = {
   dataset: [
@@ -48,7 +49,7 @@ describe('ScatterChart - click event', () => {
           />
         </div>,
       );
-      const svg = document.querySelector<HTMLElement>('svg')!;
+      const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
       await user.pointer([
         {
@@ -134,7 +135,7 @@ describe('ScatterChart - click event', () => {
           />
         </div>,
       );
-      const svg = document.querySelector<HTMLElement>('svg')!;
+      const svg = document.querySelector<HTMLElement>(CHART_SELECTOR)!;
 
       await user.pointer([
         {

--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -8,16 +8,7 @@ function isSsr(): boolean {
 const stringCache = new Map<string, { width: number; height: number }>();
 
 const MAX_CACHE_NUM = 2000;
-const SPAN_STYLE = {
-  position: 'absolute',
-  top: '-20000px',
-  left: 0,
-  padding: 0,
-  margin: 0,
-  border: 'none',
-  whiteSpace: 'pre',
-};
-const STYLE_LIST = [
+const STYLE_SET = new Set([
   'minWidth',
   'maxWidth',
   'width',
@@ -37,7 +28,7 @@ const STYLE_LIST = [
   'marginRight',
   'marginTop',
   'marginBottom',
-];
+]);
 export const MEASUREMENT_SPAN_ID = 'mui_measurement_span';
 
 /**
@@ -47,7 +38,7 @@ export const MEASUREMENT_SPAN_ID = 'mui_measurement_span';
  * @returns add 'px' for distance properties
  */
 function autoCompleteStyle(name: string, value: number) {
-  if (STYLE_LIST.indexOf(name) >= 0 && value === +value) {
+  if (STYLE_SET.has(name) && value === +value) {
     return `${value}px`;
   }
 
@@ -90,8 +81,6 @@ export const getStyleString = (style: React.CSSProperties) =>
       '',
     );
 
-let domCleanTimeout: ReturnType<typeof setTimeout> | undefined;
-
 /**
  *
  * @param text The string to estimate
@@ -113,24 +102,23 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
   }
 
   try {
-    let measurementSpan = document.getElementById(MEASUREMENT_SPAN_ID);
-    if (measurementSpan === null) {
-      measurementSpan = document.createElement('span');
-      measurementSpan.setAttribute('id', MEASUREMENT_SPAN_ID);
-      measurementSpan.setAttribute('aria-hidden', 'true');
-      document.body.appendChild(measurementSpan);
-    }
+    const measurementSpanContainer = getMeasurementContainer();
+    const measurementElem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+
     // Need to use CSS Object Model (CSSOM) to be able to comply with Content Security Policy (CSP)
     // https://en.wikipedia.org/wiki/Content_Security_Policy
-    const measurementSpanStyle: Record<string, any> = { ...SPAN_STYLE, ...style };
-
-    Object.keys(measurementSpanStyle).map((styleKey) => {
-      (measurementSpan!.style as Record<string, any>)[camelToMiddleLine(styleKey)] =
-        autoCompleteStyle(styleKey, measurementSpanStyle[styleKey]);
+    Object.keys(style as Record<string, any>).map((styleKey) => {
+      (measurementElem!.style as Record<string, any>)[camelToMiddleLine(styleKey)] =
+        autoCompleteStyle(styleKey, (style as Record<string, any>)[styleKey]);
       return styleKey;
     });
-    measurementSpan.textContent = str;
-    const rect = measurementSpan.getBoundingClientRect();
+
+    // measurementElem.style.whiteSpace = 'pre';
+    measurementElem.textContent = str;
+
+    measurementSpanContainer.replaceChildren(measurementElem);
+
+    const rect = measurementElem.getBoundingClientRect();
     const result = { width: rect.width, height: rect.height };
 
     stringCache.set(cacheKey, result);
@@ -141,15 +129,7 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
 
     if (process.env.NODE_ENV === 'test') {
       // In test environment, we clean the measurement span immediately
-      measurementSpan.textContent = '';
-    } else {
-      if (domCleanTimeout) {
-        clearTimeout(domCleanTimeout);
-      }
-      domCleanTimeout = setTimeout(() => {
-        // Limit node cleaning to once per render cycle
-        measurementSpan.textContent = '';
-      }, 0);
+      measurementSpanContainer.replaceChildren();
     }
 
     return result;
@@ -157,3 +137,32 @@ export const getStringSize = (text: string | number, style: React.CSSProperties 
     return { width: 0, height: 0 };
   }
 };
+
+/**
+ * Get (or create) a hidden span element to measure text size.
+ */
+function getMeasurementContainer() {
+  let measurementContainer = document.getElementById(
+    MEASUREMENT_SPAN_ID,
+  ) as unknown as SVGSVGElement;
+
+  if (measurementContainer === null) {
+    measurementContainer = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    measurementContainer.setAttribute('aria-hidden', 'true');
+    measurementContainer.setAttribute('id', MEASUREMENT_SPAN_ID);
+
+    measurementContainer.style.position = 'absolute';
+    measurementContainer.style.top = '-20000px';
+    measurementContainer.style.left = '0';
+    measurementContainer.style.padding = '0';
+    measurementContainer.style.margin = '0';
+    measurementContainer.style.border = 'none';
+    measurementContainer.style.pointerEvents = 'none';
+    measurementContainer.style.visibility = 'hidden';
+    measurementContainer.style.contain = 'strict';
+
+    document.body.appendChild(measurementContainer);
+  }
+
+  return measurementContainer;
+}

--- a/packages/x-charts/src/tests/constants.ts
+++ b/packages/x-charts/src/tests/constants.ts
@@ -1,0 +1,1 @@
+export const CHART_SELECTOR = 'svg:not([aria-hidden="true"])';


### PR DESCRIPTION
Measure string sizes using SVG elements. We're rendering the measured text using SVG `text` and `tspan` anyway, so there's no benefit in measuring the text size using HTML elements. In fact, it introduces discrepancies, such as [this one](https://github.com/mui/mui-x/pull/19972#issuecomment-3407262957).

There are some difference in Argos, but as far as I can tell, they are valid changes. The measured string size matches the size the text is taking up on the chart. 