### PR TITLE
[scheduler] Drop `EventProps` interface

### DIFF
--- a/packages/x-scheduler/src/internals/components/event/Event.types.ts
+++ b/packages/x-scheduler/src/internals/components/event/Event.types.ts
@@ -1,8 +1,0 @@
-import { CalendarEvent } from '@mui/x-scheduler-headless/models';
-
-export interface EventProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Callback fired when the event is clicked.
-   */
-  onEventClick?: (event: React.MouseEvent, calendarEvent: CalendarEvent) => void;
-}

--- a/packages/x-scheduler/src/internals/components/event/day-grid-event/DayGridEvent.tsx
+++ b/packages/x-scheduler/src/internals/components/event/day-grid-event/DayGridEvent.tsx
@@ -24,7 +24,6 @@ export const DayGridEvent = React.forwardRef(function DayGridEvent(
     occurrence,
     variant,
     className: classNameProp,
-    onEventClick,
     id: idProp,
     style: styleProp,
     ...other

--- a/packages/x-scheduler/src/internals/components/event/day-grid-event/DayGridEvent.types.ts
+++ b/packages/x-scheduler/src/internals/components/event/day-grid-event/DayGridEvent.types.ts
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { CalendarEventOccurrenceWithDayGridPosition } from '@mui/x-scheduler-headless/models';
-import { EventProps } from '../Event.types';
 
-export interface DayGridEventProps extends EventProps {
+export interface DayGridEventProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * The event occurrence to render.
    */

--- a/packages/x-scheduler/src/internals/components/event/event-item/EventItem.tsx
+++ b/packages/x-scheduler/src/internals/components/event/event-item/EventItem.tsx
@@ -27,7 +27,6 @@ export const EventItem = React.forwardRef(function EventItem(
     occurrence,
     ariaLabelledBy,
     className,
-    onEventClick,
     id: idProp,
     style,
     variant = 'regular',

--- a/packages/x-scheduler/src/internals/components/event/event-item/EventItem.types.ts
+++ b/packages/x-scheduler/src/internals/components/event/event-item/EventItem.types.ts
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { CalendarEventOccurrence } from '@mui/x-scheduler-headless/models';
-import { EventProps } from '../Event.types';
 
-export interface EventItemProps extends EventProps {
+export interface EventItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * The event occurrence to render.
    */

--- a/packages/x-scheduler/src/internals/components/event/time-grid-event/TimeGridEvent.types.ts
+++ b/packages/x-scheduler/src/internals/components/event/time-grid-event/TimeGridEvent.types.ts
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { CalendarEventOccurrenceWithTimePosition } from '@mui/x-scheduler-headless/models';
-import { EventProps } from '../Event.types';
 
-export interface TimeGridEventProps extends EventProps {
+export interface TimeGridEventProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * The event occurrence to render.
    */

--- a/packages/x-scheduler/src/timeline/content/timeline-event-row/timeline-event/TimelineEvent.tsx
+++ b/packages/x-scheduler/src/timeline/content/timeline-event-row/timeline-event/TimelineEvent.tsx
@@ -14,15 +14,7 @@ export const TimelineEvent = React.forwardRef(function TimelineEvent(
   props: TimelineEventProps,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const {
-    occurrence,
-    ariaLabelledBy,
-    className,
-    onEventClick,
-    id: idProp,
-    style,
-    ...other
-  } = props;
+  const { occurrence, ariaLabelledBy, className, id: idProp, style, ...other } = props;
 
   const store = useTimelineStoreContext();
 

--- a/packages/x-scheduler/src/timeline/content/timeline-event-row/timeline-event/TimelineEvent.types.ts
+++ b/packages/x-scheduler/src/timeline/content/timeline-event-row/timeline-event/TimelineEvent.types.ts
@@ -1,7 +1,7 @@
+import * as React from 'react';
 import { CalendarEventOccurrenceWithTimePosition } from '@mui/x-scheduler-headless/models';
-import { EventProps } from '../../../../internals/components/event/Event.types';
 
-export interface TimelineEventProps extends EventProps {
+export interface TimelineEventProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * The event occurrence to render.
    */


### PR DESCRIPTION
Extracted from #20145
We never used `onEventClick()`