### PR TITLE
[DataGridPro] Retain the expansion state with expansion configuration props

### DIFF
--- a/packages/x-data-grid-pro/src/utils/tree/utils.ts
+++ b/packages/x-data-grid-pro/src/utils/tree/utils.ts
@@ -57,6 +57,12 @@ export const checkGroupChildrenExpansion = (
     return false;
   }
 
+  // If group existed in previous tree, preserve its expansion state
+  if (prevChildrenExpanded !== undefined) {
+    return prevChildrenExpanded;
+  }
+
+  // For new groups, apply default expansion configuration
   let childrenExpanded: boolean;
   if (node.id === GRID_ROOT_GROUP_ID) {
     childrenExpanded = true;
@@ -64,9 +70,7 @@ export const checkGroupChildrenExpansion = (
     childrenExpanded = isGroupExpandedByDefault(node);
   } else {
     childrenExpanded =
-      defaultGroupingExpansionDepth === -1 ||
-      defaultGroupingExpansionDepth > node.depth ||
-      (prevChildrenExpanded ?? false);
+      defaultGroupingExpansionDepth === -1 || defaultGroupingExpansionDepth > node.depth;
   }
 
   return childrenExpanded;


### PR DESCRIPTION
Apply #19697 on props `isGroupExpandedByDefault` and `defaultGroupingExpansionDepth` too
- Before: https://stackblitz.com/edit/4ug6uohs-cyljuhqt?file=src%2FDemo.tsx
- After: https://stackblitz.com/edit/itctssbg?file=src%2FDemo.tsx

Context: https://github.com/mui/mui-x/issues/20049#issuecomment-3458442364