### PR TITLE
[charts] Use directly selector from `@mui/x-internals`

### DIFF
--- a/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/useChartFunnelAxisRendering.selectors.ts
+++ b/packages/x-charts-pro/src/FunnelChart/funnelAxisPlugin/useChartFunnelAxisRendering.selectors.ts
@@ -1,6 +1,5 @@
-import { createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import {
-  createSelector,
   selectorChartSeriesConfig,
   selectorChartSeriesProcessed,
   selectorChartDrawingArea,
@@ -14,7 +13,7 @@ import { UseChartFunnelAxisSignature } from './useChartFunnelAxis.types';
 export const selectorFunnel = (state: ChartState<[], [UseChartFunnelAxisSignature]>) =>
   state.funnel;
 
-export const selectorFunnelGap = createSelector([selectorFunnel], (funnel) => funnel?.gap ?? 0);
+export const selectorFunnelGap = createSelector(selectorFunnel, (funnel) => funnel?.gap ?? 0);
 
 export const selectorChartXAxis = createSelectorMemoized(
   selectorChartRawXAxis,

--- a/packages/x-charts-pro/src/SankeyChart/plugins/useSankeyHighlight.selectors.ts
+++ b/packages/x-charts-pro/src/SankeyChart/plugins/useSankeyHighlight.selectors.ts
@@ -1,8 +1,5 @@
-import {
-  createSelector,
-  type ChartRootSelector,
-  type UseChartSeriesSignature,
-} from '@mui/x-charts/internals';
+import { createSelector } from '@mui/x-internals/store';
+import { type ChartRootSelector, type UseChartSeriesSignature } from '@mui/x-charts/internals';
 import type { UseSankeyHighlightSignature } from './useSankeyHighlight.types';
 import type { SankeyLayoutLink, SankeyNodeId } from '../sankey.types';
 import type {
@@ -17,7 +14,7 @@ const selectorSankeyHighlight = (state: UseSankeyHighlightSignature['state']) =>
 const selectSeries: ChartRootSelector<UseChartSeriesSignature> = (state) => state.series;
 
 const selectorSankeySeries = createSelector(
-  [selectSeries],
+  selectSeries,
   (series) =>
     series.processedSeries.sankey?.series[series.processedSeries.sankey?.seriesOrder[0]] || null,
 );
@@ -31,7 +28,7 @@ const DEFAULT_FADE: SankeyNodeFade & SankeyLinkFade = 'none';
  * Defaults to 'nodes' if not specified.
  */
 export const selectorNodeHighlightConfig = createSelector(
-  [selectorSankeySeries],
+  selectorSankeySeries,
   (series): SankeyNodeHighlight => series?.nodeOptions?.highlight ?? DEFAULT_NODE_HIGHLIGHT,
 );
 
@@ -40,7 +37,7 @@ export const selectorNodeHighlightConfig = createSelector(
  * Defaults to 'none' if not specified.
  */
 export const selectorNodeFadeConfig = createSelector(
-  [selectorSankeySeries],
+  selectorSankeySeries,
   (series): SankeyNodeFade => series?.nodeOptions?.fade ?? DEFAULT_FADE,
 );
 
@@ -49,7 +46,7 @@ export const selectorNodeFadeConfig = createSelector(
  * Defaults to 'links' if not specified.
  */
 export const selectorLinkHighlightConfig = createSelector(
-  [selectorSankeySeries],
+  selectorSankeySeries,
   (series): SankeyLinkHighlight => series?.linkOptions?.highlight ?? DEFAULT_LINK_HIGHLIGHT,
 );
 
@@ -58,7 +55,7 @@ export const selectorLinkHighlightConfig = createSelector(
  * Defaults to 'none' if not specified.
  */
 export const selectorLinkFadeConfig = createSelector(
-  [selectorSankeySeries],
+  selectorSankeySeries,
   (series): SankeyLinkFade => series?.linkOptions?.fade ?? DEFAULT_FADE,
 );
 
@@ -68,7 +65,7 @@ export const selectorLinkFadeConfig = createSelector(
  * @returns {SankeyItemIdentifier | null} The highlighted item identifier or null.
  */
 export const selectorSankeyHighlightedItem = createSelector(
-  [selectorSankeyHighlight],
+  selectorSankeyHighlight,
   (highlight) => highlight.item,
 );
 
@@ -79,7 +76,9 @@ export const selectorSankeyHighlightedItem = createSelector(
  * - It's connected to a highlighted link (based on linkOptions.highlight)
  */
 export const selectorIsNodeHighlighted = createSelector(
-  [selectorSankeyHighlightedItem, selectorNodeHighlightConfig, selectorLinkHighlightConfig],
+  selectorSankeyHighlightedItem,
+  selectorNodeHighlightConfig,
+  selectorLinkHighlightConfig,
   (highlightedItem, nodeHighlight, linkHighlight, nodeId: SankeyNodeId): boolean => {
     if (!highlightedItem) {
       return false;
@@ -119,7 +118,9 @@ export const selectorIsNodeHighlighted = createSelector(
  * - It's connected to a highlighted node (based on nodeOptions.highlight)
  */
 export const selectorIsLinkHighlighted = createSelector(
-  [selectorSankeyHighlightedItem, selectorNodeHighlightConfig, selectorLinkHighlightConfig],
+  selectorSankeyHighlightedItem,
+  selectorNodeHighlightConfig,
+  selectorLinkHighlightConfig,
   (highlightedItem, nodeHighlight, linkHighlight, link: SankeyLayoutLink): boolean => {
     if (!highlightedItem) {
       return false;
@@ -164,7 +165,9 @@ export const selectorIsLinkHighlighted = createSelector(
  * - The fade mode is 'global' for the highlighted element type
  */
 export const selectorIsSankeyItemFaded = createSelector(
-  [selectorSankeyHighlightedItem, selectorNodeFadeConfig, selectorLinkFadeConfig],
+  selectorSankeyHighlightedItem,
+  selectorNodeFadeConfig,
+  selectorLinkFadeConfig,
   (highlightedItem, nodeFade, linkFade, isHighlighted: boolean): boolean => {
     if (!highlightedItem || isHighlighted) {
       return false;

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/ZoomInteractionConfig.selectors.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/ZoomInteractionConfig.selectors.ts
@@ -1,21 +1,23 @@
-import { createSelector, selectorChartZoomOptionsLookup } from '@mui/x-charts/internals';
+import { createSelector } from '@mui/x-internals/store';
+import { selectorChartZoomOptionsLookup } from '@mui/x-charts/internals';
 import { selectorChartZoomState } from './useChartProZoom.selectors';
 import type { ZoomInteractionName, PanInteractionName } from './ZoomInteractionConfig.types';
 
 export const selectorZoomInteractionConfig = createSelector(
-  [selectorChartZoomState],
+  selectorChartZoomState,
   (zoomState, interactionName: ZoomInteractionName) =>
     zoomState.zoomInteractionConfig.zoom[interactionName] ?? null,
 );
 
 export const selectorPanInteractionConfig = createSelector(
-  [selectorChartZoomState],
+  selectorChartZoomState,
   (zoomState, interactionName: PanInteractionName) =>
     zoomState.zoomInteractionConfig.pan[interactionName] ?? null,
 );
 
 export const selectorIsZoomBrushEnabled = createSelector(
-  [selectorChartZoomOptionsLookup, (state) => selectorZoomInteractionConfig(state, 'brush')],
+  selectorChartZoomOptionsLookup,
+  (state) => selectorZoomInteractionConfig(state, 'brush'),
   (zoomOptions, zoomInteractionConfig) =>
     (Object.keys(zoomOptions).length > 0 && zoomInteractionConfig) || false,
 );

--- a/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.selectors.ts
+++ b/packages/x-charts-pro/src/internals/plugins/useChartProZoom/useChartProZoom.selectors.ts
@@ -1,7 +1,7 @@
+import { createSelector } from '@mui/x-internals/store';
 import {
   AxisId,
   ChartRootSelector,
-  createSelector,
   selectorChartZoomMap,
   selectorChartZoomOptionsLookup,
 } from '@mui/x-charts/internals';
@@ -12,22 +12,23 @@ export const selectorChartZoomState: ChartRootSelector<UseChartProZoomSignature,
 ) => state.zoom;
 
 export const selectorChartZoomIsInteracting = createSelector(
-  [selectorChartZoomState],
+  selectorChartZoomState,
   (zoom) => zoom.isInteracting,
 );
 
 export const selectorChartZoomIsEnabled = createSelector(
-  [selectorChartZoomOptionsLookup],
+  selectorChartZoomOptionsLookup,
   (optionsLookup) => Object.keys(optionsLookup).length > 0,
 );
 
 export const selectorChartAxisZoomData = createSelector(
-  [selectorChartZoomMap],
+  selectorChartZoomMap,
   (zoomMap, axisId: AxisId) => zoomMap?.get(axisId),
 );
 
 export const selectorChartCanZoomOut = createSelector(
-  [selectorChartZoomState, selectorChartZoomOptionsLookup],
+  selectorChartZoomState,
+  selectorChartZoomOptionsLookup,
   (zoomState, zoomOptions) => {
     return zoomState.zoomData.every((zoomData) => {
       const span = zoomData.end - zoomData.start;
@@ -41,7 +42,8 @@ export const selectorChartCanZoomOut = createSelector(
 );
 
 export const selectorChartCanZoomIn = createSelector(
-  [selectorChartZoomState, selectorChartZoomOptionsLookup],
+  selectorChartZoomState,
+  selectorChartZoomOptionsLookup,
   (zoomState, zoomOptions) => {
     return zoomState.zoomData.every((zoomData) => {
       const span = zoomData.end - zoomData.start;

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartAnimation/useChartAnimation.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartAnimation/useChartAnimation.selectors.ts
@@ -1,10 +1,11 @@
-import { ChartRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartRootSelector } from '../../utils/selectors';
 import type { UseChartAnimationSignature } from './useChartAnimation.types';
 
 const selectorChartAnimationState: ChartRootSelector<UseChartAnimationSignature> = (state) =>
   state.animation;
 
 export const selectorChartSkipAnimation = createSelector(
-  [selectorChartAnimationState],
+  selectorChartAnimationState,
   (state) => state.skip || state.skipAnimationRequests > 0,
 );

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartDimensions/useChartDimensions.selectors.ts
@@ -1,5 +1,5 @@
-import { createSelectorMemoized } from '@mui/x-internals/store';
-import { ChartRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
+import { ChartRootSelector } from '../../utils/selectors';
 import type { UseChartDimensionsSignature } from './useChartDimensions.types';
 import { selectorChartAxisSizes } from '../../featurePlugins/useChartCartesianAxis/useChartAxisSize.selectors';
 import { ChartState } from '../../models/chart';
@@ -32,21 +32,21 @@ export const selectorChartDrawingArea = createSelectorMemoized(
 );
 
 export const selectorChartSvgWidth = createSelector(
-  [selectorChartDimensionsState],
+  selectorChartDimensionsState,
   (dimensionsState) => dimensionsState.width,
 );
 
 export const selectorChartSvgHeight = createSelector(
-  [selectorChartDimensionsState],
+  selectorChartDimensionsState,
   (dimensionsState) => dimensionsState.height,
 );
 
 export const selectorChartPropsWidth = createSelector(
-  [selectorChartDimensionsState],
+  selectorChartDimensionsState,
   (dimensionsState) => dimensionsState.propsWidth,
 );
 
 export const selectorChartPropsHeight = createSelector(
-  [selectorChartDimensionsState],
+  selectorChartDimensionsState,
   (dimensionsState) => dimensionsState.propsHeight,
 );

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartExperimentalFeature/useChartExperimentalFeature.selectors.ts
@@ -1,4 +1,5 @@
-import { ChartRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartRootSelector } from '../../utils/selectors';
 import type { UseChartExperimentalFeaturesSignature } from './useChartExperimentalFeature.types';
 
 export const selectorChartExperimentalFeaturesState: ChartRootSelector<
@@ -6,6 +7,6 @@ export const selectorChartExperimentalFeaturesState: ChartRootSelector<
 > = (state) => state.experimentalFeatures;
 
 export const selectorPreferStrictDomainInLineCharts = createSelector(
-  [selectorChartExperimentalFeaturesState],
+  selectorChartExperimentalFeaturesState,
   (features) => Boolean(features?.preferStrictDomainInLineCharts),
 );

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartId/useChartId.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartId/useChartId.selectors.ts
@@ -1,4 +1,5 @@
-import { createSelector, ChartRootSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartRootSelector } from '../../utils/selectors';
 import { UseChartIdSignature } from './useChartId.types';
 
 const selectorChartIdState: ChartRootSelector<UseChartIdSignature> = (state) => state.id;
@@ -8,4 +9,4 @@ const selectorChartIdState: ChartRootSelector<UseChartIdSignature> = (state) => 
  * @param {ChartState<[UseChartIdSignature]>} state The state of the chart.
  * @returns {string} The id attribute of the chart.
  */
-export const selectorChartId = createSelector([selectorChartIdState], (idState) => idState.chartId);
+export const selectorChartId = createSelector(selectorChartIdState, (idState) => idState.chartId);

--- a/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/corePlugins/useChartSeries/useChartSeries.selectors.ts
@@ -1,16 +1,17 @@
-import { ChartRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartRootSelector } from '../../utils/selectors';
 import { UseChartSeriesSignature } from './useChartSeries.types';
 
 export const selectorChartSeriesState: ChartRootSelector<UseChartSeriesSignature> = (state) =>
   state.series;
 
 export const selectorChartSeriesProcessed = createSelector(
-  [selectorChartSeriesState],
+  selectorChartSeriesState,
   (seriesState) => seriesState.processedSeries,
 );
 
 export const selectorChartSeriesConfig = createSelector(
-  [selectorChartSeriesState],
+  selectorChartSeriesState,
   (seriesState) => seriesState.seriesConfig,
 );
 
@@ -20,6 +21,6 @@ export const selectorChartSeriesConfig = createSelector(
  * @returns {DatasetType | undefined} The dataset.
  */
 export const selectorChartDataset = createSelector(
-  [selectorChartSeriesState],
+  selectorChartSeriesState,
   (seriesState) => seriesState.dataset,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartBrush/useChartBrush.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartBrush/useChartBrush.selectors.ts
@@ -1,4 +1,5 @@
-import { createSelector, type ChartOptionalRootSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import type { ChartOptionalRootSelector } from '../../utils/selectors';
 import { selectorChartZoomOptionsLookup } from '../useChartCartesianAxis/useChartCartesianAxisRendering.selectors';
 import type { UseChartBrushSignature } from './useChartBrush.types';
 import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
@@ -6,32 +7,35 @@ import { selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
 export const selectorBrush: ChartOptionalRootSelector<UseChartBrushSignature> = (state) =>
   state.brush;
 
-export const selectorBrushStart = createSelector([selectorBrush], (brush) => brush?.start);
+export const selectorBrushStart = createSelector(selectorBrush, (brush) => brush?.start);
 
-export const selectorBrushCurrent = createSelector([selectorBrush], (brush) => brush?.current);
+export const selectorBrushCurrent = createSelector(selectorBrush, (brush) => brush?.current);
 
 export const selectorBrushStartX = createSelector(
-  [selectorBrush],
+  selectorBrush,
   (brush) => brush?.start?.x ?? null,
 );
 
 export const selectorBrushStartY = createSelector(
-  [selectorBrush],
+  selectorBrush,
   (brush) => brush?.start?.y ?? null,
 );
 
 export const selectorBrushCurrentX = createSelector(
-  [selectorBrush],
+  selectorBrush,
   (brush) => brush?.current?.x ?? null,
 );
 
 export const selectorBrushCurrentY = createSelector(
-  [selectorBrush],
+  selectorBrush,
   (brush) => brush?.current?.y ?? null,
 );
 
 export const selectorBrushState = createSelector(
-  [selectorBrushStartX, selectorBrushStartY, selectorBrushCurrentX, selectorBrushCurrentY],
+  selectorBrushStartX,
+  selectorBrushStartY,
+  selectorBrushCurrentX,
+  selectorBrushCurrentY,
   (startX, startY, currentX, currentY) => {
     if (startX === null || startY === null || currentX === null || currentY === null) {
       return null;
@@ -43,33 +47,30 @@ export const selectorBrushState = createSelector(
   },
 );
 
-export const selectorBrushConfigNoZoom = createSelector(
-  [selectorChartSeriesProcessed],
-  (series) => {
-    let hasHorizontal = false;
-    let isBothDirections = false;
-    if (series) {
-      Object.entries(series).forEach(([seriesType, seriesData]) => {
-        if (Object.values(seriesData.series).some((s) => s.layout === 'horizontal')) {
-          hasHorizontal = true;
-        }
-        if (seriesType === 'scatter' && seriesData.seriesOrder.length > 0) {
-          isBothDirections = true;
-        }
-      });
-    }
-    if (isBothDirections) {
-      return 'xy';
-    }
-    if (hasHorizontal) {
-      return 'y';
-    }
-    return 'x';
-  },
-);
+export const selectorBrushConfigNoZoom = createSelector(selectorChartSeriesProcessed, (series) => {
+  let hasHorizontal = false;
+  let isBothDirections = false;
+  if (series) {
+    Object.entries(series).forEach(([seriesType, seriesData]) => {
+      if (Object.values(seriesData.series).some((s) => s.layout === 'horizontal')) {
+        hasHorizontal = true;
+      }
+      if (seriesType === 'scatter' && seriesData.seriesOrder.length > 0) {
+        isBothDirections = true;
+      }
+    });
+  }
+  if (isBothDirections) {
+    return 'xy';
+  }
+  if (hasHorizontal) {
+    return 'y';
+  }
+  return 'x';
+});
 
 export const selectorBrushConfigZoom = createSelector(
-  [selectorChartZoomOptionsLookup],
+  selectorChartZoomOptionsLookup,
   function selectorBrushConfigZoom(optionsLookup) {
     let hasX = false;
     let hasY = false;
@@ -95,28 +96,32 @@ export const selectorBrushConfigZoom = createSelector(
 );
 
 export const selectorBrushConfig = createSelector(
-  [selectorBrushConfigNoZoom, selectorBrushConfigZoom],
+  selectorBrushConfigNoZoom,
+  selectorBrushConfigZoom,
   (configNoZoom, configZoom) => configZoom ?? configNoZoom,
 );
 
 export const selectorIsBrushEnabled = createSelector(
-  [selectorBrush],
+  selectorBrush,
   (brush) => brush?.enabled || brush?.isZoomBrushEnabled,
 );
 
 export const selectorIsBrushSelectionActive = createSelector(
-  [selectorIsBrushEnabled, selectorBrush],
+  selectorIsBrushEnabled,
+  selectorBrush,
   (isBrushEnabled, brush) => {
     return isBrushEnabled && brush?.start !== null && brush?.current !== null;
   },
 );
 
 export const selectorBrushShouldPreventAxisHighlight = createSelector(
-  [selectorBrush, selectorIsBrushSelectionActive],
+  selectorBrush,
+  selectorIsBrushSelectionActive,
   (brush, isBrushSelectionActive) => isBrushSelectionActive && brush?.preventHighlight,
 );
 
 export const selectorBrushShouldPreventTooltip = createSelector(
-  [selectorBrush, selectorIsBrushSelectionActive],
+  selectorBrush,
+  selectorIsBrushSelectionActive,
   (brush, isBrushSelectionActive) => isBrushSelectionActive && brush?.preventTooltip,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPreview.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisPreview.selectors.ts
@@ -1,5 +1,5 @@
+import { createSelector } from '@mui/x-internals/store';
 import type { ChartDrawingArea } from '../../../../hooks/useDrawingArea';
-import { createSelector } from '../../utils/selectors';
 import {
   selectorChartRawXAxis,
   selectorChartRawYAxis,
@@ -54,12 +54,10 @@ function createPreviewDrawingArea(
 }
 
 export const selectorChartPreviewXScales = createSelector(
-  [
-    selectorChartRawXAxis,
-    selectorChartDrawingArea,
-    selectorChartZoomOptionsLookup,
-    selectorChartNormalizedXScales,
-  ],
+  selectorChartRawXAxis,
+  selectorChartDrawingArea,
+  selectorChartZoomOptionsLookup,
+  selectorChartNormalizedXScales,
   function selectorChartPreviewXScales(
     xAxes,
     chartDrawingArea,
@@ -90,15 +88,12 @@ export const selectorChartPreviewXScales = createSelector(
 );
 
 export const selectorChartPreviewComputedXAxis = createSelector(
-  [
-    selectorChartSeriesProcessed,
-    selectorChartSeriesConfig,
-    selectorChartZoomOptionsLookup,
-    selectorChartDrawingArea,
-    selectorChartPreviewXScales,
-    selectorChartXAxisWithDomains,
-  ],
-
+  selectorChartSeriesProcessed,
+  selectorChartSeriesConfig,
+  selectorChartZoomOptionsLookup,
+  selectorChartDrawingArea,
+  selectorChartPreviewXScales,
+  selectorChartXAxisWithDomains,
   (
     formattedSeries,
     seriesConfig,
@@ -136,12 +131,10 @@ export const selectorChartPreviewComputedXAxis = createSelector(
 );
 
 export const selectorChartPreviewYScales = createSelector(
-  [
-    selectorChartRawYAxis,
-    selectorChartDrawingArea,
-    selectorChartZoomOptionsLookup,
-    selectorChartNormalizedYScales,
-  ],
+  selectorChartRawYAxis,
+  selectorChartDrawingArea,
+  selectorChartZoomOptionsLookup,
+  selectorChartNormalizedYScales,
   function selectorChartPreviewYScales(
     yAxes,
     chartDrawingArea,
@@ -177,14 +170,12 @@ export const selectorChartPreviewYScales = createSelector(
 );
 
 export const selectorChartPreviewComputedYAxis = createSelector(
-  [
-    selectorChartSeriesProcessed,
-    selectorChartSeriesConfig,
-    selectorChartZoomOptionsLookup,
-    selectorChartDrawingArea,
-    selectorChartPreviewYScales,
-    selectorChartYAxisWithDomains,
-  ],
+  selectorChartSeriesProcessed,
+  selectorChartSeriesConfig,
+  selectorChartZoomOptionsLookup,
+  selectorChartDrawingArea,
+  selectorChartPreviewYScales,
+  selectorChartYAxisWithDomains,
   (
     formattedSeries,
     seriesConfig,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianAxisRendering.selectors.ts
@@ -1,11 +1,10 @@
 import { NumberValue } from '@mui/x-charts-vendor/d3-scale';
-import { createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import { selectorChartDrawingArea } from '../../corePlugins/useChartDimensions';
 import {
   selectorChartSeriesConfig,
   selectorChartSeriesProcessed,
 } from '../../corePlugins/useChartSeries';
-import { createSelector } from '../../utils/selectors';
 import { computeAxisValue } from './computeAxisValue';
 import { ExtremumFilter, UseChartCartesianAxisSignature } from './useChartCartesianAxis.types';
 import { ChartState } from '../../models/chart';
@@ -54,7 +53,8 @@ const selectorChartZoomState = (state: ChartState<[], [UseChartCartesianAxisSign
   state.zoom;
 
 export const selectorChartHasZoom = createSelector(
-  [selectorChartRawXAxis, selectorChartRawYAxis],
+  selectorChartRawXAxis,
+  selectorChartRawYAxis,
   (xAxes, yAxes) =>
     xAxes?.some((axis) => Boolean(axis.zoom)) || yAxes?.some((axis) => Boolean(axis.zoom)) || false,
 );
@@ -64,7 +64,7 @@ export const selectorChartHasZoom = createSelector(
  */
 
 export const selectorChartZoomIsInteracting = createSelector(
-  [selectorChartZoomState],
+  selectorChartZoomState,
   (zoom) => zoom?.isInteracting,
 );
 
@@ -76,7 +76,7 @@ export const selectorChartZoomMap = createSelectorMemoized(
 );
 
 export const selectorChartAxisZoomData = createSelector(
-  [selectorChartZoomMap],
+  selectorChartZoomMap,
   (zoomMap, axisId: AxisId) => zoomMap?.get(axisId),
 );
 
@@ -92,19 +92,19 @@ export const selectorChartZoomOptionsLookup = createSelectorMemoized(
 );
 
 export const selectorChartAxisZoomOptionsLookup = createSelector(
-  [selectorChartZoomOptionsLookup],
+  selectorChartZoomOptionsLookup,
   (axisLookup, axisId: AxisId) => axisLookup[axisId],
 );
 
 export const selectorDefaultXAxisTickNumber = createSelector(
-  [selectorChartDrawingArea],
+  selectorChartDrawingArea,
   function selectorDefaultXAxisTickNumber(drawingArea) {
     return getDefaultTickNumber(drawingArea.width);
   },
 );
 
 export const selectorDefaultYAxisTickNumber = createSelector(
-  [selectorChartDrawingArea],
+  selectorChartDrawingArea,
   function selectorDefaultYAxisTickNumber(drawingArea) {
     return getDefaultTickNumber(drawingArea.height);
   },
@@ -550,12 +550,14 @@ export const selectorChartYAxis = createSelectorMemoized(
 );
 
 export const selectorChartAxis = createSelector(
-  [selectorChartXAxis, selectorChartYAxis],
+  selectorChartXAxis,
+  selectorChartYAxis,
   (xAxes, yAxes, axisId: AxisId) => xAxes?.axis[axisId] ?? yAxes?.axis[axisId],
 );
 
 export const selectorChartRawAxis = createSelector(
-  [selectorChartRawXAxis, selectorChartRawYAxis],
+  selectorChartRawXAxis,
+  selectorChartRawYAxis,
   (xAxes, yAxes, axisId: AxisId) => {
     const axis = xAxes?.find((a) => a.id === axisId) ?? yAxes?.find((a) => a.id === axisId) ?? null;
 
@@ -568,12 +570,12 @@ export const selectorChartRawAxis = createSelector(
 );
 
 export const selectorChartDefaultXAxisId = createSelector(
-  [selectorChartRawXAxis],
+  selectorChartRawXAxis,
   (xAxes) => xAxes![0].id,
 );
 
 export const selectorChartDefaultYAxisId = createSelector(
-  [selectorChartRawYAxis],
+  selectorChartRawYAxis,
   (yAxes) => yAxes![0].id,
 );
 

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianHighlight.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianHighlight.selectors.ts
@@ -1,5 +1,4 @@
-import { createSelectorMemoized } from '@mui/x-internals/store';
-import { createSelector } from '../../utils/selectors';
+import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import { AxisItemIdentifier, ChartsAxisProps } from '../../../../models/axis';
 import { selectorChartXAxis, selectorChartYAxis } from './useChartCartesianAxisRendering.selectors';
 import {
@@ -109,28 +108,26 @@ const selectAxisHighlightWithValue = (
 };
 
 export const selectorChartsHighlightXAxisValue = createSelector(
-  [
-    selectorChartsInteractionXAxisIndex,
-    selectorChartsInteractionXAxisValue,
-    selectorChartXAxis,
-    selectorChartControlledCartesianAxisHighlight,
-    selectorChartsKeyboardXAxisIndex,
-    selectorChartsLastInteraction,
-    selectorBrushShouldPreventAxisHighlight,
-  ],
+  selectorChartsInteractionXAxisIndex,
+  selectorChartsInteractionXAxisValue,
+  selectorChartXAxis,
+  selectorChartControlledCartesianAxisHighlight,
+  selectorChartsKeyboardXAxisIndex,
+  selectorChartsLastInteraction,
+  selectorBrushShouldPreventAxisHighlight,
+
   selectAxisHighlightWithValue,
 );
 
 export const selectorChartsHighlightYAxisValue = createSelector(
-  [
-    selectorChartsInteractionYAxisIndex,
-    selectorChartsInteractionYAxisValue,
-    selectorChartYAxis,
-    selectorChartControlledCartesianAxisHighlight,
-    selectorChartsKeyboardYAxisIndex,
-    selectorChartsLastInteraction,
-    selectorBrushShouldPreventAxisHighlight,
-  ],
+  selectorChartsInteractionYAxisIndex,
+  selectorChartsInteractionYAxisValue,
+  selectorChartYAxis,
+  selectorChartControlledCartesianAxisHighlight,
+  selectorChartsKeyboardYAxisIndex,
+  selectorChartsLastInteraction,
+  selectorBrushShouldPreventAxisHighlight,
+
   selectAxisHighlightWithValue,
 );
 
@@ -155,11 +152,13 @@ const selectAxis = (
 };
 
 export const selectorChartsHighlightXAxis = createSelector(
-  [selectorChartControlledCartesianAxisHighlight, selectorChartXAxis],
+  selectorChartControlledCartesianAxisHighlight,
+  selectorChartXAxis,
   selectAxis,
 );
 
 export const selectorChartsHighlightYAxis = createSelector(
-  [selectorChartControlledCartesianAxisHighlight, selectorChartYAxis],
+  selectorChartControlledCartesianAxisHighlight,
+  selectorChartYAxis,
   selectAxis,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianInteraction.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartCartesianAxis/useChartCartesianInteraction.selectors.ts
@@ -1,6 +1,5 @@
 import { isDeepEqual } from '@mui/x-internals/isDeepEqual';
-import { createSelectorMemoizedWithOptions } from '@mui/x-internals/store';
-import { createSelector } from '../../utils/selectors';
+import { createSelector, createSelectorMemoizedWithOptions } from '@mui/x-internals/store';
 import { AxisId, AxisItemIdentifier, ChartsAxisProps } from '../../../../models/axis';
 import {
   selectorChartsInteractionPointerX,
@@ -38,22 +37,23 @@ export const selectChartsInteractionAxisIndex = (
 };
 
 export const selectorChartsInteractionXAxisIndex = createSelector(
-  [selectorChartsInteractionPointerX, selectorChartXAxis],
+  selectorChartsInteractionPointerX,
+  selectorChartXAxis,
   selectChartsInteractionAxisIndex,
 );
 
 export const selectorChartsInteractionYAxisIndex = createSelector(
-  [selectorChartsInteractionPointerY, selectorChartYAxis],
+  selectorChartsInteractionPointerY,
+  selectorChartYAxis,
   selectChartsInteractionAxisIndex,
 );
 
 export const selectorChartAxisInteraction = createSelector(
-  [
-    selectorChartsInteractionPointerX,
-    selectorChartsInteractionPointerY,
-    selectorChartXAxis,
-    selectorChartYAxis,
-  ],
+  selectorChartsInteractionPointerX,
+  selectorChartsInteractionPointerY,
+  selectorChartXAxis,
+  selectorChartYAxis,
+
   (x, y, xAxis, yAxis) =>
     [
       ...(x === null
@@ -104,7 +104,9 @@ function valueGetter(
 }
 
 export const selectorChartsInteractionXAxisValue = createSelector(
-  [selectorChartsInteractionPointerX, selectorChartXAxis, selectorChartsInteractionXAxisIndex],
+  selectorChartsInteractionPointerX,
+  selectorChartXAxis,
+  selectorChartsInteractionXAxisIndex,
   (x, xAxes, xIndex, id?: AxisId) => {
     if (x === null || xAxes.axisIds.length === 0) {
       return null;
@@ -114,7 +116,9 @@ export const selectorChartsInteractionXAxisValue = createSelector(
 );
 
 export const selectorChartsInteractionYAxisValue = createSelector(
-  [selectorChartsInteractionPointerY, selectorChartYAxis, selectorChartsInteractionYAxisIndex],
+  selectorChartsInteractionPointerY,
+  selectorChartYAxis,
+  selectorChartsInteractionYAxisIndex,
   (y, yAxes, yIndex, id?: AxisId) => {
     if (y === null || yAxes.axisIds.length === 0) {
       return null;
@@ -181,6 +185,7 @@ export const selectorChartsInteractionTooltipYAxes = createSelectorMemoizedWithO
  * Return `true` if the axis tooltip has something to display.
  */
 export const selectorChartsInteractionAxisTooltip = createSelector(
-  [selectorChartsInteractionTooltipXAxes, selectorChartsInteractionTooltipYAxes],
+  selectorChartsInteractionTooltipXAxes,
+  selectorChartsInteractionTooltipYAxes,
   (xTooltip, yTooltip) => xTooltip.length > 0 || yTooltip.length > 0,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartClosestPoint/useChartClosestPoint.selectors.ts
@@ -1,9 +1,10 @@
-import { ChartRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartRootSelector } from '../../utils/selectors';
 import { UseChartClosestPointSignature } from './useChartClosestPoint.types';
 
 const selectVoronoi: ChartRootSelector<UseChartClosestPointSignature> = (state) => state.voronoi;
 
 export const selectorChartsIsVoronoiEnabled = createSelector(
-  [selectVoronoi],
+  selectVoronoi,
   (voronoi) => voronoi?.isVoronoiEnabled,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartHighlight/useChartHighlight.selectors.ts
@@ -1,8 +1,8 @@
-import { createSelectorMemoized } from '@mui/x-internals/store';
+import { createSelector, createSelectorMemoized } from '@mui/x-internals/store';
 import { SeriesId } from '../../../../models/seriesType/common';
 import { ChartSeriesType } from '../../../../models/seriesType/config';
 import { UseChartSeriesSignature } from '../../corePlugins/useChartSeries/useChartSeries.types';
-import { ChartRootSelector, createSelector } from '../../utils/selectors';
+import { ChartRootSelector } from '../../utils/selectors';
 import { HighlightItemData, UseChartHighlightSignature } from './useChartHighlight.types';
 import { HighlightScope } from './highlightConfig.types';
 import { createIsHighlighted } from './createIsHighlighted';
@@ -20,7 +20,7 @@ const selectHighlight: ChartRootSelector<UseChartHighlightSignature> = (state) =
 const selectSeries: ChartRootSelector<UseChartSeriesSignature> = (state) => state.series;
 
 export const selectorChartsHighlightScopePerSeriesId = createSelector(
-  [selectSeries],
+  selectSeries,
   (series): Map<SeriesId, Partial<HighlightScope> | undefined> => {
     const map = new Map<SeriesId, Partial<HighlightScope> | undefined>();
 
@@ -44,7 +44,8 @@ export const selectorChartsHighlightedItem = createSelectorMemoized(
 );
 
 export const selectorChartsHighlightScope = createSelector(
-  [selectorChartsHighlightScopePerSeriesId, selectorChartsHighlightedItem],
+  selectorChartsHighlightScopePerSeriesId,
+  selectorChartsHighlightedItem,
   function selectorChartsHighlightScope(seriesIdToHighlightScope, highlightedItem) {
     if (!highlightedItem) {
       return null;
@@ -60,17 +61,20 @@ export const selectorChartsHighlightScope = createSelector(
 );
 
 export const selectorChartsIsHighlightedCallback = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   createIsHighlighted,
 );
 
 export const selectorChartsIsFadedCallback = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   createIsFaded,
 );
 
 export const selectorChartsIsHighlighted = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   function selectorChartsIsHighlighted(
     highlightScope,
     highlightedItem,
@@ -81,27 +85,32 @@ export const selectorChartsIsHighlighted = createSelector(
 );
 
 export const selectorChartIsSeriesHighlighted = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   isSeriesHighlighted,
 );
 
 export const selectorChartIsSeriesFaded = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   isSeriesFaded,
 );
 
 export const selectorChartSeriesUnfadedItem = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   getSeriesUnfadedItem,
 );
 
 export const selectorChartSeriesHighlightedItem = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   getSeriesHighlightedItem,
 );
 
 export const selectorChartsIsFaded = createSelector(
-  [selectorChartsHighlightScope, selectorChartsHighlightedItem],
+  selectorChartsHighlightScope,
+  selectorChartsHighlightedItem,
   function selectorChartsIsFaded(highlightScope, highlightedItem, item: HighlightItemData | null) {
     return createIsFaded(highlightScope, highlightedItem)(item);
   },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartInteraction/useChartInteraction.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartInteraction/useChartInteraction.selectors.ts
@@ -1,40 +1,41 @@
-import { ChartOptionalRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartOptionalRootSelector } from '../../utils/selectors';
 import { UseChartInteractionSignature } from './useChartInteraction.types';
 
 const selectInteraction: ChartOptionalRootSelector<UseChartInteractionSignature> = (state) =>
   state.interaction;
 
 export const selectorChartsInteractionIsInitialized = createSelector(
-  [selectInteraction],
+  selectInteraction,
   (interaction) => interaction !== undefined,
 );
 
 export const selectorChartsInteractionItem = createSelector(
-  [selectInteraction],
+  selectInteraction,
   (interaction) => interaction?.item ?? null,
 );
 
 export const selectorChartsInteractionPointer = createSelector(
-  [selectInteraction],
+  selectInteraction,
   (interaction) => interaction?.pointer ?? null,
 );
 
 export const selectorChartsInteractionPointerX = createSelector(
-  [selectorChartsInteractionPointer],
+  selectorChartsInteractionPointer,
   (pointer) => pointer && pointer.x,
 );
 
 export const selectorChartsInteractionPointerY = createSelector(
-  [selectorChartsInteractionPointer],
+  selectorChartsInteractionPointer,
   (pointer) => pointer && pointer.y,
 );
 
 export const selectorChartsInteractionItemIsDefined = createSelector(
-  [selectorChartsInteractionItem],
+  selectorChartsInteractionItem,
   (item) => item !== null,
 );
 
 export const selectorChartsLastInteraction = createSelector(
-  [selectInteraction],
+  selectInteraction,
   (interaction) => interaction?.lastUpdate,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartInteraction/useChartTooltip.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartInteraction/useChartTooltip.selectors.ts
@@ -1,3 +1,4 @@
+import { createSelector } from '@mui/x-internals/store';
 import {
   ChartItemIdentifierWithData,
   ChartSeriesDefaultized,
@@ -9,7 +10,6 @@ import {
   selectorChartSeriesProcessed,
 } from '../../corePlugins/useChartSeries';
 import { TooltipPositionGetterAxesConfig } from '../../models/seriesConfig/tooltipItemPositionGetter.types';
-import { createSelector } from '../../utils/selectors';
 import {
   selectorChartXAxis,
   selectorChartYAxis,
@@ -31,31 +31,31 @@ import { ChartDrawingArea } from '../../../../hooks/useDrawingArea';
 import { isCartesianSeries } from '../../../isCartesian';
 
 export const selectorChartsTooltipItem = createSelector(
-  [selectorChartsLastInteraction, selectorChartsInteractionItem, selectorChartsKeyboardItem],
+  selectorChartsLastInteraction,
+  selectorChartsInteractionItem,
+  selectorChartsKeyboardItem,
   (lastInteraction, interactionItem, keyboardItem) =>
     lastInteraction === 'keyboard' ? keyboardItem : (interactionItem ?? null),
 );
 
 export const selectorChartsTooltipItemIsDefined = createSelector(
-  [
-    selectorChartsLastInteraction,
-    selectorChartsInteractionItemIsDefined,
-    selectorChartsKeyboardItemIsDefined,
-  ],
+  selectorChartsLastInteraction,
+  selectorChartsInteractionItemIsDefined,
+  selectorChartsKeyboardItemIsDefined,
+
   (lastInteraction, interactionItemIsDefined, keyboardItemIsDefined) =>
     lastInteraction === 'keyboard' ? keyboardItemIsDefined : interactionItemIsDefined,
 );
 
 export const selectorChartsTooltipItemPosition = createSelector(
-  [
-    selectorChartsTooltipItem,
-    selectorChartDrawingArea,
-    selectorChartSeriesConfig,
-    selectorChartXAxis,
-    selectorChartYAxis,
-    selectorChartSeriesProcessed,
-    (_, placement?: 'top' | 'bottom' | 'left' | 'right') => placement,
-  ],
+  selectorChartsTooltipItem,
+  selectorChartDrawingArea,
+  selectorChartSeriesConfig,
+  selectorChartXAxis,
+  selectorChartYAxis,
+  selectorChartSeriesProcessed,
+  (_, placement?: 'top' | 'bottom' | 'left' | 'right') => placement,
+
   function selectorChartsTooltipItemPosition<T extends ChartSeriesType>(
     identifier: ChartItemIdentifierWithData<T> | null,
     drawingArea: ChartDrawingArea,

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartKeyboardNavigation/useChartKeyboardNavigation.selectors.ts
@@ -1,4 +1,5 @@
-import { ChartOptionalRootSelector, createSelector } from '../../utils/selectors';
+import { createSelector } from '@mui/x-internals/store';
+import { ChartOptionalRootSelector } from '../../utils/selectors';
 import { UseChartKeyboardNavigationSignature } from './useChartKeyboardNavigation.types';
 import { ProcessedSeries, selectorChartSeriesProcessed } from '../../corePlugins/useChartSeries';
 import {
@@ -16,7 +17,7 @@ const selectKeyboardNavigation: ChartOptionalRootSelector<UseChartKeyboardNaviga
 ) => state.keyboardNavigation;
 
 export const selectorChartsItemIsFocused = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   (keyboardNavigationState, item: FocusedItemData) => {
     return (
       keyboardNavigationState?.item != null &&
@@ -28,27 +29,27 @@ export const selectorChartsItemIsFocused = createSelector(
 );
 
 export const selectorChartsHasFocusedItem = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   (keyboardNavigationState) => keyboardNavigationState?.item != null,
 );
 
 export const selectorChartsFocusedSeriesType = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   (keyboardNavigationState) => keyboardNavigationState?.item?.type,
 );
 
 export const selectorChartsFocusedSeriesId = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   (keyboardNavigationState) => keyboardNavigationState?.item?.seriesId,
 );
 
 export const selectorChartsFocusedDataIndex = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   (keyboardNavigationState) => keyboardNavigationState?.item?.dataIndex,
 );
 
 export const selectorChartsIsKeyboardNavigationEnabled = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   (keyboardNavigationState) => !!keyboardNavigationState?.enableKeyboardNavigation,
 );
 
@@ -87,29 +88,25 @@ const createSelectAxisHighlight =
   };
 
 export const selectorChartsKeyboardXAxisIndex = createSelector(
-  [
-    selectorChartsFocusedSeriesType,
-    selectorChartsFocusedSeriesId,
-    selectorChartsFocusedDataIndex,
-    selectorChartXAxis,
-    selectorChartSeriesProcessed,
-  ],
+  selectorChartsFocusedSeriesType,
+  selectorChartsFocusedSeriesId,
+  selectorChartsFocusedDataIndex,
+  selectorChartXAxis,
+  selectorChartSeriesProcessed,
   createSelectAxisHighlight('x'),
 );
 
 export const selectorChartsKeyboardYAxisIndex = createSelector(
-  [
-    selectorChartsFocusedSeriesType,
-    selectorChartsFocusedSeriesId,
-    selectorChartsFocusedDataIndex,
-    selectorChartYAxis,
-    selectorChartSeriesProcessed,
-  ],
+  selectorChartsFocusedSeriesType,
+  selectorChartsFocusedSeriesId,
+  selectorChartsFocusedDataIndex,
+  selectorChartYAxis,
+  selectorChartSeriesProcessed,
   createSelectAxisHighlight('y'),
 );
 
 export const selectorChartsKeyboardItem = createSelector(
-  [selectKeyboardNavigation],
+  selectKeyboardNavigation,
   function selectorChartsKeyboardItem(keyboardState) {
     if (keyboardState?.item == null) {
       return null;
@@ -124,7 +121,9 @@ export const selectorChartsKeyboardItem = createSelector(
 );
 
 export const selectorChartsKeyboardItemIsDefined = createSelector(
-  [selectorChartsFocusedSeriesType, selectorChartsFocusedSeriesId, selectorChartsFocusedDataIndex],
+  selectorChartsFocusedSeriesType,
+  selectorChartsFocusedSeriesId,
+  selectorChartsFocusedDataIndex,
   function selectorChartsKeyboardItemIsDefined(seriesType, seriesId, dataIndex) {
     return seriesId !== undefined && dataIndex !== undefined;
   },

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarAxis.selectors.ts
@@ -1,9 +1,9 @@
+import { createSelector } from '@mui/x-internals/store';
 import { selectorChartDrawingArea } from '../../corePlugins/useChartDimensions';
 import {
   selectorChartSeriesConfig,
   selectorChartSeriesProcessed,
 } from '../../corePlugins/useChartSeries';
-import { createSelector } from '../../utils/selectors';
 import { UseChartPolarAxisSignature } from './useChartPolarAxis.types';
 import { ChartState } from '../../models/chart';
 import { computeAxisValue } from './computeAxisValue';
@@ -12,12 +12,12 @@ export const selectorChartPolarAxisState = (state: ChartState<[], [UseChartPolar
   state.polarAxis;
 
 export const selectorChartRawRotationAxis = createSelector(
-  [selectorChartPolarAxisState],
+  selectorChartPolarAxisState,
   (axis) => axis?.rotation,
 );
 
 export const selectorChartRawRadiusAxis = createSelector(
-  [selectorChartPolarAxisState],
+  selectorChartPolarAxisState,
   (axis) => axis?.radius,
 );
 
@@ -26,12 +26,10 @@ export const selectorChartRawRadiusAxis = createSelector(
  */
 
 export const selectorChartRotationAxis = createSelector(
-  [
-    selectorChartRawRotationAxis,
-    selectorChartDrawingArea,
-    selectorChartSeriesProcessed,
-    selectorChartSeriesConfig,
-  ],
+  selectorChartRawRotationAxis,
+  selectorChartDrawingArea,
+  selectorChartSeriesProcessed,
+  selectorChartSeriesConfig,
   (axis, drawingArea, formattedSeries, seriesConfig) =>
     computeAxisValue({
       drawingArea,
@@ -43,12 +41,10 @@ export const selectorChartRotationAxis = createSelector(
 );
 
 export const selectorChartRadiusAxis = createSelector(
-  [
-    selectorChartRawRadiusAxis,
-    selectorChartDrawingArea,
-    selectorChartSeriesProcessed,
-    selectorChartSeriesConfig,
-  ],
+  selectorChartRawRadiusAxis,
+  selectorChartDrawingArea,
+  selectorChartSeriesProcessed,
+  selectorChartSeriesConfig,
   (axis, drawingArea, formattedSeries, seriesConfig) =>
     computeAxisValue({
       drawingArea,
@@ -59,10 +55,7 @@ export const selectorChartRadiusAxis = createSelector(
     }),
 );
 
-export const selectorChartPolarCenter = createSelector(
-  [selectorChartDrawingArea],
-  (drawingArea) => ({
-    cx: drawingArea.left + drawingArea.width / 2,
-    cy: drawingArea.top + drawingArea.height / 2,
-  }),
-);
+export const selectorChartPolarCenter = createSelector(selectorChartDrawingArea, (drawingArea) => ({
+  cx: drawingArea.left + drawingArea.width / 2,
+  cy: drawingArea.top + drawingArea.height / 2,
+}));

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarInteraction.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartPolarAxis/useChartPolarInteraction.selectors.ts
@@ -1,7 +1,6 @@
 import { isDeepEqual } from '@mui/x-internals/isDeepEqual';
-import { createSelectorMemoizedWithOptions } from '@mui/x-internals/store';
+import { createSelector, createSelectorMemoizedWithOptions } from '@mui/x-internals/store';
 import { AxisId, ChartsAxisProps, AxisItemIdentifier } from '../../../../models/axis';
-import { createSelector } from '../../utils/selectors';
 import {
   selectorChartsInteractionPointerX,
   selectorChartsInteractionPointerY,
@@ -34,7 +33,9 @@ function indexGetter(
  * Helper to get the rotation associated to the interaction coordinate.
  */
 const selectorChartsInteractionRotationAngle = createSelector(
-  [selectorChartsInteractionPointerX, selectorChartsInteractionPointerY, selectorChartPolarCenter],
+  selectorChartsInteractionPointerX,
+  selectorChartsInteractionPointerY,
+  selectorChartPolarCenter,
   (x, y, center) => {
     if (x === null || y === null) {
       return null;
@@ -44,19 +45,25 @@ const selectorChartsInteractionRotationAngle = createSelector(
 );
 
 export const selectorChartsInteractionRotationAxisIndex = createSelector(
-  [selectorChartsInteractionRotationAngle, selectorChartRotationAxis, optionalGetAxisId],
+  selectorChartsInteractionRotationAngle,
+  selectorChartRotationAxis,
+  optionalGetAxisId,
   (rotation, rotationAxis, id = rotationAxis.axisIds[0]) =>
     rotation === null ? null : indexGetter(rotation, rotationAxis, id),
 );
 
 export const selectorChartsInteractionRotationAxisIndexes = createSelector(
-  [selectorChartsInteractionRotationAngle, selectorChartRotationAxis, optionalGetAxisIds],
+  selectorChartsInteractionRotationAngle,
+  selectorChartRotationAxis,
+  optionalGetAxisIds,
   (rotation, rotationAxis, ids = rotationAxis.axisIds) =>
     rotation === null ? null : indexGetter(rotation, rotationAxis, ids),
 );
 
 export const selectorChartsInteractionRotationAxisValue = createSelector(
-  [selectorChartRotationAxis, selectorChartsInteractionRotationAxisIndex, optionalGetAxisId],
+  selectorChartRotationAxis,
+  selectorChartsInteractionRotationAxisIndex,
+  optionalGetAxisId,
   (rotationAxis, rotationIndex, id = rotationAxis.axisIds[0]) => {
     if (rotationIndex === null || rotationIndex === -1 || rotationAxis.axisIds.length === 0) {
       return null;
@@ -71,7 +78,9 @@ export const selectorChartsInteractionRotationAxisValue = createSelector(
 );
 
 export const selectorChartsInteractionRotationAxisValues = createSelector(
-  [selectorChartRotationAxis, selectorChartsInteractionRotationAxisIndexes, optionalGetAxisIds],
+  selectorChartRotationAxis,
+  selectorChartsInteractionRotationAxisIndexes,
+  optionalGetAxisIds,
   (rotationAxis, rotationIndexes, ids = rotationAxis.axisIds) => {
     if (rotationIndexes === null) {
       return null;
@@ -124,6 +133,6 @@ export const selectorChartsInteractionTooltipRadiusAxes = () => {
  * Return `true` if the axis tooltip has something to display.
  */
 export const selectorChartsInteractionPolarAxisTooltip = createSelector(
-  [selectorChartsInteractionTooltipRotationAxes],
+  selectorChartsInteractionTooltipRotationAxes,
   (rotationTooltip) => rotationTooltip.length > 0,
 );

--- a/packages/x-charts/src/internals/plugins/featurePlugins/useChartZAxis/useChartZAxis.selectors.ts
+++ b/packages/x-charts/src/internals/plugins/featurePlugins/useChartZAxis/useChartZAxis.selectors.ts
@@ -1,7 +1,7 @@
+import { createSelector } from '@mui/x-internals/store';
 import { ChartState } from '../../models/chart';
-import { createSelector } from '../../utils/selectors';
 import { UseChartZAxisSignature } from './useChartZAxis.types';
 
 const selectRootState = (state: ChartState<[UseChartZAxisSignature]>) => state;
 
-export const selectorChartZAxis = createSelector([selectRootState], (state) => state.zAxis);
+export const selectorChartZAxis = createSelector(selectRootState, (state) => state.zAxis);

--- a/packages/x-charts/src/internals/plugins/utils/selectors.ts
+++ b/packages/x-charts/src/internals/plugins/utils/selectors.ts
@@ -1,5 +1,4 @@
 import type { Selector } from 'reselect';
-import { createSelector as internalCreateSelector } from '@mui/x-internals/store';
 import { ChartAnyPluginSignature } from '../models/plugin';
 import { ChartState } from '../models/chart';
 
@@ -12,63 +11,3 @@ export type ChartOptionalRootSelector<TSignature extends ChartAnyPluginSignature
   ChartState<[], [TSignature]>,
   TSignature['state'][keyof TSignature['state']] | undefined
 >;
-
-type StateFromSelectorList<Selectors extends readonly any[]> = Selectors extends [
-  f: infer F,
-  ...other: infer R,
-]
-  ? StateFromSelector<F> extends StateFromSelectorList<R>
-    ? StateFromSelector<F>
-    : StateFromSelectorList<R>
-  : {};
-
-type StateFromSelector<T> = T extends (first: infer F, ...args: any[]) => any ? F : never;
-
-type Fn = (...args: any[]) => any;
-
-type ReturnTypes<FunctionsArray extends readonly Fn[]> = {
-  [Index in keyof FunctionsArray]: FunctionsArray[Index] extends FunctionsArray[number]
-    ? ReturnType<FunctionsArray[Index]>
-    : never;
-};
-
-type MergeParams<
-  STypes extends readonly unknown[],
-  CTypes extends readonly unknown[],
-> = STypes['length'] extends 0 ? CTypes : MergeParams<DropFirst<STypes>, DropFirst<CTypes>>;
-
-type DropFirst<T> = T extends [any, ...infer Xs] ? Xs : [];
-
-type SelectorArgs<
-  Args extends any[],
-  Selectors extends ReadonlyArray<Selector<any>>,
-  Combiner extends (...args: readonly [...ReturnTypes<Selectors>, ...Args]) => any,
-> = Selectors['length'] extends 0
-  ? MergeParams<ReturnTypes<Selectors>, Parameters<Combiner>>
-  : [
-      StateFromSelectorList<Selectors>,
-      ...MergeParams<ReturnTypes<Selectors>, Parameters<Combiner>>,
-    ];
-
-type ChartSelector<
-  Args extends any[],
-  Selectors extends ReadonlyArray<Selector<any>>,
-  Combiner extends (...args: readonly [...ReturnTypes<Selectors>, ...Args]) => any,
-> = (...args: SelectorArgs<Args, Selectors, Combiner>) => ReturnType<Combiner>;
-
-/**
- * Method wrapping reselect's createChartSelector to provide caching for chart instances.
- */
-export const createSelector = <
-  const Args extends any[],
-  const Selectors extends ReadonlyArray<Selector<any>>,
-  const Combiner extends (...args: readonly [...ReturnTypes<Selectors>, ...Args]) => any,
->(
-  inputSelectors: [...Selectors],
-  combiner: Combiner,
-) =>
-  internalCreateSelector<Args, Selectors, Combiner>(...inputSelectors, combiner) as ChartSelector<
-    Args,
-    Selectors,
-    Combiner
-  >;


### PR DESCRIPTION
Nothing special. Just removed the array wrapping selectors, and modified all imports.

I just tested locally typescript. Let's see what the CI think about that :)
