### PR TITLE
[DataGrid] Remove unnecessary generic from `useGridApiRef`

### DIFF
--- a/packages/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid-premium/src/hooks/utils/useGridApiRef.ts
@@ -1,7 +1,5 @@
 import { RefObject } from '@mui/x-internals/types';
-import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
+import { useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPremium } from '../../models/gridApiPremium';
 
-export const useGridApiRef: <
-  Api extends GridApiCommon = GridApiPremium,
->() => RefObject<Api | null> = useCommunityGridApiRef;
+export const useGridApiRef = useCommunityGridApiRef as () => RefObject<GridApiPremium | null>;

--- a/packages/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid-pro/src/hooks/utils/useGridApiRef.ts
@@ -1,6 +1,5 @@
 import { RefObject } from '@mui/x-internals/types';
-import { GridApiCommon, useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
+import { useGridApiRef as useCommunityGridApiRef } from '@mui/x-data-grid';
 import { GridApiPro } from '../../models/gridApiPro';
 
-export const useGridApiRef: <Api extends GridApiCommon = GridApiPro>() => RefObject<Api | null> =
-  useCommunityGridApiRef;
+export const useGridApiRef = useCommunityGridApiRef as () => RefObject<GridApiPro | null>;

--- a/packages/x-data-grid/src/hooks/utils/useGridApiRef.ts
+++ b/packages/x-data-grid/src/hooks/utils/useGridApiRef.ts
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { RefObject } from '@mui/x-internals/types';
-import { GridApiCommon } from '../../models';
 import { GridApiCommunity } from '../../models/api/gridApiCommunity';
 
 /**
  * Hook that instantiate a [[GridApiRef]].
  */
-export const useGridApiRef = <Api extends GridApiCommon = GridApiCommunity>() =>
-  React.useRef(null) as RefObject<Api | null>;
+export const useGridApiRef = () => React.useRef(null) as RefObject<GridApiCommunity | null>;


### PR DESCRIPTION
This was added for internal use in https://github.com/mui/mui-x/pull/6423 for simplification, but eventually it had to be done differently – https://github.com/mui/mui-x/pull/16328
So the leftover generic can be removed to avoid confusion.