### PR TITLE
[scheduler] Patch Base UI `useScrollLock` to fix `PreferencesMenu` test

### DIFF
--- a/patches/@base-ui-components__react.patch
+++ b/patches/@base-ui-components__react.patch
@@ -1,5 +1,5 @@
 diff --git a/utils/useScrollLock.js b/utils/useScrollLock.js
-index 58ccee9f790bd2d64f04a642c115f36fc73e9264..eff9fe5b4185304481be193d60b3a56ee9b3485a 100644
+index 58ccee9f790bd2d64f04a642c115f36fc73e9264..14c95eee35d54ecae013f1f4f07ff29e66f4bb1f 100644
 --- a/utils/useScrollLock.js
 +++ b/utils/useScrollLock.js
 @@ -124,7 +124,9 @@ function preventScrollStandard(referenceElement) {
@@ -7,7 +7,7 @@ index 58ccee9f790bd2d64f04a642c115f36fc73e9264..eff9fe5b4185304481be193d60b3a56e
      resizeFrame.cancel();
      cleanup();
 -    win.removeEventListener('resize', handleResize);
-+    if (win.removeEventListener) {
++    if (typeof win.removeEventListener === 'function') {
 +      win.removeEventListener('resize', handleResize);
 +    }
    };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,7 +221,7 @@ packageExtensionsChecksum: sha256-GmuHKPl+EPPmpH9o6dpG/x6YUd/4eHjpfdYnSqH1GqA=
 
 patchedDependencies:
   '@base-ui-components/react':
-    hash: a23a5e3d2555fd74b3b6a83cfe733742964f01052d2aaa76925d7c6cdccdcdbf
+    hash: d4271385b91b00eef23d65d6e7cd705e4bddf0db5b9b792fa9c0f0027cabd221
     path: patches/@base-ui-components__react.patch
 
 importers:
@@ -1610,7 +1610,7 @@ importers:
         version: 7.28.4
       '@base-ui-components/react':
         specifier: ^1.0.0-beta.4
-        version: 1.0.0-beta.4(patch_hash=a23a5e3d2555fd74b3b6a83cfe733742964f01052d2aaa76925d7c6cdccdcdbf)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.0.0-beta.4(patch_hash=d4271385b91b00eef23d65d6e7cd705e4bddf0db5b9b792fa9c0f0027cabd221)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@base-ui-components/utils':
         specifier: ^0.1.2
         version: 0.1.2(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1669,7 +1669,7 @@ importers:
         version: 7.28.4
       '@base-ui-components/react':
         specifier: ^1.0.0-beta.4
-        version: 1.0.0-beta.4(patch_hash=a23a5e3d2555fd74b3b6a83cfe733742964f01052d2aaa76925d7c6cdccdcdbf)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 1.0.0-beta.4(patch_hash=d4271385b91b00eef23d65d6e7cd705e4bddf0db5b9b792fa9c0f0027cabd221)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@base-ui-components/utils':
         specifier: ^0.1.2
         version: 0.1.2(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -13579,7 +13579,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui-components/react@1.0.0-beta.4(patch_hash=a23a5e3d2555fd74b3b6a83cfe733742964f01052d2aaa76925d7c6cdccdcdbf)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@base-ui-components/react@1.0.0-beta.4(patch_hash=d4271385b91b00eef23d65d6e7cd705e4bddf0db5b9b792fa9c0f0027cabd221)(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@base-ui-components/utils': 0.1.2(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)


### PR DESCRIPTION
Patch Base UI `useScrollLock` to fix `PreferencesMenu` test.

The [previous attempt](https://github.com/mui/mui-x/pull/20331) didn't work ([failure](https://app.circleci.com/pipelines/github/mui/mui-x/110251/workflows/1660375f-8648-4746-a738-9ffc93e0d7da/jobs/680149)), so I'm trying another approach. 

Base UI PR: https://github.com/mui/base-ui/pull/3264

[Made 3 runs to ensure it's working as expected](https://app.circleci.com/pipelines/github/mui/mui-x?branch=pull%2F20375).