### PR TITLE
[charts-premium] Add explicit return type to `ChartsRenderer` for better compatibility with React 18

### DIFF
--- a/packages/x-charts-premium/src/ChartsRenderer/ChartsRenderer.tsx
+++ b/packages/x-charts-premium/src/ChartsRenderer/ChartsRenderer.tsx
@@ -335,16 +335,25 @@ ChartsRenderer.propTypes = {
   // | These PropTypes are generated from the TypeScript type definitions |
   // | To update them edit the TypeScript types and run "pnpm proptypes"  |
   // ----------------------------------------------------------------------
-  categories: PropTypes.arrayOf(
+  chartType: PropTypes.string.isRequired,
+  configuration: PropTypes.object.isRequired,
+  dimensions: PropTypes.arrayOf(
     PropTypes.shape({
-      data: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])).isRequired,
+      data: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.number, PropTypes.string]),
+      ).isRequired,
       id: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
     }),
   ).isRequired,
-  chartType: PropTypes.string.isRequired,
-  configuration: PropTypes.object.isRequired,
-  series: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onRender: PropTypes.func,
+  values: PropTypes.arrayOf(
+    PropTypes.shape({
+      data: PropTypes.arrayOf(PropTypes.number).isRequired,
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
 } as any;
 
 export { ChartsRenderer };


### PR DESCRIPTION
Context https://github.com/mui/mui-x/issues/20316#issuecomment-3532985457
After building our package with React 19 explicit and implicit type mismatches with React 18.

Before the change, in the declaration file, `ChartsRenderer` was typed as
```
declare function ChartsRenderer({
  dimensions,
  values,
  chartType,
  configuration,
  onRender
}: ChartsRendererProps): string | number | bigint | boolean | Iterable<React.ReactNode> | Promise<string | number | bigint | boolean | React.ReactPortal | React.ReactElement<unknown, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | null | undefined> | import("react/jsx-runtime").JSX.Element | null | undefined;
```
After the change
```
declare function ChartsRenderer({
  dimensions,
  values,
  chartType,
  configuration,
  onRender
}: ChartsRendererProps): React.ReactNode;
```