### PR TITLE
[charts-pro] Improve vertical zoom slider thumb on mobile

### DIFF
--- a/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderThumb.tsx
+++ b/packages/x-charts-pro/src/ChartZoomSlider/internals/ChartAxisZoomSliderThumb.tsx
@@ -38,6 +38,10 @@ export interface ChartZoomSliderThumbProps
   extends Omit<React.ComponentProps<'rect'>, 'orientation'>,
     ChartZoomSliderThumbOwnerState {}
 
+function preventDefault(event: Event) {
+  event.preventDefault();
+}
+
 /**
  * Renders the zoom slider thumb, which is responsible for resizing the zoom range.
  * @internal
@@ -58,19 +62,21 @@ export const ChartAxisZoomSliderThumb = React.forwardRef<SVGRectElement, ChartZo
       const thumb = thumbRef.current;
 
       if (!thumb) {
-        return;
+        return () => {};
       }
 
-      let prevTouchAction = 'auto';
+      // Prevent scrolling on touch devices when dragging the thumb
+      thumb.addEventListener('touchmove', preventDefault, { passive: false });
 
       const onPointerMove = rafThrottle((event: PointerEvent) => {
         onMoveEvent(event);
       });
 
-      const onPointerUp = () => {
+      const onPointerEnd = (event: PointerEvent) => {
         thumb.removeEventListener('pointermove', onPointerMove);
-        thumb.removeEventListener('pointerup', onPointerUp);
-        document.body.style.touchAction = prevTouchAction;
+        thumb.removeEventListener('pointerup', onPointerEnd);
+        thumb.removeEventListener('pointercancel', onPointerEnd);
+        thumb.releasePointerCapture(event.pointerId);
       };
 
       const onPointerDown = (event: PointerEvent) => {
@@ -79,19 +85,19 @@ export const ChartAxisZoomSliderThumb = React.forwardRef<SVGRectElement, ChartZo
         event.stopPropagation();
         thumb.setPointerCapture(event.pointerId);
 
-        /* Disable touch scrolling while dragging to improve slider thumb usage on mobile */
-        prevTouchAction = document.body.style.touchAction;
-        document.body.style.touchAction = 'none';
-
-        thumb.addEventListener('pointerup', onPointerUp);
         thumb.addEventListener('pointermove', onPointerMove);
+        thumb.addEventListener('pointercancel', onPointerEnd);
+        thumb.addEventListener('pointerup', onPointerEnd);
       };
 
       thumb.addEventListener('pointerdown', onPointerDown);
 
-      // eslint-disable-next-line consistent-return
       return () => {
         thumb.removeEventListener('pointerdown', onPointerDown);
+        thumb.removeEventListener('pointermove', onPointerMove);
+        thumb.removeEventListener('pointercancel', onPointerEnd);
+        thumb.removeEventListener('pointerup', onPointerEnd);
+        thumb.removeEventListener('touchmove', preventDefault);
         onPointerMove.clear();
       };
     }, [onMoveEvent, orientation]);


### PR DESCRIPTION
Improve vertical zoom slider thumb on mobile. 

Before:

https://github.com/user-attachments/assets/c7811ac1-016a-4369-8211-bc441f34e573


Applying `touch-action: none` (initial approach):

https://github.com/user-attachments/assets/4d9a2eaa-8a00-44ee-b09c-fdb7015e47d7

Using `preventDefault` in `touchmove`:

https://github.com/user-attachments/assets/e6e24cff-1b66-4b4f-9ca4-084ce69f242f

Chrome on Android also seems to work:


https://github.com/user-attachments/assets/fe5c76ea-335e-4bb7-ad49-27342e46b70b



