### PR TITLE
[x-telemetry] Skip telemetry tests on browser mode

### DIFF
--- a/packages/x-telemetry/src/runtime/config.test.ts
+++ b/packages/x-telemetry/src/runtime/config.test.ts
@@ -2,9 +2,10 @@
 
 import { vi } from 'vitest';
 import { muiXTelemetrySettings } from '@mui/x-telemetry';
+import { isJSDOM } from '@mui/x-internals/platform';
 import { getTelemetryEnvConfig } from './config';
 
-describe('Telemetry: getTelemetryConfig', () => {
+describe.runIf(isJSDOM)('Telemetry: getTelemetryConfig', () => {
   beforeEach(() => {
     vi.stubEnv('NODE_ENV', 'development');
   });


### PR DESCRIPTION
Skip telemetry tests on browser mode. Fixes an issue in the [migration to Vitest v4](https://github.com/mui/mui-x/pull/20102) where `process` is no longer available in browser mode. 
