### PR TITLE
[pickers] Do not loose `slotProps.field.slotProps`

### DIFF
--- a/docs/data/date-pickers/custom-field/MultiInputFieldSeparatorSlotProps.js
+++ b/docs/data/date-pickers/custom-field/MultiInputFieldSeparatorSlotProps.js
@@ -12,7 +12,9 @@ export default function MultiInputFieldSeparatorSlotProps() {
           slotProps={{ separator: { sx: { opacity: 0.5 } } }}
         />
         <DateRangePicker
-          slotProps={{ separator: { sx: { opacity: 0.5 } } }}
+          slotProps={{
+            field: { slotProps: { separator: { sx: { opacity: 0.5 } } } },
+          }}
           slots={{ field: MultiInputDateRangeField }}
         />
       </DemoContainer>

--- a/docs/data/date-pickers/custom-field/MultiInputFieldSeparatorSlotProps.tsx
+++ b/docs/data/date-pickers/custom-field/MultiInputFieldSeparatorSlotProps.tsx
@@ -12,7 +12,9 @@ export default function MultiInputFieldSeparatorSlotProps() {
           slotProps={{ separator: { sx: { opacity: 0.5 } } }}
         />
         <DateRangePicker
-          slotProps={{ separator: { sx: { opacity: 0.5 } } } as any}
+          slotProps={{
+            field: { slotProps: { separator: { sx: { opacity: 0.5 } } } } as any,
+          }}
           slots={{ field: MultiInputDateRangeField }}
         />
       </DemoContainer>

--- a/docs/data/date-pickers/custom-field/MultiInputFieldSeparatorSlotProps.tsx.preview
+++ b/docs/data/date-pickers/custom-field/MultiInputFieldSeparatorSlotProps.tsx.preview
@@ -2,6 +2,8 @@
   slotProps={{ separator: { sx: { opacity: 0.5 } } }}
 />
 <DateRangePicker
-  slotProps={{ separator: { sx: { opacity: 0.5 } } } as any}
+  slotProps={{
+    field: { slotProps: { separator: { sx: { opacity: 0.5 } } } } as any,
+  }}
   slots={{ field: MultiInputDateRangeField }}
 />

--- a/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useDesktopRangePicker/useDesktopRangePicker.tsx
@@ -83,8 +83,8 @@ export const useDesktopRangePicker = <
       <PickerRangePositionContext.Provider value={rangePositionResponse}>
         <Field
           {...fieldProps}
-          slots={slots}
-          slotProps={slotProps}
+          slots={{ ...slots, ...(fieldProps as any).slots }}
+          slotProps={{ ...slotProps, ...(fieldProps as any).slotProps }}
           {...(isSingleInput && {
             inputRef,
           })}

--- a/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
+++ b/packages/x-date-pickers-pro/src/internals/hooks/useMobileRangePicker/useMobileRangePicker.tsx
@@ -133,8 +133,8 @@ export const useMobileRangePicker = <
       <PickerRangePositionContext.Provider value={rangePositionResponse}>
         <Field
           {...fieldProps}
-          slots={slots}
-          slotProps={slotProps}
+          slots={{ ...slots, ...(fieldProps as any).slots }}
+          slotProps={{ ...slotProps, ...(fieldProps as any).slotProps }}
           {...(isSingleInput && {
             inputRef,
           })}

--- a/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useDesktopPicker/useDesktopPicker.tsx
@@ -83,7 +83,12 @@ export const useDesktopPicker = <
 
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
-      <Field {...fieldProps} slots={slots} slotProps={slotProps} inputRef={inputRef} />
+      <Field
+        {...fieldProps}
+        slots={{ ...slots, ...(fieldProps as any).slots }}
+        slotProps={{ ...slotProps, ...(fieldProps as any).slotProps }}
+        inputRef={inputRef}
+      />
       <PickerPopper slots={slots} slotProps={slotProps}>
         <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
           {renderCurrentView()}

--- a/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
+++ b/packages/x-date-pickers/src/internals/hooks/useMobilePicker/useMobilePicker.tsx
@@ -83,7 +83,12 @@ export const useMobilePicker = <
 
   const renderPicker = () => (
     <PickerProvider {...providerProps}>
-      <Field {...fieldProps} slots={slots} slotProps={slotProps} inputRef={inputRef} />
+      <Field
+        {...fieldProps}
+        slots={{ ...slots, ...(fieldProps as any).slots }}
+        slotProps={{ ...slotProps, ...(fieldProps as any).slotProps }}
+        inputRef={inputRef}
+      />
       <PickersModalDialog slots={slots} slotProps={slotProps}>
         <Layout {...slotProps?.layout} slots={slots} slotProps={slotProps}>
           {renderCurrentView()}


### PR DESCRIPTION
Follow up on #20293

I think this was broken during the latest refactoring of the slots propagation.
We do need `slotProps.field.slotProps` to work (same for `slotProps.field.slots`)