### PR TITLE
[charts] Improve string measurement benchmarks

### DIFF
--- a/packages/x-charts/src/internals/domUtils.bench.ts
+++ b/packages/x-charts/src/internals/domUtils.bench.ts
@@ -1,7 +1,7 @@
 import { bench, describe } from 'vitest';
-import { getStringSize } from './domUtils';
+import { clearStringMeasurementCache, getStringSize } from './domUtils';
 
-export const countryNames = [
+export const strings = [
   'Aruba',
   'Afghanistan',
   'Angola',
@@ -220,19 +220,40 @@ export const countryNames = [
   'South Africa',
   'Zambia',
   'Zimbabwe',
-] as const;
+];
+
+const baseDate = new Date(1760670813770);
+for (let i = 0; i < 10_000; i += 1) {
+  const date = new Date(baseDate);
+  date.setDate(i + 1);
+  strings.push(date.toISOString());
+}
+
+const setup = () => {
+  // Call once to create the measuring dom element
+  getStringSize('Warmup');
+  clearStringMeasurementCache();
+};
 
 describe('getStringSize', () => {
-  bench('without styles', () => {
-    countryNames.forEach((countryName) => getStringSize(countryName));
-  });
+  bench(
+    'without styles',
+    () => {
+      strings.forEach((countryName) => getStringSize(countryName));
+    },
+    { setup },
+  );
 
-  bench('with alternating styles', () => {
-    const style1 = { fontSize: 12, fontFamily: 'Arial' };
-    const style2 = { fontSize: 16, fontFamily: 'Times New Roman', fontWeight: 'bold' };
+  bench(
+    'with alternating styles',
+    () => {
+      const style1 = { fontSize: 12, fontFamily: 'Arial' };
+      const style2 = { fontSize: 16, fontFamily: 'Times New Roman', fontWeight: 'bold' };
 
-    countryNames.forEach((countryName, i) =>
-      getStringSize(countryName, i % 2 === 0 ? style1 : style2),
-    );
-  });
+      strings.forEach((countryName, i) =>
+        getStringSize(countryName, i % 2 === 0 ? style1 : style2),
+      );
+    },
+    { setup },
+  );
 });

--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -7,6 +7,10 @@ function isSsr(): boolean {
 
 const stringCache = new Map<string, { width: number; height: number }>();
 
+export function clearStringMeasurementCache() {
+  stringCache.clear();
+}
+
 const MAX_CACHE_NUM = 2000;
 const STYLE_SET = new Set([
   'minWidth',


### PR DESCRIPTION
Improve string measurement benchmarks by:
1. Clearing the string cache before each run
2. Calling `getStringSize` before each run to ensure the measurement DOM element is present
3. Increasing the number of strings being measured to 10k


Results:

```
 ✓  x-charts (chromium)  src/internals/domUtils.bench.ts > getStringSize 3118ms
     name                          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · without styles           13.6593  69.6000  76.2000  73.2100  75.8000  76.2000  76.2000  76.2000  ±2.48%       10
   · with alternating styles   9.2894   103.50   112.20   107.65   111.40   112.20   112.20   112.20  ±2.18%       10
```