### PR TITLE
[date-pickers] Fix inconsistent invalid date for controlled date field

### DIFF
--- a/packages/x-date-pickers/src/DateField/tests/onChangeInvalidDate.DateField.test.tsx
+++ b/packages/x-date-pickers/src/DateField/tests/onChangeInvalidDate.DateField.test.tsx
@@ -18,7 +18,6 @@ describeAdapters(
 
       await view.selectSectionAsync('month');
       view.pressKey(0, '0');
-      view.pressKey(0, '0');
 
       expect(handleChange.callCount).to.be.greaterThan(0);
 
@@ -42,7 +41,6 @@ describeAdapters(
       });
 
       await view.selectSectionAsync('month');
-      view.pressKey(0, '0');
       view.pressKey(0, '0');
 
       handleChange.resetHistory();

--- a/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
+++ b/packages/x-date-pickers/src/internals/hooks/useField/useFieldState.ts
@@ -372,13 +372,10 @@ export const useFieldState = <
     }
 
     /**
-     * If all the sections are filled but the date is invalid and the previous date is invalid or null,
+     * If the date is invalid and all the sections are filled,
      * Then we publish an invalid date.
      */
-    if (
-      newActiveDateSections.every((sectionBis) => sectionBis.value !== '') &&
-      (activeDate == null || !adapter.isValid(activeDate))
-    ) {
+    if (newActiveDateSections.every((sectionBis) => sectionBis.value !== '')) {
       setSectionUpdateToApplyOnNextInvalidDate(newSectionValue);
       return publishValue(fieldValueManager.updateDateInValue(value, section, newActiveDate));
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- You can use `## Changelog` to create a description for this change in the next release. -->

## Issue

**Reproduction**: https://stackblitz.com/edit/1kmt3frx?file=src%2FDemo.tsx

While checking https://github.com/mui/mui-x/pull/20040, I found another bug shown in the recording below.
The value return from `onChange` callback is swapping between `null` and invalid date.

https://github.com/user-attachments/assets/8ce85a42-642b-4e8b-9494-556643ff1984

## Fix

It should check for previous invalid date, not valid.

Test added.


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-x/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
