### PR TITLE
[scheduler] Remove unnecessary useMemo usages

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/current-time-indicator/CalendarGridCurrentTimeIndicator.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/current-time-indicator/CalendarGridCurrentTimeIndicator.tsx
@@ -55,7 +55,7 @@ export const CalendarGridCurrentTimeIndicator = React.forwardRef(
       [position],
     );
 
-    const props = React.useMemo(() => ({ style }), [style]);
+    const props = { style };
 
     const isOutOfRange =
       adapter.isBefore(nowForColumn, columnStart) || adapter.isAfter(nowForColumn, columnEnd);

--- a/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-cell/CalendarGridDayCell.tsx
@@ -24,7 +24,7 @@ export const CalendarGridDayCell = React.forwardRef(function CalendarGridDayCell
   const { ref: listItemRef, index } = useCompositeListItem();
   const dropTargetRef = useDayCellDropTarget({ value, addPropertiesToDroppedEvent });
 
-  const props = React.useMemo(() => ({ role: 'gridcell' }), []);
+  const props = { role: 'gridcell' };
 
   const contextValue: CalendarGridDayCellContext = React.useMemo(
     () => ({

--- a/packages/x-scheduler-headless/src/calendar-grid/day-event-placeholder/CalendarGridDayEventPlaceholder.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event-placeholder/CalendarGridDayEventPlaceholder.tsx
@@ -4,8 +4,6 @@ import { useRenderElement } from '../../base-ui-copy/utils/useRenderElement';
 import { BaseUIComponentProps } from '../../base-ui-copy/utils/types';
 import { useEvent } from '../../utils/useEvent';
 
-const EVENT_PLACEHOLDER_PROPS = { style: { pointerEvents: 'none' as const } };
-
 export const CalendarGridDayEventPlaceholder = React.forwardRef(
   function CalendarGridDayEventPlaceholder(
     componentProps: CalendarGridDayEventPlaceholder.Props,
@@ -27,7 +25,7 @@ export const CalendarGridDayEventPlaceholder = React.forwardRef(
     return useRenderElement('div', componentProps, {
       state,
       ref: [forwardedRef],
-      props: [elementProps, EVENT_PLACEHOLDER_PROPS],
+      props: [elementProps, { style: { pointerEvents: 'none' as const } }],
     });
   },
 );

--- a/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-event/CalendarGridDayEvent.tsx
@@ -17,8 +17,6 @@ import { useEventCalendarStoreContext } from '../../use-event-calendar-store-con
 import { useCalendarGridDayCellContext } from '../day-cell/CalendarGridDayCellContext';
 import { useCalendarGridRootContext } from '../root/CalendarGridRootContext';
 
-const EVENT_STYLE_WHILE_DRAGGING = { pointerEvents: 'none' as const };
-
 export const CalendarGridDayEvent = React.forwardRef(function CalendarGridDayEvent(
   componentProps: CalendarGridDayEvent.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
@@ -127,14 +125,11 @@ export const CalendarGridDayEvent = React.forwardRef(function CalendarGridDayEve
 
   const columnHeaderId = getCalendarGridHeaderCellId(rootId, cellIndex);
 
-  const props = React.useMemo(
-    () => ({
-      id,
-      'aria-labelledby': `${columnHeaderId} ${id}`,
-      style: hasPlaceholder ? EVENT_STYLE_WHILE_DRAGGING : undefined,
-    }),
-    [hasPlaceholder, columnHeaderId, id],
-  );
+  const props = {
+    id,
+    'aria-labelledby': `${columnHeaderId} ${id}`,
+    style: hasPlaceholder ? { pointerEvents: 'none' as const } : undefined,
+  };
 
   const contextValue: CalendarGridDayEventContext = React.useMemo(
     () => ({ ...draggableEventContextValue, getSharedDragData }),

--- a/packages/x-scheduler-headless/src/calendar-grid/day-row/CalendarGridDayRow.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/day-row/CalendarGridDayRow.tsx
@@ -21,7 +21,7 @@ export const CalendarGridDayRow = React.forwardRef(function CalendarGridDayRow(
     ...elementProps
   } = componentProps;
 
-  const props = React.useMemo(() => ({ role: 'row' }), []);
+  const props = { role: 'row' };
   const cellsRefs = React.useRef<(HTMLDivElement | null)[]>([]);
 
   const contextValue: CalendarGridDayRowContext = React.useMemo(

--- a/packages/x-scheduler-headless/src/calendar-grid/header-cell/CalendarGridHeaderCell.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/header-cell/CalendarGridHeaderCell.tsx
@@ -40,14 +40,11 @@ export const CalendarGridHeaderCell = React.forwardRef(function CalendarGridHead
   const { ref: listItemRef, index } = useCompositeListItem();
   const id = getCalendarGridHeaderCellId(rootId, index);
 
-  const props = React.useMemo(
-    () => ({
-      role: 'columnheader',
-      id,
-      'aria-label': `${adapter.formatByString(date.value, ariaLabelFormat)}`,
-    }),
-    [adapter, date, id, ariaLabelFormat],
-  );
+  const props = {
+    role: 'columnheader',
+    id,
+    'aria-label': `${adapter.formatByString(date.value, ariaLabelFormat)}`,
+  };
 
   const state: CalendarGridHeaderCell.State = React.useMemo(
     () => ({

--- a/packages/x-scheduler-headless/src/calendar-grid/header-row/CalendarGridHeaderRow.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/header-row/CalendarGridHeaderRow.tsx
@@ -16,7 +16,7 @@ export const CalendarGridHeaderRow = React.forwardRef(function CalendarGridHeade
     ...elementProps
   } = componentProps;
 
-  const props = React.useMemo(() => ({ role: 'row' }), []);
+  const props = { role: 'row' };
   const cellsRefs = React.useRef<(HTMLDivElement | null)[]>([]);
 
   const element = useRenderElement('div', componentProps, {

--- a/packages/x-scheduler-headless/src/calendar-grid/root/CalendarGridRoot.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/root/CalendarGridRoot.tsx
@@ -20,7 +20,7 @@ export const CalendarGridRoot = React.forwardRef(function CalendarGridRoot(
 
   const id = useId(idProp);
 
-  const props = React.useMemo(() => ({ role: 'grid', id }), [id]);
+  const props = { role: 'grid', id };
 
   const contextValue: CalendarGridRootContext = React.useMemo(() => ({ id }), [id]);
 

--- a/packages/x-scheduler-headless/src/calendar-grid/time-column/CalendarGridTimeColumn.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-column/CalendarGridTimeColumn.tsx
@@ -42,7 +42,7 @@ export const CalendarGridTimeColumn = React.forwardRef(function CalendarGridTime
     [isCurrentDay],
   );
 
-  const props = React.useMemo(() => ({ role: 'gridcell' }), []);
+  const props = { role: 'gridcell' };
 
   const contextValue: CalendarGridTimeColumnContext = React.useMemo(
     () => ({

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event-placeholder/CalendarGridTimeEventPlaceholder.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event-placeholder/CalendarGridTimeEventPlaceholder.tsx
@@ -41,7 +41,7 @@ export const CalendarGridTimeEventPlaceholder = React.forwardRef(
       [position, duration],
     );
 
-    const props = React.useMemo(() => ({ style }), [style]);
+    const props = { style };
 
     const { state } = useEvent({ start, end });
 

--- a/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/time-event/CalendarGridTimeEvent.tsx
@@ -135,10 +135,7 @@ export const CalendarGridTimeEvent = React.forwardRef(function CalendarGridTimeE
 
   const columnHeaderId = getCalendarGridHeaderCellId(rootId, columnIndex);
 
-  const props = React.useMemo(
-    () => ({ id, style, 'aria-labelledby': `${columnHeaderId} ${id}` }),
-    [style, columnHeaderId, id],
-  );
+  const props = { id, style, 'aria-labelledby': `${columnHeaderId} ${id}` };
 
   const contextValue: CalendarGridTimeEventContext = React.useMemo(
     () => ({ ...draggableEventContextValue, getSharedDragData }),

--- a/packages/x-scheduler-headless/src/timeline/cell/TimelineCell.tsx
+++ b/packages/x-scheduler-headless/src/timeline/cell/TimelineCell.tsx
@@ -16,7 +16,7 @@ export const TimelineCell = React.forwardRef(function TimelineCell(
   } = componentProps;
 
   // TODO: Add aria-colindex using Composite.
-  const props = React.useMemo(() => ({ role: 'cell' }), []);
+  const props = { role: 'cell' };
 
   return useRenderElement('div', componentProps, {
     ref: [forwardedRef],

--- a/packages/x-scheduler-headless/src/timeline/event-row/TimelineEventRow.tsx
+++ b/packages/x-scheduler-headless/src/timeline/event-row/TimelineEventRow.tsx
@@ -21,7 +21,7 @@ export const TimelineEventRow = React.forwardRef(function TimelineEventRow(
   } = componentProps;
 
   // TODO: Add aria-rowindex using Composite.
-  const props = React.useMemo(() => ({ role: 'row' }), []);
+  const props = { role: 'row' };
 
   const contextValue: TimelineEventRowContext = React.useMemo(() => ({ start, end }), [start, end]);
 

--- a/packages/x-scheduler-headless/src/timeline/event/TimelineEvent.tsx
+++ b/packages/x-scheduler-headless/src/timeline/event/TimelineEvent.tsx
@@ -51,7 +51,7 @@ export const TimelineEvent = React.forwardRef(function TimelineEvent(
     [position, duration],
   );
 
-  const props = React.useMemo(() => ({ style }), [style]);
+  const props = { style };
 
   const { state } = useEvent({ start, end });
 

--- a/packages/x-scheduler-headless/src/timeline/root/TimelineRoot.tsx
+++ b/packages/x-scheduler-headless/src/timeline/root/TimelineRoot.tsx
@@ -22,7 +22,7 @@ export const TimelineRoot = React.forwardRef(function TimelineRoot(
     ...elementProps
   } = componentProps;
 
-  const props = React.useMemo(() => ({ role: 'grid' }), []);
+  const props = { role: 'grid' };
 
   const store = useRefWithInit(() => new Store<State>({ items: itemsProp })).current;
 

--- a/packages/x-scheduler-headless/src/timeline/row/TimelineRow.tsx
+++ b/packages/x-scheduler-headless/src/timeline/row/TimelineRow.tsx
@@ -16,7 +16,7 @@ export const TimelineRow = React.forwardRef(function TimelineRow(
   } = componentProps;
 
   // TODO: Add aria-rowindex using Composite.
-  const props = React.useMemo(() => ({ role: 'row' }), []);
+  const props = { role: 'row' };
 
   return useRenderElement('div', componentProps, {
     ref: [forwardedRef],

--- a/packages/x-scheduler-headless/src/timeline/sub-grid/TimelineSubGrid.tsx
+++ b/packages/x-scheduler-headless/src/timeline/sub-grid/TimelineSubGrid.tsx
@@ -31,7 +31,7 @@ export const TimelineSubGrid = React.forwardRef(function TimelineSubGrid<Item = 
     return childrenProp;
   }, [childrenProp, items]);
 
-  const props = React.useMemo(() => ({ role: 'rowgroup', children }), [children]);
+  const props = { role: 'rowgroup', children };
 
   return useRenderElement('div', componentProps, {
     ref: [forwardedRef],


### PR DESCRIPTION
This PR removes unnecessary usages of useMemo over props that are passes in the `useRenderElement` hook.

Example usage:

```
 const props = React.useMemo(() => ({ role: 'gridcell' }), []);

 const element = useRenderElement('div', componentProps, {
    ref: [forwardedRef, dropTargetRef, listItemRef],
    props: [props, elementProps],
  });
```

The `useRenderElement` hook will more or less conver the call to

```
<div {...mergeProps(componentProps, props, elementProps)} ref={mergedRefs} />
```

so there is no need for memoization. On the opposite side, memoizing would just add more overhead. The transformation should also improve readability as a bonus.