### PR TITLE
[test] Fix browser tests skipping some projects

### DIFF
--- a/packages/x-data-grid-pro/vitest.config.browser.mts
+++ b/packages/x-data-grid-pro/vitest.config.browser.mts
@@ -8,7 +8,10 @@ export default mergeConfig(
     test: {
       name: getTestName(import.meta.url),
       exclude: ['**/materialVersion.test.tsx'],
-      browser: { enabled: true },
+      browser: {
+        enabled: true,
+        instances: [{ browser: 'chromium' }],
+      },
     },
   }),
 );

--- a/packages/x-data-grid/vitest.config.browser.mts
+++ b/packages/x-data-grid/vitest.config.browser.mts
@@ -8,7 +8,10 @@ export default mergeConfig(
     test: {
       name: getTestName(import.meta.url),
       exclude: ['**/materialVersion.test.tsx'],
-      browser: { enabled: true },
+      browser: {
+        enabled: true,
+        instances: [{ browser: 'chromium' }],
+      },
     },
   }),
 );

--- a/packages/x-virtualizer/vitest.config.browser.mts
+++ b/packages/x-virtualizer/vitest.config.browser.mts
@@ -7,7 +7,10 @@ export default mergeConfig(
   defineConfig({
     test: {
       name: getTestName(import.meta.url),
-      browser: { enabled: true },
+      browser: {
+        enabled: true,
+        instances: [{ browser: 'chromium' }],
+      },
     },
   }),
 );


### PR DESCRIPTION
While working on tests in https://github.com/mui/mui-x/pull/15041, I noticed that `x-data-grid` project is completely ignored in browser tests:

```sh
pnpm test:browser --project "x-data-grid"

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: No projects matched the filter "x-data-grid".
```

While `x-data-grid-premium` project worked fine.
I noticed that some projects did not have `instances: [{ browser: 'chromium' }],` entry in their vitest configs.
They were accidentally removed in https://github.com/mui/mui-x/pull/20102