### PR TITLE
[charts] Improve `getStringSize` and `batchMeasureStrings` performance

### DIFF
--- a/packages/x-charts/src/internals/domUtils.test.ts
+++ b/packages/x-charts/src/internals/domUtils.test.ts
@@ -1,0 +1,15 @@
+import { getStyleString } from './domUtils';
+
+describe('getStyleString', () => {
+  it('should convert style object to a string', () => {
+    const style = {
+      fontSize: 12,
+      fontFamily: 'Arial',
+      fontLanguageOverride: 'body',
+    };
+
+    expect(getStyleString(style)).to.eq(
+      'font-size:12px;font-family:Arial;font-language-override:body;',
+    );
+  });
+});

--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -36,7 +36,7 @@ const PIXEL_STYLES = new Set([
 ]);
 
 /**
- *
+ * Convert number value to pixel value for certain CSS properties
  * @param name CSS property name
  * @param value
  * @returns add 'px' for distance properties
@@ -50,9 +50,8 @@ function convertPixelValue(name: string, value: number | string) {
 }
 
 /**
- *
+ * Converts camelcase to dash-case
  * @param text camelcase css property
- * @returns css property
  */
 const AZ = /([A-Z])/g;
 function camelCaseToDashCase(text: string) {
@@ -60,11 +59,11 @@ function camelCaseToDashCase(text: string) {
 }
 
 /**
- *
+ * Converts a style object into a string to be used as a cache key
  * @param style React style object
  * @returns CSS styling string
  */
-function getStyleString(style: React.CSSProperties) {
+export function getStyleString(style: React.CSSProperties) {
   let result = '';
 
   for (const key in style) {


### PR DESCRIPTION
Improve `getStringSize` performance based on @romgrk's [PR](https://github.com/mui/mui-x/pull/19991).

In these specific benchmarks, we're seeing minor improvements, with the biggest being around 20%.

### Results

Ran `pnpm bench:browser domUtils`:

Before:

```
 ✓  x-charts (chromium)  src/internals/domUtils.bench.ts > getStringSize 3147ms
     name                          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · without styles           13.3743  70.0000  78.5000  74.7700  76.6000  78.5000  78.5000  78.5000  ±2.54%       10
   · with alternating styles   9.3853   102.80   110.70   106.55   108.20   110.70   110.70   110.70  ±1.58%       10

 ✓  x-charts (chromium)  src/internals/domUtils.bench.ts > batchMeasureStrings 1754ms
     name                          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · without styles           19.6464  46.5000  60.9000  50.9000  51.8000  60.9000  60.9000  60.9000  ±6.68%       10
   · with alternating styles  20.8689  42.6000  58.5000  47.9182  52.6000  58.5000  58.5000  58.5000  ±7.96%       11
```

After:

```
 ✓  x-charts (chromium)  src/internals/domUtils.bench.ts > getStringSize 2728ms
     name                          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · without styles           14.1743  66.8000  74.2000  70.5500  72.7000  74.2000  74.2000  74.2000  ±2.39%       10
   · with alternating styles  11.3109  83.4000  92.7000  88.4100  90.7000  92.7000  92.7000  92.7000  ±2.44%       10

 ✓  x-charts (chromium)  src/internals/domUtils.bench.ts > batchMeasureStrings 1726ms
     name                          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · without styles           19.6812  46.7000  61.1000  50.8100  51.0000  61.1000  61.1000  61.1000  ±6.34%       10
   · with alternating styles  21.4383  41.8000  52.7000  46.6455  50.6000  52.7000  52.7000  52.7000  ±5.93%       11
```