### PR TITLE
[charts] Revert `useIsHydrated` to default=false

### DIFF
--- a/packages/x-charts/src/hooks/useIsHydrated.ts
+++ b/packages/x-charts/src/hooks/useIsHydrated.ts
@@ -5,9 +5,7 @@ import * as React from 'react';
  *
  * Basically a implementation of Option 2 of this gist: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#option-2-lazily-show-component-with-uselayouteffect. */
 export function useIsHydrated() {
-  const [isHydrated, setIsHydrated] = React.useState(
-    typeof window !== 'undefined' || process.env.NODE_ENV === 'test',
-  );
+  const [isHydrated, setIsHydrated] = React.useState(false);
 
   React.useEffect(() => {
     setIsHydrated(true);


### PR DESCRIPTION
Now that vitest is stable we don't need this fix anymore