### PR TITLE
[charts] Fix tick label overflow on multiple axes and series demo

### DIFF
--- a/docs/src/modules/components/overview/charts/advancedFeatures/MultiAxesDemo.tsx
+++ b/docs/src/modules/components/overview/charts/advancedFeatures/MultiAxesDemo.tsx
@@ -60,6 +60,7 @@ function MultiAxes() {
         xAxis={[
           {
             scaleType: 'band',
+            height: 50,
             dataKey: 'month',
             label: 'Month',
             valueFormatter: (value, context) =>


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/20150.

It seems that the pre-defined value doesn't work across all OSes and browsers. 

@prakhargupta1 can you confirm this works on your side? 