### PR TITLE
[x-charts] Fix applying dark mode styles to slider

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderActiveTrack.tsx
@@ -30,10 +30,10 @@ import { useUtilityClasses } from './chartAxisZoomSliderTrackClasses';
 const ZoomSliderActiveTrackRect = styled('rect', {
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'preview',
 })<{ preview: boolean }>(({ theme }) => ({
-  fill:
-    theme.palette.mode === 'dark'
-      ? (theme.vars || theme).palette.grey[500]
-      : (theme.vars || theme).palette.grey[600],
+  fill: (theme.vars || theme).palette.grey[600],
+  ...theme.applyStyles('dark', {
+    fill: (theme.vars || theme).palette.grey[500],
+  }),
   cursor: 'grab',
   variants: [
     {

--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderTrack.tsx
@@ -19,10 +19,10 @@ const ZoomSliderTrack = styled('rect', {
   shouldForwardProp: (prop) =>
     shouldForwardProp(prop) && prop !== 'axisDirection' && prop !== 'isSelecting',
 })<{ axisDirection: 'x' | 'y'; isSelecting: boolean }>(({ theme }) => ({
-  fill:
-    theme.palette.mode === 'dark'
-      ? (theme.vars || theme).palette.grey[800]
-      : (theme.vars || theme).palette.grey[300],
+  fill: (theme.vars || theme).palette.grey[300],
+  ...theme.applyStyles('dark', {
+    fill: (theme.vars || theme).palette.grey[800],
+  }),
   cursor: 'pointer',
   variants: [
     {


### PR DESCRIPTION
closes: https://github.com/mui/mui-x/issues/20210

**preview**  : https://deploy-preview-20220--material-ui-x.netlify.app/x/react-charts/

### Before
<img width="1964" height="1204" alt="image" src="https://github.com/user-attachments/assets/3ba23bf2-a8ca-4d4f-ad1e-a975c37c3f56" />

### After
![Screenshot_20251106_101909_Chrome](https://github.com/user-attachments/assets/e782ea08-add4-4708-899e-b1e5b7c63c37)
