### PR TITLE
[charts] Handle `undefined` id and color in series

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts-pro/src/FunnelChart/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,12 +6,12 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'funnel'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
     borderRadius: seriesData.borderRadius ?? 8,
     data: seriesData.data.map((d, index) => ({
-      color: colors[index % colors.length],
       ...d,
+      color: d.color ?? colors[index % colors.length],
     })),
   };
 };

--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,9 +6,9 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'heatmap'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
     color: colors[seriesIndex % colors.length],
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
   };
 };
 

--- a/packages/x-charts/src/BarChart/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,9 +6,9 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'bar'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
-    color: colors[seriesIndex % colors.length],
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
+    color: seriesData.color ?? colors[seriesIndex % colors.length],
   };
 };
 

--- a/packages/x-charts/src/LineChart/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,9 +6,9 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'line'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
-    color: colors[seriesIndex % colors.length],
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
+    color: seriesData.color ?? colors[seriesIndex % colors.length],
   };
 };
 

--- a/packages/x-charts/src/PieChart/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts/src/PieChart/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,11 +6,11 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'pie'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
     data: seriesData.data.map((d, index) => ({
-      color: colors[index % colors.length],
       ...d,
+      color: d.color ?? colors[index % colors.length],
     })),
   };
 };

--- a/packages/x-charts/src/RadarChart/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts/src/RadarChart/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,9 +6,9 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'radar'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
-    color: colors[seriesIndex % colors.length],
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
+    color: seriesData.color ?? colors[seriesIndex % colors.length],
   };
 };
 

--- a/packages/x-charts/src/ScatterChart/seriesConfig/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/getSeriesWithDefaultValues.ts
@@ -6,9 +6,9 @@ const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'scatter'> = (
   colors,
 ) => {
   return {
-    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
-    color: colors[seriesIndex % colors.length],
     ...seriesData,
+    id: seriesData.id ?? `auto-generated-id-${seriesIndex}`,
+    color: seriesData.color ?? colors[seriesIndex % colors.length],
   };
 };
 


### PR DESCRIPTION
Handle `undefined` id and color in series. 

Previously, a pattern like the following would result in an `undefined` `fill` property if `condition` is false:

```tsx
series: [{
  color: condition ? '#ab12ef' : undefined,
}]
```

Now, it will use the default color. The same logic applies to the `id` property.

To work around that behavior, a user would need to do this, which is worse DX IMO:

```tsx
series: [{
  ...(condition ? { color: '#ab12ef' } : {}),
}]
```

## Results


Before:

https://github.com/user-attachments/assets/803ce68f-a7f2-4948-9d14-9729d60c8bab

After:


https://github.com/user-attachments/assets/9644a666-9877-4490-a126-cd20473b2b82

