### PR TITLE
[charts] Performance: use selector with arguments

### DIFF
--- a/packages/x-charts/src/BarChart/BarElement.tsx
+++ b/packages/x-charts/src/BarChart/BarElement.tsx
@@ -68,11 +68,16 @@ function BarElement(props: BarElementProps) {
     seriesId: id,
     dataIndex,
   });
-  const isFocused = useIsItemFocused({
-    seriesType: 'bar',
-    seriesId: id,
-    dataIndex,
-  });
+  const isFocused = useIsItemFocused(
+    React.useMemo(
+      () => ({
+        seriesType: 'bar',
+        seriesId: id,
+        dataIndex,
+      }),
+      [id, dataIndex],
+    ),
+  );
 
   const ownerState = {
     id,

--- a/packages/x-charts/src/hooks/useIsItemFocused.ts
+++ b/packages/x-charts/src/hooks/useIsItemFocused.ts
@@ -1,5 +1,8 @@
 'use client';
+import { useStore } from '../internals/store/useStore';
+import { useSelector } from '../internals/store/useSelector';
 import { FocusedItemData, useFocusedItem } from './useFocusedItem';
+import { selectorChartsIsFocused } from '../internals/plugins/featurePlugins/useChartKeyboardNavigation';
 
 type UseItemFocusedParams = FocusedItemData;
 
@@ -12,12 +15,6 @@ type UseItemFocusedParams = FocusedItemData;
  * @returns {boolean} the focus state
  */
 export function useIsItemFocused(item: UseItemFocusedParams): boolean {
-  const focusedItem = useFocusedItem();
-
-  return (
-    focusedItem !== null &&
-    focusedItem.seriesType === item.seriesType &&
-    focusedItem.seriesId === item.seriesId &&
-    focusedItem.dataIndex === item.dataIndex
-  );
+  const store = useStore();
+  return useSelector(store, selectorChartsIsFocused, [item] as const);
 }

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
@@ -1,3 +1,4 @@
+import { createSelector as createSelectorX } from '@mui/x-internals/store';
 import { ChartOptionalRootSelector, createSelector } from '../../utils/selectors';
 import { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import { ProcessedSeries, selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
@@ -7,6 +8,7 @@ import {
 } from '../useChartCartesianAxis/useChartCartesianAxisRendering.selectors';
 import { ComputeResult } from '../useChartCartesianAxis/computeAxisValue';
 import { ChartSeriesType } from '../../../../models/seriesType/config';
+import { FocusedItemData } from '../../../../hooks/useFocusedItem';
 import { SeriesId } from '../../../../models/seriesType/common';
 import { AxisId, AxisItemIdentifier, ChartsAxisProps } from '../../../../models/axis';
 
@@ -37,6 +39,21 @@ export const selectorChartsFocusedDataIndex = createSelector(
 export const selectorChartsIsKeyboardNavigationEnabled = createSelector(
   [selectKeyboardNavigation],
   (keyboardNavigationState) => !!keyboardNavigationState?.enableKeyboardNavigation,
+);
+
+export const selectorChartsIsFocused = createSelectorX(
+  selectKeyboardNavigation,
+  (keyboardNavigationState, item: FocusedItemData) => {
+    const focusedItem = keyboardNavigationState?.item;
+
+    return Boolean(
+      item &&
+        focusedItem &&
+        focusedItem.type === item.seriesType &&
+        focusedItem.seriesId === item.seriesId &&
+        focusedItem.dataIndex === item.dataIndex,
+    );
+  },
 );
 
 /**


### PR DESCRIPTION
Follow-up of https://mui-org.slack.com/archives/C02EQ97NV8F/p1761007734897309?thread_ts=1761007527.308189&cid=C02EQ97NV8F

Use selector with argument to avoid some overhead. A similar transformation can probably be applied to the `isHighlighted` logic.