### PR TITLE
[test] Update `use-react-version` pnpm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:argos": "code-infra argos-push --folder test/regressions/screenshots/chrome",
     "typescript": "lerna run --no-bail --parallel typescript",
     "typescript:ci": "lerna run --concurrency 1 --no-bail --no-sort typescript",
-    "use-react-18": "code-infra set-version-overrides --pkg react@^18",
+    "use-react-18": "code-infra set-version-overrides --pkg react@18",
     "use-material-ui-v6": "code-infra set-version-overrides --pkg @mui/material@6",
     "use-material-ui-next": "code-infra set-version-overrides --pkg @mui/material@next",
     "release:changelog": "node scripts/releaseChangelog.mjs",

--- a/test/README.md
+++ b/test/README.md
@@ -122,8 +122,8 @@ You can check integration of different versions of React (for example different 
 
 Possible values for `version`:
 
-- an NPM tag, for example `next`, `experimental` or `latest`
-- an older version, for example `^18.0.0`
+- an npm tag, for example `next`, `experimental` or `latest`
+- an older version, for example `18`
 
 For React 18 specifically, you can run the `pnpm use-react-18` script.
 


### PR DESCRIPTION
`use-react-version` pnpm script runs a script that doesn't exist anymore, since `code-infra set-version-overrides` is now used to override package versions. So I used it instead, and updated the readme as well.