### PR TITLE
[scheduler] New store method: `registerStoreEffect`

### DIFF
--- a/packages/x-scheduler-headless/src/utils/SchedulerStore/SchedulerStore.ts
+++ b/packages/x-scheduler-headless/src/utils/SchedulerStore/SchedulerStore.ts
@@ -199,8 +199,29 @@ export class SchedulerStore<
     this.parameters = parameters;
   };
 
+  /**
+   * Returns a cleanup function that need to be called when the store is destroyed.
+   */
   public disposeEffect = () => {
     return this.timeoutManager.clearAll;
+  };
+
+  /**
+   * Registers an effect to be run when the value returned by the selector changes.
+   */
+  public registerStoreEffect = <Value>(
+    selector: (state: State) => Value,
+    effect: (previous: Value, next: Value) => void,
+  ) => {
+    let previousValue = selector(this.state);
+
+    return this.subscribe((state) => {
+      const nextValue = selector(state);
+      if (nextValue !== previousValue) {
+        effect(previousValue, nextValue);
+        previousValue = nextValue;
+      }
+    });
   };
 
   protected setVisibleDate = (visibleDate: SchedulerValidDate, event: React.UIEvent) => {


### PR DESCRIPTION
Here is an example of how to use it, taken from the `TreeViewFocusPlugin`:

```ts
export class TreeViewFocusPlugin {
  constructor(store: any) {
    this.store = store;

    // Whenever the items change, we need to ensure the focused item is still present.
    this.store.registerStoreEffect(itemsSelectors.itemMetaLookup, () => {
      const focusedItemId = focusSelectors.focusedItemId(store.state);
      if (focusedItemId == null) {
        return;
      }

      const hasItemBeenRemoved = !itemsSelectors.itemMeta(store.state, focusedItemId);
      if (!hasItemBeenRemoved) {
        return;
      }

      const defaultFocusableItemId = focusSelectors.defaultFocusableItemId(store.state);
      if (defaultFocusableItemId == null) {
        this.setFocusedItemId(null);
        return;
      }

      this.applyItemFocus(null, defaultFocusableItemId);
    });
  }
}
```