### PR TITLE
[scheduler] Make sure selector returned values are stable

### DIFF
--- a/packages/x-scheduler-headless/src/calendar-grid/header-cell/CalendarGridHeaderCell.tsx
+++ b/packages/x-scheduler-headless/src/calendar-grid/header-cell/CalendarGridHeaderCell.tsx
@@ -1,15 +1,21 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui-components/utils/store';
+import { createSelector, useStore } from '@base-ui-components/utils/store';
 import { useRenderElement } from '../../base-ui-copy/utils/useRenderElement';
 import { BaseUIComponentProps } from '../../base-ui-copy/utils/types';
 import { useCompositeListItem } from '../../base-ui-copy/composite/list/useCompositeListItem';
 import { useAdapter } from '../../use-adapter';
 import { useEventCalendarStoreContext } from '../../use-event-calendar-store-context';
-import { SchedulerProcessedDate } from '../../models';
+import { SchedulerProcessedDate, SchedulerValidDate } from '../../models';
 import { getCalendarGridHeaderCellId } from '../../utils/accessibility-utils';
 import { useCalendarGridRootContext } from '../root/CalendarGridRootContext';
 import { schedulerNowSelectors } from '../../scheduler-selectors';
+import { EventCalendarState as State } from '../../use-event-calendar';
+
+const selectorIsCurrentDate = createSelector(
+  (state: State, date: SchedulerValidDate, skipDataCurrent: boolean | undefined) =>
+    !skipDataCurrent && schedulerNowSelectors.isCurrentDay(state, date),
+);
 
 export const CalendarGridHeaderCell = React.forwardRef(function CalendarGridHeaderCell(
   componentProps: CalendarGridHeaderCell.Props,
@@ -31,11 +37,7 @@ export const CalendarGridHeaderCell = React.forwardRef(function CalendarGridHead
 
   const store = useEventCalendarStoreContext();
   const { id: rootId } = useCalendarGridRootContext();
-  const isCurrentDay = useStore(
-    store,
-    skipDataCurrent ? () => false : schedulerNowSelectors.isCurrentDay,
-    date.value,
-  );
+  const isCurrentDay = useStore(store, selectorIsCurrentDate, date.value, skipDataCurrent);
 
   const { ref: listItemRef, index } = useCompositeListItem();
   const id = getCalendarGridHeaderCellId(rootId, index);

--- a/packages/x-scheduler-headless/src/event-calendar-selectors/eventCalendarPreferenceSelectors.ts
+++ b/packages/x-scheduler-headless/src/event-calendar-selectors/eventCalendarPreferenceSelectors.ts
@@ -1,8 +1,8 @@
-import { createSelector } from '@base-ui-components/utils/store';
+import { createSelector, createSelectorMemoized } from '@base-ui-components/utils/store';
 import { EventCalendarState as State } from '../use-event-calendar';
 import { DEFAULT_EVENT_CALENDAR_PREFERENCES } from '../use-event-calendar/EventCalendarStore';
 
-const allPreferencesSelector = createSelector(
+const allPreferencesSelector = createSelectorMemoized(
   (state: State) => state.preferences,
   (preferences) => ({
     ...DEFAULT_EVENT_CALENDAR_PREFERENCES,

--- a/packages/x-scheduler-headless/src/scheduler-selectors/schedulerEventSelectors.ts
+++ b/packages/x-scheduler-headless/src/scheduler-selectors/schedulerEventSelectors.ts
@@ -19,7 +19,7 @@ const isEventReadOnlySelector = createSelector(
 );
 
 export const schedulerEventSelectors = {
-  creationConfig: createSelector(
+  creationConfig: createSelectorMemoized(
     (state: State) => state.readOnly,
     (state: State) => state.eventCreation,
     (isSchedulerReadOnly, creationConfig) => {

--- a/packages/x-scheduler-headless/src/scheduler-selectors/schedulerPreferenceSelectors.ts
+++ b/packages/x-scheduler-headless/src/scheduler-selectors/schedulerPreferenceSelectors.ts
@@ -1,8 +1,8 @@
-import { createSelector } from '@base-ui-components/utils/store';
+import { createSelector, createSelectorMemoized } from '@base-ui-components/utils/store';
 import { SchedulerState as State } from '../utils/SchedulerStore/SchedulerStore.types';
 import { DEFAULT_SCHEDULER_PREFERENCES } from '../utils/SchedulerStore';
 
-const allSchedulerPreferencesSelector = createSelector(
+const allSchedulerPreferencesSelector = createSelectorMemoized(
   (state: State) => state.preferences,
   (preferences) => ({
     ...DEFAULT_SCHEDULER_PREFERENCES,


### PR DESCRIPTION
Prepares the scheduler for when @romgrk applies #20447 to the Base UI version of the store.

This PR makes sure that:
1. Calling a selector twice will always return the same value for the same inputs (so if the selector returns an object, and array of a date, it should be memoized)
2. The selector passed to `useStore` remain the same accross renders.