### PR TITLE
[DataGridPremium] Fix grouping column valueFormatter crash 

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/features/rowGrouping/createGroupingColDef.tsx
+++ b/packages/x-data-grid-premium/src/hooks/features/rowGrouping/createGroupingColDef.tsx
@@ -139,12 +139,12 @@ function getGroupingCriteriaProperties(
       const rowId = gridRowIdSelector(apiRef, row);
       const rowNode = gridRowNodeSelector(apiRef, rowId);
       if (rowNode?.type === 'group') {
-        const originalColDef = columnsLookup[rowNode.groupingField!]!;
-        if (originalColDef.type === 'singleSelect') {
+        const originalColDef = rowNode.groupingField ? columnsLookup[rowNode.groupingField] : null;
+        if (originalColDef?.type === 'singleSelect') {
           // the default valueFormatter of a singleSelect colDef won't work with the grouping column values
           return value;
         }
-        const columnValueFormatter = originalColDef.valueFormatter;
+        const columnValueFormatter = originalColDef?.valueFormatter;
         if (typeof columnValueFormatter === 'function') {
           return columnValueFormatter(value as never, row, column, apiRef);
         }


### PR DESCRIPTION
closes https://github.com/mui/mui-x/issues/20044

### Steps to reproduce

1. open https://mui.com/x/react-data-grid/server-side-data/row-grouping/
2. expand 1st row
3. click on `Regenerate data button`

**working preview**: https://deploy-preview-20070--material-ui-x.netlify.app/x/react-data-grid/server-side-data/row-grouping/
