### PR TITLE
[charts] Avoid sub-pixel label overlap check

### DIFF
--- a/packages/x-charts/src/ChartsXAxis/ChartsSingleXAxisTicks.tsx
+++ b/packages/x-charts/src/ChartsXAxis/ChartsSingleXAxisTicks.tsx
@@ -65,14 +65,18 @@ function ChartsSingleXAxisTicks(inProps: ChartsSingleXAxisProps) {
     direction: 'x',
   });
 
-  const visibleLabels = getVisibleLabels(xTicks, {
-    tickLabelStyle: axisTickLabelProps.style,
-    tickLabelInterval,
-    tickLabelMinGap,
-    reverse,
-    isMounted,
-    isXInside: instance.isXInside,
-  });
+  const visibleLabels =
+    typeof tickLabelInterval === 'function'
+      ? new Set(xTicks.filter((item, index) => tickLabelInterval(item.value, index)))
+      : getVisibleLabels(
+          xTicks,
+          axisTickLabelProps.style,
+          tickLabelMinGap,
+          reverse ?? false,
+          isMounted,
+          instance.isXInside,
+          drawingArea.width,
+        );
 
   /* If there's an axis title, the tick labels have less space to render  */
   const tickLabelsMaxHeight = Math.max(


### PR DESCRIPTION
Avoid sub-pixel label overlap check.

When there are more labels than the width in pixels, it means each label will take up less than a pixel. With this PR, I'm assuming that it makes no sense to have labels that take up less than one pixel, so we just take the first label that fills up a specific pixel and every other subsequent label that shares the same pixel won't even be considered. 

This reduces the amount of measurements we need to make to the number of pixels in the drawing area, improving performance for bar charts with loads of potential tick labels.

### Results

4x CPU throttling

Before:

`getVisibleLabels`: 107.2ms

After:

`getVisibleLabels`: 13.25ms

This results in a 8x speed-up. This huge speed-up is partially because we're no longer exhausting the cache, causing it to be cleared. Since we're now well below the 2000 strings we don't need evict all strings. To make a fairer comparison, I increased the cache size to 10k and `getVisibleLabels` took 17.5ms, so if we don't account for the cache, there's still a 33% improvement. 

With the changes from this PR, the time spent measuring strings will now only scale with the minimum of candidate tick labels and width in pixels. Effectively, in large bar charts, this should cap the number of strings we need to measure to the width of said chart.
