### PR TITLE
[code-infra] Configure pnpm `minimumReleaseAge` option

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,3 +94,7 @@ onlyBuiltDependencies:
   - nx
   - sharp
   - unrs-resolver
+
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@mui/*'


### PR DESCRIPTION
Configures [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage) in pnpm workspace.

> To reduce the risk of installing compromised packages, you can delay the installation of newly published versions. In most cases, malicious releases are discovered and removed from the registry within an hour.