### PR TITLE
[charts] Organize series config

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
+++ b/packages/x-charts-pro/src/FunnelChart/FunnelChart.tsx
@@ -15,7 +15,7 @@ import { FunnelPlot, FunnelPlotProps } from './FunnelPlot';
 import { FunnelSeriesType } from './funnel.types';
 import { useFunnelChartProps } from './useFunnelChartProps';
 import { ChartContainerProProps } from '../ChartContainerPro';
-import { seriesConfig as funnelSeriesConfig } from './seriesConfig';
+import { funnelSeriesConfig } from './seriesConfig';
 import { useChartContainerProProps } from '../ChartContainerPro/useChartContainerProProps';
 import { ChartDataProviderPro } from '../ChartDataProviderPro';
 import { FunnelChartSlotExtension } from './funnelSlots.types';

--- a/packages/x-charts-pro/src/FunnelChart/seriesConfig/index.ts
+++ b/packages/x-charts-pro/src/FunnelChart/seriesConfig/index.ts
@@ -7,7 +7,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import tooltipItemPositionGetter from './tooltipPosition';
 
-export const seriesConfig: ChartSeriesTypeConfig<'funnel'> = {
+export const funnelSeriesConfig: ChartSeriesTypeConfig<'funnel'> = {
   seriesProcessor,
   colorProcessor: getColor,
   legendGetter,

--- a/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
+++ b/packages/x-charts-pro/src/Heatmap/Heatmap.tsx
@@ -34,7 +34,7 @@ import { ChartsSlotPropsPro, ChartsSlotsPro } from '../internals/material';
 import { ChartContainerProProps } from '../ChartContainerPro';
 import { HeatmapSeriesType } from '../models/seriesType/heatmap';
 import { HeatmapPlot } from './HeatmapPlot';
-import { seriesConfig as heatmapSeriesConfig } from './seriesConfig';
+import { heatmapSeriesConfig } from './seriesConfig';
 import { HeatmapTooltip, HeatmapTooltipProps } from './HeatmapTooltip';
 import { HeatmapItemSlotProps, HeatmapItemSlots } from './HeatmapItem';
 import { HEATMAP_PLUGINS, HeatmapPluginSignatures } from './Heatmap.plugins';

--- a/packages/x-charts-pro/src/Heatmap/seriesConfig/index.ts
+++ b/packages/x-charts-pro/src/Heatmap/seriesConfig/index.ts
@@ -6,7 +6,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import tooltipItemPositionGetter from './tooltipPosition';
 
-export const seriesConfig: ChartSeriesTypeConfig<'heatmap'> = {
+export const heatmapSeriesConfig: ChartSeriesTypeConfig<'heatmap'> = {
   seriesProcessor,
   colorProcessor: getColor,
   legendGetter: () => [],

--- a/packages/x-charts-pro/src/SankeyChart/SankeyChart.tsx
+++ b/packages/x-charts-pro/src/SankeyChart/SankeyChart.tsx
@@ -14,7 +14,7 @@ import { SankeyPlot, type SankeyPlotProps } from './SankeyPlot';
 import { useSankeyChartProps } from './useSankeyChartProps';
 import { SANKEY_CHART_PLUGINS, type SankeyChartPluginSignatures } from './SankeyChart.plugins';
 import type { SankeySeriesType } from './sankey.types';
-import { seriesConfig as sankeySeriesConfig } from './seriesConfig';
+import { sankeySeriesConfig } from './seriesConfig';
 import { SankeyTooltip } from './SankeyTooltip';
 import type { SankeyChartSlotExtension } from './sankeySlots.types';
 

--- a/packages/x-charts-pro/src/SankeyChart/seriesConfig/index.ts
+++ b/packages/x-charts-pro/src/SankeyChart/seriesConfig/index.ts
@@ -7,7 +7,7 @@ const seriesProcessor = (series: any) => series;
 const colorProcessor = (series: any) => series;
 const legendGetter = () => [];
 
-export const seriesConfig: ChartSeriesTypeConfig<'sankey'> = {
+export const sankeySeriesConfig: ChartSeriesTypeConfig<'sankey'> = {
   seriesProcessor,
   colorProcessor,
   legendGetter,

--- a/packages/x-charts/src/BarChart/extremums.test.ts
+++ b/packages/x-charts/src/BarChart/extremums.test.ts
@@ -1,4 +1,4 @@
-import { getExtremumX, getExtremumY } from './seriesConfig/extremums';
+import { getExtremumX, getExtremumY } from './seriesConfig/bar/extremums';
 import { CartesianExtremumGetter } from '../internals/plugins/models';
 
 const buildData = (

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/extremums.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/extremums.ts
@@ -1,5 +1,5 @@
-import { CartesianExtremumGetter } from '../../internals/plugins/models/seriesConfig';
-import { findMinMax } from '../../internals/findMinMax';
+import { CartesianExtremumGetter } from '../../../internals/plugins/models/seriesConfig';
+import { findMinMax } from '../../../internals/findMinMax';
 
 const createResult = (data: any, direction: 'x' | 'y') => {
   if (direction === 'x') {

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/getColor.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/getColor.ts
@@ -1,4 +1,4 @@
-import { ColorProcessor } from '../../internals/plugins/models';
+import { ColorProcessor } from '../../../internals/plugins/models';
 
 const getColor: ColorProcessor<'bar'> = (series, xAxis, yAxis) => {
   const verticalLayout = series.layout === 'vertical';

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/getSeriesWithDefaultValues.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/getSeriesWithDefaultValues.ts
@@ -1,4 +1,4 @@
-import type { GetSeriesWithDefaultValues } from '../../internals/plugins/models/seriesConfig';
+import type { GetSeriesWithDefaultValues } from '../../../internals/plugins/models/seriesConfig';
 
 const getSeriesWithDefaultValues: GetSeriesWithDefaultValues<'bar'> = (
   seriesData,

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/legend.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/legend.ts
@@ -1,6 +1,6 @@
-import type { LegendItemParams } from '../../ChartsLegend';
-import { getLabel } from '../../internals/getLabel';
-import { LegendGetter } from '../../internals/plugins/models';
+import type { LegendItemParams } from '../../../ChartsLegend';
+import { getLabel } from '../../../internals/getLabel';
+import { LegendGetter } from '../../../internals/plugins/models';
 
 const legendGetter: LegendGetter<'bar'> = (params) => {
   const { seriesOrder, series } = params;

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/seriesProcessor.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/seriesProcessor.ts
@@ -1,10 +1,10 @@
 import { stack as d3Stack } from '@mui/x-charts-vendor/d3-shape';
 import { warnOnce } from '@mui/x-internals/warning';
-import type { DefaultizedBarSeriesType } from '../../models';
-import { getStackingGroups } from '../../internals/stackSeries';
-import { DatasetElementType, DatasetType } from '../../models/seriesType/config';
-import { SeriesId } from '../../models/seriesType/common';
-import { SeriesProcessor } from '../../internals/plugins/models';
+import type { DefaultizedBarSeriesType } from '../../../models';
+import { getStackingGroups } from '../../../internals/stackSeries';
+import { DatasetElementType, DatasetType } from '../../../models/seriesType/config';
+import { SeriesId } from '../../../models/seriesType/common';
+import { SeriesProcessor } from '../../../internals/plugins/models';
 
 type BarDataset = DatasetType<number | null>;
 

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/tooltip.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/tooltip.ts
@@ -1,5 +1,5 @@
-import { getLabel } from '../../internals/getLabel';
-import type { AxisTooltipGetter, TooltipGetter } from '../../internals/plugins/models';
+import { getLabel } from '../../../internals/getLabel';
+import type { AxisTooltipGetter, TooltipGetter } from '../../../internals/plugins/models';
 
 const tooltipGetter: TooltipGetter<'bar'> = (params) => {
   const { series, getColor, identifier } = params;

--- a/packages/x-charts/src/BarChart/seriesConfig/bar/tooltipPosition.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/bar/tooltipPosition.ts
@@ -1,5 +1,5 @@
-import type { TooltipItemPositionGetter } from '../../internals/plugins/models/seriesConfig/tooltipItemPositionGetter.types';
-import { getBarDimensions } from '../useBarPlotData';
+import type { TooltipItemPositionGetter } from '../../../internals/plugins/models/seriesConfig/tooltipItemPositionGetter.types';
+import { getBarDimensions } from '../../useBarPlotData';
 
 const tooltipItemPositionGetter: TooltipItemPositionGetter<'bar'> = (params) => {
   const { series, identifier, axesConfig, placement } = params;

--- a/packages/x-charts/src/BarChart/seriesConfig/index.ts
+++ b/packages/x-charts/src/BarChart/seriesConfig/index.ts
@@ -1,13 +1,13 @@
 import { ChartSeriesTypeConfig } from '../../internals/plugins/models/seriesConfig';
-import { getExtremumX, getExtremumY } from './extremums';
-import seriesProcessor from './seriesProcessor';
-import legendGetter from './legend';
-import getColor from './getColor';
-import tooltipGetter, { axisTooltipGetter } from './tooltip';
-import tooltipItemPositionGetter from './tooltipPosition';
-import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
+import { getExtremumX, getExtremumY } from './bar/extremums';
+import seriesProcessor from './bar/seriesProcessor';
+import legendGetter from './bar/legend';
+import getColor from './bar/getColor';
+import tooltipGetter, { axisTooltipGetter } from './bar/tooltip';
+import tooltipItemPositionGetter from './bar/tooltipPosition';
+import getSeriesWithDefaultValues from './bar/getSeriesWithDefaultValues';
 
-export const seriesConfig: ChartSeriesTypeConfig<'bar'> = {
+export const barSeriesConfig: ChartSeriesTypeConfig<'bar'> = {
   seriesProcessor,
   colorProcessor: getColor,
   legendGetter,

--- a/packages/x-charts/src/BarChart/useBarPlotData.ts
+++ b/packages/x-charts/src/BarChart/useBarPlotData.ts
@@ -1,5 +1,5 @@
 import { ChartsXAxisProps, ChartsYAxisProps, ComputedAxis, ScaleName } from '../models/axis';
-import getColor from './seriesConfig/getColor';
+import getColor from './seriesConfig/bar/getColor';
 import { ChartDrawingArea, useChartId, useXAxes, useYAxes } from '../hooks';
 import { MaskData, ProcessedBarData, ProcessedBarSeriesData } from './types';
 import { checkScaleErrors } from './checkScaleErrors';

--- a/packages/x-charts/src/LineChart/seriesConfig/index.ts
+++ b/packages/x-charts/src/LineChart/seriesConfig/index.ts
@@ -7,7 +7,7 @@ import tooltipGetter, { axisTooltipGetter } from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import tooltipItemPositionGetter from './tooltipPosition';
 
-export const seriesConfig: ChartSeriesTypeConfig<'line'> = {
+export const lineSeriesConfig: ChartSeriesTypeConfig<'line'> = {
   colorProcessor: getColor,
   seriesProcessor,
   legendGetter,

--- a/packages/x-charts/src/PieChart/seriesConfig/index.ts
+++ b/packages/x-charts/src/PieChart/seriesConfig/index.ts
@@ -6,7 +6,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import tooltipItemPositionGetter from './tooltipPosition';
 
-export const seriesConfig: ChartSeriesTypeConfig<'pie'> = {
+export const pieSeriesConfig: ChartSeriesTypeConfig<'pie'> = {
   colorProcessor: getColor,
   seriesProcessor,
   legendGetter,

--- a/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
+++ b/packages/x-charts/src/ScatterChart/ScatterPlot.tsx
@@ -5,7 +5,7 @@ import { Scatter, ScatterProps, ScatterSlotProps, ScatterSlots } from './Scatter
 import { useScatterSeriesContext } from '../hooks/useScatterSeries';
 import { useXAxes, useYAxes } from '../hooks';
 import { useZAxes } from '../hooks/useZAxis';
-import { seriesConfig as scatterSeriesConfig } from './seriesConfig';
+import { scatterSeriesConfig as scatterSeriesConfig } from './seriesConfig';
 import { BatchScatter } from './BatchScatter';
 
 export interface ScatterPlotSlots extends ScatterSlots {

--- a/packages/x-charts/src/ScatterChart/seriesConfig/index.ts
+++ b/packages/x-charts/src/ScatterChart/seriesConfig/index.ts
@@ -7,7 +7,7 @@ import tooltipGetter from './tooltip';
 import getSeriesWithDefaultValues from './getSeriesWithDefaultValues';
 import tooltipItemPositionGetter from './tooltipPosition';
 
-export const seriesConfig: ChartSeriesTypeConfig<'scatter'> = {
+export const scatterSeriesConfig: ChartSeriesTypeConfig<'scatter'> = {
   seriesProcessor,
   colorProcessor: getColor,
   legendGetter,

--- a/packages/x-charts/src/context/ChartProvider/ChartProvider.tsx
+++ b/packages/x-charts/src/context/ChartProvider/ChartProvider.tsx
@@ -12,10 +12,10 @@ import { useChartCartesianAxis } from '../../internals/plugins/featurePlugins/us
 import { useChartInteraction } from '../../internals/plugins/featurePlugins/useChartInteraction';
 import { useChartZAxis } from '../../internals/plugins/featurePlugins/useChartZAxis';
 import { useChartHighlight } from '../../internals/plugins/featurePlugins/useChartHighlight/useChartHighlight';
-import { seriesConfig as barSeriesConfig } from '../../BarChart/seriesConfig';
-import { seriesConfig as scatterSeriesConfig } from '../../ScatterChart/seriesConfig';
-import { seriesConfig as lineSeriesConfig } from '../../LineChart/seriesConfig';
-import { seriesConfig as pieSeriesConfig } from '../../PieChart/seriesConfig';
+import { barSeriesConfig } from '../../BarChart/seriesConfig';
+import { scatterSeriesConfig } from '../../ScatterChart/seriesConfig';
+import { lineSeriesConfig } from '../../LineChart/seriesConfig';
+import { pieSeriesConfig } from '../../PieChart/seriesConfig';
 import { ChartSeriesType } from '../../models/seriesType/config';
 
 export const defaultSeriesConfig: ChartSeriesConfig<'bar' | 'scatter' | 'line' | 'pie'> = {

--- a/packages/x-charts/src/internals/index.ts
+++ b/packages/x-charts/src/internals/index.ts
@@ -9,7 +9,7 @@ export { useInteractionItemProps } from '../hooks/useInteractionItemProps';
 export { useDrawingArea } from '../hooks/useDrawingArea';
 export { useScatterChartProps } from '../ScatterChart/useScatterChartProps';
 export { useScatterPlotData } from '../ScatterChart/useScatterPlotData';
-export { seriesConfig as scatterSeriesConfig } from '../ScatterChart/seriesConfig';
+export { scatterSeriesConfig as scatterSeriesConfig } from '../ScatterChart/seriesConfig';
 export { useLineChartProps } from '../LineChart/useLineChartProps';
 export { useAreaPlotData } from '../LineChart/useAreaPlotData';
 export { useLinePlotData } from '../LineChart/useLinePlotData';


### PR DESCRIPTION
Organize series config as described [here](https://mui-org.slack.com/archives/C02EQ97NV8F/p1761838835067199), as a precursor to https://github.com/mui/mui-x/pull/20033.

### Problem
With the introduction of barRangeSeriesConfig, the current architecture where each chart component contains its own seriesConfig directory creates a naming conflict. Both the standard bar series and bar range series configurations would need to coexist within the BarChart component, but they cannot both be named seriesConfig.

### Solution

1. Adopt explicit naming convention: Rename each series configuration to follow the pattern `<seriesType>SeriesConfig` (e.g., `barSeriesConfig`, `barRangeSeriesConfig`)
2. Export structure: Each chart type's configuration file exports all relevant series configs. For example, `BarChart/seriesConfig/index.ts` exports both `barSeriesConfig` and `barRangeSeriesConfig`.