### PR TITLE
[charts] Use `getBBox()` for correct SVG sizes in firefox

### DIFF
--- a/packages/x-charts/src/internals/domUtils.ts
+++ b/packages/x-charts/src/internals/domUtils.ts
@@ -211,8 +211,15 @@ export function batchMeasureStrings(
  */
 function measureSVGTextElement(element: SVGTextElement): { width: number; height: number } {
   // getBBox() is more reliable across browsers for SVG elements
-  const result = element.getBBox();
-  return { width: result.width, height: result.height };
+  try {
+    const result = element.getBBox();
+    return { width: result.width, height: result.height };
+  } catch {
+    // Fallback to getBoundingClientRect if getBBox fails
+    // This can happen in tests
+    const result = element.getBoundingClientRect();
+    return { width: result.width, height: result.height };
+  }
 }
 
 let measurementContainer: SVGSVGElement | null = null;


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/20291

Issue was due to our current performance changes

The correct way of accessing SVG element sizes is to use `getBBox` as it returns accurate values across browsers/systems.

`getBoundingClientRect` can return different values for SVG elements.


```ts
On Firefox on windows
// bbox:
const SVGRect = {
  x: -14.300000190734863,
  y: -7,
  width: 14.300000190734863,
  height: 14,
};
// rect:
const DOMRect = {
  x: -15.316665649414062,
  y: -20824,
  width: 16.333328247070312,
  height: 16,
};
```