### PR TITLE
[charts-pro] Provide arguments to the `AreaPlotRoot` styled component

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/previews/AreaPreviewPlot.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/previews/AreaPreviewPlot.tsx
@@ -14,7 +14,7 @@ import { PreviewPlotProps } from './PreviewPlot.types';
 const AreaPlotRoot = styled('g', {
   name: 'MuiAreaPlot',
   slot: 'Root',
-})();
+})({});
 
 interface AreaPreviewPlotProps extends PreviewPlotProps {}
 


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/20316#issuecomment-3544080483
Closes https://github.com/mui/mui-x/issues/20316
