### PR TITLE
[code-infra] Fix cci job timeout due to buffered test output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,6 @@ jobs:
           react-version: << parameters.react-version >>
       - run:
           name: Test JSDOM
-          # test output is buffered until all tests are completed
-          no_output_timeout: 30m
           command: |
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
             pnpm exec concurrently "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=1/2" "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=2/2" || TEST_EXIT_CODE=$?


### PR DESCRIPTION
Test output is buffered until all tests are completed. This allows them to be merged afterwards from the different processes. This leaves the command without output for potentially 10 minutes, which is a timeout for the cci runner to kill the step. See https://app.circleci.com/pipelines/github/mui/mui-x/108651/workflows/3697566a-48e2-4e50-a39e-75b6e4f4fa08/jobs/667839

We can just enable the `dot` reporter as well to create some output during the test run. It's not pretty, but it does the job: https://app.circleci.com/pipelines/github/mui/mui-x/108667/workflows/c0b07d82-77ff-496d-a5b5-892271cb7a1f/jobs/667983/parallel-runs/0/steps/0-105

Alternatively, a custom `no_output_timeout`.