### PR TITLE
[code-infra] Remove invalid `environment: 'browser'` from vitest browser config

### DIFF
--- a/packages/x-charts-premium/vitest.config.browser.mts
+++ b/packages/x-charts-premium/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-charts-pro/vitest.config.browser.mts
+++ b/packages/x-charts-pro/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-charts-vendor/vitest.config.browser.mts
+++ b/packages/x-charts-vendor/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-charts/vitest.config.browser.mts
+++ b/packages/x-charts/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-data-grid-premium/vitest.config.browser.mts
+++ b/packages/x-data-grid-premium/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-data-grid-pro/vitest.config.browser.mts
+++ b/packages/x-data-grid-pro/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-data-grid/vitest.config.browser.mts
+++ b/packages/x-data-grid/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-date-pickers-pro/vitest.config.browser.mts
+++ b/packages/x-date-pickers-pro/vitest.config.browser.mts
@@ -7,7 +7,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     setupFiles: [fileURLToPath(new URL('../../test/utils/setupPickers.js', import.meta.url))],
     browser: {
       enabled: true,

--- a/packages/x-date-pickers/vitest.config.browser.mts
+++ b/packages/x-date-pickers/vitest.config.browser.mts
@@ -18,7 +18,6 @@ export default mergeConfig(sharedConfig, {
   },
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     setupFiles: [fileURLToPath(new URL('../../test/utils/setupPickers.js', import.meta.url))],
     browser: {
       enabled: true,

--- a/packages/x-internal-gestures/vitest.config.browser.mts
+++ b/packages/x-internal-gestures/vitest.config.browser.mts
@@ -7,7 +7,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     setupFiles: [fileURLToPath(new URL('./src/matchers/index.ts', import.meta.url))],
     browser: {
       enabled: true,

--- a/packages/x-license/vitest.config.browser.mts
+++ b/packages/x-license/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-scheduler-headless/vitest.config.browser.mts
+++ b/packages/x-scheduler-headless/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-scheduler/vitest.config.browser.mts
+++ b/packages/x-scheduler/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-telemetry/vitest.config.browser.mts
+++ b/packages/x-telemetry/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-tree-view-pro/vitest.config.browser.mts
+++ b/packages/x-tree-view-pro/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-tree-view/vitest.config.browser.mts
+++ b/packages/x-tree-view/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [

--- a/packages/x-virtualizer/vitest.config.browser.mts
+++ b/packages/x-virtualizer/vitest.config.browser.mts
@@ -6,7 +6,6 @@ import { getTestName } from '../../scripts/getTestName.mts';
 export default mergeConfig(sharedConfig, {
   test: {
     name: getTestName(import.meta.url),
-    environment: 'browser',
     browser: {
       enabled: true,
       instances: [


### PR DESCRIPTION
`environment: 'browser'` isn't a valid option ([docs](https://vitest.dev/config/#environment), [GitHub issue](https://github.com/vitest-dev/vitest/issues/8279))

