### PR TITLE
[DataGrid] Ignore `Ctrl+A` key combination for the row selection in the community version

### DIFF
--- a/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
+++ b/packages/x-data-grid/src/hooks/features/rowSelection/useGridRowSelection.ts
@@ -835,13 +835,11 @@ export const useGridRowSelection = (
         return;
       }
 
-      if (
-        String.fromCharCode(event.keyCode) === 'A' &&
-        (event.ctrlKey || event.metaKey) &&
-        canHaveMultipleSelection
-      ) {
+      if (String.fromCharCode(event.keyCode) === 'A' && (event.ctrlKey || event.metaKey)) {
         event.preventDefault();
-        toggleAllRows(true);
+        if (canHaveMultipleSelection) {
+          toggleAllRows(true);
+        }
       }
     },
     [apiRef, canHaveMultipleSelection, handleSingleRowSelection, toggleAllRows],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes [#20086](https://github.com/mui/mui-x/issues/20086)
