### PR TITLE
[code-infra] Improve dot reporter output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           name: Test JSDOM
           command: |
             # Fully saturate all the available CPUs by splitting the tests in 1 shard per CPU
-            pnpm exec concurrently "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=1/2" "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=2/2" || TEST_EXIT_CODE=$?
+            pnpm exec concurrently --raw "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=1/2" "pnpm test:unit:jsdom --reporter=blob  --reporter=dot --shard=2/2" || TEST_EXIT_CODE=$?
             pnpm exec vitest run --merge-reports
             # Reports merged, we can now exit with the stored code
             exit ${TEST_EXIT_CODE:-0}


### PR DESCRIPTION
Interleave the output of dot reporters of all sharded test runs with the `--raw` option

[before](https://app.circleci.com/pipelines/github/mui/mui-x/108667/workflows/c0b07d82-77ff-496d-a5b5-892271cb7a1f/jobs/667983/parallel-runs/0/steps/0-105):

```
[1] 
[1] > @8.16.0 test:unit:jsdom /tmp/mui
[1] > cross-env NODE_ENV=test TZ=UTC vitest --reporter=blob --reporter=dot --shard=2/2
[1] 
[0] 
[0] > @8.16.0 test:unit:jsdom /tmp/mui
[0] > cross-env NODE_ENV=test TZ=UTC vitest --reporter=blob --reporter=dot --shard=1/2
[0] 
[1] 
[1]  RUN  v3.2.4 /tmp/mui
[1] 
[0] 
[0]  RUN  v3.2.4 /tmp/mui
[0] 
[1] ······
[0] ······
[1] ---------------------------------------------
[0] ····
[1] ·
[0] ··
[1] ·
[0] ···
[1] ·
[0] ·
[1] ·
[0] ·
[1] ·
[0] ·
[1] ·
[0] ··
[1] ·
...
```

[after](https://app.circleci.com/pipelines/github/mui/mui-x/108677/workflows/96b5e28f-f706-4b3e-9fc0-16fec7a2cf69/jobs/668047/parallel-runs/0/steps/0-105):

```
> @8.16.0 test:unit:jsdom /Users/janpotoms/Projects/mui-x
> cross-env NODE_ENV=test TZ=UTC vitest --reporter=blob --reporter=dot --shard=1/2


> @8.16.0 test:unit:jsdom /Users/janpotoms/Projects/mui-x
> cross-env NODE_ENV=test TZ=UTC vitest --reporter=blob --reporter=dot --shard=2/2


 RUN  v3.2.4 /Users/janpotoms/Projects/mui-x


 RUN  v3.2.4 /Users/janpotoms/Projects/mui-x

·······································································································································--·········-·····················--·····················-························--··--·······················································--------------···················----·····--···--·····-·················································-············--··--···················································-·················--··--····································-······························----·····--------------------------···············-······-···-·-···-·······················-···················---··································································---------·-······-···········---------------------------··················----------------·-········
...
```