### PR TITLE
[charts] Fix applying dark mode styles in ChartAxisZoomSliderThumb

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderThumb.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderThumb.tsx
@@ -13,14 +13,12 @@ import {
 
 const Rect = styled('rect')(({ theme }) => ({
   [`&.${chartAxisZoomSliderThumbClasses.root}`]: {
-    fill:
-      theme.palette.mode === 'dark'
-        ? (theme.vars || theme).palette.grey[300]
-        : (theme.vars || theme).palette.common.white,
-    stroke:
-      theme.palette.mode === 'dark'
-        ? (theme.vars || theme).palette.grey[600]
-        : (theme.vars || theme).palette.grey[500],
+    fill: (theme.vars || theme).palette.common.white,
+    stroke: (theme.vars || theme).palette.grey[500],
+    ...theme.applyStyles('dark', {
+      fill: (theme.vars || theme).palette.grey[300],
+      stroke: (theme.vars || theme).palette.grey[600],
+    }),
   },
   [`&.${chartAxisZoomSliderThumbClasses.horizontal}`]: {
     cursor: 'ew-resize',


### PR DESCRIPTION
This PR only fixes styling of thumb in dark mode, styling of slider is already fixed in https://github.com/mui/mui-x/pull/20220

### Before https://deploy-preview-20220--material-ui-x.netlify.app/x/react-charts/
<img width="273" height="287" alt="image" src="https://github.com/user-attachments/assets/c9020148-94d7-4768-bc1c-e102c80cb1a1" />


### After https://deploy-preview-20232--material-ui-x.netlify.app/x/react-charts/


<img width="280" height="287" alt="image" src="https://github.com/user-attachments/assets/4a1a8424-a833-4c51-9017-d8d7b65375e2" />

