### PR TITLE
[charts-pro] Fix Content-Security-Policy nonce not being correctly set on export

### DIFF
--- a/packages/x-internals/src/export/loadStyleSheets.tsx
+++ b/packages/x-internals/src/export/loadStyleSheets.tsx
@@ -45,6 +45,12 @@ export function loadStyleSheets(document: Document, root: Document | ShadowRoot,
     }
 
     document.head.appendChild(newHeadStyleElement);
+
+    if (nonce) {
+      // I don't understand why we need to set the nonce again after appending the element, but I've tested it, and it's
+      // the only way I could find to fix Chrome's warning about a CSP violation.
+      newHeadStyleElement.setAttribute('nonce', nonce);
+    }
   }
 
   return stylesheetLoadPromises;


### PR DESCRIPTION
Another attempt at fixing https://github.com/mui/mui-x/issues/20037.

Fixes Content-Security-Policy nonce not being correctly set on export.

You can test the fix by cloning [this repo's commit](https://github.com/bernardobelchior/mui-x-next-csp/tree/b66e71b0065e4b5865307d89925c05cca26a9822), replacing the `@mui/x-charts-pro` version with the one from this PR, and then running `npm install && npm run build && npm run start`. 

Remember to clear the `.next` folder if you update dependencies as it sometimes becomes stale). 

Result:

https://github.com/user-attachments/assets/14e5aafc-d274-401c-9963-a2da37ac3b31



