### PR TITLE
[charts] Update axis domain limit types to use `NumberValue` for improved type safety

### DIFF
--- a/docs/pages/x/api/charts/axis-config.json
+++ b/docs/pages/x/api/charts/axis-config.json
@@ -14,11 +14,7 @@
     "dataKey": { "type": { "description": "string" } },
     "disableLine": { "type": { "description": "boolean" }, "default": "false" },
     "disableTicks": { "type": { "description": "boolean" }, "default": "false" },
-    "domainLimit": {
-      "type": {
-        "description": "'nice' | 'strict' | ((min: NumberValue, max: NumberValue) =&gt; { min: NumberValue; max: NumberValue })"
-      }
-    },
+    "domainLimit": { "type": { "description": "DomainLimit" } },
     "height": { "type": { "description": "number" }, "default": "30" },
     "hideTooltip": { "type": { "description": "boolean" } },
     "ignoreTooltip": { "type": { "description": "boolean" } },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisDomainLimit.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/getAxisDomainLimit.ts
@@ -1,5 +1,4 @@
-import { NumberValue } from '@mui/x-charts-vendor/d3-scale';
-import { AxisConfig } from '../../../../models/axis';
+import { AxisConfig, type DomainLimit } from '../../../../models/axis';
 import { CartesianChartSeriesType } from '../../../../models/seriesType/config';
 import { ProcessedSeries } from '../../corePlugins/useChartSeries';
 
@@ -8,10 +7,7 @@ export const getAxisDomainLimit = <T extends CartesianChartSeriesType>(
   axisDirection: 'x' | 'y',
   axisIndex: number,
   formattedSeries: ProcessedSeries<T | 'line'>,
-):
-  | 'nice'
-  | 'strict'
-  | ((min: NumberValue, max: NumberValue) => { min: NumberValue; max: NumberValue }) => {
+): DomainLimit => {
   if (axis.domainLimit !== undefined) {
     return axis.domainLimit;
   }

--- a/packages/x-charts/src/models/axis.ts
+++ b/packages/x-charts/src/models/axis.ts
@@ -19,6 +19,11 @@ import type { TickParams } from '../hooks/useTicks';
 import { ChartsTextProps } from '../ChartsText';
 import { ContinuousColorConfig, OrdinalColorConfig, PiecewiseColorConfig } from './colorMapping';
 
+export type DomainLimit =
+  | 'nice'
+  | 'strict'
+  | ((min: NumberValue, max: NumberValue) => { min: NumberValue; max: NumberValue });
+
 export type AxisId = string | number;
 
 export type D3Scale<
@@ -498,10 +503,7 @@ type CommonAxisConfig<S extends ScaleName = ScaleName, V = any> = {
    * - 'strict': Set the domain to the min/max value provided. No extra space is added.
    * - function: Receives the calculated extremums as parameters, and should return the axis domain.
    */
-  domainLimit?:
-    | 'nice'
-    | 'strict'
-    | ((min: NumberValue, max: NumberValue) => { min: NumberValue; max: NumberValue });
+  domainLimit?: DomainLimit;
   /**
    * If `true`, the axis will be ignored by the tooltip with `trigger='axis'`.
    */


### PR DESCRIPTION
Closes https://github.com/mui/mui-x/pull/19710
Fixes #19622

- Update axis domain limit types to use NumberValue for improved type safety.
- [charts] docs: update axis types to NumberValue in API documentation
   Update min/max properties and domainLimit function signature to use
   NumberValue instead of number | Date to align with D3 scale types.