### PR TITLE
[code-infra] Increase JSDOM test parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
             pnpm exec concurrently "pnpm test:unit:jsdom --reporter=blob --shard=1/2" "pnpm test:unit:jsdom --reporter=blob --shard=2/2" || TEST_EXIT_CODE=$?
             pnpm exec vitest run --merge-reports
-            # Reports merged, we can now exit with the right code
+            # Reports merged, we can now exit with the stored code
             exit ${TEST_EXIT_CODE:-0}
       - store_test_results:
           path: test-results


### PR DESCRIPTION
We have 2 CPUs available for the medium resource class. But having the tests run serially cause a lot of underutiization.

<img width="1293" height="880" alt="Screenshot 2025-11-03 at 12 52 25" src="https://github.com/user-attachments/assets/464ca242-1a8a-4be4-9741-223b3071afd3" />

We can fully saturate them instead by sharding our tests and have 2 runs in parallel.

<img width="1298" height="877" alt="Screenshot 2025-11-03 at 12 55 52" src="https://github.com/user-attachments/assets/b3e9c26b-6ce8-40b4-a95b-603fa3fa9edb" />


This makes optimal use of the available resources and brings the runtime of this job down by ~35% and thus also the consumed credits. Which brings it right into the ballpark of our second slowest job (`test_browser`). If we want we can increase resource class to medium+ and add another shard to dip below the runtime of that job.

<img width="646" height="504" alt="Screenshot 2025-11-04 at 10 23 54" src="https://github.com/user-attachments/assets/098f2e28-9518-4218-9246-68aa290239ca" />


For the test output it works as follows: `--reporter=blob` overrides the configured reporters to a representation that can be pieced together with `vitest run --merge-reports` into what's configured by the vitest config:
* successful run: https://app.circleci.com/pipelines/github/mui/mui-x/108569/workflows/9ce011be-b41a-432b-8258-e30c5fd74acc/jobs/667214/parallel-runs/0/steps/0-105
* failure: https://app.circleci.com/pipelines/github/mui/mui-x/108572/workflows/f8d70915-bf32-48c0-802c-c97f03dc8fa0/jobs/667248/parallel-runs/0/steps/0-105

We make sure to propagate the exit code afterwards as to make the job fail.